### PR TITLE
feat(media): add DELETE endpoint for movies

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -9,6 +9,7 @@ from src.modules.media.application.use_cases.add_file_variant import AddFileVari
 from src.modules.media.application.use_cases.bulk_enrich_metadata import (
     BulkEnrichMetadataUseCase,
 )
+from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
 from src.modules.media.application.use_cases.enrich_movie_metadata import (
     EnrichMovieMetadataUseCase,
 )
@@ -83,6 +84,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     list_movies = providers.Factory(
         ListMoviesUseCase,
+        movie_repository=movie_repository,
+    )
+
+    delete_movie = providers.Factory(
+        DeleteMovieUseCase,
         movie_repository=movie_repository,
     )
 

--- a/src/modules/media/application/dtos/__init__.py
+++ b/src/modules/media/application/dtos/__init__.py
@@ -8,6 +8,7 @@ from src.modules.media.application.dtos.media_file_dtos import (
     SetPrimaryFileInput,
 )
 from src.modules.media.application.dtos.movie_dtos import (
+    DeleteMovieInput,
     GetMovieByIdInput,
     ListMoviesInput,
     ListMoviesOutput,
@@ -32,6 +33,7 @@ __all__ = [
     "RemoveFileVariantInput",
     "SetPrimaryFileInput",
     # Movie DTOs
+    "DeleteMovieInput",
     "GetMovieByIdInput",
     "ListMoviesInput",
     "ListMoviesOutput",

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -21,6 +21,17 @@ class GetMovieByIdInput:
 
 
 @dataclass(frozen=True)
+class DeleteMovieInput:
+    """Input for DeleteMovieUseCase.
+
+    Attributes:
+        movie_id: External ID of the movie (mov_xxx format).
+    """
+
+    movie_id: str
+
+
+@dataclass(frozen=True)
 class MovieOutput:
     """Output representation of a Movie.
 

--- a/src/modules/media/application/use_cases/__init__.py
+++ b/src/modules/media/application/use_cases/__init__.py
@@ -1,6 +1,7 @@
 """Media use cases."""
 
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
+from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
@@ -11,6 +12,7 @@ from src.modules.media.application.use_cases.set_primary_file import SetPrimaryF
 
 __all__ = [
     "AddFileVariantUseCase",
+    "DeleteMovieUseCase",
     "GetFileVariantsUseCase",
     "GetMovieByIdUseCase",
     "GetSeriesByIdUseCase",

--- a/src/modules/media/application/use_cases/delete_movie.py
+++ b/src/modules/media/application/use_cases/delete_movie.py
@@ -1,0 +1,44 @@
+"""DeleteMovieUseCase - Soft-delete a movie by ID."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.movie_dtos import DeleteMovieInput
+from src.modules.media.domain.repositories import MovieRepository
+from src.modules.media.domain.value_objects import MovieId
+
+
+class DeleteMovieUseCase:
+    """Soft-delete a movie by its external ID.
+
+    Marks the movie as deleted in the database. The record is not
+    physically removed, allowing for future recovery if needed.
+
+    Example:
+        >>> use_case = DeleteMovieUseCase(movie_repository)
+        >>> await use_case.execute(DeleteMovieInput("mov_abc123"))
+    """
+
+    def __init__(self, movie_repository: MovieRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            movie_repository: Repository for movie persistence.
+        """
+        self._movie_repository = movie_repository
+
+    async def execute(self, input_dto: DeleteMovieInput) -> None:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains the movie_id to delete.
+
+        Raises:
+            ResourceNotFoundException: If movie with given ID doesn't exist.
+        """
+        movie_id = MovieId(input_dto.movie_id)
+        deleted = await self._movie_repository.delete(movie_id)
+
+        if not deleted:
+            raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)
+
+
+__all__ = ["DeleteMovieUseCase"]

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -12,8 +12,13 @@ from src.modules.media.application.dtos.media_file_dtos import (
     RemoveFileVariantInput,
     SetPrimaryFileInput,
 )
-from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput, ListMoviesInput
+from src.modules.media.application.dtos.movie_dtos import (
+    DeleteMovieInput,
+    GetMovieByIdInput,
+    ListMoviesInput,
+)
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
+from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.list_movies import ListMoviesUseCase
@@ -62,6 +67,18 @@ async def get_movie(
         "type": "movie",
         "data": _dataclass_to_dict(result),
     }
+
+
+@router.delete("/{movie_id}", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def delete_movie(
+    movie_id: str,
+    use_case: DeleteMovieUseCase = Depends(
+        Provide[ApplicationContainer.media.delete_movie],
+    ),
+) -> None:
+    """Delete a movie by ID."""
+    await use_case.execute(DeleteMovieInput(movie_id=movie_id))
 
 
 # ── File variant endpoints ──────────────────────────────────────────

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -77,7 +77,11 @@ async def delete_movie(
         Provide[ApplicationContainer.media.delete_movie],
     ),
 ) -> None:
-    """Delete a movie by ID."""
+    """Soft-delete a movie by ID.
+
+    The movie record is marked as deleted but not physically removed,
+    allowing for future recovery if needed.
+    """
     await use_case.execute(DeleteMovieInput(movie_id=movie_id))
 
 

--- a/tests/modules/media/unit/application/use_cases/test_delete_movie.py
+++ b/tests/modules/media/unit/application/use_cases/test_delete_movie.py
@@ -1,0 +1,47 @@
+"""Tests for DeleteMovieUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos import DeleteMovieInput
+from src.modules.media.application.use_cases import DeleteMovieUseCase
+from src.modules.media.domain.repositories import MovieRepository
+
+
+class TestDeleteMovieUseCase:
+    """Tests for DeleteMovieUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_delete_movie_when_found(self):
+        mock_repo = AsyncMock(spec=MovieRepository)
+        mock_repo.delete.return_value = True
+        use_case = DeleteMovieUseCase(movie_repository=mock_repo)
+
+        await use_case.execute(DeleteMovieInput(movie_id="mov_abc123def456"))
+
+        mock_repo.delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_not_found_when_movie_missing(self):
+        mock_repo = AsyncMock(spec=MovieRepository)
+        mock_repo.delete.return_value = False
+        use_case = DeleteMovieUseCase(movie_repository=mock_repo)
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(DeleteMovieInput(movie_id="mov_nonexistent1"))
+
+        assert exc_info.value.resource_type == "Movie"
+        assert exc_info.value.resource_id == "mov_nonexistent1"
+
+    @pytest.mark.asyncio
+    async def test_should_call_repository_with_correct_movie_id(self):
+        mock_repo = AsyncMock(spec=MovieRepository)
+        mock_repo.delete.return_value = True
+        use_case = DeleteMovieUseCase(movie_repository=mock_repo)
+
+        await use_case.execute(DeleteMovieInput(movie_id="mov_abc123def456"))
+
+        call_arg = mock_repo.delete.call_args[0][0]
+        assert str(call_arg) == "mov_abc123def456"


### PR DESCRIPTION
## Summary

- `DELETE /api/v1/movies/{movie_id}` — soft-deletes a movie (sets `deleted_at` timestamp)
- Returns 204 No Content on success, 404 if movie not found
- `DeleteMovieUseCase` with `DeleteMovieInput` DTO
- Registered in `MediaContainer` DI

## Test plan

- [ ] Delete a movie via `DELETE /api/v1/movies/mov_xxx` — returns 204
- [ ] Verify movie no longer appears in `GET /api/v1/movies`
- [ ] Delete non-existent movie — returns 404

## Summary by Sourcery

Add support for soft-deleting movies via a new application use case and HTTP endpoint.

New Features:
- Expose DELETE /api/v1/movies/{movie_id} endpoint to soft-delete movies by external ID.
- Introduce DeleteMovieUseCase and DeleteMovieInput DTO to encapsulate movie deletion logic.

Enhancements:
- Register the delete-movie use case in the media dependency injection container for routing integration.