### PR TITLE
fix(infra): database wiring, session management, and enrich improvements

### DIFF
--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -7,6 +7,7 @@ infrastructure components.
 from collections.abc import AsyncGenerator
 
 from dependency_injector import containers, providers
+from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from src.config.settings import Settings
@@ -17,9 +18,13 @@ async def _init_engine(
 ) -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
     """Create engine and session factory with lifecycle management."""
     is_sqlite = database_url.startswith("sqlite")
+
     engine_kwargs: dict[str, object] = {"echo": False}
 
-    if not is_sqlite:
+    if is_sqlite:
+        # SQLite: use NullPool to avoid connection limit issues
+        engine_kwargs["poolclass"] = pool.NullPool
+    else:
         engine_kwargs["pool_size"] = 5
         engine_kwargs["max_overflow"] = 10
 

--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -12,10 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from src.config.settings import Settings
 
 
-async def _create_session(
+async def _init_engine(
     database_url: str,
 ) -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
-    """Create an async session factory with engine lifecycle management."""
+    """Create engine and session factory with lifecycle management."""
     is_sqlite = database_url.startswith("sqlite")
     engine_kwargs: dict[str, object] = {"echo": False}
 
@@ -32,14 +32,14 @@ async def _create_session(
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    session_factory = async_sessionmaker(
+    factory = async_sessionmaker(
         bind=engine,
         class_=AsyncSession,
         expire_on_commit=False,
         autoflush=False,
     )
 
-    yield session_factory
+    yield factory
 
     await engine.dispose()
 
@@ -50,7 +50,7 @@ class InfrastructureContainer(containers.DeclarativeContainer):  # type: ignore[
     config = providers.Dependency(instance_of=Settings)
 
     session_factory = providers.Resource(
-        _create_session,
+        _init_engine,
         database_url=config.provided.database_url,
     )
 

--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -30,12 +30,15 @@ async def _init_engine(
 
     engine = create_async_engine(database_url, **engine_kwargs)
 
-    # Create tables for dev (Alembic handles prod migrations)
-    import src.modules.media.infrastructure.persistence.models  # noqa: F401
-    from src.config.persistence.base import Base
+    # Auto-create tables only in dev (prod uses Alembic migrations)
+    from src.config.settings import get_settings
 
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    if get_settings().is_development:
+        import src.modules.media.infrastructure.persistence.models  # noqa: F401
+        from src.config.persistence.base import Base
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
 
     factory = async_sessionmaker(
         bind=engine,

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -55,6 +55,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     media = providers.Container(
         MediaContainer,
         session=infrastructure.session,
+        tmdb_api_key=config.provided.tmdb_api_key,
     )
 
     library = providers.Container(LibraryContainer)

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -145,7 +145,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # =========================================================================
 
     # Must be wired from parent container (Settings.tmdb_api_key)
-    tmdb_api_key = providers.Dependency()
+    tmdb_api_key = providers.Dependency(default="")
 
     tmdb_client = providers.Singleton(TmdbClient, api_key=tmdb_api_key)
 

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -1,5 +1,7 @@
 """Use case for enriching a movie with external metadata."""
 
+import logging
+
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.enrichment_dtos import (
     EnrichMediaInput,
@@ -17,6 +19,8 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 class EnrichMovieMetadataUseCase:
@@ -106,6 +110,7 @@ class EnrichMovieMetadataUseCase:
             if metadata:
                 return metadata, "omdb"
 
+        _logger.warning("No metadata found for movie %r", title)
         return None, None
 
 
@@ -113,29 +118,30 @@ def _clean_title(title: str) -> str:
     """Remove common quality tags and noise from a title for better search."""
     import re
 
-    # Remove resolution/codec/source tags
+    # Remove words containing resolution (e.g. "TetraBD720p", "1080p", "FHD")
+    result = re.sub(r"\S*\d{3,4}p\S*", "", title, flags=re.IGNORECASE)
+
+    # Remove known tags
     patterns = [
-        r"\b\d{3,4}p\b",
         r"\b(?:4K|UHD|FHD|HD|SD)\b",
         r"\b(?:BluRay|BDRip|BRRip|WEB-?DL|WEB-?Rip|HDTV|DVDRip|REMUX)\b",
-        r"\b(?:HEVC|H\.?265|H\.?264|x264|x265|AV1|VP9)\b",
+        r"\b(?:HEVC|H\.?265|H\.?264|x264|x265|AV1|VP9|MPEG4)\b",
         r"\b(?:HDR10\+?|HDR|DolbyVision|DV|HLG)\b",
         r"\b(?:DTS(?:-HD)?(?:\.?MA)?|TrueHD|Atmos|AAC|AC3|FLAC|EAC3)\b",
-        r"\b(?:PROPER|REPACK|EXTENDED|UNRATED|IMAX)\b",
-        r"\b(?:TetraBD|MemoriadaTV)\b",
+        r"\b(?:PROPER|REPACK|EXTENDED|UNRATED|IMAX|DC)\b",
+        r"\b(?:TetraBD|MemoriadaTV|YIFY|RARBG|NTb|FGT|EVO|SPARKS)\b",
         r"\b\d{1,2}\.\d\b",  # audio channels like 5.1
         r"\[.*?\]",
         r"\(.*?\)",
     ]
-    result = title
     for pattern in patterns:
         result = re.sub(pattern, "", result, flags=re.IGNORECASE)
 
-    # Remove trailing numbers that look like year but aren't (e.g. "86")
+    # Remove standalone 2-digit numbers (e.g. "86" from year in filename)
     result = re.sub(r"\b\d{2}\b", "", result)
 
-    # Clean up whitespace
-    result = re.sub(r"\s+", " ", result).strip()
+    # Clean up whitespace and trailing punctuation
+    result = re.sub(r"\s+", " ", result).strip().strip("-._")
     return result
 
 
@@ -143,6 +149,8 @@ def _apply_movie_metadata(movie: Movie, metadata: MediaMetadata) -> Movie:
     """Apply metadata fields to a movie entity."""
     updates: dict[str, object] = {}
 
+    if metadata.title:
+        updates["title"] = Title(metadata.title)
     if metadata.synopsis and not movie.synopsis:
         updates["synopsis"] = metadata.synopsis
     if metadata.tmdb_id:

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -71,22 +71,72 @@ class EnrichMovieMetadataUseCase:
         return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)
 
     async def _fetch_metadata(self, movie: Movie) -> tuple[MediaMetadata | None, str | None]:
-        """Try primary provider, then fallback."""
+        """Try primary provider, then fallback.
+
+        Searches with original title first, then retries with a
+        cleaned title (quality tags removed) and without year.
+        """
         if movie.tmdb_id:
             metadata = await self._primary.get_movie_by_id(movie.tmdb_id.value)
             if metadata:
                 return metadata, "tmdb"
 
-        metadata = await self._primary.search_movie(movie.title.value, movie.year.value)
+        title = movie.title.value
+        year = movie.year.value
+
+        # Try with original title + year
+        metadata = await self._primary.search_movie(title, year)
+        if metadata:
+            return metadata, "tmdb"
+
+        # Retry with cleaned title (remove quality tags) and no year
+        clean = _clean_title(title)
+        if clean != title:
+            metadata = await self._primary.search_movie(clean)
+            if metadata:
+                return metadata, "tmdb"
+
+        # Retry with just the title, no year
+        metadata = await self._primary.search_movie(title)
         if metadata:
             return metadata, "tmdb"
 
         if self._fallback:
-            metadata = await self._fallback.search_movie(movie.title.value, movie.year.value)
+            metadata = await self._fallback.search_movie(clean or title)
             if metadata:
                 return metadata, "omdb"
 
         return None, None
+
+
+def _clean_title(title: str) -> str:
+    """Remove common quality tags and noise from a title for better search."""
+    import re
+
+    # Remove resolution/codec/source tags
+    patterns = [
+        r"\b\d{3,4}p\b",
+        r"\b(?:4K|UHD|FHD|HD|SD)\b",
+        r"\b(?:BluRay|BDRip|BRRip|WEB-?DL|WEB-?Rip|HDTV|DVDRip|REMUX)\b",
+        r"\b(?:HEVC|H\.?265|H\.?264|x264|x265|AV1|VP9)\b",
+        r"\b(?:HDR10\+?|HDR|DolbyVision|DV|HLG)\b",
+        r"\b(?:DTS(?:-HD)?(?:\.?MA)?|TrueHD|Atmos|AAC|AC3|FLAC|EAC3)\b",
+        r"\b(?:PROPER|REPACK|EXTENDED|UNRATED|IMAX)\b",
+        r"\b(?:TetraBD|MemoriadaTV)\b",
+        r"\b\d{1,2}\.\d\b",  # audio channels like 5.1
+        r"\[.*?\]",
+        r"\(.*?\)",
+    ]
+    result = title
+    for pattern in patterns:
+        result = re.sub(pattern, "", result, flags=re.IGNORECASE)
+
+    # Remove trailing numbers that look like year but aren't (e.g. "86")
+    result = re.sub(r"\b\d{2}\b", "", result)
+
+    # Clean up whitespace
+    result = re.sub(r"\s+", " ", result).strip()
+    return result
 
 
 def _apply_movie_metadata(movie: Movie, metadata: MediaMetadata) -> Movie:

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -87,6 +87,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
             self._session.add(model)
             await self._session.flush()
 
+        await self._session.commit()
+
         # Reload with relationships to return a complete entity
         assert movie.id is not None
         result_entity = await self.find_by_id(movie.id)
@@ -114,6 +116,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         model.soft_delete()
         await self._session.flush()
+        await self._session.commit()
         return True
 
     async def list_all(self) -> Sequence[Movie]:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -142,6 +142,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 episode.soft_delete()
 
         await self._session.flush()
+        await self._session.commit()
         return True
 
     async def list_all(self) -> Sequence[Series]:
@@ -299,6 +300,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 self._session.add(episode_model)
 
         await self._session.flush()
+        await self._session.commit()
 
         # Reload and return (series.id is guaranteed to exist after _ensure_ids)
         assert series.id is not None
@@ -352,6 +354,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 ep_model.soft_delete()
 
         await self._session.flush()
+        await self._session.commit()
 
         # Reload and return (series.id is guaranteed to exist)
         assert series.id is not None


### PR DESCRIPTION
## Summary

- Wire database session from `InfrastructureContainer` into `MediaContainer` via `ApplicationContainer`
- Auto-create tables on startup for dev (Alembic handles prod)
- Init/shutdown database resources in application lifespan
- Add explicit `commit()` after `flush()` in repositories to persist data
- Use `NullPool` for SQLite to prevent connection pool exhaustion
- Wire `tmdb_api_key` from Settings to `MediaContainer`
- Clean movie titles (remove quality tags) before TMDB search for better matching
- Update movie title from TMDB metadata on enrich

## Test plan

- [x] All 742 tests pass
- [x] Manual test: scan + enrich end-to-end working
- [x] Pre-commit hooks pass

## Summary by Sourcery

Wire database lifecycle and sessions into the application and media module, and improve TMDB-based movie metadata enrichment.

New Features:
- Introduce an async SQLAlchemy engine and session factory managed via the infrastructure container with app lifespan initialization and teardown.
- Wire a TMDB API key and database session into the media container for external metadata retrieval and persistence.
- Enhance movie metadata enrichment by cleaning noisy quality tags from titles, retrying searches, and updating local titles from TMDB metadata.

Bug Fixes:
- Ensure movie and series persistence operations explicitly commit after flush to reliably save changes and soft deletes.
- Use a NullPool for SQLite connections to avoid connection pool exhaustion in development and test environments.

Enhancements:
- Auto-create database tables at startup for development environments while leaving migrations to Alembic in production.
- Add logging when no external metadata is found for a movie to aid debugging of enrichment failures.