### PR TITLE
feat(media): multi-audio track and subtitle support for HLS

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -34,7 +34,7 @@ from src.modules.media.infrastructure.persistence.repositories.movie_repository 
 from src.modules.media.infrastructure.persistence.repositories.series_repository import (
     SQLAlchemySeriesRepository,
 )
-from src.modules.media.infrastructure.streaming.hls_service import HlsService
+from src.modules.media.infrastructure.streaming import HlsService, MediaProbeService
 
 
 class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
@@ -132,7 +132,13 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     variant_detector = providers.Factory(VariantDetector)
 
-    hls_service = providers.Singleton(HlsService, cache_dir=hls_cache_directory)
+    media_probe_service = providers.Singleton(MediaProbeService)
+
+    hls_service = providers.Singleton(
+        HlsService,
+        cache_dir=hls_cache_directory,
+        probe_service=media_probe_service,
+    )
 
     # =========================================================================
     # Use Cases — Scan

--- a/src/modules/media/infrastructure/streaming/__init__.py
+++ b/src/modules/media/infrastructure/streaming/__init__.py
@@ -1,1 +1,9 @@
 """Video streaming infrastructure."""
+
+from src.modules.media.infrastructure.streaming.hls_service import HlsService
+from src.modules.media.infrastructure.streaming.media_probe_service import (
+    MediaProbeResult,
+    MediaProbeService,
+)
+
+__all__ = ["HlsService", "MediaProbeResult", "MediaProbeService"]

--- a/src/modules/media/infrastructure/streaming/__init__.py
+++ b/src/modules/media/infrastructure/streaming/__init__.py
@@ -1,9 +1,19 @@
 """Video streaming infrastructure."""
 
-from src.modules.media.infrastructure.streaming.hls_service import HlsService
+from src.modules.media.infrastructure.streaming.hls_service import (
+    HlsService,
+    media_type_for,
+    rewrite_m3u8,
+)
 from src.modules.media.infrastructure.streaming.media_probe_service import (
     MediaProbeResult,
     MediaProbeService,
 )
 
-__all__ = ["HlsService", "MediaProbeResult", "MediaProbeService"]
+__all__ = [
+    "HlsService",
+    "MediaProbeResult",
+    "MediaProbeService",
+    "media_type_for",
+    "rewrite_m3u8",
+]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -28,6 +28,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import re
 import shutil
 import subprocess
 import threading
@@ -47,6 +48,37 @@ _POLL_TIMEOUT = 120  # max seconds to wait for first segment
 _BROWSER_SAFE_CODECS = {"h264", "mpeg4", "mpeg2video"}
 
 _VIDEO_DIR = "video"
+
+# -- Playlist rewriting utilities (used by routes) ----------------------------
+
+# Matches standalone relative references (non-comment lines)
+_RELATIVE_REF_RE = re.compile(
+    r"^(?!#)(?!https?://)(?!/)(.+)$",
+    re.MULTILINE,
+)
+# Matches URI="..." with relative paths only (skip absolute/protocol URIs)
+_URI_ATTR_RE = re.compile(r'URI="(?!https?://)(?!/)([^"]+)"')
+
+_MEDIA_TYPES: dict[str, str] = {
+    ".m3u8": "application/vnd.apple.mpegurl",
+    ".ts": "video/mp2t",
+    ".vtt": "text/vtt",
+}
+
+
+def rewrite_m3u8(m3u8_text: str, base_url: str) -> str:
+    """Prefix all relative references in an m3u8 with an absolute base URL."""
+    result = _URI_ATTR_RE.sub(rf'URI="{base_url}/\1"', m3u8_text)
+    return _RELATIVE_REF_RE.sub(rf"{base_url}/\1", result)
+
+
+def media_type_for(filename: str) -> str:
+    """Determine media type from file extension."""
+    suffix = Path(filename).suffix.lower()
+    return _MEDIA_TYPES.get(suffix, "application/octet-stream")
+
+
+# -- Module helpers -----------------------------------------------------------
 
 
 def _primary_audio_index(probe: MediaProbeResult) -> int:
@@ -82,13 +114,14 @@ class HlsService:
     def get_file_by_hash(self, path_hash: str, relative_path: str) -> Path | None:
         """Get any file from cache by hash + relative path.
 
-        Includes path traversal protection.
+        Includes path traversal protection via ``Path.is_relative_to``.
         """
         cache_root = (self._cache_dir / path_hash).resolve()
         target = (cache_root / relative_path).resolve()
 
-        # Prevent directory traversal
-        if not str(target).startswith(str(cache_root)):
+        try:
+            target.relative_to(cache_root)
+        except ValueError:
             return None
 
         return target if target.is_file() else None
@@ -97,7 +130,6 @@ class HlsService:
         """Check if generation is fully complete."""
         video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
         if not video_playlist.is_file():
-            # Backward compat: check flat playlist
             flat = self._cache_dir / path_hash / "playlist.m3u8"
             if not flat.is_file():
                 return False
@@ -112,31 +144,13 @@ class HlsService:
 
     def get_master_playlist(self, path_hash: str) -> str | None:
         """Get master playlist content, falling back to legacy flat playlist."""
-        master = self._cache_dir / path_hash / "master.m3u8"
-        if master.is_file():
-            try:
-                return master.read_text(encoding="utf-8")
-            except OSError:
-                return None
-
-        # Backward compat: flat playlist from old cache
-        flat = self._cache_dir / path_hash / "playlist.m3u8"
-        if flat.is_file():
-            try:
-                return flat.read_text(encoding="utf-8")
-            except OSError:
-                return None
-
-        return None
-
-    def get_sub_playlist(self, path_hash: str, relative_path: str) -> str | None:
-        """Get a sub-playlist (video, audio, subtitle) content."""
-        path = self.get_file_by_hash(path_hash, relative_path)
-        if path and path.suffix == ".m3u8":
-            try:
-                return path.read_text(encoding="utf-8")
-            except OSError:
-                return None
+        for name in ("master.m3u8", "playlist.m3u8"):
+            path = self._cache_dir / path_hash / name
+            if path.is_file():
+                try:
+                    return path.read_text(encoding="utf-8")
+                except OSError:
+                    continue
         return None
 
     def get_cached_tracks(self, path_hash: str) -> dict[str, Any] | None:
@@ -179,7 +193,6 @@ class HlsService:
 
         await asyncio.to_thread(self._start_generation, file_path)
 
-        # Poll until video playlist has at least one segment
         video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
         attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
         for _ in range(attempts):
@@ -191,16 +204,9 @@ class HlsService:
                 except OSError:
                     pass
 
-            # Check if main process died
-            with self._lock:
-                procs = self._processes.get(path_hash, [])
-            if procs and procs[0].poll() is not None:
-                stderr = procs[0].stderr.read().decode() if procs[0].stderr else ""
-                _logger.error("FFmpeg exited with code %d: %s", procs[0].returncode, stderr)
-                output_dir = self._cache_dir / path_hash
-                shutil.rmtree(output_dir, ignore_errors=True)
-                msg = f"FFmpeg failed (exit {procs[0].returncode}): {stderr}"
-                raise RuntimeError(msg)
+            main_proc = self._get_main_process(path_hash)
+            if main_proc and main_proc.poll() is not None:
+                self._handle_generation_failure(path_hash, main_proc)
 
             await asyncio.sleep(_POLL_INTERVAL)
 
@@ -223,22 +229,41 @@ class HlsService:
         """
         if file_path:
             path_hash = self.get_path_hash(file_path)
-            output_dir = self._cache_dir / path_hash
-            # Kill running processes
-            with self._lock:
-                for proc in self._processes.pop(path_hash, []):
-                    if proc.poll() is None:
-                        proc.kill()
-            shutil.rmtree(output_dir, ignore_errors=True)
+            self._kill_processes(path_hash)
+            shutil.rmtree(self._cache_dir / path_hash, ignore_errors=True)
         else:
             with self._lock:
-                for procs in self._processes.values():
-                    for proc in procs:
-                        if proc.poll() is None:
-                            proc.kill()
-                self._processes.clear()
+                for path_hash in list(self._processes):
+                    self._kill_processes(path_hash)
             shutil.rmtree(self._cache_dir, ignore_errors=True)
             self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- Private: process management -------------------------------------------
+
+    def _get_main_process(self, path_hash: str) -> subprocess.Popen[bytes] | None:
+        """Get the main (video) FFmpeg process for a generation, if any."""
+        with self._lock:
+            procs = self._processes.get(path_hash, [])
+        return procs[0] if procs else None
+
+    def _kill_processes(self, path_hash: str) -> None:
+        """Kill all running FFmpeg processes for a path hash."""
+        with self._lock:
+            for proc in self._processes.pop(path_hash, []):
+                if proc.poll() is None:
+                    proc.kill()
+
+    def _handle_generation_failure(
+        self,
+        path_hash: str,
+        proc: subprocess.Popen[bytes],
+    ) -> None:
+        """Log error, clean up cache, and raise for a failed FFmpeg process."""
+        stderr = proc.stderr.read().decode() if proc.stderr else ""
+        _logger.error("FFmpeg exited with code %d: %s", proc.returncode, stderr)
+        shutil.rmtree(self._cache_dir / path_hash, ignore_errors=True)
+        msg = f"FFmpeg failed (exit {proc.returncode}): {stderr}"
+        raise RuntimeError(msg)
 
     # -- Private: generation ---------------------------------------------------
 
@@ -248,16 +273,21 @@ class HlsService:
         safe_path = str(source)
         path_hash = self.get_path_hash(file_path)
 
+        if self.is_complete(path_hash):
+            return path_hash
+
+        # Probe outside the lock (potentially slow I/O)
+        probe_result = self._probe.probe(safe_path)
+
         with self._lock:
+            # Re-check after acquiring lock
             if self.is_complete(path_hash):
                 return path_hash
 
-            # Already running
-            if path_hash in self._processes:
-                running = [p for p in self._processes[path_hash] if p.poll() is None]
-                if running:
-                    return path_hash
-                del self._processes[path_hash]
+            running = [p for p in self._processes.get(path_hash, []) if p.poll() is None]
+            if running:
+                return path_hash
+            self._processes.pop(path_hash, None)
 
             # Clean stale cache
             output_dir = self._cache_dir / path_hash
@@ -266,19 +296,16 @@ class HlsService:
                 shutil.rmtree(output_dir, ignore_errors=True)
 
             output_dir.mkdir(parents=True, exist_ok=True)
-
-            # Probe tracks
-            probe_result = self._probe.probe(safe_path)
             self._save_probe_cache(output_dir, probe_result)
 
             procs: list[subprocess.Popen[bytes]] = []
 
-            # 1. Main: video + default audio
+            # 1. Main: video + default audio (always first in list)
             video_dir = output_dir / _VIDEO_DIR
             video_dir.mkdir()
             cmd = self._build_video_cmd(safe_path, video_dir, probe_result)
             _logger.info("Starting video HLS for %s", safe_path)
-            procs.append(subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE))
+            procs.append(self._spawn_ffmpeg(cmd))
 
             # 2. Additional audio tracks (audio-only HLS)
             primary_audio_idx = _primary_audio_index(probe_result)
@@ -294,11 +321,9 @@ class HlsService:
                     track.language.value,
                     safe_path,
                 )
-                procs.append(
-                    subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-                )
+                procs.append(self._spawn_ffmpeg(cmd))
 
-            # 3. Extract subtitles to WebVTT
+            # 3. Extract subtitles to WebVTT (synchronous, fast)
             self._extract_subtitles(safe_path, output_dir, probe_result)
 
             # 4. Build master playlist
@@ -307,6 +332,19 @@ class HlsService:
             self._processes[path_hash] = procs
 
         return path_hash
+
+    @staticmethod
+    def _spawn_ffmpeg(cmd: list[str]) -> subprocess.Popen[bytes]:
+        """Spawn an FFmpeg subprocess.
+
+        All arguments are built internally from validated paths,
+        not from user-controlled input.
+        """
+        return subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
 
     # -- Private: FFmpeg commands ----------------------------------------------
 
@@ -354,7 +392,6 @@ class HlsService:
             _logger.info("Source codec %s — copying", codec)
             video_args = ["-c:v", "copy"]
 
-        # Use the primary (first) audio track for the video stream
         primary_idx = _primary_audio_index(probe)
         audio_map = f"0:a:{primary_idx}"
 
@@ -432,7 +469,6 @@ class HlsService:
         probe: MediaProbeResult,
     ) -> None:
         """Extract text-based subtitles to WebVTT files."""
-        # Embedded text subtitles
         for track in probe.subtitle_tracks:
             if not track.is_text_based:
                 _logger.info(
@@ -474,7 +510,6 @@ class HlsService:
             except subprocess.TimeoutExpired:
                 _logger.warning("Subtitle extraction timed out for track %d", track.index)
 
-        # External subtitles
         for track in probe.external_subtitles:
             if not track.is_text_based or not track.file_path:
                 continue
@@ -523,14 +558,12 @@ class HlsService:
         text_subs = [s for s in probe.all_subtitles if s.is_text_based]
         sub_group = 'SUBTITLES="subs"' if text_subs else ""
 
-        # Audio renditions
         primary_idx = _primary_audio_index(probe)
         if has_alt_audio:
             for track in probe.audio_tracks:
                 is_primary = track.index == primary_idx
                 name = track.title or f"{track.language.value.upper()} ({track.channel_layout})"
                 if is_primary:
-                    # Default audio is muxed in video stream — omit URI per HLS spec
                     lines.append(
                         f'#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",'
                         f'NAME="{name}",LANGUAGE="{track.language.value}",'
@@ -544,7 +577,6 @@ class HlsService:
                         f'URI="audio_{track.index}/playlist.m3u8"'
                     )
 
-        # Subtitle tracks
         for sub in text_subs:
             sub_name = sub.title or f"{sub.language.value.upper()}"
             is_forced = "YES" if sub.is_forced else "NO"
@@ -555,7 +587,6 @@ class HlsService:
                 f'URI="sub_{sub.index}/playlist.m3u8"'
             )
 
-        # Stream inf
         groups = ",".join(filter(None, [audio_group, sub_group]))
         stream_inf = "#EXT-X-STREAM-INF:BANDWIDTH=5000000"
         if groups:
@@ -644,7 +675,7 @@ class HlsService:
                 is_default=t.get("is_default", False),
                 is_forced=t.get("is_forced", False),
                 is_external=True,
-                file_path=None,  # Not needed from cache
+                file_path=None,
             )
             for t in data.get("subtitle_tracks", [])
             if t.get("is_external", False)
@@ -678,4 +709,4 @@ def _write_subtitle_playlist(sub_dir: Path) -> None:
     )
 
 
-__all__ = ["HlsService"]
+__all__ = ["HlsService", "media_type_for", "rewrite_m3u8"]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -4,15 +4,40 @@ Supports progressive playback: FFmpeg runs in the background and
 the playlist is returned as soon as the first segments are ready.
 hls.js treats a playlist without ``#EXT-X-ENDLIST`` as a live stream
 and keeps polling for new segments until the tag appears.
+
+Multi-track support generates a master playlist with separate audio
+renditions and WebVTT subtitle tracks via ``#EXT-X-MEDIA`` tags.
+
+Cache structure per file::
+
+    <path_hash>/
+    ├── master.m3u8           # Multivariant playlist (built by Python)
+    ├── video/
+    │   ├── playlist.m3u8     # Video + default audio
+    │   └── segment_0000.ts
+    ├── audio_1/
+    │   ├── playlist.m3u8     # Audio-only alternative track
+    │   └── segment_0000.ts
+    ├── sub_0/
+    │   ├── playlist.m3u8     # WebVTT wrapper playlist
+    │   └── sub.vtt
+    └── tracks.json           # Cached probe result
 """
 
 import asyncio
 import hashlib
+import json
 import logging
 import shutil
 import subprocess
 import threading
 from pathlib import Path
+from typing import Any
+
+from src.modules.media.infrastructure.streaming.media_probe_service import (
+    MediaProbeResult,
+    MediaProbeService,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -21,64 +46,273 @@ _POLL_INTERVAL = 0.5  # seconds between readiness checks
 _POLL_TIMEOUT = 120  # max seconds to wait for first segment
 _BROWSER_SAFE_CODECS = {"h264", "mpeg4", "mpeg2video"}
 
+_VIDEO_DIR = "video"
+
+
+def _primary_audio_index(probe: MediaProbeResult) -> int:
+    """Get the index of the primary audio track (first one, always index 0)."""
+    return probe.audio_tracks[0].index if probe.audio_tracks else 0
+
 
 class HlsService:
     """Generate and cache HLS segments for video files.
 
-    Converts any video format to HLS (m3u8 + ts segments) via FFmpeg.
-    Segments are cached in a directory keyed by file path hash,
-    so subsequent plays skip the generation step.
-
     Args:
         cache_dir: Directory to store generated HLS files.
+        probe_service: Service to discover audio/subtitle tracks.
     """
 
-    def __init__(self, cache_dir: str = "./hls_cache") -> None:
+    def __init__(
+        self,
+        cache_dir: str = "./hls_cache",
+        probe_service: MediaProbeService | None = None,
+    ) -> None:
         self._cache_dir = Path(cache_dir)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
-        self._processes: dict[str, subprocess.Popen[bytes]] = {}
+        self._probe = probe_service or MediaProbeService()
+        self._processes: dict[str, list[subprocess.Popen[bytes]]] = {}
         self._lock = threading.Lock()
+
+    # -- Public API ------------------------------------------------------------
 
     def get_path_hash(self, file_path: str) -> str:
         """Get the hash key for a file path."""
         return hashlib.md5(file_path.encode()).hexdigest()
 
-    def _get_output_dir(self, file_path: str) -> Path:
-        """Get the cache directory for a specific video file."""
-        return self._cache_dir / self.get_path_hash(file_path)
+    def get_file_by_hash(self, path_hash: str, relative_path: str) -> Path | None:
+        """Get any file from cache by hash + relative path.
 
-    def get_segment_by_hash(self, path_hash: str, segment_name: str) -> Path | None:
-        """Get a segment file by its path hash, without needing the original file path."""
-        segment = self._cache_dir / path_hash / segment_name
-        return segment if segment.is_file() else None
+        Includes path traversal protection.
+        """
+        cache_root = (self._cache_dir / path_hash).resolve()
+        target = (cache_root / relative_path).resolve()
+
+        # Prevent directory traversal
+        if not str(target).startswith(str(cache_root)):
+            return None
+
+        return target if target.is_file() else None
 
     def is_complete(self, path_hash: str) -> bool:
-        """Check if generation is fully complete (playlist has ENDLIST tag)."""
-        playlist = self._cache_dir / path_hash / "playlist.m3u8"
-        if not playlist.is_file():
-            return False
+        """Check if generation is fully complete."""
+        video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
+        if not video_playlist.is_file():
+            # Backward compat: check flat playlist
+            flat = self._cache_dir / path_hash / "playlist.m3u8"
+            if not flat.is_file():
+                return False
+            try:
+                return "#EXT-X-ENDLIST" in flat.read_text(encoding="utf-8")
+            except OSError:
+                return False
         try:
-            return "#EXT-X-ENDLIST" in playlist.read_text(encoding="utf-8")
+            return "#EXT-X-ENDLIST" in video_playlist.read_text(encoding="utf-8")
         except OSError:
             return False
 
-    def get_playlist_content(self, path_hash: str) -> str | None:
-        """Get current playlist content, or None if not ready yet."""
-        playlist = self._cache_dir / path_hash / "playlist.m3u8"
-        if not playlist.is_file():
+    def get_master_playlist(self, path_hash: str) -> str | None:
+        """Get master playlist content, falling back to legacy flat playlist."""
+        master = self._cache_dir / path_hash / "master.m3u8"
+        if master.is_file():
+            try:
+                return master.read_text(encoding="utf-8")
+            except OSError:
+                return None
+
+        # Backward compat: flat playlist from old cache
+        flat = self._cache_dir / path_hash / "playlist.m3u8"
+        if flat.is_file():
+            try:
+                return flat.read_text(encoding="utf-8")
+            except OSError:
+                return None
+
+        return None
+
+    def get_sub_playlist(self, path_hash: str, relative_path: str) -> str | None:
+        """Get a sub-playlist (video, audio, subtitle) content."""
+        path = self.get_file_by_hash(path_hash, relative_path)
+        if path and path.suffix == ".m3u8":
+            try:
+                return path.read_text(encoding="utf-8")
+            except OSError:
+                return None
+        return None
+
+    def get_cached_tracks(self, path_hash: str) -> dict[str, Any] | None:
+        """Get cached probe result from tracks.json."""
+        tracks_file = self._cache_dir / path_hash / "tracks.json"
+        if not tracks_file.is_file():
             return None
         try:
-            return playlist.read_text(encoding="utf-8")
-        except OSError:
+            data: dict[str, Any] = json.loads(tracks_file.read_text(encoding="utf-8"))
+            return data
+        except (OSError, json.JSONDecodeError):
             return None
+
+    async def ensure_playlist(self, file_path: str) -> str:
+        """Start generation and wait until the first segments are ready.
+
+        Args:
+            file_path: Absolute path to the source video file.
+
+        Returns:
+            The path hash for this file.
+
+        Raises:
+            RuntimeError: If FFmpeg is not available, fails, or times out.
+            FileNotFoundError: If the source file does not exist.
+        """
+        path_hash = self.get_path_hash(file_path)
+
+        if self.is_complete(path_hash):
+            return path_hash
+
+        if not shutil.which("ffmpeg"):
+            msg = "FFmpeg is required for HLS streaming but was not found"
+            raise RuntimeError(msg)
+
+        source = Path(file_path)
+        if not source.is_file():
+            msg = f"Source file not found: {file_path}"
+            raise FileNotFoundError(msg)
+
+        await asyncio.to_thread(self._start_generation, file_path)
+
+        # Poll until video playlist has at least one segment
+        video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
+        attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
+        for _ in range(attempts):
+            if video_playlist.is_file():
+                try:
+                    content = video_playlist.read_text(encoding="utf-8")
+                    if "segment_" in content:
+                        return path_hash
+                except OSError:
+                    pass
+
+            # Check if main process died
+            with self._lock:
+                procs = self._processes.get(path_hash, [])
+            if procs and procs[0].poll() is not None:
+                stderr = procs[0].stderr.read().decode() if procs[0].stderr else ""
+                _logger.error("FFmpeg exited with code %d: %s", procs[0].returncode, stderr)
+                output_dir = self._cache_dir / path_hash
+                shutil.rmtree(output_dir, ignore_errors=True)
+                msg = f"FFmpeg failed (exit {procs[0].returncode}): {stderr}"
+                raise RuntimeError(msg)
+
+            await asyncio.sleep(_POLL_INTERVAL)
+
+        msg = f"Timeout waiting for HLS segments ({_POLL_TIMEOUT}s)"
+        raise RuntimeError(msg)
+
+    def probe_tracks(self, file_path: str) -> MediaProbeResult:
+        """Probe a file for tracks, using cache when available."""
+        path_hash = self.get_path_hash(file_path)
+        cached = self.get_cached_tracks(path_hash)
+        if cached:
+            return self._deserialize_probe(cached)
+        return self._probe.probe(file_path)
+
+    def clear_cache(self, file_path: str | None = None) -> None:
+        """Clear cached HLS segments.
+
+        Args:
+            file_path: Clear cache for specific file, or all if None.
+        """
+        if file_path:
+            path_hash = self.get_path_hash(file_path)
+            output_dir = self._cache_dir / path_hash
+            # Kill running processes
+            with self._lock:
+                for proc in self._processes.pop(path_hash, []):
+                    if proc.poll() is None:
+                        proc.kill()
+            shutil.rmtree(output_dir, ignore_errors=True)
+        else:
+            with self._lock:
+                for procs in self._processes.values():
+                    for proc in procs:
+                        if proc.poll() is None:
+                            proc.kill()
+                self._processes.clear()
+            shutil.rmtree(self._cache_dir, ignore_errors=True)
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- Private: generation ---------------------------------------------------
+
+    def _start_generation(self, file_path: str) -> str:
+        """Start all FFmpeg processes for multi-track HLS generation."""
+        source = self._validate_source(file_path)
+        safe_path = str(source)
+        path_hash = self.get_path_hash(file_path)
+
+        with self._lock:
+            if self.is_complete(path_hash):
+                return path_hash
+
+            # Already running
+            if path_hash in self._processes:
+                running = [p for p in self._processes[path_hash] if p.poll() is None]
+                if running:
+                    return path_hash
+                del self._processes[path_hash]
+
+            # Clean stale cache
+            output_dir = self._cache_dir / path_hash
+            if output_dir.exists():
+                _logger.info("Cleaning stale cache for %s", path_hash)
+                shutil.rmtree(output_dir, ignore_errors=True)
+
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            # Probe tracks
+            probe_result = self._probe.probe(safe_path)
+            self._save_probe_cache(output_dir, probe_result)
+
+            procs: list[subprocess.Popen[bytes]] = []
+
+            # 1. Main: video + default audio
+            video_dir = output_dir / _VIDEO_DIR
+            video_dir.mkdir()
+            cmd = self._build_video_cmd(safe_path, video_dir, probe_result)
+            _logger.info("Starting video HLS for %s", safe_path)
+            procs.append(subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE))
+
+            # 2. Additional audio tracks (audio-only HLS)
+            primary_audio_idx = _primary_audio_index(probe_result)
+            for track in probe_result.audio_tracks:
+                if track.index == primary_audio_idx:
+                    continue
+                audio_dir = output_dir / f"audio_{track.index}"
+                audio_dir.mkdir()
+                cmd = self._build_audio_cmd(safe_path, audio_dir, track.index)
+                _logger.info(
+                    "Starting audio HLS for track %d (%s) of %s",
+                    track.index,
+                    track.language.value,
+                    safe_path,
+                )
+                procs.append(
+                    subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+                )
+
+            # 3. Extract subtitles to WebVTT
+            self._extract_subtitles(safe_path, output_dir, probe_result)
+
+            # 4. Build master playlist
+            self._build_master_playlist(output_dir, probe_result)
+
+            self._processes[path_hash] = procs
+
+        return path_hash
+
+    # -- Private: FFmpeg commands ----------------------------------------------
 
     @staticmethod
     def _probe_video_codec(file_path: str) -> str | None:
-        """Detect video codec using ffprobe.
-
-        Args:
-            file_path: Already-validated absolute path to the source file.
-        """
+        """Detect video codec using ffprobe."""
         try:
             result = subprocess.run(
                 [
@@ -103,21 +337,26 @@ class HlsService:
         except Exception:
             return None
 
-    def _build_ffmpeg_cmd(self, file_path: str, output_dir: Path) -> list[str]:
-        """Build FFmpeg command, transcoding to H.264 if needed."""
+    def _build_video_cmd(
+        self,
+        file_path: str,
+        output_dir: Path,
+        probe: MediaProbeResult,
+    ) -> list[str]:
+        """Build FFmpeg command for video + default audio."""
         codec = self._probe_video_codec(file_path)
         needs_transcode = codec not in _BROWSER_SAFE_CODECS
 
         if needs_transcode:
-            _logger.info(
-                "Source codec is %s — transcoding to H.264 for %s",
-                codec,
-                file_path,
-            )
+            _logger.info("Source codec %s — transcoding to H.264", codec)
             video_args = ["-c:v", "libx264", "-preset", "ultrafast", "-crf", "23"]
         else:
-            _logger.info("Source codec is %s — copying for %s", codec, file_path)
+            _logger.info("Source codec %s — copying", codec)
             video_args = ["-c:v", "copy"]
+
+        # Use the primary (first) audio track for the video stream
+        primary_idx = _primary_audio_index(probe)
+        audio_map = f"0:a:{primary_idx}"
 
         return [
             "ffmpeg",
@@ -126,7 +365,7 @@ class HlsService:
             "-map",
             "0:v:0",
             "-map",
-            "0:a:0",
+            audio_map,
             "-sn",
             *video_args,
             "-c:a",
@@ -150,134 +389,293 @@ class HlsService:
         ]
 
     @staticmethod
+    def _build_audio_cmd(
+        file_path: str,
+        output_dir: Path,
+        audio_index: int,
+    ) -> list[str]:
+        """Build FFmpeg command for audio-only HLS track."""
+        return [
+            "ffmpeg",
+            "-i",
+            file_path,
+            "-map",
+            f"0:a:{audio_index}",
+            "-vn",
+            "-sn",
+            "-c:a",
+            "aac",
+            "-ac",
+            "2",
+            "-ar",
+            "48000",
+            "-hls_time",
+            str(_SEGMENT_DURATION),
+            "-hls_list_size",
+            "0",
+            "-hls_playlist_type",
+            "event",
+            "-hls_segment_filename",
+            str(output_dir / "segment_%04d.ts"),
+            "-loglevel",
+            "error",
+            "-y",
+            str(output_dir / "playlist.m3u8"),
+        ]
+
+    # -- Private: subtitle extraction ------------------------------------------
+
+    @staticmethod
+    def _extract_subtitles(
+        file_path: str,
+        output_dir: Path,
+        probe: MediaProbeResult,
+    ) -> None:
+        """Extract text-based subtitles to WebVTT files."""
+        # Embedded text subtitles
+        for track in probe.subtitle_tracks:
+            if not track.is_text_based:
+                _logger.info(
+                    "Skipping image-based subtitle track %d (%s)",
+                    track.index,
+                    track.format,
+                )
+                continue
+
+            sub_dir = output_dir / f"sub_{track.index}"
+            sub_dir.mkdir(exist_ok=True)
+            vtt_path = sub_dir / "sub.vtt"
+
+            try:
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-i",
+                        file_path,
+                        "-map",
+                        f"0:s:{track.index}",
+                        "-c:s",
+                        "webvtt",
+                        "-loglevel",
+                        "error",
+                        "-y",
+                        str(vtt_path),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=60,
+                )
+                if vtt_path.is_file():
+                    _write_subtitle_playlist(sub_dir)
+                    _logger.info("Extracted subtitle track %d to %s", track.index, vtt_path)
+                else:
+                    _logger.warning("Failed to extract subtitle track %d", track.index)
+            except subprocess.TimeoutExpired:
+                _logger.warning("Subtitle extraction timed out for track %d", track.index)
+
+        # External subtitles
+        for track in probe.external_subtitles:
+            if not track.is_text_based or not track.file_path:
+                continue
+
+            sub_dir = output_dir / f"sub_{track.index}"
+            sub_dir.mkdir(exist_ok=True)
+            vtt_path = sub_dir / "sub.vtt"
+
+            try:
+                subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-i",
+                        track.file_path.value,
+                        "-c:s",
+                        "webvtt",
+                        "-loglevel",
+                        "error",
+                        "-y",
+                        str(vtt_path),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=60,
+                )
+                if vtt_path.is_file():
+                    _write_subtitle_playlist(sub_dir)
+                    _logger.info(
+                        "Converted external subtitle %s to %s",
+                        track.file_path.value,
+                        vtt_path,
+                    )
+            except subprocess.TimeoutExpired:
+                _logger.warning("External subtitle conversion timed out for %s", track.file_path)
+
+    # -- Private: master playlist ----------------------------------------------
+
+    @staticmethod
+    def _build_master_playlist(output_dir: Path, probe: MediaProbeResult) -> None:
+        """Generate master.m3u8 with audio renditions and subtitle tracks."""
+        lines = ["#EXTM3U", "#EXT-X-VERSION:3"]
+
+        has_alt_audio = len(probe.audio_tracks) > 1
+        audio_group = 'AUDIO="audio"' if has_alt_audio else ""
+        text_subs = [s for s in probe.all_subtitles if s.is_text_based]
+        sub_group = 'SUBTITLES="subs"' if text_subs else ""
+
+        # Audio renditions
+        primary_idx = _primary_audio_index(probe)
+        if has_alt_audio:
+            for track in probe.audio_tracks:
+                is_primary = track.index == primary_idx
+                name = track.title or f"{track.language.value.upper()} ({track.channel_layout})"
+                if is_primary:
+                    # Default audio is muxed in video stream — omit URI per HLS spec
+                    lines.append(
+                        f'#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",'
+                        f'NAME="{name}",LANGUAGE="{track.language.value}",'
+                        f"DEFAULT=YES,AUTOSELECT=YES"
+                    )
+                else:
+                    lines.append(
+                        f'#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",'
+                        f'NAME="{name}",LANGUAGE="{track.language.value}",'
+                        f"DEFAULT=NO,AUTOSELECT=NO,"
+                        f'URI="audio_{track.index}/playlist.m3u8"'
+                    )
+
+        # Subtitle tracks
+        for sub in text_subs:
+            sub_name = sub.title or f"{sub.language.value.upper()}"
+            is_forced = "YES" if sub.is_forced else "NO"
+            lines.append(
+                f'#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",'
+                f'NAME="{sub_name}",LANGUAGE="{sub.language.value}",'
+                f"DEFAULT=NO,AUTOSELECT=NO,FORCED={is_forced},"
+                f'URI="sub_{sub.index}/playlist.m3u8"'
+            )
+
+        # Stream inf
+        groups = ",".join(filter(None, [audio_group, sub_group]))
+        stream_inf = "#EXT-X-STREAM-INF:BANDWIDTH=5000000"
+        if groups:
+            stream_inf += f",{groups}"
+        lines.append(stream_inf)
+        lines.append("video/playlist.m3u8")
+
+        master_path = output_dir / "master.m3u8"
+        master_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        _logger.info("Master playlist written to %s", master_path)
+
+    # -- Private: probe cache --------------------------------------------------
+
+    @staticmethod
+    def _save_probe_cache(output_dir: Path, probe: MediaProbeResult) -> None:
+        """Save probe result as JSON for the tracks API."""
+        data = {
+            "audio_tracks": [
+                {
+                    "index": t.index,
+                    "language": t.language.value,
+                    "codec": t.codec,
+                    "channels": t.channels,
+                    "title": t.title,
+                    "is_default": t.is_default,
+                    "bitrate": t.bitrate,
+                }
+                for t in probe.audio_tracks
+            ],
+            "subtitle_tracks": [
+                {
+                    "index": t.index,
+                    "language": t.language.value,
+                    "format": t.format,
+                    "title": t.title,
+                    "is_default": t.is_default,
+                    "is_forced": t.is_forced,
+                    "is_external": t.is_external,
+                    "is_image_based": t.is_image_based,
+                }
+                for t in probe.all_subtitles
+            ],
+        }
+        (output_dir / "tracks.json").write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _deserialize_probe(data: dict[str, Any]) -> MediaProbeResult:
+        """Reconstruct MediaProbeResult from cached JSON."""
+        from src.shared_kernel.value_objects.language_code import LanguageCode
+        from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+        audio = [
+            AudioTrack(
+                index=t["index"],
+                language=LanguageCode(t["language"]),
+                codec=t["codec"],
+                channels=t["channels"],
+                title=t.get("title"),
+                is_default=t["is_default"],
+                bitrate=t.get("bitrate"),
+            )
+            for t in data.get("audio_tracks", [])
+        ]
+        subs = [
+            SubtitleTrack(
+                index=t["index"],
+                language=LanguageCode(t["language"]),
+                format=t["format"],
+                title=t.get("title"),
+                is_default=t.get("is_default", False),
+                is_forced=t.get("is_forced", False),
+                is_external=t.get("is_external", False),
+            )
+            for t in data.get("subtitle_tracks", [])
+            if not t.get("is_external", False)
+        ]
+        ext = [
+            SubtitleTrack(
+                index=t["index"],
+                language=LanguageCode(t["language"]),
+                format=t["format"],
+                title=t.get("title"),
+                is_default=t.get("is_default", False),
+                is_forced=t.get("is_forced", False),
+                is_external=True,
+                file_path=None,  # Not needed from cache
+            )
+            for t in data.get("subtitle_tracks", [])
+            if t.get("is_external", False)
+        ]
+        return MediaProbeResult(audio_tracks=audio, subtitle_tracks=subs, external_subtitles=ext)
+
+    # -- Private: validation ---------------------------------------------------
+
+    @staticmethod
     def _validate_source(file_path: str) -> Path:
-        """Resolve and validate that file_path is an existing file.
-
-        Prevents path traversal and ensures the subprocess only
-        receives a resolved absolute path to a real file.
-
-        Raises:
-            FileNotFoundError: If path does not point to an existing file.
-        """
+        """Resolve and validate that file_path is an existing file."""
         resolved = Path(file_path).resolve()
         if not resolved.is_file():
             msg = f"Source file not found: {file_path}"
             raise FileNotFoundError(msg)
         return resolved
 
-    def _start_ffmpeg(self, file_path: str) -> str:
-        """Start FFmpeg in background if not already running.
 
-        Returns:
-            The path hash for this file.
-        """
-        source = self._validate_source(file_path)
-        safe_path = str(source)
-        path_hash = self.get_path_hash(file_path)
-
-        with self._lock:
-            # Already complete
-            if self.is_complete(path_hash):
-                return path_hash
-
-            # Already running
-            if path_hash in self._processes:
-                proc = self._processes[path_hash]
-                if proc.poll() is None:
-                    return path_hash
-                # Process finished (maybe with error) — clean up handle
-                del self._processes[path_hash]
-
-            # Clean up stale incomplete cache from a previous run
-            output_dir = self._cache_dir / path_hash
-            if output_dir.exists():
-                _logger.info("Cleaning stale cache for %s", path_hash)
-                shutil.rmtree(output_dir, ignore_errors=True)
-
-            output_dir.mkdir(parents=True, exist_ok=True)
-
-            cmd = self._build_ffmpeg_cmd(safe_path, output_dir)
-
-            _logger.info("Starting HLS generation for %s", safe_path)
-            proc = subprocess.Popen(
-                cmd,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-            )
-            self._processes[path_hash] = proc
-
-        return path_hash
-
-    async def ensure_playlist(self, file_path: str) -> str:
-        """Start generation and wait until the playlist has at least one segment.
-
-        For already-cached files this returns immediately. Otherwise
-        FFmpeg is launched in the background and we poll until the
-        m3u8 file appears with at least one segment entry.
-
-        Args:
-            file_path: Absolute path to the source video file.
-
-        Returns:
-            The path hash for this file.
-
-        Raises:
-            RuntimeError: If FFmpeg is not available, fails, or times out.
-            FileNotFoundError: If the source file does not exist.
-        """
-        path_hash = self.get_path_hash(file_path)
-
-        # Fast path: already fully generated
-        if self.is_complete(path_hash):
-            return path_hash
-
-        if not shutil.which("ffmpeg"):
-            msg = "FFmpeg is required for HLS streaming but was not found"
-            raise RuntimeError(msg)
-
-        source = Path(file_path)
-        if not source.is_file():
-            msg = f"Source file not found: {file_path}"
-            raise FileNotFoundError(msg)
-
-        await asyncio.to_thread(self._start_ffmpeg, file_path)
-
-        # Poll until playlist has at least one segment
-        attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
-        for _ in range(attempts):
-            content = self.get_playlist_content(path_hash)
-            if content and "segment_" in content:
-                return path_hash
-
-            # Check if process died
-            with self._lock:
-                proc = self._processes.get(path_hash)
-            if proc and proc.poll() is not None:
-                stderr = proc.stderr.read().decode() if proc.stderr else ""
-                _logger.error("FFmpeg exited with code %d: %s", proc.returncode, stderr)
-                # Clean up failed output
-                output_dir = self._cache_dir / path_hash
-                shutil.rmtree(output_dir, ignore_errors=True)
-                msg = f"FFmpeg failed (exit {proc.returncode}): {stderr}"
-                raise RuntimeError(msg)
-
-            await asyncio.sleep(_POLL_INTERVAL)
-
-        msg = f"Timeout waiting for HLS segments ({_POLL_TIMEOUT}s)"
-        raise RuntimeError(msg)
-
-    def clear_cache(self, file_path: str | None = None) -> None:
-        """Clear cached HLS segments.
-
-        Args:
-            file_path: Clear cache for specific file, or all if None.
-        """
-        if file_path:
-            output_dir = self._get_output_dir(file_path)
-            shutil.rmtree(output_dir, ignore_errors=True)
-        else:
-            shutil.rmtree(self._cache_dir, ignore_errors=True)
-            self._cache_dir.mkdir(parents=True, exist_ok=True)
+def _write_subtitle_playlist(sub_dir: Path) -> None:
+    """Write a simple HLS playlist wrapping a single VTT file."""
+    playlist = sub_dir / "playlist.m3u8"
+    playlist.write_text(
+        "#EXTM3U\n"
+        "#EXT-X-VERSION:3\n"
+        "#EXT-X-TARGETDURATION:99999\n"
+        "#EXT-X-PLAYLIST-TYPE:VOD\n"
+        "#EXTINF:99999,\n"
+        "sub.vtt\n"
+        "#EXT-X-ENDLIST\n",
+        encoding="utf-8",
+    )
 
 
 __all__ = ["HlsService"]

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -1,0 +1,345 @@
+"""Media file probe service using ffprobe.
+
+Discovers audio tracks, subtitle tracks (embedded and external)
+from a media file, returning structured domain value objects.
+"""
+
+import json
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+_logger = logging.getLogger(__name__)
+
+_FFPROBE_TIMEOUT = 15  # seconds
+
+# ffprobe codec_name → SubtitleTrack format
+_SUBTITLE_CODEC_MAP: dict[str, str] = {
+    "subrip": "srt",
+    "srt": "srt",
+    "ass": "ass",
+    "ssa": "ass",
+    "webvtt": "vtt",
+    "mov_text": "srt",
+    "hdmv_pgs_subtitle": "pgs",
+    "pgssub": "pgs",
+    "dvd_subtitle": "vobsub",
+    "dvdsub": "vobsub",
+}
+
+# External subtitle file extensions
+_EXTERNAL_SUB_EXTENSIONS = {".srt", ".ass", ".ssa", ".vtt", ".sub"}
+
+# Pattern to extract language from subtitle filenames
+# e.g. Movie.en.srt, Movie.English.srt, Movie.pt-BR.srt
+_LANG_FILENAME_PATTERN = re.compile(
+    r"\.([a-z]{2}(?:-[A-Za-z]{2})?)\.(?:srt|ass|ssa|vtt|sub)$",
+    re.IGNORECASE,
+)
+
+# Common language name → ISO 639-1 mapping for filenames
+_LANG_NAME_MAP: dict[str, str] = {
+    "english": "en",
+    "portuguese": "pt",
+    "spanish": "es",
+    "french": "fr",
+    "german": "de",
+    "italian": "it",
+    "japanese": "ja",
+    "korean": "ko",
+    "chinese": "zh",
+    "russian": "ru",
+    "arabic": "ar",
+    "dutch": "nl",
+    "polish": "pl",
+    "swedish": "sv",
+    "norwegian": "no",
+    "danish": "da",
+    "finnish": "fi",
+    "turkish": "tr",
+    "greek": "el",
+    "czech": "cs",
+    "hungarian": "hu",
+    "romanian": "ro",
+    "ukrainian": "uk",
+    "thai": "th",
+    "vietnamese": "vi",
+    "indonesian": "id",
+    "malay": "ms",
+    "hebrew": "he",
+    "hindi": "hi",
+}
+
+_LANG_FULLNAME_PATTERN = re.compile(
+    r"\.(" + "|".join(_LANG_NAME_MAP.keys()) + r")\.(?:srt|ass|ssa|vtt|sub)$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class MediaProbeResult:
+    """Result of probing a media file for available tracks."""
+
+    audio_tracks: list[AudioTrack] = field(default_factory=list)
+    subtitle_tracks: list[SubtitleTrack] = field(default_factory=list)
+    external_subtitles: list[SubtitleTrack] = field(default_factory=list)
+
+    @property
+    def all_subtitles(self) -> list[SubtitleTrack]:
+        """All subtitle tracks (embedded + external)."""
+        return [*self.subtitle_tracks, *self.external_subtitles]
+
+    @property
+    def text_subtitles(self) -> list[SubtitleTrack]:
+        """Only text-based subtitles that can be converted to WebVTT."""
+        return [s for s in self.all_subtitles if s.is_text_based]
+
+
+class MediaProbeService:
+    """Probe media files for audio and subtitle track information.
+
+    Uses ffprobe to inspect embedded streams and scans the file's
+    parent directory for external subtitle files.
+
+    Example:
+        >>> service = MediaProbeService()
+        >>> result = service.probe("/movies/Movie.mkv")
+        >>> len(result.audio_tracks)
+        2
+    """
+
+    def probe(self, file_path: str) -> MediaProbeResult:
+        """Probe a media file for all available tracks.
+
+        Args:
+            file_path: Absolute path to the media file.
+
+        Returns:
+            MediaProbeResult with discovered tracks.
+        """
+        source = Path(file_path).resolve()
+        if not source.is_file():
+            _logger.warning("Cannot probe non-existent file: %s", file_path)
+            return MediaProbeResult()
+
+        streams = self._run_ffprobe(str(source))
+        audio_tracks = self._parse_audio_tracks(streams)
+        subtitle_tracks = self._parse_subtitle_tracks(streams)
+        external_subs = self._scan_external_subtitles(source, len(subtitle_tracks))
+
+        _logger.info(
+            "Probed %s: %d audio, %d embedded subs, %d external subs",
+            source.name,
+            len(audio_tracks),
+            len(subtitle_tracks),
+            len(external_subs),
+        )
+
+        return MediaProbeResult(
+            audio_tracks=audio_tracks,
+            subtitle_tracks=subtitle_tracks,
+            external_subtitles=external_subs,
+        )
+
+    @staticmethod
+    def _run_ffprobe(file_path: str) -> list[dict[str, Any]]:
+        """Run ffprobe and return stream data as JSON."""
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-show_streams",
+                    "-of",
+                    "json",
+                    file_path,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=_FFPROBE_TIMEOUT,
+            )
+            if result.returncode != 0:
+                _logger.error("ffprobe failed for %s: %s", file_path, result.stderr)
+                return []
+            data: dict[str, Any] = json.loads(result.stdout)
+            return list(data.get("streams", []))
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError) as e:
+            _logger.error("ffprobe error for %s: %s", file_path, e)
+            return []
+
+    @staticmethod
+    def _extract_language(stream: dict[str, Any]) -> str:
+        """Extract ISO 639-1 language code from stream tags."""
+        tags: dict[str, Any] = dict(stream.get("tags", {}))
+        lang = str(tags.get("language", tags.get("LANGUAGE", "und")))
+        lang = lang.lower().strip()
+
+        # Handle 3-letter codes by taking first 2
+        if len(lang) == 3 and lang != "und":
+            lang = lang[:2]
+
+        # Validate: must be 2 lowercase letters
+        if re.match(r"^[a-z]{2}$", lang):
+            return lang
+        return "un"
+
+    @staticmethod
+    def _parse_audio_tracks(streams: list[dict[str, Any]]) -> list[AudioTrack]:
+        """Parse audio streams into AudioTrack value objects."""
+        tracks = []
+        audio_index = 0
+        for stream in streams:
+            if stream.get("codec_type") != "audio":
+                continue
+
+            disposition = stream.get("disposition", {})
+            tags = stream.get("tags", {})
+
+            lang = MediaProbeService._extract_language(stream)
+            codec = stream.get("codec_name", "unknown")
+            channels = int(stream.get("channels", 2))
+            title = tags.get("title", tags.get("TITLE"))
+            is_default = bool(disposition.get("default", 0))
+            bitrate = None
+
+            # Try to get bitrate from multiple sources
+            for key in ("bit_rate", "BPS", "BPS-eng"):
+                raw = stream.get(key) or tags.get(key)
+                if raw and str(raw).isdigit():
+                    bitrate = int(raw) // 1000  # Convert to kbps
+                    break
+
+            tracks.append(
+                AudioTrack(
+                    index=audio_index,
+                    language=LanguageCode(lang),
+                    codec=codec,
+                    channels=min(channels, 16),
+                    title=title,
+                    is_default=is_default,
+                    bitrate=bitrate,
+                )
+            )
+            audio_index += 1
+
+        # Ensure at least one track is default
+        if tracks and not any(t.is_default for t in tracks):
+            tracks[0] = AudioTrack(
+                index=tracks[0].index,
+                language=tracks[0].language,
+                codec=tracks[0].codec,
+                channels=tracks[0].channels,
+                title=tracks[0].title,
+                is_default=True,
+                bitrate=tracks[0].bitrate,
+            )
+
+        return tracks
+
+    @staticmethod
+    def _parse_subtitle_tracks(streams: list[dict[str, Any]]) -> list[SubtitleTrack]:
+        """Parse subtitle streams into SubtitleTrack value objects."""
+        tracks = []
+        sub_index = 0
+        for stream in streams:
+            if stream.get("codec_type") != "subtitle":
+                continue
+
+            disposition = stream.get("disposition", {})
+            tags = stream.get("tags", {})
+
+            codec_name = stream.get("codec_name", "unknown").lower()
+            fmt = _SUBTITLE_CODEC_MAP.get(codec_name, codec_name)
+            lang = MediaProbeService._extract_language(stream)
+            title = tags.get("title", tags.get("TITLE"))
+
+            tracks.append(
+                SubtitleTrack(
+                    index=sub_index,
+                    language=LanguageCode(lang),
+                    format=fmt,
+                    title=title,
+                    is_default=bool(disposition.get("default", 0)),
+                    is_forced=bool(disposition.get("forced", 0)),
+                    is_external=False,
+                )
+            )
+            sub_index += 1
+
+        return tracks
+
+    @staticmethod
+    def _scan_external_subtitles(
+        video_path: Path,
+        start_index: int,
+    ) -> list[SubtitleTrack]:
+        """Scan directory for external subtitle files matching the video."""
+        parent = video_path.parent
+        video_stem = video_path.stem.lower()
+
+        if not parent.is_dir():
+            return []
+
+        tracks = []
+        idx = start_index
+
+        for path in sorted(parent.iterdir()):
+            if path.suffix.lower() not in _EXTERNAL_SUB_EXTENSIONS:
+                continue
+            if not path.stem.lower().startswith(video_stem):
+                continue
+
+            lang = MediaProbeService._detect_subtitle_language(path.name)
+            fmt = path.suffix.lstrip(".").lower()
+            if fmt == "ssa":
+                fmt = "ass"
+
+            tracks.append(
+                SubtitleTrack(
+                    index=idx,
+                    language=LanguageCode(lang),
+                    format=fmt,
+                    title=f"External ({path.suffix.upper().lstrip('.')})",
+                    is_external=True,
+                    file_path=FilePath(str(path)),
+                )
+            )
+            idx += 1
+
+        return tracks
+
+    @staticmethod
+    def _detect_subtitle_language(filename: str) -> str:
+        """Detect language from subtitle filename patterns.
+
+        Supports patterns like: Movie.en.srt, Movie.English.srt, Movie.pt-BR.srt
+        """
+        # Try ISO code pattern: Movie.en.srt
+        match = _LANG_FILENAME_PATTERN.search(filename)
+        if match:
+            code = match.group(1).lower()
+            # Handle pt-br → pt
+            if "-" in code:
+                code = code.split("-")[0]
+            if len(code) == 2:
+                return code
+
+        # Try full language name: Movie.English.srt
+        match = _LANG_FULLNAME_PATTERN.search(filename)
+        if match:
+            name = match.group(1).lower()
+            return _LANG_NAME_MAP.get(name, "un")
+
+        return "un"
+
+
+__all__ = ["MediaProbeResult", "MediaProbeService"]

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -7,6 +7,7 @@ from a media file, returning structured domain value objects.
 import json
 import logging
 import re
+import shutil
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -151,6 +152,9 @@ class MediaProbeService:
     @staticmethod
     def _run_ffprobe(file_path: str) -> list[dict[str, Any]]:
         """Run ffprobe and return stream data as JSON."""
+        if not shutil.which("ffprobe"):
+            _logger.warning("ffprobe not found — cannot probe %s", file_path)
+            return []
         try:
             result = subprocess.run(
                 [

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -7,7 +7,6 @@ database — only the initial playlist request needs a DB lookup.
 """
 
 import logging
-import re
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
@@ -20,25 +19,16 @@ from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
 from src.modules.media.application.dtos.series_dtos import GetSeriesByIdInput
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
-from src.modules.media.infrastructure.streaming.hls_service import HlsService
+from src.modules.media.infrastructure.streaming.hls_service import (
+    HlsService,
+    media_type_for,
+    rewrite_m3u8,
+)
+from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeResult
 
 _logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
-
-# Matches standalone relative references (non-comment lines)
-_RELATIVE_REF_RE = re.compile(
-    r"^(?!#)(?!https?://)(?!/)(.+)$",
-    re.MULTILINE,
-)
-# Matches URI="..." attributes inside #EXT-X-MEDIA and similar tags
-_URI_ATTR_RE = re.compile(r'URI="([^"]+)"')
-
-_MEDIA_TYPES: dict[str, str] = {
-    ".m3u8": "application/vnd.apple.mpegurl",
-    ".ts": "video/mp2t",
-    ".vtt": "text/vtt",
-}
 
 
 def _resolve_file(file_path: str | None) -> Path:
@@ -51,18 +41,50 @@ def _resolve_file(file_path: str | None) -> Path:
     return path
 
 
-def _rewrite_m3u8(m3u8_text: str, base_url: str) -> str:
-    """Prefix all relative references in an m3u8 with an absolute base URL."""
-    # Rewrite URI="..." attributes inside #EXT-X-MEDIA tags
-    result = _URI_ATTR_RE.sub(rf'URI="{base_url}/\1"', m3u8_text)
-    # Rewrite standalone relative references (segment/playlist filenames)
-    return _RELATIVE_REF_RE.sub(rf"{base_url}/\1", result)
+def _serialize_tracks(probe: MediaProbeResult) -> dict[str, list[dict[str, object]]]:
+    """Serialize probe result into API response format."""
+    return {
+        "audio_tracks": [
+            {
+                "index": t.index,
+                "language": t.language.value,
+                "codec": t.codec,
+                "channels": t.channels,
+                "channel_layout": t.channel_layout,
+                "title": t.title,
+                "is_default": t.is_default,
+            }
+            for t in probe.audio_tracks
+        ],
+        "subtitle_tracks": [
+            {
+                "index": t.index,
+                "language": t.language.value,
+                "format": t.format,
+                "title": t.title,
+                "is_default": t.is_default,
+                "is_forced": t.is_forced,
+                "is_external": t.is_external,
+                "is_image_based": t.is_image_based,
+            }
+            for t in probe.all_subtitles
+            if t.is_text_based
+        ],
+    }
 
 
-def _media_type_for(filename: str) -> str:
-    """Determine media type from file extension."""
-    suffix = Path(filename).suffix.lower()
-    return _MEDIA_TYPES.get(suffix, "application/octet-stream")
+def _serve_master_playlist(hls: HlsService, path_hash: str) -> Response:
+    """Read master playlist and rewrite all relative URLs."""
+    content = hls.get_master_playlist(path_hash)
+    if not content:
+        raise HTTPException(status_code=404, detail="Playlist not found")
+
+    base_url = f"/api/v1/stream/hls/{path_hash}"
+    return Response(
+        content=rewrite_m3u8(content, base_url),
+        media_type="application/vnd.apple.mpegurl",
+        headers={"Cache-Control": "no-cache"},
+    )
 
 
 # -- HLS file serving (no DB access) ------------------------------------------
@@ -86,14 +108,12 @@ async def hls_file(
     if not resolved:
         raise HTTPException(status_code=404, detail="File not found")
 
-    # Sub-playlists need URL rewriting
     if resolved.suffix == ".m3u8":
         try:
             content = resolved.read_text(encoding="utf-8")
         except OSError as e:
             raise HTTPException(status_code=404, detail="Playlist not readable") from e
 
-        # Base URL is the parent directory of this playlist
         parent_parts = str(Path(file_path).parent)
         if parent_parts == ".":
             base_url = f"/api/v1/stream/hls/{path_hash}"
@@ -101,14 +121,14 @@ async def hls_file(
             base_url = f"/api/v1/stream/hls/{path_hash}/{parent_parts}"
 
         return Response(
-            content=_rewrite_m3u8(content, base_url),
+            content=rewrite_m3u8(content, base_url),
             media_type="application/vnd.apple.mpegurl",
             headers={"Cache-Control": "no-cache"},
         )
 
     return FileResponse(
         str(resolved),
-        media_type=_media_type_for(file_path),
+        media_type=media_type_for(file_path),
     )
 
 
@@ -173,21 +193,6 @@ async def episode_hls_playlist(
     return _serve_master_playlist(hls, path_hash)
 
 
-def _serve_master_playlist(hls: HlsService, path_hash: str) -> Response:
-    """Read master playlist and rewrite all relative URLs."""
-    content = hls.get_master_playlist(path_hash)
-    if not content:
-        raise HTTPException(status_code=404, detail="Playlist not found")
-
-    base_url = f"/api/v1/stream/hls/{path_hash}"
-
-    return Response(
-        content=_rewrite_m3u8(content, base_url),
-        media_type="application/vnd.apple.mpegurl",
-        headers={"Cache-Control": "no-cache"},
-    )
-
-
 # -- Track info ----------------------------------------------------------------
 
 
@@ -206,35 +211,7 @@ async def movie_tracks(
     movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
     file_path = _resolve_file(movie.file_path)
     probe = hls.probe_tracks(str(file_path))
-
-    return {
-        "audio_tracks": [
-            {
-                "index": t.index,
-                "language": t.language.value,
-                "codec": t.codec,
-                "channels": t.channels,
-                "channel_layout": t.channel_layout,
-                "title": t.title,
-                "is_default": t.is_default,
-            }
-            for t in probe.audio_tracks
-        ],
-        "subtitle_tracks": [
-            {
-                "index": t.index,
-                "language": t.language.value,
-                "format": t.format,
-                "title": t.title,
-                "is_default": t.is_default,
-                "is_forced": t.is_forced,
-                "is_external": t.is_external,
-                "is_image_based": t.is_image_based,
-            }
-            for t in probe.all_subtitles
-            if t.is_text_based  # Only include text-based (playable) subtitles
-        ],
-    }
+    return _serialize_tracks(probe)
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}/tracks")  # type: ignore[misc]
@@ -254,35 +231,7 @@ async def episode_tracks(
     file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
     path = _resolve_file(file_path)
     probe = hls.probe_tracks(str(path))
-
-    return {
-        "audio_tracks": [
-            {
-                "index": t.index,
-                "language": t.language.value,
-                "codec": t.codec,
-                "channels": t.channels,
-                "channel_layout": t.channel_layout,
-                "title": t.title,
-                "is_default": t.is_default,
-            }
-            for t in probe.audio_tracks
-        ],
-        "subtitle_tracks": [
-            {
-                "index": t.index,
-                "language": t.language.value,
-                "format": t.format,
-                "title": t.title,
-                "is_default": t.is_default,
-                "is_forced": t.is_forced,
-                "is_external": t.is_external,
-                "is_image_based": t.is_image_based,
-            }
-            for t in probe.all_subtitles
-            if t.is_text_based
-        ],
-    }
+    return _serialize_tracks(probe)
 
 
 # -- Cache management ----------------------------------------------------------

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -1,9 +1,7 @@
 """Video streaming REST API routes.
 
 Uses HLS (HTTP Live Streaming) for all video formats via FFmpeg.
-Segments are cached for subsequent plays. MP4/WebM also support
-direct Range-based streaming as fallback.
-
+Supports multi-audio and subtitle tracks via master playlist.
 Segment endpoints use a path-hash scheme so they never touch the
 database — only the initial playlist request needs a DB lookup.
 """
@@ -28,7 +26,19 @@ _logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
 
-_SEGMENT_RE = re.compile(r"^(segment_\d{4}\.ts)$", re.MULTILINE)
+# Matches standalone relative references (non-comment lines)
+_RELATIVE_REF_RE = re.compile(
+    r"^(?!#)(?!https?://)(?!/)(.+)$",
+    re.MULTILINE,
+)
+# Matches URI="..." attributes inside #EXT-X-MEDIA and similar tags
+_URI_ATTR_RE = re.compile(r'URI="([^"]+)"')
+
+_MEDIA_TYPES: dict[str, str] = {
+    ".m3u8": "application/vnd.apple.mpegurl",
+    ".ts": "video/mp2t",
+    ".vtt": "text/vtt",
+}
 
 
 def _resolve_file(file_path: str | None) -> Path:
@@ -41,32 +51,65 @@ def _resolve_file(file_path: str | None) -> Path:
     return path
 
 
-def _rewrite_playlist(m3u8_text: str, path_hash: str) -> str:
-    """Replace relative segment names with hash-based absolute URLs."""
-    return _SEGMENT_RE.sub(
-        rf"/api/v1/stream/hls/{path_hash}/\1",
-        m3u8_text,
-    )
+def _rewrite_m3u8(m3u8_text: str, base_url: str) -> str:
+    """Prefix all relative references in an m3u8 with an absolute base URL."""
+    # Rewrite URI="..." attributes inside #EXT-X-MEDIA tags
+    result = _URI_ATTR_RE.sub(rf'URI="{base_url}/\1"', m3u8_text)
+    # Rewrite standalone relative references (segment/playlist filenames)
+    return _RELATIVE_REF_RE.sub(rf"{base_url}/\1", result)
 
 
-# -- HLS segments (no DB access) ----------------------------------------------
+def _media_type_for(filename: str) -> str:
+    """Determine media type from file extension."""
+    suffix = Path(filename).suffix.lower()
+    return _MEDIA_TYPES.get(suffix, "application/octet-stream")
 
 
-@router.get("/hls/{path_hash}/{segment}")  # type: ignore[misc]
+# -- HLS file serving (no DB access) ------------------------------------------
+
+
+@router.get("/hls/{path_hash}/{file_path:path}")  # type: ignore[misc]
 @inject  # type: ignore[misc]
-async def hls_segment(
+async def hls_file(
     path_hash: str,
-    segment: str,
+    file_path: str,
     hls: HlsService = Depends(
         Provide[ApplicationContainer.media.hls_service],
     ),
-) -> FileResponse:
-    """Serve an HLS segment by cache hash. No database access needed."""
-    segment_path = hls.get_segment_by_hash(path_hash, segment)
-    if not segment_path:
-        raise HTTPException(status_code=404, detail="Segment not found")
+) -> Response:
+    """Serve any HLS file (segment, sub-playlist, VTT) by cache hash.
 
-    return FileResponse(str(segment_path), media_type="video/mp2t")
+    For .m3u8 files, rewrites relative references to absolute URLs.
+    No database access needed.
+    """
+    resolved = hls.get_file_by_hash(path_hash, file_path)
+    if not resolved:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # Sub-playlists need URL rewriting
+    if resolved.suffix == ".m3u8":
+        try:
+            content = resolved.read_text(encoding="utf-8")
+        except OSError as e:
+            raise HTTPException(status_code=404, detail="Playlist not readable") from e
+
+        # Base URL is the parent directory of this playlist
+        parent_parts = str(Path(file_path).parent)
+        if parent_parts == ".":
+            base_url = f"/api/v1/stream/hls/{path_hash}"
+        else:
+            base_url = f"/api/v1/stream/hls/{path_hash}/{parent_parts}"
+
+        return Response(
+            content=_rewrite_m3u8(content, base_url),
+            media_type="application/vnd.apple.mpegurl",
+            headers={"Cache-Control": "no-cache"},
+        )
+
+    return FileResponse(
+        str(resolved),
+        media_type=_media_type_for(file_path),
+    )
 
 
 # -- HLS playlist endpoints (need DB to resolve file path) ---------------------
@@ -83,12 +126,7 @@ async def movie_hls_playlist(
         Provide[ApplicationContainer.media.hls_service],
     ),
 ) -> Response:
-    """Generate and serve HLS playlist for a movie.
-
-    Starts FFmpeg in the background and returns the playlist as soon
-    as the first segments are available. hls.js will keep polling
-    until ``#EXT-X-ENDLIST`` appears.
-    """
+    """Generate and serve HLS master playlist for a movie."""
     movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
     file_path = _resolve_file(movie.file_path)
 
@@ -99,7 +137,7 @@ async def movie_hls_playlist(
         detail = str(e) or f"{type(e).__name__}: check server logs"
         raise HTTPException(status_code=500, detail=detail) from e
 
-    return _serve_playlist(hls, path_hash)
+    return _serve_master_playlist(hls, path_hash)
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/playlist.m3u8")  # type: ignore[misc]
@@ -115,7 +153,7 @@ async def episode_hls_playlist(
         Provide[ApplicationContainer.media.hls_service],
     ),
 ) -> Response:
-    """Generate and serve HLS playlist for an episode."""
+    """Generate and serve HLS master playlist for an episode."""
     file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
     path = _resolve_file(file_path)
 
@@ -132,20 +170,119 @@ async def episode_hls_playlist(
         detail = str(e) or f"{type(e).__name__}: check server logs"
         raise HTTPException(status_code=500, detail=detail) from e
 
-    return _serve_playlist(hls, path_hash)
+    return _serve_master_playlist(hls, path_hash)
 
 
-def _serve_playlist(hls: HlsService, path_hash: str) -> Response:
-    """Read current m3u8 content and rewrite segment URLs."""
-    content = hls.get_playlist_content(path_hash)
+def _serve_master_playlist(hls: HlsService, path_hash: str) -> Response:
+    """Read master playlist and rewrite all relative URLs."""
+    content = hls.get_master_playlist(path_hash)
     if not content:
         raise HTTPException(status_code=404, detail="Playlist not found")
 
+    base_url = f"/api/v1/stream/hls/{path_hash}"
+
     return Response(
-        content=_rewrite_playlist(content, path_hash),
+        content=_rewrite_m3u8(content, base_url),
         media_type="application/vnd.apple.mpegurl",
         headers={"Cache-Control": "no-cache"},
     )
+
+
+# -- Track info ----------------------------------------------------------------
+
+
+@router.get("/movie/{movie_id}/tracks")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def movie_tracks(
+    movie_id: str,
+    use_case: GetMovieByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_movie_by_id],
+    ),
+    hls: HlsService = Depends(
+        Provide[ApplicationContainer.media.hls_service],
+    ),
+) -> dict[str, list[dict[str, object]]]:
+    """Get available audio and subtitle tracks for a movie."""
+    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
+    file_path = _resolve_file(movie.file_path)
+    probe = hls.probe_tracks(str(file_path))
+
+    return {
+        "audio_tracks": [
+            {
+                "index": t.index,
+                "language": t.language.value,
+                "codec": t.codec,
+                "channels": t.channels,
+                "channel_layout": t.channel_layout,
+                "title": t.title,
+                "is_default": t.is_default,
+            }
+            for t in probe.audio_tracks
+        ],
+        "subtitle_tracks": [
+            {
+                "index": t.index,
+                "language": t.language.value,
+                "format": t.format,
+                "title": t.title,
+                "is_default": t.is_default,
+                "is_forced": t.is_forced,
+                "is_external": t.is_external,
+                "is_image_based": t.is_image_based,
+            }
+            for t in probe.all_subtitles
+            if t.is_text_based  # Only include text-based (playable) subtitles
+        ],
+    }
+
+
+@router.get("/episode/{series_id}/{season_number}/{episode_number}/tracks")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def episode_tracks(
+    series_id: str,
+    season_number: int,
+    episode_number: int,
+    use_case: GetSeriesByIdUseCase = Depends(
+        Provide[ApplicationContainer.media.get_series_by_id],
+    ),
+    hls: HlsService = Depends(
+        Provide[ApplicationContainer.media.hls_service],
+    ),
+) -> dict[str, list[dict[str, object]]]:
+    """Get available audio and subtitle tracks for an episode."""
+    file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
+    path = _resolve_file(file_path)
+    probe = hls.probe_tracks(str(path))
+
+    return {
+        "audio_tracks": [
+            {
+                "index": t.index,
+                "language": t.language.value,
+                "codec": t.codec,
+                "channels": t.channels,
+                "channel_layout": t.channel_layout,
+                "title": t.title,
+                "is_default": t.is_default,
+            }
+            for t in probe.audio_tracks
+        ],
+        "subtitle_tracks": [
+            {
+                "index": t.index,
+                "language": t.language.value,
+                "format": t.format,
+                "title": t.title,
+                "is_default": t.is_default,
+                "is_forced": t.is_forced,
+                "is_external": t.is_external,
+                "is_image_based": t.is_image_based,
+            }
+            for t in probe.all_subtitles
+            if t.is_text_based
+        ],
+    }
 
 
 # -- Cache management ----------------------------------------------------------


### PR DESCRIPTION
## Summary

- **MediaProbeService**: ffprobe-based service that discovers all audio tracks, embedded subtitles, and external subtitle files (.srt/.ass/.vtt) matching the video filename
- **Multi-audio HLS generation**: master playlist with `#EXT-X-MEDIA` entries, separate audio-only streams per track, default audio muxed in video stream (no URI per HLS spec)
- **Subtitle support**: text-based subtitles (SRT/ASS) extracted to WebVTT, image-based (PGS) skipped with log warning
- **Cache structure**: `video/`, `audio_N/`, `sub_N/` subdirectories with `master.m3u8` and `tracks.json`
- **Track info API**: `GET /stream/movie/{id}/tracks` and `GET /stream/episode/.../tracks`
- **Segment endpoint**: supports subpaths (`{path_hash}/{file:path}`) with dynamic content-type and path traversal protection
- **URI rewriting**: handles both standalone references and `URI="..."` attributes in `#EXT-X-MEDIA` tags
- **Backward compatible**: old flat cache (no `master.m3u8`) still served correctly

## Test plan

- [ ] Play movie with multiple audio tracks — verify audio menu appears and switching works
- [ ] Play movie with embedded text subtitles — verify subtitle menu and rendering
- [ ] Play movie with external .srt files — verify they appear in subtitle menu
- [ ] Play movie with only PGS subtitles — verify no subtitle menu (image-based skipped)
- [ ] Play movie with single audio track — verify no audio menu shown
- [ ] Clear cache and replay — verify clean regeneration with new structure
- [ ] Verify `GET /stream/movie/{id}/tracks` returns correct track info
- [ ] Verify old cached movies (flat structure) still play correctly

## Summary by Sourcery

Add multi-track HLS streaming with master playlists, multi-audio renditions, and subtitle support, plus track discovery and track info APIs.

New Features:
- Support multi-audio HLS generation with a master playlist and separate audio-only streams per track.
- Add WebVTT-based subtitle support from embedded and external subtitle sources, exposed via HLS subtitle playlists.
- Introduce a media probe service to discover audio and subtitle tracks using ffprobe and cache the results in tracks.json.
- Expose track metadata via new movie and episode track info endpoints.

Enhancements:
- Refactor HLS caching to a structured directory layout with video, audio, and subtitle subdirectories and a master playlist.
- Extend HLS file serving to handle generic HLS assets (segments, playlists, subtitles) with content-type detection and URL rewriting, while remaining backward compatible with legacy flat caches.
- Wire the new media probe service and enhanced HLS service into the media DI container.