### PR TITLE
feat(collections): add Watchlist (My List) module

### DIFF
--- a/src/config/containers/collections.py
+++ b/src/config/containers/collections.py
@@ -1,0 +1,54 @@
+"""Collections bounded context dependency container."""
+
+from dependency_injector import containers, providers
+
+from src.modules.collections.application.use_cases import (
+    CheckWatchlistUseCase,
+    GetWatchlistUseCase,
+    ToggleWatchlistUseCase,
+)
+from src.modules.collections.infrastructure.persistence.repositories import (
+    SQLAlchemyWatchlistRepository,
+)
+
+
+class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[misc]
+    """Container for Collections bounded context dependencies.
+
+    The ``session``, ``movie_repository``, and ``series_repository``
+    dependencies must be wired from the parent container.
+    """
+
+    session = providers.Dependency()
+    movie_repository = providers.Dependency()
+    series_repository = providers.Dependency()
+
+    # =========================================================================
+    # Repositories
+    # =========================================================================
+
+    watchlist_repository = providers.Factory(
+        SQLAlchemyWatchlistRepository,
+        session=session,
+    )
+
+    # =========================================================================
+    # Use Cases
+    # =========================================================================
+
+    toggle_watchlist = providers.Factory(
+        ToggleWatchlistUseCase,
+        watchlist_repository=watchlist_repository,
+    )
+
+    get_watchlist = providers.Factory(
+        GetWatchlistUseCase,
+        watchlist_repository=watchlist_repository,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
+    )
+
+    check_watchlist = providers.Factory(
+        CheckWatchlistUseCase,
+        watchlist_repository=watchlist_repository,
+    )

--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -34,6 +34,7 @@ async def _init_engine(
     from src.config.settings import get_settings
 
     if get_settings().is_development:
+        import src.modules.collections.infrastructure.persistence.models
         import src.modules.media.infrastructure.persistence.models
         import src.modules.watch_progress.infrastructure.persistence.models  # noqa: F401
         from src.config.persistence.base import Base

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -8,6 +8,7 @@ See ADR-004 for the rationale behind this design.
 
 from dependency_injector import containers, providers
 
+from src.config.containers.collections import CollectionsContainer
 from src.config.containers.infrastructure import InfrastructureContainer
 from src.config.containers.library import LibraryContainer
 from src.config.containers.media import MediaContainer
@@ -66,6 +67,13 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         WatchProgressContainer,
         session=infrastructure.session,
         movie_repository=media.movie_repository,
+    )
+
+    collections = providers.Container(
+        CollectionsContainer,
+        session=infrastructure.session,
+        movie_repository=media.movie_repository,
+        series_repository=media.series_repository,
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.config.containers import ApplicationContainer
 from src.config.logging import get_logger, setup_logging
 from src.config.settings import get_settings
+from src.modules.collections.presentation.routes import watchlist_router
 from src.modules.media.presentation.routes import (
     enrichment_router,
     movie_router,
@@ -64,6 +65,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "src.modules.media.presentation.routes.series_routes",
             "src.modules.media.presentation.routes.stream_routes",
             "src.modules.watch_progress.presentation.routes.progress_routes",
+            "src.modules.collections.presentation.routes.watchlist_routes",
         ],
     )
     app.state.container = container
@@ -120,6 +122,7 @@ def create_app() -> FastAPI:
     app.include_router(series_router)
     app.include_router(stream_router)
     app.include_router(progress_router)
+    app.include_router(watchlist_router)
 
     return app
 

--- a/src/modules/collections/__init__.py
+++ b/src/modules/collections/__init__.py
@@ -1,0 +1,1 @@
+"""Collections bounded context."""

--- a/src/modules/collections/application/__init__.py
+++ b/src/modules/collections/application/__init__.py
@@ -1,0 +1,1 @@
+"""Collections application layer."""

--- a/src/modules/collections/application/dtos/__init__.py
+++ b/src/modules/collections/application/dtos/__init__.py
@@ -1,0 +1,15 @@
+"""Watchlist DTOs."""
+
+from src.modules.collections.application.dtos.watchlist_dtos import (
+    GetWatchlistInput,
+    ToggleWatchlistInput,
+    ToggleWatchlistOutput,
+    WatchlistItemOutput,
+)
+
+__all__ = [
+    "GetWatchlistInput",
+    "ToggleWatchlistInput",
+    "ToggleWatchlistOutput",
+    "WatchlistItemOutput",
+]

--- a/src/modules/collections/application/dtos/watchlist_dtos.py
+++ b/src/modules/collections/application/dtos/watchlist_dtos.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from src.modules.collections.domain.entities import WatchlistItem
@@ -19,7 +19,7 @@ class ToggleWatchlistInput:
     """
 
     media_id: str
-    media_type: str
+    media_type: Literal["movie", "series"]
 
 
 @dataclass(frozen=True)

--- a/src/modules/collections/application/dtos/watchlist_dtos.py
+++ b/src/modules/collections/application/dtos/watchlist_dtos.py
@@ -1,0 +1,92 @@
+"""Watchlist DTOs for application layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.modules.collections.domain.entities import WatchlistItem
+
+
+@dataclass(frozen=True)
+class ToggleWatchlistInput:
+    """Input for ToggleWatchlistUseCase.
+
+    Attributes:
+        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_type: Type of media ("movie" or "series").
+    """
+
+    media_id: str
+    media_type: str
+
+
+@dataclass(frozen=True)
+class ToggleWatchlistOutput:
+    """Output for ToggleWatchlistUseCase.
+
+    Attributes:
+        media_id: External ID of the media.
+        added: True if added to list, False if removed.
+    """
+
+    media_id: str
+    added: bool
+
+
+@dataclass(frozen=True)
+class WatchlistItemOutput:
+    """Output representing a single watchlist item with media metadata.
+
+    Attributes:
+        media_id: External ID of the media.
+        media_type: Type of media.
+        title: Display title (localized).
+        poster_path: URL to poster image.
+        added_at: ISO timestamp when added to watchlist.
+    """
+
+    media_id: str
+    media_type: str
+    title: str
+    poster_path: str | None
+    added_at: str
+
+    @classmethod
+    def from_entity(
+        cls,
+        entity: WatchlistItem,
+        title: str,
+        poster_path: str | None,
+    ) -> WatchlistItemOutput:
+        """Create output DTO from a WatchlistItem entity with metadata.
+
+        Args:
+            entity: The WatchlistItem domain entity.
+            title: Localized display title.
+            poster_path: URL to poster image.
+
+        Returns:
+            WatchlistItemOutput DTO.
+        """
+        return cls(
+            media_id=entity.media_id,
+            media_type=entity.media_type,
+            title=title,
+            poster_path=poster_path,
+            added_at=entity.added_at.isoformat(),
+        )
+
+
+@dataclass(frozen=True)
+class GetWatchlistInput:
+    """Input for GetWatchlistUseCase.
+
+    Attributes:
+        limit: Maximum number of items to return.
+        lang: Language code for localized metadata.
+    """
+
+    limit: int = 100
+    lang: str = "en"

--- a/src/modules/collections/application/use_cases/__init__.py
+++ b/src/modules/collections/application/use_cases/__init__.py
@@ -1,0 +1,17 @@
+"""Collections use cases."""
+
+from src.modules.collections.application.use_cases.check_watchlist import (
+    CheckWatchlistUseCase,
+)
+from src.modules.collections.application.use_cases.get_watchlist import (
+    GetWatchlistUseCase,
+)
+from src.modules.collections.application.use_cases.toggle_watchlist import (
+    ToggleWatchlistUseCase,
+)
+
+__all__ = [
+    "CheckWatchlistUseCase",
+    "GetWatchlistUseCase",
+    "ToggleWatchlistUseCase",
+]

--- a/src/modules/collections/application/use_cases/check_watchlist.py
+++ b/src/modules/collections/application/use_cases/check_watchlist.py
@@ -1,0 +1,36 @@
+"""CheckWatchlistUseCase - Check if a media item is in the watchlist."""
+
+from src.modules.collections.domain.repositories import WatchlistRepository
+
+
+class CheckWatchlistUseCase:
+    """Check whether a media item exists in the user's watchlist.
+
+    Example:
+        >>> use_case = CheckWatchlistUseCase(watchlist_repository)
+        >>> in_list = await use_case.execute("mov_abc123def456")
+        >>> in_list
+        True
+    """
+
+    def __init__(self, watchlist_repository: WatchlistRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            watchlist_repository: Repository for watchlist persistence.
+        """
+        self._repo = watchlist_repository
+
+    async def execute(self, media_id: str) -> bool:
+        """Execute the use case.
+
+        Args:
+            media_id: External ID of the media to check.
+
+        Returns:
+            True if the item is in the watchlist, False otherwise.
+        """
+        return await self._repo.exists(media_id)
+
+
+__all__ = ["CheckWatchlistUseCase"]

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -9,6 +9,7 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.domain.entities import WatchlistItem
 from src.modules.collections.domain.repositories import WatchlistRepository
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.value_objects import MovieId, SeriesId
 
 _logger = logging.getLogger(__name__)
 
@@ -78,8 +79,6 @@ class GetWatchlistUseCase:
             WatchlistItemOutput with metadata, or None if media not found.
         """
         if item.media_type == "movie":
-            from src.modules.media.domain.value_objects import MovieId
-
             movie = await self._movie_repo.find_by_id(MovieId(item.media_id))
             if not movie:
                 return None
@@ -90,8 +89,6 @@ class GetWatchlistUseCase:
             )
 
         if item.media_type == "series":
-            from src.modules.media.domain.value_objects import SeriesId
-
             series = await self._series_repo.find_by_id(SeriesId(item.media_id))
             if not series:
                 return None

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -1,0 +1,107 @@
+"""GetWatchlistUseCase - List watchlist items with media metadata."""
+
+import logging
+
+from src.modules.collections.application.dtos import (
+    GetWatchlistInput,
+    WatchlistItemOutput,
+)
+from src.modules.collections.domain.entities import WatchlistItem
+from src.modules.collections.domain.repositories import WatchlistRepository
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+_logger = logging.getLogger(__name__)
+
+
+class GetWatchlistUseCase:
+    """List all items in the user's watchlist with display metadata.
+
+    Joins watchlist records with movie/series data to provide
+    title and poster for the My List UI section.
+
+    Example:
+        >>> use_case = GetWatchlistUseCase(watchlist_repo, movie_repo, series_repo)
+        >>> items = await use_case.execute(GetWatchlistInput(limit=50, lang="pt-BR"))
+    """
+
+    def __init__(
+        self,
+        watchlist_repository: WatchlistRepository,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        """Initialize the use case.
+
+        Args:
+            watchlist_repository: Repository for watchlist items.
+            movie_repository: Repository for movie metadata.
+            series_repository: Repository for series metadata.
+        """
+        self._watchlist_repo = watchlist_repository
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
+
+    async def execute(self, input_dto: GetWatchlistInput) -> list[WatchlistItemOutput]:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains limit and language.
+
+        Returns:
+            List of WatchlistItemOutput with media metadata.
+        """
+        items = await self._watchlist_repo.list_all(limit=input_dto.limit)
+        _logger.info("Found %d watchlist items", len(items))
+
+        result: list[WatchlistItemOutput] = []
+        for item in items:
+            output = await self._enrich_with_metadata(item, input_dto.lang)
+            if output:
+                result.append(output)
+            else:
+                _logger.warning("Could not find media for watchlist item: %s", item.media_id)
+
+        return result
+
+    async def _enrich_with_metadata(
+        self,
+        item: WatchlistItem,
+        lang: str,
+    ) -> WatchlistItemOutput | None:
+        """Enrich a watchlist item with media metadata.
+
+        Args:
+            item: The watchlist item.
+            lang: Language code for localized metadata.
+
+        Returns:
+            WatchlistItemOutput with metadata, or None if media not found.
+        """
+        if item.media_type == "movie":
+            from src.modules.media.domain.value_objects import MovieId
+
+            movie = await self._movie_repo.find_by_id(MovieId(item.media_id))
+            if not movie:
+                return None
+            return WatchlistItemOutput.from_entity(
+                entity=item,
+                title=movie.get_title(lang),
+                poster_path=movie.poster_path.value if movie.poster_path else None,
+            )
+
+        if item.media_type == "series":
+            from src.modules.media.domain.value_objects import SeriesId
+
+            series = await self._series_repo.find_by_id(SeriesId(item.media_id))
+            if not series:
+                return None
+            return WatchlistItemOutput.from_entity(
+                entity=item,
+                title=series.get_title(lang),
+                poster_path=series.poster_path.value if series.poster_path else None,
+            )
+
+        return None
+
+
+__all__ = ["GetWatchlistUseCase"]

--- a/src/modules/collections/application/use_cases/toggle_watchlist.py
+++ b/src/modules/collections/application/use_cases/toggle_watchlist.py
@@ -1,0 +1,58 @@
+"""ToggleWatchlistUseCase - Add or remove an item from the watchlist."""
+
+from src.modules.collections.application.dtos import (
+    ToggleWatchlistInput,
+    ToggleWatchlistOutput,
+)
+from src.modules.collections.domain.entities import WatchlistItem
+from src.modules.collections.domain.repositories import WatchlistRepository
+
+
+class ToggleWatchlistUseCase:
+    """Toggle a media item in the user's watchlist.
+
+    If the item is already in the watchlist, it is removed.
+    If it is not in the watchlist, it is added.
+
+    Example:
+        >>> use_case = ToggleWatchlistUseCase(watchlist_repository)
+        >>> result = await use_case.execute(ToggleWatchlistInput(
+        ...     media_id="mov_abc123def456",
+        ...     media_type="movie",
+        ... ))
+        >>> result.added
+        True
+    """
+
+    def __init__(self, watchlist_repository: WatchlistRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            watchlist_repository: Repository for watchlist persistence.
+        """
+        self._repo = watchlist_repository
+
+    async def execute(self, input_dto: ToggleWatchlistInput) -> ToggleWatchlistOutput:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains media_id and media_type.
+
+        Returns:
+            ToggleWatchlistOutput with added=True if added, False if removed.
+        """
+        exists = await self._repo.exists(input_dto.media_id)
+
+        if exists:
+            await self._repo.remove(input_dto.media_id)
+            return ToggleWatchlistOutput(media_id=input_dto.media_id, added=False)
+
+        item = WatchlistItem.create(
+            media_id=input_dto.media_id,
+            media_type=input_dto.media_type,
+        )
+        await self._repo.add(item)
+        return ToggleWatchlistOutput(media_id=input_dto.media_id, added=True)
+
+
+__all__ = ["ToggleWatchlistUseCase"]

--- a/src/modules/collections/domain/__init__.py
+++ b/src/modules/collections/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Collections domain layer."""

--- a/src/modules/collections/domain/entities/__init__.py
+++ b/src/modules/collections/domain/entities/__init__.py
@@ -1,0 +1,5 @@
+"""Collections entities."""
+
+from src.modules.collections.domain.entities.watchlist_item import WatchlistItem
+
+__all__ = ["WatchlistItem"]

--- a/src/modules/collections/domain/entities/watchlist_item.py
+++ b/src/modules/collections/domain/entities/watchlist_item.py
@@ -1,0 +1,60 @@
+"""WatchlistItem aggregate root."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import Field
+
+from src.building_blocks.domain import AggregateRoot
+from src.modules.collections.domain.value_objects import ListId
+
+
+class WatchlistItem(AggregateRoot[ListId]):
+    """An item saved to the user's watchlist (My List).
+
+    Represents a movie or series that the user wants to watch later.
+
+    Attributes:
+        id: External ID (lst_xxx format).
+        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_type: Type of media ("movie" or "series").
+        added_at: Timestamp when the item was added.
+
+    Example:
+        >>> item = WatchlistItem.create(
+        ...     media_id="mov_abc123def456",
+        ...     media_type="movie",
+        ... )
+    """
+
+    id: ListId | None = Field(default=None)
+
+    media_id: str
+    media_type: str  # "movie" or "series"
+    added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @classmethod
+    def create(
+        cls,
+        media_id: str,
+        media_type: str,
+    ) -> WatchlistItem:
+        """Factory method with automatic ID generation.
+
+        Args:
+            media_id: External ID of the media (mov_xxx or ser_xxx).
+            media_type: Type of media ("movie" or "series").
+
+        Returns:
+            A new WatchlistItem instance.
+        """
+        return cls(
+            id=ListId.generate(),
+            media_id=media_id,
+            media_type=media_type,
+            added_at=datetime.now(UTC),
+        )
+
+
+__all__ = ["WatchlistItem"]

--- a/src/modules/collections/domain/repositories/__init__.py
+++ b/src/modules/collections/domain/repositories/__init__.py
@@ -1,0 +1,7 @@
+"""Collections repository interfaces."""
+
+from src.modules.collections.domain.repositories.watchlist_repository import (
+    WatchlistRepository,
+)
+
+__all__ = ["WatchlistRepository"]

--- a/src/modules/collections/domain/repositories/watchlist_repository.py
+++ b/src/modules/collections/domain/repositories/watchlist_repository.py
@@ -1,0 +1,71 @@
+"""Watchlist repository interface."""
+
+from abc import ABC, abstractmethod
+
+from src.modules.collections.domain.entities import WatchlistItem
+
+
+class WatchlistRepository(ABC):
+    """Abstract repository for WatchlistItem persistence.
+
+    Example:
+        >>> item = await repo.find_by_media_id("mov_abc123def456")
+    """
+
+    @abstractmethod
+    async def find_by_media_id(self, media_id: str) -> WatchlistItem | None:
+        """Find a watchlist item by media external ID.
+
+        Args:
+            media_id: External ID of the media (mov_xxx or ser_xxx).
+
+        Returns:
+            WatchlistItem if found, None otherwise.
+        """
+
+    @abstractmethod
+    async def add(self, item: WatchlistItem) -> WatchlistItem:
+        """Add an item to the watchlist.
+
+        Args:
+            item: The WatchlistItem entity to persist.
+
+        Returns:
+            The persisted WatchlistItem.
+        """
+
+    @abstractmethod
+    async def remove(self, media_id: str) -> bool:
+        """Soft-delete an item from the watchlist.
+
+        Args:
+            media_id: External ID of the media.
+
+        Returns:
+            True if removed, False if not found.
+        """
+
+    @abstractmethod
+    async def list_all(self, limit: int = 100) -> list[WatchlistItem]:
+        """List all watchlist items ordered by most recently added.
+
+        Args:
+            limit: Maximum number of items to return.
+
+        Returns:
+            List of WatchlistItem entities.
+        """
+
+    @abstractmethod
+    async def exists(self, media_id: str) -> bool:
+        """Check if a media item is in the watchlist.
+
+        Args:
+            media_id: External ID of the media.
+
+        Returns:
+            True if the item exists, False otherwise.
+        """
+
+
+__all__ = ["WatchlistRepository"]

--- a/src/modules/collections/domain/value_objects/__init__.py
+++ b/src/modules/collections/domain/value_objects/__init__.py
@@ -1,0 +1,5 @@
+"""Collections value objects."""
+
+from src.modules.collections.domain.value_objects.list_id import ListId
+
+__all__ = ["ListId"]

--- a/src/modules/collections/domain/value_objects/list_id.py
+++ b/src/modules/collections/domain/value_objects/list_id.py
@@ -1,0 +1,18 @@
+"""List external ID value object."""
+
+from typing import ClassVar
+
+from src.building_blocks.domain.external_id import ExternalId
+
+
+class ListId(ExternalId):
+    """External ID for watchlist items.
+
+    Format: lst_{base62_12chars}
+    Example: lst_3yL8nQsT9mK5
+    """
+
+    EXPECTED_PREFIX: ClassVar[str] = "lst"
+
+
+__all__ = ["ListId"]

--- a/src/modules/collections/infrastructure/__init__.py
+++ b/src/modules/collections/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Collections infrastructure layer."""

--- a/src/modules/collections/infrastructure/persistence/__init__.py
+++ b/src/modules/collections/infrastructure/persistence/__init__.py
@@ -1,0 +1,1 @@
+"""Collections persistence layer."""

--- a/src/modules/collections/infrastructure/persistence/mappers/__init__.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/__init__.py
@@ -1,0 +1,7 @@
+"""Collections mappers."""
+
+from src.modules.collections.infrastructure.persistence.mappers.watchlist_item_mapper import (
+    WatchlistItemMapper,
+)
+
+__all__ = ["WatchlistItemMapper"]

--- a/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
@@ -1,0 +1,75 @@
+"""Mapper between WatchlistItem entity and WatchlistItemModel."""
+
+from src.modules.collections.domain.entities import WatchlistItem
+from src.modules.collections.domain.value_objects import ListId
+from src.modules.collections.infrastructure.persistence.models import (
+    WatchlistItemModel,
+)
+
+
+class WatchlistItemMapper:
+    """Bidirectional mapper between WatchlistItem entity and ORM model.
+
+    Example:
+        >>> model = WatchlistItemMapper.to_model(entity)
+        >>> entity = WatchlistItemMapper.to_entity(model)
+    """
+
+    @staticmethod
+    def to_model(entity: WatchlistItem) -> WatchlistItemModel:
+        """Convert WatchlistItem entity to ORM model.
+
+        Args:
+            entity: The domain entity.
+
+        Returns:
+            SQLAlchemy model ready for persistence.
+        """
+        if entity.id is None:
+            msg = "Cannot map entity without ID to model"
+            raise ValueError(msg)
+
+        return WatchlistItemModel(
+            external_id=str(entity.id),
+            media_id=entity.media_id,
+            media_type=entity.media_type,
+            added_at=entity.added_at,
+        )
+
+    @staticmethod
+    def to_entity(model: WatchlistItemModel) -> WatchlistItem:
+        """Convert ORM model to WatchlistItem entity.
+
+        Args:
+            model: The SQLAlchemy model.
+
+        Returns:
+            Domain WatchlistItem entity.
+        """
+        return WatchlistItem(
+            id=ListId(model.external_id),
+            media_id=model.media_id,
+            media_type=model.media_type,
+            added_at=model.added_at,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    @staticmethod
+    def update_model(model: WatchlistItemModel, entity: WatchlistItem) -> WatchlistItemModel:
+        """Update existing ORM model with entity data.
+
+        Args:
+            model: The existing model.
+            entity: The updated entity.
+
+        Returns:
+            The updated model.
+        """
+        model.media_id = entity.media_id
+        model.media_type = entity.media_type
+        model.added_at = entity.added_at
+        return model
+
+
+__all__ = ["WatchlistItemMapper"]

--- a/src/modules/collections/infrastructure/persistence/models/__init__.py
+++ b/src/modules/collections/infrastructure/persistence/models/__init__.py
@@ -1,0 +1,7 @@
+"""Collections ORM models."""
+
+from src.modules.collections.infrastructure.persistence.models.watchlist_item_model import (
+    WatchlistItemModel,
+)
+
+__all__ = ["WatchlistItemModel"]

--- a/src/modules/collections/infrastructure/persistence/models/watchlist_item_model.py
+++ b/src/modules/collections/infrastructure/persistence/models/watchlist_item_model.py
@@ -1,0 +1,34 @@
+"""WatchlistItem ORM model."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.config.persistence.base import Base
+
+
+class WatchlistItemModel(Base):
+    """SQLAlchemy model for WatchlistItem.
+
+    Maps to the 'watchlist_items' table. One row per media item.
+
+    Attributes:
+        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_type: Type of media ("movie" or "series").
+        added_at: Timestamp when the item was added.
+    """
+
+    media_id: Mapped[str] = mapped_column(String(50), nullable=False, unique=True, index=True)
+    media_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    added_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"<WatchlistItemModel(id={self.id}, media_id={self.media_id!r}, "
+            f"media_type={self.media_type!r})>"
+        )
+
+
+__all__ = ["WatchlistItemModel"]

--- a/src/modules/collections/infrastructure/persistence/repositories/__init__.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/__init__.py
@@ -1,0 +1,7 @@
+"""Collections repository implementations."""
+
+from src.modules.collections.infrastructure.persistence.repositories.watchlist_repository import (
+    SQLAlchemyWatchlistRepository,
+)
+
+__all__ = ["SQLAlchemyWatchlistRepository"]

--- a/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
@@ -40,7 +40,26 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         return None if model is None else WatchlistItemMapper.to_entity(model)
 
     async def add(self, item: WatchlistItem) -> WatchlistItem:
-        """Add an item to the watchlist."""
+        """Add an item to the watchlist.
+
+        If a soft-deleted record exists for the same media_id,
+        restores it instead of creating a duplicate.
+        """
+        # Check for soft-deleted record to restore
+        stmt = select(WatchlistItemModel).where(
+            WatchlistItemModel.media_id == item.media_id,
+            WatchlistItemModel.deleted_at.is_not(None),
+        )
+        result = await self._session.execute(stmt)
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.restore()
+            WatchlistItemMapper.update_model(existing, item)
+            await self._session.commit()
+            await self._session.refresh(existing)
+            return WatchlistItemMapper.to_entity(existing)
+
         model = WatchlistItemMapper.to_model(item)
         self._session.add(model)
         await self._session.commit()

--- a/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
@@ -87,7 +87,7 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         stmt = (
             select(WatchlistItemModel)
             .where(WatchlistItemModel.deleted_at.is_(None))
-            .order_by(WatchlistItemModel.created_at.desc())
+            .order_by(WatchlistItemModel.added_at.desc())
             .limit(limit)
         )
         result = await self._session.execute(stmt)

--- a/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
@@ -1,0 +1,91 @@
+"""SQLAlchemy implementation of WatchlistRepository."""
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.collections.domain.entities import WatchlistItem
+from src.modules.collections.domain.repositories import WatchlistRepository
+from src.modules.collections.infrastructure.persistence.mappers import (
+    WatchlistItemMapper,
+)
+from src.modules.collections.infrastructure.persistence.models import (
+    WatchlistItemModel,
+)
+
+
+class SQLAlchemyWatchlistRepository(WatchlistRepository):
+    """SQLAlchemy implementation of WatchlistRepository.
+
+    Example:
+        >>> repo = SQLAlchemyWatchlistRepository(session)
+        >>> item = await repo.find_by_media_id("mov_abc123def456")
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize repository with database session.
+
+        Args:
+            session: SQLAlchemy async session.
+        """
+        self._session = session
+
+    async def find_by_media_id(self, media_id: str) -> WatchlistItem | None:
+        """Find a watchlist item by media external ID."""
+        stmt = select(WatchlistItemModel).where(
+            WatchlistItemModel.media_id == media_id,
+            WatchlistItemModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else WatchlistItemMapper.to_entity(model)
+
+    async def add(self, item: WatchlistItem) -> WatchlistItem:
+        """Add an item to the watchlist."""
+        model = WatchlistItemMapper.to_model(item)
+        self._session.add(model)
+        await self._session.commit()
+        await self._session.refresh(model)
+        return WatchlistItemMapper.to_entity(model)
+
+    async def remove(self, media_id: str) -> bool:
+        """Soft-delete an item from the watchlist."""
+        stmt = select(WatchlistItemModel).where(
+            WatchlistItemModel.media_id == media_id,
+            WatchlistItemModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+
+        if model is None:
+            return False
+
+        model.soft_delete()
+        await self._session.commit()
+        return True
+
+    async def list_all(self, limit: int = 100) -> list[WatchlistItem]:
+        """List all watchlist items ordered by most recently added."""
+        stmt = (
+            select(WatchlistItemModel)
+            .where(WatchlistItemModel.deleted_at.is_(None))
+            .order_by(WatchlistItemModel.created_at.desc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [WatchlistItemMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def exists(self, media_id: str) -> bool:
+        """Check if a media item is in the watchlist."""
+        stmt = (
+            select(func.count())
+            .select_from(WatchlistItemModel)
+            .where(
+                WatchlistItemModel.media_id == media_id,
+                WatchlistItemModel.deleted_at.is_(None),
+            )
+        )
+        result = await self._session.execute(stmt)
+        return (result.scalar() or 0) > 0
+
+
+__all__ = ["SQLAlchemyWatchlistRepository"]

--- a/src/modules/collections/presentation/__init__.py
+++ b/src/modules/collections/presentation/__init__.py
@@ -1,0 +1,1 @@
+"""Collections presentation layer."""

--- a/src/modules/collections/presentation/routes/__init__.py
+++ b/src/modules/collections/presentation/routes/__init__.py
@@ -1,0 +1,7 @@
+"""Collections routes."""
+
+from src.modules.collections.presentation.routes.watchlist_routes import (
+    router as watchlist_router,
+)
+
+__all__ = ["watchlist_router"]

--- a/src/modules/collections/presentation/routes/watchlist_routes.py
+++ b/src/modules/collections/presentation/routes/watchlist_routes.py
@@ -1,7 +1,7 @@
 """Watchlist REST API routes."""
 
 from dataclasses import asdict
-from typing import Any
+from typing import Any, Literal
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
@@ -28,7 +28,7 @@ class ToggleWatchlistRequest(BaseModel):
     """Request body for toggling a watchlist item."""
 
     media_id: str
-    media_type: str
+    media_type: Literal["movie", "series"]
 
 
 # -- Endpoints -----------------------------------------------------------------

--- a/src/modules/collections/presentation/routes/watchlist_routes.py
+++ b/src/modules/collections/presentation/routes/watchlist_routes.py
@@ -1,0 +1,85 @@
+"""Watchlist REST API routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from src.config.containers import ApplicationContainer
+from src.modules.collections.application.dtos import (
+    GetWatchlistInput,
+    ToggleWatchlistInput,
+)
+from src.modules.collections.application.use_cases import (
+    CheckWatchlistUseCase,
+    GetWatchlistUseCase,
+    ToggleWatchlistUseCase,
+)
+
+router = APIRouter(prefix="/api/v1/watchlist", tags=["Watchlist"])
+
+
+# -- Schemas -------------------------------------------------------------------
+
+
+class ToggleWatchlistRequest(BaseModel):
+    """Request body for toggling a watchlist item."""
+
+    media_id: str
+    media_type: str
+
+
+# -- Endpoints -----------------------------------------------------------------
+
+
+@router.post("/toggle")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def toggle_watchlist(
+    body: ToggleWatchlistRequest,
+    use_case: ToggleWatchlistUseCase = Depends(
+        Provide[ApplicationContainer.collections.toggle_watchlist],
+    ),
+) -> dict[str, Any]:
+    """Add or remove a media item from the watchlist."""
+    result = await use_case.execute(
+        ToggleWatchlistInput(
+            media_id=body.media_id,
+            media_type=body.media_type,
+        ),
+    )
+    return {"type": "watchlist", "data": asdict(result)}
+
+
+@router.get("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_watchlist(
+    limit: int = Query(100, ge=1, le=500),
+    lang: str = "en",
+    use_case: GetWatchlistUseCase = Depends(
+        Provide[ApplicationContainer.collections.get_watchlist],
+    ),
+) -> dict[str, Any]:
+    """List all items in the user's watchlist."""
+    items = await use_case.execute(GetWatchlistInput(limit=limit, lang=lang))
+    return {
+        "type": "list",
+        "data": [asdict(item) for item in items],
+    }
+
+
+@router.get("/check/{media_id}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def check_watchlist(
+    media_id: str,
+    use_case: CheckWatchlistUseCase = Depends(
+        Provide[ApplicationContainer.collections.check_watchlist],
+    ),
+) -> dict[str, Any]:
+    """Check if a media item is in the watchlist."""
+    in_list = await use_case.execute(media_id)
+    return {"type": "watchlist", "data": {"in_list": in_list}}
+
+
+__all__ = ["router"]


### PR DESCRIPTION
## Summary

New `collections` bounded context with Watchlist support:

- **Domain**: `WatchlistItem` entity with `ListId` (lst_xxx), `WatchlistRepository` ABC
- **Application**: `ToggleWatchlistUseCase` (add/remove), `GetWatchlistUseCase` (with media metadata), `CheckWatchlistUseCase`
- **Infrastructure**: SQLAlchemy model, mapper, repository with soft delete
- **Presentation**: `POST /toggle`, `GET /`, `GET /check/{media_id}`
- **DI**: `CollectionsContainer` wired with session and media repositories

Closes #45

## Test plan

- [ ] `POST /api/v1/watchlist/toggle` with media_id adds item (returns `added: true`)
- [ ] Toggle again removes item (returns `added: false`)
- [ ] `GET /api/v1/watchlist` returns items with title and poster
- [ ] `GET /api/v1/watchlist/check/{media_id}` returns `in_list: true/false`
- [ ] All 783 tests pass

## Summary by Sourcery

Introduce a new collections bounded context to support user watchlists (My List) with full API, domain, application, and infrastructure wiring.

New Features:
- Add WatchlistItem aggregate and repository interface for managing user watchlist entries.
- Expose watchlist REST API endpoints to toggle items, list the watchlist with media metadata, and check membership for a given media ID.
- Implement SQLAlchemy persistence, mappers, and repository for watchlist items with soft-delete semantics.
- Wire a dedicated CollectionsContainer into the main application and register watchlist routes with FastAPI and the ORM metadata.