### PR TITLE
refactor(external-id): enforce EXPECTED_PREFIX via __init_subclass__

### DIFF
--- a/src/domain/shared/models/external_id.py
+++ b/src/domain/shared/models/external_id.py
@@ -94,9 +94,14 @@ class ExternalId(StringValueObject):
 
         Returns:
             A new instance with a unique base62 random part.
+
+        Raises:
+            TypeError: If called directly on ExternalId base class.
         """
+        if cls is ExternalId:
+            raise TypeError("generate() must be called on a subclass with EXPECTED_PREFIX defined")
         random_part = "".join(secrets.choice(BASE62_ALPHABET) for _ in range(RANDOM_PART_LENGTH))
-        return cls(f"{cls.EXPECTED_PREFIX}_{random_part}")
+        return cls(root=f"{cls.EXPECTED_PREFIX}_{random_part}")
 
     @property
     def value(self) -> str:

--- a/tests/unit/domain/shared/models/test_external_id.py
+++ b/tests/unit/domain/shared/models/test_external_id.py
@@ -193,7 +193,7 @@ class TestExternalIdSubclassValidation:
             class InvalidExternalId(ExternalId):
                 pass
 
-            InvalidExternalId.generate()
+            _ = InvalidExternalId
 
     def test_should_raise_type_error_when_expected_prefix_is_empty(self):
         with pytest.raises(TypeError, match="must define a non-empty EXPECTED_PREFIX"):
@@ -201,11 +201,17 @@ class TestExternalIdSubclassValidation:
             class InvalidExternalId(ExternalId):
                 EXPECTED_PREFIX: ClassVar[str] = ""
 
-            InvalidExternalId.generate()
+            _ = InvalidExternalId
 
     def test_should_allow_subclass_with_valid_expected_prefix(self):
-        # Should not raise
         class ValidExternalId(ExternalId):
             EXPECTED_PREFIX: ClassVar[str] = "val"
 
-        assert ValidExternalId.EXPECTED_PREFIX == "val"
+        generated = ValidExternalId.generate()
+
+        assert generated.value.startswith("val_")
+        assert len(generated.random_part) == RANDOM_PART_LENGTH
+
+    def test_should_raise_type_error_when_generate_called_on_base_class(self):
+        with pytest.raises(TypeError, match="generate\\(\\) must be called on a subclass"):
+            ExternalId.generate()


### PR DESCRIPTION
Move generate() and validate_prefix() to ExternalId base class and add __init_subclass__ to validate EXPECTED_PREFIX at class definition time. Subclasses now only need to declare EXPECTED_PREFIX.

## Summary by Sourcery

Enforce declaration of a non-empty EXPECTED_PREFIX on all ExternalId subclasses at class definition time and centralize prefix validation and ID generation in the ExternalId base class.

Enhancements:
- Add __init_subclass__ hook on ExternalId to validate that subclasses define a non-empty EXPECTED_PREFIX.
- Simplify ExternalId subclasses so they rely on inherited generate() and prefix validation instead of reimplementing them.

Tests:
- Add tests covering subclass validation of EXPECTED_PREFIX via __init_subclass__ and behaviour for missing, empty, and valid prefixes.