### PR TITLE
 refactor(infrastructure): use with_updates for ID assignment in repositories

### DIFF
--- a/src/domain/shared/models/external_id.py
+++ b/src/domain/shared/models/external_id.py
@@ -103,6 +103,22 @@ class ExternalId(StringValueObject):
         random_part = "".join(secrets.choice(BASE62_ALPHABET) for _ in range(RANDOM_PART_LENGTH))
         return cls(root=f"{cls.EXPECTED_PREFIX}_{random_part}")
 
+    @classmethod
+    def generate_if_absent(cls, existing: Self | None) -> Self:
+        """Return the existing ID if present, or generate a new one.
+
+        Standardizes the pattern of assigning IDs in repositories:
+        instead of ``id if id is not None else IdType.generate()``,
+        use ``IdType.generate_if_absent(id)``.
+
+        Args:
+            existing: An existing ID instance, or None.
+
+        Returns:
+            The existing ID unchanged, or a newly generated one.
+        """
+        return existing if existing is not None else cls.generate()
+
     @property
     def value(self) -> str:
         """Get the full ID string."""

--- a/src/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/infrastructure/persistence/repositories/movie_repository.py
@@ -57,9 +57,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
         Returns:
             The saved movie (with generated ID if new).
         """
-        # Generate ID if not present
-        if movie.id is None:
-            movie = movie.with_updates(id=MovieId.generate())
+        movie = movie.with_updates(id=MovieId.generate_if_absent(movie.id))
 
         # Check if the movie already exists (including soft-deleted for restore)
         stmt = select(MovieModel).where(MovieModel.external_id == str(movie.id))

--- a/src/infrastructure/persistence/repositories/series_repository.py
+++ b/src/infrastructure/persistence/repositories/series_repository.py
@@ -180,20 +180,16 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         Returns:
             Series with all IDs populated.
         """
-        series_id = series.id if series.id is not None else SeriesId.generate()
+        series_id = SeriesId.generate_if_absent(series.id)
 
         updated_seasons: list[Season] = []
         for season in series.seasons:
-            season_id = season.id if season.id is not None else SeasonId.generate()
+            season_id = SeasonId.generate_if_absent(season.id)
 
             updated_episodes: list[Episode] = []
             for episode in season.episodes:
-                updated_episodes.append(
-                    episode.with_updates(
-                        id=episode.id if episode.id is not None else EpisodeId.generate(),
-                        series_id=series_id,
-                    )
-                )
+                episode_id = EpisodeId.generate_if_absent(episode.id)
+                updated_episodes.append(episode.with_updates(id=episode_id, series_id=series_id))
 
             updated_seasons.append(
                 season.with_updates(

--- a/tests/unit/domain/shared/models/test_external_id.py
+++ b/tests/unit/domain/shared/models/test_external_id.py
@@ -99,6 +99,24 @@ class SampleExternalIdGeneration:
         assert len(unique_ids) == 100
 
 
+class TestExternalIdGenerateIfAbsent:
+    """Tests for ExternalId.generate_if_absent()."""
+
+    def test_should_return_existing_id_when_present(self):
+        existing = SampleExternalId("tst_abc123abc123")
+
+        result = SampleExternalId.generate_if_absent(existing)
+
+        assert result is existing
+
+    def test_should_generate_new_id_when_none(self):
+        result = SampleExternalId.generate_if_absent(None)
+
+        assert isinstance(result, SampleExternalId)
+        assert result.prefix == "tst"
+        assert len(result.random_part) == RANDOM_PART_LENGTH
+
+
 class SampleExternalIdProperties:
     """Tests for ExternalId properties."""
 


### PR DESCRIPTION
Summary

  - Replace manual field-by-field entity re-instantiation with DomainEntity.with_updates() when generating IDs in MovieRepository.save() and SeriesRepository._ensure_ids()
  - Reduces boilerplate and prevents fields from being silently dropped when new fields are added to entities
  - Simplifies _ensure_ids from ~50 lines to ~15 lines

  Motivation

  The previous approach manually copied every field when creating a new entity instance with a generated ID. This was fragile — adding a new field to Movie, Series, Season, or Episode required updating the corresponding repository code, and forgetting to do so would silently drop the field's value.

  Test plan

  - Existing repository unit and integration tests pass without changes
  - Verify MovieRepository.save() correctly assigns IDs to new movies
  - Verify SeriesRepository._ensure_ids() correctly assigns IDs to series, seasons, and episodes

## Summary by Sourcery

Refactor repository ID assignment to use domain entities’ with_updates helpers instead of manually reconstructing objects.

Enhancements:
- Use with_updates for assigning generated IDs in MovieRepository.save to avoid manual field copying.
- Simplify SeriesRepository._ensure_ids to populate series, season, and episode IDs via with_updates while preserving all other fields.