### PR TITLE
refactor(domain): make entities immutable with with_* convention

### DIFF
--- a/docs/adr/ADR-007-immutable-entities-with-convention.md
+++ b/docs/adr/ADR-007-immutable-entities-with-convention.md
@@ -26,16 +26,16 @@ Nós iremos:
 
 1. **Tornar `DomainEntity` frozen** adicionando `frozen=True` ao `model_config` da classe base, eliminando a necessidade de repetir a configuração em cada entidade concreta.
 
-2. **Remover `touch()`** de `DomainEntity` — cada método `with_*` inclui `updated_at=utc_now()` explicitamente.
+2. **Remover `touch()`** de `DomainEntity` — `with_updates()` agora atualiza `updated_at` automaticamente via `setdefault`.
 
-3. **Adotar a convenção `with_*`/`without_*`** para todos os métodos que modificam estado, retornando `Self`:
-   - `Movie.add_genre()` → `Movie.with_genre()` → retorna nova instância
-   - `Series.add_season()` → `Series.with_season()` → retorna nova instância
-   - `Season.add_episode()` → `Season.with_episode()` → retorna nova instância
-   - `Library.add_path()` → `Library.with_path()` → retorna nova instância
-   - `Library.remove_path()` → `Library.without_path()` → retorna self se não encontrado
+3. **`with_updates()` faz bump automático de `updated_at`** — usa `kwargs.setdefault("updated_at", utc_now())` para que chamadores não precisem lembrar de passar o timestamp. Valores explícitos ainda são respeitados.
 
-4. **`with_updates()` permanece como utilitário low-level** — não atualiza `updated_at` automaticamente.
+4. **Adotar a convenção `with_*`/`without_*`** para todos os métodos que modificam estado, retornando `Self`:
+   - `Movie.add_genre()` → `Movie.with_genre()` → retorna nova instância, ou `self` para duplicata
+   - `Series.add_season()` → `Series.with_season()` → retorna nova instância, ou `self` para duplicata
+   - `Season.add_episode()` → `Season.with_episode()` → retorna nova instância, ou `self` para duplicata
+   - `Library.add_path()` → `Library.with_path()` → retorna nova instância (erro para duplicata)
+   - `Library.remove_path()` → `Library.without_path()` → retorna nova instância, ou `self` se não encontrado
 
 ## Consequências
 
@@ -83,7 +83,7 @@ Abandonar Pydantic para entidades e usar dataclasses frozen.
 
 ## Notas de Implementação
 
-Padrão para métodos `with_*`:
+Padrão para métodos `with_*` (`with_updates` faz bump automático de `updated_at`):
 
 ```python
 def with_genre(self, genre: Genre | str) -> Self:
@@ -91,10 +91,7 @@ def with_genre(self, genre: Genre | str) -> Self:
         genre = Genre(genre)
     if genre in self.genres:
         return self  # no-op para duplicatas
-    return self.with_updates(
-        genres=[*self.genres, genre],
-        updated_at=utc_now(),
-    )
+    return self.with_updates(genres=[*self.genres, genre])
 ```
 
 Padrão para métodos `without_*`:
@@ -107,11 +104,10 @@ def without_path(self, path: FilePath | str) -> Self:
         return self  # no-op se não encontrado
     if len(self.paths) == 1:
         raise ValueError("Cannot remove the last path")
-    return self.with_updates(
-        paths=[p for p in self.paths if p != path],
-        updated_at=utc_now(),
-    )
+    return self.with_updates(paths=[p for p in self.paths if p != path])
 ```
+
+Todos os métodos `with_*`/`without_*` devem retornar `self` quando não há mudança (duplicata ou item não encontrado), garantindo comportamento uniforme.
 
 ## Historico de Revisoes
 

--- a/docs/adr/ADR-007-immutable-entities-with-convention.md
+++ b/docs/adr/ADR-007-immutable-entities-with-convention.md
@@ -1,0 +1,120 @@
+# ADR-007: Immutable Entities with `with_*` Convention
+
+**Status:** Aceito
+**Data:** 2026-02-17
+**Deciders:** Lucas
+**Technical Story:** Alinhar entidades com o padrão de imutabilidade já usado em Value Objects
+
+---
+
+## Contexto
+
+Domain entities (Movie, Series, Season, Episode, Library) eram **mutáveis** — métodos como `add_genre()`, `add_season()` alteravam o estado interno in-place sem retornar nada. Isso criava uma classe de bugs onde chamadores esqueciam que a operação era void e não reatribuíam o resultado:
+
+```python
+# Bug silencioso: add_genre retorna None, movie não muda na referência do chamador
+movie.add_genre("Sci-Fi")  # muta internamente, mas fácil esquecer o padrão
+```
+
+Value Objects já usavam `frozen=True` desde ADR-001. Entities precisavam seguir o mesmo padrão para consistência arquitetural.
+
+Além disso, `DomainEntity.touch()` (que atualizava `updated_at` in-place) era incompatível com imutabilidade e representava acoplamento desnecessário — cada método `with_*` agora gerencia o timestamp explicitamente.
+
+## Decisão
+
+Nós iremos:
+
+1. **Tornar `DomainEntity` frozen** adicionando `frozen=True` ao `model_config` da classe base, eliminando a necessidade de repetir a configuração em cada entidade concreta.
+
+2. **Remover `touch()`** de `DomainEntity` — cada método `with_*` inclui `updated_at=utc_now()` explicitamente.
+
+3. **Adotar a convenção `with_*`/`without_*`** para todos os métodos que modificam estado, retornando `Self`:
+   - `Movie.add_genre()` → `Movie.with_genre()` → retorna nova instância
+   - `Series.add_season()` → `Series.with_season()` → retorna nova instância
+   - `Season.add_episode()` → `Season.with_episode()` → retorna nova instância
+   - `Library.add_path()` → `Library.with_path()` → retorna nova instância
+   - `Library.remove_path()` → `Library.without_path()` → retorna self se não encontrado
+
+4. **`with_updates()` permanece como utilitário low-level** — não atualiza `updated_at` automaticamente.
+
+## Consequências
+
+### Positivas
+
+- **Elimina bugs de mutação silenciosa** — chamadores são forçados a capturar o retorno
+- **Consistência** — Entities e Value Objects seguem o mesmo padrão frozen
+- **Thread-safety** — objetos imutáveis são inherentemente thread-safe
+- **Código auto-documentado** — `with_genre()` torna claro que retorna uma nova instância
+- **Menos duplicação de config** — `model_config` definido uma vez em `DomainEntity`, herdado por todas as entidades
+
+### Negativas
+
+- **Alocação extra** — cada operação cria um novo objeto (impacto negligível para domain objects)
+- **Verbosidade no chamador** — requer reatribuição: `movie = movie.with_genre("Sci-Fi")`
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Performance com muitas operações encadeadas | Baixa | Baixo | Domain objects são leves; operações em batch são raras |
+| PrivateAttr (`_events`) não funcionar com frozen | Baixa | Alto | Testado — PrivateAttr NÃO é afetado por frozen=True |
+
+## Alternativas Consideradas
+
+### 1. Manter entidades mutáveis com retorno de `Self`
+
+Mudar a assinatura de `add_genre() -> None` para `add_genre() -> Self` retornando `self`, mantendo mutabilidade.
+
+**Rejeitado porque:** Não resolve o problema — o chamador ainda pode ignorar o retorno e o objeto teria sido mutado silenciosamente. Frozen + `with_*` é a única forma de tornar o padrão obrigatório.
+
+### 2. Usar `@dataclass(frozen=True)` em vez de Pydantic
+
+Abandonar Pydantic para entidades e usar dataclasses frozen.
+
+**Rejeitado porque:** Perderíamos validação automática, conversão de tipos, e model_validate — benefícios centrais de ADR-001.
+
+## Referências
+
+- ADR-001: Pydantic para Domain Models
+- [Pydantic v2 — Frozen Models](https://docs.pydantic.dev/latest/concepts/config/#frozen)
+- Domain-Driven Design — Entity immutability patterns
+
+---
+
+## Notas de Implementação
+
+Padrão para métodos `with_*`:
+
+```python
+def with_genre(self, genre: Genre | str) -> Self:
+    if isinstance(genre, str):
+        genre = Genre(genre)
+    if genre in self.genres:
+        return self  # no-op para duplicatas
+    return self.with_updates(
+        genres=[*self.genres, genre],
+        updated_at=utc_now(),
+    )
+```
+
+Padrão para métodos `without_*`:
+
+```python
+def without_path(self, path: FilePath | str) -> Self:
+    if isinstance(path, str):
+        path = FilePath(path)
+    if path not in self.paths:
+        return self  # no-op se não encontrado
+    if len(self.paths) == 1:
+        raise ValueError("Cannot remove the last path")
+    return self.with_updates(
+        paths=[p for p in self.paths if p != path],
+        updated_at=utc_now(),
+    )
+```
+
+## Historico de Revisoes
+
+| Data | Autor | Mudanca |
+|------|-------|---------|
+| 2026-02-17 | Lucas | Criacao inicial |

--- a/src/domain/library/entities/library.py
+++ b/src/domain/library/entities/library.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Self
+from typing import TYPE_CHECKING, Any, Self
 
-from pydantic import ConfigDict, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -47,11 +47,6 @@ class Library(AggregateRoot[LibraryId]):
         >>> library.name.value
         'Anime'
     """
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(
-        validate_assignment=True,
-        extra="forbid",
-    )
 
     # Identity
     id: LibraryId | None = Field(default=None)

--- a/src/domain/library/entities/library.py
+++ b/src/domain/library/entities/library.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 from pydantic import ConfigDict, Field, field_validator, model_validator
 
@@ -18,6 +18,7 @@ from src.domain.library.value_objects.library_type import LibraryType
 from src.domain.library.value_objects.metadata_provider import MetadataProviderConfig
 from src.domain.media.value_objects.file_path import FilePath
 from src.domain.shared.models import AggregateRoot
+from src.domain.shared.models.entity import utc_now
 
 
 class Library(AggregateRoot[LibraryId]):
@@ -136,11 +137,14 @@ class Library(AggregateRoot[LibraryId]):
 
         return self
 
-    def add_path(self, path: FilePath | str) -> None:
-        """Add a new path to the library.
+    def with_path(self, path: FilePath | str) -> Self:
+        """Return a copy with the path added.
 
         Args:
             path: Filesystem path to add.
+
+        Returns:
+            A new Library with the path added.
 
         Raises:
             ValueError: If path already exists in the library.
@@ -153,17 +157,19 @@ class Library(AggregateRoot[LibraryId]):
                 f"Path already exists in library [{LibraryRuleCodes.LIBRARY_DUPLICATE_PATH}]"
             )
 
-        self.paths.append(path)
-        self.touch()
+        return self.with_updates(
+            paths=[*self.paths, path],
+            updated_at=utc_now(),
+        )
 
-    def remove_path(self, path: FilePath | str) -> bool:
-        """Remove a path from the library.
+    def without_path(self, path: FilePath | str) -> Self:
+        """Return a copy with the path removed.
 
         Args:
             path: Filesystem path to remove.
 
         Returns:
-            True if path was removed, False if not found.
+            A new Library without the path, or self if not found.
 
         Raises:
             ValueError: If removing the last path.
@@ -172,7 +178,7 @@ class Library(AggregateRoot[LibraryId]):
             path = FilePath(path)
 
         if path not in self.paths:
-            return False
+            return self
 
         if len(self.paths) == 1:
             raise ValueError(
@@ -180,9 +186,10 @@ class Library(AggregateRoot[LibraryId]):
                 f"[{LibraryRuleCodes.LIBRARY_NO_PATHS}]"
             )
 
-        self.paths.remove(path)
-        self.touch()
-        return True
+        return self.with_updates(
+            paths=[p for p in self.paths if p != path],
+            updated_at=utc_now(),
+        )
 
     def get_enabled_providers(self) -> list[MetadataProviderConfig]:
         """Get enabled metadata providers sorted by priority.

--- a/src/domain/library/entities/library.py
+++ b/src/domain/library/entities/library.py
@@ -18,7 +18,6 @@ from src.domain.library.value_objects.library_type import LibraryType
 from src.domain.library.value_objects.metadata_provider import MetadataProviderConfig
 from src.domain.media.value_objects.file_path import FilePath
 from src.domain.shared.models import AggregateRoot
-from src.domain.shared.models.entity import utc_now
 
 
 class Library(AggregateRoot[LibraryId]):
@@ -152,10 +151,7 @@ class Library(AggregateRoot[LibraryId]):
                 f"Path already exists in library [{LibraryRuleCodes.LIBRARY_DUPLICATE_PATH}]"
             )
 
-        return self.with_updates(
-            paths=[*self.paths, path],
-            updated_at=utc_now(),
-        )
+        return self.with_updates(paths=[*self.paths, path])
 
     def without_path(self, path: FilePath | str) -> Self:
         """Return a copy with the path removed.
@@ -181,10 +177,7 @@ class Library(AggregateRoot[LibraryId]):
                 f"[{LibraryRuleCodes.LIBRARY_NO_PATHS}]"
             )
 
-        return self.with_updates(
-            paths=[p for p in self.paths if p != path],
-            updated_at=utc_now(),
-        )
+        return self.with_updates(paths=[p for p in self.paths if p != path])
 
     def get_enabled_providers(self) -> list[MetadataProviderConfig]:
         """Get enabled metadata providers sorted by priority.

--- a/src/domain/media/entities/episode.py
+++ b/src/domain/media/entities/episode.py
@@ -1,9 +1,8 @@
 """Episode entity for TV series."""
 
 from datetime import date
-from typing import ClassVar
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
 
 from src.domain.media.value_objects import (
     Duration,
@@ -34,11 +33,6 @@ class Episode(DomainEntity[EpisodeId]):
         ...     resolution=Resolution("1080p"),
         ... )
     """
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(
-        validate_assignment=True,
-        extra="forbid",
-    )
 
     # Identity
     id: EpisodeId | None = Field(default=None)

--- a/src/domain/media/entities/movie.py
+++ b/src/domain/media/entities/movie.py
@@ -16,7 +16,6 @@ from src.domain.media.value_objects import (
     Year,
 )
 from src.domain.shared.models import AggregateRoot
-from src.domain.shared.models.entity import utc_now
 
 
 class Movie(AggregateRoot[MovieId]):
@@ -91,10 +90,7 @@ class Movie(AggregateRoot[MovieId]):
             genre = Genre(genre)
         if genre in self.genres:
             return self
-        return self.with_updates(
-            genres=[*self.genres, genre],
-            updated_at=utc_now(),
-        )
+        return self.with_updates(genres=[*self.genres, genre])
 
     @classmethod
     def create(

--- a/src/domain/media/entities/movie.py
+++ b/src/domain/media/entities/movie.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Self
+from typing import Any, Self
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
 
 from src.domain.media.value_objects import (
     Duration,
@@ -35,11 +35,6 @@ class Movie(AggregateRoot[MovieId]):
         ...     resolution="1080p",
         ... )
     """
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(
-        validate_assignment=True,
-        extra="forbid",
-    )
 
     # Identity
     id: MovieId | None = Field(default=None)

--- a/src/domain/media/entities/movie.py
+++ b/src/domain/media/entities/movie.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Self
 
 from pydantic import ConfigDict, Field, field_validator
 
@@ -16,6 +16,7 @@ from src.domain.media.value_objects import (
     Year,
 )
 from src.domain.shared.models import AggregateRoot
+from src.domain.shared.models.entity import utc_now
 
 
 class Movie(AggregateRoot[MovieId]):
@@ -82,17 +83,23 @@ class Movie(AggregateRoot[MovieId]):
         """Convert string list to Genre list."""
         return [] if v is None else [Genre(g) if isinstance(g, str) else g for g in v]
 
-    def add_genre(self, genre: Genre | str) -> None:
-        """Add a genre to this movie.
+    def with_genre(self, genre: Genre | str) -> Self:
+        """Return a copy with the genre added.
 
         Args:
             genre: The genre to add (string or Genre object).
+
+        Returns:
+            A new Movie with the genre added, or self if duplicate.
         """
         if isinstance(genre, str):
             genre = Genre(genre)
-        if genre not in self.genres:
-            self.genres.append(genre)
-            self.touch()
+        if genre in self.genres:
+            return self
+        return self.with_updates(
+            genres=[*self.genres, genre],
+            updated_at=utc_now(),
+        )
 
     @classmethod
     def create(

--- a/src/domain/media/entities/season.py
+++ b/src/domain/media/entities/season.py
@@ -11,7 +11,6 @@ from src.domain.media.rule_codes import MediaRuleCodes
 from src.domain.media.value_objects import FilePath, SeasonId, SeriesId, Title
 from src.domain.shared.exceptions.domain import BusinessRuleViolationException
 from src.domain.shared.models import DomainEntity
-from src.domain.shared.models.entity import utc_now
 
 if TYPE_CHECKING:
     from src.domain.media import Episode
@@ -74,7 +73,7 @@ class Season(DomainEntity[SeasonId]):
             episode: The episode to add.
 
         Returns:
-            A new Season with the episode added.
+            A new Season with the episode added, or self if already present.
 
         Raises:
             BusinessRuleViolationException: If episode series_id or season_number doesn't match.
@@ -89,10 +88,9 @@ class Season(DomainEntity[SeasonId]):
                 message="Episode season_number must match Season",
                 rule_code=MediaRuleCodes.EPISODE_SEASON_MISMATCH,
             )
-        return self.with_updates(
-            episodes=[*self.episodes, episode],
-            updated_at=utc_now(),
-        )
+        if episode in self.episodes:
+            return self
+        return self.with_updates(episodes=[*self.episodes, episode])
 
     def get_episode(self, episode_number: int) -> Episode | None:
         """Find an episode by its number.

--- a/src/domain/media/entities/season.py
+++ b/src/domain/media/entities/season.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from datetime import date  # noqa: TCH003
-from typing import TYPE_CHECKING, ClassVar, Self
+from typing import TYPE_CHECKING, Self
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import Field, field_validator
 
 from src.domain.media.rule_codes import MediaRuleCodes
 from src.domain.media.value_objects import FilePath, SeasonId, SeriesId, Title
@@ -30,11 +30,6 @@ class Season(DomainEntity[SeasonId]):
         ...     title=Title("Season One"),
         ... )
     """
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(
-        validate_assignment=True,
-        extra="forbid",
-    )
 
     # Identity - override base id type
     id: SeasonId | None = Field(default=None)

--- a/src/domain/media/entities/season.py
+++ b/src/domain/media/entities/season.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date  # noqa: TCH003
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Self
 
 from pydantic import ConfigDict, Field, field_validator
 
@@ -11,6 +11,7 @@ from src.domain.media.rule_codes import MediaRuleCodes
 from src.domain.media.value_objects import FilePath, SeasonId, SeriesId, Title
 from src.domain.shared.exceptions.domain import BusinessRuleViolationException
 from src.domain.shared.models import DomainEntity
+from src.domain.shared.models.entity import utc_now
 
 if TYPE_CHECKING:
     from src.domain.media import Episode
@@ -71,11 +72,14 @@ class Season(DomainEntity[SeasonId]):
         """
         return len(self.episodes)
 
-    def add_episode(self, episode: Episode) -> None:
-        """Add an episode to this season.
+    def with_episode(self, episode: Episode) -> Self:
+        """Return a copy with the episode added.
 
         Args:
             episode: The episode to add.
+
+        Returns:
+            A new Season with the episode added.
 
         Raises:
             BusinessRuleViolationException: If episode series_id or season_number doesn't match.
@@ -90,8 +94,10 @@ class Season(DomainEntity[SeasonId]):
                 message="Episode season_number must match Season",
                 rule_code=MediaRuleCodes.EPISODE_SEASON_MISMATCH,
             )
-        self.episodes.append(episode)
-        self.touch()
+        return self.with_updates(
+            episodes=[*self.episodes, episode],
+            updated_at=utc_now(),
+        )
 
     def get_episode(self, episode_number: int) -> Episode | None:
         """Find an episode by its number.

--- a/src/domain/media/entities/series.py
+++ b/src/domain/media/entities/series.py
@@ -10,7 +10,6 @@ from src.domain.media.rule_codes import MediaRuleCodes
 from src.domain.media.value_objects import FilePath, Genre, SeriesId, Title, Year
 from src.domain.shared.exceptions.domain import BusinessRuleViolationException
 from src.domain.shared.models import AggregateRoot
-from src.domain.shared.models.entity import utc_now
 
 if TYPE_CHECKING:
     from src.domain.media.entities.season import Season
@@ -104,7 +103,7 @@ class Series(AggregateRoot[SeriesId]):
             season: The season to add.
 
         Returns:
-            A new Series with the season added.
+            A new Series with the season added, or self if already present.
 
         Raises:
             BusinessRuleViolationException: If season series_id doesn't match.
@@ -114,10 +113,9 @@ class Series(AggregateRoot[SeriesId]):
                 message="Season series_id must match Series id",
                 rule_code=MediaRuleCodes.SEASON_SERIES_MISMATCH,
             )
-        return self.with_updates(
-            seasons=[*self.seasons, season],
-            updated_at=utc_now(),
-        )
+        if season in self.seasons:
+            return self
+        return self.with_updates(seasons=[*self.seasons, season])
 
     def get_season(self, season_number: int) -> Season | None:
         """Find a season by its number.

--- a/src/domain/media/entities/series.py
+++ b/src/domain/media/entities/series.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 from pydantic import ConfigDict, Field, field_validator, model_validator
 
@@ -10,6 +10,7 @@ from src.domain.media.rule_codes import MediaRuleCodes
 from src.domain.media.value_objects import FilePath, Genre, SeriesId, Title, Year
 from src.domain.shared.exceptions.domain import BusinessRuleViolationException
 from src.domain.shared.models import AggregateRoot
+from src.domain.shared.models.entity import utc_now
 
 if TYPE_CHECKING:
     from src.domain.media.entities.season import Season
@@ -101,11 +102,14 @@ class Series(AggregateRoot[SeriesId]):
         """
         return self.end_year is None
 
-    def add_season(self, season: Season) -> None:
-        """Add a season to this series.
+    def with_season(self, season: Season) -> Self:
+        """Return a copy with the season added.
 
         Args:
             season: The season to add.
+
+        Returns:
+            A new Series with the season added.
 
         Raises:
             BusinessRuleViolationException: If season series_id doesn't match.
@@ -115,8 +119,10 @@ class Series(AggregateRoot[SeriesId]):
                 message="Season series_id must match Series id",
                 rule_code=MediaRuleCodes.SEASON_SERIES_MISMATCH,
             )
-        self.seasons.append(season)
-        self.touch()
+        return self.with_updates(
+            seasons=[*self.seasons, season],
+            updated_at=utc_now(),
+        )
 
     def get_season(self, season_number: int) -> Season | None:
         """Find a season by its number.

--- a/src/domain/media/entities/series.py
+++ b/src/domain/media/entities/series.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, ClassVar, Self
+from typing import TYPE_CHECKING, Any, Self
 
-from pydantic import ConfigDict, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from src.domain.media.rule_codes import MediaRuleCodes
 from src.domain.media.value_objects import FilePath, Genre, SeriesId, Title, Year
@@ -28,11 +28,6 @@ class Series(AggregateRoot[SeriesId]):
         ...     start_year=2008,
         ... )
     """
-
-    model_config: ClassVar[ConfigDict] = ConfigDict(
-        validate_assignment=True,
-        extra="forbid",
-    )
 
     # Identity
     id: SeriesId | None = Field(default=None)

--- a/src/domain/shared/models/entity.py
+++ b/src/domain/shared/models/entity.py
@@ -24,6 +24,7 @@ class DomainEntity(DomainModel, Generic[IdT]):
     """
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
+        frozen=True,
         validate_assignment=True,
         extra="forbid",
     )
@@ -41,10 +42,6 @@ class DomainEntity(DomainModel, Generic[IdT]):
         if self.id is None:
             return hash(id(self))
         return hash((self.__class__.__name__, self.id))
-
-    def touch(self) -> None:
-        """Update the updated_at timestamp."""
-        self.updated_at = utc_now()
 
     def with_updates(self, **kwargs: Any) -> Self:
         """Create a new, fully validated instance by applying updates atomically.

--- a/src/domain/shared/models/entity.py
+++ b/src/domain/shared/models/entity.py
@@ -46,6 +46,9 @@ class DomainEntity(DomainModel, Generic[IdT]):
     def with_updates(self, **kwargs: Any) -> Self:
         """Create a new, fully validated instance by applying updates atomically.
 
+        Automatically bumps ``updated_at`` to the current UTC time unless
+        an explicit value is provided in *kwargs*.
+
         Args:
             **kwargs: Fields to update with their new values.
 
@@ -55,6 +58,8 @@ class DomainEntity(DomainModel, Generic[IdT]):
         Raises:
             DomainValidationException: If the resulting state is invalid.
         """
+        kwargs.setdefault("updated_at", utc_now())
+
         current_data = self.model_dump()
         current_data.update(kwargs)
 

--- a/tests/unit/application/media/use_cases/test_get_movie_by_id.py
+++ b/tests/unit/application/media/use_cases/test_get_movie_by_id.py
@@ -65,8 +65,8 @@ class TestGetMovieByIdUseCase:
             file_size=1_000_000_000,
             resolution="1080p",
         )
-        movie.add_genre("Action")
-        movie.add_genre("Sci-Fi")
+        movie = movie.with_genre("Action")
+        movie = movie.with_genre("Sci-Fi")
         mock_repo.find_by_id.return_value = movie
         use_case = GetMovieByIdUseCase(movie_repository=mock_repo)
 

--- a/tests/unit/application/media/use_cases/test_get_series_by_id.py
+++ b/tests/unit/application/media/use_cases/test_get_series_by_id.py
@@ -78,7 +78,7 @@ class TestGetSeriesByIdUseCase:
             file_size=1_500_000_000,
             resolution="1080p",
         )
-        season.add_episode(episode)
+        season = season.with_episode(episode)
         series = series.with_season(season)
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(series_repository=mock_repo)

--- a/tests/unit/application/media/use_cases/test_get_series_by_id.py
+++ b/tests/unit/application/media/use_cases/test_get_series_by_id.py
@@ -45,7 +45,7 @@ class TestGetSeriesByIdUseCase:
             series_id=series.id,
             season_number=1,
         )
-        series.add_season(season)
+        series = series.with_season(season)
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
 
@@ -79,7 +79,7 @@ class TestGetSeriesByIdUseCase:
             resolution="1080p",
         )
         season.add_episode(episode)
-        series.add_season(season)
+        series = series.with_season(season)
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
 

--- a/tests/unit/application/media/use_cases/test_list_movies.py
+++ b/tests/unit/application/media/use_cases/test_list_movies.py
@@ -54,7 +54,7 @@ class TestListMoviesUseCase:
             file_size=1_000_000_000,
             resolution="1080p",
         )
-        movie.add_genre("Action")
+        movie = movie.with_genre("Action")
         mock_repo.list_all.return_value = [movie]
         use_case = ListMoviesUseCase(movie_repository=mock_repo)
 

--- a/tests/unit/domain/library/entities/test_library.py
+++ b/tests/unit/domain/library/entities/test_library.py
@@ -88,19 +88,19 @@ class TestLibraryValidation:
 class TestLibraryPathManagement:
     """Tests for Library path operations."""
 
-    def test_add_path_should_add_new_path(self):
+    def test_with_path_should_add_new_path(self):
         library = Library(
             name="Movies",
             library_type=LibraryType.MOVIES,
             paths=["/media/movies"],
         )
 
-        library.add_path("/backup/movies")
+        library = library.with_path("/backup/movies")
 
         assert len(library.paths) == 2
         assert FilePath("/backup/movies") in library.paths
 
-    def test_add_path_should_raise_error_for_duplicate(self):
+    def test_with_path_should_raise_error_for_duplicate(self):
         library = Library(
             name="Movies",
             library_type=LibraryType.MOVIES,
@@ -108,32 +108,31 @@ class TestLibraryPathManagement:
         )
 
         with pytest.raises(ValueError, match="already exists"):
-            library.add_path("/media/movies")
+            library.with_path("/media/movies")
 
-    def test_remove_path_should_remove_existing_path(self):
+    def test_without_path_should_remove_existing_path(self):
         library = Library(
             name="Movies",
             library_type=LibraryType.MOVIES,
             paths=["/media/movies", "/backup/movies"],
         )
 
-        result = library.remove_path("/backup/movies")
+        library = library.without_path("/backup/movies")
 
-        assert result is True
         assert len(library.paths) == 1
 
-    def test_remove_path_should_return_false_for_nonexistent(self):
+    def test_without_path_should_return_self_for_nonexistent(self):
         library = Library(
             name="Movies",
             library_type=LibraryType.MOVIES,
             paths=["/media/movies"],
         )
 
-        result = library.remove_path("/other/path")
+        result = library.without_path("/other/path")
 
-        assert result is False
+        assert result is library
 
-    def test_remove_path_should_raise_error_for_last_path(self):
+    def test_without_path_should_raise_error_for_last_path(self):
         library = Library(
             name="Movies",
             library_type=LibraryType.MOVIES,
@@ -141,7 +140,7 @@ class TestLibraryPathManagement:
         )
 
         with pytest.raises(ValueError, match="last path"):
-            library.remove_path("/media/movies")
+            library.without_path("/media/movies")
 
 
 class TestLibraryMetadataProviders:
@@ -252,4 +251,5 @@ class TestLibrarySpecializedFactories:
         assert library.library_type == LibraryType.SERIES
         assert library.language.value == "ja"
         assert library.settings.preferred_audio_language.value == "ja"
+        assert library.settings.preferred_subtitle_language is not None
         assert library.settings.preferred_subtitle_language.value == "en"

--- a/tests/unit/domain/library/entities/test_library.py
+++ b/tests/unit/domain/library/entities/test_library.py
@@ -253,3 +253,54 @@ class TestLibrarySpecializedFactories:
         assert library.settings.preferred_audio_language.value == "ja"
         assert library.settings.preferred_subtitle_language is not None
         assert library.settings.preferred_subtitle_language.value == "en"
+
+
+class TestLibraryImmutability:
+    """Tests for Library frozen (immutable) behavior."""
+
+    def test_should_reject_direct_attribute_assignment(self):
+        library = Library(
+            name="Movies",
+            library_type=LibraryType.MOVIES,
+            paths=["/media/movies"],
+        )
+
+        with pytest.raises(DomainValidationException):
+            library.name = LibraryName("Changed")  # type: ignore[misc]
+
+    def test_with_path_should_return_new_instance(self):
+        library = Library(
+            name="Movies",
+            library_type=LibraryType.MOVIES,
+            paths=["/media/movies"],
+        )
+
+        updated = library.with_path("/backup/movies")
+
+        assert updated is not library
+        assert len(updated.paths) == 2
+        assert len(library.paths) == 1
+
+    def test_without_path_should_return_new_instance(self):
+        library = Library(
+            name="Movies",
+            library_type=LibraryType.MOVIES,
+            paths=["/media/movies", "/backup/movies"],
+        )
+
+        updated = library.without_path("/backup/movies")
+
+        assert updated is not library
+        assert len(updated.paths) == 1
+        assert len(library.paths) == 2
+
+    def test_without_path_nonexistent_should_return_self(self):
+        library = Library(
+            name="Movies",
+            library_type=LibraryType.MOVIES,
+            paths=["/media/movies"],
+        )
+
+        result = library.without_path("/other/path")
+
+        assert result is library

--- a/tests/unit/domain/media/entities/test_episode.py
+++ b/tests/unit/domain/media/entities/test_episode.py
@@ -341,9 +341,7 @@ class TestEpisodeTimestamps:
 
         assert episode.created_at is not None
 
-    def test_should_update_timestamp_on_touch(self):
-        from datetime import UTC, datetime
-
+    def test_should_reject_direct_attribute_assignment(self):
         from src.domain.media.entities import Episode
         from src.domain.media.value_objects import (
             Duration,
@@ -362,10 +360,7 @@ class TestEpisodeTimestamps:
             file_path=FilePath("/series/show/s01e01.mkv"),
             file_size=1_000_000_000,
             resolution=Resolution("1080p"),
-            updated_at=datetime(2020, 1, 1, tzinfo=UTC),
         )
 
-        old_updated_at = episode.updated_at
-        episode.touch()
-
-        assert episode.updated_at > old_updated_at
+        with pytest.raises(DomainValidationException):
+            episode.season_number = 2  # type: ignore[misc]

--- a/tests/unit/domain/media/entities/test_movie.py
+++ b/tests/unit/domain/media/entities/test_movie.py
@@ -285,7 +285,7 @@ class TestMovieImmutability:
         assert len(updated.genres) == 1
         assert len(movie.genres) == 0
 
-    def test_with_genre_duplicate_should_return_self(self):
+    def test_with_genre_duplicate_string_should_return_self(self):
         from src.domain.media.entities import Movie
 
         movie = Movie.create(
@@ -299,5 +299,23 @@ class TestMovieImmutability:
         movie = movie.with_genre("Sci-Fi")
 
         result = movie.with_genre("Sci-Fi")
+
+        assert result is movie
+
+    def test_with_genre_duplicate_value_object_should_return_self(self):
+        from src.domain.media.entities import Movie
+        from src.domain.media.value_objects import Genre
+
+        movie = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        movie = movie.with_genre(Genre("Sci-Fi"))
+
+        result = movie.with_genre(Genre("Sci-Fi"))
 
         assert result is movie

--- a/tests/unit/domain/media/entities/test_movie.py
+++ b/tests/unit/domain/media/entities/test_movie.py
@@ -247,3 +247,57 @@ class TestMovieEvents:
 
         assert len(events) == 1
         assert movie.has_pending_events is False
+
+
+class TestMovieImmutability:
+    """Tests for Movie frozen (immutable) behavior."""
+
+    def test_should_reject_direct_attribute_assignment(self):
+        from src.domain.media.entities import Movie
+
+        movie = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+
+        with pytest.raises(DomainValidationException):
+            movie.year = 2020  # type: ignore[assignment, misc]
+
+    def test_with_genre_should_return_new_instance(self):
+        from src.domain.media.entities import Movie
+
+        movie = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+
+        updated = movie.with_genre("Sci-Fi")
+
+        assert updated is not movie
+        assert len(updated.genres) == 1
+        assert len(movie.genres) == 0
+
+    def test_with_genre_duplicate_should_return_self(self):
+        from src.domain.media.entities import Movie
+
+        movie = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        movie = movie.with_genre("Sci-Fi")
+
+        result = movie.with_genre("Sci-Fi")
+
+        assert result is movie

--- a/tests/unit/domain/media/entities/test_movie.py
+++ b/tests/unit/domain/media/entities/test_movie.py
@@ -122,6 +122,7 @@ class TestMovieOptionalFields:
             imdb_id="tt1375666",
         )
 
+        assert movie.original_title is not None
         assert movie.original_title.value == "Inception"
         assert movie.synopsis is not None
         assert len(movie.genres) == 2
@@ -144,7 +145,7 @@ class TestMovieGenreManagement:
             resolution="1080p",
         )
 
-        movie.add_genre("Sci-Fi")
+        movie = movie.with_genre("Sci-Fi")
 
         assert len(movie.genres) == 1
         assert movie.genres[0].value == "Sci-Fi"
@@ -162,7 +163,7 @@ class TestMovieGenreManagement:
             resolution="1080p",
         )
 
-        movie.add_genre(Genre("Action"))
+        movie = movie.with_genre(Genre("Action"))
 
         assert len(movie.genres) == 1
 
@@ -178,8 +179,8 @@ class TestMovieGenreManagement:
             resolution="1080p",
         )
 
-        movie.add_genre("Sci-Fi")
-        movie.add_genre("Sci-Fi")
+        movie = movie.with_genre("Sci-Fi")
+        movie = movie.with_genre("Sci-Fi")
 
         assert len(movie.genres) == 1
 

--- a/tests/unit/domain/media/entities/test_season.py
+++ b/tests/unit/domain/media/entities/test_season.py
@@ -89,6 +89,7 @@ class TestSeasonOptionalFields:
             title=Title("Season One"),
         )
 
+        assert season.title is not None
         assert season.title.value == "Season One"
 
     def test_should_create_with_synopsis(self):
@@ -172,7 +173,7 @@ class TestSeasonEpisodeManagement:
             resolution=Resolution("1080p"),
         )
 
-        season.add_episode(episode)
+        season = season.with_episode(episode)
 
         assert season.episode_count == 1
         assert season.episodes[0] == episode
@@ -204,7 +205,7 @@ class TestSeasonEpisodeManagement:
         )
 
         with pytest.raises(BusinessRuleViolationException, match="series_id"):
-            season.add_episode(episode)
+            season.with_episode(episode)
 
     def test_should_raise_error_when_adding_episode_with_wrong_season_number(self):
         from src.domain.media.entities import Episode, Season
@@ -234,7 +235,7 @@ class TestSeasonEpisodeManagement:
         )
 
         with pytest.raises(BusinessRuleViolationException, match="season_number"):
-            season.add_episode(episode)
+            season.with_episode(episode)
 
     def test_should_get_episode_by_number(self):
         from src.domain.media.entities import Episode, Season
@@ -265,7 +266,7 @@ class TestSeasonEpisodeManagement:
             resolution=Resolution("1080p"),
         )
 
-        season.add_episode(episode)
+        season = season.with_episode(episode)
 
         found = season.get_episode(5)
         assert found == episode

--- a/tests/unit/domain/media/entities/test_season.py
+++ b/tests/unit/domain/media/entities/test_season.py
@@ -309,3 +309,89 @@ class TestSeasonEquality:
         season2 = Season(id=SeasonId.generate(), series_id=series_id, season_number=1)
 
         assert season1 != season2
+
+
+class TestSeasonImmutability:
+    """Tests for Season frozen (immutable) behavior."""
+
+    def test_should_reject_direct_attribute_assignment(self):
+        from src.domain.media.entities import Season
+        from src.domain.media.value_objects import SeriesId
+
+        season = Season(
+            series_id=SeriesId.generate(),
+            season_number=1,
+        )
+
+        with pytest.raises(DomainValidationException):
+            season.season_number = 2  # type: ignore[misc]
+
+    def test_with_episode_should_return_new_instance(self):
+        from src.domain.media.entities import Episode, Season
+        from src.domain.media.value_objects import (
+            Duration,
+            EpisodeId,
+            FilePath,
+            Resolution,
+            SeriesId,
+            Title,
+        )
+
+        series_id = SeriesId.generate()
+        season = Season(
+            series_id=series_id,
+            season_number=1,
+        )
+
+        episode = Episode(
+            id=EpisodeId.generate(),
+            series_id=series_id,
+            season_number=1,
+            episode_number=1,
+            title=Title("Pilot"),
+            duration=Duration(2700),
+            file_path=FilePath("/series/show/s01e01.mkv"),
+            file_size=1_000_000_000,
+            resolution=Resolution("1080p"),
+        )
+
+        updated = season.with_episode(episode)
+
+        assert updated is not season
+        assert updated.episode_count == 1
+        assert season.episode_count == 0
+
+    def test_with_episode_should_preserve_identity(self):
+        from src.domain.media.entities import Episode, Season
+        from src.domain.media.value_objects import (
+            Duration,
+            EpisodeId,
+            FilePath,
+            Resolution,
+            SeasonId,
+            SeriesId,
+            Title,
+        )
+
+        series_id = SeriesId.generate()
+        season = Season(
+            id=SeasonId.generate(),
+            series_id=series_id,
+            season_number=1,
+        )
+
+        episode = Episode(
+            id=EpisodeId.generate(),
+            series_id=series_id,
+            season_number=1,
+            episode_number=1,
+            title=Title("Pilot"),
+            duration=Duration(2700),
+            file_path=FilePath("/series/show/s01e01.mkv"),
+            file_size=1_000_000_000,
+            resolution=Resolution("1080p"),
+        )
+
+        updated = season.with_episode(episode)
+
+        assert updated == season  # same id

--- a/tests/unit/domain/media/entities/test_season.py
+++ b/tests/unit/domain/media/entities/test_season.py
@@ -395,3 +395,37 @@ class TestSeasonImmutability:
         updated = season.with_episode(episode)
 
         assert updated == season  # same id
+
+    def test_with_episode_duplicate_should_return_self(self):
+        from src.domain.media.entities import Episode, Season
+        from src.domain.media.value_objects import (
+            Duration,
+            EpisodeId,
+            FilePath,
+            Resolution,
+            SeriesId,
+            Title,
+        )
+
+        series_id = SeriesId.generate()
+        season = Season(
+            series_id=series_id,
+            season_number=1,
+        )
+
+        episode = Episode(
+            id=EpisodeId.generate(),
+            series_id=series_id,
+            season_number=1,
+            episode_number=1,
+            title=Title("Pilot"),
+            duration=Duration(2700),
+            file_path=FilePath("/series/show/s01e01.mkv"),
+            file_size=1_000_000_000,
+            resolution=Resolution("1080p"),
+        )
+        season = season.with_episode(episode)
+
+        result = season.with_episode(episode)
+
+        assert result is season

--- a/tests/unit/domain/media/entities/test_series.py
+++ b/tests/unit/domain/media/entities/test_series.py
@@ -223,3 +223,19 @@ class TestSeriesImmutability:
         updated = series.with_season(season)
 
         assert updated == series  # same id
+
+    def test_with_season_duplicate_should_return_self(self):
+        from src.domain.media.entities import Season, Series
+        from src.domain.media.value_objects import SeasonId
+
+        series = Series.create(title="Breaking Bad", start_year=2008)
+        season = Season(
+            id=SeasonId.generate(),
+            series_id=series.id,
+            season_number=1,
+        )
+        series = series.with_season(season)
+
+        result = series.with_season(season)
+
+        assert result is series

--- a/tests/unit/domain/media/entities/test_series.py
+++ b/tests/unit/domain/media/entities/test_series.py
@@ -179,3 +179,47 @@ class TestSeriesEvents:
 
         assert len(events) == 1
         assert series.has_pending_events is False
+
+
+class TestSeriesImmutability:
+    """Tests for Series frozen (immutable) behavior."""
+
+    def test_should_reject_direct_attribute_assignment(self):
+        from src.domain.media.entities import Series
+
+        series = Series.create(title="Breaking Bad", start_year=2008)
+
+        with pytest.raises(DomainValidationException):
+            series.start_year = 2020  # type: ignore[assignment, misc]
+
+    def test_with_season_should_return_new_instance(self):
+        from src.domain.media.entities import Season, Series
+        from src.domain.media.value_objects import SeasonId
+
+        series = Series.create(title="Breaking Bad", start_year=2008)
+        season = Season(
+            id=SeasonId.generate(),
+            series_id=series.id,
+            season_number=1,
+        )
+
+        updated = series.with_season(season)
+
+        assert updated is not series
+        assert updated.season_count == 1
+        assert series.season_count == 0
+
+    def test_with_season_should_preserve_identity(self):
+        from src.domain.media.entities import Season, Series
+        from src.domain.media.value_objects import SeasonId
+
+        series = Series.create(title="Breaking Bad", start_year=2008)
+        season = Season(
+            id=SeasonId.generate(),
+            series_id=series.id,
+            season_number=1,
+        )
+
+        updated = series.with_season(season)
+
+        assert updated == series  # same id

--- a/tests/unit/domain/media/entities/test_series.py
+++ b/tests/unit/domain/media/entities/test_series.py
@@ -49,6 +49,7 @@ class TestSeriesCreation:
             end_year=Year(2013),
         )
 
+        assert series.end_year is not None
         assert series.end_year.value == 2013
         assert series.is_ongoing is False
 
@@ -93,7 +94,7 @@ class TestSeriesSeasonManagement:
             season_number=1,
         )
 
-        series.add_season(season)
+        series = series.with_season(season)
 
         assert series.season_count == 1
 
@@ -110,7 +111,7 @@ class TestSeriesSeasonManagement:
         )
 
         with pytest.raises(BusinessRuleViolationException, match="series_id"):
-            series.add_season(season)
+            series.with_season(season)
 
     def test_should_get_season_by_number(self):
         from src.domain.media.entities import Season, Series
@@ -124,7 +125,7 @@ class TestSeriesSeasonManagement:
             season_number=2,
         )
 
-        series.add_season(season)
+        series = series.with_season(season)
 
         found = series.get_season(2)
         assert found == season

--- a/tests/unit/domain/shared/models/test_entity.py
+++ b/tests/unit/domain/shared/models/test_entity.py
@@ -198,6 +198,26 @@ class TestDomainEntityFrozen:
         assert entity.tags == ["a"]
         assert updated.tags == ["a", "b"]
 
+    def test_with_updates_should_auto_bump_updated_at(self):
+        custom_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        entity = SampleEntity(id="test_123", name="Original", updated_at=custom_time)
+
+        before = datetime.now(UTC)
+        updated = entity.with_updates(name="Changed")
+        after = datetime.now(UTC)
+
+        assert updated.name == "Changed"
+        assert before <= updated.updated_at <= after
+        assert entity.updated_at == custom_time
+
+    def test_with_updates_should_respect_explicit_updated_at(self):
+        explicit_time = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
+        entity = SampleEntity(id="test_123", name="Original")
+
+        updated = entity.with_updates(name="Changed", updated_at=explicit_time)
+
+        assert updated.updated_at == explicit_time
+
     def test_aggregate_root_should_also_be_frozen(self):
         aggregate = SampleAggregateRoot(name="Test")
 

--- a/tests/unit/domain/shared/models/test_entity.py
+++ b/tests/unit/domain/shared/models/test_entity.py
@@ -2,16 +2,20 @@
 
 from datetime import UTC, datetime
 
+import pytest
+from pydantic import Field
+
+from src.domain.shared.exceptions.domain import DomainValidationException
 from src.domain.shared.models import AggregateRoot, DomainEntity, utc_now
 
 
-class SampleEntity(DomainEntity):
+class SampleEntity(DomainEntity[str]):
     """Sample entity for testing."""
 
     name: str
 
 
-class SampleAggregateRoot(AggregateRoot):
+class SampleAggregateRoot(AggregateRoot[str]):
     """Sample aggregate root for testing."""
 
     name: str
@@ -134,27 +138,82 @@ class TestDomainEntityHashing:
         assert hash(entity) == hash(id(entity))
 
 
-class TestDomainEntityTouch:
-    """Tests for DomainEntity.touch() method."""
+class SampleEntityWithList(DomainEntity[str]):
+    """Sample entity with a list field for testing."""
 
-    def test_should_update_updated_at_timestamp(self):
-        entity = SampleEntity(
-            name="Test",
-            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
-        )
-        old_updated_at = entity.updated_at
+    name: str
+    tags: list[str] = Field(default_factory=list)
 
-        entity.touch()
 
-        assert entity.updated_at > old_updated_at
+class TestDomainEntityFrozen:
+    """Tests for DomainEntity frozen behavior."""
 
-    def test_should_not_change_created_at(self):
-        created_time = datetime(2024, 1, 1, tzinfo=UTC)
-        entity = SampleEntity(name="Test", created_at=created_time)
+    def test_should_reject_direct_attribute_assignment(self):
+        entity = SampleEntity(name="Test")
 
-        entity.touch()
+        with pytest.raises(DomainValidationException):
+            entity.name = "Changed"  # type: ignore[misc]
 
-        assert entity.created_at == created_time
+    def test_should_reject_id_assignment(self):
+        entity = SampleEntity(name="Test")
+
+        with pytest.raises(DomainValidationException):
+            entity.id = "new_id"  # type: ignore[misc]
+
+    def test_should_reject_timestamp_assignment(self):
+        entity = SampleEntity(name="Test")
+
+        with pytest.raises(DomainValidationException):
+            entity.updated_at = datetime.now(UTC)  # type: ignore[misc]
+
+    def test_with_updates_should_return_new_instance(self):
+        entity = SampleEntity(id="test_123", name="Original")
+
+        updated = entity.with_updates(name="Changed")
+
+        assert updated is not entity
+        assert updated.name == "Changed"
+        assert entity.name == "Original"
+
+    def test_with_updates_should_preserve_unchanged_fields(self):
+        entity = SampleEntity(id="test_123", name="Original")
+
+        updated = entity.with_updates(name="Changed")
+
+        assert updated.id == entity.id
+        assert updated.created_at == entity.created_at
+
+    def test_with_updates_should_preserve_identity(self):
+        entity = SampleEntity(id="test_123", name="Original")
+
+        updated = entity.with_updates(name="Changed")
+
+        assert updated == entity  # same id
+
+    def test_original_list_should_not_be_affected_by_with_updates(self):
+        entity = SampleEntityWithList(name="Test", tags=["a"])
+
+        updated = entity.with_updates(tags=[*entity.tags, "b"])
+
+        assert entity.tags == ["a"]
+        assert updated.tags == ["a", "b"]
+
+    def test_aggregate_root_should_also_be_frozen(self):
+        aggregate = SampleAggregateRoot(name="Test")
+
+        with pytest.raises(DomainValidationException):
+            aggregate.name = "Changed"  # type: ignore[misc]
+
+    def test_aggregate_root_events_should_still_work_when_frozen(self):
+        aggregate = SampleAggregateRoot(name="Test")
+
+        aggregate.add_event({"type": "Created"})
+        aggregate.add_event({"type": "Updated"})
+
+        assert aggregate.has_pending_events is True
+        events = aggregate.pull_events()
+        assert len(events) == 2
+        assert aggregate.has_pending_events is False
 
 
 class TestAggregateRootCreation:


### PR DESCRIPTION
## Summary
  - Make `DomainEntity` frozen (`frozen=True`) and remove `touch()`, aligning entities with the immutability pattern already used by Value Objects
  - Rename mutating methods to `with_*`/`without_*` returning `Self` (`add_genre` → `with_genre`, `add_season` → `with_season`, `add_episode` → `with_episode`, `add_path` → `with_path`, `remove_path` → `without_path`)
  - Remove redundant `model_config` from all concrete entities — inherited from `DomainEntity`
  - Add ADR-007 documenting the decision

  ## Motivation

  Mutating methods (`add_genre() -> None`) created a class of silent bugs where callers forgot the operation was void. With frozen entities and `with_*` returning new instances, callers are forced to capture the result:

  ```python
  # Before — bug-prone
  movie.add_genre("Sci-Fi")  # returns None, easy to misuse

  # After — self-documenting
  movie = movie.with_genre("Sci-Fi")  # must reassign
```
  Test plan

  - 577 tests passing (13 new immutability tests added)
  - All pre-commit hooks green (ruff, mypy, conventional commits)
  - Verified PrivateAttr (_events) still works with frozen entities
  - Verified duplicate/no-op cases return self (same reference)

## Summary by Sourcery

Make domain entities immutable by freezing the base DomainEntity and replacing in-place mutation methods with `with_*`/`without_*` methods that return new instances, updating usages and documentation accordingly.

New Features:
- Introduce `with_*`/`without_*` methods on entities (Movie, Series, Season, Library) that return updated instances instead of mutating state in-place.

Bug Fixes:
- Prevent silent mutation bugs by disallowing direct attribute assignment on entities and requiring callers to use immutable `with_*`-style operations.

Enhancements:
- Mark DomainEntity (and AggregateRoot derivatives) as frozen, removing redundant per-entity model_config definitions and the mutable `touch()` helper.
- Adjust library path management and media collection operations to use immutable updates while preserving identity semantics for no-op and duplicate cases.

Documentation:
- Add ADR-007 documenting the decision to use immutable entities with the `with_*`/`without_*` convention and its rationale.

Tests:
- Update existing tests and add new immutability-focused tests for entities and aggregates, including behavior of with_* methods, event handling, and rejection of direct attribute assignment.