### PR TITLE
chore(config): change default API port to 8005

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     # =========================================================================
 
     host: str = Field(default="0.0.0.0")
-    port: int = Field(default=8000)
+    port: int = Field(default=8005)
     allowed_origins: list[str] = Field(default=["http://localhost:3000", "http://localhost:5173"])
 
     @field_validator("allowed_origins", mode="before")


### PR DESCRIPTION
## Summary

- Change default API port from 8000 to 8005 to avoid conflicts
- Frontend proxy is configured to target localhost:8005

## Test plan

- [x] All tests pass
- [x] Pre-commit hooks pass

## Summary by Sourcery

Enhancements:
- Change the default API port setting from 8000 to 8005 in the backend configuration to avoid local port conflicts.