### PR TITLE
refactor(arch): add shared_kernel package

### DIFF
--- a/src/shared_kernel/__init__.py
+++ b/src/shared_kernel/__init__.py
@@ -1,0 +1,1 @@
+"""Shared kernel: cross-module business value objects."""

--- a/src/shared_kernel/integration_events/__init__.py
+++ b/src/shared_kernel/integration_events/__init__.py
@@ -1,0 +1,1 @@
+"""Integration events for inter-module communication."""

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -1,0 +1,12 @@
+"""Shared value objects used across multiple modules."""
+
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+__all__ = [
+    "AudioTrack",
+    "FilePath",
+    "LanguageCode",
+    "SubtitleTrack",
+]

--- a/src/shared_kernel/value_objects/file_path.py
+++ b/src/shared_kernel/value_objects/file_path.py
@@ -1,0 +1,107 @@
+"""FilePath value object for filesystem paths."""
+
+import re
+from pathlib import PurePath, PurePosixPath, PureWindowsPath
+
+from pydantic import model_validator
+
+from src.building_blocks.domain.value_objects import StringValueObject
+
+# Pattern to detect Windows-style paths (e.g., C:\, D:\)
+_WINDOWS_PATH_PATTERN = re.compile(r"^[a-zA-Z]:[\\/]")
+
+
+class FilePath(StringValueObject):
+    """Absolute file path for media content.
+
+    Validates that the path is:
+    - Absolute (starts with / on Unix or drive letter on Windows)
+    - Does not contain directory traversal (..)
+    - Non-empty
+
+    Example:
+        >>> path = FilePath("/movies/inception.mkv")
+        >>> path.filename
+        'inception.mkv'
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_file_path(cls, value: str) -> str:
+        """Validate and normalize the file path.
+
+        Args:
+            value: The raw file path string.
+
+        Returns:
+            The validated and normalized file path.
+
+        Raises:
+            ValueError: If path is invalid, relative, or contains traversal.
+        """
+        if not isinstance(value, str):
+            raise ValueError("FilePath must be a string")
+
+        value = value.strip()
+
+        if not value:
+            raise ValueError("FilePath cannot be empty")
+
+        # Check for directory traversal BEFORE normalization
+        if ".." in value:
+            raise ValueError("FilePath cannot contain directory traversal (..)")
+
+        # Check for absolute path - use appropriate path class
+        # PurePath on Linux doesn't recognize Windows paths as absolute
+        if _WINDOWS_PATH_PATTERN.match(value):
+            path: PurePath = PureWindowsPath(value)
+        else:
+            path = PurePosixPath(value)
+
+        if not path.is_absolute():
+            raise ValueError("FilePath must be an absolute path")
+
+        # Normalize the path (resolve redundant separators)
+        normalized = str(path)
+
+        # Check again for traversal after normalization
+        if ".." in normalized:
+            raise ValueError("FilePath cannot contain directory traversal (..)")
+
+        return normalized
+
+    def _get_path(self) -> PurePath:
+        """Get the appropriate PurePath instance for this path."""
+        if _WINDOWS_PATH_PATTERN.match(self.value):
+            return PureWindowsPath(self.value)
+        return PurePosixPath(self.value)
+
+    @property
+    def filename(self) -> str:
+        """Get the file name from the path.
+
+        Returns:
+            The file name without the directory path.
+        """
+        return self._get_path().name
+
+    @property
+    def extension(self) -> str:
+        """Get the file extension.
+
+        Returns:
+            The file extension including the dot, or empty string if none.
+        """
+        return self._get_path().suffix
+
+    @property
+    def directory(self) -> str:
+        """Get the parent directory path.
+
+        Returns:
+            The directory containing this file.
+        """
+        return str(self._get_path().parent)
+
+
+__all__ = ["FilePath"]

--- a/src/shared_kernel/value_objects/file_path.py
+++ b/src/shared_kernel/value_objects/file_path.py
@@ -7,8 +7,8 @@ from pydantic import model_validator
 
 from src.building_blocks.domain.value_objects import StringValueObject
 
-# Pattern to detect Windows-style paths (e.g., C:\, D:\)
-_WINDOWS_PATH_PATTERN = re.compile(r"^[a-zA-Z]:[\\/]")
+# Pattern to detect Windows-style paths (e.g., C:\, D:\) and UNC paths (e.g., \\server\share)
+_WINDOWS_PATH_PATTERN = re.compile(r"^(?:[a-zA-Z]:[\\/]|\\\\[^\\]+\\[^\\]+)")
 
 
 class FilePath(StringValueObject):

--- a/src/shared_kernel/value_objects/language_code.py
+++ b/src/shared_kernel/value_objects/language_code.py
@@ -86,9 +86,10 @@ class LanguageCode(StringValueObject):
         value = value.strip().lower()
 
         if not cls._PATTERN.match(value):
+            examples = ", ".join(sorted(cls.COMMON_CODES)[:5])
             raise ValueError(
                 f"Invalid ISO 639-1 language code: '{value}'. "
-                f"Must be exactly 2 lowercase letters "
+                f"Must be exactly 2 lowercase letters (e.g. {examples}) "
                 f"[{cls._RULE_CODE}]"
             )
 

--- a/src/shared_kernel/value_objects/language_code.py
+++ b/src/shared_kernel/value_objects/language_code.py
@@ -1,0 +1,113 @@
+"""Language code value object (ISO 639-1)."""
+
+import re
+from typing import ClassVar
+
+from pydantic import model_validator
+
+from src.building_blocks.domain.value_objects import StringValueObject
+
+
+class LanguageCode(StringValueObject):
+    """ISO 639-1 two-letter language code.
+
+    Used for specifying preferred languages for metadata, audio tracks,
+    and subtitles.
+
+    Attributes:
+        COMMON_CODES: Set of commonly used language codes for validation hints.
+
+    Example:
+        >>> lang = LanguageCode("en")
+        >>> lang.value
+        'en'
+        >>> LanguageCode("PT").value  # Normalized to lowercase
+        'pt'
+    """
+
+    # Common language codes (not exhaustive, just for documentation)
+    COMMON_CODES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "en",  # English
+            "pt",  # Portuguese
+            "es",  # Spanish
+            "fr",  # French
+            "de",  # German
+            "it",  # Italian
+            "ja",  # Japanese
+            "ko",  # Korean
+            "zh",  # Chinese
+            "ru",  # Russian
+            "ar",  # Arabic
+            "hi",  # Hindi
+            "nl",  # Dutch
+            "pl",  # Polish
+            "sv",  # Swedish
+            "no",  # Norwegian
+            "da",  # Danish
+            "fi",  # Finnish
+            "tr",  # Turkish
+            "th",  # Thai
+            "vi",  # Vietnamese
+            "id",  # Indonesian
+            "ms",  # Malay
+            "he",  # Hebrew
+            "el",  # Greek
+            "cs",  # Czech
+            "hu",  # Hungarian
+            "ro",  # Romanian
+            "uk",  # Ukrainian
+        }
+    )
+
+    # ISO 639-1 pattern: exactly 2 lowercase letters
+    _PATTERN: ClassVar[re.Pattern[str]] = re.compile(r"^[a-z]{2}$")
+
+    # Inline rule code to avoid cross-context dependency on LibraryRuleCodes
+    _RULE_CODE: ClassVar[str] = "SHARED.LANGUAGE.INVALID_CODE"
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_code(cls, value: str) -> str:
+        """Validate and normalize the language code.
+
+        Args:
+            value: The raw language code.
+
+        Returns:
+            The lowercase language code.
+
+        Raises:
+            ValueError: If code is not a valid ISO 639-1 format.
+        """
+        if not isinstance(value, str):
+            raise ValueError("Language code must be a string")
+
+        value = value.strip().lower()
+
+        if not cls._PATTERN.match(value):
+            raise ValueError(
+                f"Invalid ISO 639-1 language code: '{value}'. "
+                f"Must be exactly 2 lowercase letters "
+                f"[{cls._RULE_CODE}]"
+            )
+
+        return value
+
+    @classmethod
+    def english(cls) -> "LanguageCode":
+        """Factory for English language code."""
+        return cls("en")
+
+    @classmethod
+    def portuguese(cls) -> "LanguageCode":
+        """Factory for Portuguese language code."""
+        return cls("pt")
+
+    @classmethod
+    def japanese(cls) -> "LanguageCode":
+        """Factory for Japanese language code."""
+        return cls("ja")
+
+
+__all__ = ["LanguageCode"]

--- a/src/shared_kernel/value_objects/tracks.py
+++ b/src/shared_kernel/value_objects/tracks.py
@@ -1,0 +1,148 @@
+"""Audio and subtitle track value objects."""
+
+from pydantic import Field, model_validator
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+
+
+class AudioTrack(CompoundValueObject):
+    """An audio track within a media file.
+
+    Represents a single audio stream in a video container (MKV, MP4, etc.)
+    with its technical characteristics.
+
+    Attributes:
+        index: Track index in the container (0-based).
+        language: ISO 639-1 language code.
+        codec: Audio codec (aac, ac3, dts, dts-hd, truehd, etc.).
+        channels: Number of audio channels (2=stereo, 6=5.1, 8=7.1).
+        title: Descriptive title from file metadata.
+        is_default: Whether marked as default in the container.
+        bitrate: Bitrate in kbps, if available.
+
+    Example:
+        >>> track = AudioTrack(
+        ...     index=0,
+        ...     language=LanguageCode("en"),
+        ...     codec="dts-hd",
+        ...     channels=8,
+        ...     title="English DTS-HD MA 7.1",
+        ...     is_default=True,
+        ... )
+        >>> track.is_surround
+        True
+    """
+
+    index: int = Field(ge=0)
+    language: LanguageCode
+    codec: str
+    channels: int = Field(ge=1, le=16)
+    title: str | None = None
+    is_default: bool = False
+    bitrate: int | None = Field(default=None, ge=0)
+
+    @property
+    def is_stereo(self) -> bool:
+        """Check if track is stereo (2 channels)."""
+        return self.channels == 2
+
+    @property
+    def is_surround(self) -> bool:
+        """Check if track is surround sound (more than 2 channels)."""
+        return self.channels > 2
+
+    @property
+    def channel_layout(self) -> str:
+        """Get human-readable channel layout.
+
+        Returns:
+            Channel layout string (e.g., "5.1", "7.1", "Stereo").
+        """
+        layouts = {
+            1: "Mono",
+            2: "Stereo",
+            6: "5.1",
+            8: "7.1",
+        }
+        return layouts.get(self.channels, f"{self.channels}ch")
+
+
+class SubtitleTrack(CompoundValueObject):
+    """A subtitle track for a media file.
+
+    Can be embedded in the container or an external file.
+
+    Attributes:
+        index: Track index (0-based, unique across embedded + external).
+        language: ISO 639-1 language code.
+        format: Subtitle format (srt, ass, vtt, pgs, sup).
+        title: Descriptive title.
+        is_default: Whether marked as default.
+        is_forced: Whether this is a forced subtitle track (signs only).
+        is_external: True if from separate file, False if embedded.
+        file_path: Path to external subtitle file, if applicable.
+
+    Example:
+        >>> embedded = SubtitleTrack(
+        ...     index=0,
+        ...     language=LanguageCode("en"),
+        ...     format="pgs",
+        ...     is_default=True,
+        ...     is_external=False,
+        ... )
+        >>> external = SubtitleTrack(
+        ...     index=2,
+        ...     language=LanguageCode("pt"),
+        ...     format="srt",
+        ...     is_external=True,
+        ...     file_path=FilePath("/movies/Movie.pt-BR.srt"),
+        ... )
+    """
+
+    index: int = Field(ge=0)
+    language: LanguageCode
+    format: str
+    title: str | None = None
+    is_default: bool = False
+    is_forced: bool = False
+    is_external: bool = False
+    file_path: FilePath | None = None
+
+    @model_validator(mode="after")
+    def validate_external_file_path(self) -> "SubtitleTrack":
+        """Validate that external tracks have a file path.
+
+        Returns:
+            The validated track.
+
+        Raises:
+            ValueError: If external track has no file_path.
+        """
+        if self.is_external and self.file_path is None:
+            raise ValueError("External subtitle track must have a file_path")
+        return self
+
+    @property
+    def is_text_based(self) -> bool:
+        """Check if subtitle is text-based (can be styled/searched).
+
+        Returns:
+            True for SRT, ASS, VTT formats; False for image-based (PGS, SUP).
+        """
+        text_formats = {"srt", "ass", "ssa", "vtt", "sub"}
+        return self.format.lower() in text_formats
+
+    @property
+    def is_image_based(self) -> bool:
+        """Check if subtitle is image-based (bitmap).
+
+        Returns:
+            True for PGS, SUP, VOBSUB formats.
+        """
+        image_formats = {"pgs", "sup", "vobsub", "idx"}
+        return self.format.lower() in image_formats
+
+
+__all__ = ["AudioTrack", "SubtitleTrack"]

--- a/src/shared_kernel/value_objects/tracks.py
+++ b/src/shared_kernel/value_objects/tracks.py
@@ -1,10 +1,20 @@
 """Audio and subtitle track value objects."""
 
+from typing import ClassVar
+
 from pydantic import Field, model_validator
 
 from src.building_blocks.domain.value_objects import CompoundValueObject
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
+
+# Channel count to human-readable layout mapping
+CHANNEL_LAYOUTS: dict[int, str] = {
+    1: "Mono",
+    2: "Stereo",
+    6: "5.1",
+    8: "7.1",
+}
 
 
 class AudioTrack(CompoundValueObject):
@@ -60,13 +70,7 @@ class AudioTrack(CompoundValueObject):
         Returns:
             Channel layout string (e.g., "5.1", "7.1", "Stereo").
         """
-        layouts = {
-            1: "Mono",
-            2: "Stereo",
-            6: "5.1",
-            8: "7.1",
-        }
-        return layouts.get(self.channels, f"{self.channels}ch")
+        return CHANNEL_LAYOUTS.get(self.channels, f"{self.channels}ch")
 
 
 class SubtitleTrack(CompoundValueObject):
@@ -101,6 +105,9 @@ class SubtitleTrack(CompoundValueObject):
         ... )
     """
 
+    TEXT_FORMATS: ClassVar[frozenset[str]] = frozenset({"srt", "ass", "ssa", "vtt", "sub"})
+    IMAGE_FORMATS: ClassVar[frozenset[str]] = frozenset({"pgs", "sup", "vobsub", "idx"})
+
     index: int = Field(ge=0)
     language: LanguageCode
     format: str
@@ -131,8 +138,7 @@ class SubtitleTrack(CompoundValueObject):
         Returns:
             True for SRT, ASS, VTT formats; False for image-based (PGS, SUP).
         """
-        text_formats = {"srt", "ass", "ssa", "vtt", "sub"}
-        return self.format.lower() in text_formats
+        return self.format.lower() in self.TEXT_FORMATS
 
     @property
     def is_image_based(self) -> bool:
@@ -141,8 +147,7 @@ class SubtitleTrack(CompoundValueObject):
         Returns:
             True for PGS, SUP, VOBSUB formats.
         """
-        image_formats = {"pgs", "sup", "vobsub", "idx"}
-        return self.format.lower() in image_formats
+        return self.format.lower() in self.IMAGE_FORMATS
 
 
 __all__ = ["AudioTrack", "SubtitleTrack"]


### PR DESCRIPTION
## Summary

- Extract cross-module business value objects into `src/shared_kernel/`
- **FilePath**, **LanguageCode**, **AudioTrack**, **SubtitleTrack** — used by both `media` and `library` modules
- Add `integration_events/` placeholder for future inter-module communication
- Fix typo in `building_blocks/domain/external_id.py` `__all__` export

## Context

Part of the Screaming Architecture migration (Phase 2). The shared kernel contains the **minimal** set of business concepts shared across bounded contexts, following the DDD principle of keeping it as small as possible.

### Dependency rule
```
modules → shared_kernel → building_blocks
```

Modules will import shared VOs from `src.shared_kernel.value_objects` instead of `src.domain.shared.value_objects`. Old paths still work (not yet removed — that happens in a later phase).

## Test plan

- [x] All 644 tests pass
- [x] `from src.shared_kernel.value_objects import FilePath, LanguageCode, AudioTrack, SubtitleTrack` works
- [x] Pre-commit hooks (ruff, mypy, ruff-format) pass

## Summary by Sourcery

Introduce a shared kernel package to host cross-module business value objects for media and library domains.

New Features:
- Add shared_kernel package with shared value objects for file paths, language codes, and media tracks.
- Expose shared_kernel value objects via a consolidated value_objects package interface.
- Introduce an integration_events namespace as a placeholder for future inter-module communication.

Enhancements:
- Encapsulate media-related audio and subtitle track metadata into dedicated compound value objects with validation and helper properties.
- Strengthen validation and normalization of language codes and file paths via dedicated value object types.