### PR TITLE
refactor(arch): add building_blocks package

### DIFF
--- a/src/building_blocks/__init__.py
+++ b/src/building_blocks/__init__.py
@@ -1,0 +1,1 @@
+"""Building blocks: domain-agnostic base classes and utilities."""

--- a/src/building_blocks/application/__init__.py
+++ b/src/building_blocks/application/__init__.py
@@ -1,0 +1,17 @@
+"""Application building blocks: base exceptions for use cases."""
+
+from src.building_blocks.application.errors import (
+    ApplicationException,
+    ForbiddenOperationException,
+    ResourceNotFoundException,
+    UnauthorizedOperationException,
+    UseCaseValidationException,
+)
+
+__all__ = [
+    "ApplicationException",
+    "ForbiddenOperationException",
+    "ResourceNotFoundException",
+    "UnauthorizedOperationException",
+    "UseCaseValidationException",
+]

--- a/src/building_blocks/application/errors.py
+++ b/src/building_blocks/application/errors.py
@@ -1,0 +1,273 @@
+"""Application layer exceptions.
+
+These exceptions represent errors in use case flow, authorization,
+and input validation at the application level.
+
+See exception-hierarchy-clean-architecture.md for full documentation.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.building_blocks.domain.errors import (
+    CoreException,
+    ExceptionDetail,
+    Severity,
+)
+
+
+@dataclass
+class ApplicationException(CoreException):
+    """Base exception for all application layer errors.
+
+    Use for errors related to application flow, not domain rules.
+
+    Default HTTP status: 400 (Bad Request)
+    """
+
+    code: str = "APPLICATION_ERROR"
+    severity: Severity = Severity.MEDIUM
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 400 (Bad Request)."""
+        return 400
+
+
+@dataclass
+class UseCaseValidationException(ApplicationException):
+    """Invalid use case input.
+
+    Different from DomainValidationException:
+    - UseCaseValidation: request input is malformed/invalid
+    - DomainValidation: domain object cannot exist in this state
+
+    Example:
+        >>> raise UseCaseValidationException.required_field("movie_id")
+
+        >>> raise UseCaseValidationException.from_violations({
+        ...     "limit": ("INVALID_RANGE", "Limit must be between 1 and 100"),
+        ...     "cursor": ("INVALID_FORMAT", "Invalid cursor format")
+        ... })
+    """
+
+    code: str = "USE_CASE_VALIDATION_ERROR"
+    message_code: str = "INVALID_INPUT"
+
+    @classmethod
+    def from_violations(
+        cls,
+        violations: dict[str, tuple[str, str]],
+        **kwargs: Any,
+    ) -> "UseCaseValidationException":
+        """Factory to create exception from multiple input violations.
+
+        Args:
+            violations: Dict of field -> (code, message) tuples
+            **kwargs: Additional arguments for the exception
+
+        Returns:
+            UseCaseValidationException with details populated
+        """
+        details = [
+            ExceptionDetail(
+                code=code,
+                message=msg,
+                field=field_name,
+            )
+            for field_name, (code, msg) in violations.items()
+        ]
+        return cls(
+            message="Invalid input",
+            details=details,
+            **kwargs,
+        )
+
+    @classmethod
+    def required_field(cls, field_name: str) -> "UseCaseValidationException":
+        """Factory for missing required field.
+
+        Args:
+            field_name: Name of the required field
+
+        Returns:
+            UseCaseValidationException for missing field
+        """
+        return cls(
+            message=f"Field '{field_name}' is required",
+            message_code="REQUIRED_FIELD",
+            message_params={"field": field_name},
+            details=[
+                ExceptionDetail(
+                    code="REQUIRED_FIELD",
+                    message="Field is required",
+                    field=field_name,
+                )
+            ],
+        )
+
+    @classmethod
+    def invalid_format(
+        cls,
+        field_name: str,
+        expected: str,
+    ) -> "UseCaseValidationException":
+        """Factory for invalid field format.
+
+        Args:
+            field_name: Name of the field
+            expected: Expected format description
+
+        Returns:
+            UseCaseValidationException for invalid format
+        """
+        return cls(
+            message=f"Invalid format for '{field_name}'. Expected: {expected}",
+            message_code="INVALID_FORMAT",
+            message_params={"field": field_name, "expected": expected},
+            details=[
+                ExceptionDetail(
+                    code="INVALID_FORMAT",
+                    message=f"Expected: {expected}",
+                    field=field_name,
+                )
+            ],
+        )
+
+
+@dataclass
+class UnauthorizedOperationException(ApplicationException):
+    """User is not authenticated.
+
+    Use when the operation requires authentication but the user
+    is not authenticated or the token is invalid.
+
+    Example:
+        >>> raise UnauthorizedOperationException(
+        ...     message="Authentication required",
+        ...     message_code="AUTH_REQUIRED"
+        ... )
+    """
+
+    code: str = "UNAUTHORIZED"
+    message_code: str = "UNAUTHORIZED"
+    severity: Severity = Severity.LOW
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 401 (Unauthorized)."""
+        return 401
+
+
+@dataclass
+class ForbiddenOperationException(ApplicationException):
+    """User doesn't have permission for the operation.
+
+    Use when the user is authenticated but lacks the required
+    permissions for the operation.
+
+    Attributes:
+        required_permission: Permission that was required
+
+    Example:
+        >>> raise ForbiddenOperationException(
+        ...     message="Admin access required",
+        ...     message_code="ADMIN_REQUIRED",
+        ...     required_permission="admin"
+        ... )
+    """
+
+    code: str = "FORBIDDEN"
+    message_code: str = "FORBIDDEN"
+    required_permission: str = ""
+    severity: Severity = Severity.LOW
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 403 (Forbidden)."""
+        return 403
+
+    def __post_init__(self) -> None:
+        """Initialize and add required_permission to tags if set."""
+        super().__post_init__()
+        if self.required_permission:
+            self.tags["required_permission"] = self.required_permission
+
+
+@dataclass
+class ResourceNotFoundException(ApplicationException):
+    """Resource not found at the application level.
+
+    Use when the use case wants to abstract domain details or
+    when the "resource" isn't necessarily an aggregate.
+
+    Note:
+        Both DomainNotFoundException and ResourceNotFoundException
+        map to HTTP 404. Use ResourceNotFoundException when you want
+        to hide domain details or enrich the error at the use case level.
+
+    Attributes:
+        resource_type: Type of resource
+        resource_id: Identifier of the resource
+
+    Example:
+        >>> raise ResourceNotFoundException(
+        ...     message="Movie not found",
+        ...     message_code="MOVIE_NOT_FOUND",
+        ...     resource_type="Movie",
+        ...     resource_id="mov_2xK9mPqR7nL4"
+        ... )
+    """
+
+    code: str = "RESOURCE_NOT_FOUND"
+    message_code: str = "RESOURCE_NOT_FOUND"
+    resource_type: str = ""
+    resource_id: str = ""
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 404 (Not Found)."""
+        return 404
+
+    def __post_init__(self) -> None:
+        """Initialize and add resource metadata to tags and message_params."""
+        super().__post_init__()
+        if self.resource_type:
+            self.tags["resource_type"] = self.resource_type
+        if self.resource_id:
+            self.tags["resource_id"] = self.resource_id
+        self.message_params = {
+            "resource": self.resource_type,
+            "id": self.resource_id,
+        }
+
+    @classmethod
+    def for_resource(
+        cls,
+        resource_type: str,
+        resource_id: str,
+    ) -> "ResourceNotFoundException":
+        """Factory for resource not found.
+
+        Args:
+            resource_type: Type of resource
+            resource_id: External ID of the resource
+
+        Returns:
+            ResourceNotFoundException configured for the resource
+        """
+        return cls(
+            message=f"{resource_type} with id '{resource_id}' not found",
+            message_code=f"{resource_type.upper()}_NOT_FOUND",
+            resource_type=resource_type,
+            resource_id=resource_id,
+        )
+
+
+__all__ = [
+    "ApplicationException",
+    "ForbiddenOperationException",
+    "ResourceNotFoundException",
+    "UnauthorizedOperationException",
+    "UseCaseValidationException",
+]

--- a/src/building_blocks/domain/__init__.py
+++ b/src/building_blocks/domain/__init__.py
@@ -1,0 +1,53 @@
+"""Domain building blocks: base models, value objects, entities, and errors."""
+
+from src.building_blocks.domain.aggregate_root import AggregateRoot
+from src.building_blocks.domain.entity import DomainEntity, utc_now
+from src.building_blocks.domain.errors import (
+    BusinessRuleViolationException,
+    CoreException,
+    DomainConflictException,
+    DomainException,
+    DomainNotFoundException,
+    DomainValidationException,
+    ExceptionDetail,
+    Severity,
+)
+from src.building_blocks.domain.external_id import (
+    BASE62_ALPHABET,
+    RANDOM_PART_LENGTH,
+    ExternalId,
+)
+from src.building_blocks.domain.models import DomainModel, SupportsUpdates
+from src.building_blocks.domain.value_objects import (
+    CompoundValueObject,
+    DateValueObject,
+    FloatValueObject,
+    IntValueObject,
+    StringValueObject,
+    ValueObject,
+)
+
+__all__ = [
+    "AggregateRoot",
+    "BASE62_ALPHABET",
+    "BusinessRuleViolationException",
+    "CompoundValueObject",
+    "CoreException",
+    "DateValueObject",
+    "DomainConflictException",
+    "DomainEntity",
+    "DomainException",
+    "DomainModel",
+    "DomainNotFoundException",
+    "DomainValidationException",
+    "ExceptionDetail",
+    "ExternalId",
+    "FloatValueObject",
+    "IntValueObject",
+    "RANDOM_PART_LENGTH",
+    "Severity",
+    "StringValueObject",
+    "SupportsUpdates",
+    "ValueObject",
+    "utc_now",
+]

--- a/src/building_blocks/domain/aggregate_root.py
+++ b/src/building_blocks/domain/aggregate_root.py
@@ -1,0 +1,5 @@
+"""Aggregate Root base class."""
+
+from src.building_blocks.domain.entity import AggregateRoot
+
+__all__ = ["AggregateRoot"]

--- a/src/building_blocks/domain/entity.py
+++ b/src/building_blocks/domain/entity.py
@@ -1,0 +1,100 @@
+"""Base classes for Domain Entities and Aggregate Roots."""
+
+from datetime import UTC, datetime
+from typing import Any, ClassVar, Generic, Self, TypeVar
+
+from pydantic import ConfigDict, Field, PrivateAttr, ValidationError
+
+from src.building_blocks.domain.models import DomainModel, _raise_domain_validation
+
+# Type variable for entity ID
+IdT = TypeVar("IdT")
+
+
+def utc_now() -> datetime:
+    """Return current UTC datetime."""
+    return datetime.now(UTC)
+
+
+class DomainEntity(DomainModel, Generic[IdT]):
+    """Base class for Domain Entities.
+
+    Entities have identity (id) that persists over time and lifecycle timestamps.
+    Provides with_updates() for creating modified copies.
+    """
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        frozen=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+    id: IdT | None = Field(default=None)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return False if self.id is None or other.id is None else self.id == other.id
+
+    def __hash__(self) -> int:
+        if self.id is None:
+            return hash(id(self))
+        return hash((self.__class__.__name__, self.id))
+
+    def with_updates(self, **kwargs: Any) -> Self:
+        """Create a new, fully validated instance by applying updates atomically.
+
+        Automatically bumps ``updated_at`` to the current UTC time unless
+        an explicit value is provided in *kwargs*.
+
+        Args:
+            **kwargs: Fields to update with their new values.
+
+        Returns:
+            A new instance with the updates applied.
+
+        Raises:
+            DomainValidationException: If the resulting state is invalid.
+        """
+        kwargs.setdefault("updated_at", utc_now())
+
+        current_data = self.model_dump()
+        current_data.update(kwargs)
+
+        try:
+            return self.__class__.model_validate(current_data)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+
+class AggregateRoot(DomainEntity[IdT]):
+    """Base class for Aggregate Roots.
+
+    Includes domain events collection.
+    """
+
+    _events: list[Any] = PrivateAttr(default_factory=list)
+
+    def add_event(self, event: Any) -> None:
+        """Add a domain event."""
+        self._events.append(event)
+
+    def pull_events(self) -> list[Any]:
+        """Retrieve and clear all pending domain events."""
+        events = self._events[:]
+        self._events.clear()
+        return events
+
+    def clear_events(self) -> None:
+        """Clear all pending domain events."""
+        self._events.clear()
+
+    @property
+    def has_pending_events(self) -> bool:
+        """Return True if there are pending domain events."""
+        return len(self._events) > 0
+
+
+__all__ = ["AggregateRoot", "DomainEntity", "utc_now"]

--- a/src/building_blocks/domain/errors.py
+++ b/src/building_blocks/domain/errors.py
@@ -1,0 +1,544 @@
+"""Domain building block errors.
+
+This module combines the base exception classes and domain-specific exceptions
+into a single module for the building_blocks package.
+
+Provides:
+- CoreException: Base for all application exceptions
+- ExceptionDetail / Severity: Supporting types
+- DomainException hierarchy: Domain layer error types
+
+See exception-hierarchy-clean-architecture.md for full documentation.
+"""
+
+import uuid
+from dataclasses import dataclass, replace
+from dataclasses import field as dataclass_field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any
+
+
+class Severity(str, Enum):
+    """Severity levels for observability and alerting.
+
+    Used to determine log level and alert priority.
+    """
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+@dataclass
+class ExceptionDetail:
+    """Structured error detail for composite errors.
+
+    Used for validation errors with multiple fields, where each field
+    can have its own error message.
+
+    Attributes:
+        code: Error code (e.g., "FIELD_INVALID", "REQUIRED_FIELD")
+        message: Human-readable error message (translated)
+        field: Related field name (optional)
+        metadata: Additional context data (optional)
+    """
+
+    code: str
+    message: str
+    field: str | None = None
+    metadata: dict[str, Any] = dataclass_field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary, excluding None values."""
+        result: dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.field is not None:
+            result["field"] = self.field
+        if self.metadata:
+            result["metadata"] = self.metadata
+        return result
+
+
+@dataclass
+class CoreException(Exception):
+    """Base exception for all application exceptions.
+
+    Provides:
+    - Standardized, serializable structure
+    - Traceability via exception_id
+    - Observability support via severity and tags
+    - i18n support via message_code
+
+    Attributes:
+        message: Human-readable error message (can be translated)
+        code: Unique error type code (e.g., "DOMAIN_VALIDATION_ERROR")
+        message_code: i18n message key for translation lookup
+        message_params: Parameters for message interpolation
+        details: List of detailed errors for composite errors
+        exception_id: Unique UUID for tracing
+        timestamp: When the exception was created
+        severity: Severity level for alerting
+        tags: Metadata for observability (not sent to client)
+
+    Example:
+        >>> raise CoreException(
+        ...     message="Something went wrong",
+        ...     code="GENERIC_ERROR",
+        ...     message_code="INTERNAL_ERROR",
+        ...     severity=Severity.HIGH,
+        ...     tags={"user_id": "123"}
+        ... )
+    """
+
+    message: str
+    code: str = "CORE_ERROR"
+    message_code: str | None = None  # i18n key
+    message_params: dict[str, Any] = dataclass_field(default_factory=dict)
+    details: list[ExceptionDetail] = dataclass_field(default_factory=list)
+    exception_id: str = dataclass_field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = dataclass_field(default_factory=lambda: datetime.now(UTC))
+    severity: Severity = Severity.MEDIUM
+    tags: dict[str, Any] = dataclass_field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Initialize the base Exception with the message."""
+        super().__init__(self.message)
+
+        # Default message_code to code if not provided
+        if self.message_code is None:
+            self.message_code = self.code
+
+    @property
+    def http_status(self) -> int:
+        """HTTP status code for this error.
+
+        Override in subclasses to map to appropriate status.
+        Default is 500 (Internal Server Error).
+        """
+        return 500
+
+    def to_dict(self, include_internal: bool = False) -> dict[str, Any]:
+        """Serialize exception to API response format.
+
+        Follows the API Response Standard REST v3.0 error format.
+
+        Args:
+            include_internal: If True, include sensitive data.
+                              Use ONLY for logs, NEVER for HTTP response.
+
+        Returns:
+            Dictionary with standardized error structure.
+
+        Example output:
+            {
+                "type": "validation_error",
+                "message": "Validation failed",
+                "code": "DOMAIN_VALIDATION_ERROR",
+                "details": [{"code": "...", "message": "...", "field": "..."}]
+            }
+        """
+        # Base error structure (v3.0 flat format)
+        result: dict[str, Any] = {
+            "type": self._get_error_type(),
+            "message": self.message,
+            "code": self.code,
+        }
+
+        # Add details if present
+        if self.details:
+            result["details"] = [d.to_dict() for d in self.details]
+
+        # Internal data for logging only
+        if include_internal:
+            result["_internal"] = {
+                "exception_id": self.exception_id,
+                "severity": self.severity.value,
+                "tags": self.tags,
+                "timestamp": self.timestamp.isoformat(),
+                "message_code": self.message_code,
+                "message_params": self.message_params,
+            }
+            if self.__cause__:
+                result["_internal"]["cause"] = str(self.__cause__)
+                result["_internal"]["cause_type"] = type(self.__cause__).__name__
+
+        return result
+
+    def _get_error_type(self) -> str:
+        """Get the error type for API response.
+
+        Maps to standard error types like 'validation_error',
+        'not_found_error', etc.
+        """
+        # Default mapping based on http_status
+        status_to_type = {
+            400: "invalid_request_error",
+            401: "authentication_error",
+            403: "permission_error",
+            404: "not_found_error",
+            409: "conflict_error",
+            422: "validation_error",
+            429: "rate_limit_error",
+            500: "api_error",
+            502: "bad_gateway_error",
+            503: "service_unavailable_error",
+            504: "gateway_timeout_error",
+        }
+        return status_to_type.get(self.http_status, "api_error")
+
+    def with_translation(self, translated_message: str) -> "CoreException":
+        """Create a copy with translated message.
+
+        Used by the i18n middleware/handler to translate messages
+        before sending to the client.
+
+        Args:
+            translated_message: The translated message
+
+        Returns:
+            New exception instance with translated message
+        """
+        # Create a shallow copy with new message
+        return replace(self, message=translated_message)
+
+    def add_detail(
+        self,
+        code: str,
+        message: str,
+        field: str | None = None,
+        **metadata: Any,
+    ) -> "CoreException":
+        """Add a detail to this exception (fluent interface).
+
+        Args:
+            code: Error code
+            message: Error message
+            field: Related field name
+            **metadata: Additional context
+
+        Returns:
+            Self for chaining
+        """
+        self.details.append(
+            ExceptionDetail(
+                code=code,
+                message=message,
+                field=field,
+                metadata=metadata or {},
+            )
+        )
+        return self
+
+
+# =============================================================================
+# Domain Exceptions
+# =============================================================================
+
+
+@dataclass
+class DomainException(CoreException):
+    """Base exception for all domain layer errors.
+
+    Use for errors that represent violations of domain rules,
+    regardless of how the application was invoked (API, CLI, event).
+
+    Default HTTP status: 422 (Unprocessable Entity)
+    """
+
+    code: str = "DOMAIN_ERROR"
+    severity: Severity = Severity.MEDIUM
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 422 (Unprocessable Entity)."""
+        return 422
+
+
+@dataclass
+class DomainValidationException(DomainException):
+    """Invalid state for a domain object (Entity, Value Object, Aggregate).
+
+    Different from UseCaseValidationException:
+    - DomainValidation: domain object cannot exist in this state
+    - UseCaseValidation: request input is malformed
+
+    Attributes:
+        object_type: Type of object being validated (e.g., "CPF", "Movie", "Duration")
+
+    Example:
+        >>> raise DomainValidationException(
+        ...     message="Invalid CPF",
+        ...     message_code="INVALID_CPF",
+        ...     object_type="CPF"
+        ... )
+
+        >>> # Or with multiple violations:
+        >>> raise DomainValidationException.from_violations(
+        ...     object_type="Movie",
+        ...     violations={
+        ...         "title": ("REQUIRED_FIELD", "Title is required"),
+        ...         "year": ("INVALID_YEAR", "Year must be between 1888 and 2030")
+        ...     }
+        ... )
+    """
+
+    code: str = "DOMAIN_VALIDATION_ERROR"
+    message_code: str = "VALIDATION_FAILED"
+    object_type: str = ""
+
+    def __post_init__(self) -> None:
+        """Initialize and add object_type to tags if set."""
+        super().__post_init__()
+        if self.object_type:
+            self.tags["object_type"] = self.object_type
+
+    @classmethod
+    def from_violations(
+        cls,
+        object_type: str,
+        violations: dict[str, tuple[str, str]],
+        **kwargs: Any,
+    ) -> "DomainValidationException":
+        """Factory to create exception from multiple violations.
+
+        Args:
+            object_type: Name of the type being validated
+            violations: Dict of field -> (code, message) tuples
+            **kwargs: Additional arguments for the exception
+
+        Returns:
+            DomainValidationException with details populated
+
+        Example:
+            >>> exc = DomainValidationException.from_violations(
+            ...     object_type="Movie",
+            ...     violations={
+            ...         "year": ("INVALID_YEAR", "Year out of range"),
+            ...         "duration": ("NEGATIVE_DURATION", "Duration must be positive"),
+            ...     }
+            ... )
+        """
+        details = [
+            ExceptionDetail(
+                code=code,
+                message=msg,
+                field=field_name,
+            )
+            for field_name, (code, msg) in violations.items()
+        ]
+        return cls(
+            message=f"Validation failed for {object_type}",
+            message_code="VALIDATION_FAILED_FOR_TYPE",
+            message_params={"type": object_type},
+            object_type=object_type,
+            details=details,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_pydantic_errors(
+        cls,
+        object_type: str,
+        pydantic_errors: list[Any],
+        **kwargs: Any,
+    ) -> "DomainValidationException":
+        """Factory to create exception from Pydantic validation errors.
+
+        Args:
+            object_type: Name of the type being validated
+            pydantic_errors: List of Pydantic error dicts
+            **kwargs: Additional arguments for the exception
+
+        Returns:
+            DomainValidationException with details populated
+        """
+        details = [
+            ExceptionDetail(
+                code=err.get("type", "VALIDATION_ERROR"),
+                message=err.get("msg", "Validation error"),
+                field=".".join(str(loc) for loc in err.get("loc", [])),
+                metadata={"input": err.get("input")} if "input" in err else {},
+            )
+            for err in pydantic_errors
+        ]
+
+        # Build message including Pydantic error messages for better debugging
+        error_messages = [err.get("msg", "Validation error") for err in pydantic_errors]
+        combined_message = "; ".join(error_messages) if error_messages else "Validation failed"
+
+        return cls(
+            message=combined_message,
+            message_code="VALIDATION_FAILED_FOR_TYPE",
+            message_params={"type": object_type},
+            object_type=object_type,
+            details=details,
+            **kwargs,
+        )
+
+    @classmethod
+    def single_field(
+        cls,
+        object_type: str,
+        field: str,
+        code: str,
+        message: str,
+    ) -> "DomainValidationException":
+        """Factory for single-field validation error.
+
+        Args:
+            object_type: Name of the type being validated
+            field: Field name that failed validation
+            code: Error code
+            message: Error message
+
+        Returns:
+            DomainValidationException with single detail
+        """
+        return cls(
+            message=message,
+            message_code=code,
+            object_type=object_type,
+            details=[ExceptionDetail(code=code, message=message, field=field)],
+        )
+
+
+@dataclass
+class BusinessRuleViolationException(DomainException):
+    """Violation of a business rule.
+
+    Use when an operation violates a domain rule that isn't simply
+    data validation.
+
+    Attributes:
+        rule_code: Identifier for the violated rule
+
+    Common rule_codes:
+    - MEDIA_ALREADY_EXISTS: Media file already in library
+    - PROGRESS_EXCEEDS_DURATION: Progress cannot exceed media duration
+    - LIST_LIMIT_EXCEEDED: Maximum lists/items reached
+    - INVALID_EPISODE_ORDER: Episode number conflict
+
+    Example:
+        >>> raise BusinessRuleViolationException(
+        ...     message="Media file already exists in library",
+        ...     message_code="MEDIA_ALREADY_EXISTS",
+        ...     rule_code="MEDIA_ALREADY_EXISTS",
+        ...     tags={"file_path": "/movies/inception.mkv"}
+        ... )
+    """
+
+    code: str = "BUSINESS_RULE_VIOLATION"
+    rule_code: str = ""
+
+    def __post_init__(self) -> None:
+        """Initialize and add rule_code to tags, using it as message_code if not set."""
+        super().__post_init__()
+        if self.rule_code:
+            self.tags["rule_code"] = self.rule_code
+            # Use rule_code as message_code if not set
+            if self.message_code == self.code:
+                self.message_code = self.rule_code
+
+
+@dataclass
+class DomainNotFoundException(DomainException):
+    """Aggregate or Entity not found in the domain.
+
+    Typically raised by repositories or domain services when
+    an expected aggregate doesn't exist.
+
+    Attributes:
+        resource_type: Type of resource (e.g., "Movie", "Series", "Episode")
+        resource_id: Identifier of the resource not found
+
+    Example:
+        >>> raise DomainNotFoundException(
+        ...     message="Movie not found",
+        ...     message_code="MOVIE_NOT_FOUND",
+        ...     resource_type="Movie",
+        ...     resource_id="mov_2xK9mPqR7nL4"
+        ... )
+    """
+
+    code: str = "DOMAIN_NOT_FOUND"
+    message_code: str = "RESOURCE_NOT_FOUND"
+    resource_type: str = ""
+    resource_id: str = ""
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 404 (Not Found)."""
+        return 404
+
+    def __post_init__(self) -> None:
+        """Initialize and add resource metadata to tags and message_params."""
+        super().__post_init__()
+        self.tags["resource_type"] = self.resource_type
+        self.tags["resource_id"] = self.resource_id
+
+        # Set message_params for i18n interpolation
+        self.message_params = {
+            "resource": self.resource_type,
+            "id": self.resource_id,
+        }
+
+    @classmethod
+    def for_entity(
+        cls,
+        entity_type: str,
+        entity_id: str,
+    ) -> "DomainNotFoundException":
+        """Factory for entity not found.
+
+        Args:
+            entity_type: Type of entity (e.g., "Movie", "Episode")
+            entity_id: External ID of the entity
+
+        Returns:
+            DomainNotFoundException configured for the entity
+        """
+        return cls(
+            message=f"{entity_type} with id '{entity_id}' not found",
+            message_code=f"{entity_type.upper()}_NOT_FOUND",
+            resource_type=entity_type,
+            resource_id=entity_id,
+        )
+
+
+@dataclass
+class DomainConflictException(DomainException):
+    """Conflict in domain state.
+
+    Use for situations like:
+    - Concurrent operations on the same aggregate
+    - Attempt to create a resource that already exists
+    - Version conflict (optimistic locking)
+
+    Example:
+        >>> raise DomainConflictException(
+        ...     message="Movie with this file path already exists",
+        ...     message_code="DUPLICATE_MEDIA_FILE",
+        ...     tags={"file_path": "/movies/inception.mkv"}
+        ... )
+    """
+
+    code: str = "DOMAIN_CONFLICT"
+    message_code: str = "CONFLICT"
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 409 (Conflict)."""
+        return 409
+
+
+__all__ = [
+    "BusinessRuleViolationException",
+    "CoreException",
+    "DomainConflictException",
+    "DomainException",
+    "DomainNotFoundException",
+    "DomainValidationException",
+    "ExceptionDetail",
+    "Severity",
+]

--- a/src/building_blocks/domain/external_id.py
+++ b/src/building_blocks/domain/external_id.py
@@ -1,0 +1,160 @@
+"""External ID base class for API exposure.
+
+Format: {prefix}_{base62_random_12chars}
+Example: mov_2xK9mPqR7nL4
+
+See ADR-002 for context and decision details.
+
+Specific ID types (MovieId, SeriesId, etc.) are defined in their
+respective bounded contexts under value_objects/ids.py.
+"""
+
+import secrets
+import string
+from typing import Any, ClassVar, Self
+
+from pydantic import ConfigDict, model_validator
+
+from src.building_blocks.domain.value_objects import StringValueObject
+
+BASE62_ALPHABET = string.ascii_letters + string.digits
+RANDOM_PART_LENGTH = 12
+
+
+class ExternalId(StringValueObject):
+    """Base class for prefixed external IDs.
+
+    Format: {prefix}_{base62_random_12chars}
+
+    Subclasses must define EXPECTED_PREFIX.
+    The generate() method and prefix validation are inherited from this base class.
+
+    Example:
+        >>> class MovieId(ExternalId):
+        ...     EXPECTED_PREFIX: ClassVar[str] = "mov"
+        ...
+        >>> movie_id = MovieId.generate()
+        >>> movie_id.prefix
+        'mov'
+    """
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+    )
+
+    # Subclasses must override this
+    EXPECTED_PREFIX: ClassVar[str] = ""
+
+    root: str
+
+    @classmethod
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Ensure subclasses define EXPECTED_PREFIX."""
+        super().__init_subclass__(**kwargs)  # type: ignore[no-untyped-call]
+        if cls is not ExternalId and not cls.EXPECTED_PREFIX:
+            raise TypeError(f"{cls.__name__} must define a non-empty EXPECTED_PREFIX")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_format(cls, value: Any) -> str:
+        """Validate the external ID format."""
+        if not isinstance(value, str):
+            raise ValueError("External ID must be a string")
+
+        value = value.strip()
+
+        if "_" not in value:
+            raise ValueError(f"External ID must contain underscore separator: {value}")
+
+        parts = value.split("_", 1)
+        if len(parts) != 2:
+            raise ValueError(f"Invalid external ID format: {value}")
+
+        _prefix, random_part = parts
+
+        if len(random_part) != RANDOM_PART_LENGTH:
+            raise ValueError(f"Random part must be {RANDOM_PART_LENGTH} characters")
+
+        if any(c not in BASE62_ALPHABET for c in random_part):
+            raise ValueError("Random part must only contain Base62 characters")
+
+        return str(value)
+
+    @model_validator(mode="after")
+    def validate_prefix(self) -> Self:
+        """Validate that the ID has the expected prefix for this type."""
+        if self.prefix != self.EXPECTED_PREFIX:
+            raise ValueError(f"{self.__class__.__name__} must have '{self.EXPECTED_PREFIX}' prefix")
+        return self
+
+    @classmethod
+    def generate(cls) -> Self:
+        """Generate a new external ID with the class prefix.
+
+        Returns:
+            A new instance with a unique base62 random part.
+
+        Raises:
+            TypeError: If called directly on ExternalId base class.
+        """
+        if cls is ExternalId:
+            raise TypeError("generate() must be called on a subclass with EXPECTED_PREFIX defined")
+        random_part = "".join(secrets.choice(BASE62_ALPHABET) for _ in range(RANDOM_PART_LENGTH))
+        return cls(root=f"{cls.EXPECTED_PREFIX}_{random_part}")
+
+    @classmethod
+    def generate_if_absent(cls, existing: Self | None) -> Self:
+        """Return the existing ID if present, or generate a new one.
+
+        Standardizes the pattern of assigning IDs in repositories:
+        instead of ``id if id is not None else IdType.generate()``,
+        use ``IdType.generate_if_absent(id)``.
+
+        Args:
+            existing: An existing ID instance, or None.
+
+        Returns:
+            The existing ID unchanged, or a newly generated one.
+        """
+        return existing if existing is not None else cls.generate()
+
+    @property
+    def value(self) -> str:
+        """Get the full ID string."""
+        return self.root
+
+    @property
+    def prefix(self) -> str:
+        """Get the prefix part of the ID."""
+        return self.root.split("_")[0]
+
+    @property
+    def random_part(self) -> str:
+        """Get the random part of the ID."""
+        return self.root.split("_")[1]
+
+    def __str__(self) -> str:
+        """Return the ID as a string."""
+        return self.value
+
+    def __repr__(self) -> str:
+        """Return a detailed string representation."""
+        return f"{self.__class__.__name__}({self.value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality with another ExternalId."""
+        if not isinstance(other, ExternalId):
+            return NotImplemented
+        return self.value == other.value
+
+    def __hash__(self) -> int:
+        """Return hash for use in sets and dicts."""
+        return hash((self.__class__.__name__, self.value))
+
+
+__all__ = [
+    "BASE62_ALPHABET",
+    "RANDOM_PART_LENGTH",
+    "ExternalId",
+]

--- a/src/building_blocks/domain/models.py
+++ b/src/building_blocks/domain/models.py
@@ -1,0 +1,153 @@
+"""Base model for all domain objects using Pydantic.
+
+See ADR-001 for context and decision details.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, NoReturn, Protocol, Self, Unpack, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, RootModel, ValidationError
+
+from src.building_blocks.domain.errors import DomainValidationException
+
+
+@runtime_checkable
+class SupportsUpdates(Protocol):
+    """Protocol for domain objects that support atomic updates.
+
+    Classes implementing this protocol provide a with_updates() method
+    that creates a new instance with modified field values.
+
+    Example:
+        >>> def apply_discount(obj: SupportsUpdates) -> SupportsUpdates:
+        ...     return obj.with_updates(price=obj.price * 0.9)
+    """
+
+    def with_updates(self, **kwargs: Any) -> Self:
+        """Create a new instance with the specified updates applied."""
+        ...
+
+
+def _raise_domain_validation(exc: ValidationError, object_type: str) -> NoReturn:
+    """Convert Pydantic ValidationError to DomainValidationException.
+
+    Args:
+        exc: The Pydantic validation error.
+        object_type: Name of the type being validated.
+
+    Raises:
+        DomainValidationException: Always raised with converted error details.
+    """
+    raise DomainValidationException.from_pydantic_errors(
+        object_type=object_type,
+        pydantic_errors=list(exc.errors()),
+    ) from exc
+
+
+class DomainModel(BaseModel):
+    """Base model for domain objects (Value Objects, Entities) using Pydantic.
+
+    Features:
+    - Wraps Pydantic ValidationError in DomainValidationException
+    - Enforces strict configuration (extra='forbid', validate_assignment=True)
+
+    See ADR-001 for context and decision details.
+    """
+
+    model_config = ConfigDict(
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+    def __init_subclass__(cls, **kwargs: Unpack[ConfigDict]) -> None:
+        """Validate model_config at class definition time.
+
+        Ensures all DomainModel subclasses use:
+        - extra='forbid' to prevent unknown attributes
+        - validate_assignment=True to validate on attribute changes
+        """
+        super().__init_subclass__(**kwargs)
+
+        config = cls.model_config
+        extra = config.get("extra")
+        validate_assignment = config.get("validate_assignment")
+        if not (extra == "forbid" or (extra is None and issubclass(cls, RootModel))):
+            raise TypeError(
+                f"Domain model {cls.__name__} must use extra='forbid', got extra={extra!r}"
+            )
+
+        if validate_assignment is not True:
+            raise TypeError(f"Domain model {cls.__name__} must use validate_assignment=True")
+
+    def __init__(self, **data: Any) -> None:
+        try:
+            super().__init__(**data)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    @classmethod
+    def model_validate(
+        cls,
+        obj: Any,
+        *,
+        strict: bool | None = None,
+        from_attributes: bool | None = None,
+        context: Any | None = None,
+        extra: Literal["allow", "ignore", "forbid"] | None = None,
+        by_alias: bool | None = None,
+        by_name: bool | None = None,
+    ) -> Self:
+        """Validate input data and create a new model instance.
+
+        Wraps Pydantic ValidationError in DomainValidationException.
+        """
+        try:
+            return super().model_validate(
+                obj,
+                strict=strict,
+                from_attributes=from_attributes,
+                context=context,
+                extra=extra,
+                by_alias=by_alias,
+                by_name=by_name,
+            )
+        except ValidationError as e:
+            _raise_domain_validation(e, cls.__name__)
+
+    @classmethod
+    def model_validate_json(
+        cls,
+        json_data: str | bytes | bytearray,
+        *,
+        strict: bool | None = None,
+        context: Any | None = None,
+        extra: Literal["allow", "ignore", "forbid"] | None = None,
+        by_alias: bool | None = None,
+        by_name: bool | None = None,
+    ) -> Self:
+        """Validate JSON data and create a new model instance.
+
+        Wraps Pydantic ValidationError in DomainValidationException.
+        """
+        try:
+            return super().model_validate_json(
+                json_data,
+                strict=strict,
+                context=context,
+                extra=extra,
+                by_alias=by_alias,
+                by_name=by_name,
+            )
+        except ValidationError as e:
+            _raise_domain_validation(e, cls.__name__)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Wraps attribute setting to convert ValidationError to DomainValidationException."""
+        try:
+            super().__setattr__(name, value)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+
+__all__ = ["DomainModel", "SupportsUpdates", "_raise_domain_validation"]

--- a/src/building_blocks/domain/value_objects.py
+++ b/src/building_blocks/domain/value_objects.py
@@ -1,0 +1,287 @@
+"""Base classes for Value Objects.
+
+Value Objects are immutable objects identified by their value, not identity.
+"""
+
+from datetime import date
+from typing import Any, ClassVar, Self
+
+from pydantic import ConfigDict, RootModel, ValidationError
+
+from src.building_blocks.domain.models import DomainModel, _raise_domain_validation
+
+
+class ValueObject(DomainModel):
+    """Abstract base class for all Value Objects.
+
+    Do not instantiate directly.
+
+    Value Objects are immutable objects identified by their value, not identity.
+    All subclasses MUST be immutable (frozen=True).
+
+    This class can be used for type checking: isinstance(obj, ValueObject)
+    """
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        frozen=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+
+class CompoundValueObject(ValueObject):
+    """Base class for Value Objects with multiple fields.
+
+    Use this class when your Value Object has multiple attributes that
+    together represent a single concept (e.g., Address, DateRange, Money).
+
+    Provides with_updates() for creating modified copies.
+
+    Example:
+        >>> class Address(CompoundValueObject):
+        ...     street: str
+        ...     city: str
+        ...     zip_code: str
+        ...
+        >>> addr = Address(street="123 Main", city="NYC", zip_code="10001")
+        >>> new_addr = addr.with_updates(city="LA", zip_code="90001")
+    """
+
+    def with_updates(self, **kwargs: Any) -> Self:
+        """Create a new, fully validated instance by applying updates atomically.
+
+        Args:
+            **kwargs: Fields to update with their new values.
+
+        Returns:
+            A new instance with the updates applied.
+
+        Raises:
+            DomainValidationException: If the resulting state is invalid.
+        """
+        current_data = self.model_dump()
+        current_data.update(kwargs)
+
+        try:
+            return self.__class__.model_validate(current_data)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+
+class StringValueObject(RootModel[str], ValueObject):
+    """Base class for Value Objects wrapping a single string value."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        frozen=True, str_strip_whitespace=True, extra=None
+    )
+
+    root: str
+
+    def __init__(self, root: Any = None, /, **data: Any) -> None:
+        try:
+            if root is not None:
+                super().__init__(root)
+            else:
+                super().__init__(**data)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        try:
+            super().__setattr__(name, value)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    @property
+    def value(self) -> str:
+        """Return the wrapped string value."""
+        return self.root
+
+    def __str__(self) -> str:
+        """Return the string value."""
+        return self.value
+
+    def __repr__(self) -> str:
+        """Return a detailed string representation."""
+        return f"{self.__class__.__name__}({self.value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality with another StringValueObject of the same type."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.value == other.value
+
+    def __hash__(self) -> int:
+        """Return hash for use in sets and dicts."""
+        return hash((self.__class__, self.value))
+
+
+class IntValueObject(RootModel[int], ValueObject):
+    """Base class for Value Objects wrapping a single integer value."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True, extra=None)
+
+    root: int
+
+    def __init__(self, root: Any = None, /, **data: Any) -> None:
+        try:
+            if root is not None:
+                super().__init__(root)
+            else:
+                super().__init__(**data)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        try:
+            super().__setattr__(name, value)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    @property
+    def value(self) -> int:
+        """Return the wrapped integer value."""
+        return self.root
+
+    def __str__(self) -> str:
+        """Return the string representation of the integer value."""
+        return str(self.value)
+
+    def __repr__(self) -> str:
+        """Return a detailed string representation."""
+        return f"{self.__class__.__name__}({self.value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality with another IntValueObject of the same type."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.value == other.value
+
+    def __hash__(self) -> int:
+        """Return hash for use in sets and dicts."""
+        return hash((self.__class__, self.value))
+
+    def __lt__(self, other: object) -> bool:
+        """Check if this value is less than another."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.value < other.value
+
+    def __le__(self, other: object) -> bool:
+        """Check if this value is less than or equal to another."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.value <= other.value
+
+    def __gt__(self, other: object) -> bool:
+        """Check if this value is greater than another."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.value > other.value
+
+    def __ge__(self, other: object) -> bool:
+        """Check if this value is greater than or equal to another."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.value >= other.value
+
+
+class FloatValueObject(RootModel[float], ValueObject):
+    """Base class for Value Objects wrapping a single float value."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True, extra=None)
+
+    root: float
+
+    def __init__(self, root: Any = None, /, **data: Any) -> None:
+        try:
+            if root is not None:
+                super().__init__(root)
+            else:
+                super().__init__(**data)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        try:
+            super().__setattr__(name, value)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    @property
+    def value(self) -> float:
+        """Return the wrapped float value."""
+        return self.root
+
+    def __str__(self) -> str:
+        """Return the string representation of the float value."""
+        return str(self.value)
+
+    def __repr__(self) -> str:
+        """Return a detailed string representation."""
+        return f"{self.__class__.__name__}({self.value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality with another FloatValueObject of the same type."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.value == other.value
+
+    def __hash__(self) -> int:
+        """Return hash for use in sets and dicts."""
+        return hash((self.__class__, self.value))
+
+
+class DateValueObject(RootModel[date], ValueObject):
+    """Base class for Value Objects wrapping a date value."""
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True, extra=None)
+
+    root: date
+
+    def __init__(self, root: Any = None, /, **data: Any) -> None:
+        try:
+            if root is not None:
+                super().__init__(root)
+            else:
+                super().__init__(**data)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        try:
+            super().__setattr__(name, value)
+        except ValidationError as e:
+            _raise_domain_validation(e, self.__class__.__name__)
+
+    @property
+    def value(self) -> date:
+        """Return the wrapped date value."""
+        return self.root
+
+    def __str__(self) -> str:
+        """Return the ISO format string representation of the date."""
+        return self.value.isoformat()
+
+    def __repr__(self) -> str:
+        """Return a detailed string representation."""
+        return f"{self.__class__.__name__}({self.value!r})"
+
+    def __eq__(self, other: object) -> bool:
+        """Check equality with another DateValueObject of the same type."""
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.value == other.value
+
+    def __hash__(self) -> int:
+        """Return hash for use in sets and dicts."""
+        return hash((self.__class__, self.value))
+
+
+__all__ = [
+    "CompoundValueObject",
+    "DateValueObject",
+    "FloatValueObject",
+    "IntValueObject",
+    "StringValueObject",
+]

--- a/src/building_blocks/infrastructure/__init__.py
+++ b/src/building_blocks/infrastructure/__init__.py
@@ -1,0 +1,9 @@
+"""Infrastructure building blocks: base exceptions for infrastructure."""
+
+from src.building_blocks.infrastructure.errors import (
+    InfrastructureException,
+)
+
+__all__ = [
+    "InfrastructureException",
+]

--- a/src/building_blocks/infrastructure/errors.py
+++ b/src/building_blocks/infrastructure/errors.py
@@ -1,0 +1,343 @@
+"""Infrastructure layer exceptions.
+
+These exceptions represent errors in communication with external
+services, databases, and other infrastructure components.
+
+See exception-hierarchy-clean-architecture.md for full documentation.
+"""
+
+from dataclasses import dataclass
+
+from src.building_blocks.domain.errors import (
+    CoreException,
+    Severity,
+)
+
+
+@dataclass
+class InfrastructureException(CoreException):
+    """Base exception for all infrastructure layer errors.
+
+    IMPORTANT: These exceptions should NEVER expose internal
+    details to the client. Use `internal_message` for logging.
+
+    Attributes:
+        internal_message: Technical details for logs only
+
+    Default HTTP status: 500 (Internal Server Error)
+    """
+
+    code: str = "INFRASTRUCTURE_ERROR"
+    internal_message: str = ""  # For logs only, never exposed
+    severity: Severity = Severity.HIGH
+
+    def __post_init__(self) -> None:
+        """Initialize and add internal_message to tags if set."""
+        super().__post_init__()
+        if self.internal_message:
+            self.tags["internal_message"] = self.internal_message
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 500 (Internal Server Error)."""
+        return 500
+
+
+# =============================================================================
+# Gateway Exceptions (External Services)
+# =============================================================================
+
+
+@dataclass
+class GatewayException(InfrastructureException):
+    """Base for external service (gateway) errors.
+
+    Attributes:
+        gateway_name: Name of the external service (e.g., "TMDB", "OMDb")
+    """
+
+    code: str = "GATEWAY_ERROR"
+    gateway_name: str = ""
+
+    def __post_init__(self) -> None:
+        """Initialize and add gateway_name to tags if set."""
+        super().__post_init__()
+        if self.gateway_name:
+            self.tags["gateway_name"] = self.gateway_name
+
+
+@dataclass
+class GatewayTimeoutException(GatewayException):
+    """Timeout communicating with external service.
+
+    Example:
+        >>> raise GatewayTimeoutException(
+        ...     message="External service timed out",
+        ...     message_code="SERVICE_TIMEOUT",
+        ...     gateway_name="TMDB",
+        ...     internal_message="Timeout after 30s connecting to api.themoviedb.org"
+        ... )
+    """
+
+    code: str = "GATEWAY_TIMEOUT"
+    message_code: str = "SERVICE_TIMEOUT"
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 504 (Gateway Timeout)."""
+        return 504
+
+
+@dataclass
+class GatewayUnavailableException(GatewayException):
+    """External service is unavailable.
+
+    Example:
+        >>> raise GatewayUnavailableException(
+        ...     message="External service unavailable",
+        ...     message_code="SERVICE_UNAVAILABLE",
+        ...     gateway_name="TMDB",
+        ...     internal_message="HTTP 503 from api.themoviedb.org"
+        ... )
+    """
+
+    code: str = "GATEWAY_UNAVAILABLE"
+    message_code: str = "SERVICE_UNAVAILABLE"
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 503 (Service Unavailable)."""
+        return 503
+
+
+@dataclass
+class GatewayRateLimitException(GatewayException):
+    """Rate limited by external service.
+
+    Attributes:
+        retry_after_seconds: Suggested retry delay
+
+    Example:
+        >>> raise GatewayRateLimitException(
+        ...     message="Rate limit exceeded",
+        ...     message_code="RATE_LIMIT_EXCEEDED",
+        ...     gateway_name="TMDB",
+        ...     retry_after_seconds=60
+        ... )
+    """
+
+    code: str = "GATEWAY_RATE_LIMIT"
+    message_code: str = "RATE_LIMIT_EXCEEDED"
+    retry_after_seconds: int = 60
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 429 (Too Many Requests)."""
+        return 429
+
+    def __post_init__(self) -> None:
+        """Initialize and add retry_after_seconds to tags and message_params."""
+        super().__post_init__()
+        self.tags["retry_after_seconds"] = self.retry_after_seconds
+        self.message_params = {"seconds": self.retry_after_seconds}
+
+
+@dataclass
+class GatewayBadResponseException(GatewayException):
+    """Invalid response from external service.
+
+    Example:
+        >>> raise GatewayBadResponseException(
+        ...     message="Invalid response from external service",
+        ...     message_code="INVALID_GATEWAY_RESPONSE",
+        ...     gateway_name="TMDB",
+        ...     internal_message="Expected JSON, got HTML: <!DOCTYPE..."
+        ... )
+    """
+
+    code: str = "GATEWAY_BAD_RESPONSE"
+    message_code: str = "INVALID_GATEWAY_RESPONSE"
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 502 (Bad Gateway)."""
+        return 502
+
+
+@dataclass
+class CircuitOpenException(GatewayException):
+    """Circuit breaker is open, requests are being blocked.
+
+    This exception is raised when the circuit breaker has detected
+    too many failures and is preventing further requests to protect
+    the system from cascading failures.
+
+    Attributes:
+        circuit_timeout: Seconds until circuit will attempt to close
+
+    Example:
+        >>> raise CircuitOpenException(
+        ...     message="Service temporarily unavailable",
+        ...     message_code="SERVICE_CIRCUIT_OPEN",
+        ...     gateway_name="TMDB",
+        ...     circuit_timeout=30
+        ... )
+    """
+
+    code: str = "CIRCUIT_OPEN"
+    message_code: str = "SERVICE_CIRCUIT_OPEN"
+    circuit_timeout: int = 30
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 503 (Service Unavailable)."""
+        return 503
+
+    def __post_init__(self) -> None:
+        """Initialize and add circuit_timeout to tags."""
+        super().__post_init__()
+        self.tags["circuit_timeout"] = self.circuit_timeout
+
+
+# =============================================================================
+# Repository Exceptions (Database)
+# =============================================================================
+
+
+@dataclass
+class RepositoryException(InfrastructureException):
+    """Base for database/repository errors."""
+
+    code: str = "REPOSITORY_ERROR"
+
+
+@dataclass
+class DatabaseConnectionException(RepositoryException):
+    """Failed to connect to database.
+
+    Example:
+        >>> raise DatabaseConnectionException(
+        ...     message="Database connection failed",
+        ...     message_code="DATABASE_UNAVAILABLE",
+        ...     internal_message="Connection refused: localhost:5432"
+        ... )
+    """
+
+    code: str = "DATABASE_CONNECTION_ERROR"
+    message_code: str = "DATABASE_UNAVAILABLE"
+    severity: Severity = Severity.CRITICAL
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 503 (Service Unavailable)."""
+        return 503
+
+
+@dataclass
+class DataIntegrityException(RepositoryException):
+    """Database constraint violation.
+
+    Attributes:
+        constraint_name: Name of the violated constraint (if available)
+
+    Example:
+        >>> raise DataIntegrityException(
+        ...     message="Data integrity violation",
+        ...     message_code="DATA_CONFLICT",
+        ...     constraint_name="uq_movies_external_id",
+        ...     internal_message="UNIQUE violation on movies.external_id"
+        ... )
+    """
+
+    code: str = "DATA_INTEGRITY_ERROR"
+    message_code: str = "DATA_CONFLICT"
+    constraint_name: str = ""
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 409 (Conflict)."""
+        return 409
+
+    def __post_init__(self) -> None:
+        """Initialize and add constraint_name to tags if set."""
+        super().__post_init__()
+        if self.constraint_name:
+            self.tags["constraint_name"] = self.constraint_name
+
+
+# =============================================================================
+# Filesystem Exceptions
+# =============================================================================
+
+
+@dataclass
+class FilesystemException(InfrastructureException):
+    """Base for filesystem errors.
+
+    Attributes:
+        path: Path that caused the error
+    """
+
+    code: str = "FILESYSTEM_ERROR"
+    path: str = ""
+
+    def __post_init__(self) -> None:
+        """Initialize and add path to tags if set."""
+        super().__post_init__()
+        if self.path:
+            self.tags["path"] = self.path
+
+
+@dataclass
+class FileNotFoundException(FilesystemException):
+    """File not found on filesystem.
+
+    Example:
+        >>> raise FileNotFoundException(
+        ...     message="Media file not found",
+        ...     message_code="FILE_NOT_FOUND",
+        ...     path="/movies/inception.mkv"
+        ... )
+    """
+
+    code: str = "FILE_NOT_FOUND"
+    message_code: str = "FILE_NOT_FOUND"
+
+    @property
+    def http_status(self) -> int:
+        """Return HTTP status code 404 (Not Found)."""
+        return 404
+
+
+@dataclass
+class FileAccessException(FilesystemException):
+    """Cannot access file (permission denied, etc.).
+
+    Example:
+        >>> raise FileAccessException(
+        ...     message="Cannot access media file",
+        ...     message_code="FILE_ACCESS_DENIED",
+        ...     path="/movies/inception.mkv",
+        ...     internal_message="Permission denied: read access"
+        ... )
+    """
+
+    code: str = "FILE_ACCESS_ERROR"
+    message_code: str = "FILE_ACCESS_DENIED"
+
+
+__all__ = [
+    "CircuitOpenException",
+    "DataIntegrityException",
+    "DatabaseConnectionException",
+    "FileAccessException",
+    "FileNotFoundException",
+    "FilesystemException",
+    "GatewayBadResponseException",
+    "GatewayException",
+    "GatewayRateLimitException",
+    "GatewayTimeoutException",
+    "GatewayUnavailableException",
+    "InfrastructureException",
+    "RepositoryException",
+]


### PR DESCRIPTION
## Summary
- Extract framework-agnostic base classes into `src/building_blocks/` package
- Includes `DomainModel`, `DomainEntity`, `AggregateRoot`, `ValueObject` hierarchy, `ExternalId`, and error classes
- Provides reusable foundation for Screaming Architecture migration (new modules will import from building_blocks instead of domain.shared)

## Test plan
- [ ] Verify all pre-commit hooks pass (ruff, mypy, formatting)
- [ ] Confirm no existing tests break (building_blocks is additive, no imports changed yet)
- [ ] Review that building_blocks mirrors domain.shared models/errors faithfully

## Summary by Sourcery

Introduce a framework-agnostic building_blocks package containing shared domain, application, and infrastructure primitives for future architectural migration.

New Features:
- Add CoreException-based error hierarchies for domain, application, and infrastructure layers with HTTP/status, severity, and structured details.
- Introduce domain modeling primitives including DomainModel, ValueObject variants, DomainEntity, AggregateRoot, and base ExternalId type for prefixed identifiers.

Enhancements:
- Expose curated public APIs via building_blocks package and subpackage __init__ modules to serve as the new import surface for shared building blocks.