### PR TITLE
feat(media): add random featured media endpoint

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -16,6 +16,7 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
 from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
 )
+from src.modules.media.application.use_cases.get_featured_media import GetFeaturedMediaUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
@@ -76,6 +77,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # =========================================================================
     # Use Cases — Query
     # =========================================================================
+
+    get_featured_media = providers.Factory(
+        GetFeaturedMediaUseCase,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
+    )
 
     get_movie_by_id = providers.Factory(
         GetMovieByIdUseCase,

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.config.settings import get_settings
 from src.modules.collections.presentation.routes import custom_list_router, watchlist_router
 from src.modules.media.presentation.routes import (
     enrichment_router,
+    featured_router,
     movie_router,
     scan_router,
     series_router,
@@ -60,6 +61,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     container.wire(
         modules=[
             "src.modules.media.presentation.routes.enrichment_routes",
+            "src.modules.media.presentation.routes.featured_routes",
             "src.modules.media.presentation.routes.movie_routes",
             "src.modules.media.presentation.routes.scan_routes",
             "src.modules.media.presentation.routes.series_routes",
@@ -118,6 +120,7 @@ def create_app() -> FastAPI:
     # Register routes
     register_health_routes(app)
     app.include_router(enrichment_router)
+    app.include_router(featured_router)
     app.include_router(movie_router)
     app.include_router(scan_router)
     app.include_router(series_router)

--- a/src/modules/media/application/dtos/__init__.py
+++ b/src/modules/media/application/dtos/__init__.py
@@ -1,5 +1,9 @@
 """Media DTOs for application layer."""
 
+from src.modules.media.application.dtos.featured_dtos import (
+    FeaturedItemOutput,
+    GetFeaturedInput,
+)
 from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
     GetFileVariantsInput,
@@ -26,6 +30,9 @@ from src.modules.media.application.dtos.series_dtos import (
 )
 
 __all__ = [
+    # Featured DTOs
+    "FeaturedItemOutput",
+    "GetFeaturedInput",
     # MediaFile DTOs
     "AddFileVariantInput",
     "GetFileVariantsInput",

--- a/src/modules/media/application/dtos/featured_dtos.py
+++ b/src/modules/media/application/dtos/featured_dtos.py
@@ -1,0 +1,45 @@
+"""Featured media DTOs for the hero banner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GetFeaturedInput:
+    """Input for GetFeaturedMediaUseCase.
+
+    Attributes:
+        media_type: Filter by type — "all", "movie", or "series".
+        limit: Maximum number of items to return.
+        lang: Language code for localized metadata.
+    """
+
+    media_type: str = "all"
+    limit: int = 6
+    lang: str = "en"
+
+
+@dataclass(frozen=True)
+class FeaturedItemOutput:
+    """A single featured media item for the hero banner.
+
+    Attributes:
+        id: External media ID.
+        type: "movie" or "series".
+        title: Localized display title.
+        synopsis: Localized synopsis.
+        year: Release year.
+        duration_formatted: Duration string (movies only).
+        genres: List of genre strings.
+        backdrop_path: Path to backdrop image.
+    """
+
+    id: str
+    type: str
+    title: str
+    synopsis: str | None
+    year: int
+    duration_formatted: str | None
+    genres: list[str]
+    backdrop_path: str | None

--- a/src/modules/media/application/use_cases/__init__.py
+++ b/src/modules/media/application/use_cases/__init__.py
@@ -2,6 +2,7 @@
 
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
 from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
+from src.modules.media.application.use_cases.get_featured_media import GetFeaturedMediaUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
@@ -13,6 +14,7 @@ from src.modules.media.application.use_cases.set_primary_file import SetPrimaryF
 __all__ = [
     "AddFileVariantUseCase",
     "DeleteMovieUseCase",
+    "GetFeaturedMediaUseCase",
     "GetFileVariantsUseCase",
     "GetMovieByIdUseCase",
     "GetSeriesByIdUseCase",

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -1,0 +1,94 @@
+"""GetFeaturedMediaUseCase - Random media for hero banner."""
+
+import random
+
+from src.modules.media.application.dtos.featured_dtos import (
+    FeaturedItemOutput,
+    GetFeaturedInput,
+)
+from src.modules.media.domain.entities import Movie, Series
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+class GetFeaturedMediaUseCase:
+    """Return random movies and/or series for the hero banner.
+
+    Fetches items with backdrop images from the database using
+    random ordering, then maps to a flat output list.
+
+    Example:
+        >>> use_case = GetFeaturedMediaUseCase(movie_repo, series_repo)
+        >>> items = await use_case.execute(GetFeaturedInput(media_type="all", limit=6))
+    """
+
+    def __init__(
+        self,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        """Initialize the use case.
+
+        Args:
+            movie_repository: Repository for movie persistence.
+            series_repository: Repository for series persistence.
+        """
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
+
+    async def execute(self, input_dto: GetFeaturedInput) -> list[FeaturedItemOutput]:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains media_type, limit, and lang.
+
+        Returns:
+            List of FeaturedItemOutput for the hero banner.
+        """
+        results: list[FeaturedItemOutput] = []
+        lang = input_dto.lang
+
+        if input_dto.media_type in ("all", "movie"):
+            limit = input_dto.limit if input_dto.media_type == "movie" else input_dto.limit
+            movies = await self._movie_repo.find_random(limit, with_backdrop=True)
+            results.extend(self._movie_to_output(m, lang) for m in movies)
+
+        if input_dto.media_type in ("all", "series"):
+            limit = input_dto.limit if input_dto.media_type == "series" else input_dto.limit
+            series_list = await self._series_repo.find_random(limit, with_backdrop=True)
+            results.extend(self._series_to_output(s, lang) for s in series_list)
+
+        if input_dto.media_type == "all":
+            random.shuffle(results)
+
+        return results[: input_dto.limit]
+
+    @staticmethod
+    def _movie_to_output(movie: Movie, lang: str) -> FeaturedItemOutput:
+        """Convert Movie entity to featured output."""
+        return FeaturedItemOutput(
+            id=str(movie.id),
+            type="movie",
+            title=movie.get_title(lang),
+            synopsis=movie.get_synopsis(lang),
+            year=movie.year.value,
+            duration_formatted=movie.duration.format_hms(),
+            genres=movie.get_genres(lang),
+            backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+        )
+
+    @staticmethod
+    def _series_to_output(series: Series, lang: str) -> FeaturedItemOutput:
+        """Convert Series entity to featured output."""
+        return FeaturedItemOutput(
+            id=str(series.id),
+            type="series",
+            title=series.get_title(lang),
+            synopsis=series.get_synopsis(lang),
+            year=series.start_year.value,
+            duration_formatted=None,
+            genres=series.get_genres(lang),
+            backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+        )
+
+
+__all__ = ["GetFeaturedMediaUseCase"]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -60,6 +60,19 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:
+        """Return random movies, optionally filtering to those with backdrop.
+
+        Args:
+            limit: Maximum number of movies to return.
+            with_backdrop: If True, only return movies with a backdrop_path.
+
+        Returns:
+            Sequence of randomly selected movies.
+        """
+        ...
+
+    @abstractmethod
     async def find_by_ids(self, movie_ids: Sequence[MovieId]) -> dict[str, Movie]:
         """Find multiple movies by their IDs in a single query.
 

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -60,6 +60,19 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Series]:
+        """Return random series, optionally filtering to those with backdrop.
+
+        Args:
+            limit: Maximum number of series to return.
+            with_backdrop: If True, only return series with a backdrop_path.
+
+        Returns:
+            Sequence of randomly selected series.
+        """
+        ...
+
+    @abstractmethod
     async def find_by_ids(self, series_ids: Sequence[SeriesId]) -> dict[str, Series]:
         """Find multiple series by their IDs in a single query.
 

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -136,6 +136,24 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         return [MovieMapper.to_entity(model) for model in models]
 
+    async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:
+        """Return random movies."""
+        from sqlalchemy.sql.expression import func
+
+        stmt = (
+            select(MovieModel)
+            .where(MovieModel.deleted_at.is_(None))
+            .options(selectinload(MovieModel.file_variants))
+        )
+        if with_backdrop:
+            stmt = stmt.where(
+                MovieModel.backdrop_path.is_not(None),
+                MovieModel.backdrop_path != "",
+            )
+        stmt = stmt.order_by(func.random()).limit(limit)
+        result = await self._session.execute(stmt)
+        return [MovieMapper.to_entity(m) for m in result.scalars().all()]
+
     async def find_by_ids(self, movie_ids: Sequence[MovieId]) -> dict[str, Movie]:
         """Find multiple movies by their IDs in a single query."""
         if not movie_ids:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -162,6 +162,24 @@ class SQLAlchemySeriesRepository(SeriesRepository):
 
         return [SeriesMapper.to_entity(model) for model in models]
 
+    async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Series]:
+        """Return random series."""
+        from sqlalchemy.sql.expression import func
+
+        stmt = (
+            select(SeriesModel)
+            .where(SeriesModel.deleted_at.is_(None))
+            .options(*self._series_load_options())
+        )
+        if with_backdrop:
+            stmt = stmt.where(
+                SeriesModel.backdrop_path.is_not(None),
+                SeriesModel.backdrop_path != "",
+            )
+        stmt = stmt.order_by(func.random()).limit(limit)
+        result = await self._session.execute(stmt)
+        return [SeriesMapper.to_entity(m) for m in result.scalars().all()]
+
     async def find_by_title(self, title: Title) -> Series | None:
         """Find a series by its title (case-insensitive).
 

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -1,9 +1,17 @@
 """Media API routes."""
 
 from src.modules.media.presentation.routes.enrichment_routes import router as enrichment_router
+from src.modules.media.presentation.routes.featured_routes import router as featured_router
 from src.modules.media.presentation.routes.movie_routes import router as movie_router
 from src.modules.media.presentation.routes.scan_routes import router as scan_router
 from src.modules.media.presentation.routes.series_routes import router as series_router
 from src.modules.media.presentation.routes.stream_routes import router as stream_router
 
-__all__ = ["enrichment_router", "movie_router", "scan_router", "series_router", "stream_router"]
+__all__ = [
+    "enrichment_router",
+    "featured_router",
+    "movie_router",
+    "scan_router",
+    "series_router",
+    "stream_router",
+]

--- a/src/modules/media/presentation/routes/featured_routes.py
+++ b/src/modules/media/presentation/routes/featured_routes.py
@@ -1,0 +1,34 @@
+"""Featured media REST API routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, Query
+
+from src.config.containers import ApplicationContainer
+from src.modules.media.application.dtos.featured_dtos import GetFeaturedInput
+from src.modules.media.application.use_cases.get_featured_media import GetFeaturedMediaUseCase
+
+router = APIRouter(prefix="/api/v1/featured", tags=["Featured"])
+
+
+@router.get("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_featured(
+    type: str = Query("all", pattern="^(all|movie|series)$"),
+    limit: int = Query(6, ge=1, le=20),
+    lang: str = "en",
+    use_case: GetFeaturedMediaUseCase = Depends(
+        Provide[ApplicationContainer.media.get_featured_media],
+    ),
+) -> dict[str, Any]:
+    """Get random featured media for the hero banner."""
+    items = await use_case.execute(GetFeaturedInput(media_type=type, limit=limit, lang=lang))
+    return {
+        "type": "list",
+        "data": [asdict(item) for item in items],
+    }
+
+
+__all__ = ["router"]


### PR DESCRIPTION
## Summary

- Add `find_random` method to Movie and Series repository interfaces with `ORDER BY RANDOM()` DB query
- Create `GetFeaturedMediaUseCase` that returns random items with backdrop images, supporting type filter (all/movie/series)
- Expose `GET /api/v1/featured?type=all|movie|series&limit=6&lang=en` for the hero banner

## Test plan

- [ ] `GET /api/v1/featured` returns 6 random items with backdrops
- [ ] `GET /api/v1/featured?type=movie` returns only movies
- [ ] `GET /api/v1/featured?type=series` returns only series
- [ ] Results change on each request (random order)
- [ ] All 783 existing tests still pass

## Summary by Sourcery

Add an endpoint and use case to serve random featured media items for the hero banner, sourced from movies and series with backdrops.

New Features:
- Expose a /api/v1/featured HTTP endpoint to return random featured media with optional type and language filters.
- Introduce GetFeaturedMediaUseCase to aggregate random movies and series with backdrops into a unified featured item response DTO.
- Add FeaturedInput and FeaturedItemOutput DTOs to model featured media request parameters and response items.
- Extend movie and series repositories with a find_random method to retrieve random entities, optionally constrained to those with backdrops.

Enhancements:
- Wire the new featured media use case and routes into the media dependency injection container and FastAPI application routing.