### PR TITLE
fix(infra): wire database session into DI containers

### DIFF
--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -4,23 +4,57 @@ Provides database connections, external API clients, and other
 infrastructure components.
 """
 
+from collections.abc import AsyncGenerator
+
 from dependency_injector import containers, providers
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from src.config.settings import Settings
 
 
+async def _create_session(
+    database_url: str,
+) -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """Create an async session factory with engine lifecycle management."""
+    is_sqlite = database_url.startswith("sqlite")
+    engine_kwargs: dict[str, object] = {"echo": False}
+
+    if not is_sqlite:
+        engine_kwargs["pool_size"] = 5
+        engine_kwargs["max_overflow"] = 10
+
+    engine = create_async_engine(database_url, **engine_kwargs)
+
+    # Create tables for dev (Alembic handles prod migrations)
+    import src.modules.media.infrastructure.persistence.models  # noqa: F401
+    from src.config.persistence.base import Base
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+    yield session_factory
+
+    await engine.dispose()
+
+
 class InfrastructureContainer(containers.DeclarativeContainer):  # type: ignore[misc]
-    """Container for infrastructure dependencies.
+    """Container for infrastructure dependencies."""
 
-    Includes:
-    - Database connections
-    - External API clients (TMDB, OMDb)
-    - File system services
-
-    Note:
-        Database, external API clients, and file system services
-        will be added as providers when their implementations are ready.
-    """
-
-    # Settings is provided by parent container
     config = providers.Dependency(instance_of=Settings)
+
+    session_factory = providers.Resource(
+        _create_session,
+        database_url=config.provided.database_url,
+    )
+
+    session = providers.Factory(
+        lambda factory: factory(),
+        factory=session_factory,
+    )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -52,7 +52,10 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     # Bounded Context Containers
     # =========================================================================
 
-    media = providers.Container(MediaContainer)
+    media = providers.Container(
+        MediaContainer,
+        session=infrastructure.session,
+    )
 
     library = providers.Container(LibraryContainer)
 

--- a/src/main.py
+++ b/src/main.py
@@ -64,13 +64,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
     app.state.container = container
 
+    # Initialize database
+    await container.infrastructure.init_resources()
+
     logger.info("Application ready")
 
     yield
 
     # Shutdown
     logger.info("Application shutting down")
-
+    await container.infrastructure.shutdown_resources()
     logger.info("Application stopped")
 
 


### PR DESCRIPTION
## Summary

- Add async session factory `Resource` to `InfrastructureContainer` with engine lifecycle management
- Auto-create tables on startup for dev (Alembic handles prod)
- Wire `session` from `InfrastructureContainer` into `MediaContainer` via `ApplicationContainer`
- Init/shutdown database resources in application lifespan

This fixes the `Dependency "ApplicationContainer.media.session" is not defined` error that occurred on all API calls.

## Test plan

- [x] All 742 tests pass
- [x] Pre-commit hooks pass
- [x] Manual test: API starts and serves `/api/v1/movies` successfully

## Summary by Sourcery

Wire the asynchronous database session into the dependency injection containers and manage its lifecycle during application startup and shutdown.

New Features:
- Introduce an async SQLAlchemy session factory resource in the infrastructure container with engine lifecycle management.

Bug Fixes:
- Provide the media container with a database session dependency to resolve missing dependency errors on API calls.

Enhancements:
- Automatically create database tables on startup for development environments while keeping production migrations managed externally.
- Initialize and shut down infrastructure resources, including the database engine, within the FastAPI application lifespan.