### PR TITLE
refactor(config): reorganize DI containers per module

### DIFF
--- a/src/config/containers/__init__.py
+++ b/src/config/containers/__init__.py
@@ -1,13 +1,19 @@
 """Dependency injection containers.
 
-This package organizes DI containers by responsibility:
+This package organizes DI containers per bounded context:
 - infrastructure: Database, external clients
-- repositories: Data access implementations
-- use_cases/: Application use cases by bounded context
+- media: Media module repositories and use cases
+- library: Library module services and repositories
 
 The main ApplicationContainer composes all sub-containers.
 """
 
+from src.config.containers.library import LibraryContainer
 from src.config.containers.main import ApplicationContainer
+from src.config.containers.media import MediaContainer
 
-__all__ = ["ApplicationContainer"]
+__all__ = [
+    "ApplicationContainer",
+    "LibraryContainer",
+    "MediaContainer",
+]

--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -9,7 +9,7 @@ from dependency_injector import containers, providers
 from src.config.settings import Settings
 
 
-class InfrastructureContainer(containers.DeclarativeContainer):
+class InfrastructureContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for infrastructure dependencies.
 
     Includes:

--- a/src/config/containers/library.py
+++ b/src/config/containers/library.py
@@ -1,0 +1,30 @@
+"""Library bounded context dependency container.
+
+Provides repositories and services for the Library module.
+"""
+
+from dependency_injector import containers, providers
+
+from src.modules.library.domain.services.track_selector import TrackSelector
+
+
+class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
+    """Container for Library bounded context dependencies.
+
+    Provides:
+    - Domain services
+    - Repository implementations (when infrastructure is added)
+
+    Example:
+        >>> container = LibraryContainer()
+        >>> selector = container.track_selector()
+    """
+
+    # Database session provided by parent container (for future use)
+    session = providers.Dependency(default=None)
+
+    # =========================================================================
+    # Domain Services
+    # =========================================================================
+
+    track_selector = providers.Factory(TrackSelector)

--- a/src/config/containers/library.py
+++ b/src/config/containers/library.py
@@ -1,6 +1,6 @@
 """Library bounded context dependency container.
 
-Provides repositories and services for the Library module.
+Provides services for the Library module.
 """
 
 from dependency_injector import containers, providers
@@ -13,15 +13,10 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     Provides:
     - Domain services
-    - Repository implementations (when infrastructure is added)
 
-    Example:
-        >>> container = LibraryContainer()
-        >>> selector = container.track_selector()
+    A ``session`` dependency will be added here when library
+    persistence is implemented, wired from InfrastructureContainer.
     """
-
-    # Database session provided by parent container (for future use)
-    session = providers.Dependency(default=None)
 
     # =========================================================================
     # Domain Services

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -9,10 +9,12 @@ See ADR-004 for the rationale behind this design.
 from dependency_injector import containers, providers
 
 from src.config.containers.infrastructure import InfrastructureContainer
+from src.config.containers.library import LibraryContainer
+from src.config.containers.media import MediaContainer
 from src.config.settings import Settings
 
 
-class ApplicationContainer(containers.DeclarativeContainer):
+class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Main application dependency injection container.
 
     This container composes all sub-containers and serves as the
@@ -21,12 +23,9 @@ class ApplicationContainer(containers.DeclarativeContainer):
     Structure:
         ApplicationContainer
         ├── config (Settings)
-        └── infrastructure (InfrastructureContainer)
-            ├── database
-            └── ...
-
-    Bounded context containers (repositories, use_cases) are added
-    as each context is implemented.
+        ├── infrastructure (InfrastructureContainer)
+        ├── media (MediaContainer)
+        └── library (LibraryContainer)
 
     Example:
         >>> container = ApplicationContainer()
@@ -48,6 +47,14 @@ class ApplicationContainer(containers.DeclarativeContainer):
         InfrastructureContainer,
         config=config,
     )
+
+    # =========================================================================
+    # Bounded Context Containers
+    # =========================================================================
+
+    media = providers.Container(MediaContainer)
+
+    library = providers.Container(LibraryContainer)
 
 
 # Convenience alias

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -1,0 +1,71 @@
+"""Media bounded context dependency container.
+
+Provides repositories and use cases for the Media module.
+"""
+
+from dependency_injector import containers, providers
+
+from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
+from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
+from src.modules.media.application.use_cases.list_movies import ListMoviesUseCase
+from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
+from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
+    SQLAlchemyMovieRepository,
+)
+from src.modules.media.infrastructure.persistence.repositories.series_repository import (
+    SQLAlchemySeriesRepository,
+)
+
+
+class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
+    """Container for Media bounded context dependencies.
+
+    Provides:
+    - Repository implementations (SQLAlchemy)
+    - Use cases for movie and series operations
+
+    Example:
+        >>> container = MediaContainer(session=session_provider)
+        >>> use_case = container.get_movie_by_id()
+    """
+
+    # Database session provided by parent container
+    session = providers.Dependency()
+
+    # =========================================================================
+    # Repositories
+    # =========================================================================
+
+    movie_repository = providers.Factory(
+        SQLAlchemyMovieRepository,
+        session=session,
+    )
+
+    series_repository = providers.Factory(
+        SQLAlchemySeriesRepository,
+        session=session,
+    )
+
+    # =========================================================================
+    # Use Cases
+    # =========================================================================
+
+    get_movie_by_id = providers.Factory(
+        GetMovieByIdUseCase,
+        movie_repository=movie_repository,
+    )
+
+    list_movies = providers.Factory(
+        ListMoviesUseCase,
+        movie_repository=movie_repository,
+    )
+
+    get_series_by_id = providers.Factory(
+        GetSeriesByIdUseCase,
+        series_repository=series_repository,
+    )
+
+    list_series = providers.Factory(
+        ListSeriesUseCase,
+        series_repository=series_repository,
+    )

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -24,12 +24,15 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     - Repository implementations (SQLAlchemy)
     - Use cases for movie and series operations
 
+    The ``session`` dependency must be wired from the parent container
+    once the database provider is added to InfrastructureContainer.
+
     Example:
         >>> container = MediaContainer(session=session_provider)
         >>> use_case = container.get_movie_by_id()
     """
 
-    # Database session provided by parent container
+    # Must be wired from InfrastructureContainer.session
     session = providers.Dependency()
 
     # =========================================================================

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -10,7 +10,7 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):
+class Settings(BaseSettings):  # type: ignore[misc]
     """Application settings.
 
     All settings can be overridden via environment variables.


### PR DESCRIPTION
## Summary

- Add `MediaContainer` with repos (SQLAlchemyMovieRepository, SQLAlchemySeriesRepository) and use cases (GetMovieById, ListMovies, GetSeriesById, ListSeries)
- Add `LibraryContainer` with domain services (TrackSelector)
- Compose both in `ApplicationContainer` alongside `InfrastructureContainer`
- Fix pre-existing mypy errors on `DeclarativeContainer` and `BaseSettings` subclassing with `# type: ignore[misc]`

## Test plan

- [x] All 644 tests pass
- [x] `ruff check` clean
- [x] `mypy` clean (pre-commit hook)

## Summary by Sourcery

Introduce bounded-context DI containers for media and library modules and compose them into the main application container.

New Features:
- Add MediaContainer providing SQLAlchemy media repositories and media use case factories.
- Add LibraryContainer providing library domain services and future repository dependencies.

Enhancements:
- Expose media and library containers from the config.containers package and register them in the ApplicationContainer alongside infrastructure.
- Document container layout around bounded contexts in the containers package docstring.
- Add explicit type ignores for DeclarativeContainer and BaseSettings subclassing to satisfy static type checking.