### PR TITLE
docs: add ADR-008 for screaming architecture

### DIFF
--- a/docs/adr/ADR-003-package-structure.md
+++ b/docs/adr/ADR-003-package-structure.md
@@ -1,8 +1,8 @@
 # ADR-003: Estrutura de Pacotes e Organização do Projeto
 
-**Status:** Aceito  
-**Data:** 2025-01-28  
-**Deciders:** Lucas  
+**Status:** Substituído por [ADR-008](ADR-008-screaming-architecture.md)
+**Data:** 2025-01-28
+**Deciders:** Lucas
 **Technical Story:** Definir organização de pastas seguindo Clean Architecture
 
 ---
@@ -173,7 +173,7 @@ application/shared/
 
 ```
 domain/shared/exceptions/          # DomainException
-application/shared/exceptions/     # ApplicationException  
+application/shared/exceptions/     # ApplicationException
 infrastructure/exceptions/         # InfrastructureException
 presentation/exceptions/           # PresentationException
 ```

--- a/docs/adr/ADR-008-screaming-architecture.md
+++ b/docs/adr/ADR-008-screaming-architecture.md
@@ -1,0 +1,152 @@
+# ADR-008: Screaming Architecture with Modules
+
+**Status:** Aceito
+**Data:** 2026-04-02
+**Deciders:** Lucas
+**Technical Story:** Reorganizar projeto para Screaming Architecture com módulos
+**Substitui:** ADR-003
+
+---
+
+## Contexto
+
+A estrutura anterior (ADR-003) organizava o código por **camadas técnicas** na raiz (`domain/`, `application/`, `infrastructure/`, `presentation/`), com bounded contexts aninhados dentro de cada camada. Isso significava:
+
+1. Para entender a feature "Media", era necessário navegar 4 diretórios top-level
+2. A pasta `src/` "gritava" arquitetura técnica, não domínio de negócio
+3. À medida que novos contextos fossem adicionados, a fragmentação aumentaria
+4. Shared code misturava base classes técnicas com value objects de negócio
+
+## Decisão
+
+**Adotamos Screaming Architecture: módulos de negócio como eixo primário, com camadas técnicas internas a cada módulo.**
+
+Olhando `src/modules/`, o desenvolvedor entende imediatamente que o sistema gerencia **media** e **libraries**.
+
+### Estrutura Adotada
+
+```
+src/
+├── building_blocks/              # Base técnica domain-agnostic
+│   ├── domain/
+│   │   ├── models.py             # DomainModel, SupportsUpdates
+│   │   ├── value_objects.py      # ValueObject, StringVO, IntVO, etc.
+│   │   ├── entity.py             # DomainEntity, AggregateRoot
+│   │   ├── external_id.py        # ExternalId (prefixed IDs)
+│   │   └── errors.py             # CoreException, DomainException hierarchy
+│   ├── application/
+│   │   └── errors.py             # ApplicationException hierarchy
+│   └── infrastructure/
+│       └── errors.py             # InfrastructureException hierarchy
+│
+├── shared_kernel/                # Conceitos de negócio cross-module
+│   └── value_objects/
+│       ├── file_path.py          # FilePath
+│       ├── language_code.py      # LanguageCode
+│       └── tracks.py             # AudioTrack, SubtitleTrack
+│
+├── modules/
+│   ├── media/                    # Bounded Context: Media Catalog
+│   │   ├── domain/
+│   │   │   ├── entities/         # Movie, Series, Season, Episode
+│   │   │   ├── value_objects/    # MovieId, Title, Year, Duration, etc.
+│   │   │   ├── repositories/     # MovieRepository, SeriesRepository (ABCs)
+│   │   │   ├── services/         # FileSelector
+│   │   │   └── rule_codes.py
+│   │   ├── application/
+│   │   │   ├── use_cases/        # GetMovieById, ListMovies, etc.
+│   │   │   └── dtos/             # MovieOutput, SeriesOutput, etc.
+│   │   ├── infrastructure/
+│   │   │   └── persistence/
+│   │   │       ├── models/       # SQLAlchemy ORM models
+│   │   │       ├── repositories/ # SQLAlchemy implementations
+│   │   │       └── mappers/      # Entity <-> ORM mappers
+│   │   └── presentation/
+│   │       └── routes/
+│   │
+│   └── library/                  # Bounded Context: Library Management
+│       ├── domain/
+│       │   ├── entities/         # Library
+│       │   ├── value_objects/    # LibraryId, LibraryName, etc.
+│       │   ├── repositories/     # LibraryRepository (ABC)
+│       │   ├── services/         # TrackSelector
+│       │   └── rule_codes.py
+│       ├── application/
+│       ├── infrastructure/
+│       └── presentation/
+│
+├── infrastructure/               # Infra compartilhada cross-module
+│   └── persistence/
+│       ├── database.py
+│       └── models/
+│           └── base.py           # SQLAlchemy Base
+│
+├── config/
+│   ├── settings.py
+│   ├── logging.py
+│   └── containers/
+│       ├── main.py               # ApplicationContainer
+│       ├── infrastructure.py     # InfrastructureContainer
+│       ├── media.py              # MediaContainer
+│       └── library.py            # LibraryContainer
+│
+└── main.py
+```
+
+### Princípios
+
+1. **Módulos não importam entre si** — comunicação futura via integration events no shared_kernel
+2. **building_blocks é domain-agnostic** — apenas base classes e patterns técnicos
+3. **shared_kernel é mínimo** — apenas VOs genuinamente usados por múltiplos módulos
+4. **Cada módulo tem as 4 camadas** — domain, application, infrastructure, presentation
+5. **Regra de dependência** — `modules → shared_kernel → building_blocks`
+
+## Consequências
+
+### Positivas
+
+1. **O código "grita" domínio** — `src/modules/media/` diz mais que `src/domain/media/`
+2. **Feature completa em um lugar** — tudo sobre Media está sob `modules/media/`
+3. **Melhor isolamento** — módulos são independentes, facilitam extração futura
+4. **DI containers por módulo** — MediaContainer, LibraryContainer com suas dependências
+
+### Negativas
+
+1. **Paths mais profundos** — `src.modules.media.domain.value_objects.resolution`
+2. **Mais boilerplate em `__init__.py`** — cada módulo tem ~10 init files
+3. **shared_kernel requer disciplina** — fácil abusar jogando coisas que são de um módulo só
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| shared_kernel crescer demais | Média | Médio | Code review + regra: só entra se 2+ módulos usam |
+| Imports circulares entre módulos | Baixa | Alto | Módulos não importam entre si; usar integration events |
+
+## Alternativas Consideradas
+
+### 1. Manter ADR-003 (Camadas na Raiz)
+
+Estrutura anterior com `src/domain/`, `src/application/`, etc.
+
+**Rejeitado porque:** Feature espalhada em 4 diretórios. À medida que o projeto cresce, fica cada vez mais difícil raciocinar sobre um bounded context completo.
+
+### 2. Vertical Slices sem building_blocks
+
+Módulos diretos sem base classes compartilhadas.
+
+**Rejeitado porque:** Duplicação de base classes (Entity, ValueObject, exception hierarchy) em cada módulo.
+
+## Referências
+
+- [Screaming Architecture - Uncle Bob](https://blog.cleancoder.com/uncle-bob/2011/09/30/Screaming-Architecture.html)
+- [Clean Architecture - Uncle Bob](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
+- ADR-003 (substituído por este ADR)
+
+---
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-02 | Lucas | Criação inicial |

--- a/docs/adr/ADR-008-screaming-architecture.md
+++ b/docs/adr/ADR-008-screaming-architecture.md
@@ -101,6 +101,39 @@ src/
 4. **Cada módulo tem as 4 camadas** — domain, application, infrastructure, presentation
 5. **Regra de dependência** — `modules → shared_kernel → building_blocks`
 
+### Infrastructure: top-level vs module-level
+
+| Camada | Localização | Responsabilidade |
+|--------|-------------|------------------|
+| **Shared** | `src/infrastructure/` | Recursos cross-module: `database.py` (engine, session factory), `models/base.py` (SQLAlchemy Base com soft delete, timestamps) |
+| **Module** | `src/modules/<ctx>/infrastructure/` | Implementações específicas do módulo: ORM models, repository implementations, mappers, API clients |
+
+A regra é simples: se **todos** os módulos precisam (Base, Database), fica em `src/infrastructure/`. Se é **específico** de um módulo (MovieModel, SQLAlchemyMovieRepository), fica em `modules/<ctx>/infrastructure/`. Module infrastructure importa de shared infrastructure (e.g., `from src.infrastructure.persistence.models.base import Base`), mas nunca o contrário.
+
+### Imports permitidos e proibidos
+
+```python
+# ✅ Permitido — módulo importa de building_blocks, shared_kernel, e sua própria infra
+from src.building_blocks.domain.entity import AggregateRoot
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.modules.media.domain.entities import Movie                    # dentro do próprio módulo
+from src.infrastructure.persistence.models.base import Base            # shared infra
+
+# ✅ Permitido — config/containers importa de módulos (é o composition root)
+from src.modules.media.infrastructure.persistence.repositories import SQLAlchemyMovieRepository
+
+# ❌ Proibido — módulo importa de outro módulo
+from src.modules.library.domain.entities import Library                # dentro de modules/media/
+
+# ❌ Proibido — módulo importa de config (inversão de dependência)
+from src.config.containers import ApplicationContainer                 # dentro de modules/media/
+
+# ❌ Proibido — shared infra importa de módulo
+from src.modules.media.infrastructure.persistence.models import MovieModel  # dentro de src/infrastructure/
+```
+
+`config/containers/` é o **composition root** — o único lugar que conhece módulos e infra simultaneamente para montar o grafo de dependências.
+
 ## Consequências
 
 ### Positivas


### PR DESCRIPTION
## Summary

- Add **ADR-008** documenting the migration to screaming architecture with `building_blocks`, `shared_kernel`, and `modules`
- Mark **ADR-003** (package structure) as superseded by ADR-008

## ADR-008 covers

- Context: why layer-first structure was problematic
- Decision: modules as primary axis with internal 4-layer structure
- Structure diagram of the final architecture
- Principles: module isolation, minimal shared_kernel, dependency rule
- Consequences and risks

## Summary by Sourcery

Document the adoption of a screaming, module-first architecture and mark the previous package structure ADR as superseded.

Documentation:
- Add ADR-008 describing the new module-oriented screaming architecture, including structure, principles, consequences, risks, and alternatives.
- Update ADR-003 to indicate it has been superseded by ADR-008 and fix minor formatting.