### PR TITLE
  refactor(external-id): move generate() and validate_prefix() to base class

### DIFF
--- a/src/domain/media/value_objects/media_id.py
+++ b/src/domain/media/value_objects/media_id.py
@@ -9,8 +9,6 @@ Typed external IDs for the Media bounded context:
 
 from typing import ClassVar
 
-from pydantic import model_validator
-
 from src.domain.media.rule_codes import MediaRuleCodes
 from src.domain.shared.exceptions.domain import DomainValidationException
 from src.domain.shared.models.external_id import ExternalId
@@ -25,19 +23,6 @@ class MovieId(ExternalId):
 
     EXPECTED_PREFIX: ClassVar[str] = "mov"
 
-    @model_validator(mode="after")
-    def validate_prefix(self) -> "MovieId":
-        """Ensure the ID has the correct prefix."""
-        if self.prefix != self.EXPECTED_PREFIX:
-            raise ValueError(f"MovieId must have '{self.EXPECTED_PREFIX}' prefix")
-        return self
-
-    @classmethod
-    def generate(cls) -> "MovieId":
-        """Generate a new MovieId."""
-        base = cls._generate_with_prefix(cls.EXPECTED_PREFIX)
-        return cls(base.value)
-
 
 class SeriesId(ExternalId):
     """External ID for TV series.
@@ -47,19 +32,6 @@ class SeriesId(ExternalId):
     """
 
     EXPECTED_PREFIX: ClassVar[str] = "ser"
-
-    @model_validator(mode="after")
-    def validate_prefix(self) -> "SeriesId":
-        """Ensure the ID has the correct prefix."""
-        if self.prefix != self.EXPECTED_PREFIX:
-            raise ValueError(f"SeriesId must have '{self.EXPECTED_PREFIX}' prefix")
-        return self
-
-    @classmethod
-    def generate(cls) -> "SeriesId":
-        """Generate a new SeriesId."""
-        base = cls._generate_with_prefix(cls.EXPECTED_PREFIX)
-        return cls(base.value)
 
 
 class SeasonId(ExternalId):
@@ -71,19 +43,6 @@ class SeasonId(ExternalId):
 
     EXPECTED_PREFIX: ClassVar[str] = "ssn"
 
-    @model_validator(mode="after")
-    def validate_prefix(self) -> "SeasonId":
-        """Ensure the ID has the correct prefix."""
-        if self.prefix != self.EXPECTED_PREFIX:
-            raise ValueError(f"SeasonId must have '{self.EXPECTED_PREFIX}' prefix")
-        return self
-
-    @classmethod
-    def generate(cls) -> "SeasonId":
-        """Generate a new SeasonId."""
-        base = cls._generate_with_prefix(cls.EXPECTED_PREFIX)
-        return cls(base.value)
-
 
 class EpisodeId(ExternalId):
     """External ID for episodes.
@@ -93,19 +52,6 @@ class EpisodeId(ExternalId):
     """
 
     EXPECTED_PREFIX: ClassVar[str] = "epi"
-
-    @model_validator(mode="after")
-    def validate_prefix(self) -> "EpisodeId":
-        """Ensure the ID has the correct prefix."""
-        if self.prefix != self.EXPECTED_PREFIX:
-            raise ValueError(f"EpisodeId must have '{self.EXPECTED_PREFIX}' prefix")
-        return self
-
-    @classmethod
-    def generate(cls) -> "EpisodeId":
-        """Generate a new EpisodeId."""
-        base = cls._generate_with_prefix(cls.EXPECTED_PREFIX)
-        return cls(base.value)
 
 
 # Type alias for any media ID

--- a/src/domain/shared/models/external_id.py
+++ b/src/domain/shared/models/external_id.py
@@ -26,15 +26,16 @@ class ExternalId(StringValueObject):
 
     Format: {prefix}_{base62_random_12chars}
 
-    Subclasses should define EXPECTED_PREFIX and override generate().
+    Subclasses only need to define EXPECTED_PREFIX. The generate() method
+    and prefix validation are inherited from this base class.
 
     Example:
         >>> class MovieId(ExternalId):
         ...     EXPECTED_PREFIX: ClassVar[str] = "mov"
         ...
-        ...     @classmethod
-        ...     def generate(cls) -> "MovieId":
-        ...         return cls._generate_with_prefix(cls.EXPECTED_PREFIX)
+        >>> movie_id = MovieId.generate()
+        >>> movie_id.prefix
+        'mov'
     """
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
@@ -42,7 +43,7 @@ class ExternalId(StringValueObject):
         str_strip_whitespace=True,
     )
 
-    # Subclasses should override this
+    # Subclasses must override this
     EXPECTED_PREFIX: ClassVar[str] = ""
 
     root: str
@@ -73,14 +74,27 @@ class ExternalId(StringValueObject):
 
         return str(value)
 
-    @classmethod
-    def _generate_with_prefix(cls, prefix: str) -> Self:
-        """Generate a new external ID with the given prefix.
+    @model_validator(mode="after")
+    def validate_prefix(self) -> Self:
+        """Validate that the ID has the expected prefix for this type."""
+        if self.EXPECTED_PREFIX and self.prefix != self.EXPECTED_PREFIX:
+            raise ValueError(f"{self.__class__.__name__} must have '{self.EXPECTED_PREFIX}' prefix")
+        return self
 
-        This is a helper for subclasses to use in their generate() method.
+    @classmethod
+    def generate(cls) -> Self:
+        """Generate a new external ID with the class prefix.
+
+        Returns:
+            A new instance with a unique base62 random part.
+
+        Raises:
+            ValueError: If EXPECTED_PREFIX is not defined in the subclass.
         """
+        if not cls.EXPECTED_PREFIX:
+            raise ValueError(f"{cls.__name__} must define EXPECTED_PREFIX to use generate()")
         random_part = "".join(secrets.choice(BASE62_ALPHABET) for _ in range(RANDOM_PART_LENGTH))
-        return cls(f"{prefix}_{random_part}")
+        return cls(f"{cls.EXPECTED_PREFIX}_{random_part}")
 
     @property
     def value(self) -> str:


### PR DESCRIPTION
Summary

  - Move duplicated generate() and validate_prefix() methods from ExternalId subclasses to the base ExternalId class
  - Subclasses (MovieId, SeriesId, SeasonId, EpisodeId) now only need to define EXPECTED_PREFIX
  - Remove ~54 lines of duplicated code

  Test plan

  - Run make test to verify all existing tests pass
  - Verify MovieId.generate(), SeriesId.generate(), etc. still work correctly
  - Verify prefix validation still rejects invalid prefixes

## Summary by Sourcery

Refactor ExternalId handling to centralize ID generation and prefix validation in the base class, simplifying media ID subclasses.

Enhancements:
- Move generate() and prefix validation logic from MovieId, SeriesId, SeasonId, and EpisodeId into the ExternalId base class so subclasses only define EXPECTED_PREFIX.
- Replace the helper _generate_with_prefix() with a unified generate() method on ExternalId that constructs IDs using the subclass prefix and validates that EXPECTED_PREFIX is configured.