### PR TITLE
feat(media): add video streaming endpoint with Range support

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ from src.modules.media.presentation.routes import (
     movie_router,
     scan_router,
     series_router,
+    stream_router,
 )
 
 
@@ -60,6 +61,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "src.modules.media.presentation.routes.movie_routes",
             "src.modules.media.presentation.routes.scan_routes",
             "src.modules.media.presentation.routes.series_routes",
+            "src.modules.media.presentation.routes.stream_routes",
         ],
     )
     app.state.container = container
@@ -114,6 +116,7 @@ def create_app() -> FastAPI:
     app.include_router(movie_router)
     app.include_router(scan_router)
     app.include_router(series_router)
+    app.include_router(stream_router)
 
     return app
 

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -4,5 +4,6 @@ from src.modules.media.presentation.routes.enrichment_routes import router as en
 from src.modules.media.presentation.routes.movie_routes import router as movie_router
 from src.modules.media.presentation.routes.scan_routes import router as scan_router
 from src.modules.media.presentation.routes.series_routes import router as series_router
+from src.modules.media.presentation.routes.stream_routes import router as stream_router
 
-__all__ = ["enrichment_router", "movie_router", "scan_router", "series_router"]
+__all__ = ["enrichment_router", "movie_router", "scan_router", "series_router", "stream_router"]

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -1,0 +1,156 @@
+"""Video streaming REST API routes."""
+
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from src.config.containers import ApplicationContainer
+from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
+from src.modules.media.application.dtos.series_dtos import GetSeriesByIdInput
+from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
+from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
+
+router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
+
+_CHUNK_SIZE = 1024 * 1024  # 1 MB
+
+_MIME_TYPES = {
+    ".mp4": "video/mp4",
+    ".mkv": "video/x-matroska",
+    ".avi": "video/x-msvideo",
+    ".mov": "video/quicktime",
+    ".wmv": "video/x-ms-wmv",
+    ".webm": "video/webm",
+}
+
+
+def _get_mime_type(file_path: str) -> str:
+    """Get MIME type based on file extension."""
+    ext = Path(file_path).suffix.lower()
+    return _MIME_TYPES.get(ext, "application/octet-stream")
+
+
+async def _stream_file(
+    file_path: str,
+    start: int,
+    end: int,
+) -> AsyncGenerator[bytes, None]:
+    """Stream file bytes in chunks."""
+    with Path(file_path).open("rb") as f:
+        f.seek(start)
+        remaining = end - start + 1
+        while remaining > 0:
+            chunk_size = min(_CHUNK_SIZE, remaining)
+            data = f.read(chunk_size)
+            if not data:
+                break
+            remaining -= len(data)
+            yield data
+
+
+def _build_range_response(
+    file_path: str,
+    file_size: int,
+    range_header: str | None,
+) -> StreamingResponse:
+    """Build a streaming response with Range support."""
+    content_type = _get_mime_type(file_path)
+
+    if range_header:
+        # Parse Range header: "bytes=start-end"
+        range_spec = range_header.replace("bytes=", "")
+        parts = range_spec.split("-")
+
+        start = int(parts[0]) if parts[0] else 0
+        end = int(parts[1]) if parts[1] else file_size - 1
+
+        start = max(0, start)
+        end = min(end, file_size - 1)
+        content_length = end - start + 1
+
+        return StreamingResponse(
+            _stream_file(file_path, start, end),
+            status_code=206,
+            media_type=content_type,
+            headers={
+                "Content-Range": f"bytes {start}-{end}/{file_size}",
+                "Accept-Ranges": "bytes",
+                "Content-Length": str(content_length),
+            },
+        )
+
+    return StreamingResponse(
+        _stream_file(file_path, 0, file_size - 1),
+        media_type=content_type,
+        headers={
+            "Accept-Ranges": "bytes",
+            "Content-Length": str(file_size),
+        },
+    )
+
+
+@router.get("/movie/{movie_id}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def stream_movie(
+    movie_id: str,
+    request: Request,
+    use_case: GetMovieByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_movie_by_id],
+    ),
+) -> StreamingResponse:
+    """Stream a movie's primary video file."""
+    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
+
+    if not movie.file_path:
+        raise HTTPException(status_code=404, detail="No video file available")
+
+    path = Path(movie.file_path)
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="Video file not found on disk")
+
+    file_size = path.stat().st_size
+    range_header = request.headers.get("range")
+
+    return _build_range_response(movie.file_path, file_size, range_header)
+
+
+@router.get("/episode/{series_id}/{season_number}/{episode_number}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def stream_episode(
+    series_id: str,
+    season_number: int,
+    episode_number: int,
+    request: Request,
+    use_case: GetSeriesByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_series_by_id],
+    ),
+) -> StreamingResponse:
+    """Stream an episode's primary video file."""
+    series = await use_case.execute(GetSeriesByIdInput(series_id=series_id))
+
+    file_path = None
+    for season in series.seasons:
+        if season.season_number == season_number:
+            for episode in season.episodes:
+                if episode.episode_number == episode_number:
+                    file_path = episode.file_path
+                    break
+            break
+
+    if not file_path:
+        raise HTTPException(status_code=404, detail="Episode file not found")
+
+    path = Path(file_path)
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="Video file not found on disk")
+
+    file_size = path.stat().st_size
+    range_header = request.headers.get("range")
+
+    return _build_range_response(file_path, file_size, range_header)
+
+
+__all__ = ["router"]

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -1,5 +1,12 @@
-"""Video streaming REST API routes."""
+"""Video streaming REST API routes.
 
+Supports direct streaming for MP4/WebM and FFmpeg transmuxing
+for MKV/AVI/MOV/WMV to MP4 (container conversion without
+re-encoding for browser compatibility).
+"""
+
+import asyncio
+import shutil
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -15,66 +22,124 @@ from src.modules.media.application.use_cases.get_series_by_id import GetSeriesBy
 
 router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
 
-_CHUNK_SIZE = 1024 * 1024  # 1 MB
+_CHUNK_SIZE = 64 * 1024  # 64 KB for transmuxed streams
 
-_MIME_TYPES = {
-    ".mp4": "video/mp4",
-    ".mkv": "video/x-matroska",
-    ".avi": "video/x-msvideo",
-    ".mov": "video/quicktime",
-    ".wmv": "video/x-ms-wmv",
-    ".webm": "video/webm",
-}
+# Formats that browsers can play natively
+_NATIVE_FORMATS = {".mp4", ".webm"}
 
 
-def _get_mime_type(file_path: str) -> str:
-    """Get MIME type based on file extension."""
-    ext = Path(file_path).suffix.lower()
-    return _MIME_TYPES.get(ext, "application/octet-stream")
+def _needs_transmux(file_path: str) -> bool:
+    """Check if file needs FFmpeg transmuxing for browser playback."""
+    return Path(file_path).suffix.lower() not in _NATIVE_FORMATS
 
 
-async def _stream_file(
+def _ffmpeg_available() -> bool:
+    """Check if FFmpeg is available on the system."""
+    return shutil.which("ffmpeg") is not None
+
+
+async def _stream_native(
     file_path: str,
     start: int,
     end: int,
 ) -> AsyncGenerator[bytes, None]:
-    """Stream file bytes in chunks."""
+    """Stream native file bytes in chunks."""
     with Path(file_path).open("rb") as f:
         f.seek(start)
         remaining = end - start + 1
+        chunk_size = 1024 * 1024  # 1 MB for native
         while remaining > 0:
-            chunk_size = min(_CHUNK_SIZE, remaining)
-            data = f.read(chunk_size)
+            read_size = min(chunk_size, remaining)
+            data = f.read(read_size)
             if not data:
                 break
             remaining -= len(data)
             yield data
 
 
-def _build_range_response(
+async def _stream_transmux(file_path: str) -> AsyncGenerator[bytes, None]:
+    """Transmux video to MP4 via FFmpeg (copy codecs, no re-encoding)."""
+    cmd = [
+        "ffmpeg",
+        "-i",
+        file_path,
+        "-c:v",
+        "copy",
+        "-c:a",
+        "aac",  # Re-encode audio to AAC for browser compat
+        "-movflags",
+        "frag_keyframe+empty_moov+faststart",
+        "-f",
+        "mp4",
+        "-loglevel",
+        "error",
+        "pipe:1",
+    ]
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    try:
+        assert process.stdout is not None
+        while True:
+            chunk = await process.stdout.read(_CHUNK_SIZE)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        if process.returncode is None:
+            process.kill()
+        await process.wait()
+
+
+def _resolve_file(file_path: str | None) -> Path:
+    """Validate file path exists and return Path object."""
+    if not file_path:
+        raise HTTPException(status_code=404, detail="No video file available")
+
+    path = Path(file_path)
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="Video file not found on disk")
+
+    return path
+
+
+def _build_response(
     file_path: str,
     file_size: int,
     range_header: str | None,
 ) -> StreamingResponse:
-    """Build a streaming response with Range support."""
-    content_type = _get_mime_type(file_path)
+    """Build streaming response — native with Range or transmuxed."""
+    if _needs_transmux(file_path):
+        if not _ffmpeg_available():
+            raise HTTPException(
+                status_code=500,
+                detail="FFmpeg is required to stream MKV/AVI files but was not found",
+            )
+        # Transmuxed streams don't support Range (live pipe)
+        return StreamingResponse(
+            _stream_transmux(file_path),
+            media_type="video/mp4",
+            headers={"Accept-Ranges": "none"},
+        )
 
+    # Native MP4/WebM — support Range requests
     if range_header:
-        # Parse Range header: "bytes=start-end"
         range_spec = range_header.replace("bytes=", "")
         parts = range_spec.split("-")
-
         start = int(parts[0]) if parts[0] else 0
         end = int(parts[1]) if parts[1] else file_size - 1
-
         start = max(0, start)
         end = min(end, file_size - 1)
         content_length = end - start + 1
 
         return StreamingResponse(
-            _stream_file(file_path, start, end),
+            _stream_native(file_path, start, end),
             status_code=206,
-            media_type=content_type,
+            media_type="video/mp4",
             headers={
                 "Content-Range": f"bytes {start}-{end}/{file_size}",
                 "Accept-Ranges": "bytes",
@@ -83,8 +148,8 @@ def _build_range_response(
         )
 
     return StreamingResponse(
-        _stream_file(file_path, 0, file_size - 1),
-        media_type=content_type,
+        _stream_native(file_path, 0, file_size - 1),
+        media_type="video/mp4",
         headers={
             "Accept-Ranges": "bytes",
             "Content-Length": str(file_size),
@@ -103,18 +168,13 @@ async def stream_movie(
 ) -> StreamingResponse:
     """Stream a movie's primary video file."""
     movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
+    path = _resolve_file(movie.file_path)
 
-    if not movie.file_path:
-        raise HTTPException(status_code=404, detail="No video file available")
-
-    path = Path(movie.file_path)
-    if not path.is_file():
-        raise HTTPException(status_code=404, detail="Video file not found on disk")
-
-    file_size = path.stat().st_size
-    range_header = request.headers.get("range")
-
-    return _build_range_response(movie.file_path, file_size, range_header)
+    return _build_response(
+        str(path),
+        path.stat().st_size,
+        request.headers.get("range"),
+    )
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}")  # type: ignore[misc]
@@ -140,17 +200,13 @@ async def stream_episode(
                     break
             break
 
-    if not file_path:
-        raise HTTPException(status_code=404, detail="Episode file not found")
+    path = _resolve_file(file_path)
 
-    path = Path(file_path)
-    if not path.is_file():
-        raise HTTPException(status_code=404, detail="Video file not found on disk")
-
-    file_size = path.stat().st_size
-    range_header = request.headers.get("range")
-
-    return _build_range_response(file_path, file_size, range_header)
+    return _build_response(
+        str(path),
+        path.stat().st_size,
+        request.headers.get("range"),
+    )
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -5,8 +5,8 @@ for MKV/AVI/MOV/WMV to MP4 (container conversion without
 re-encoding for browser compatibility).
 """
 
-import asyncio
 import shutil
+import subprocess
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -66,7 +66,7 @@ async def _stream_transmux(file_path: str) -> AsyncGenerator[bytes, None]:
         "-c:v",
         "copy",
         "-c:a",
-        "aac",  # Re-encode audio to AAC for browser compat
+        "aac",
         "-movflags",
         "frag_keyframe+empty_moov+faststart",
         "-f",
@@ -76,23 +76,22 @@ async def _stream_transmux(file_path: str) -> AsyncGenerator[bytes, None]:
         "pipe:1",
     ]
 
-    process = await asyncio.create_subprocess_exec(
-        *cmd,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
 
     try:
         assert process.stdout is not None
         while True:
-            chunk = await process.stdout.read(_CHUNK_SIZE)
+            chunk = process.stdout.read(_CHUNK_SIZE)
             if not chunk:
                 break
             yield chunk
     finally:
-        if process.returncode is None:
-            process.kill()
-        await process.wait()
+        process.kill()
+        process.wait()
 
 
 def _resolve_file(file_path: str | None) -> Path:


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/stream/movie/{movie_id}` for streaming movie files
- Add `GET /api/v1/stream/episode/{series_id}/{season}/{episode}` for streaming episodes
- HTTP Range Requests support for seeking without re-downloading
- 1MB chunk streaming for efficient memory usage
- MIME type detection from file extension (mp4, mkv, avi, mov, wmv, webm)

## Test plan

- [x] All 755 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual test: stream video in browser via `/api/v1/stream/movie/{id}`

## Summary by Sourcery

Add REST endpoints for streaming movie and episode video files with HTTP Range support for efficient partial content delivery.

New Features:
- Expose /api/v1/stream/movie/{movie_id} endpoint to stream a movie's primary video file.
- Expose /api/v1/stream/episode/{series_id}/{season_number}/{episode_number} endpoint to stream an episode's primary video file.
- Support HTTP Range requests with chunked streaming for large video files and basic MIME type detection based on file extension.

Enhancements:
- Register the new streaming router in the FastAPI application and media routes package for unified API exposure.