### PR TITLE
feat(media): add HLS streaming with segment caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ temp/
 
 # Claude Code context
 CLAUDE.md
+hls_cache/

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ setup: install-dev pc-install
 # =============================================================================
 
 dev:
-	poetry run uvicorn src.main:app --reload --host 0.0.0.0 --port 8000
+	poetry run uvicorn src.main:app --reload --host 0.0.0.0 --port 8005
 
 test:
 	poetry run pytest

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -56,6 +56,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         MediaContainer,
         session=infrastructure.session,
         tmdb_api_key=config.provided.tmdb_api_key,
+        hls_cache_directory=config.provided.hls_cache_directory,
     )
 
     library = providers.Container(LibraryContainer)

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -34,6 +34,7 @@ from src.modules.media.infrastructure.persistence.repositories.movie_repository 
 from src.modules.media.infrastructure.persistence.repositories.series_repository import (
     SQLAlchemySeriesRepository,
 )
+from src.modules.media.infrastructure.streaming.hls_service import HlsService
 
 
 class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
@@ -53,6 +54,9 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     # Must be wired from InfrastructureContainer.session
     session = providers.Dependency()
+
+    # Must be wired from parent container (Settings.hls_cache_directory)
+    hls_cache_directory = providers.Dependency(default="./hls_cache")
 
     # =========================================================================
     # Repositories
@@ -127,6 +131,8 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     file_scanner = providers.Factory(LocalFileSystemScanner)
 
     variant_detector = providers.Factory(VariantDetector)
+
+    hls_service = providers.Singleton(HlsService, cache_dir=hls_cache_directory)
 
     # =========================================================================
     # Use Cases — Scan

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -78,6 +78,10 @@ class Settings(BaseSettings):  # type: ignore[misc]
         default="./thumbnails",
         description="Directory to store generated thumbnails",
     )
+    hls_cache_directory: str = Field(
+        default="./hls_cache",
+        description="Directory to store cached HLS segments",
+    )
 
     @field_validator("media_directories", mode="before")
     @classmethod

--- a/src/modules/media/infrastructure/streaming/__init__.py
+++ b/src/modules/media/infrastructure/streaming/__init__.py
@@ -1,0 +1,1 @@
+"""Video streaming infrastructure."""

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -1,14 +1,25 @@
-"""HLS segment generation and caching service."""
+"""HLS segment generation and caching service.
 
+Supports progressive playback: FFmpeg runs in the background and
+the playlist is returned as soon as the first segments are ready.
+hls.js treats a playlist without ``#EXT-X-ENDLIST`` as a live stream
+and keeps polling for new segments until the tag appears.
+"""
+
+import asyncio
 import hashlib
 import logging
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
 _SEGMENT_DURATION = 10  # seconds per segment
+_POLL_INTERVAL = 0.5  # seconds between readiness checks
+_POLL_TIMEOUT = 120  # max seconds to wait for first segment
+_BROWSER_SAFE_CODECS = {"h264", "mpeg4", "mpeg2video"}
 
 
 class HlsService:
@@ -25,45 +36,178 @@ class HlsService:
     def __init__(self, cache_dir: str = "./hls_cache") -> None:
         self._cache_dir = Path(cache_dir)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._processes: dict[str, subprocess.Popen[bytes]] = {}
+        self._lock = threading.Lock()
+
+    def get_path_hash(self, file_path: str) -> str:
+        """Get the hash key for a file path."""
+        return hashlib.md5(file_path.encode()).hexdigest()
 
     def _get_output_dir(self, file_path: str) -> Path:
         """Get the cache directory for a specific video file."""
-        path_hash = hashlib.md5(file_path.encode()).hexdigest()
-        return self._cache_dir / path_hash
+        return self._cache_dir / self.get_path_hash(file_path)
 
-    def get_playlist_path(self, file_path: str) -> Path | None:
-        """Get the playlist path if segments exist, None otherwise."""
-        output_dir = self._get_output_dir(file_path)
-        playlist = output_dir / "playlist.m3u8"
-        return playlist if playlist.is_file() else None
-
-    def get_segment_path(self, file_path: str, segment_name: str) -> Path | None:
-        """Get a segment file path if it exists."""
-        output_dir = self._get_output_dir(file_path)
-        segment = output_dir / segment_name
+    def get_segment_by_hash(self, path_hash: str, segment_name: str) -> Path | None:
+        """Get a segment file by its path hash, without needing the original file path."""
+        segment = self._cache_dir / path_hash / segment_name
         return segment if segment.is_file() else None
 
-    def generate(self, file_path: str) -> Path:
-        """Generate HLS segments for a video file.
+    def is_complete(self, path_hash: str) -> bool:
+        """Check if generation is fully complete (playlist has ENDLIST tag)."""
+        playlist = self._cache_dir / path_hash / "playlist.m3u8"
+        if not playlist.is_file():
+            return False
+        try:
+            return "#EXT-X-ENDLIST" in playlist.read_text(encoding="utf-8")
+        except OSError:
+            return False
 
-        If segments already exist in cache, returns immediately.
-        Otherwise runs FFmpeg to create m3u8 + ts segments.
+    def get_playlist_content(self, path_hash: str) -> str | None:
+        """Get current playlist content, or None if not ready yet."""
+        playlist = self._cache_dir / path_hash / "playlist.m3u8"
+        if not playlist.is_file():
+            return None
+        try:
+            return playlist.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+    @staticmethod
+    def _probe_video_codec(file_path: str) -> str | None:
+        """Detect video codec using ffprobe."""
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=codec_name",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    file_path,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+            codec = result.stdout.strip().lower()
+            return codec if codec else None
+        except Exception:
+            return None
+
+    def _build_ffmpeg_cmd(self, file_path: str, output_dir: Path) -> list[str]:
+        """Build FFmpeg command, transcoding to H.264 if needed."""
+        codec = self._probe_video_codec(file_path)
+        needs_transcode = codec not in _BROWSER_SAFE_CODECS
+
+        if needs_transcode:
+            _logger.info(
+                "Source codec is %s — transcoding to H.264 for %s",
+                codec,
+                file_path,
+            )
+            video_args = ["-c:v", "libx264", "-preset", "ultrafast", "-crf", "23"]
+        else:
+            _logger.info("Source codec is %s — copying for %s", codec, file_path)
+            video_args = ["-c:v", "copy"]
+
+        return [
+            "ffmpeg",
+            "-i",
+            file_path,
+            "-map",
+            "0:v:0",
+            "-map",
+            "0:a:0",
+            "-sn",
+            *video_args,
+            "-c:a",
+            "aac",
+            "-ac",
+            "2",
+            "-ar",
+            "48000",
+            "-hls_time",
+            str(_SEGMENT_DURATION),
+            "-hls_list_size",
+            "0",
+            "-hls_playlist_type",
+            "event",
+            "-hls_segment_filename",
+            str(output_dir / "segment_%04d.ts"),
+            "-loglevel",
+            "error",
+            "-y",
+            str(output_dir / "playlist.m3u8"),
+        ]
+
+    def _start_ffmpeg(self, file_path: str) -> str:
+        """Start FFmpeg in background if not already running.
+
+        Returns:
+            The path hash for this file.
+        """
+        path_hash = self.get_path_hash(file_path)
+
+        with self._lock:
+            # Already complete
+            if self.is_complete(path_hash):
+                return path_hash
+
+            # Already running
+            if path_hash in self._processes:
+                proc = self._processes[path_hash]
+                if proc.poll() is None:
+                    return path_hash
+                # Process finished (maybe with error) — clean up handle
+                del self._processes[path_hash]
+
+            # Clean up stale incomplete cache from a previous run
+            output_dir = self._cache_dir / path_hash
+            if output_dir.exists():
+                _logger.info("Cleaning stale cache for %s", path_hash)
+                shutil.rmtree(output_dir, ignore_errors=True)
+
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            cmd = self._build_ffmpeg_cmd(file_path, output_dir)
+
+            _logger.info("Starting HLS generation for %s", file_path)
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+            self._processes[path_hash] = proc
+
+        return path_hash
+
+    async def ensure_playlist(self, file_path: str) -> str:
+        """Start generation and wait until the playlist has at least one segment.
+
+        For already-cached files this returns immediately. Otherwise
+        FFmpeg is launched in the background and we poll until the
+        m3u8 file appears with at least one segment entry.
 
         Args:
             file_path: Absolute path to the source video file.
 
         Returns:
-            Path to the generated playlist.m3u8 file.
+            The path hash for this file.
 
         Raises:
-            RuntimeError: If FFmpeg is not available or fails.
+            RuntimeError: If FFmpeg is not available, fails, or times out.
+            FileNotFoundError: If the source file does not exist.
         """
-        output_dir = self._get_output_dir(file_path)
-        playlist = output_dir / "playlist.m3u8"
+        path_hash = self.get_path_hash(file_path)
 
-        # Return cached if exists
-        if playlist.is_file():
-            return playlist
+        # Fast path: already fully generated
+        if self.is_complete(path_hash):
+            return path_hash
 
         if not shutil.which("ffmpeg"):
             msg = "FFmpeg is required for HLS streaming but was not found"
@@ -74,45 +218,31 @@ class HlsService:
             msg = f"Source file not found: {file_path}"
             raise FileNotFoundError(msg)
 
-        output_dir.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._start_ffmpeg, file_path)
 
-        cmd = [
-            "ffmpeg",
-            "-i",
-            file_path,
-            "-c:v",
-            "copy",
-            "-c:a",
-            "aac",
-            "-hls_time",
-            str(_SEGMENT_DURATION),
-            "-hls_list_size",
-            "0",
-            "-hls_segment_filename",
-            str(output_dir / "segment_%04d.ts"),
-            "-loglevel",
-            "error",
-            "-y",
-            str(playlist),
-        ]
+        # Poll until playlist has at least one segment
+        attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
+        for _ in range(attempts):
+            content = self.get_playlist_content(path_hash)
+            if content and "segment_" in content:
+                return path_hash
 
-        _logger.info("Generating HLS segments for %s", file_path)
+            # Check if process died
+            with self._lock:
+                proc = self._processes.get(path_hash)
+            if proc and proc.poll() is not None:
+                stderr = proc.stderr.read().decode() if proc.stderr else ""
+                _logger.error("FFmpeg exited with code %d: %s", proc.returncode, stderr)
+                # Clean up failed output
+                output_dir = self._cache_dir / path_hash
+                shutil.rmtree(output_dir, ignore_errors=True)
+                msg = f"FFmpeg failed (exit {proc.returncode}): {stderr}"
+                raise RuntimeError(msg)
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+            await asyncio.sleep(_POLL_INTERVAL)
 
-        if result.returncode != 0:
-            # Clean up on failure
-            shutil.rmtree(output_dir, ignore_errors=True)
-            msg = f"FFmpeg failed: {result.stderr}"
-            raise RuntimeError(msg)
-
-        _logger.info("HLS segments generated at %s", output_dir)
-        return playlist
+        msg = f"Timeout waiting for HLS segments ({_POLL_TIMEOUT}s)"
+        raise RuntimeError(msg)
 
     def clear_cache(self, file_path: str | None = None) -> None:
         """Clear cached HLS segments.

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -1,0 +1,131 @@
+"""HLS segment generation and caching service."""
+
+import hashlib
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+_SEGMENT_DURATION = 10  # seconds per segment
+
+
+class HlsService:
+    """Generate and cache HLS segments for video files.
+
+    Converts any video format to HLS (m3u8 + ts segments) via FFmpeg.
+    Segments are cached in a directory keyed by file path hash,
+    so subsequent plays skip the generation step.
+
+    Args:
+        cache_dir: Directory to store generated HLS files.
+    """
+
+    def __init__(self, cache_dir: str = "./hls_cache") -> None:
+        self._cache_dir = Path(cache_dir)
+        self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_output_dir(self, file_path: str) -> Path:
+        """Get the cache directory for a specific video file."""
+        path_hash = hashlib.md5(file_path.encode()).hexdigest()
+        return self._cache_dir / path_hash
+
+    def get_playlist_path(self, file_path: str) -> Path | None:
+        """Get the playlist path if segments exist, None otherwise."""
+        output_dir = self._get_output_dir(file_path)
+        playlist = output_dir / "playlist.m3u8"
+        return playlist if playlist.is_file() else None
+
+    def get_segment_path(self, file_path: str, segment_name: str) -> Path | None:
+        """Get a segment file path if it exists."""
+        output_dir = self._get_output_dir(file_path)
+        segment = output_dir / segment_name
+        return segment if segment.is_file() else None
+
+    def generate(self, file_path: str) -> Path:
+        """Generate HLS segments for a video file.
+
+        If segments already exist in cache, returns immediately.
+        Otherwise runs FFmpeg to create m3u8 + ts segments.
+
+        Args:
+            file_path: Absolute path to the source video file.
+
+        Returns:
+            Path to the generated playlist.m3u8 file.
+
+        Raises:
+            RuntimeError: If FFmpeg is not available or fails.
+        """
+        output_dir = self._get_output_dir(file_path)
+        playlist = output_dir / "playlist.m3u8"
+
+        # Return cached if exists
+        if playlist.is_file():
+            return playlist
+
+        if not shutil.which("ffmpeg"):
+            msg = "FFmpeg is required for HLS streaming but was not found"
+            raise RuntimeError(msg)
+
+        source = Path(file_path)
+        if not source.is_file():
+            msg = f"Source file not found: {file_path}"
+            raise FileNotFoundError(msg)
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "ffmpeg",
+            "-i",
+            file_path,
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            "-hls_time",
+            str(_SEGMENT_DURATION),
+            "-hls_list_size",
+            "0",
+            "-hls_segment_filename",
+            str(output_dir / "segment_%04d.ts"),
+            "-loglevel",
+            "error",
+            "-y",
+            str(playlist),
+        ]
+
+        _logger.info("Generating HLS segments for %s", file_path)
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        if result.returncode != 0:
+            # Clean up on failure
+            shutil.rmtree(output_dir, ignore_errors=True)
+            msg = f"FFmpeg failed: {result.stderr}"
+            raise RuntimeError(msg)
+
+        _logger.info("HLS segments generated at %s", output_dir)
+        return playlist
+
+    def clear_cache(self, file_path: str | None = None) -> None:
+        """Clear cached HLS segments.
+
+        Args:
+            file_path: Clear cache for specific file, or all if None.
+        """
+        if file_path:
+            output_dir = self._get_output_dir(file_path)
+            shutil.rmtree(output_dir, ignore_errors=True)
+        else:
+            shutil.rmtree(self._cache_dir, ignore_errors=True)
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+
+__all__ = ["HlsService"]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -74,7 +74,11 @@ class HlsService:
 
     @staticmethod
     def _probe_video_codec(file_path: str) -> str | None:
-        """Detect video codec using ffprobe."""
+        """Detect video codec using ffprobe.
+
+        Args:
+            file_path: Already-validated absolute path to the source file.
+        """
         try:
             result = subprocess.run(
                 [
@@ -145,12 +149,30 @@ class HlsService:
             str(output_dir / "playlist.m3u8"),
         ]
 
+    @staticmethod
+    def _validate_source(file_path: str) -> Path:
+        """Resolve and validate that file_path is an existing file.
+
+        Prevents path traversal and ensures the subprocess only
+        receives a resolved absolute path to a real file.
+
+        Raises:
+            FileNotFoundError: If path does not point to an existing file.
+        """
+        resolved = Path(file_path).resolve()
+        if not resolved.is_file():
+            msg = f"Source file not found: {file_path}"
+            raise FileNotFoundError(msg)
+        return resolved
+
     def _start_ffmpeg(self, file_path: str) -> str:
         """Start FFmpeg in background if not already running.
 
         Returns:
             The path hash for this file.
         """
+        source = self._validate_source(file_path)
+        safe_path = str(source)
         path_hash = self.get_path_hash(file_path)
 
         with self._lock:
@@ -174,9 +196,9 @@ class HlsService:
 
             output_dir.mkdir(parents=True, exist_ok=True)
 
-            cmd = self._build_ffmpeg_cmd(file_path, output_dir)
+            cmd = self._build_ffmpeg_cmd(safe_path, output_dir)
 
-            _logger.info("Starting HLS generation for %s", file_path)
+            _logger.info("Starting HLS generation for %s", safe_path)
             proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -3,14 +3,19 @@
 Uses HLS (HTTP Live Streaming) for all video formats via FFmpeg.
 Segments are cached for subsequent plays. MP4/WebM also support
 direct Range-based streaming as fallback.
+
+Segment endpoints use a path-hash scheme so they never touch the
+database — only the initial playlist request needs a DB lookup.
 """
 
+import logging
+import re
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, Response, StreamingResponse
 
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
@@ -19,9 +24,11 @@ from src.modules.media.application.use_cases.get_movie_by_id import GetMovieById
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
 from src.modules.media.infrastructure.streaming.hls_service import HlsService
 
+_logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
 
-_hls = HlsService()
+_SEGMENT_RE = re.compile(r"^(segment_\d{4}\.ts)$", re.MULTILINE)
 
 
 def _resolve_file(file_path: str | None) -> Path:
@@ -34,7 +41,35 @@ def _resolve_file(file_path: str | None) -> Path:
     return path
 
 
-# ── HLS endpoints ────────────────────────────────────────────
+def _rewrite_playlist(m3u8_text: str, path_hash: str) -> str:
+    """Replace relative segment names with hash-based absolute URLs."""
+    return _SEGMENT_RE.sub(
+        rf"/api/v1/stream/hls/{path_hash}/\1",
+        m3u8_text,
+    )
+
+
+# -- HLS segments (no DB access) ----------------------------------------------
+
+
+@router.get("/hls/{path_hash}/{segment}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def hls_segment(
+    path_hash: str,
+    segment: str,
+    hls: HlsService = Depends(
+        Provide[ApplicationContainer.media.hls_service],
+    ),
+) -> FileResponse:
+    """Serve an HLS segment by cache hash. No database access needed."""
+    segment_path = hls.get_segment_by_hash(path_hash, segment)
+    if not segment_path:
+        raise HTTPException(status_code=404, detail="Segment not found")
+
+    return FileResponse(str(segment_path), media_type="video/mp2t")
+
+
+# -- HLS playlist endpoints (need DB to resolve file path) ---------------------
 
 
 @router.get("/movie/{movie_id}/hls/playlist.m3u8")  # type: ignore[misc]
@@ -44,41 +79,27 @@ async def movie_hls_playlist(
     use_case: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
-) -> FileResponse:
-    """Generate and serve HLS playlist for a movie."""
+    hls: HlsService = Depends(
+        Provide[ApplicationContainer.media.hls_service],
+    ),
+) -> Response:
+    """Generate and serve HLS playlist for a movie.
+
+    Starts FFmpeg in the background and returns the playlist as soon
+    as the first segments are available. hls.js will keep polling
+    until ``#EXT-X-ENDLIST`` appears.
+    """
     movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
-    path = _resolve_file(movie.file_path)
+    file_path = _resolve_file(movie.file_path)
 
     try:
-        playlist = _hls.generate(str(path))
-    except RuntimeError as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        path_hash = await hls.ensure_playlist(str(file_path))
+    except Exception as e:
+        _logger.exception("HLS generation failed for movie %s (file=%s)", movie_id, file_path)
+        detail = str(e) or f"{type(e).__name__}: check server logs"
+        raise HTTPException(status_code=500, detail=detail) from e
 
-    return FileResponse(
-        str(playlist),
-        media_type="application/vnd.apple.mpegurl",
-        headers={"Cache-Control": "no-cache"},
-    )
-
-
-@router.get("/movie/{movie_id}/hls/{segment}")  # type: ignore[misc]
-@inject  # type: ignore[misc]
-async def movie_hls_segment(
-    movie_id: str,
-    segment: str,
-    use_case: GetMovieByIdUseCase = Depends(
-        Provide[ApplicationContainer.media.get_movie_by_id],
-    ),
-) -> FileResponse:
-    """Serve an HLS segment file."""
-    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
-    path = _resolve_file(movie.file_path)
-
-    segment_path = _hls.get_segment_path(str(path), segment)
-    if not segment_path:
-        raise HTTPException(status_code=404, detail="Segment not found")
-
-    return FileResponse(str(segment_path), media_type="video/mp2t")
+    return _serve_playlist(hls, path_hash)
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/playlist.m3u8")  # type: ignore[misc]
@@ -90,46 +111,65 @@ async def episode_hls_playlist(
     use_case: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
-) -> FileResponse:
+    hls: HlsService = Depends(
+        Provide[ApplicationContainer.media.hls_service],
+    ),
+) -> Response:
     """Generate and serve HLS playlist for an episode."""
     file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
     path = _resolve_file(file_path)
 
     try:
-        playlist = _hls.generate(str(path))
-    except RuntimeError as e:
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        path_hash = await hls.ensure_playlist(str(path))
+    except Exception as e:
+        _logger.exception(
+            "HLS generation failed for episode %s/S%sE%s (file=%s)",
+            series_id,
+            season_number,
+            episode_number,
+            path,
+        )
+        detail = str(e) or f"{type(e).__name__}: check server logs"
+        raise HTTPException(status_code=500, detail=detail) from e
 
-    return FileResponse(
-        str(playlist),
+    return _serve_playlist(hls, path_hash)
+
+
+def _serve_playlist(hls: HlsService, path_hash: str) -> Response:
+    """Read current m3u8 content and rewrite segment URLs."""
+    content = hls.get_playlist_content(path_hash)
+    if not content:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+
+    return Response(
+        content=_rewrite_playlist(content, path_hash),
         media_type="application/vnd.apple.mpegurl",
         headers={"Cache-Control": "no-cache"},
     )
 
 
-@router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/{segment}")  # type: ignore[misc]
+# -- Cache management ----------------------------------------------------------
+
+
+@router.delete("/movie/{movie_id}/hls/cache")  # type: ignore[misc]
 @inject  # type: ignore[misc]
-async def episode_hls_segment(
-    series_id: str,
-    season_number: int,
-    episode_number: int,
-    segment: str,
-    use_case: GetSeriesByIdUseCase = Depends(
-        Provide[ApplicationContainer.media.get_series_by_id],
+async def clear_movie_hls_cache(
+    movie_id: str,
+    use_case: GetMovieByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_movie_by_id],
     ),
-) -> FileResponse:
-    """Serve an HLS segment file for an episode."""
-    file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
-    path = _resolve_file(file_path)
+    hls: HlsService = Depends(
+        Provide[ApplicationContainer.media.hls_service],
+    ),
+) -> Response:
+    """Clear cached HLS segments for a movie, forcing regeneration."""
+    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
+    if movie.file_path:
+        hls.clear_cache(movie.file_path)
+    return Response(status_code=204)
 
-    segment_path = _hls.get_segment_path(str(path), segment)
-    if not segment_path:
-        raise HTTPException(status_code=404, detail="Segment not found")
 
-    return FileResponse(str(segment_path), media_type="video/mp2t")
-
-
-# ── Direct streaming (fallback for MP4/WebM) ────────────────
+# -- Direct streaming (fallback for MP4/WebM) ---------------------------------
 
 
 @router.get("/movie/{movie_id}")  # type: ignore[misc]
@@ -166,7 +206,7 @@ async def stream_episode(
     return _build_range_response(str(path), path.stat().st_size, request.headers.get("range"))
 
 
-# ── Helpers ──────────────────────────────────────────────────
+# -- Helpers -------------------------------------------------------------------
 
 
 async def _find_episode_file(

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -1,159 +1,135 @@
 """Video streaming REST API routes.
 
-Supports direct streaming for MP4/WebM and FFmpeg transmuxing
-for MKV/AVI/MOV/WMV to MP4 (container conversion without
-re-encoding for browser compatibility).
+Uses HLS (HTTP Live Streaming) for all video formats via FFmpeg.
+Segments are cached for subsequent plays. MP4/WebM also support
+direct Range-based streaming as fallback.
 """
 
-import shutil
-import subprocess
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import FileResponse, StreamingResponse
 
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
 from src.modules.media.application.dtos.series_dtos import GetSeriesByIdInput
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
+from src.modules.media.infrastructure.streaming.hls_service import HlsService
 
 router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
 
-_CHUNK_SIZE = 64 * 1024  # 64 KB for transmuxed streams
-
-# Formats that browsers can play natively
-_NATIVE_FORMATS = {".mp4", ".webm"}
-
-
-def _needs_transmux(file_path: str) -> bool:
-    """Check if file needs FFmpeg transmuxing for browser playback."""
-    return Path(file_path).suffix.lower() not in _NATIVE_FORMATS
-
-
-def _ffmpeg_available() -> bool:
-    """Check if FFmpeg is available on the system."""
-    return shutil.which("ffmpeg") is not None
-
-
-async def _stream_native(
-    file_path: str,
-    start: int,
-    end: int,
-) -> AsyncGenerator[bytes, None]:
-    """Stream native file bytes in chunks."""
-    with Path(file_path).open("rb") as f:
-        f.seek(start)
-        remaining = end - start + 1
-        chunk_size = 1024 * 1024  # 1 MB for native
-        while remaining > 0:
-            read_size = min(chunk_size, remaining)
-            data = f.read(read_size)
-            if not data:
-                break
-            remaining -= len(data)
-            yield data
-
-
-async def _stream_transmux(file_path: str) -> AsyncGenerator[bytes, None]:
-    """Transmux video to MP4 via FFmpeg (copy codecs, no re-encoding)."""
-    cmd = [
-        "ffmpeg",
-        "-i",
-        file_path,
-        "-c:v",
-        "copy",
-        "-c:a",
-        "aac",
-        "-movflags",
-        "frag_keyframe+empty_moov+faststart",
-        "-f",
-        "mp4",
-        "-loglevel",
-        "error",
-        "pipe:1",
-    ]
-
-    process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    try:
-        assert process.stdout is not None
-        while True:
-            chunk = process.stdout.read(_CHUNK_SIZE)
-            if not chunk:
-                break
-            yield chunk
-    finally:
-        process.kill()
-        process.wait()
+_hls = HlsService()
 
 
 def _resolve_file(file_path: str | None) -> Path:
     """Validate file path exists and return Path object."""
     if not file_path:
         raise HTTPException(status_code=404, detail="No video file available")
-
     path = Path(file_path)
     if not path.is_file():
         raise HTTPException(status_code=404, detail="Video file not found on disk")
-
     return path
 
 
-def _build_response(
-    file_path: str,
-    file_size: int,
-    range_header: str | None,
-) -> StreamingResponse:
-    """Build streaming response — native with Range or transmuxed."""
-    if _needs_transmux(file_path):
-        if not _ffmpeg_available():
-            raise HTTPException(
-                status_code=500,
-                detail="FFmpeg is required to stream MKV/AVI files but was not found",
-            )
-        # Transmuxed streams don't support Range (live pipe)
-        return StreamingResponse(
-            _stream_transmux(file_path),
-            media_type="video/mp4",
-            headers={"Accept-Ranges": "none"},
-        )
+# ── HLS endpoints ────────────────────────────────────────────
 
-    # Native MP4/WebM — support Range requests
-    if range_header:
-        range_spec = range_header.replace("bytes=", "")
-        parts = range_spec.split("-")
-        start = int(parts[0]) if parts[0] else 0
-        end = int(parts[1]) if parts[1] else file_size - 1
-        start = max(0, start)
-        end = min(end, file_size - 1)
-        content_length = end - start + 1
 
-        return StreamingResponse(
-            _stream_native(file_path, start, end),
-            status_code=206,
-            media_type="video/mp4",
-            headers={
-                "Content-Range": f"bytes {start}-{end}/{file_size}",
-                "Accept-Ranges": "bytes",
-                "Content-Length": str(content_length),
-            },
-        )
+@router.get("/movie/{movie_id}/hls/playlist.m3u8")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def movie_hls_playlist(
+    movie_id: str,
+    use_case: GetMovieByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_movie_by_id],
+    ),
+) -> FileResponse:
+    """Generate and serve HLS playlist for a movie."""
+    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
+    path = _resolve_file(movie.file_path)
 
-    return StreamingResponse(
-        _stream_native(file_path, 0, file_size - 1),
-        media_type="video/mp4",
-        headers={
-            "Accept-Ranges": "bytes",
-            "Content-Length": str(file_size),
-        },
+    try:
+        playlist = _hls.generate(str(path))
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    return FileResponse(
+        str(playlist),
+        media_type="application/vnd.apple.mpegurl",
+        headers={"Cache-Control": "no-cache"},
     )
+
+
+@router.get("/movie/{movie_id}/hls/{segment}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def movie_hls_segment(
+    movie_id: str,
+    segment: str,
+    use_case: GetMovieByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_movie_by_id],
+    ),
+) -> FileResponse:
+    """Serve an HLS segment file."""
+    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
+    path = _resolve_file(movie.file_path)
+
+    segment_path = _hls.get_segment_path(str(path), segment)
+    if not segment_path:
+        raise HTTPException(status_code=404, detail="Segment not found")
+
+    return FileResponse(str(segment_path), media_type="video/mp2t")
+
+
+@router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/playlist.m3u8")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def episode_hls_playlist(
+    series_id: str,
+    season_number: int,
+    episode_number: int,
+    use_case: GetSeriesByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_series_by_id],
+    ),
+) -> FileResponse:
+    """Generate and serve HLS playlist for an episode."""
+    file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
+    path = _resolve_file(file_path)
+
+    try:
+        playlist = _hls.generate(str(path))
+    except RuntimeError as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    return FileResponse(
+        str(playlist),
+        media_type="application/vnd.apple.mpegurl",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
+@router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/{segment}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def episode_hls_segment(
+    series_id: str,
+    season_number: int,
+    episode_number: int,
+    segment: str,
+    use_case: GetSeriesByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_series_by_id],
+    ),
+) -> FileResponse:
+    """Serve an HLS segment file for an episode."""
+    file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
+    path = _resolve_file(file_path)
+
+    segment_path = _hls.get_segment_path(str(path), segment)
+    if not segment_path:
+        raise HTTPException(status_code=404, detail="Segment not found")
+
+    return FileResponse(str(segment_path), media_type="video/mp2t")
+
+
+# ── Direct streaming (fallback for MP4/WebM) ────────────────
 
 
 @router.get("/movie/{movie_id}")  # type: ignore[misc]
@@ -165,15 +141,11 @@ async def stream_movie(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
 ) -> StreamingResponse:
-    """Stream a movie's primary video file."""
+    """Direct stream a movie file with Range support (MP4/WebM only)."""
     movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
     path = _resolve_file(movie.file_path)
 
-    return _build_response(
-        str(path),
-        path.stat().st_size,
-        request.headers.get("range"),
-    )
+    return _build_range_response(str(path), path.stat().st_size, request.headers.get("range"))
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}")  # type: ignore[misc]
@@ -187,24 +159,83 @@ async def stream_episode(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
 ) -> StreamingResponse:
-    """Stream an episode's primary video file."""
-    series = await use_case.execute(GetSeriesByIdInput(series_id=series_id))
+    """Direct stream an episode file with Range support."""
+    file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
+    path = _resolve_file(file_path)
 
-    file_path = None
+    return _build_range_response(str(path), path.stat().st_size, request.headers.get("range"))
+
+
+# ── Helpers ──────────────────────────────────────────────────
+
+
+async def _find_episode_file(
+    use_case: GetSeriesByIdUseCase,
+    series_id: str,
+    season_number: int,
+    episode_number: int,
+) -> str | None:
+    """Find episode file path from series hierarchy."""
+    series = await use_case.execute(GetSeriesByIdInput(series_id=series_id))
     for season in series.seasons:
         if season.season_number == season_number:
             for episode in season.episodes:
                 if episode.episode_number == episode_number:
-                    file_path = episode.file_path
-                    break
+                    return episode.file_path
             break
+    return None
 
-    path = _resolve_file(file_path)
 
-    return _build_response(
-        str(path),
-        path.stat().st_size,
-        request.headers.get("range"),
+async def _stream_range(
+    file_path: str,
+    start: int,
+    end: int,
+) -> AsyncGenerator[bytes, None]:
+    """Stream file bytes in 1MB chunks."""
+    chunk_size = 1024 * 1024
+    with Path(file_path).open("rb") as f:
+        f.seek(start)
+        remaining = end - start + 1
+        while remaining > 0:
+            data = f.read(min(chunk_size, remaining))
+            if not data:
+                break
+            remaining -= len(data)
+            yield data
+
+
+def _build_range_response(
+    file_path: str,
+    file_size: int,
+    range_header: str | None,
+) -> StreamingResponse:
+    """Build Range-based streaming response."""
+    if range_header:
+        range_spec = range_header.replace("bytes=", "")
+        parts = range_spec.split("-")
+        start = int(parts[0]) if parts[0] else 0
+        end = int(parts[1]) if parts[1] else file_size - 1
+        start = max(0, start)
+        end = min(end, file_size - 1)
+
+        return StreamingResponse(
+            _stream_range(file_path, start, end),
+            status_code=206,
+            media_type="video/mp4",
+            headers={
+                "Content-Range": f"bytes {start}-{end}/{file_size}",
+                "Accept-Ranges": "bytes",
+                "Content-Length": str(end - start + 1),
+            },
+        )
+
+    return StreamingResponse(
+        _stream_range(file_path, 0, file_size - 1),
+        media_type="video/mp4",
+        headers={
+            "Accept-Ranges": "bytes",
+            "Content-Length": str(file_size),
+        },
     )
 
 


### PR DESCRIPTION
## Summary

- Add `HlsService` that generates m3u8 playlist + ts segments via FFmpeg
- Cache segments by file path hash for instant replay on subsequent plays
- HLS endpoints for movies: `GET /api/v1/stream/movie/{id}/hls/playlist.m3u8` and `GET .../hls/{segment}`
- HLS endpoints for episodes: same pattern with series/season/episode path
- Keep direct Range-based streaming as fallback for MP4/WebM
- Frontend updated to use hls.js for playback with full seeking support

## Test plan

- [x] All 755 tests pass
- [x] Pre-commit hooks pass
- [ ] Manual test: play MKV file with seeking and audio

## Summary by Sourcery

Introduce HLS-based streaming with cached segment generation while retaining direct Range-based streaming as a fallback for compatible formats.

New Features:
- Add an HlsService that generates and caches HLS playlists and segments per video file.
- Expose HLS playlist and segment endpoints for movie and episode streaming APIs.

Enhancements:
- Refine media streaming routes to share episode file resolution logic and range-based streaming helpers.
- Document the streaming layer to clarify HLS usage and fallback behavior.