### PR TITLE
feat(watch-progress): add backdrop_path to continue watching items

### DIFF
--- a/src/modules/watch_progress/application/dtos/progress_dtos.py
+++ b/src/modules/watch_progress/application/dtos/progress_dtos.py
@@ -115,6 +115,7 @@ class ContinueWatchingItem:
     media_type: str
     title: str
     poster_path: str | None
+    backdrop_path: str | None
     position_seconds: int
     duration_seconds: int
     percentage: float

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -91,6 +91,7 @@ class GetContinueWatchingUseCase:
                 media_type=progress.media_type,
                 title=movie.get_title(lang),
                 poster_path=movie.poster_path.value if movie.poster_path else None,
+                backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
                 position_seconds=progress.position_seconds,
                 duration_seconds=progress.duration_seconds,
                 percentage=progress.percentage,


### PR DESCRIPTION
## Summary

- Add `backdrop_path` field to `ContinueWatchingItem` DTO
- Return movie's `backdrop_path` (landscape image) in continue watching response
- Enables frontend to display 16:9 thumbnails instead of posters

## Test plan

- [ ] `GET /progress/continue-watching` returns `backdrop_path` for movies
- [ ] All tests pass

## Summary by Sourcery

New Features:
- Add a backdrop_path field to the ContinueWatchingItem DTO to expose landscape artwork in continue watching responses.