### PR TITLE
refactor(imports): update all tests to canonical module paths

### DIFF
--- a/tests/integration/infrastructure/persistence/repositories/test_movie_repository.py
+++ b/tests/integration/infrastructure/persistence/repositories/test_movie_repository.py
@@ -3,8 +3,8 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.media.entities import Movie
-from src.domain.media.value_objects import (
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects import (
     Duration,
     FilePath,
     Genre,
@@ -14,7 +14,7 @@ from src.domain.media.value_objects import (
     Title,
     Year,
 )
-from src.infrastructure.persistence.repositories import SQLAlchemyMovieRepository
+from src.modules.media.infrastructure.persistence.repositories import SQLAlchemyMovieRepository
 
 
 def _create_movie(

--- a/tests/integration/infrastructure/persistence/repositories/test_series_repository.py
+++ b/tests/integration/infrastructure/persistence/repositories/test_series_repository.py
@@ -3,8 +3,8 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.domain.media.entities import Episode, Season, Series
-from src.domain.media.value_objects import (
+from src.modules.media.domain.entities import Episode, Season, Series
+from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
     FilePath,
@@ -16,7 +16,7 @@ from src.domain.media.value_objects import (
     Title,
     Year,
 )
-from src.infrastructure.persistence.repositories import SQLAlchemySeriesRepository
+from src.modules.media.infrastructure.persistence.repositories import SQLAlchemySeriesRepository
 
 
 def _create_episode(

--- a/tests/unit/application/media/use_cases/test_get_movie_by_id.py
+++ b/tests/unit/application/media/use_cases/test_get_movie_by_id.py
@@ -4,11 +4,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.application.media.dtos import GetMovieByIdInput, MovieOutput
-from src.application.media.use_cases import GetMovieByIdUseCase
-from src.application.shared.exceptions import ResourceNotFoundException
-from src.domain.media.entities import Movie
-from src.domain.media.repositories import MovieRepository
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos import GetMovieByIdInput, MovieOutput
+from src.modules.media.application.use_cases import GetMovieByIdUseCase
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.repositories import MovieRepository
 
 
 class TestGetMovieByIdUseCase:

--- a/tests/unit/application/media/use_cases/test_get_series_by_id.py
+++ b/tests/unit/application/media/use_cases/test_get_series_by_id.py
@@ -4,12 +4,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.application.media.dtos import GetSeriesByIdInput, SeriesOutput
-from src.application.media.use_cases import GetSeriesByIdUseCase
-from src.application.shared.exceptions import ResourceNotFoundException
-from src.domain.media.entities import Episode, Season, Series
-from src.domain.media.repositories import SeriesRepository
-from src.domain.media.value_objects import (
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos import GetSeriesByIdInput, SeriesOutput
+from src.modules.media.application.use_cases import GetSeriesByIdUseCase
+from src.modules.media.domain.entities import Episode, Season, Series
+from src.modules.media.domain.repositories import SeriesRepository
+from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
     FilePath,

--- a/tests/unit/application/media/use_cases/test_list_movies.py
+++ b/tests/unit/application/media/use_cases/test_list_movies.py
@@ -4,10 +4,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.application.media.dtos import ListMoviesInput, ListMoviesOutput, MovieSummaryOutput
-from src.application.media.use_cases import ListMoviesUseCase
-from src.domain.media.entities import Movie
-from src.domain.media.repositories import MovieRepository
+from src.modules.media.application.dtos import ListMoviesInput, ListMoviesOutput, MovieSummaryOutput
+from src.modules.media.application.use_cases import ListMoviesUseCase
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.repositories import MovieRepository
 
 
 class TestListMoviesUseCase:

--- a/tests/unit/application/media/use_cases/test_list_series.py
+++ b/tests/unit/application/media/use_cases/test_list_series.py
@@ -4,10 +4,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.application.media.dtos import ListSeriesInput, ListSeriesOutput, SeriesSummaryOutput
-from src.application.media.use_cases import ListSeriesUseCase
-from src.domain.media.entities import Series
-from src.domain.media.repositories import SeriesRepository
+from src.modules.media.application.dtos import (
+    ListSeriesInput,
+    ListSeriesOutput,
+    SeriesSummaryOutput,
+)
+from src.modules.media.application.use_cases import ListSeriesUseCase
+from src.modules.media.domain.entities import Series
+from src.modules.media.domain.repositories import SeriesRepository
 
 
 class TestListSeriesUseCase:

--- a/tests/unit/domain/library/entities/test_library.py
+++ b/tests/unit/domain/library/entities/test_library.py
@@ -2,12 +2,12 @@
 
 import pytest
 
-from src.domain.library.entities.library import Library
-from src.domain.library.value_objects.library_name import LibraryName
-from src.domain.library.value_objects.library_type import LibraryType
-from src.domain.library.value_objects.metadata_provider import MetadataProviderConfig
-from src.domain.media.value_objects.file_path import FilePath
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.domain.value_objects.library_name import LibraryName
+from src.modules.library.domain.value_objects.library_type import LibraryType
+from src.modules.library.domain.value_objects.metadata_provider import MetadataProviderConfig
+from src.shared_kernel.value_objects.file_path import FilePath
 
 
 class TestLibraryCreation:

--- a/tests/unit/domain/library/services/test_track_selector.py
+++ b/tests/unit/domain/library/services/test_track_selector.py
@@ -1,9 +1,9 @@
 """Tests for TrackSelector domain service."""
 
-from src.domain.library.services.track_selector import TrackSelector
-from src.domain.library.value_objects.language_code import LanguageCode
-from src.domain.library.value_objects.subtitle_mode import SubtitleMode
-from src.domain.library.value_objects.tracks import AudioTrack, SubtitleTrack
+from src.modules.library.domain.services.track_selector import TrackSelector
+from src.modules.library.domain.value_objects.subtitle_mode import SubtitleMode
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 
 class TestTrackSelectorAudioSelection:

--- a/tests/unit/domain/library/value_objects/test_language_code.py
+++ b/tests/unit/domain/library/value_objects/test_language_code.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from src.domain.library.value_objects.language_code import LanguageCode
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
+from src.shared_kernel.value_objects.language_code import LanguageCode
 
 
 class TestLanguageCodeCreation:

--- a/tests/unit/domain/library/value_objects/test_library_id.py
+++ b/tests/unit/domain/library/value_objects/test_library_id.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from src.domain.library.value_objects.library_id import LibraryId
-from src.domain.shared.exceptions.domain import DomainValidationException
-from src.domain.shared.models.external_id import RANDOM_PART_LENGTH
+from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.external_id import RANDOM_PART_LENGTH
+from src.modules.library.domain.value_objects.library_id import LibraryId
 
 
 class TestLibraryIdCreation:

--- a/tests/unit/domain/library/value_objects/test_library_name.py
+++ b/tests/unit/domain/library/value_objects/test_library_name.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from src.domain.library.value_objects.library_name import LibraryName
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.library.domain.value_objects.library_name import LibraryName
 
 
 class TestLibraryNameCreation:

--- a/tests/unit/domain/library/value_objects/test_library_settings.py
+++ b/tests/unit/domain/library/value_objects/test_library_settings.py
@@ -1,8 +1,8 @@
 """Tests for LibrarySettings value object."""
 
-from src.domain.library.value_objects.language_code import LanguageCode
-from src.domain.library.value_objects.library_settings import LibrarySettings
-from src.domain.library.value_objects.subtitle_mode import SubtitleMode
+from src.modules.library.domain.value_objects.library_settings import LibrarySettings
+from src.modules.library.domain.value_objects.subtitle_mode import SubtitleMode
+from src.shared_kernel.value_objects.language_code import LanguageCode
 
 
 class TestLibrarySettingsCreation:
@@ -29,7 +29,7 @@ class TestLibrarySettingsCreation:
         )
 
         assert settings.preferred_audio_language.value == "ja"
-        assert settings.preferred_subtitle_language.value == "en"
+        assert settings.preferred_subtitle_language.value == "en"  # type: ignore[union-attr]
         assert settings.subtitle_mode == SubtitleMode.ALWAYS
         assert settings.generate_thumbnails is False
         assert settings.detect_intros is True
@@ -50,16 +50,16 @@ class TestLibrarySettingsFactories:
         settings = LibrarySettings.for_anime()
 
         assert settings.preferred_audio_language.value == "ja"
-        assert settings.preferred_subtitle_language.value == "en"
+        assert settings.preferred_subtitle_language.value == "en"  # type: ignore[union-attr]
         assert settings.subtitle_mode == SubtitleMode.ALWAYS
 
     def test_for_foreign_films_should_return_foreign_audio_mode(self):
         settings = LibrarySettings.for_foreign_films()
 
-        assert settings.preferred_subtitle_language.value == "en"
+        assert settings.preferred_subtitle_language.value == "en"  # type: ignore[union-attr]
         assert settings.subtitle_mode == SubtitleMode.FOREIGN_AUDIO_ONLY
 
     def test_for_foreign_films_should_accept_custom_subtitle_language(self):
         settings = LibrarySettings.for_foreign_films(subtitle_language="pt")
 
-        assert settings.preferred_subtitle_language.value == "pt"
+        assert settings.preferred_subtitle_language.value == "pt"  # type: ignore[union-attr]

--- a/tests/unit/domain/library/value_objects/test_library_type.py
+++ b/tests/unit/domain/library/value_objects/test_library_type.py
@@ -1,6 +1,6 @@
 """Tests for LibraryType enumeration."""
 
-from src.domain.library.value_objects.library_type import LibraryType
+from src.modules.library.domain.value_objects.library_type import LibraryType
 
 
 class TestLibraryType:

--- a/tests/unit/domain/library/value_objects/test_metadata_provider.py
+++ b/tests/unit/domain/library/value_objects/test_metadata_provider.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from src.domain.library.value_objects.metadata_provider import (
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.library.domain.value_objects.metadata_provider import (
     MetadataProvider,
     MetadataProviderConfig,
 )
-from src.domain.shared.exceptions.domain import DomainValidationException
 
 
 class TestMetadataProvider:

--- a/tests/unit/domain/library/value_objects/test_subtitle_mode.py
+++ b/tests/unit/domain/library/value_objects/test_subtitle_mode.py
@@ -1,6 +1,6 @@
 """Tests for SubtitleMode enumeration."""
 
-from src.domain.library.value_objects.subtitle_mode import SubtitleMode
+from src.modules.library.domain.value_objects.subtitle_mode import SubtitleMode
 
 
 class TestSubtitleMode:

--- a/tests/unit/domain/library/value_objects/test_tracks.py
+++ b/tests/unit/domain/library/value_objects/test_tracks.py
@@ -2,10 +2,10 @@
 
 import pytest
 
-from src.domain.library.value_objects.language_code import LanguageCode
-from src.domain.library.value_objects.tracks import AudioTrack, SubtitleTrack
-from src.domain.media.value_objects.file_path import FilePath
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 
 class TestAudioTrackCreation:

--- a/tests/unit/domain/media/entities/test_episode.py
+++ b/tests/unit/domain/media/entities/test_episode.py
@@ -4,8 +4,8 @@ from datetime import date
 
 import pytest
 
-from src.domain.media.value_objects import FilePath, MediaFile, Resolution
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
 
 def _make_file(**overrides: object) -> MediaFile:
@@ -24,8 +24,8 @@ class TestEpisodeCreation:
     """Tests for Episode instantiation."""
 
     def test_should_create_with_required_fields(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             SeriesId,
             Title,
@@ -45,8 +45,8 @@ class TestEpisodeCreation:
         assert episode.title.value == "Pilot"
 
     def test_should_create_with_explicit_id(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             EpisodeId,
             SeriesId,
@@ -67,8 +67,8 @@ class TestEpisodeCreation:
         assert episode.id == episode_id
 
     def test_should_accept_string_id_and_convert(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             EpisodeId,
             SeriesId,
@@ -89,8 +89,8 @@ class TestEpisodeCreation:
         assert episode.id.value == "epi_abc123abc123"
 
     def test_should_allow_season_number_zero_for_specials(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             FilePath,
             MediaFile,
@@ -118,8 +118,8 @@ class TestEpisodeCreation:
         assert episode.season_number == 0
 
     def test_should_raise_error_for_negative_episode_number(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             SeriesId,
             Title,
@@ -136,8 +136,8 @@ class TestEpisodeCreation:
             )
 
     def test_should_create_with_no_files(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             SeriesId,
             Title,
@@ -158,8 +158,8 @@ class TestEpisodeOptionalFields:
     """Tests for Episode optional fields."""
 
     def test_should_create_with_synopsis(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             SeriesId,
             Title,
@@ -178,8 +178,8 @@ class TestEpisodeOptionalFields:
         assert episode.synopsis == "The first episode of the series."
 
     def test_should_create_with_thumbnail_path(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             FilePath,
             SeriesId,
@@ -199,8 +199,8 @@ class TestEpisodeOptionalFields:
         assert episode.thumbnail_path is not None
 
     def test_should_create_with_air_date(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             SeriesId,
             Title,
@@ -224,8 +224,8 @@ class TestEpisodeFileManagement:
     """Tests for Episode file variant management."""
 
     def test_primary_file_should_return_primary(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import Duration, SeriesId, Title
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import Duration, SeriesId, Title
 
         episode = Episode(
             series_id=SeriesId.generate(),
@@ -240,8 +240,8 @@ class TestEpisodeFileManagement:
         assert episode.primary_file.is_primary is True
 
     def test_with_file_should_add_new_variant(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             FilePath,
             MediaFile,
@@ -270,8 +270,8 @@ class TestEpisodeFileManagement:
         assert len(episode.files) == 2
 
     def test_best_file_should_return_highest_resolution(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             FilePath,
             MediaFile,
@@ -304,8 +304,8 @@ class TestEpisodeEquality:
     """Tests for Episode equality based on ID."""
 
     def test_should_be_equal_when_same_id(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             EpisodeId,
             SeriesId,
@@ -338,8 +338,8 @@ class TestEpisodeEquality:
         assert episode1 == episode2
 
     def test_should_not_be_equal_when_different_id(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             EpisodeId,
             SeriesId,
@@ -375,8 +375,8 @@ class TestEpisodeTimestamps:
     """Tests for Episode timestamp management."""
 
     def test_should_have_created_at_on_creation(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             SeriesId,
             Title,
@@ -394,8 +394,8 @@ class TestEpisodeTimestamps:
         assert episode.created_at is not None
 
     def test_should_reject_direct_attribute_assignment(self):
-        from src.domain.media.entities import Episode
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
             Duration,
             SeriesId,
             Title,

--- a/tests/unit/domain/media/entities/test_movie.py
+++ b/tests/unit/domain/media/entities/test_movie.py
@@ -2,15 +2,15 @@
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
 
 
 class TestMovieCreation:
     """Tests for Movie instantiation."""
 
     def test_should_create_with_required_fields(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import (
             Duration,
             FilePath,
             MediaFile,
@@ -38,8 +38,8 @@ class TestMovieCreation:
         assert movie.year.value == 2010
 
     def test_should_create_via_factory_with_auto_id(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import MovieId
 
         movie = Movie.create(
             title="Inception",
@@ -55,7 +55,7 @@ class TestMovieCreation:
         assert movie.id.prefix == "mov"
 
     def test_factory_should_create_primary_file(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -72,8 +72,8 @@ class TestMovieCreation:
         assert movie.files[0].resolution.name == "1080p"
 
     def test_should_accept_string_id_and_convert(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import (
             Duration,
             MovieId,
             Title,
@@ -94,8 +94,8 @@ class TestMovieOptionalFields:
     """Tests for Movie optional fields."""
 
     def test_should_create_with_all_optional_fields(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import (
             Duration,
             FilePath,
             Genre,
@@ -138,7 +138,7 @@ class TestMovieGenreManagement:
     """Tests for Movie genre management."""
 
     def test_should_add_genre(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -155,8 +155,8 @@ class TestMovieGenreManagement:
         assert movie.genres[0].value == "Sci-Fi"
 
     def test_should_add_genre_as_value_object(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import Genre
 
         movie = Movie.create(
             title="Inception",
@@ -172,7 +172,7 @@ class TestMovieGenreManagement:
         assert len(movie.genres) == 1
 
     def test_should_not_add_duplicate_genre(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -193,7 +193,7 @@ class TestMovieFileManagement:
     """Tests for Movie file variant management."""
 
     def test_primary_file_should_return_primary(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -209,8 +209,8 @@ class TestMovieFileManagement:
         assert primary.is_primary is True
 
     def test_primary_file_should_return_none_when_no_files(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import Duration, Title, Year
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import Duration, Title, Year
 
         movie = Movie(
             title=Title("Test"),
@@ -221,8 +221,8 @@ class TestMovieFileManagement:
         assert movie.primary_file is None
 
     def test_best_file_should_return_highest_resolution(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import FilePath, MediaFile, Resolution
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
             title="Inception",
@@ -245,8 +245,8 @@ class TestMovieFileManagement:
         assert best.resolution.name == "4K"
 
     def test_available_resolutions_should_be_sorted_highest_first(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import FilePath, MediaFile, Resolution
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
             title="Inception",
@@ -268,8 +268,8 @@ class TestMovieFileManagement:
         assert [r.name for r in resolutions] == ["4K", "720p"]
 
     def test_total_size_should_sum_all_files(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import FilePath, MediaFile, Resolution
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
             title="Inception",
@@ -290,8 +290,8 @@ class TestMovieFileManagement:
         assert movie.total_size == 24_000_000_000
 
     def test_with_file_should_add_new_variant(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import FilePath, MediaFile, Resolution
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
             title="Inception",
@@ -313,7 +313,7 @@ class TestMovieFileManagement:
         assert len(movie.files) == 2
 
     def test_with_file_should_not_add_duplicate_path(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -324,7 +324,7 @@ class TestMovieFileManagement:
             resolution="1080p",
         )
 
-        from src.domain.media.value_objects import FilePath, MediaFile, Resolution
+        from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         result = movie.with_file(
             MediaFile(
@@ -337,7 +337,7 @@ class TestMovieFileManagement:
         assert result is movie  # same object, no change
 
     def test_get_file_by_resolution_should_find_match(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -353,7 +353,7 @@ class TestMovieFileManagement:
         assert found.resolution.name == "1080p"
 
     def test_get_file_by_resolution_should_return_none_when_not_found(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -372,8 +372,8 @@ class TestMovieEquality:
     """Tests for Movie equality based on ID."""
 
     def test_should_be_equal_when_same_id(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import (
             Duration,
             MovieId,
             Title,
@@ -403,7 +403,7 @@ class TestMovieEvents:
     """Tests for Movie domain events."""
 
     def test_should_add_and_pull_events(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -428,7 +428,7 @@ class TestMovieImmutability:
     """Tests for Movie frozen (immutable) behavior."""
 
     def test_should_reject_direct_attribute_assignment(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -443,7 +443,7 @@ class TestMovieImmutability:
             movie.year = 2020  # type: ignore[assignment, misc]
 
     def test_with_genre_should_return_new_instance(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -461,7 +461,7 @@ class TestMovieImmutability:
         assert len(movie.genres) == 0
 
     def test_with_genre_duplicate_string_should_return_self(self):
-        from src.domain.media.entities import Movie
+        from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
             title="Inception",
@@ -478,8 +478,8 @@ class TestMovieImmutability:
         assert result is movie
 
     def test_with_genre_duplicate_value_object_should_return_self(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import Genre
 
         movie = Movie.create(
             title="Inception",
@@ -496,8 +496,8 @@ class TestMovieImmutability:
         assert result is movie
 
     def test_with_file_should_return_new_instance(self):
-        from src.domain.media.entities import Movie
-        from src.domain.media.value_objects import FilePath, MediaFile, Resolution
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
             title="Inception",

--- a/tests/unit/domain/media/entities/test_season.py
+++ b/tests/unit/domain/media/entities/test_season.py
@@ -4,8 +4,12 @@ from datetime import date
 
 import pytest
 
-from src.domain.media.entities import Episode
-from src.domain.media.value_objects import (
+from src.building_blocks.domain.errors import (
+    BusinessRuleViolationException,
+    DomainValidationException,
+)
+from src.modules.media.domain.entities import Episode
+from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
     FilePath,
@@ -13,10 +17,6 @@ from src.domain.media.value_objects import (
     Resolution,
     SeriesId,
     Title,
-)
-from src.domain.shared.exceptions.domain import (
-    BusinessRuleViolationException,
-    DomainValidationException,
 )
 
 
@@ -49,8 +49,8 @@ class TestSeasonCreation:
     """Tests for Season instantiation."""
 
     def test_should_create_with_required_fields(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId.generate()
         season = Season(
@@ -64,8 +64,8 @@ class TestSeasonCreation:
         assert season.episodes == []
 
     def test_should_create_with_explicit_id(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeasonId, SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeasonId, SeriesId
 
         season_id = SeasonId.generate()
         season = Season(
@@ -77,8 +77,8 @@ class TestSeasonCreation:
         assert season.id == season_id
 
     def test_should_accept_string_id_and_convert(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeasonId, SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeasonId, SeriesId
 
         season = Season(
             id="ssn_abc123abc123",
@@ -90,8 +90,8 @@ class TestSeasonCreation:
         assert season.id.value == "ssn_abc123abc123"
 
     def test_should_allow_season_number_zero_for_specials(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         season = Season(
             series_id=SeriesId.generate(),
@@ -101,8 +101,8 @@ class TestSeasonCreation:
         assert season.season_number == 0
 
     def test_should_raise_error_for_negative_season_number(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         with pytest.raises(DomainValidationException):
             Season(
@@ -115,8 +115,8 @@ class TestSeasonOptionalFields:
     """Tests for Season optional fields."""
 
     def test_should_create_with_title(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId, Title
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId, Title
 
         season = Season(
             series_id=SeriesId.generate(),
@@ -128,8 +128,8 @@ class TestSeasonOptionalFields:
         assert season.title.value == "Season One"
 
     def test_should_create_with_synopsis(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         season = Season(
             series_id=SeriesId.generate(),
@@ -140,8 +140,8 @@ class TestSeasonOptionalFields:
         assert season.synopsis == "The first season of the show."
 
     def test_should_create_with_poster_path(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import FilePath, SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import FilePath, SeriesId
 
         season = Season(
             series_id=SeriesId.generate(),
@@ -152,8 +152,8 @@ class TestSeasonOptionalFields:
         assert season.poster_path is not None
 
     def test_should_create_with_air_date(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         air_date = date(2024, 1, 15)
         season = Season(
@@ -169,8 +169,8 @@ class TestSeasonEpisodeManagement:
     """Tests for Season episode management."""
 
     def test_episode_count_should_return_zero_when_empty(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         season = Season(
             series_id=SeriesId.generate(),
@@ -180,8 +180,8 @@ class TestSeasonEpisodeManagement:
         assert season.episode_count == 0
 
     def test_should_add_episode(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId.generate()
         season = Season(
@@ -196,8 +196,8 @@ class TestSeasonEpisodeManagement:
         assert season.episodes[0] == episode
 
     def test_should_raise_error_when_adding_episode_with_wrong_series_id(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         season = Season(
             series_id=SeriesId.generate(),
@@ -210,8 +210,8 @@ class TestSeasonEpisodeManagement:
             season.with_episode(episode)
 
     def test_should_raise_error_when_adding_episode_with_wrong_season_number(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId.generate()
         season = Season(
@@ -225,8 +225,8 @@ class TestSeasonEpisodeManagement:
             season.with_episode(episode)
 
     def test_should_get_episode_by_number(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId.generate()
         season = Season(
@@ -241,8 +241,8 @@ class TestSeasonEpisodeManagement:
         assert found == episode
 
     def test_should_return_none_when_episode_not_found(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         season = Season(
             series_id=SeriesId.generate(),
@@ -257,8 +257,8 @@ class TestSeasonEquality:
     """Tests for Season equality based on ID."""
 
     def test_should_be_equal_when_same_id(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeasonId, SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeasonId, SeriesId
 
         season_id = SeasonId.generate()
         series_id = SeriesId.generate()
@@ -269,8 +269,8 @@ class TestSeasonEquality:
         assert season1 == season2
 
     def test_should_not_be_equal_when_different_id(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeasonId, SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeasonId, SeriesId
 
         series_id = SeriesId.generate()
 
@@ -284,8 +284,8 @@ class TestSeasonImmutability:
     """Tests for Season frozen (immutable) behavior."""
 
     def test_should_reject_direct_attribute_assignment(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         season = Season(
             series_id=SeriesId.generate(),
@@ -296,8 +296,8 @@ class TestSeasonImmutability:
             season.season_number = 2  # type: ignore[misc]
 
     def test_with_episode_should_return_new_instance(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId.generate()
         season = Season(
@@ -313,8 +313,8 @@ class TestSeasonImmutability:
         assert season.episode_count == 0
 
     def test_with_episode_should_preserve_identity(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeasonId, SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeasonId, SeriesId
 
         series_id = SeriesId.generate()
         season = Season(
@@ -329,8 +329,8 @@ class TestSeasonImmutability:
         assert updated == season  # same id
 
     def test_with_episode_duplicate_should_return_self(self):
-        from src.domain.media.entities import Season
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId.generate()
         season = Season(

--- a/tests/unit/domain/media/entities/test_series.py
+++ b/tests/unit/domain/media/entities/test_series.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.domain.shared.exceptions.domain import (
+from src.building_blocks.domain.errors import (
     BusinessRuleViolationException,
     DomainValidationException,
 )
@@ -12,8 +12,8 @@ class TestSeriesCreation:
     """Tests for Series instantiation."""
 
     def test_should_create_with_required_fields(self):
-        from src.domain.media.entities import Series
-        from src.domain.media.value_objects import Title, Year
+        from src.modules.media.domain.entities import Series
+        from src.modules.media.domain.value_objects import Title, Year
 
         series = Series(
             title=Title("Breaking Bad"),
@@ -27,8 +27,8 @@ class TestSeriesCreation:
         assert series.is_ongoing is True
 
     def test_should_create_via_factory_with_auto_id(self):
-        from src.domain.media.entities import Series
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.entities import Series
+        from src.modules.media.domain.value_objects import SeriesId
 
         series = Series.create(
             title="Breaking Bad",
@@ -40,8 +40,8 @@ class TestSeriesCreation:
         assert series.id.prefix == "ser"
 
     def test_should_create_with_end_year(self):
-        from src.domain.media.entities import Series
-        from src.domain.media.value_objects import Title, Year
+        from src.modules.media.domain.entities import Series
+        from src.modules.media.domain.value_objects import Title, Year
 
         series = Series(
             title=Title("Breaking Bad"),
@@ -54,8 +54,8 @@ class TestSeriesCreation:
         assert series.is_ongoing is False
 
     def test_should_raise_error_when_end_year_before_start_year(self):
-        from src.domain.media.entities import Series
-        from src.domain.media.value_objects import Title, Year
+        from src.modules.media.domain.entities import Series
+        from src.modules.media.domain.value_objects import Title, Year
 
         with pytest.raises(DomainValidationException, match="end_year"):
             Series(
@@ -69,22 +69,22 @@ class TestSeriesSeasonManagement:
     """Tests for Series season management."""
 
     def test_season_count_should_return_zero_when_empty(self):
-        from src.domain.media.entities import Series
+        from src.modules.media.domain.entities import Series
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
         assert series.season_count == 0
 
     def test_total_episodes_should_return_zero_when_empty(self):
-        from src.domain.media.entities import Series
+        from src.modules.media.domain.entities import Series
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
         assert series.total_episodes == 0
 
     def test_should_add_season(self):
-        from src.domain.media.entities import Season, Series
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
@@ -99,8 +99,8 @@ class TestSeriesSeasonManagement:
         assert series.season_count == 1
 
     def test_should_raise_error_when_adding_season_with_wrong_series_id(self):
-        from src.domain.media.entities import Season, Series
-        from src.domain.media.value_objects import SeasonId, SeriesId
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId, SeriesId
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
@@ -114,8 +114,8 @@ class TestSeriesSeasonManagement:
             series.with_season(season)
 
     def test_should_get_season_by_number(self):
-        from src.domain.media.entities import Season, Series
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
@@ -131,7 +131,7 @@ class TestSeriesSeasonManagement:
         assert found == season
 
     def test_should_return_none_when_season_not_found(self):
-        from src.domain.media.entities import Series
+        from src.modules.media.domain.entities import Series
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
@@ -143,8 +143,8 @@ class TestSeriesEquality:
     """Tests for Series equality based on ID."""
 
     def test_should_be_equal_when_same_id(self):
-        from src.domain.media.entities import Series
-        from src.domain.media.value_objects import SeriesId, Title, Year
+        from src.modules.media.domain.entities import Series
+        from src.modules.media.domain.value_objects import SeriesId, Title, Year
 
         series_id = SeriesId.generate()
 
@@ -167,7 +167,7 @@ class TestSeriesEvents:
     """Tests for Series domain events."""
 
     def test_should_add_and_pull_events(self):
-        from src.domain.media.entities import Series
+        from src.modules.media.domain.entities import Series
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
@@ -185,7 +185,7 @@ class TestSeriesImmutability:
     """Tests for Series frozen (immutable) behavior."""
 
     def test_should_reject_direct_attribute_assignment(self):
-        from src.domain.media.entities import Series
+        from src.modules.media.domain.entities import Series
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
@@ -193,8 +193,8 @@ class TestSeriesImmutability:
             series.start_year = 2020  # type: ignore[assignment, misc]
 
     def test_with_season_should_return_new_instance(self):
-        from src.domain.media.entities import Season, Series
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId
 
         series = Series.create(title="Breaking Bad", start_year=2008)
         season = Season(
@@ -210,8 +210,8 @@ class TestSeriesImmutability:
         assert series.season_count == 0
 
     def test_with_season_should_preserve_identity(self):
-        from src.domain.media.entities import Season, Series
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId
 
         series = Series.create(title="Breaking Bad", start_year=2008)
         season = Season(
@@ -225,8 +225,8 @@ class TestSeriesImmutability:
         assert updated == series  # same id
 
     def test_with_season_duplicate_should_return_self(self):
-        from src.domain.media.entities import Season, Series
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId
 
         series = Series.create(title="Breaking Bad", start_year=2008)
         season = Season(

--- a/tests/unit/domain/media/services/test_file_selector.py
+++ b/tests/unit/domain/media/services/test_file_selector.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from src.domain.media.services import FileSelector
-from src.domain.media.value_objects import (
+from src.modules.media.domain.services import FileSelector
+from src.modules.media.domain.value_objects import (
     FilePath,
     HdrFormat,
     MediaFile,

--- a/tests/unit/domain/media/value_objects/test_duration.py
+++ b/tests/unit/domain/media/value_objects/test_duration.py
@@ -2,93 +2,93 @@
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
 
 
 class TestDurationCreation:
     """Tests for Duration instantiation."""
 
     def test_should_create_with_zero_value(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(0)
 
         assert duration.value == 0
 
     def test_should_create_with_positive_value(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(7200)  # 2 hours
 
         assert duration.value == 7200
 
     def test_should_raise_error_for_negative_value(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         with pytest.raises(DomainValidationException, match="non-negative"):
             Duration(-1)
 
     def test_should_raise_error_for_non_integer_input(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         with pytest.raises(DomainValidationException):
-            Duration("7200")
+            Duration("7200")  # type: ignore[arg-type]
 
 
 class TestDurationProperties:
     """Tests for Duration computed properties."""
 
     def test_minutes_property_should_return_whole_minutes(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(90)  # 90 seconds = 1 minute
 
         assert duration.minutes == 1
 
     def test_minutes_property_should_truncate_partial_minutes(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(89)  # 89 seconds = 1.48 minutes
 
         assert duration.minutes == 1
 
     def test_hours_property_should_return_whole_hours(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(7200)  # 7200 seconds = 2 hours
 
         assert duration.hours == 2
 
     def test_hours_property_should_truncate_partial_hours(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(5400)  # 5400 seconds = 1.5 hours
 
         assert duration.hours == 1
 
     def test_format_hms_should_return_formatted_string(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(3723)  # 1h 2m 3s
 
         assert duration.format_hms() == "01:02:03"
 
     def test_format_hms_with_zero_duration(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(0)
 
         assert duration.format_hms() == "00:00:00"
 
     def test_format_hms_with_large_duration(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(36000)  # 10 hours
 
         assert duration.format_hms() == "10:00:00"
 
     def test_format_hms_with_seconds_only(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(45)  # 45 seconds
 
@@ -99,7 +99,7 @@ class TestDurationComparison:
     """Tests for Duration comparison operators."""
 
     def test_should_compare_less_than(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration1 = Duration(100)
         duration2 = Duration(200)
@@ -107,7 +107,7 @@ class TestDurationComparison:
         assert duration1 < duration2
 
     def test_should_compare_greater_than(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration1 = Duration(200)
         duration2 = Duration(100)
@@ -115,7 +115,7 @@ class TestDurationComparison:
         assert duration1 > duration2
 
     def test_should_compare_less_than_or_equal(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration1 = Duration(100)
         duration2 = Duration(100)
@@ -123,7 +123,7 @@ class TestDurationComparison:
         assert duration1 <= duration2
 
     def test_should_compare_greater_than_or_equal(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration1 = Duration(100)
         duration2 = Duration(100)
@@ -131,7 +131,7 @@ class TestDurationComparison:
         assert duration1 >= duration2
 
     def test_comparison_with_wrong_type_returns_not_implemented(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(100)
 
@@ -142,7 +142,7 @@ class TestDurationEquality:
     """Tests for Duration equality and hashing."""
 
     def test_should_be_equal_when_same_value(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration1 = Duration(7200)
         duration2 = Duration(7200)
@@ -150,7 +150,7 @@ class TestDurationEquality:
         assert duration1 == duration2
 
     def test_should_not_be_equal_when_different_value(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration1 = Duration(7200)
         duration2 = Duration(3600)
@@ -158,7 +158,7 @@ class TestDurationEquality:
         assert duration1 != duration2
 
     def test_should_be_hashable(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(7200)
 
@@ -167,7 +167,7 @@ class TestDurationEquality:
         assert duration in duration_set
 
     def test_should_have_same_hash_when_equal(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration1 = Duration(7200)
         duration2 = Duration(7200)
@@ -179,14 +179,14 @@ class TestDurationStringRepresentation:
     """Tests for Duration string conversion."""
 
     def test_should_convert_to_string(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(7200)
 
         assert str(duration) == "7200"
 
     def test_should_have_descriptive_repr(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(7200)
 
@@ -197,9 +197,9 @@ class TestDurationImmutability:
     """Tests for Duration immutability."""
 
     def test_should_be_immutable(self):
-        from src.domain.media.value_objects import Duration
+        from src.modules.media.domain.value_objects import Duration
 
         duration = Duration(7200)
 
         with pytest.raises(DomainValidationException):
-            duration.root = 3600
+            duration.root = 3600  # type: ignore[misc]

--- a/tests/unit/domain/media/value_objects/test_file_path.py
+++ b/tests/unit/domain/media/value_objects/test_file_path.py
@@ -3,14 +3,14 @@
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
 
 
 class TestFilePathCreation:
     """Tests for FilePath instantiation."""
 
     def test_should_create_with_valid_unix_path(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/inception.mkv")
 
@@ -19,7 +19,7 @@ class TestFilePathCreation:
         assert "inception.mkv" in file_path.value
 
     def test_should_create_with_valid_windows_path(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("C:\\Movies\\inception.mkv")
 
@@ -27,7 +27,7 @@ class TestFilePathCreation:
         assert "inception.mkv" in file_path.value
 
     def test_should_strip_whitespace(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("  /movies/inception.mkv  ")
 
@@ -38,7 +38,7 @@ class TestFilePathCreation:
         assert not file_path.value.endswith(" ")
 
     def test_should_normalize_path(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies//subdir///inception.mkv")
 
@@ -46,68 +46,68 @@ class TestFilePathCreation:
         assert "//" not in file_path.value
 
     def test_should_raise_error_for_relative_path(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         with pytest.raises(DomainValidationException, match="absolute"):
             FilePath("movies/inception.mkv")
 
     def test_should_raise_error_for_directory_traversal(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         with pytest.raises(DomainValidationException, match="traversal"):
             FilePath("/movies/../etc/passwd")
 
     def test_should_raise_error_for_hidden_directory_traversal(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         with pytest.raises(DomainValidationException, match="traversal"):
             FilePath("/movies/subdir/../../etc/passwd")
 
     def test_should_raise_error_for_empty_string(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         with pytest.raises(DomainValidationException, match="cannot be empty"):
             FilePath("")
 
     def test_should_raise_error_for_whitespace_only(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         with pytest.raises(DomainValidationException, match="cannot be empty"):
             FilePath("   ")
 
     def test_should_raise_error_for_non_string_input(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         with pytest.raises(DomainValidationException):
-            FilePath(123)
+            FilePath(123)  # type: ignore[arg-type]
 
 
 class TestFilePathProperties:
     """Tests for FilePath computed properties."""
 
     def test_filename_should_return_file_name(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/inception.mkv")
 
         assert file_path.filename == "inception.mkv"
 
     def test_extension_should_return_file_extension(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/inception.mkv")
 
         assert file_path.extension == ".mkv"
 
     def test_extension_should_return_empty_for_no_extension(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/inception")
 
         assert file_path.extension == ""
 
     def test_directory_should_return_parent_directory(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/action/inception.mkv")
 
@@ -119,7 +119,7 @@ class TestFilePathEquality:
     """Tests for FilePath equality and hashing."""
 
     def test_should_be_equal_when_same_value(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         path1 = FilePath("/movies/inception.mkv")
         path2 = FilePath("/movies/inception.mkv")
@@ -127,7 +127,7 @@ class TestFilePathEquality:
         assert path1 == path2
 
     def test_should_not_be_equal_when_different_value(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         path1 = FilePath("/movies/inception.mkv")
         path2 = FilePath("/movies/interstellar.mkv")
@@ -135,7 +135,7 @@ class TestFilePathEquality:
         assert path1 != path2
 
     def test_should_be_hashable(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/inception.mkv")
 
@@ -144,7 +144,7 @@ class TestFilePathEquality:
         assert file_path in path_set
 
     def test_should_have_same_hash_when_equal(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         path1 = FilePath("/movies/inception.mkv")
         path2 = FilePath("/movies/inception.mkv")
@@ -156,7 +156,7 @@ class TestFilePathStringRepresentation:
     """Tests for FilePath string conversion."""
 
     def test_should_convert_to_string(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/inception.mkv")
 
@@ -164,7 +164,7 @@ class TestFilePathStringRepresentation:
         assert "inception.mkv" in str(file_path)
 
     def test_should_have_descriptive_repr(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/inception.mkv")
 
@@ -177,9 +177,9 @@ class TestFilePathImmutability:
     """Tests for FilePath immutability."""
 
     def test_should_be_immutable(self):
-        from src.domain.media.value_objects import FilePath
+        from src.modules.media.domain.value_objects import FilePath
 
         file_path = FilePath("/movies/inception.mkv")
 
         with pytest.raises(DomainValidationException):
-            file_path.root = "/movies/other.mkv"
+            file_path.root = "/movies/other.mkv"  # type: ignore[misc]

--- a/tests/unit/domain/media/value_objects/test_genre.py
+++ b/tests/unit/domain/media/value_objects/test_genre.py
@@ -2,40 +2,40 @@
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
 
 
 class TestGenreCreation:
     """Tests for Genre instantiation."""
 
     def test_should_create_with_valid_genre(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre = Genre("Action")
 
         assert genre.value == "Action"
 
     def test_should_strip_whitespace(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre = Genre("  Action  ")
 
         assert genre.value == "Action"
 
     def test_should_raise_error_for_empty_string(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         with pytest.raises(DomainValidationException, match="cannot be empty"):
             Genre("")
 
     def test_should_raise_error_for_whitespace_only(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         with pytest.raises(DomainValidationException, match="cannot be empty"):
             Genre("   ")
 
     def test_should_raise_error_when_exceeds_max_length(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         long_genre = "A" * 51
 
@@ -43,7 +43,7 @@ class TestGenreCreation:
             Genre(long_genre)
 
     def test_should_accept_genre_at_max_length(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         max_genre = "A" * 50
 
@@ -52,17 +52,17 @@ class TestGenreCreation:
         assert len(genre.value) == 50
 
     def test_should_raise_error_for_non_string_input(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         with pytest.raises(DomainValidationException):
-            Genre(123)
+            Genre(123)  # type: ignore[arg-type]
 
 
 class TestGenreEquality:
     """Tests for Genre equality and hashing."""
 
     def test_should_be_equal_when_same_value(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre1 = Genre("Action")
         genre2 = Genre("Action")
@@ -70,7 +70,7 @@ class TestGenreEquality:
         assert genre1 == genre2
 
     def test_should_not_be_equal_when_different_value(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre1 = Genre("Action")
         genre2 = Genre("Comedy")
@@ -78,7 +78,7 @@ class TestGenreEquality:
         assert genre1 != genre2
 
     def test_should_be_hashable(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre = Genre("Action")
 
@@ -87,7 +87,7 @@ class TestGenreEquality:
         assert genre in genre_set
 
     def test_should_have_same_hash_when_equal(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre1 = Genre("Action")
         genre2 = Genre("Action")
@@ -99,14 +99,14 @@ class TestGenreStringRepresentation:
     """Tests for Genre string conversion."""
 
     def test_should_convert_to_string(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre = Genre("Action")
 
         assert str(genre) == "Action"
 
     def test_should_have_descriptive_repr(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre = Genre("Action")
 
@@ -117,9 +117,9 @@ class TestGenreImmutability:
     """Tests for Genre immutability."""
 
     def test_should_be_immutable(self):
-        from src.domain.media.value_objects import Genre
+        from src.modules.media.domain.value_objects import Genre
 
         genre = Genre("Action")
 
         with pytest.raises(DomainValidationException):
-            genre.root = "Comedy"
+            genre.root = "Comedy"  # type: ignore[misc]

--- a/tests/unit/domain/media/value_objects/test_hdr_format.py
+++ b/tests/unit/domain/media/value_objects/test_hdr_format.py
@@ -1,6 +1,6 @@
 """Tests for HdrFormat enum."""
 
-from src.domain.media.value_objects import HdrFormat
+from src.modules.media.domain.value_objects import HdrFormat
 
 
 class TestHdrFormat:

--- a/tests/unit/domain/media/value_objects/test_media_file.py
+++ b/tests/unit/domain/media/value_objects/test_media_file.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from src.domain.media.value_objects import (
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.media.domain.value_objects import (
     AudioTrack,
     FilePath,
     HdrFormat,
@@ -11,8 +12,7 @@ from src.domain.media.value_objects import (
     SubtitleTrack,
     VideoCodec,
 )
-from src.domain.shared.exceptions.domain import DomainValidationException
-from src.domain.shared.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.language_code import LanguageCode
 
 
 class TestMediaFileCreation:

--- a/tests/unit/domain/media/value_objects/test_media_id.py
+++ b/tests/unit/domain/media/value_objects/test_media_id.py
@@ -2,35 +2,35 @@
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
-from src.domain.shared.models.external_id import RANDOM_PART_LENGTH
+from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.external_id import RANDOM_PART_LENGTH
 
 
 class TestMovieIdCreation:
     """Tests for MovieId instantiation."""
 
     def test_should_create_with_valid_format(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         movie_id = MovieId("mov_abc123abc123")
 
         assert movie_id.value == "mov_abc123abc123"
 
     def test_should_have_mov_prefix(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         movie_id = MovieId("mov_abc123abc123")
 
         assert movie_id.prefix == "mov"
 
     def test_should_raise_error_for_wrong_prefix(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         with pytest.raises(DomainValidationException, match="prefix"):
             MovieId("ser_abc123abc123")
 
     def test_should_raise_error_for_invalid_format(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         with pytest.raises(DomainValidationException):
             MovieId("mov_short")
@@ -40,21 +40,21 @@ class TestMovieIdGeneration:
     """Tests for MovieId.generate()."""
 
     def test_should_generate_with_mov_prefix(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         movie_id = MovieId.generate()
 
         assert movie_id.prefix == "mov"
 
     def test_should_generate_with_correct_random_part_length(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         movie_id = MovieId.generate()
 
         assert len(movie_id.random_part) == RANDOM_PART_LENGTH
 
     def test_should_generate_unique_ids(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         ids = [MovieId.generate() for _ in range(100)]
         unique_ids = {id_.value for id_ in ids}
@@ -66,21 +66,21 @@ class TestSeriesIdCreation:
     """Tests for SeriesId instantiation."""
 
     def test_should_create_with_valid_format(self):
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId("ser_abc123abc123")
 
         assert series_id.value == "ser_abc123abc123"
 
     def test_should_have_ser_prefix(self):
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId("ser_abc123abc123")
 
         assert series_id.prefix == "ser"
 
     def test_should_raise_error_for_wrong_prefix(self):
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.value_objects import SeriesId
 
         with pytest.raises(DomainValidationException, match="prefix"):
             SeriesId("mov_abc123abc123")
@@ -90,14 +90,14 @@ class TestSeriesIdGeneration:
     """Tests for SeriesId.generate()."""
 
     def test_should_generate_with_ser_prefix(self):
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.value_objects import SeriesId
 
         series_id = SeriesId.generate()
 
         assert series_id.prefix == "ser"
 
     def test_should_generate_unique_ids(self):
-        from src.domain.media.value_objects import SeriesId
+        from src.modules.media.domain.value_objects import SeriesId
 
         ids = [SeriesId.generate() for _ in range(100)]
         unique_ids = {id_.value for id_ in ids}
@@ -109,21 +109,21 @@ class TestSeasonIdCreation:
     """Tests for SeasonId instantiation."""
 
     def test_should_create_with_valid_format(self):
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.value_objects import SeasonId
 
         season_id = SeasonId("ssn_abc123abc123")
 
         assert season_id.value == "ssn_abc123abc123"
 
     def test_should_have_ssn_prefix(self):
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.value_objects import SeasonId
 
         season_id = SeasonId("ssn_abc123abc123")
 
         assert season_id.prefix == "ssn"
 
     def test_should_raise_error_for_wrong_prefix(self):
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.value_objects import SeasonId
 
         with pytest.raises(DomainValidationException, match="prefix"):
             SeasonId("mov_abc123abc123")
@@ -133,14 +133,14 @@ class TestSeasonIdGeneration:
     """Tests for SeasonId.generate()."""
 
     def test_should_generate_with_ssn_prefix(self):
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.value_objects import SeasonId
 
         season_id = SeasonId.generate()
 
         assert season_id.prefix == "ssn"
 
     def test_should_generate_unique_ids(self):
-        from src.domain.media.value_objects import SeasonId
+        from src.modules.media.domain.value_objects import SeasonId
 
         ids = [SeasonId.generate() for _ in range(100)]
         unique_ids = {id_.value for id_ in ids}
@@ -152,21 +152,21 @@ class TestEpisodeIdCreation:
     """Tests for EpisodeId instantiation."""
 
     def test_should_create_with_valid_format(self):
-        from src.domain.media.value_objects import EpisodeId
+        from src.modules.media.domain.value_objects import EpisodeId
 
         episode_id = EpisodeId("epi_abc123abc123")
 
         assert episode_id.value == "epi_abc123abc123"
 
     def test_should_have_epi_prefix(self):
-        from src.domain.media.value_objects import EpisodeId
+        from src.modules.media.domain.value_objects import EpisodeId
 
         episode_id = EpisodeId("epi_abc123abc123")
 
         assert episode_id.prefix == "epi"
 
     def test_should_raise_error_for_wrong_prefix(self):
-        from src.domain.media.value_objects import EpisodeId
+        from src.modules.media.domain.value_objects import EpisodeId
 
         with pytest.raises(DomainValidationException, match="prefix"):
             EpisodeId("mov_abc123abc123")
@@ -176,14 +176,14 @@ class TestEpisodeIdGeneration:
     """Tests for EpisodeId.generate()."""
 
     def test_should_generate_with_epi_prefix(self):
-        from src.domain.media.value_objects import EpisodeId
+        from src.modules.media.domain.value_objects import EpisodeId
 
         episode_id = EpisodeId.generate()
 
         assert episode_id.prefix == "epi"
 
     def test_should_generate_unique_ids(self):
-        from src.domain.media.value_objects import EpisodeId
+        from src.modules.media.domain.value_objects import EpisodeId
 
         ids = [EpisodeId.generate() for _ in range(100)]
         unique_ids = {id_.value for id_ in ids}
@@ -195,7 +195,7 @@ class TestMediaIdEquality:
     """Tests for MediaId equality between different types."""
 
     def test_movie_id_should_not_equal_series_id_with_same_random_part(self):
-        from src.domain.media.value_objects import MovieId, SeriesId
+        from src.modules.media.domain.value_objects import MovieId, SeriesId
 
         movie_id = MovieId("mov_abc123abc123")
         series_id = SeriesId("ser_abc123abc123")
@@ -204,7 +204,7 @@ class TestMediaIdEquality:
         assert movie_id != series_id
 
     def test_same_movie_ids_should_be_equal(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         id1 = MovieId("mov_abc123abc123")
         id2 = MovieId("mov_abc123abc123")
@@ -212,7 +212,7 @@ class TestMediaIdEquality:
         assert id1 == id2
 
     def test_movie_id_should_be_hashable(self):
-        from src.domain.media.value_objects import MovieId
+        from src.modules.media.domain.value_objects import MovieId
 
         movie_id = MovieId("mov_abc123abc123")
 
@@ -225,7 +225,7 @@ class TestParseMediaId:
     """Tests for parse_media_id function."""
 
     def test_should_parse_movie_id(self):
-        from src.domain.media.value_objects import MovieId, parse_media_id
+        from src.modules.media.domain.value_objects import MovieId, parse_media_id
 
         result = parse_media_id("mov_abc123abc123")
 
@@ -233,7 +233,7 @@ class TestParseMediaId:
         assert result.value == "mov_abc123abc123"
 
     def test_should_parse_series_id(self):
-        from src.domain.media.value_objects import SeriesId, parse_media_id
+        from src.modules.media.domain.value_objects import SeriesId, parse_media_id
 
         result = parse_media_id("ser_abc123abc123")
 
@@ -241,7 +241,7 @@ class TestParseMediaId:
         assert result.value == "ser_abc123abc123"
 
     def test_should_parse_episode_id(self):
-        from src.domain.media.value_objects import EpisodeId, parse_media_id
+        from src.modules.media.domain.value_objects import EpisodeId, parse_media_id
 
         result = parse_media_id("epi_abc123abc123")
 
@@ -249,7 +249,7 @@ class TestParseMediaId:
         assert result.value == "epi_abc123abc123"
 
     def test_should_parse_season_id(self):
-        from src.domain.media.value_objects import SeasonId, parse_media_id
+        from src.modules.media.domain.value_objects import SeasonId, parse_media_id
 
         result = parse_media_id("ssn_abc123abc123")
 
@@ -257,19 +257,19 @@ class TestParseMediaId:
         assert result.value == "ssn_abc123abc123"
 
     def test_should_raise_error_for_unknown_prefix(self):
-        from src.domain.media.value_objects import parse_media_id
+        from src.modules.media.domain.value_objects import parse_media_id
 
         with pytest.raises(DomainValidationException, match="Unknown media prefix"):
             parse_media_id("xyz_abc123abc123")
 
     def test_should_raise_error_for_invalid_format(self):
-        from src.domain.media.value_objects import parse_media_id
+        from src.modules.media.domain.value_objects import parse_media_id
 
         with pytest.raises(DomainValidationException, match="Invalid media ID format"):
             parse_media_id("invalidformat")
 
     def test_should_raise_error_for_empty_string(self):
-        from src.domain.media.value_objects import parse_media_id
+        from src.modules.media.domain.value_objects import parse_media_id
 
         with pytest.raises(DomainValidationException, match="Invalid media ID format"):
             parse_media_id("")

--- a/tests/unit/domain/media/value_objects/test_resolution.py
+++ b/tests/unit/domain/media/value_objects/test_resolution.py
@@ -2,14 +2,14 @@
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
 
 
 class TestResolutionCreation:
     """Tests for Resolution instantiation."""
 
     def test_should_create_with_360p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("360p")
 
@@ -18,7 +18,7 @@ class TestResolutionCreation:
         assert resolution.height == 360
 
     def test_should_create_with_480p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("480p")
 
@@ -27,7 +27,7 @@ class TestResolutionCreation:
         assert resolution.height == 480
 
     def test_should_create_with_720p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("720p")
 
@@ -36,7 +36,7 @@ class TestResolutionCreation:
         assert resolution.height == 720
 
     def test_should_create_with_1080p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("1080p")
 
@@ -45,7 +45,7 @@ class TestResolutionCreation:
         assert resolution.height == 1080
 
     def test_should_create_with_2k(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("2K")
 
@@ -54,7 +54,7 @@ class TestResolutionCreation:
         assert resolution.height == 1440
 
     def test_should_create_with_4k(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("4K")
 
@@ -63,7 +63,7 @@ class TestResolutionCreation:
         assert resolution.height == 2160
 
     def test_should_create_with_unknown(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("Unknown")
 
@@ -72,26 +72,26 @@ class TestResolutionCreation:
         assert resolution.height == 0
 
     def test_should_strip_whitespace(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("  1080p  ")
 
         assert resolution.value == "1080p"
 
     def test_should_raise_error_for_invalid_resolution(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         with pytest.raises(DomainValidationException, match="must be one of"):
             Resolution("240p")
 
     def test_should_raise_error_for_empty_string(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         with pytest.raises(DomainValidationException):
             Resolution("")
 
     def test_should_raise_error_for_non_string_input(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         with pytest.raises((DomainValidationException, ValueError, TypeError)):
             Resolution(1080)
@@ -101,14 +101,14 @@ class TestResolutionFactoryMethods:
     """Tests for Resolution factory methods."""
 
     def test_unknown_factory_should_create_unknown_resolution(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution.unknown()
 
         assert resolution.value == "Unknown"
 
     def test_from_name_should_create_resolution(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution.from_name("4K")
 
@@ -120,91 +120,91 @@ class TestResolutionProperties:
     """Tests for Resolution computed properties."""
 
     def test_is_sd_should_return_true_for_360p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("360p")
 
         assert resolution.is_sd is True
 
     def test_is_sd_should_return_true_for_480p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("480p")
 
         assert resolution.is_sd is True
 
     def test_is_sd_should_return_false_for_720p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("720p")
 
         assert resolution.is_sd is False
 
     def test_is_sd_should_return_false_for_unknown(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("Unknown")
 
         assert resolution.is_sd is False
 
     def test_is_hd_should_return_true_for_720p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("720p")
 
         assert resolution.is_hd is True
 
     def test_is_hd_should_return_true_for_1080p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("1080p")
 
         assert resolution.is_hd is True
 
     def test_is_hd_should_return_true_for_2k(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("2K")
 
         assert resolution.is_hd is True
 
     def test_is_hd_should_return_true_for_4k(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("4K")
 
         assert resolution.is_hd is True
 
     def test_is_hd_should_return_false_for_360p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("360p")
 
         assert resolution.is_hd is False
 
     def test_is_hd_should_return_false_for_480p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("480p")
 
         assert resolution.is_hd is False
 
     def test_is_hd_should_return_false_for_unknown(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("Unknown")
 
         assert resolution.is_hd is False
 
     def test_is_4k_should_return_true_for_4k(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("4K")
 
         assert resolution.is_4k is True
 
     def test_is_4k_should_return_false_for_1080p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("1080p")
 
@@ -215,21 +215,21 @@ class TestResolutionPixels:
     """Tests for Resolution pixel computations."""
 
     def test_total_pixels_for_1080p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("1080p")
 
         assert resolution.total_pixels == 1920 * 1080
 
     def test_total_pixels_for_4k(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("4K")
 
         assert resolution.total_pixels == 3840 * 2160
 
     def test_total_pixels_for_unknown(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("Unknown")
 
@@ -240,17 +240,17 @@ class TestResolutionComparison:
     """Tests for Resolution comparison operators."""
 
     def test_4k_should_be_greater_than_1080p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         assert Resolution("4K") > Resolution("1080p")
 
     def test_720p_should_be_less_than_1080p(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         assert Resolution("720p") < Resolution("1080p")
 
     def test_same_resolution_should_be_ge_and_le(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         r1 = Resolution("1080p")
         r2 = Resolution("1080p")
@@ -259,7 +259,7 @@ class TestResolutionComparison:
         assert r1 <= r2
 
     def test_all_resolutions_sort_correctly(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolutions = [
             Resolution("4K"),
@@ -286,7 +286,7 @@ class TestResolutionEquality:
     """Tests for Resolution equality and hashing."""
 
     def test_should_be_equal_when_same_value(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         res1 = Resolution("1080p")
         res2 = Resolution("1080p")
@@ -294,7 +294,7 @@ class TestResolutionEquality:
         assert res1 == res2
 
     def test_should_not_be_equal_when_different_value(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         res1 = Resolution("1080p")
         res2 = Resolution("4K")
@@ -302,7 +302,7 @@ class TestResolutionEquality:
         assert res1 != res2
 
     def test_should_be_hashable(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("1080p")
 
@@ -315,14 +315,14 @@ class TestResolutionStringRepresentation:
     """Tests for Resolution string conversion."""
 
     def test_should_convert_to_string(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("1080p")
 
         assert str(resolution) == "1080p"
 
     def test_should_have_descriptive_repr(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("1080p")
 
@@ -333,7 +333,7 @@ class TestResolutionImmutability:
     """Tests for Resolution immutability."""
 
     def test_should_be_immutable(self):
-        from src.domain.media.value_objects import Resolution
+        from src.modules.media.domain.value_objects import Resolution
 
         resolution = Resolution("1080p")
 
@@ -345,7 +345,7 @@ class TestResolutionPydanticFieldValidation:
     """Tests that Resolution works as a Pydantic field with string input."""
 
     def test_string_input_in_pydantic_model(self):
-        from src.domain.media.value_objects import (
+        from src.modules.media.domain.value_objects import (
             FilePath,
             MediaFile,
         )

--- a/tests/unit/domain/media/value_objects/test_title.py
+++ b/tests/unit/domain/media/value_objects/test_title.py
@@ -2,68 +2,68 @@
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
 
 
 class TestTitleCreation:
     """Tests for Title instantiation."""
 
     def test_should_create_with_valid_title(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("Inception")
 
         assert title.value == "Inception"
 
     def test_should_strip_leading_whitespace(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("   Inception")
 
         assert title.value == "Inception"
 
     def test_should_strip_trailing_whitespace(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("Inception   ")
 
         assert title.value == "Inception"
 
     def test_should_strip_both_leading_and_trailing_whitespace(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("   Inception   ")
 
         assert title.value == "Inception"
 
     def test_should_collapse_multiple_spaces_to_single(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("The    Dark    Knight")
 
         assert title.value == "The Dark Knight"
 
     def test_should_handle_tabs_and_newlines(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("The\t\tDark\n\nKnight")
 
         assert title.value == "The Dark Knight"
 
     def test_should_raise_error_for_empty_string(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         with pytest.raises(DomainValidationException, match="cannot be empty"):
             Title("")
 
     def test_should_raise_error_for_whitespace_only(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         with pytest.raises(DomainValidationException, match="cannot be empty"):
             Title("   ")
 
     def test_should_raise_error_when_exceeds_max_length(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         long_title = "A" * 501
 
@@ -71,7 +71,7 @@ class TestTitleCreation:
             Title(long_title)
 
     def test_should_accept_title_at_max_length(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         max_title = "A" * 500
 
@@ -80,17 +80,17 @@ class TestTitleCreation:
         assert len(title.value) == 500
 
     def test_should_raise_error_for_non_string_input(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         with pytest.raises(DomainValidationException):
-            Title(123)
+            Title(123)  # type: ignore[arg-type]
 
 
 class TestTitleEquality:
     """Tests for Title equality and hashing."""
 
     def test_should_be_equal_when_same_value(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title1 = Title("Inception")
         title2 = Title("Inception")
@@ -98,7 +98,7 @@ class TestTitleEquality:
         assert title1 == title2
 
     def test_should_not_be_equal_when_different_value(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title1 = Title("Inception")
         title2 = Title("Interstellar")
@@ -106,7 +106,7 @@ class TestTitleEquality:
         assert title1 != title2
 
     def test_should_be_equal_after_normalization(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title1 = Title("The Dark Knight")
         title2 = Title("  The   Dark   Knight  ")
@@ -114,7 +114,7 @@ class TestTitleEquality:
         assert title1 == title2
 
     def test_should_be_hashable(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("Inception")
 
@@ -123,7 +123,7 @@ class TestTitleEquality:
         assert title in title_set
 
     def test_should_have_same_hash_when_equal(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title1 = Title("Inception")
         title2 = Title("Inception")
@@ -135,14 +135,14 @@ class TestTitleStringRepresentation:
     """Tests for Title string conversion."""
 
     def test_should_convert_to_string(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("Inception")
 
         assert str(title) == "Inception"
 
     def test_should_have_descriptive_repr(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("Inception")
 
@@ -153,9 +153,9 @@ class TestTitleImmutability:
     """Tests for Title immutability."""
 
     def test_should_be_immutable(self):
-        from src.domain.media.value_objects import Title
+        from src.modules.media.domain.value_objects import Title
 
         title = Title("Inception")
 
         with pytest.raises(DomainValidationException):
-            title.root = "Interstellar"
+            title.root = "Interstellar"  # type: ignore[misc]

--- a/tests/unit/domain/media/value_objects/test_video_codec.py
+++ b/tests/unit/domain/media/value_objects/test_video_codec.py
@@ -1,6 +1,6 @@
 """Tests for VideoCodec enum."""
 
-from src.domain.media.value_objects import VideoCodec
+from src.modules.media.domain.value_objects import VideoCodec
 
 
 class TestVideoCodec:

--- a/tests/unit/domain/media/value_objects/test_year.py
+++ b/tests/unit/domain/media/value_objects/test_year.py
@@ -4,28 +4,28 @@ from datetime import datetime
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
+from src.building_blocks.domain.errors import DomainValidationException
 
 
 class TestYearCreation:
     """Tests for Year instantiation."""
 
     def test_should_create_with_valid_year(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year = Year(2024)
 
         assert year.value == 2024
 
     def test_should_create_with_minimum_valid_year(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year = Year(1800)
 
         assert year.value == 1800
 
     def test_should_create_with_future_year_within_limit(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         current_year = datetime.now().year
         future_year = current_year + 10
@@ -35,13 +35,13 @@ class TestYearCreation:
         assert year.value == future_year
 
     def test_should_raise_error_for_year_before_minimum(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         with pytest.raises(DomainValidationException, match="1800"):
             Year(1799)
 
     def test_should_raise_error_for_year_too_far_in_future(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         current_year = datetime.now().year
         too_far = current_year + 11
@@ -50,17 +50,17 @@ class TestYearCreation:
             Year(too_far)
 
     def test_should_raise_error_for_non_integer_input(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         with pytest.raises(DomainValidationException):
-            Year("2024")
+            Year("2024")  # type: ignore[arg-type]
 
 
 class TestYearComparison:
     """Tests for Year comparison operators."""
 
     def test_should_compare_less_than(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year1 = Year(2020)
         year2 = Year(2024)
@@ -68,7 +68,7 @@ class TestYearComparison:
         assert year1 < year2
 
     def test_should_compare_greater_than(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year1 = Year(2024)
         year2 = Year(2020)
@@ -76,7 +76,7 @@ class TestYearComparison:
         assert year1 > year2
 
     def test_should_compare_less_than_or_equal(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year1 = Year(2024)
         year2 = Year(2024)
@@ -84,7 +84,7 @@ class TestYearComparison:
         assert year1 <= year2
 
     def test_should_compare_greater_than_or_equal(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year1 = Year(2024)
         year2 = Year(2024)
@@ -96,7 +96,7 @@ class TestYearEquality:
     """Tests for Year equality and hashing."""
 
     def test_should_be_equal_when_same_value(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year1 = Year(2024)
         year2 = Year(2024)
@@ -104,7 +104,7 @@ class TestYearEquality:
         assert year1 == year2
 
     def test_should_not_be_equal_when_different_value(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year1 = Year(2024)
         year2 = Year(2020)
@@ -112,7 +112,7 @@ class TestYearEquality:
         assert year1 != year2
 
     def test_should_be_hashable(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year = Year(2024)
 
@@ -125,14 +125,14 @@ class TestYearStringRepresentation:
     """Tests for Year string conversion."""
 
     def test_should_convert_to_string(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year = Year(2024)
 
         assert str(year) == "2024"
 
     def test_should_have_descriptive_repr(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year = Year(2024)
 
@@ -143,9 +143,9 @@ class TestYearImmutability:
     """Tests for Year immutability."""
 
     def test_should_be_immutable(self):
-        from src.domain.media.value_objects import Year
+        from src.modules.media.domain.value_objects import Year
 
         year = Year(2024)
 
         with pytest.raises(DomainValidationException):
-            year.root = 2020
+            year.root = 2020  # type: ignore[misc]

--- a/tests/unit/domain/shared/exceptions/test_base.py
+++ b/tests/unit/domain/shared/exceptions/test_base.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-from src.domain.shared.exceptions.base import (
+from src.building_blocks.domain.errors import (
     CoreException,
     ExceptionDetail,
     Severity,

--- a/tests/unit/domain/shared/exceptions/test_domain.py
+++ b/tests/unit/domain/shared/exceptions/test_domain.py
@@ -1,12 +1,12 @@
 """Tests for domain layer exceptions."""
 
-from src.domain.shared.exceptions.base import Severity
-from src.domain.shared.exceptions.domain import (
+from src.building_blocks.domain.errors import (
     BusinessRuleViolationException,
     DomainConflictException,
     DomainException,
     DomainNotFoundException,
     DomainValidationException,
+    Severity,
 )
 
 

--- a/tests/unit/domain/shared/models/test_domain_model.py
+++ b/tests/unit/domain/shared/models/test_domain_model.py
@@ -4,8 +4,8 @@ from typing import ClassVar
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
-from src.domain.shared.models import DomainModel
+from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.models import DomainModel
 
 
 class SampleModel(DomainModel):
@@ -30,11 +30,11 @@ class TestDomainModelCreation:
 
     def test_should_raise_domain_validation_error_for_missing_required_field(self):
         with pytest.raises(DomainValidationException):
-            SampleModel(name="John")
+            SampleModel(name="John")  # type: ignore[call-arg]
 
     def test_should_forbid_extra_attributes(self):
         with pytest.raises(DomainValidationException):
-            SampleModel(name="John", age=30, extra="not_allowed")
+            SampleModel(name="John", age=30, extra="not_allowed")  # type: ignore[call-arg]
 
 
 class TestDomainModelValidation:
@@ -68,7 +68,7 @@ class TestDomainModelAssignment:
         model = SampleModel(name="John", age=30)
 
         with pytest.raises(DomainValidationException):
-            model.age = "invalid"
+            model.age = "invalid"  # type: ignore[assignment]
 
     def test_should_allow_valid_assignment(self):
         model = SampleModel(name="John", age=30)
@@ -113,7 +113,7 @@ class TestDomainModelConfigValidation:
         with pytest.raises(TypeError, match="extra='forbid'"):
             # This class definition should fail because extra="allow" is not permitted
             class InvalidExtraModel(DomainModel):
-                model_config: ClassVar[dict[str, object]] = {
+                model_config: ClassVar[dict[str, object]] = {  # type: ignore[assignment]
                     "extra": "allow",
                     "validate_assignment": True,
                 }
@@ -123,7 +123,7 @@ class TestDomainModelConfigValidation:
         with pytest.raises(TypeError, match="validate_assignment=True"):
 
             class InvalidValidationModel(DomainModel):
-                model_config: ClassVar[dict[str, object]] = {
+                model_config: ClassVar[dict[str, object]] = {  # type: ignore[assignment]
                     "extra": "forbid",
                     "validate_assignment": False,
                 }

--- a/tests/unit/domain/shared/models/test_entity.py
+++ b/tests/unit/domain/shared/models/test_entity.py
@@ -5,8 +5,8 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import Field
 
-from src.domain.shared.exceptions.domain import DomainValidationException
-from src.domain.shared.models import AggregateRoot, DomainEntity, utc_now
+from src.building_blocks.domain.entity import AggregateRoot, DomainEntity, utc_now
+from src.building_blocks.domain.errors import DomainValidationException
 
 
 class SampleEntity(DomainEntity[str]):

--- a/tests/unit/domain/shared/models/test_external_id.py
+++ b/tests/unit/domain/shared/models/test_external_id.py
@@ -4,8 +4,8 @@ from typing import ClassVar
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
-from src.domain.shared.models.external_id import (
+from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.external_id import (
     BASE62_ALPHABET,
     RANDOM_PART_LENGTH,
     ExternalId,

--- a/tests/unit/domain/shared/models/test_value_object.py
+++ b/tests/unit/domain/shared/models/test_value_object.py
@@ -4,8 +4,8 @@ from datetime import date
 
 import pytest
 
-from src.domain.shared.exceptions.domain import DomainValidationException
-from src.domain.shared.models import (
+from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.value_objects import (
     CompoundValueObject,
     DateValueObject,
     FloatValueObject,
@@ -58,7 +58,7 @@ class TestCompoundValueObject:
         vo = SampleCompoundVO(name="Test", code=123)
 
         with pytest.raises(DomainValidationException):
-            vo.name = "Changed"
+            vo.name = "Changed"  # type: ignore[misc]
 
     def test_should_support_with_updates(self):
         original = SampleCompoundVO(name="Test", code=123)
@@ -125,7 +125,7 @@ class TestStringValueObject:
 
     def test_should_raise_error_for_non_string_input(self):
         with pytest.raises(DomainValidationException):
-            SampleStringVO(123)
+            SampleStringVO(123)  # type: ignore[arg-type]
 
 
 class TestIntValueObject:
@@ -207,7 +207,7 @@ class TestIntValueObject:
 
     def test_should_raise_error_for_non_integer_input(self):
         with pytest.raises(DomainValidationException):
-            SampleIntVO("not_an_int")
+            SampleIntVO("not_an_int")  # type: ignore[arg-type]
 
 
 class TestFloatValueObject:
@@ -254,7 +254,7 @@ class TestFloatValueObject:
 
     def test_should_raise_error_for_non_numeric_input(self):
         with pytest.raises(DomainValidationException):
-            SampleFloatVO("not_a_float")
+            SampleFloatVO("not_a_float")  # type: ignore[arg-type]
 
 
 class TestDateValueObject:
@@ -298,10 +298,10 @@ class TestDateValueObject:
         assert vo in vo_set
 
     def test_should_parse_date_from_string(self):
-        vo = SampleDateVO("2024-06-15")
+        vo = SampleDateVO("2024-06-15")  # type: ignore[arg-type]
 
         assert vo.value == date(2024, 6, 15)
 
     def test_should_raise_error_for_invalid_date_string(self):
         with pytest.raises(DomainValidationException):
-            SampleDateVO("not-a-date")
+            SampleDateVO("not-a-date")  # type: ignore[arg-type]

--- a/tests/unit/infrastructure/persistence/mappers/test_movie_mapper.py
+++ b/tests/unit/infrastructure/persistence/mappers/test_movie_mapper.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from src.domain.media.entities import Movie
-from src.domain.media.value_objects import (
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects import (
     Duration,
     FilePath,
     MediaFile,
@@ -12,7 +12,7 @@ from src.domain.media.value_objects import (
     Title,
     Year,
 )
-from src.infrastructure.persistence.mappers import MovieMapper
+from src.modules.media.infrastructure.persistence.mappers import MovieMapper
 
 
 def _create_movie(movie_id: MovieId | None = None) -> Movie:

--- a/tests/unit/infrastructure/persistence/mappers/test_series_mapper.py
+++ b/tests/unit/infrastructure/persistence/mappers/test_series_mapper.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from src.domain.media.entities import Episode, Season, Series
-from src.domain.media.value_objects import (
+from src.modules.media.domain.entities import Episode, Season, Series
+from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
     FilePath,
@@ -14,7 +14,11 @@ from src.domain.media.value_objects import (
     Title,
     Year,
 )
-from src.infrastructure.persistence.mappers import EpisodeMapper, SeasonMapper, SeriesMapper
+from src.modules.media.infrastructure.persistence.mappers import (
+    EpisodeMapper,
+    SeasonMapper,
+    SeriesMapper,
+)
 
 
 def _create_episode(


### PR DESCRIPTION
## Summary

- Update import paths in all 41 test files from legacy paths to canonical module paths
- Import substitution map:
  - `src.domain.shared.models` → `src.building_blocks.domain.*`
  - `src.domain.shared.exceptions.*` → `src.building_blocks.domain.errors`
  - `src.application.shared.exceptions` → `src.building_blocks.application.errors`
  - `src.domain.media.*` → `src.modules.media.domain.*`
  - `src.domain.library.*` → `src.modules.library.domain.*`
  - `src.application.media.*` → `src.modules.media.application.*`
  - `src.infrastructure.persistence.{mappers,repositories}.*` → `src.modules.media.infrastructure.persistence.*`
  - Shared VOs (FilePath, LanguageCode, tracks) → `src.shared_kernel.value_objects.*`
- Add `# type: ignore` comments for 25 pre-existing mypy errors in tests (intentional invalid-input tests)

## Test plan

- [x] All 644 tests pass
- [x] `ruff check` clean
- [x] `mypy` clean (pre-commit hook)

## Summary by Sourcery

Align tests with new modular package structure and shared kernel abstractions.

Enhancements:
- Update test imports to use canonical module paths for media, library, building blocks, and shared kernel packages.
- Switch tests from legacy domain/shared exception and model modules to centralized building_blocks and shared_kernel equivalents.
- Annotate intentionally invalid type usages in tests with type: ignore to keep mypy checks clean.