### PR TITLE
chore(mypy): disable untyped decorator checks in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ plugins = ["pydantic.mypy", "sqlalchemy.ext.mypy.plugin"]
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+disallow_untyped_decorators = false
 
 # =============================================================================
 # Pytest

--- a/tests/modules/media/integration/conftest.py
+++ b/tests/modules/media/integration/conftest.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from src.config.persistence import Base
 
 
-@pytest.fixture(scope="function")  # type: ignore[misc]  # pytest.fixture untyped
+@pytest.fixture(scope="function")
 async def db_session() -> AsyncGenerator[AsyncSession, None]:
     """Create an in-memory SQLite database session for testing.
 

--- a/tests/modules/media/unit/infrastructure/file_system/test_variant_detector.py
+++ b/tests/modules/media/unit/infrastructure/file_system/test_variant_detector.py
@@ -5,7 +5,7 @@ import pytest
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
 
 
-@pytest.fixture  # type: ignore[misc]
+@pytest.fixture
 def detector() -> VariantDetector:
     return VariantDetector()
 


### PR DESCRIPTION
## Summary

- Add `disallow_untyped_decorators = false` to mypy test overrides
- Remove redundant `# type: ignore[misc]` from pytest fixtures

## Test plan

- [x] All 693 tests pass
- [x] All pre-commit hooks pass

## Summary by Sourcery

Relax mypy strictness for test modules and clean up redundant type ignores in pytest fixtures.

Build:
- Update mypy configuration for tests to allow untyped decorators.

Tests:
- Remove unnecessary mypy `type: ignore` markers from pytest fixtures in media tests.