### PR TITLE
ci: add develop branch to CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Extend GitHub Actions CI workflow to trigger on pull requests and pushes targeting the develop branch in addition to main.