### PR TITLE
refactor(media): replace raw date with AirDate value object

### DIFF
--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -101,7 +101,7 @@ class GetSeriesByIdUseCase:
             title=season.title.value if season.title else None,
             synopsis=season.synopsis,
             poster_path=season.poster_path.value if season.poster_path else None,
-            air_date=str(season.air_date) if season.air_date else None,
+            air_date=season.air_date.value.isoformat() if season.air_date else None,
             episode_count=season.episode_count,
             episodes=[self._to_episode_output(e) for e in season.episodes],
         )
@@ -129,7 +129,7 @@ class GetSeriesByIdUseCase:
             resolution=primary.resolution.value if primary else None,
             files=[to_media_file_output(f) for f in episode.files],
             thumbnail_path=episode.thumbnail_path.value if episode.thumbnail_path else None,
-            air_date=str(episode.air_date) if episode.air_date else None,
+            air_date=episode.air_date.value.isoformat() if episode.air_date else None,
         )
 
 

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -101,7 +101,7 @@ class GetSeriesByIdUseCase:
             title=season.title.value if season.title else None,
             synopsis=season.synopsis,
             poster_path=season.poster_path.value if season.poster_path else None,
-            air_date=season.air_date.isoformat() if season.air_date else None,
+            air_date=str(season.air_date) if season.air_date else None,
             episode_count=season.episode_count,
             episodes=[self._to_episode_output(e) for e in season.episodes],
         )
@@ -129,7 +129,7 @@ class GetSeriesByIdUseCase:
             resolution=primary.resolution.value if primary else None,
             files=[to_media_file_output(f) for f in episode.files],
             thumbnail_path=episode.thumbnail_path.value if episode.thumbnail_path else None,
-            air_date=episode.air_date.isoformat() if episode.air_date else None,
+            air_date=str(episode.air_date) if episode.air_date else None,
         )
 
 

--- a/src/modules/media/domain/entities/episode.py
+++ b/src/modules/media/domain/entities/episode.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import date  # noqa: TCH003 - Pydantic needs this at runtime
-
 from pydantic import Field, field_validator
 
 from src.building_blocks.domain import DomainEntity
 from src.modules.media.domain.entities.file_variant_mixin import FileVariantMixin
 from src.modules.media.domain.value_objects import (
+    AirDate,
     Duration,
     EpisodeId,
     FilePath,
@@ -58,7 +57,7 @@ class Episode(FileVariantMixin, DomainEntity[EpisodeId]):
     thumbnail_path: FilePath | None = None
 
     # Metadata
-    air_date: date | None = None
+    air_date: AirDate | None = None
 
     # noinspection PyNestedDecorators
     @field_validator("id", mode="before")

--- a/src/modules/media/domain/entities/season.py
+++ b/src/modules/media/domain/entities/season.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import date  # noqa: TCH003
 from typing import TYPE_CHECKING, Self
 
 from pydantic import Field, field_validator
@@ -10,7 +9,7 @@ from pydantic import Field, field_validator
 from src.building_blocks.domain import DomainEntity
 from src.building_blocks.domain.errors import BusinessRuleViolationException
 from src.modules.media.domain.rule_codes import MediaRuleCodes
-from src.modules.media.domain.value_objects import FilePath, SeasonId, SeriesId, Title
+from src.modules.media.domain.value_objects import AirDate, FilePath, SeasonId, SeriesId, Title
 
 if TYPE_CHECKING:
     from src.modules.media.domain.entities.episode import Episode
@@ -43,7 +42,7 @@ class Season(DomainEntity[SeasonId]):
     poster_path: FilePath | None = None
 
     # Metadata
-    air_date: date | None = None
+    air_date: AirDate | None = None
 
     # Composition
     episodes: list[Episode] = Field(default_factory=list)

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -1,5 +1,6 @@
 """Media domain value objects."""
 
+from src.modules.media.domain.value_objects.air_date import AirDate
 from src.modules.media.domain.value_objects.duration import Duration
 from src.modules.media.domain.value_objects.genre import Genre
 from src.modules.media.domain.value_objects.hdr_format import HdrFormat
@@ -20,6 +21,7 @@ from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 __all__ = [
+    "AirDate",
     "AudioTrack",
     "Duration",
     "EpisodeId",

--- a/src/modules/media/domain/value_objects/air_date.py
+++ b/src/modules/media/domain/value_objects/air_date.py
@@ -1,0 +1,56 @@
+"""Air date value object for media content."""
+
+from datetime import date, timedelta
+from typing import ClassVar
+
+from pydantic import model_validator
+
+from src.building_blocks.domain import DateValueObject
+
+
+class AirDate(DateValueObject):
+    """Original air date for episodes and seasons.
+
+    Validates that the date is within a reasonable range:
+    - Minimum: 1800-01-01 (covers early cinema history)
+    - Maximum: today + 2 years (allows for announced future releases)
+
+    Example:
+        >>> air_date = AirDate(date(2024, 1, 15))
+        >>> air_date.value
+        datetime.date(2024, 1, 15)
+        >>> str(air_date)
+        '2024-01-15'
+    """
+
+    MIN_DATE: ClassVar[date] = date(1800, 1, 1)
+    MAX_YEARS_AHEAD: ClassVar[int] = 2
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_date_range(cls, value: date) -> date:
+        """Validate that air date is within the allowed range.
+
+        Args:
+            value: The date value.
+
+        Returns:
+            The validated date value.
+
+        Raises:
+            ValueError: If date is outside the valid range.
+        """
+        if not isinstance(value, date):
+            raise ValueError("AirDate must be a date")
+
+        if value < cls.MIN_DATE:
+            raise ValueError(f"Air date cannot be before {cls.MIN_DATE.isoformat()}")
+
+        max_date = date.today() + timedelta(days=cls.MAX_YEARS_AHEAD * 365)
+        if value > max_date:
+            raise ValueError(f"Air date cannot be after {max_date.isoformat()}")
+
+        return value
+
+
+__all__ = ["AirDate"]

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -2,6 +2,7 @@
 
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
+    AirDate,
     Duration,
     EpisodeId,
     FilePath,
@@ -61,7 +62,7 @@ class EpisodeMapper:
             file_size=primary.file_size if primary else None,
             resolution=primary.resolution.value if primary else None,
             thumbnail_path=entity.thumbnail_path.value if entity.thumbnail_path else None,
-            air_date=entity.air_date,
+            air_date=entity.air_date.value if entity.air_date else None,
         )
 
         for file in entity.files:
@@ -107,7 +108,7 @@ class EpisodeMapper:
             duration=Duration(model.duration),
             files=files,
             thumbnail_path=FilePath(model.thumbnail_path) if model.thumbnail_path else None,
-            air_date=model.air_date,
+            air_date=AirDate(model.air_date) if model.air_date else None,
             created_at=model.created_at,
             updated_at=model.updated_at,
         )
@@ -135,7 +136,7 @@ class EpisodeMapper:
         model.file_size = primary.file_size if primary else None
         model.resolution = primary.resolution.value if primary else None
         model.thumbnail_path = entity.thumbnail_path.value if entity.thumbnail_path else None
-        model.air_date = entity.air_date
+        model.air_date = entity.air_date.value if entity.air_date else None
 
         _sync_episode_file_variants(model.file_variants, entity.files)
 
@@ -170,7 +171,7 @@ class SeasonMapper:
             title=entity.title.value if entity.title else None,
             synopsis=entity.synopsis,
             poster_path=entity.poster_path.value if entity.poster_path else None,
-            air_date=entity.air_date,
+            air_date=entity.air_date.value if entity.air_date else None,
         )
 
     @staticmethod
@@ -197,7 +198,7 @@ class SeasonMapper:
             title=Title(model.title) if model.title else None,
             synopsis=model.synopsis,
             poster_path=FilePath(model.poster_path) if model.poster_path else None,
-            air_date=model.air_date,
+            air_date=AirDate(model.air_date) if model.air_date else None,
             episodes=episode_list,
             created_at=model.created_at,
             updated_at=model.updated_at,
@@ -218,7 +219,7 @@ class SeasonMapper:
         model.title = entity.title.value if entity.title else None
         model.synopsis = entity.synopsis
         model.poster_path = entity.poster_path.value if entity.poster_path else None
-        model.air_date = entity.air_date
+        model.air_date = entity.air_date.value if entity.air_date else None
 
         return model
 

--- a/tests/modules/media/unit/domain/entities/test_episode.py
+++ b/tests/modules/media/unit/domain/entities/test_episode.py
@@ -201,12 +201,13 @@ class TestEpisodeOptionalFields:
     def test_should_create_with_air_date(self):
         from src.modules.media.domain.entities import Episode
         from src.modules.media.domain.value_objects import (
+            AirDate,
             Duration,
             SeriesId,
             Title,
         )
 
-        air_date = date(2024, 1, 15)
+        air_date = AirDate(date(2024, 1, 15))
         episode = Episode(
             series_id=SeriesId.generate(),
             season_number=1,

--- a/tests/modules/media/unit/domain/entities/test_season.py
+++ b/tests/modules/media/unit/domain/entities/test_season.py
@@ -153,9 +153,9 @@ class TestSeasonOptionalFields:
 
     def test_should_create_with_air_date(self):
         from src.modules.media.domain.entities import Season
-        from src.modules.media.domain.value_objects import SeriesId
+        from src.modules.media.domain.value_objects import AirDate, SeriesId
 
-        air_date = date(2024, 1, 15)
+        air_date = AirDate(date(2024, 1, 15))
         season = Season(
             series_id=SeriesId.generate(),
             season_number=1,

--- a/tests/modules/media/unit/domain/value_objects/test_air_date.py
+++ b/tests/modules/media/unit/domain/value_objects/test_air_date.py
@@ -1,0 +1,96 @@
+"""Tests for AirDate value object."""
+
+from datetime import date, timedelta
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+
+
+class TestAirDateCreation:
+    """Tests for AirDate instantiation."""
+
+    def test_should_create_with_valid_date(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        air_date = AirDate(date(2024, 1, 15))
+
+        assert air_date.value == date(2024, 1, 15)
+
+    def test_should_create_with_minimum_valid_date(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        air_date = AirDate(date(1800, 1, 1))
+
+        assert air_date.value == date(1800, 1, 1)
+
+    def test_should_create_with_today(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        today = date.today()
+        air_date = AirDate(today)
+
+        assert air_date.value == today
+
+    def test_should_create_with_future_date_within_limit(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        future_date = date.today() + timedelta(days=365)
+        air_date = AirDate(future_date)
+
+        assert air_date.value == future_date
+
+    def test_should_raise_error_for_date_before_minimum(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        with pytest.raises(DomainValidationException, match="1800"):
+            AirDate(date(1799, 12, 31))
+
+    def test_should_raise_error_for_date_too_far_in_future(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        far_future = date.today() + timedelta(days=3 * 365)
+
+        with pytest.raises(DomainValidationException, match="Air date"):
+            AirDate(far_future)
+
+
+class TestAirDateBehavior:
+    """Tests for AirDate value object behavior."""
+
+    def test_str_should_return_iso_format(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        air_date = AirDate(date(2024, 1, 15))
+
+        assert str(air_date) == "2024-01-15"
+
+    def test_should_be_equal_when_same_date(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        date1 = AirDate(date(2024, 1, 15))
+        date2 = AirDate(date(2024, 1, 15))
+
+        assert date1 == date2
+
+    def test_should_not_be_equal_when_different_date(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        date1 = AirDate(date(2024, 1, 15))
+        date2 = AirDate(date(2024, 1, 16))
+
+        assert date1 != date2
+
+    def test_should_be_hashable(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        air_date = AirDate(date(2024, 1, 15))
+
+        assert hash(air_date) == hash(AirDate(date(2024, 1, 15)))
+
+    def test_should_be_usable_in_set(self):
+        from src.modules.media.domain.value_objects import AirDate
+
+        dates = {AirDate(date(2024, 1, 15)), AirDate(date(2024, 1, 15))}
+
+        assert len(dates) == 1

--- a/tests/modules/media/unit/domain/value_objects/test_air_date.py
+++ b/tests/modules/media/unit/domain/value_objects/test_air_date.py
@@ -40,6 +40,14 @@ class TestAirDateCreation:
 
         assert air_date.value == future_date
 
+    def test_should_create_with_upper_boundary_date(self):
+        from src.modules.media.domain.value_objects.air_date import AirDate
+
+        upper_boundary = date.today() + timedelta(days=AirDate.MAX_YEARS_AHEAD * 365)
+        air_date = AirDate(upper_boundary)
+
+        assert air_date.value == upper_boundary
+
     def test_should_raise_error_for_date_before_minimum(self):
         from src.modules.media.domain.value_objects import AirDate
 


### PR DESCRIPTION
## Summary

- Add `AirDate` value object with min/max validation (1800-01-01 to today + 2 years)
- Replace raw `date` type in `Season` and `Episode` entities with `AirDate`
- Update mappers to wrap/unwrap `AirDate` at persistence boundary
- Update use case to use `str(air_date)` instead of `.isoformat()`

## Test plan

- [x] New `test_air_date.py` with 11 tests (creation, validation, equality, hashing)
- [x] Existing Season/Episode tests updated to use `AirDate`
- [x] All 692 tests pass
- [x] All pre-commit hooks pass (ruff, mypy, conventional commit)

## Summary by Sourcery

Introduce an AirDate value object for media entities and integrate it across domain, persistence, and application layers.

New Features:
- Add an AirDate value object with validation for acceptable air date ranges.

Enhancements:
- Update Season and Episode domain entities to use the AirDate value object instead of raw date types.
- Adjust persistence mappers to wrap and unwrap AirDate at the database boundary.
- Update series retrieval use case outputs to serialize AirDate using its string representation.

Tests:
- Add unit tests for the AirDate value object covering creation, validation, equality, hashing, and usage in sets.
- Update existing Season and Episode domain tests to construct entities with AirDate instances.