### PR TITLE
chore: enable mypy type checking in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,16 +27,16 @@ repos:
       # Formatter
       - id: ruff-format
 
-  # MyPy - Type checking (optional, can be slow)
-  # Uncomment when you want stricter checks
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.8.0
-  #   hooks:
-  #     - id: mypy
-  #       additional_dependencies:
-  #         - pydantic>=2.0
-  #         - types-sqlalchemy
-  #       args: [--ignore-missing-imports]
+  # MyPy - Type checking
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - pydantic>=2.0
+          - sqlalchemy>=2.0
+          - types-sqlalchemy
+        args: [--ignore-missing-imports]
 
   # Conventional commits
   - repo: https://github.com/compilerla/conventional-pre-commit


### PR DESCRIPTION
- Uncomment mypy hook configuration
- Add sqlalchemy>=2.0 to additional dependencies

## Summary by Sourcery

Build:
- Add mypy mirror repo to pre-commit and include SQLAlchemy runtime and typing dependencies for the hook.