### PR TITLE
feat(collections): add Custom Lists module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ temp/
 # Claude Code context
 CLAUDE.md
 hls_cache/
+
+# Specs and evidence (local references only)
+specs/
+evidence/

--- a/src/config/containers/collections.py
+++ b/src/config/containers/collections.py
@@ -3,11 +3,19 @@
 from dependency_injector import containers, providers
 
 from src.modules.collections.application.use_cases import (
+    AddItemToCustomListUseCase,
     CheckWatchlistUseCase,
+    CreateCustomListUseCase,
+    DeleteCustomListUseCase,
+    GetCustomListItemsUseCase,
     GetWatchlistUseCase,
+    ListCustomListsUseCase,
+    RemoveItemFromCustomListUseCase,
+    RenameCustomListUseCase,
     ToggleWatchlistUseCase,
 )
 from src.modules.collections.infrastructure.persistence.repositories import (
+    SQLAlchemyCustomListRepository,
     SQLAlchemyWatchlistRepository,
 )
 
@@ -32,8 +40,13 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
         session=session,
     )
 
+    custom_list_repository = providers.Factory(
+        SQLAlchemyCustomListRepository,
+        session=session,
+    )
+
     # =========================================================================
-    # Use Cases
+    # Watchlist Use Cases
     # =========================================================================
 
     toggle_watchlist = providers.Factory(
@@ -51,4 +64,45 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
     check_watchlist = providers.Factory(
         CheckWatchlistUseCase,
         watchlist_repository=watchlist_repository,
+    )
+
+    # =========================================================================
+    # Custom List Use Cases
+    # =========================================================================
+
+    create_custom_list = providers.Factory(
+        CreateCustomListUseCase,
+        custom_list_repository=custom_list_repository,
+    )
+
+    list_custom_lists = providers.Factory(
+        ListCustomListsUseCase,
+        custom_list_repository=custom_list_repository,
+    )
+
+    rename_custom_list = providers.Factory(
+        RenameCustomListUseCase,
+        custom_list_repository=custom_list_repository,
+    )
+
+    delete_custom_list = providers.Factory(
+        DeleteCustomListUseCase,
+        custom_list_repository=custom_list_repository,
+    )
+
+    add_item_to_custom_list = providers.Factory(
+        AddItemToCustomListUseCase,
+        custom_list_repository=custom_list_repository,
+    )
+
+    remove_item_from_custom_list = providers.Factory(
+        RemoveItemFromCustomListUseCase,
+        custom_list_repository=custom_list_repository,
+    )
+
+    get_custom_list_items = providers.Factory(
+        GetCustomListItemsUseCase,
+        custom_list_repository=custom_list_repository,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from src.config.containers import ApplicationContainer
 from src.config.logging import get_logger, setup_logging
 from src.config.settings import get_settings
-from src.modules.collections.presentation.routes import watchlist_router
+from src.modules.collections.presentation.routes import custom_list_router, watchlist_router
 from src.modules.media.presentation.routes import (
     enrichment_router,
     movie_router,
@@ -66,6 +66,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "src.modules.media.presentation.routes.stream_routes",
             "src.modules.watch_progress.presentation.routes.progress_routes",
             "src.modules.collections.presentation.routes.watchlist_routes",
+            "src.modules.collections.presentation.routes.custom_list_routes",
         ],
     )
     app.state.container = container
@@ -123,6 +124,7 @@ def create_app() -> FastAPI:
     app.include_router(stream_router)
     app.include_router(progress_router)
     app.include_router(watchlist_router)
+    app.include_router(custom_list_router)
 
     return app
 

--- a/src/modules/collections/application/dtos/__init__.py
+++ b/src/modules/collections/application/dtos/__init__.py
@@ -1,5 +1,14 @@
-"""Watchlist DTOs."""
+"""Collections DTOs."""
 
+from src.modules.collections.application.dtos.custom_list_dtos import (
+    AddItemToCustomListInput,
+    CreateCustomListInput,
+    CustomListItemOutput,
+    CustomListOutput,
+    GetCustomListItemsInput,
+    RemoveItemFromCustomListInput,
+    RenameCustomListInput,
+)
 from src.modules.collections.application.dtos.watchlist_dtos import (
     GetWatchlistInput,
     ToggleWatchlistInput,
@@ -8,7 +17,14 @@ from src.modules.collections.application.dtos.watchlist_dtos import (
 )
 
 __all__ = [
+    "AddItemToCustomListInput",
+    "CreateCustomListInput",
+    "CustomListItemOutput",
+    "CustomListOutput",
+    "GetCustomListItemsInput",
     "GetWatchlistInput",
+    "RemoveItemFromCustomListInput",
+    "RenameCustomListInput",
     "ToggleWatchlistInput",
     "ToggleWatchlistOutput",
     "WatchlistItemOutput",

--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.modules.collections.domain.entities import CustomList, CustomListItem
+    from src.shared_kernel.value_objects import CollectionMediaType
 
 
 @dataclass(frozen=True)
@@ -82,7 +83,7 @@ class AddItemToCustomListInput:
 
     list_id: str
     media_id: str
-    media_type: Literal["movie", "series"]
+    media_type: CollectionMediaType
 
 
 @dataclass(frozen=True)
@@ -125,7 +126,7 @@ class CustomListItemOutput:
     """
 
     media_id: str
-    media_type: str
+    media_type: CollectionMediaType
     title: str
     poster_path: str | None
     position: int

--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -1,0 +1,158 @@
+"""Custom list DTOs for application layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from src.modules.collections.domain.entities import CustomList, CustomListItem
+
+
+@dataclass(frozen=True)
+class CreateCustomListInput:
+    """Input for CreateCustomListUseCase.
+
+    Attributes:
+        name: Display name for the new list.
+    """
+
+    name: str
+
+
+@dataclass(frozen=True)
+class CustomListOutput:
+    """Output representing a custom list.
+
+    Attributes:
+        id: External ID (lst_xxx format).
+        name: Display name of the list.
+        item_count: Number of items in the list.
+        created_at: ISO timestamp when the list was created.
+        updated_at: ISO timestamp when the list was last updated.
+    """
+
+    id: str
+    name: str
+    item_count: int
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_entity(cls, entity: CustomList) -> CustomListOutput:
+        """Create output DTO from a CustomList entity.
+
+        Args:
+            entity: The CustomList domain entity.
+
+        Returns:
+            CustomListOutput DTO.
+        """
+        return cls(
+            id=str(entity.id),
+            name=entity.name,
+            item_count=entity.item_count,
+            created_at=entity.created_at.isoformat(),
+            updated_at=entity.updated_at.isoformat(),
+        )
+
+
+@dataclass(frozen=True)
+class RenameCustomListInput:
+    """Input for RenameCustomListUseCase.
+
+    Attributes:
+        list_id: External ID of the list.
+        name: New display name.
+    """
+
+    list_id: str
+    name: str
+
+
+@dataclass(frozen=True)
+class AddItemToCustomListInput:
+    """Input for AddItemToCustomListUseCase.
+
+    Attributes:
+        list_id: External ID of the list.
+        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_type: Type of media ("movie" or "series").
+    """
+
+    list_id: str
+    media_id: str
+    media_type: Literal["movie", "series"]
+
+
+@dataclass(frozen=True)
+class RemoveItemFromCustomListInput:
+    """Input for RemoveItemFromCustomListUseCase.
+
+    Attributes:
+        list_id: External ID of the list.
+        media_id: External ID of the media.
+    """
+
+    list_id: str
+    media_id: str
+
+
+@dataclass(frozen=True)
+class GetCustomListItemsInput:
+    """Input for GetCustomListItemsUseCase.
+
+    Attributes:
+        list_id: External ID of the list.
+        lang: Language code for localized metadata.
+    """
+
+    list_id: str
+    lang: str = "en"
+
+
+@dataclass(frozen=True)
+class CustomListItemOutput:
+    """Output representing an item in a custom list with media metadata.
+
+    Attributes:
+        media_id: External ID of the media.
+        media_type: Type of media.
+        title: Display title (localized).
+        poster_path: URL to poster image.
+        position: Ordering position within the list.
+        added_at: ISO timestamp when added to the list.
+    """
+
+    media_id: str
+    media_type: str
+    title: str
+    poster_path: str | None
+    position: int
+    added_at: str
+
+    @classmethod
+    def from_entity(
+        cls,
+        entity: CustomListItem,
+        title: str,
+        poster_path: str | None,
+    ) -> CustomListItemOutput:
+        """Create output DTO from a CustomListItem entity with metadata.
+
+        Args:
+            entity: The CustomListItem domain entity.
+            title: Localized display title.
+            poster_path: URL to poster image.
+
+        Returns:
+            CustomListItemOutput DTO.
+        """
+        return cls(
+            media_id=entity.media_id,
+            media_type=entity.media_type,
+            title=title,
+            poster_path=poster_path,
+            position=entity.position,
+            added_at=entity.added_at.isoformat(),
+        )

--- a/src/modules/collections/application/dtos/watchlist_dtos.py
+++ b/src/modules/collections/application/dtos/watchlist_dtos.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.modules.collections.domain.entities import WatchlistItem
+    from src.shared_kernel.value_objects import CollectionMediaType
 
 
 @dataclass(frozen=True)
@@ -15,11 +16,11 @@ class ToggleWatchlistInput:
 
     Attributes:
         media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media ("movie" or "series").
+        media_type: Type of media (movie or series).
     """
 
     media_id: str
-    media_type: Literal["movie", "series"]
+    media_type: CollectionMediaType
 
 
 @dataclass(frozen=True)
@@ -48,7 +49,7 @@ class WatchlistItemOutput:
     """
 
     media_id: str
-    media_type: str
+    media_type: CollectionMediaType
     title: str
     poster_path: str | None
     added_at: str

--- a/src/modules/collections/application/use_cases/__init__.py
+++ b/src/modules/collections/application/use_cases/__init__.py
@@ -1,17 +1,45 @@
 """Collections use cases."""
 
+from src.modules.collections.application.use_cases.add_item_to_custom_list import (
+    AddItemToCustomListUseCase,
+)
 from src.modules.collections.application.use_cases.check_watchlist import (
     CheckWatchlistUseCase,
 )
+from src.modules.collections.application.use_cases.create_custom_list import (
+    CreateCustomListUseCase,
+)
+from src.modules.collections.application.use_cases.delete_custom_list import (
+    DeleteCustomListUseCase,
+)
+from src.modules.collections.application.use_cases.get_custom_list_items import (
+    GetCustomListItemsUseCase,
+)
 from src.modules.collections.application.use_cases.get_watchlist import (
     GetWatchlistUseCase,
+)
+from src.modules.collections.application.use_cases.list_custom_lists import (
+    ListCustomListsUseCase,
+)
+from src.modules.collections.application.use_cases.remove_item_from_custom_list import (
+    RemoveItemFromCustomListUseCase,
+)
+from src.modules.collections.application.use_cases.rename_custom_list import (
+    RenameCustomListUseCase,
 )
 from src.modules.collections.application.use_cases.toggle_watchlist import (
     ToggleWatchlistUseCase,
 )
 
 __all__ = [
+    "AddItemToCustomListUseCase",
     "CheckWatchlistUseCase",
+    "CreateCustomListUseCase",
+    "DeleteCustomListUseCase",
+    "GetCustomListItemsUseCase",
     "GetWatchlistUseCase",
+    "ListCustomListsUseCase",
+    "RemoveItemFromCustomListUseCase",
+    "RenameCustomListUseCase",
     "ToggleWatchlistUseCase",
 ]

--- a/src/modules/collections/application/use_cases/add_item_to_custom_list.py
+++ b/src/modules/collections/application/use_cases/add_item_to_custom_list.py
@@ -54,8 +54,7 @@ class AddItemToCustomListUseCase:
         # Validate item limit via domain entity
         updated_list = custom_list.increment_item_count()
 
-        items = await self._repo.list_items(input_dto.list_id)
-        next_position = max((i.position for i in items), default=-1) + 1
+        next_position = await self._repo.get_next_position(input_dto.list_id)
 
         item = CustomListItem.create(
             media_id=input_dto.media_id,

--- a/src/modules/collections/application/use_cases/add_item_to_custom_list.py
+++ b/src/modules/collections/application/use_cases/add_item_to_custom_list.py
@@ -1,0 +1,70 @@
+"""AddItemToCustomListUseCase - Add a media item to a custom list."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.building_blocks.domain import BusinessRuleViolationException
+from src.modules.collections.application.dtos import AddItemToCustomListInput
+from src.modules.collections.domain.entities import CustomListItem
+from src.modules.collections.domain.repositories import CustomListRepository
+
+
+class AddItemToCustomListUseCase:
+    """Add a movie or series to a custom list.
+
+    Enforces item limit per list and prevents duplicates.
+
+    Example:
+        >>> use_case = AddItemToCustomListUseCase(custom_list_repository)
+        >>> await use_case.execute(AddItemToCustomListInput(
+        ...     list_id="lst_abc123",
+        ...     media_id="mov_xyz789",
+        ...     media_type="movie",
+        ... ))
+    """
+
+    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            custom_list_repository: Repository for custom list persistence.
+        """
+        self._repo = custom_list_repository
+
+    async def execute(self, input_dto: AddItemToCustomListInput) -> None:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains list_id, media_id, and media_type.
+
+        Raises:
+            ResourceNotFoundException: If the list does not exist.
+            BusinessRuleViolationException: If item already in list or list is full.
+        """
+        custom_list = await self._repo.find_by_id(input_dto.list_id)
+        if not custom_list:
+            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+
+        existing_item = await self._repo.find_item(input_dto.list_id, input_dto.media_id)
+        if existing_item:
+            raise BusinessRuleViolationException(
+                message="Item already exists in this list",
+                message_code="CUSTOM_LIST_ITEM_DUPLICATE",
+                rule_code="CUSTOM_LIST_ITEM_DUPLICATE",
+            )
+
+        # Validate item limit via domain entity
+        updated_list = custom_list.increment_item_count()
+
+        items = await self._repo.list_items(input_dto.list_id)
+        next_position = max((i.position for i in items), default=-1) + 1
+
+        item = CustomListItem.create(
+            media_id=input_dto.media_id,
+            media_type=input_dto.media_type,
+            position=next_position,
+        )
+
+        await self._repo.add_item(input_dto.list_id, item)
+        await self._repo.update(updated_list)
+
+
+__all__ = ["AddItemToCustomListUseCase"]

--- a/src/modules/collections/application/use_cases/create_custom_list.py
+++ b/src/modules/collections/application/use_cases/create_custom_list.py
@@ -1,0 +1,63 @@
+"""CreateCustomListUseCase - Create a new custom list."""
+
+from src.building_blocks.domain import BusinessRuleViolationException
+from src.modules.collections.application.dtos import (
+    CreateCustomListInput,
+    CustomListOutput,
+)
+from src.modules.collections.domain.entities import MAX_LISTS, CustomList
+from src.modules.collections.domain.repositories import CustomListRepository
+
+
+class CreateCustomListUseCase:
+    """Create a new user-defined custom list.
+
+    Enforces the maximum list limit and unique name constraint.
+
+    Example:
+        >>> use_case = CreateCustomListUseCase(custom_list_repository)
+        >>> result = await use_case.execute(CreateCustomListInput(name="Action Movies"))
+    """
+
+    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            custom_list_repository: Repository for custom list persistence.
+        """
+        self._repo = custom_list_repository
+
+    async def execute(self, input_dto: CreateCustomListInput) -> CustomListOutput:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains the list name.
+
+        Returns:
+            CustomListOutput with the created list data.
+
+        Raises:
+            BusinessRuleViolationException: If list limit reached or name already exists.
+        """
+        current_count = await self._repo.count()
+        if current_count >= MAX_LISTS:
+            raise BusinessRuleViolationException(
+                message=f"Cannot create more than {MAX_LISTS} custom lists",
+                message_code="CUSTOM_LIST_LIMIT_EXCEEDED",
+                rule_code="CUSTOM_LIST_LIMIT_EXCEEDED",
+            )
+
+        existing = await self._repo.find_by_name(input_dto.name.strip())
+        if existing:
+            raise BusinessRuleViolationException(
+                message=f"A list named '{input_dto.name.strip()}' already exists",
+                message_code="CUSTOM_LIST_NAME_DUPLICATE",
+                rule_code="CUSTOM_LIST_NAME_DUPLICATE",
+            )
+
+        custom_list = CustomList.create(name=input_dto.name)
+        saved = await self._repo.add(custom_list)
+        return CustomListOutput.from_entity(saved)
+
+
+__all__ = ["CreateCustomListUseCase"]

--- a/src/modules/collections/application/use_cases/delete_custom_list.py
+++ b/src/modules/collections/application/use_cases/delete_custom_list.py
@@ -1,0 +1,37 @@
+"""DeleteCustomListUseCase - Delete a custom list."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.collections.domain.repositories import CustomListRepository
+
+
+class DeleteCustomListUseCase:
+    """Delete a custom list and all its items.
+
+    Example:
+        >>> use_case = DeleteCustomListUseCase(custom_list_repository)
+        >>> await use_case.execute("lst_abc123def456")
+    """
+
+    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            custom_list_repository: Repository for custom list persistence.
+        """
+        self._repo = custom_list_repository
+
+    async def execute(self, list_id: str) -> None:
+        """Execute the use case.
+
+        Args:
+            list_id: External ID of the list to delete.
+
+        Raises:
+            ResourceNotFoundException: If the list does not exist.
+        """
+        removed = await self._repo.remove(list_id)
+        if not removed:
+            raise ResourceNotFoundException.for_resource("CustomList", list_id)
+
+
+__all__ = ["DeleteCustomListUseCase"]

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -1,0 +1,122 @@
+"""GetCustomListItemsUseCase - List items in a custom list with metadata."""
+
+import logging
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.collections.application.dtos import (
+    CustomListItemOutput,
+    GetCustomListItemsInput,
+)
+from src.modules.collections.domain.entities import CustomListItem
+from src.modules.collections.domain.repositories import CustomListRepository
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.value_objects import MovieId, SeriesId
+
+_logger = logging.getLogger(__name__)
+
+
+class GetCustomListItemsUseCase:
+    """List all items in a custom list with display metadata.
+
+    Joins list items with movie/series data to provide
+    title and poster for the UI.
+
+    Example:
+        >>> use_case = GetCustomListItemsUseCase(
+        ...     custom_list_repo, movie_repo, series_repo,
+        ... )
+        >>> items = await use_case.execute(
+        ...     GetCustomListItemsInput(list_id="lst_abc123", lang="pt-BR"),
+        ... )
+    """
+
+    def __init__(
+        self,
+        custom_list_repository: CustomListRepository,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        """Initialize the use case.
+
+        Args:
+            custom_list_repository: Repository for custom list items.
+            movie_repository: Repository for movie metadata.
+            series_repository: Repository for series metadata.
+        """
+        self._list_repo = custom_list_repository
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
+
+    async def execute(
+        self,
+        input_dto: GetCustomListItemsInput,
+    ) -> list[CustomListItemOutput]:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains list_id and language.
+
+        Returns:
+            List of CustomListItemOutput with media metadata.
+
+        Raises:
+            ResourceNotFoundException: If the list does not exist.
+        """
+        custom_list = await self._list_repo.find_by_id(input_dto.list_id)
+        if not custom_list:
+            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+
+        items = await self._list_repo.list_items(input_dto.list_id)
+        _logger.info("Found %d items in custom list %s", len(items), input_dto.list_id)
+
+        result: list[CustomListItemOutput] = []
+        for item in items:
+            output = await self._enrich_with_metadata(item, input_dto.lang)
+            if output:
+                result.append(output)
+            else:
+                _logger.warning(
+                    "Could not find media for custom list item: %s",
+                    item.media_id,
+                )
+
+        return result
+
+    async def _enrich_with_metadata(
+        self,
+        item: CustomListItem,
+        lang: str,
+    ) -> CustomListItemOutput | None:
+        """Enrich a custom list item with media metadata.
+
+        Args:
+            item: The custom list item.
+            lang: Language code for localized metadata.
+
+        Returns:
+            CustomListItemOutput with metadata, or None if media not found.
+        """
+        if item.media_type == "movie":
+            movie = await self._movie_repo.find_by_id(MovieId(item.media_id))
+            if not movie:
+                return None
+            return CustomListItemOutput.from_entity(
+                entity=item,
+                title=movie.get_title(lang),
+                poster_path=movie.poster_path.value if movie.poster_path else None,
+            )
+
+        if item.media_type == "series":
+            series = await self._series_repo.find_by_id(SeriesId(item.media_id))
+            if not series:
+                return None
+            return CustomListItemOutput.from_entity(
+                entity=item,
+                title=series.get_title(lang),
+                poster_path=series.poster_path.value if series.poster_path else None,
+            )
+
+        return None
+
+
+__all__ = ["GetCustomListItemsUseCase"]

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -7,10 +7,10 @@ from src.modules.collections.application.dtos import (
     CustomListItemOutput,
     GetCustomListItemsInput,
 )
-from src.modules.collections.domain.entities import CustomListItem
 from src.modules.collections.domain.repositories import CustomListRepository
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import MovieId, SeriesId
+from src.shared_kernel.value_objects import CollectionMediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ class GetCustomListItemsUseCase:
     """List all items in a custom list with display metadata.
 
     Joins list items with movie/series data to provide
-    title and poster for the UI.
+    title and poster for the UI. Uses batch lookups to avoid N+1.
 
     Example:
         >>> use_case = GetCustomListItemsUseCase(
@@ -69,54 +69,48 @@ class GetCustomListItemsUseCase:
         items = await self._list_repo.list_items(input_dto.list_id)
         _logger.info("Found %d items in custom list %s", len(items), input_dto.list_id)
 
+        if not items:
+            return []
+
+        # Batch-load all referenced movies and series
+        movie_ids = [
+            MovieId(i.media_id) for i in items if i.media_type == CollectionMediaType.MOVIE
+        ]
+        series_ids = [
+            SeriesId(i.media_id) for i in items if i.media_type == CollectionMediaType.SERIES
+        ]
+
+        movies_map = await self._movie_repo.find_by_ids(movie_ids) if movie_ids else {}
+        series_map = await self._series_repo.find_by_ids(series_ids) if series_ids else {}
+
         result: list[CustomListItemOutput] = []
         for item in items:
-            output = await self._enrich_with_metadata(item, input_dto.lang)
-            if output:
-                result.append(output)
-            else:
-                _logger.warning(
-                    "Could not find media for custom list item: %s",
-                    item.media_id,
+            if item.media_type == CollectionMediaType.MOVIE:
+                movie = movies_map.get(item.media_id)
+                if not movie:
+                    _logger.warning("Could not find movie for custom list item: %s", item.media_id)
+                    continue
+                result.append(
+                    CustomListItemOutput.from_entity(
+                        entity=item,
+                        title=movie.get_title(input_dto.lang),
+                        poster_path=movie.poster_path.value if movie.poster_path else None,
+                    )
+                )
+            elif item.media_type == CollectionMediaType.SERIES:
+                series = series_map.get(item.media_id)
+                if not series:
+                    _logger.warning("Could not find series for custom list item: %s", item.media_id)
+                    continue
+                result.append(
+                    CustomListItemOutput.from_entity(
+                        entity=item,
+                        title=series.get_title(input_dto.lang),
+                        poster_path=series.poster_path.value if series.poster_path else None,
+                    )
                 )
 
         return result
-
-    async def _enrich_with_metadata(
-        self,
-        item: CustomListItem,
-        lang: str,
-    ) -> CustomListItemOutput | None:
-        """Enrich a custom list item with media metadata.
-
-        Args:
-            item: The custom list item.
-            lang: Language code for localized metadata.
-
-        Returns:
-            CustomListItemOutput with metadata, or None if media not found.
-        """
-        if item.media_type == "movie":
-            movie = await self._movie_repo.find_by_id(MovieId(item.media_id))
-            if not movie:
-                return None
-            return CustomListItemOutput.from_entity(
-                entity=item,
-                title=movie.get_title(lang),
-                poster_path=movie.poster_path.value if movie.poster_path else None,
-            )
-
-        if item.media_type == "series":
-            series = await self._series_repo.find_by_id(SeriesId(item.media_id))
-            if not series:
-                return None
-            return CustomListItemOutput.from_entity(
-                entity=item,
-                title=series.get_title(lang),
-                poster_path=series.poster_path.value if series.poster_path else None,
-            )
-
-        return None
 
 
 __all__ = ["GetCustomListItemsUseCase"]

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -6,10 +6,10 @@ from src.modules.collections.application.dtos import (
     GetWatchlistInput,
     WatchlistItemOutput,
 )
-from src.modules.collections.domain.entities import WatchlistItem
 from src.modules.collections.domain.repositories import WatchlistRepository
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import MovieId, SeriesId
+from src.shared_kernel.value_objects import CollectionMediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -18,7 +18,8 @@ class GetWatchlistUseCase:
     """List all items in the user's watchlist with display metadata.
 
     Joins watchlist records with movie/series data to provide
-    title and poster for the My List UI section.
+    title and poster for the My List UI section. Uses batch
+    lookups to avoid N+1 queries.
 
     Example:
         >>> use_case = GetWatchlistUseCase(watchlist_repo, movie_repo, series_repo)
@@ -54,51 +55,48 @@ class GetWatchlistUseCase:
         items = await self._watchlist_repo.list_all(limit=input_dto.limit)
         _logger.info("Found %d watchlist items", len(items))
 
+        if not items:
+            return []
+
+        # Batch-load all referenced movies and series
+        movie_ids = [
+            MovieId(i.media_id) for i in items if i.media_type == CollectionMediaType.MOVIE
+        ]
+        series_ids = [
+            SeriesId(i.media_id) for i in items if i.media_type == CollectionMediaType.SERIES
+        ]
+
+        movies_map = await self._movie_repo.find_by_ids(movie_ids) if movie_ids else {}
+        series_map = await self._series_repo.find_by_ids(series_ids) if series_ids else {}
+
         result: list[WatchlistItemOutput] = []
         for item in items:
-            output = await self._enrich_with_metadata(item, input_dto.lang)
-            if output:
-                result.append(output)
-            else:
-                _logger.warning("Could not find media for watchlist item: %s", item.media_id)
+            if item.media_type == CollectionMediaType.MOVIE:
+                movie = movies_map.get(item.media_id)
+                if not movie:
+                    _logger.warning("Could not find media for watchlist item: %s", item.media_id)
+                    continue
+                result.append(
+                    WatchlistItemOutput.from_entity(
+                        entity=item,
+                        title=movie.get_title(input_dto.lang),
+                        poster_path=movie.poster_path.value if movie.poster_path else None,
+                    )
+                )
+            elif item.media_type == CollectionMediaType.SERIES:
+                series = series_map.get(item.media_id)
+                if not series:
+                    _logger.warning("Could not find media for watchlist item: %s", item.media_id)
+                    continue
+                result.append(
+                    WatchlistItemOutput.from_entity(
+                        entity=item,
+                        title=series.get_title(input_dto.lang),
+                        poster_path=series.poster_path.value if series.poster_path else None,
+                    )
+                )
 
         return result
-
-    async def _enrich_with_metadata(
-        self,
-        item: WatchlistItem,
-        lang: str,
-    ) -> WatchlistItemOutput | None:
-        """Enrich a watchlist item with media metadata.
-
-        Args:
-            item: The watchlist item.
-            lang: Language code for localized metadata.
-
-        Returns:
-            WatchlistItemOutput with metadata, or None if media not found.
-        """
-        if item.media_type == "movie":
-            movie = await self._movie_repo.find_by_id(MovieId(item.media_id))
-            if not movie:
-                return None
-            return WatchlistItemOutput.from_entity(
-                entity=item,
-                title=movie.get_title(lang),
-                poster_path=movie.poster_path.value if movie.poster_path else None,
-            )
-
-        if item.media_type == "series":
-            series = await self._series_repo.find_by_id(SeriesId(item.media_id))
-            if not series:
-                return None
-            return WatchlistItemOutput.from_entity(
-                entity=item,
-                title=series.get_title(lang),
-                poster_path=series.poster_path.value if series.poster_path else None,
-            )
-
-        return None
 
 
 __all__ = ["GetWatchlistUseCase"]

--- a/src/modules/collections/application/use_cases/list_custom_lists.py
+++ b/src/modules/collections/application/use_cases/list_custom_lists.py
@@ -1,0 +1,33 @@
+"""ListCustomListsUseCase - List all custom lists."""
+
+from src.modules.collections.application.dtos import CustomListOutput
+from src.modules.collections.domain.repositories import CustomListRepository
+
+
+class ListCustomListsUseCase:
+    """List all user-created custom lists.
+
+    Example:
+        >>> use_case = ListCustomListsUseCase(custom_list_repository)
+        >>> lists = await use_case.execute()
+    """
+
+    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            custom_list_repository: Repository for custom list persistence.
+        """
+        self._repo = custom_list_repository
+
+    async def execute(self) -> list[CustomListOutput]:
+        """Execute the use case.
+
+        Returns:
+            List of CustomListOutput DTOs.
+        """
+        lists = await self._repo.list_all()
+        return [CustomListOutput.from_entity(cl) for cl in lists]
+
+
+__all__ = ["ListCustomListsUseCase"]

--- a/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
+++ b/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
@@ -1,0 +1,48 @@
+"""RemoveItemFromCustomListUseCase - Remove a media item from a custom list."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.collections.application.dtos import RemoveItemFromCustomListInput
+from src.modules.collections.domain.repositories import CustomListRepository
+
+
+class RemoveItemFromCustomListUseCase:
+    """Remove a movie or series from a custom list.
+
+    Example:
+        >>> use_case = RemoveItemFromCustomListUseCase(custom_list_repository)
+        >>> await use_case.execute(RemoveItemFromCustomListInput(
+        ...     list_id="lst_abc123",
+        ...     media_id="mov_xyz789",
+        ... ))
+    """
+
+    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            custom_list_repository: Repository for custom list persistence.
+        """
+        self._repo = custom_list_repository
+
+    async def execute(self, input_dto: RemoveItemFromCustomListInput) -> None:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains list_id and media_id.
+
+        Raises:
+            ResourceNotFoundException: If the list or item does not exist.
+        """
+        custom_list = await self._repo.find_by_id(input_dto.list_id)
+        if not custom_list:
+            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+
+        removed = await self._repo.remove_item(input_dto.list_id, input_dto.media_id)
+        if not removed:
+            raise ResourceNotFoundException.for_resource("CustomListItem", input_dto.media_id)
+
+        updated_list = custom_list.decrement_item_count()
+        await self._repo.update(updated_list)
+
+
+__all__ = ["RemoveItemFromCustomListUseCase"]

--- a/src/modules/collections/application/use_cases/rename_custom_list.py
+++ b/src/modules/collections/application/use_cases/rename_custom_list.py
@@ -1,0 +1,63 @@
+"""RenameCustomListUseCase - Rename an existing custom list."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.building_blocks.domain import BusinessRuleViolationException
+from src.modules.collections.application.dtos import (
+    CustomListOutput,
+    RenameCustomListInput,
+)
+from src.modules.collections.domain.repositories import CustomListRepository
+
+
+class RenameCustomListUseCase:
+    """Rename an existing custom list.
+
+    Enforces unique name constraint.
+
+    Example:
+        >>> use_case = RenameCustomListUseCase(custom_list_repository)
+        >>> result = await use_case.execute(
+        ...     RenameCustomListInput(list_id="lst_abc123", name="New Name"),
+        ... )
+    """
+
+    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+        """Initialize the use case.
+
+        Args:
+            custom_list_repository: Repository for custom list persistence.
+        """
+        self._repo = custom_list_repository
+
+    async def execute(self, input_dto: RenameCustomListInput) -> CustomListOutput:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains list_id and new name.
+
+        Returns:
+            CustomListOutput with the updated list data.
+
+        Raises:
+            ResourceNotFoundException: If the list does not exist.
+            BusinessRuleViolationException: If the name is already taken.
+        """
+        custom_list = await self._repo.find_by_id(input_dto.list_id)
+        if not custom_list:
+            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+
+        new_name = input_dto.name.strip()
+        existing = await self._repo.find_by_name(new_name)
+        if existing and str(existing.id) != input_dto.list_id:
+            raise BusinessRuleViolationException(
+                message=f"A list named '{new_name}' already exists",
+                message_code="CUSTOM_LIST_NAME_DUPLICATE",
+                rule_code="CUSTOM_LIST_NAME_DUPLICATE",
+            )
+
+        updated = custom_list.rename(new_name)
+        saved = await self._repo.update(updated)
+        return CustomListOutput.from_entity(saved)
+
+
+__all__ = ["RenameCustomListUseCase"]

--- a/src/modules/collections/domain/entities/__init__.py
+++ b/src/modules/collections/domain/entities/__init__.py
@@ -1,5 +1,17 @@
 """Collections entities."""
 
+from src.modules.collections.domain.entities.custom_list import (
+    MAX_ITEMS_PER_LIST,
+    MAX_LISTS,
+    CustomList,
+    CustomListItem,
+)
 from src.modules.collections.domain.entities.watchlist_item import WatchlistItem
 
-__all__ = ["WatchlistItem"]
+__all__ = [
+    "CustomList",
+    "CustomListItem",
+    "MAX_ITEMS_PER_LIST",
+    "MAX_LISTS",
+    "WatchlistItem",
+]

--- a/src/modules/collections/domain/entities/custom_list.py
+++ b/src/modules/collections/domain/entities/custom_list.py
@@ -11,36 +11,39 @@ from src.building_blocks.domain import (
     BusinessRuleViolationException,
     DomainEntity,
 )
-from src.modules.collections.domain.value_objects import ListId
+from src.modules.collections.domain.value_objects import CustomListItemId, ListId
+from src.shared_kernel.value_objects import (
+    CollectionMediaType,  # noqa: TCH001 — runtime for Pydantic
+)
 
 MAX_LISTS = 10
 MAX_ITEMS_PER_LIST = 100
 
 
-class CustomListItem(DomainEntity[ListId]):
+class CustomListItem(DomainEntity[CustomListItemId]):
     """An item within a custom list.
 
     Represents a movie or series added to a user-created list.
 
     Attributes:
-        id: External ID (lst_xxx format).
+        id: External ID (cli_xxx format).
         media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media ("movie" or "series").
+        media_type: Type of media (movie or series).
         position: Ordering position within the list.
         added_at: Timestamp when the item was added.
 
     Example:
         >>> item = CustomListItem.create(
         ...     media_id="mov_abc123def456",
-        ...     media_type="movie",
+        ...     media_type=CollectionMediaType.MOVIE,
         ...     position=0,
         ... )
     """
 
-    id: ListId | None = Field(default=None)
+    id: CustomListItemId | None = Field(default=None)
 
     media_id: str
-    media_type: str  # "movie" or "series"
+    media_type: CollectionMediaType
     position: int = 0
     added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
@@ -48,21 +51,21 @@ class CustomListItem(DomainEntity[ListId]):
     def create(
         cls,
         media_id: str,
-        media_type: str,
+        media_type: CollectionMediaType,
         position: int = 0,
     ) -> CustomListItem:
         """Factory method with automatic ID generation.
 
         Args:
             media_id: External ID of the media (mov_xxx or ser_xxx).
-            media_type: Type of media ("movie" or "series").
+            media_type: Type of media (movie or series).
             position: Ordering position within the list.
 
         Returns:
             A new CustomListItem instance.
         """
         return cls(
-            id=ListId.generate(),
+            id=CustomListItemId.generate(),
             media_id=media_id,
             media_type=media_type,
             position=position,

--- a/src/modules/collections/domain/entities/custom_list.py
+++ b/src/modules/collections/domain/entities/custom_list.py
@@ -1,0 +1,147 @@
+"""CustomList aggregate root and CustomListItem entity."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import Field
+
+from src.building_blocks.domain import (
+    AggregateRoot,
+    BusinessRuleViolationException,
+    DomainEntity,
+)
+from src.modules.collections.domain.value_objects import ListId
+
+MAX_LISTS = 10
+MAX_ITEMS_PER_LIST = 100
+
+
+class CustomListItem(DomainEntity[ListId]):
+    """An item within a custom list.
+
+    Represents a movie or series added to a user-created list.
+
+    Attributes:
+        id: External ID (lst_xxx format).
+        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_type: Type of media ("movie" or "series").
+        position: Ordering position within the list.
+        added_at: Timestamp when the item was added.
+
+    Example:
+        >>> item = CustomListItem.create(
+        ...     media_id="mov_abc123def456",
+        ...     media_type="movie",
+        ...     position=0,
+        ... )
+    """
+
+    id: ListId | None = Field(default=None)
+
+    media_id: str
+    media_type: str  # "movie" or "series"
+    position: int = 0
+    added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @classmethod
+    def create(
+        cls,
+        media_id: str,
+        media_type: str,
+        position: int = 0,
+    ) -> CustomListItem:
+        """Factory method with automatic ID generation.
+
+        Args:
+            media_id: External ID of the media (mov_xxx or ser_xxx).
+            media_type: Type of media ("movie" or "series").
+            position: Ordering position within the list.
+
+        Returns:
+            A new CustomListItem instance.
+        """
+        return cls(
+            id=ListId.generate(),
+            media_id=media_id,
+            media_type=media_type,
+            position=position,
+            added_at=datetime.now(UTC),
+        )
+
+
+class CustomList(AggregateRoot[ListId]):
+    """A user-created custom list of media items.
+
+    Represents a named collection like Crunchyroll's "Crunchylistas".
+    Users can create up to MAX_LISTS lists, each holding up to
+    MAX_ITEMS_PER_LIST items.
+
+    Attributes:
+        id: External ID (lst_xxx format).
+        name: Display name of the list.
+        item_count: Number of items currently in the list.
+
+    Example:
+        >>> custom_list = CustomList.create(name="Action Movies")
+    """
+
+    id: ListId | None = Field(default=None)
+
+    name: str
+    item_count: int = 0
+
+    @classmethod
+    def create(cls, name: str) -> CustomList:
+        """Factory method with automatic ID generation.
+
+        Args:
+            name: Display name for the list.
+
+        Returns:
+            A new CustomList instance.
+        """
+        return cls(
+            id=ListId.generate(),
+            name=name.strip(),
+            item_count=0,
+        )
+
+    def rename(self, new_name: str) -> CustomList:
+        """Create a copy with the new name.
+
+        Args:
+            new_name: The new display name.
+
+        Returns:
+            A new CustomList instance with updated name.
+        """
+        return self.with_updates(name=new_name.strip())
+
+    def increment_item_count(self) -> CustomList:
+        """Increment item count after adding an item.
+
+        Returns:
+            A new CustomList instance with incremented count.
+
+        Raises:
+            BusinessRuleViolationException: If the list is already full.
+        """
+        if self.item_count >= MAX_ITEMS_PER_LIST:
+            raise BusinessRuleViolationException(
+                message=f"Custom list cannot have more than {MAX_ITEMS_PER_LIST} items",
+                message_code="CUSTOM_LIST_ITEM_LIMIT_EXCEEDED",
+                rule_code="CUSTOM_LIST_ITEM_LIMIT_EXCEEDED",
+            )
+        return self.with_updates(item_count=self.item_count + 1)
+
+    def decrement_item_count(self) -> CustomList:
+        """Decrement item count after removing an item.
+
+        Returns:
+            A new CustomList instance with decremented count.
+        """
+        return self.with_updates(item_count=max(0, self.item_count - 1))
+
+
+__all__ = ["CustomList", "CustomListItem", "MAX_ITEMS_PER_LIST", "MAX_LISTS"]

--- a/src/modules/collections/domain/entities/watchlist_item.py
+++ b/src/modules/collections/domain/entities/watchlist_item.py
@@ -8,6 +8,9 @@ from pydantic import Field
 
 from src.building_blocks.domain import AggregateRoot
 from src.modules.collections.domain.value_objects import ListId
+from src.shared_kernel.value_objects import (
+    CollectionMediaType,  # noqa: TCH001 — runtime for Pydantic
+)
 
 
 class WatchlistItem(AggregateRoot[ListId]):
@@ -18,33 +21,33 @@ class WatchlistItem(AggregateRoot[ListId]):
     Attributes:
         id: External ID (lst_xxx format).
         media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media ("movie" or "series").
+        media_type: Type of media (movie or series).
         added_at: Timestamp when the item was added.
 
     Example:
         >>> item = WatchlistItem.create(
         ...     media_id="mov_abc123def456",
-        ...     media_type="movie",
+        ...     media_type=CollectionMediaType.MOVIE,
         ... )
     """
 
     id: ListId | None = Field(default=None)
 
     media_id: str
-    media_type: str  # "movie" or "series"
+    media_type: CollectionMediaType
     added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     @classmethod
     def create(
         cls,
         media_id: str,
-        media_type: str,
+        media_type: CollectionMediaType,
     ) -> WatchlistItem:
         """Factory method with automatic ID generation.
 
         Args:
             media_id: External ID of the media (mov_xxx or ser_xxx).
-            media_type: Type of media ("movie" or "series").
+            media_type: Type of media (movie or series).
 
         Returns:
             A new WatchlistItem instance.

--- a/src/modules/collections/domain/repositories/__init__.py
+++ b/src/modules/collections/domain/repositories/__init__.py
@@ -1,7 +1,10 @@
 """Collections repository interfaces."""
 
+from src.modules.collections.domain.repositories.custom_list_repository import (
+    CustomListRepository,
+)
 from src.modules.collections.domain.repositories.watchlist_repository import (
     WatchlistRepository,
 )
 
-__all__ = ["WatchlistRepository"]
+__all__ = ["CustomListRepository", "WatchlistRepository"]

--- a/src/modules/collections/domain/repositories/custom_list_repository.py
+++ b/src/modules/collections/domain/repositories/custom_list_repository.py
@@ -135,5 +135,18 @@ class CustomListRepository(ABC):
             List of CustomListItem entities.
         """
 
+    @abstractmethod
+    async def get_next_position(self, list_id: str) -> int:
+        """Get the next available position for a new item in a list.
+
+        Uses a DB-level MAX query to avoid loading all items.
+
+        Args:
+            list_id: External ID of the list.
+
+        Returns:
+            The next position value (0-based).
+        """
+
 
 __all__ = ["CustomListRepository"]

--- a/src/modules/collections/domain/repositories/custom_list_repository.py
+++ b/src/modules/collections/domain/repositories/custom_list_repository.py
@@ -1,0 +1,139 @@
+"""CustomList repository interface."""
+
+from abc import ABC, abstractmethod
+
+from src.modules.collections.domain.entities import CustomList, CustomListItem
+
+
+class CustomListRepository(ABC):
+    """Abstract repository for CustomList persistence.
+
+    Example:
+        >>> lists = await repo.list_all()
+        >>> items = await repo.list_items("lst_abc123def456")
+    """
+
+    # -- List CRUD -------------------------------------------------------------
+
+    @abstractmethod
+    async def find_by_id(self, list_id: str) -> CustomList | None:
+        """Find a custom list by its external ID.
+
+        Args:
+            list_id: External ID of the list (lst_xxx).
+
+        Returns:
+            CustomList if found, None otherwise.
+        """
+
+    @abstractmethod
+    async def find_by_name(self, name: str) -> CustomList | None:
+        """Find a custom list by name (case-insensitive).
+
+        Args:
+            name: Name of the list.
+
+        Returns:
+            CustomList if found, None otherwise.
+        """
+
+    @abstractmethod
+    async def add(self, custom_list: CustomList) -> CustomList:
+        """Persist a new custom list.
+
+        Args:
+            custom_list: The CustomList entity to persist.
+
+        Returns:
+            The persisted CustomList.
+        """
+
+    @abstractmethod
+    async def update(self, custom_list: CustomList) -> CustomList:
+        """Update an existing custom list.
+
+        Args:
+            custom_list: The CustomList entity with updates.
+
+        Returns:
+            The updated CustomList.
+        """
+
+    @abstractmethod
+    async def remove(self, list_id: str) -> bool:
+        """Soft-delete a custom list and all its items.
+
+        Args:
+            list_id: External ID of the list.
+
+        Returns:
+            True if removed, False if not found.
+        """
+
+    @abstractmethod
+    async def list_all(self) -> list[CustomList]:
+        """List all custom lists ordered by most recently updated.
+
+        Returns:
+            List of CustomList entities.
+        """
+
+    @abstractmethod
+    async def count(self) -> int:
+        """Count total active custom lists.
+
+        Returns:
+            Number of non-deleted custom lists.
+        """
+
+    # -- Item management -------------------------------------------------------
+
+    @abstractmethod
+    async def find_item(self, list_id: str, media_id: str) -> CustomListItem | None:
+        """Find an item in a custom list.
+
+        Args:
+            list_id: External ID of the list.
+            media_id: External ID of the media.
+
+        Returns:
+            CustomListItem if found, None otherwise.
+        """
+
+    @abstractmethod
+    async def add_item(self, list_id: str, item: CustomListItem) -> CustomListItem:
+        """Add an item to a custom list.
+
+        Args:
+            list_id: External ID of the list.
+            item: The CustomListItem entity to persist.
+
+        Returns:
+            The persisted CustomListItem.
+        """
+
+    @abstractmethod
+    async def remove_item(self, list_id: str, media_id: str) -> bool:
+        """Remove an item from a custom list.
+
+        Args:
+            list_id: External ID of the list.
+            media_id: External ID of the media.
+
+        Returns:
+            True if removed, False if not found.
+        """
+
+    @abstractmethod
+    async def list_items(self, list_id: str) -> list[CustomListItem]:
+        """List all items in a custom list ordered by position.
+
+        Args:
+            list_id: External ID of the list.
+
+        Returns:
+            List of CustomListItem entities.
+        """
+
+
+__all__ = ["CustomListRepository"]

--- a/src/modules/collections/domain/value_objects/__init__.py
+++ b/src/modules/collections/domain/value_objects/__init__.py
@@ -1,5 +1,8 @@
 """Collections value objects."""
 
+from src.modules.collections.domain.value_objects.custom_list_item_id import (
+    CustomListItemId,
+)
 from src.modules.collections.domain.value_objects.list_id import ListId
 
-__all__ = ["ListId"]
+__all__ = ["CustomListItemId", "ListId"]

--- a/src/modules/collections/domain/value_objects/custom_list_item_id.py
+++ b/src/modules/collections/domain/value_objects/custom_list_item_id.py
@@ -1,0 +1,18 @@
+"""Custom list item external ID value object."""
+
+from typing import ClassVar
+
+from src.building_blocks.domain.external_id import ExternalId
+
+
+class CustomListItemId(ExternalId):
+    """External ID for custom list items.
+
+    Format: cli_{base62_12chars}
+    Example: cli_3yL8nQsT9mK5
+    """
+
+    EXPECTED_PREFIX: ClassVar[str] = "cli"
+
+
+__all__ = ["CustomListItemId"]

--- a/src/modules/collections/infrastructure/persistence/mappers/__init__.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/__init__.py
@@ -1,7 +1,11 @@
 """Collections mappers."""
 
+from src.modules.collections.infrastructure.persistence.mappers.custom_list_mapper import (
+    CustomListItemMapper,
+    CustomListMapper,
+)
 from src.modules.collections.infrastructure.persistence.mappers.watchlist_item_mapper import (
     WatchlistItemMapper,
 )
 
-__all__ = ["WatchlistItemMapper"]
+__all__ = ["CustomListItemMapper", "CustomListMapper", "WatchlistItemMapper"]

--- a/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
@@ -1,11 +1,12 @@
 """Mapper between CustomList/CustomListItem entities and ORM models."""
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
-from src.modules.collections.domain.value_objects import ListId
+from src.modules.collections.domain.value_objects import CustomListItemId, ListId
 from src.modules.collections.infrastructure.persistence.models import (
     CustomListItemModel,
     CustomListModel,
 )
+from src.shared_kernel.value_objects import CollectionMediaType
 
 
 class CustomListMapper:
@@ -113,9 +114,9 @@ class CustomListItemMapper:
             Domain CustomListItem entity.
         """
         return CustomListItem(
-            id=ListId(model.external_id),
+            id=CustomListItemId(model.external_id),
             media_id=model.media_id,
-            media_type=model.media_type,
+            media_type=CollectionMediaType(model.media_type),
             position=model.position,
             added_at=model.added_at,
             created_at=model.created_at,

--- a/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
@@ -1,0 +1,126 @@
+"""Mapper between CustomList/CustomListItem entities and ORM models."""
+
+from src.modules.collections.domain.entities import CustomList, CustomListItem
+from src.modules.collections.domain.value_objects import ListId
+from src.modules.collections.infrastructure.persistence.models import (
+    CustomListItemModel,
+    CustomListModel,
+)
+
+
+class CustomListMapper:
+    """Bidirectional mapper between CustomList entity and ORM model.
+
+    Example:
+        >>> model = CustomListMapper.to_model(entity)
+        >>> entity = CustomListMapper.to_entity(model)
+    """
+
+    @staticmethod
+    def to_model(entity: CustomList) -> CustomListModel:
+        """Convert CustomList entity to ORM model.
+
+        Args:
+            entity: The domain entity.
+
+        Returns:
+            SQLAlchemy model ready for persistence.
+        """
+        if entity.id is None:
+            msg = "Cannot map entity without ID to model"
+            raise ValueError(msg)
+
+        return CustomListModel(
+            external_id=str(entity.id),
+            name=entity.name,
+            item_count=entity.item_count,
+        )
+
+    @staticmethod
+    def to_entity(model: CustomListModel) -> CustomList:
+        """Convert ORM model to CustomList entity.
+
+        Args:
+            model: The SQLAlchemy model.
+
+        Returns:
+            Domain CustomList entity.
+        """
+        return CustomList(
+            id=ListId(model.external_id),
+            name=model.name,
+            item_count=model.item_count,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    @staticmethod
+    def update_model(model: CustomListModel, entity: CustomList) -> CustomListModel:
+        """Update existing ORM model with entity data.
+
+        Args:
+            model: The existing model.
+            entity: The updated entity.
+
+        Returns:
+            The updated model.
+        """
+        model.name = entity.name
+        model.item_count = entity.item_count
+        return model
+
+
+class CustomListItemMapper:
+    """Bidirectional mapper between CustomListItem entity and ORM model.
+
+    Example:
+        >>> model = CustomListItemMapper.to_model(entity, list_internal_id=1)
+        >>> entity = CustomListItemMapper.to_entity(model)
+    """
+
+    @staticmethod
+    def to_model(entity: CustomListItem, list_internal_id: int) -> CustomListItemModel:
+        """Convert CustomListItem entity to ORM model.
+
+        Args:
+            entity: The domain entity.
+            list_internal_id: Internal DB ID of the parent custom list.
+
+        Returns:
+            SQLAlchemy model ready for persistence.
+        """
+        if entity.id is None:
+            msg = "Cannot map entity without ID to model"
+            raise ValueError(msg)
+
+        return CustomListItemModel(
+            external_id=str(entity.id),
+            custom_list_id=list_internal_id,
+            media_id=entity.media_id,
+            media_type=entity.media_type,
+            position=entity.position,
+            added_at=entity.added_at,
+        )
+
+    @staticmethod
+    def to_entity(model: CustomListItemModel) -> CustomListItem:
+        """Convert ORM model to CustomListItem entity.
+
+        Args:
+            model: The SQLAlchemy model.
+
+        Returns:
+            Domain CustomListItem entity.
+        """
+        return CustomListItem(
+            id=ListId(model.external_id),
+            media_id=model.media_id,
+            media_type=model.media_type,
+            position=model.position,
+            added_at=model.added_at,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+
+__all__ = ["CustomListItemMapper", "CustomListMapper"]

--- a/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
@@ -5,6 +5,7 @@ from src.modules.collections.domain.value_objects import ListId
 from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
+from src.shared_kernel.value_objects import CollectionMediaType
 
 
 class WatchlistItemMapper:
@@ -49,7 +50,7 @@ class WatchlistItemMapper:
         return WatchlistItem(
             id=ListId(model.external_id),
             media_id=model.media_id,
-            media_type=model.media_type,
+            media_type=CollectionMediaType(model.media_type),
             added_at=model.added_at,
             created_at=model.created_at,
             updated_at=model.updated_at,

--- a/src/modules/collections/infrastructure/persistence/models/__init__.py
+++ b/src/modules/collections/infrastructure/persistence/models/__init__.py
@@ -1,7 +1,11 @@
 """Collections ORM models."""
 
+from src.modules.collections.infrastructure.persistence.models.custom_list_model import (
+    CustomListItemModel,
+    CustomListModel,
+)
 from src.modules.collections.infrastructure.persistence.models.watchlist_item_model import (
     WatchlistItemModel,
 )
 
-__all__ = ["WatchlistItemModel"]
+__all__ = ["CustomListItemModel", "CustomListModel", "WatchlistItemModel"]

--- a/src/modules/collections/infrastructure/persistence/models/custom_list_model.py
+++ b/src/modules/collections/infrastructure/persistence/models/custom_list_model.py
@@ -1,0 +1,72 @@
+"""CustomList and CustomListItem ORM models."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.config.persistence.base import Base
+
+
+class CustomListModel(Base):
+    """SQLAlchemy model for CustomList.
+
+    Maps to the 'custom_lists' table. One row per user-created list.
+
+    Attributes:
+        name: Display name of the list.
+        item_count: Number of items in the list.
+        items: Relationship to CustomListItemModel.
+    """
+
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    item_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    items: Mapped[list["CustomListItemModel"]] = relationship(
+        back_populates="custom_list",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"<CustomListModel(id={self.id}, name={self.name!r}, " f"item_count={self.item_count})>"
+        )
+
+
+class CustomListItemModel(Base):
+    """SQLAlchemy model for CustomListItem.
+
+    Maps to the 'custom_list_items' table. One row per item in a list.
+
+    Attributes:
+        custom_list_id: Foreign key to the parent custom list (internal ID).
+        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_type: Type of media ("movie" or "series").
+        position: Ordering position within the list.
+        added_at: Timestamp when the item was added.
+    """
+
+    custom_list_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("custom_lists.id"),
+        nullable=False,
+        index=True,
+    )
+    media_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    media_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    added_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    custom_list: Mapped[CustomListModel] = relationship(back_populates="items")
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"<CustomListItemModel(id={self.id}, media_id={self.media_id!r}, "
+            f"position={self.position})>"
+        )
+
+
+__all__ = ["CustomListItemModel", "CustomListModel"]

--- a/src/modules/collections/infrastructure/persistence/repositories/__init__.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/__init__.py
@@ -1,7 +1,10 @@
 """Collections repository implementations."""
 
+from src.modules.collections.infrastructure.persistence.repositories.custom_list_repository import (
+    SQLAlchemyCustomListRepository,
+)
 from src.modules.collections.infrastructure.persistence.repositories.watchlist_repository import (
     SQLAlchemyWatchlistRepository,
 )
 
-__all__ = ["SQLAlchemyWatchlistRepository"]
+__all__ = ["SQLAlchemyCustomListRepository", "SQLAlchemyWatchlistRepository"]

--- a/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
@@ -1,0 +1,229 @@
+"""SQLAlchemy implementation of CustomListRepository."""
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.collections.domain.entities import CustomList, CustomListItem
+from src.modules.collections.domain.repositories import CustomListRepository
+from src.modules.collections.infrastructure.persistence.mappers import (
+    CustomListItemMapper,
+    CustomListMapper,
+)
+from src.modules.collections.infrastructure.persistence.models import (
+    CustomListItemModel,
+    CustomListModel,
+)
+
+
+class SQLAlchemyCustomListRepository(CustomListRepository):
+    """SQLAlchemy implementation of CustomListRepository.
+
+    Example:
+        >>> repo = SQLAlchemyCustomListRepository(session)
+        >>> lists = await repo.list_all()
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize repository with database session.
+
+        Args:
+            session: SQLAlchemy async session.
+        """
+        self._session = session
+
+    # -- List CRUD -------------------------------------------------------------
+
+    async def find_by_id(self, list_id: str) -> CustomList | None:
+        """Find a custom list by its external ID."""
+        stmt = select(CustomListModel).where(
+            CustomListModel.external_id == list_id,
+            CustomListModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else CustomListMapper.to_entity(model)
+
+    async def find_by_name(self, name: str) -> CustomList | None:
+        """Find a custom list by name (case-insensitive)."""
+        stmt = select(CustomListModel).where(
+            func.lower(CustomListModel.name) == name.strip().lower(),
+            CustomListModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else CustomListMapper.to_entity(model)
+
+    async def add(self, custom_list: CustomList) -> CustomList:
+        """Persist a new custom list."""
+        model = CustomListMapper.to_model(custom_list)
+        self._session.add(model)
+        await self._session.commit()
+        await self._session.refresh(model)
+        return CustomListMapper.to_entity(model)
+
+    async def update(self, custom_list: CustomList) -> CustomList:
+        """Update an existing custom list."""
+        stmt = select(CustomListModel).where(
+            CustomListModel.external_id == str(custom_list.id),
+            CustomListModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+
+        if model is None:
+            msg = f"CustomList {custom_list.id} not found for update"
+            raise ValueError(msg)
+
+        CustomListMapper.update_model(model, custom_list)
+        await self._session.commit()
+        await self._session.refresh(model)
+        return CustomListMapper.to_entity(model)
+
+    async def remove(self, list_id: str) -> bool:
+        """Soft-delete a custom list and all its items."""
+        stmt = select(CustomListModel).where(
+            CustomListModel.external_id == list_id,
+            CustomListModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+
+        if model is None:
+            return False
+
+        # Soft-delete all items in the list
+        items_stmt = select(CustomListItemModel).where(
+            CustomListItemModel.custom_list_id == model.id,
+            CustomListItemModel.deleted_at.is_(None),
+        )
+        items_result = await self._session.execute(items_stmt)
+        for item_model in items_result.scalars().all():
+            item_model.soft_delete()
+
+        model.soft_delete()
+        await self._session.commit()
+        return True
+
+    async def list_all(self) -> list[CustomList]:
+        """List all custom lists ordered by most recently updated."""
+        stmt = (
+            select(CustomListModel)
+            .where(CustomListModel.deleted_at.is_(None))
+            .order_by(CustomListModel.updated_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return [CustomListMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def count(self) -> int:
+        """Count total active custom lists."""
+        stmt = (
+            select(func.count())
+            .select_from(CustomListModel)
+            .where(CustomListModel.deleted_at.is_(None))
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar() or 0
+
+    # -- Item management -------------------------------------------------------
+
+    async def _get_list_internal_id(self, list_id: str) -> int | None:
+        """Get the internal DB ID for a custom list by external ID.
+
+        Args:
+            list_id: External ID of the list.
+
+        Returns:
+            Internal ID if found, None otherwise.
+        """
+        stmt = select(CustomListModel.id).where(
+            CustomListModel.external_id == list_id,
+            CustomListModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def find_item(self, list_id: str, media_id: str) -> CustomListItem | None:
+        """Find an item in a custom list."""
+        internal_id = await self._get_list_internal_id(list_id)
+        if internal_id is None:
+            return None
+
+        stmt = select(CustomListItemModel).where(
+            CustomListItemModel.custom_list_id == internal_id,
+            CustomListItemModel.media_id == media_id,
+            CustomListItemModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else CustomListItemMapper.to_entity(model)
+
+    async def add_item(self, list_id: str, item: CustomListItem) -> CustomListItem:
+        """Add an item to a custom list."""
+        internal_id = await self._get_list_internal_id(list_id)
+        if internal_id is None:
+            msg = f"CustomList {list_id} not found"
+            raise ValueError(msg)
+
+        # Check for soft-deleted record to restore
+        stmt = select(CustomListItemModel).where(
+            CustomListItemModel.custom_list_id == internal_id,
+            CustomListItemModel.media_id == item.media_id,
+            CustomListItemModel.deleted_at.is_not(None),
+        )
+        result = await self._session.execute(stmt)
+        existing = result.scalar_one_or_none()
+
+        if existing:
+            existing.restore()
+            existing.position = item.position
+            existing.added_at = item.added_at
+            await self._session.commit()
+            await self._session.refresh(existing)
+            return CustomListItemMapper.to_entity(existing)
+
+        model = CustomListItemMapper.to_model(item, list_internal_id=internal_id)
+        self._session.add(model)
+        await self._session.commit()
+        await self._session.refresh(model)
+        return CustomListItemMapper.to_entity(model)
+
+    async def remove_item(self, list_id: str, media_id: str) -> bool:
+        """Remove an item from a custom list."""
+        internal_id = await self._get_list_internal_id(list_id)
+        if internal_id is None:
+            return False
+
+        stmt = select(CustomListItemModel).where(
+            CustomListItemModel.custom_list_id == internal_id,
+            CustomListItemModel.media_id == media_id,
+            CustomListItemModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+
+        if model is None:
+            return False
+
+        model.soft_delete()
+        await self._session.commit()
+        return True
+
+    async def list_items(self, list_id: str) -> list[CustomListItem]:
+        """List all items in a custom list ordered by position."""
+        internal_id = await self._get_list_internal_id(list_id)
+        if internal_id is None:
+            return []
+
+        stmt = (
+            select(CustomListItemModel)
+            .where(
+                CustomListItemModel.custom_list_id == internal_id,
+                CustomListItemModel.deleted_at.is_(None),
+            )
+            .order_by(CustomListItemModel.position.asc())
+        )
+        result = await self._session.execute(stmt)
+        return [CustomListItemMapper.to_entity(m) for m in result.scalars().all()]
+
+
+__all__ = ["SQLAlchemyCustomListRepository"]

--- a/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
@@ -225,5 +225,18 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         result = await self._session.execute(stmt)
         return [CustomListItemMapper.to_entity(m) for m in result.scalars().all()]
 
+    async def get_next_position(self, list_id: str) -> int:
+        """Get the next available position via DB MAX query."""
+        internal_id = await self._get_list_internal_id(list_id)
+        if internal_id is None:
+            return 0
+
+        stmt = select(func.coalesce(func.max(CustomListItemModel.position), -1) + 1).where(
+            CustomListItemModel.custom_list_id == internal_id,
+            CustomListItemModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar() or 0
+
 
 __all__ = ["SQLAlchemyCustomListRepository"]

--- a/src/modules/collections/presentation/routes/__init__.py
+++ b/src/modules/collections/presentation/routes/__init__.py
@@ -1,7 +1,10 @@
 """Collections routes."""
 
+from src.modules.collections.presentation.routes.custom_list_routes import (
+    router as custom_list_router,
+)
 from src.modules.collections.presentation.routes.watchlist_routes import (
     router as watchlist_router,
 )
 
-__all__ = ["watchlist_router"]
+__all__ = ["custom_list_router", "watchlist_router"]

--- a/src/modules/collections/presentation/routes/custom_list_routes.py
+++ b/src/modules/collections/presentation/routes/custom_list_routes.py
@@ -1,0 +1,142 @@
+"""Custom List REST API routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.config.containers import ApplicationContainer
+from src.modules.collections.application.dtos import (
+    AddItemToCustomListInput,
+    CreateCustomListInput,
+    GetCustomListItemsInput,
+    RemoveItemFromCustomListInput,
+    RenameCustomListInput,
+)
+from src.modules.collections.application.use_cases import (
+    AddItemToCustomListUseCase,
+    CreateCustomListUseCase,
+    DeleteCustomListUseCase,
+    GetCustomListItemsUseCase,
+    ListCustomListsUseCase,
+    RemoveItemFromCustomListUseCase,
+    RenameCustomListUseCase,
+)
+from src.modules.collections.presentation.schemas import (
+    AddItemToCustomListRequest,
+    CreateCustomListRequest,
+    RenameCustomListRequest,
+)
+
+router = APIRouter(prefix="/api/v1/custom-lists", tags=["Custom Lists"])
+
+
+# -- List CRUD -----------------------------------------------------------------
+
+
+@router.post("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def create_custom_list(
+    body: CreateCustomListRequest,
+    use_case: CreateCustomListUseCase = Depends(
+        Provide[ApplicationContainer.collections.create_custom_list],
+    ),
+) -> dict[str, Any]:
+    """Create a new custom list."""
+    result = await use_case.execute(CreateCustomListInput(name=body.name))
+    return {"type": "custom_list", "data": asdict(result)}
+
+
+@router.get("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_custom_lists(
+    use_case: ListCustomListsUseCase = Depends(
+        Provide[ApplicationContainer.collections.list_custom_lists],
+    ),
+) -> dict[str, Any]:
+    """List all custom lists."""
+    items = await use_case.execute()
+    return {"type": "list", "data": [asdict(item) for item in items]}
+
+
+@router.patch("/{list_id}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def rename_custom_list(
+    list_id: str,
+    body: RenameCustomListRequest,
+    use_case: RenameCustomListUseCase = Depends(
+        Provide[ApplicationContainer.collections.rename_custom_list],
+    ),
+) -> dict[str, Any]:
+    """Rename a custom list."""
+    result = await use_case.execute(RenameCustomListInput(list_id=list_id, name=body.name))
+    return {"type": "custom_list", "data": asdict(result)}
+
+
+@router.delete("/{list_id}", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def delete_custom_list(
+    list_id: str,
+    use_case: DeleteCustomListUseCase = Depends(
+        Provide[ApplicationContainer.collections.delete_custom_list],
+    ),
+) -> None:
+    """Delete a custom list and all its items."""
+    await use_case.execute(list_id)
+
+
+# -- Item management -----------------------------------------------------------
+
+
+@router.get("/{list_id}/items")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_custom_list_items(
+    list_id: str,
+    lang: str = "en",
+    use_case: GetCustomListItemsUseCase = Depends(
+        Provide[ApplicationContainer.collections.get_custom_list_items],
+    ),
+) -> dict[str, Any]:
+    """List all items in a custom list with media metadata."""
+    items = await use_case.execute(GetCustomListItemsInput(list_id=list_id, lang=lang))
+    return {"type": "list", "data": [asdict(item) for item in items]}
+
+
+@router.post("/{list_id}/items", status_code=201)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def add_item_to_custom_list(
+    list_id: str,
+    body: AddItemToCustomListRequest,
+    use_case: AddItemToCustomListUseCase = Depends(
+        Provide[ApplicationContainer.collections.add_item_to_custom_list],
+    ),
+) -> dict[str, Any]:
+    """Add a media item to a custom list."""
+    await use_case.execute(
+        AddItemToCustomListInput(
+            list_id=list_id,
+            media_id=body.media_id,
+            media_type=body.media_type,
+        ),
+    )
+    return {
+        "type": "custom_list",
+        "data": {"list_id": list_id, "media_id": body.media_id, "added": True},
+    }
+
+
+@router.delete("/{list_id}/items/{media_id}", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def remove_item_from_custom_list(
+    list_id: str,
+    media_id: str,
+    use_case: RemoveItemFromCustomListUseCase = Depends(
+        Provide[ApplicationContainer.collections.remove_item_from_custom_list],
+    ),
+) -> None:
+    """Remove a media item from a custom list."""
+    await use_case.execute(RemoveItemFromCustomListInput(list_id=list_id, media_id=media_id))
+
+
+__all__ = ["router"]

--- a/src/modules/collections/presentation/routes/watchlist_routes.py
+++ b/src/modules/collections/presentation/routes/watchlist_routes.py
@@ -1,7 +1,7 @@
 """Watchlist REST API routes."""
 
 from dataclasses import asdict
-from typing import Any, Literal
+from typing import Any
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
@@ -17,6 +17,7 @@ from src.modules.collections.application.use_cases import (
     GetWatchlistUseCase,
     ToggleWatchlistUseCase,
 )
+from src.shared_kernel.value_objects import CollectionMediaType
 
 router = APIRouter(prefix="/api/v1/watchlist", tags=["Watchlist"])
 
@@ -28,7 +29,7 @@ class ToggleWatchlistRequest(BaseModel):
     """Request body for toggling a watchlist item."""
 
     media_id: str
-    media_type: Literal["movie", "series"]
+    media_type: CollectionMediaType
 
 
 # -- Endpoints -----------------------------------------------------------------

--- a/src/modules/collections/presentation/schemas/__init__.py
+++ b/src/modules/collections/presentation/schemas/__init__.py
@@ -1,0 +1,13 @@
+"""Collections presentation schemas."""
+
+from src.modules.collections.presentation.schemas.custom_list_schemas import (
+    AddItemToCustomListRequest,
+    CreateCustomListRequest,
+    RenameCustomListRequest,
+)
+
+__all__ = [
+    "AddItemToCustomListRequest",
+    "CreateCustomListRequest",
+    "RenameCustomListRequest",
+]

--- a/src/modules/collections/presentation/schemas/custom_list_schemas.py
+++ b/src/modules/collections/presentation/schemas/custom_list_schemas.py
@@ -1,8 +1,8 @@
 """Custom list request/response schemas."""
 
-from typing import Literal
-
 from pydantic import BaseModel, Field
+
+from src.shared_kernel.value_objects import CollectionMediaType
 
 
 class CreateCustomListRequest(BaseModel):
@@ -21,7 +21,7 @@ class AddItemToCustomListRequest(BaseModel):
     """Request body for adding an item to a custom list."""
 
     media_id: str
-    media_type: Literal["movie", "series"]
+    media_type: CollectionMediaType
 
 
 __all__ = [

--- a/src/modules/collections/presentation/schemas/custom_list_schemas.py
+++ b/src/modules/collections/presentation/schemas/custom_list_schemas.py
@@ -1,0 +1,31 @@
+"""Custom list request/response schemas."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class CreateCustomListRequest(BaseModel):
+    """Request body for creating a custom list."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+
+
+class RenameCustomListRequest(BaseModel):
+    """Request body for renaming a custom list."""
+
+    name: str = Field(..., min_length=1, max_length=200)
+
+
+class AddItemToCustomListRequest(BaseModel):
+    """Request body for adding an item to a custom list."""
+
+    media_id: str
+    media_type: Literal["movie", "series"]
+
+
+__all__ = [
+    "AddItemToCustomListRequest",
+    "CreateCustomListRequest",
+    "RenameCustomListRequest",
+]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -60,6 +60,18 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_by_ids(self, movie_ids: Sequence[MovieId]) -> dict[str, Movie]:
+        """Find multiple movies by their IDs in a single query.
+
+        Args:
+            movie_ids: Sequence of movie external IDs.
+
+        Returns:
+            Dict mapping external ID string to Movie entity.
+        """
+        ...
+
+    @abstractmethod
     async def find_by_file_path(self, file_path: FilePath) -> Movie | None:
         """Find a movie by its file path.
 

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -60,6 +60,18 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_by_ids(self, series_ids: Sequence[SeriesId]) -> dict[str, Series]:
+        """Find multiple series by their IDs in a single query.
+
+        Args:
+            series_ids: Sequence of series external IDs.
+
+        Returns:
+            Dict mapping external ID string to Series entity.
+        """
+        ...
+
+    @abstractmethod
     async def find_by_episode_id(self, episode_id: EpisodeId) -> Series | None:
         """Find a series containing an episode with this ID.
 

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -136,6 +136,23 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         return [MovieMapper.to_entity(model) for model in models]
 
+    async def find_by_ids(self, movie_ids: Sequence[MovieId]) -> dict[str, Movie]:
+        """Find multiple movies by their IDs in a single query."""
+        if not movie_ids:
+            return {}
+
+        ext_ids = [str(mid) for mid in movie_ids]
+        stmt = (
+            select(MovieModel)
+            .where(
+                MovieModel.external_id.in_(ext_ids),
+                MovieModel.deleted_at.is_(None),
+            )
+            .options(selectinload(MovieModel.file_variants))
+        )
+        result = await self._session.execute(stmt)
+        return {model.external_id: MovieMapper.to_entity(model) for model in result.scalars().all()}
+
     async def find_by_file_path(self, file_path: FilePath) -> Movie | None:
         """Find a movie by any of its file variant paths.
 

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -185,6 +185,26 @@ class SQLAlchemySeriesRepository(SeriesRepository):
 
         return None if model is None else SeriesMapper.to_entity(model)
 
+    async def find_by_ids(self, series_ids: Sequence[SeriesId]) -> dict[str, Series]:
+        """Find multiple series by their IDs in a single query."""
+        if not series_ids:
+            return {}
+
+        ext_ids = [str(sid) for sid in series_ids]
+        stmt = (
+            select(SeriesModel)
+            .where(
+                SeriesModel.external_id.in_(ext_ids),
+                SeriesModel.deleted_at.is_(None),
+            )
+            .options(*self._series_load_options())
+            .execution_options(populate_existing=True)
+        )
+        result = await self._session.execute(stmt)
+        return {
+            model.external_id: SeriesMapper.to_entity(model) for model in result.scalars().all()
+        }
+
     async def find_by_episode_id(self, episode_id: EpisodeId) -> Series | None:
         """Find a series containing an episode with this ID.
 

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -3,10 +3,12 @@
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.image_url import ImageUrl
 from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.media_type import CollectionMediaType
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 __all__ = [
     "AudioTrack",
+    "CollectionMediaType",
     "FilePath",
     "ImageUrl",
     "LanguageCode",

--- a/src/shared_kernel/value_objects/media_type.py
+++ b/src/shared_kernel/value_objects/media_type.py
@@ -1,0 +1,23 @@
+"""Media type enum for collections (watchlist, custom lists)."""
+
+from enum import StrEnum
+
+
+class CollectionMediaType(StrEnum):
+    """Type of media that can be added to a collection.
+
+    Uses StrEnum so the value serializes directly as a string
+    in DTOs and database columns.
+
+    Example:
+        >>> CollectionMediaType.MOVIE.value
+        'movie'
+        >>> CollectionMediaType("series")
+        <CollectionMediaType.SERIES: 'series'>
+    """
+
+    MOVIE = "movie"
+    SERIES = "series"
+
+
+__all__ = ["CollectionMediaType"]


### PR DESCRIPTION
## Summary

- Add `CustomList` aggregate root and `CustomListItem` entity with business rules (max 10 lists, 100 items/list, unique names)
- Implement 7 use cases: create, rename, delete, list, add item, remove item, and get items with media metadata enrichment
- Add SQLAlchemy models (`custom_lists`, `custom_list_items`) with FK relationship and soft-delete support
- Add REST API under `/api/v1/custom-lists` with full CRUD for lists and item management
- Wire all providers into `CollectionsContainer` and register routes in `main.py`
- Add `specs/` and `evidence/` to `.gitignore`

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/v1/custom-lists` | Create a new list |
| `GET` | `/api/v1/custom-lists` | List all custom lists |
| `PATCH` | `/api/v1/custom-lists/{list_id}` | Rename a list |
| `DELETE` | `/api/v1/custom-lists/{list_id}` | Delete a list and its items |
| `GET` | `/api/v1/custom-lists/{list_id}/items` | List items with metadata |
| `POST` | `/api/v1/custom-lists/{list_id}/items` | Add item to list |
| `DELETE` | `/api/v1/custom-lists/{list_id}/items/{media_id}` | Remove item |

## Test plan

- [ ] Verify existing tests still pass (`make test` — 783 passing)
- [ ] Test create list with valid name
- [ ] Test create list rejects duplicate names
- [ ] Test create list rejects when at 10-list limit
- [ ] Test rename list
- [ ] Test delete list cascades to items
- [ ] Test add item to list
- [ ] Test add item rejects duplicates
- [ ] Test add item rejects when at 100-item limit
- [ ] Test remove item from list
- [ ] Test get list items returns enriched metadata

## Summary by Sourcery

Introduce a new Custom Lists feature for user-defined media collections, including domain entities, persistence layer, use cases, and HTTP API endpoints, and wire it into the existing collections module and application startup.

New Features:
- Add CustomList and CustomListItem domain entities with list and item limit rules exposed via constants.
- Implement application DTOs and use cases for creating, listing, renaming, deleting custom lists, and managing list items with metadata enrichment.
- Expose REST API routes under /api/v1/custom-lists for custom list CRUD operations and item management.
- Add SQLAlchemy models, mappers, and a repository implementation for persisting custom lists and their items with soft-delete support.
- Register the custom list repository and use cases in the collections DI container and include the new router in the FastAPI app.