### PR TITLE
feat(media): add TMDB metadata enrichment

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -145,7 +145,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # =========================================================================
 
     # Must be wired from parent container (Settings.tmdb_api_key)
-    tmdb_api_key = providers.Dependency(default="")
+    tmdb_api_key = providers.Dependency()
 
     tmdb_client = providers.Singleton(TmdbClient, api_key=tmdb_api_key)
 

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -6,6 +6,15 @@ Provides repositories and use cases for the Media module.
 from dependency_injector import containers, providers
 
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
+from src.modules.media.application.use_cases.bulk_enrich_metadata import (
+    BulkEnrichMetadataUseCase,
+)
+from src.modules.media.application.use_cases.enrich_movie_metadata import (
+    EnrichMovieMetadataUseCase,
+)
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
@@ -18,6 +27,7 @@ from src.modules.media.application.use_cases.scan_media_directories import (
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
 from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
+from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
 from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
     SQLAlchemyMovieRepository,
 )
@@ -126,6 +136,39 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         ScanMediaDirectoriesUseCase,
         file_scanner=file_scanner,
         variant_detector=variant_detector,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
+    )
+
+    # =========================================================================
+    # Infrastructure — Metadata Providers
+    # =========================================================================
+
+    # Must be wired from parent container (Settings.tmdb_api_key)
+    tmdb_api_key = providers.Dependency(default="")
+
+    tmdb_client = providers.Singleton(TmdbClient, api_key=tmdb_api_key)
+
+    # =========================================================================
+    # Use Cases — Enrichment
+    # =========================================================================
+
+    enrich_movie_metadata = providers.Factory(
+        EnrichMovieMetadataUseCase,
+        movie_repository=movie_repository,
+        primary_provider=tmdb_client,
+    )
+
+    enrich_series_metadata = providers.Factory(
+        EnrichSeriesMetadataUseCase,
+        series_repository=series_repository,
+        primary_provider=tmdb_client,
+    )
+
+    bulk_enrich_metadata = providers.Factory(
+        BulkEnrichMetadataUseCase,
+        enrich_movie=enrich_movie_metadata,
+        enrich_series=enrich_series_metadata,
         movie_repository=movie_repository,
         series_repository=series_repository,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.config.containers import ApplicationContainer
 from src.config.logging import get_logger, setup_logging
 from src.config.settings import get_settings
-from src.modules.media.presentation.routes import movie_router, scan_router, series_router
+from src.modules.media.presentation.routes import (
+    enrichment_router,
+    movie_router,
+    scan_router,
+    series_router,
+)
 
 
 def create_container() -> ApplicationContainer:
@@ -51,6 +56,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     container = create_container()
     container.wire(
         modules=[
+            "src.modules.media.presentation.routes.enrichment_routes",
             "src.modules.media.presentation.routes.movie_routes",
             "src.modules.media.presentation.routes.scan_routes",
             "src.modules.media.presentation.routes.series_routes",
@@ -101,6 +107,7 @@ def create_app() -> FastAPI:
 
     # Register routes
     register_health_routes(app)
+    app.include_router(enrichment_router)
     app.include_router(movie_router)
     app.include_router(scan_router)
     app.include_router(series_router)

--- a/src/modules/media/application/dtos/enrichment_dtos.py
+++ b/src/modules/media/application/dtos/enrichment_dtos.py
@@ -1,0 +1,69 @@
+"""DTOs for metadata enrichment operations."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class EnrichMediaInput:
+    """Input for enriching a single media item.
+
+    Attributes:
+        media_id: External ID of the movie or series.
+        force: Re-enrich even if metadata already exists.
+    """
+
+    media_id: str
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class EnrichMediaOutput:
+    """Output of a single media enrichment.
+
+    Attributes:
+        media_id: External ID of the enriched item.
+        enriched: Whether metadata was applied.
+        provider: Name of the provider that supplied metadata.
+        error: Error message if enrichment failed.
+    """
+
+    media_id: str
+    enriched: bool
+    provider: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class BulkEnrichInput:
+    """Input for bulk metadata enrichment.
+
+    Attributes:
+        force: Re-enrich even if metadata already exists.
+    """
+
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class BulkEnrichOutput:
+    """Output of bulk metadata enrichment.
+
+    Attributes:
+        movies_enriched: Number of movies successfully enriched.
+        series_enriched: Number of series successfully enriched.
+        skipped: Number of items skipped (already enriched).
+        errors: List of error messages.
+    """
+
+    movies_enriched: int
+    series_enriched: int
+    skipped: int
+    errors: list[str] = field(default_factory=list)
+
+
+__all__ = [
+    "BulkEnrichInput",
+    "BulkEnrichOutput",
+    "EnrichMediaInput",
+    "EnrichMediaOutput",
+]

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -5,9 +5,19 @@ from src.modules.media.application.ports.file_scanner_port import (
     MediaType,
     ScannedFile,
 )
+from src.modules.media.application.ports.metadata_provider_port import (
+    EpisodeMetadata,
+    MediaMetadata,
+    MetadataProvider,
+    SeasonMetadata,
+)
 
 __all__ = [
+    "EpisodeMetadata",
     "FileSystemScanner",
+    "MediaMetadata",
     "MediaType",
+    "MetadataProvider",
     "ScannedFile",
+    "SeasonMetadata",
 ]

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -1,0 +1,141 @@
+"""Port for external metadata providers (TMDB, OMDb)."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class EpisodeMetadata:
+    """Metadata for a single episode from an external provider.
+
+    Attributes:
+        season_number: Season number.
+        episode_number: Episode number.
+        title: Episode title.
+        synopsis: Episode overview.
+        air_date: Original air date (ISO format string).
+        duration_seconds: Runtime in seconds.
+    """
+
+    season_number: int
+    episode_number: int
+    title: str | None = None
+    synopsis: str | None = None
+    air_date: str | None = None
+    duration_seconds: int | None = None
+
+
+@dataclass(frozen=True)
+class SeasonMetadata:
+    """Metadata for a single season from an external provider.
+
+    Attributes:
+        season_number: Season number.
+        title: Season title.
+        synopsis: Season overview.
+        poster_url: URL to season poster image.
+        air_date: First air date (ISO format string).
+        episodes: Episode metadata for this season.
+    """
+
+    season_number: int
+    title: str | None = None
+    synopsis: str | None = None
+    poster_url: str | None = None
+    air_date: str | None = None
+    episodes: list[EpisodeMetadata] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class MediaMetadata:
+    """Metadata fetched from an external provider.
+
+    Attributes:
+        title: Official title.
+        original_title: Original language title.
+        year: Release year (movie) or start year (series).
+        end_year: End year (series only, None if ongoing).
+        duration_seconds: Runtime in seconds (movie only).
+        synopsis: Plot overview.
+        poster_url: URL to poster image.
+        backdrop_url: URL to backdrop image.
+        genres: List of genre names.
+        tmdb_id: TMDB numeric ID.
+        imdb_id: IMDb ID (tt1234567 format).
+        seasons: Season metadata (series only).
+    """
+
+    title: str
+    original_title: str | None = None
+    year: int | None = None
+    end_year: int | None = None
+    duration_seconds: int | None = None
+    synopsis: str | None = None
+    poster_url: str | None = None
+    backdrop_url: str | None = None
+    genres: list[str] = field(default_factory=list)
+    tmdb_id: int | None = None
+    imdb_id: str | None = None
+    seasons: list[SeasonMetadata] = field(default_factory=list)
+
+
+class MetadataProvider(ABC):
+    """Port for fetching media metadata from external services."""
+
+    @abstractmethod
+    async def search_movie(self, title: str, year: int | None = None) -> MediaMetadata | None:
+        """Search for a movie by title and optional year.
+
+        Args:
+            title: Movie title to search for.
+            year: Release year to narrow results.
+
+        Returns:
+            Metadata for the best match, or None if not found.
+        """
+        ...
+
+    @abstractmethod
+    async def search_series(self, title: str, year: int | None = None) -> MediaMetadata | None:
+        """Search for a TV series by title and optional year.
+
+        Args:
+            title: Series title to search for.
+            year: Start year to narrow results.
+
+        Returns:
+            Metadata for the best match, or None if not found.
+        """
+        ...
+
+    @abstractmethod
+    async def get_movie_by_id(self, tmdb_id: int) -> MediaMetadata | None:
+        """Fetch movie metadata by TMDB ID.
+
+        Args:
+            tmdb_id: The TMDB numeric ID.
+
+        Returns:
+            Movie metadata, or None if not found.
+        """
+        ...
+
+    @abstractmethod
+    async def get_series_by_id(self, tmdb_id: int) -> MediaMetadata | None:
+        """Fetch series metadata by TMDB ID.
+
+        Args:
+            tmdb_id: The TMDB numeric ID.
+
+        Returns:
+            Series metadata with seasons and episodes, or None.
+        """
+        ...
+
+
+__all__ = [
+    "EpisodeMetadata",
+    "MediaMetadata",
+    "MetadataProvider",
+    "SeasonMetadata",
+]

--- a/src/modules/media/application/use_cases/bulk_enrich_metadata.py
+++ b/src/modules/media/application/use_cases/bulk_enrich_metadata.py
@@ -1,0 +1,106 @@
+"""Use case for bulk metadata enrichment of all media."""
+
+from typing import Any
+
+from src.modules.media.application.dtos.enrichment_dtos import (
+    BulkEnrichInput,
+    BulkEnrichOutput,
+    EnrichMediaInput,
+)
+from src.modules.media.application.use_cases.enrich_movie_metadata import (
+    EnrichMovieMetadataUseCase,
+)
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+class BulkEnrichMetadataUseCase:
+    """Enrich all movies and series with external metadata.
+
+    Iterates through all movies and series, enriching those that
+    don't yet have metadata (or all if force=True).
+
+    Args:
+        enrich_movie: Use case for single movie enrichment.
+        enrich_series: Use case for single series enrichment.
+        movie_repository: Repository for listing movies.
+        series_repository: Repository for listing series.
+    """
+
+    def __init__(
+        self,
+        enrich_movie: EnrichMovieMetadataUseCase,
+        enrich_series: EnrichSeriesMetadataUseCase,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        self._enrich_movie = enrich_movie
+        self._enrich_series = enrich_series
+        self._movie_repository = movie_repository
+        self._series_repository = series_repository
+
+    async def execute(self, input_dto: BulkEnrichInput) -> BulkEnrichOutput:
+        """Execute bulk metadata enrichment.
+
+        Args:
+            input_dto: Input with force flag.
+
+        Returns:
+            Summary of enrichment results.
+        """
+        errors: list[str] = []
+
+        movies = await self._movie_repository.list_all()
+        m_enriched, m_skipped = await self._enrich_all(
+            items=[(str(m.id), m.title.value) for m in movies if m.id],
+            enrich_fn=self._enrich_movie.execute,
+            label="Movie",
+            force=input_dto.force,
+            errors=errors,
+        )
+
+        all_series = await self._series_repository.list_all()
+        s_enriched, s_skipped = await self._enrich_all(
+            items=[(str(s.id), s.title.value) for s in all_series if s.id],
+            enrich_fn=self._enrich_series.execute,
+            label="Series",
+            force=input_dto.force,
+            errors=errors,
+        )
+
+        return BulkEnrichOutput(
+            movies_enriched=m_enriched,
+            series_enriched=s_enriched,
+            skipped=m_skipped + s_skipped,
+            errors=errors,
+        )
+
+    @staticmethod
+    async def _enrich_all(
+        items: list[tuple[str, str]],
+        enrich_fn: Any,
+        label: str,
+        *,
+        force: bool,
+        errors: list[str],
+    ) -> tuple[int, int]:
+        """Enrich a list of media items, collecting results and errors."""
+        enriched = 0
+        skipped = 0
+        for media_id, title in items:
+            try:
+                result = await enrich_fn(EnrichMediaInput(media_id=media_id, force=force))
+                if result.enriched:
+                    enriched += 1
+                elif result.error:
+                    errors.append(f"{label} '{title}': {result.error}")
+                else:
+                    skipped += 1
+            except Exception as e:
+                errors.append(f"{label} '{title}': {e}")
+        return enriched, skipped
+
+
+__all__ = ["BulkEnrichMetadataUseCase"]

--- a/src/modules/media/application/use_cases/bulk_enrich_metadata.py
+++ b/src/modules/media/application/use_cases/bulk_enrich_metadata.py
@@ -1,11 +1,12 @@
 """Use case for bulk metadata enrichment of all media."""
 
-from typing import Any
+from collections.abc import Awaitable, Callable
 
 from src.modules.media.application.dtos.enrichment_dtos import (
     BulkEnrichInput,
     BulkEnrichOutput,
     EnrichMediaInput,
+    EnrichMediaOutput,
 )
 from src.modules.media.application.use_cases.enrich_movie_metadata import (
     EnrichMovieMetadataUseCase,
@@ -80,7 +81,7 @@ class BulkEnrichMetadataUseCase:
     @staticmethod
     async def _enrich_all(
         items: list[tuple[str, str]],
-        enrich_fn: Any,
+        enrich_fn: Callable[[EnrichMediaInput], Awaitable[EnrichMediaOutput]],
         label: str,
         *,
         force: bool,

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -1,0 +1,109 @@
+"""Use case for enriching a movie with external metadata."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.enrichment_dtos import (
+    EnrichMediaInput,
+    EnrichMediaOutput,
+)
+from src.modules.media.application.ports import MediaMetadata, MetadataProvider
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.repositories import MovieRepository
+from src.modules.media.domain.value_objects import Duration, Genre, MovieId, Title, Year
+
+
+class EnrichMovieMetadataUseCase:
+    """Enrich a movie entity with metadata from external providers.
+
+    Searches the primary provider first, falls back to the secondary
+    if the primary returns no results.
+
+    Args:
+        movie_repository: Repository for movie persistence.
+        primary_provider: Primary metadata provider (e.g., TMDB).
+        fallback_provider: Optional fallback provider (e.g., OMDb).
+    """
+
+    def __init__(
+        self,
+        movie_repository: MovieRepository,
+        primary_provider: MetadataProvider,
+        fallback_provider: MetadataProvider | None = None,
+    ) -> None:
+        self._movie_repository = movie_repository
+        self._primary = primary_provider
+        self._fallback = fallback_provider
+
+    async def execute(self, input_dto: EnrichMediaInput) -> EnrichMediaOutput:
+        """Execute movie metadata enrichment.
+
+        Args:
+            input_dto: Input with movie ID and force flag.
+
+        Returns:
+            Enrichment result with success/failure status.
+        """
+        movie = await self._movie_repository.find_by_id(MovieId(input_dto.media_id))
+        if not movie:
+            raise ResourceNotFoundException.for_resource("Movie", input_dto.media_id)
+
+        if movie.tmdb_id and not input_dto.force:
+            return EnrichMediaOutput(media_id=input_dto.media_id, enriched=False, provider=None)
+
+        metadata, provider_name = await self._fetch_metadata(movie)
+        if not metadata:
+            return EnrichMediaOutput(
+                media_id=input_dto.media_id,
+                enriched=False,
+                error="No metadata found from any provider",
+            )
+
+        movie = _apply_movie_metadata(movie, metadata)
+        await self._movie_repository.save(movie)
+
+        return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)
+
+    async def _fetch_metadata(self, movie: Movie) -> tuple[MediaMetadata | None, str | None]:
+        """Try primary provider, then fallback."""
+        if movie.tmdb_id:
+            metadata = await self._primary.get_movie_by_id(movie.tmdb_id)
+            if metadata:
+                return metadata, "tmdb"
+
+        metadata = await self._primary.search_movie(movie.title.value, movie.year.value)
+        if metadata:
+            return metadata, "tmdb"
+
+        if self._fallback:
+            metadata = await self._fallback.search_movie(movie.title.value, movie.year.value)
+            if metadata:
+                return metadata, "omdb"
+
+        return None, None
+
+
+def _apply_movie_metadata(movie: Movie, metadata: MediaMetadata) -> Movie:
+    """Apply metadata fields to a movie entity."""
+    updates: dict[str, object] = {}
+
+    if metadata.synopsis and not movie.synopsis:
+        updates["synopsis"] = metadata.synopsis
+    if metadata.tmdb_id:
+        updates["tmdb_id"] = metadata.tmdb_id
+    if metadata.imdb_id:
+        updates["imdb_id"] = metadata.imdb_id
+    if metadata.original_title:
+        updates["original_title"] = Title(metadata.original_title)
+    if metadata.duration_seconds and movie.duration.value == 0:
+        updates["duration"] = Duration(metadata.duration_seconds)
+    if metadata.year:
+        updates["year"] = Year(metadata.year)
+    if metadata.genres and not movie.genres:
+        updates["genres"] = [Genre(g) for g in metadata.genres]
+
+    if updates:
+        movie = movie.with_updates(**updates)
+
+    return movie
+
+
+__all__ = ["EnrichMovieMetadataUseCase"]

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -1,5 +1,6 @@
 """Use case for enriching a series with external metadata."""
 
+import logging
 from datetime import date
 
 from src.building_blocks.application.errors import ResourceNotFoundException
@@ -148,7 +149,9 @@ def _apply_season_metadata(season: Season, meta: SeasonMetadata) -> Season:
     if meta.synopsis and not season.synopsis:
         updates["synopsis"] = meta.synopsis
     if meta.air_date and not season.air_date:
-        updates["air_date"] = AirDate(date.fromisoformat(meta.air_date))
+        parsed = _parse_date(meta.air_date)
+        if parsed:
+            updates["air_date"] = AirDate(parsed)
 
     if updates:
         season = season.with_updates(**updates)
@@ -175,7 +178,9 @@ def _apply_episode_metadata(episode: Episode, meta: EpisodeMetadata) -> Episode:
     if meta.synopsis and not episode.synopsis:
         updates["synopsis"] = meta.synopsis
     if meta.air_date and not episode.air_date:
-        updates["air_date"] = AirDate(date.fromisoformat(meta.air_date))
+        parsed = _parse_date(meta.air_date)
+        if parsed:
+            updates["air_date"] = AirDate(parsed)
     if meta.duration_seconds and episode.duration.value == 0:
         updates["duration"] = Duration(meta.duration_seconds)
 
@@ -183,6 +188,18 @@ def _apply_episode_metadata(episode: Episode, meta: EpisodeMetadata) -> Episode:
         episode = episode.with_updates(**updates)
 
     return episode
+
+
+_logger = logging.getLogger(__name__)
+
+
+def _parse_date(value: str) -> date | None:
+    """Safely parse an ISO date string, returning None on failure."""
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        _logger.warning("Could not parse date: %s", value)
+        return None
 
 
 __all__ = ["EnrichSeriesMetadataUseCase"]

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -1,0 +1,188 @@
+"""Use case for enriching a series with external metadata."""
+
+from datetime import date
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.enrichment_dtos import (
+    EnrichMediaInput,
+    EnrichMediaOutput,
+)
+from src.modules.media.application.ports import (
+    EpisodeMetadata,
+    MediaMetadata,
+    MetadataProvider,
+    SeasonMetadata,
+)
+from src.modules.media.domain.entities import Episode, Season, Series
+from src.modules.media.domain.repositories import SeriesRepository
+from src.modules.media.domain.value_objects import (
+    AirDate,
+    Duration,
+    Genre,
+    SeriesId,
+    Title,
+    Year,
+)
+
+
+class EnrichSeriesMetadataUseCase:
+    """Enrich a series entity with metadata from external providers.
+
+    Searches the primary provider first, falls back to the secondary.
+    Enriches series-level, season-level, and episode-level metadata.
+
+    Args:
+        series_repository: Repository for series persistence.
+        primary_provider: Primary metadata provider (e.g., TMDB).
+        fallback_provider: Optional fallback provider (e.g., OMDb).
+    """
+
+    def __init__(
+        self,
+        series_repository: SeriesRepository,
+        primary_provider: MetadataProvider,
+        fallback_provider: MetadataProvider | None = None,
+    ) -> None:
+        self._series_repository = series_repository
+        self._primary = primary_provider
+        self._fallback = fallback_provider
+
+    async def execute(self, input_dto: EnrichMediaInput) -> EnrichMediaOutput:
+        """Execute series metadata enrichment.
+
+        Args:
+            input_dto: Input with series ID and force flag.
+
+        Returns:
+            Enrichment result with success/failure status.
+        """
+        series = await self._series_repository.find_by_id(SeriesId(input_dto.media_id))
+        if not series:
+            raise ResourceNotFoundException.for_resource("Series", input_dto.media_id)
+
+        if series.tmdb_id and not input_dto.force:
+            return EnrichMediaOutput(media_id=input_dto.media_id, enriched=False, provider=None)
+
+        metadata, provider_name = await self._fetch_metadata(series)
+        if not metadata:
+            return EnrichMediaOutput(
+                media_id=input_dto.media_id,
+                enriched=False,
+                error="No metadata found from any provider",
+            )
+
+        series = _apply_series_metadata(series, metadata)
+        await self._series_repository.save(series)
+
+        return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)
+
+    async def _fetch_metadata(self, series: Series) -> tuple[MediaMetadata | None, str | None]:
+        """Try primary provider, then fallback."""
+        if series.tmdb_id:
+            metadata = await self._primary.get_series_by_id(series.tmdb_id)
+            if metadata:
+                return metadata, "tmdb"
+
+        metadata = await self._primary.search_series(series.title.value, series.start_year.value)
+        if metadata:
+            return metadata, "tmdb"
+
+        if self._fallback:
+            metadata = await self._fallback.search_series(
+                series.title.value, series.start_year.value
+            )
+            if metadata:
+                return metadata, "omdb"
+
+        return None, None
+
+
+def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
+    """Apply metadata fields to a series entity."""
+    updates: dict[str, object] = {}
+
+    if metadata.synopsis and not series.synopsis:
+        updates["synopsis"] = metadata.synopsis
+    if metadata.tmdb_id:
+        updates["tmdb_id"] = metadata.tmdb_id
+    if metadata.imdb_id:
+        updates["imdb_id"] = metadata.imdb_id
+    if metadata.original_title:
+        updates["original_title"] = Title(metadata.original_title)
+    if metadata.year:
+        updates["start_year"] = Year(metadata.year)
+    if metadata.end_year:
+        updates["end_year"] = Year(metadata.end_year)
+    if metadata.genres and not series.genres:
+        updates["genres"] = [Genre(g) for g in metadata.genres]
+
+    if updates:
+        series = series.with_updates(**updates)
+
+    # Enrich seasons and episodes
+    if metadata.seasons:
+        series = _enrich_seasons(series, metadata.seasons)
+
+    return series
+
+
+def _enrich_seasons(series: Series, season_metas: list[SeasonMetadata]) -> Series:
+    """Enrich existing seasons with metadata."""
+    meta_by_num = {s.season_number: s for s in season_metas}
+
+    new_seasons = []
+    for season in series.seasons:
+        meta = meta_by_num.get(season.season_number)
+        enriched = _apply_season_metadata(season, meta) if meta else season
+        new_seasons.append(enriched)
+
+    return series.with_updates(seasons=new_seasons)
+
+
+def _apply_season_metadata(season: Season, meta: SeasonMetadata) -> Season:
+    """Apply metadata to a season and its episodes."""
+    updates: dict[str, object] = {}
+
+    if meta.title and not season.title:
+        updates["title"] = Title(meta.title)
+    if meta.synopsis and not season.synopsis:
+        updates["synopsis"] = meta.synopsis
+    if meta.air_date and not season.air_date:
+        updates["air_date"] = AirDate(date.fromisoformat(meta.air_date))
+
+    if updates:
+        season = season.with_updates(**updates)
+
+    # Enrich episodes
+    if meta.episodes:
+        ep_by_num = {e.episode_number: e for e in meta.episodes}
+        new_episodes = []
+        for ep in season.episodes:
+            ep_meta = ep_by_num.get(ep.episode_number)
+            enriched_ep = _apply_episode_metadata(ep, ep_meta) if ep_meta else ep
+            new_episodes.append(enriched_ep)
+        season = season.with_updates(episodes=new_episodes)
+
+    return season
+
+
+def _apply_episode_metadata(episode: Episode, meta: EpisodeMetadata) -> Episode:
+    """Apply metadata to an episode."""
+    updates: dict[str, object] = {}
+
+    if meta.title and episode.title.value.startswith("Episode "):
+        updates["title"] = Title(meta.title)
+    if meta.synopsis and not episode.synopsis:
+        updates["synopsis"] = meta.synopsis
+    if meta.air_date and not episode.air_date:
+        updates["air_date"] = AirDate(date.fromisoformat(meta.air_date))
+    if meta.duration_seconds and episode.duration.value == 0:
+        updates["duration"] = Duration(meta.duration_seconds)
+
+    if updates:
+        episode = episode.with_updates(**updates)
+
+    return episode
+
+
+__all__ = ["EnrichSeriesMetadataUseCase"]

--- a/src/modules/media/infrastructure/metadata/__init__.py
+++ b/src/modules/media/infrastructure/metadata/__init__.py
@@ -1,0 +1,5 @@
+"""Metadata provider implementations."""
+
+from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
+
+__all__ = ["TmdbClient"]

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -1,0 +1,187 @@
+"""TMDB API client implementing MetadataProvider port."""
+
+import httpx
+
+from src.modules.media.application.ports import (
+    EpisodeMetadata,
+    MediaMetadata,
+    MetadataProvider,
+    SeasonMetadata,
+)
+
+_TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/original"
+
+
+class TmdbClient(MetadataProvider):
+    """The Movie Database (TMDB) API client.
+
+    Args:
+        api_key: TMDB API key (v3 auth).
+        base_url: TMDB API base URL.
+    """
+
+    def __init__(self, api_key: str, base_url: str = "https://api.themoviedb.org/3") -> None:
+        self._api_key = api_key
+        self._base_url = base_url
+
+    def _params(self, **extra: str | int | None) -> dict[str, str | int]:
+        params: dict[str, str | int] = {"api_key": self._api_key}
+        for k, v in extra.items():
+            if v is not None:
+                params[k] = v
+        return params
+
+    def _image_url(self, path: str | None) -> str | None:
+        return f"{_TMDB_IMAGE_BASE}{path}" if path else None
+
+    async def search_movie(self, title: str, year: int | None = None) -> MediaMetadata | None:
+        """Search TMDB for a movie and return metadata for the best match."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self._base_url}/search/movie",
+                params=self._params(query=title, year=year),
+            )
+            resp.raise_for_status()
+            results = resp.json().get("results", [])
+
+            if not results:
+                return None
+
+            tmdb_id = results[0]["id"]
+            return await self._fetch_movie_details(client, tmdb_id)
+
+    async def search_series(self, title: str, year: int | None = None) -> MediaMetadata | None:
+        """Search TMDB for a TV series and return metadata for the best match."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self._base_url}/search/tv",
+                params=self._params(query=title, first_air_date_year=year),
+            )
+            resp.raise_for_status()
+            results = resp.json().get("results", [])
+
+            if not results:
+                return None
+
+            tmdb_id = results[0]["id"]
+            return await self._fetch_series_details(client, tmdb_id)
+
+    async def get_movie_by_id(self, tmdb_id: int) -> MediaMetadata | None:
+        """Fetch movie details by TMDB ID."""
+        async with httpx.AsyncClient() as client:
+            return await self._fetch_movie_details(client, tmdb_id)
+
+    async def get_series_by_id(self, tmdb_id: int) -> MediaMetadata | None:
+        """Fetch series details by TMDB ID."""
+        async with httpx.AsyncClient() as client:
+            return await self._fetch_series_details(client, tmdb_id)
+
+    async def _fetch_movie_details(
+        self, client: httpx.AsyncClient, tmdb_id: int
+    ) -> MediaMetadata | None:
+        """Fetch full movie details from TMDB."""
+        resp = await client.get(
+            f"{self._base_url}/movie/{tmdb_id}",
+            params=self._params(),
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+
+        year = None
+        if data.get("release_date"):
+            year = int(data["release_date"][:4])
+
+        return MediaMetadata(
+            title=data.get("title", ""),
+            original_title=data.get("original_title"),
+            year=year,
+            duration_seconds=(data.get("runtime") or 0) * 60,
+            synopsis=data.get("overview"),
+            poster_url=self._image_url(data.get("poster_path")),
+            backdrop_url=self._image_url(data.get("backdrop_path")),
+            genres=[g["name"] for g in data.get("genres", [])],
+            tmdb_id=data["id"],
+            imdb_id=data.get("imdb_id"),
+        )
+
+    async def _fetch_series_details(
+        self, client: httpx.AsyncClient, tmdb_id: int
+    ) -> MediaMetadata | None:
+        """Fetch full series details including seasons and episodes."""
+        resp = await client.get(
+            f"{self._base_url}/tv/{tmdb_id}",
+            params=self._params(),
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+
+        start_year = None
+        if data.get("first_air_date"):
+            start_year = int(data["first_air_date"][:4])
+
+        end_year = None
+        if data.get("last_air_date") and data.get("status") == "Ended":
+            end_year = int(data["last_air_date"][:4])
+
+        # Fetch season details with episodes
+        seasons: list[SeasonMetadata] = []
+        for s in data.get("seasons", []):
+            season_num = s.get("season_number", 0)
+            season_meta = await self._fetch_season(client, tmdb_id, season_num)
+            if season_meta:
+                seasons.append(season_meta)
+
+        return MediaMetadata(
+            title=data.get("name", ""),
+            original_title=data.get("original_name"),
+            year=start_year,
+            end_year=end_year,
+            synopsis=data.get("overview"),
+            poster_url=self._image_url(data.get("poster_path")),
+            backdrop_url=self._image_url(data.get("backdrop_path")),
+            genres=[g["name"] for g in data.get("genres", [])],
+            tmdb_id=data["id"],
+            imdb_id=data.get("external_ids", {}).get("imdb_id"),
+            seasons=seasons,
+        )
+
+    async def _fetch_season(
+        self, client: httpx.AsyncClient, series_id: int, season_number: int
+    ) -> SeasonMetadata | None:
+        """Fetch season details with episode list."""
+        resp = await client.get(
+            f"{self._base_url}/tv/{series_id}/season/{season_number}",
+            params=self._params(),
+        )
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        data = resp.json()
+
+        episodes = [
+            EpisodeMetadata(
+                season_number=season_number,
+                episode_number=ep.get("episode_number", 0),
+                title=ep.get("name"),
+                synopsis=ep.get("overview"),
+                air_date=ep.get("air_date"),
+                duration_seconds=(ep.get("runtime") or 0) * 60,
+            )
+            for ep in data.get("episodes", [])
+        ]
+
+        return SeasonMetadata(
+            season_number=season_number,
+            title=data.get("name"),
+            synopsis=data.get("overview"),
+            poster_url=self._image_url(data.get("poster_path")),
+            air_date=data.get("air_date"),
+            episodes=episodes,
+        )
+
+
+__all__ = ["TmdbClient"]

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -23,6 +23,7 @@ class TmdbClient(MetadataProvider):
     def __init__(self, api_key: str, base_url: str = "https://api.themoviedb.org/3") -> None:
         self._api_key = api_key
         self._base_url = base_url
+        self._client = httpx.AsyncClient(timeout=30.0)
 
     def _params(self, **extra: str | int | None) -> dict[str, str | int]:
         params: dict[str, str | int] = {"api_key": self._api_key}
@@ -36,51 +37,45 @@ class TmdbClient(MetadataProvider):
 
     async def search_movie(self, title: str, year: int | None = None) -> MediaMetadata | None:
         """Search TMDB for a movie and return metadata for the best match."""
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self._base_url}/search/movie",
-                params=self._params(query=title, year=year),
-            )
-            resp.raise_for_status()
-            results = resp.json().get("results", [])
+        resp = await self._client.get(
+            f"{self._base_url}/search/movie",
+            params=self._params(query=title, year=year),
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
 
-            if not results:
-                return None
+        if not results:
+            return None
 
-            tmdb_id = results[0]["id"]
-            return await self._fetch_movie_details(client, tmdb_id)
+        tmdb_id = results[0]["id"]
+        return await self._fetch_movie_details(tmdb_id)
 
     async def search_series(self, title: str, year: int | None = None) -> MediaMetadata | None:
         """Search TMDB for a TV series and return metadata for the best match."""
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self._base_url}/search/tv",
-                params=self._params(query=title, first_air_date_year=year),
-            )
-            resp.raise_for_status()
-            results = resp.json().get("results", [])
+        resp = await self._client.get(
+            f"{self._base_url}/search/tv",
+            params=self._params(query=title, first_air_date_year=year),
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
 
-            if not results:
-                return None
+        if not results:
+            return None
 
-            tmdb_id = results[0]["id"]
-            return await self._fetch_series_details(client, tmdb_id)
+        tmdb_id = results[0]["id"]
+        return await self._fetch_series_details(tmdb_id)
 
     async def get_movie_by_id(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch movie details by TMDB ID."""
-        async with httpx.AsyncClient() as client:
-            return await self._fetch_movie_details(client, tmdb_id)
+        return await self._fetch_movie_details(tmdb_id)
 
     async def get_series_by_id(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch series details by TMDB ID."""
-        async with httpx.AsyncClient() as client:
-            return await self._fetch_series_details(client, tmdb_id)
+        return await self._fetch_series_details(tmdb_id)
 
-    async def _fetch_movie_details(
-        self, client: httpx.AsyncClient, tmdb_id: int
-    ) -> MediaMetadata | None:
+    async def _fetch_movie_details(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch full movie details from TMDB."""
-        resp = await client.get(
+        resp = await self._client.get(
             f"{self._base_url}/movie/{tmdb_id}",
             params=self._params(),
         )
@@ -106,13 +101,11 @@ class TmdbClient(MetadataProvider):
             imdb_id=data.get("imdb_id"),
         )
 
-    async def _fetch_series_details(
-        self, client: httpx.AsyncClient, tmdb_id: int
-    ) -> MediaMetadata | None:
+    async def _fetch_series_details(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch full series details including seasons and episodes."""
-        resp = await client.get(
+        resp = await self._client.get(
             f"{self._base_url}/tv/{tmdb_id}",
-            params=self._params(),
+            params=self._params(append_to_response="external_ids"),
         )
         if resp.status_code == 404:
             return None
@@ -131,7 +124,7 @@ class TmdbClient(MetadataProvider):
         seasons: list[SeasonMetadata] = []
         for s in data.get("seasons", []):
             season_num = s.get("season_number", 0)
-            season_meta = await self._fetch_season(client, tmdb_id, season_num)
+            season_meta = await self._fetch_season(tmdb_id, season_num)
             if season_meta:
                 seasons.append(season_meta)
 
@@ -149,11 +142,9 @@ class TmdbClient(MetadataProvider):
             seasons=seasons,
         )
 
-    async def _fetch_season(
-        self, client: httpx.AsyncClient, series_id: int, season_number: int
-    ) -> SeasonMetadata | None:
+    async def _fetch_season(self, series_id: int, season_number: int) -> SeasonMetadata | None:
         """Fetch season details with episode list."""
-        resp = await client.get(
+        resp = await self._client.get(
             f"{self._base_url}/tv/{series_id}/season/{season_number}",
             params=self._params(),
         )

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -1,7 +1,8 @@
 """Media API routes."""
 
+from src.modules.media.presentation.routes.enrichment_routes import router as enrichment_router
 from src.modules.media.presentation.routes.movie_routes import router as movie_router
 from src.modules.media.presentation.routes.scan_routes import router as scan_router
 from src.modules.media.presentation.routes.series_routes import router as series_router
 
-__all__ = ["movie_router", "scan_router", "series_router"]
+__all__ = ["enrichment_router", "movie_router", "scan_router", "series_router"]

--- a/src/modules/media/presentation/routes/enrichment_routes.py
+++ b/src/modules/media/presentation/routes/enrichment_routes.py
@@ -1,0 +1,85 @@
+"""Metadata enrichment REST API routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.config.containers import ApplicationContainer
+from src.modules.media.application.dtos.enrichment_dtos import (
+    BulkEnrichInput,
+    EnrichMediaInput,
+)
+from src.modules.media.application.use_cases.bulk_enrich_metadata import (
+    BulkEnrichMetadataUseCase,
+)
+from src.modules.media.application.use_cases.enrich_movie_metadata import (
+    EnrichMovieMetadataUseCase,
+)
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
+from src.modules.media.presentation.schemas import (
+    BulkEnrichResponse,
+    EnrichRequest,
+    EnrichResponse,
+)
+
+router = APIRouter(prefix="/api/v1", tags=["Metadata Enrichment"])
+
+
+@router.post(  # type: ignore[misc]
+    "/movies/{movie_id}/enrich",
+    response_model=EnrichResponse,
+)
+@inject  # type: ignore[misc]
+async def enrich_movie(
+    movie_id: str,
+    body: EnrichRequest | None = None,
+    use_case: EnrichMovieMetadataUseCase = Depends(
+        Provide[ApplicationContainer.media.enrich_movie_metadata],
+    ),
+) -> dict[str, Any]:
+    """Enrich a movie with metadata from TMDB."""
+    force = body.force if body else False
+    output = await use_case.execute(EnrichMediaInput(media_id=movie_id, force=force))
+    return asdict(output)
+
+
+@router.post(  # type: ignore[misc]
+    "/series/{series_id}/enrich",
+    response_model=EnrichResponse,
+)
+@inject  # type: ignore[misc]
+async def enrich_series(
+    series_id: str,
+    body: EnrichRequest | None = None,
+    use_case: EnrichSeriesMetadataUseCase = Depends(
+        Provide[ApplicationContainer.media.enrich_series_metadata],
+    ),
+) -> dict[str, Any]:
+    """Enrich a series with metadata from TMDB."""
+    force = body.force if body else False
+    output = await use_case.execute(EnrichMediaInput(media_id=series_id, force=force))
+    return asdict(output)
+
+
+@router.post(  # type: ignore[misc]
+    "/enrich",
+    response_model=BulkEnrichResponse,
+)
+@inject  # type: ignore[misc]
+async def bulk_enrich(
+    body: EnrichRequest | None = None,
+    use_case: BulkEnrichMetadataUseCase = Depends(
+        Provide[ApplicationContainer.media.bulk_enrich_metadata],
+    ),
+) -> dict[str, Any]:
+    """Enrich all movies and series with metadata from TMDB."""
+    force = body.force if body else False
+    output = await use_case.execute(BulkEnrichInput(force=force))
+    return asdict(output)
+
+
+__all__ = ["router"]

--- a/src/modules/media/presentation/schemas/__init__.py
+++ b/src/modules/media/presentation/schemas/__init__.py
@@ -1,5 +1,10 @@
 """Media API request/response schemas."""
 
+from src.modules.media.presentation.schemas.enrichment_schemas import (
+    BulkEnrichResponse,
+    EnrichRequest,
+    EnrichResponse,
+)
 from src.modules.media.presentation.schemas.file_variant_schemas import (
     AddFileVariantRequest,
     RemoveFileVariantRequest,
@@ -12,6 +17,9 @@ from src.modules.media.presentation.schemas.scan_schemas import (
 
 __all__ = [
     "AddFileVariantRequest",
+    "BulkEnrichResponse",
+    "EnrichRequest",
+    "EnrichResponse",
     "RemoveFileVariantRequest",
     "ScanMediaRequest",
     "ScanMediaResponse",

--- a/src/modules/media/presentation/schemas/enrichment_schemas.py
+++ b/src/modules/media/presentation/schemas/enrichment_schemas.py
@@ -1,0 +1,33 @@
+"""Pydantic schemas for metadata enrichment endpoints."""
+
+from pydantic import BaseModel, Field
+
+
+class EnrichRequest(BaseModel):
+    """Request body for metadata enrichment."""
+
+    force: bool = Field(
+        default=False,
+        description="Re-enrich even if metadata already exists.",
+    )
+
+
+class EnrichResponse(BaseModel):
+    """Response body for single media enrichment."""
+
+    media_id: str
+    enriched: bool
+    provider: str | None = None
+    error: str | None = None
+
+
+class BulkEnrichResponse(BaseModel):
+    """Response body for bulk metadata enrichment."""
+
+    movies_enriched: int
+    series_enriched: int
+    skipped: int
+    errors: list[str] = Field(default_factory=list)
+
+
+__all__ = ["BulkEnrichResponse", "EnrichRequest", "EnrichResponse"]

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -1,0 +1,150 @@
+"""Tests for EnrichMovieMetadataUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
+from src.modules.media.application.ports import MediaMetadata, MetadataProvider
+from src.modules.media.application.use_cases.enrich_movie_metadata import (
+    EnrichMovieMetadataUseCase,
+)
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.repositories import MovieRepository
+
+
+def _make_movie() -> Movie:
+    return Movie.create(
+        title="Inception",
+        year=2010,
+        duration=0,
+        file_path="/movies/inception.mkv",
+        file_size=4_000_000_000,
+        resolution="1080p",
+    )
+
+
+def _make_metadata() -> MediaMetadata:
+    return MediaMetadata(
+        title="Inception",
+        original_title="Inception",
+        year=2010,
+        duration_seconds=8880,
+        synopsis="A mind-bending thriller.",
+        genres=["Sci-Fi", "Action"],
+        tmdb_id=27205,
+        imdb_id="tt1375666",
+    )
+
+
+@pytest.mark.unit
+class TestEnrichMovieMetadata:
+    """Tests for EnrichMovieMetadataUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_enrich_movie_with_metadata(self) -> None:
+        movie = _make_movie()
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = _make_metadata()
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is True
+        assert result.provider == "tmdb"
+        repo.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_should_skip_already_enriched_movie(self) -> None:
+        movie = _make_movie()
+        movie = movie.with_updates(tmdb_id=27205)
+
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+
+        provider = AsyncMock(spec=MetadataProvider)
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is False
+        provider.search_movie.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_force_re_enrich(self) -> None:
+        movie = _make_movie()
+        movie = movie.with_updates(tmdb_id=27205)
+
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_movie_by_id.return_value = _make_metadata()
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id), force=True))
+
+        assert result.enriched is True
+
+    @pytest.mark.asyncio
+    async def test_should_use_fallback_when_primary_fails(self) -> None:
+        movie = _make_movie()
+
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+
+        primary = AsyncMock(spec=MetadataProvider)
+        primary.search_movie.return_value = None
+
+        fallback = AsyncMock(spec=MetadataProvider)
+        fallback.search_movie.return_value = _make_metadata()
+
+        use_case = EnrichMovieMetadataUseCase(
+            movie_repository=repo,
+            primary_provider=primary,
+            fallback_provider=fallback,
+        )
+
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is True
+        assert result.provider == "omdb"
+
+    @pytest.mark.asyncio
+    async def test_should_return_error_when_no_metadata_found(self) -> None:
+        movie = _make_movie()
+
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = None
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_movie_not_found(self) -> None:
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = None
+
+        provider = AsyncMock(spec=MetadataProvider)
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+
+        from src.modules.media.domain.value_objects import MovieId
+
+        fake_id = str(MovieId.generate())
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(EnrichMediaInput(media_id=fake_id))

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -1,0 +1,145 @@
+"""Tests for EnrichSeriesMetadataUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
+from src.modules.media.application.ports import (
+    EpisodeMetadata,
+    MediaMetadata,
+    MetadataProvider,
+    SeasonMetadata,
+)
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
+from src.modules.media.domain.entities import Episode, Season, Series
+from src.modules.media.domain.repositories import SeriesRepository
+from src.modules.media.domain.value_objects import Duration, FilePath, MediaFile, Resolution, Title
+
+
+def _make_series(**kwargs: object) -> Series:
+    series = Series.create(title="Breaking Bad", start_year=2008, **kwargs)
+    assert series.id is not None
+    season = Season(series_id=series.id, season_number=1)
+    episode = Episode(
+        series_id=series.id,
+        season_number=1,
+        episode_number=1,
+        title=Title("Episode 1"),
+        duration=Duration(0),
+        files=[
+            MediaFile(
+                file_path=FilePath("/series/bb/s01e01.mkv"),
+                file_size=500_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+        ],
+    )
+    season = season.with_episode(episode)
+    return series.with_season(season)
+
+
+def _make_metadata() -> MediaMetadata:
+    return MediaMetadata(
+        title="Breaking Bad",
+        original_title="Breaking Bad",
+        year=2008,
+        end_year=2013,
+        synopsis="A chemistry teacher turns to a life of crime.",
+        genres=["Drama", "Crime"],
+        tmdb_id=1396,
+        imdb_id="tt0903747",
+        seasons=[
+            SeasonMetadata(
+                season_number=1,
+                title="Season 1",
+                synopsis="The beginning.",
+                air_date="2008-01-20",
+                episodes=[
+                    EpisodeMetadata(
+                        season_number=1,
+                        episode_number=1,
+                        title="Pilot",
+                        synopsis="Walter White begins.",
+                        air_date="2008-01-20",
+                        duration_seconds=3480,
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+@pytest.mark.unit
+class TestEnrichSeriesMetadata:
+    """Tests for EnrichSeriesMetadataUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_enrich_series_with_metadata(self) -> None:
+        series = _make_series()
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+        repo.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = _make_metadata()
+
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        assert result.enriched is True
+        assert result.provider == "tmdb"
+
+        saved = repo.save.call_args[0][0]
+        assert saved.tmdb_id == 1396
+        assert saved.synopsis is not None
+
+    @pytest.mark.asyncio
+    async def test_should_enrich_episode_title(self) -> None:
+        series = _make_series()
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+        repo.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = _make_metadata()
+
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        saved = repo.save.call_args[0][0]
+        episode = saved.seasons[0].episodes[0]
+        assert episode.title.value == "Pilot"
+
+    @pytest.mark.asyncio
+    async def test_should_skip_already_enriched(self) -> None:
+        series = _make_series()
+        series = series.with_updates(tmdb_id=1396)
+
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+
+        provider = AsyncMock(spec=MetadataProvider)
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        assert result.enriched is False
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_series_not_found(self) -> None:
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = None
+
+        provider = AsyncMock(spec=MetadataProvider)
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+
+        from src.modules.media.domain.value_objects import SeriesId
+
+        fake_id = str(SeriesId.generate())
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(EnrichMediaInput(media_id=fake_id))


### PR DESCRIPTION
## Summary

- Add `MetadataProvider` port with `MediaMetadata`, `SeasonMetadata`, and `EpisodeMetadata` data classes
- Implement `TmdbClient` using httpx for movie/series search and detail fetching (including seasons and episodes)
- Add `EnrichMovieMetadataUseCase` and `EnrichSeriesMetadataUseCase` with primary/fallback provider strategy
- Add `BulkEnrichMetadataUseCase` for enriching all unenriched media at once
- Create `POST /api/v1/movies/{id}/enrich`, `POST /api/v1/series/{id}/enrich`, and `POST /api/v1/enrich` endpoints
- Wire `TmdbClient` and enrichment use cases in `MediaContainer`

## Test plan

- [x] 6 unit tests for `EnrichMovieMetadataUseCase` (enrich, skip, force, fallback, not found, no metadata)
- [x] 4 unit tests for `EnrichSeriesMetadataUseCase` (enrich, episode title, skip, not found)
- [x] All 724 tests pass
- [x] All pre-commit hooks pass (ruff, mypy, conventional commit)

## Summary by Sourcery

Introduce external metadata enrichment for movies and series using a TMDB-backed provider and expose it via new API endpoints.

New Features:
- Add a generic metadata provider port and DTOs to model media, season, and episode metadata from external services.
- Implement a TMDB client as a concrete metadata provider for searching and fetching movie and series details including seasons and episodes.
- Add use cases to enrich movie and series entities with external metadata and a bulk enrichment use case to process all media.
- Expose REST endpoints to trigger enrichment for a single movie, a single series, or all media items.

Enhancements:
- Wire TMDB client and enrichment use cases into the media dependency injection container and application startup.
- Extend media presentation schemas to support enrichment request and response payloads.

Tests:
- Add unit test suites for movie and series enrichment use cases covering enrichment, skipping, forcing, fallback, and error scenarios.