### PR TITLE
feat(media): add content_rating to featured endpoint

### DIFF
--- a/src/modules/media/application/dtos/featured_dtos.py
+++ b/src/modules/media/application/dtos/featured_dtos.py
@@ -43,3 +43,4 @@ class FeaturedItemOutput:
     duration_formatted: str | None
     genres: list[str]
     backdrop_path: str | None
+    content_rating: str | None

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -102,6 +102,7 @@ class SeriesOutput:
     poster_path: str | None
     backdrop_path: str | None
     genres: list[str]
+    content_rating: str | None
     tmdb_id: int | None
     imdb_id: str | None
     season_count: int

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -172,6 +172,8 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
         updates["poster_path"] = ImageUrl(metadata.poster_url)
     if metadata.backdrop_url and not series.backdrop_path:
         updates["backdrop_path"] = ImageUrl(metadata.backdrop_url)
+    if metadata.content_rating and not series.content_rating:
+        updates["content_rating"] = metadata.content_rating
 
     _apply_localized(updates, series.localized, metadata)
 

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -89,7 +89,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=None,
             genres=series.get_genres(lang),
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-            content_rating=None,
+            content_rating=None,  # Series entity does not have content_rating yet
         )
 
 

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -74,6 +74,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=movie.duration.format_hms(),
             genres=movie.get_genres(lang),
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+            content_rating=movie.content_rating,
         )
 
     @staticmethod
@@ -88,6 +89,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=None,
             genres=series.get_genres(lang),
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+            content_rating=None,
         )
 
 

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -89,7 +89,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=None,
             genres=series.get_genres(lang),
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-            content_rating=None,  # Series entity does not have content_rating yet
+            content_rating=series.content_rating,
         )
 
 

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -78,6 +78,7 @@ class GetSeriesByIdUseCase:
             poster_path=series.poster_path.value if series.poster_path else None,
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
             genres=series.get_genres(lang),
+            content_rating=series.content_rating,
             tmdb_id=series.tmdb_id.value if series.tmdb_id else None,
             imdb_id=series.imdb_id.value if series.imdb_id else None,
             season_count=series.season_count,

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -52,6 +52,7 @@ class Series(AggregateRoot[SeriesId]):
 
     # Categorization
     genres: list[Genre] = Field(default_factory=list)
+    content_rating: str | None = None
 
     # Localized metadata
     localized: dict[str, dict[str, Any]] = Field(default_factory=dict)

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -177,7 +177,7 @@ class TmdbClient(MetadataProvider):
         """Fetch full series details including seasons and episodes."""
         resp = await self._client.get(
             f"{self._base_url}/tv/{tmdb_id}",
-            params=self._params(append_to_response="external_ids"),
+            params=self._params(append_to_response="external_ids,content_ratings"),
         )
         if resp.status_code == 404:
             return None
@@ -200,6 +200,10 @@ class TmdbClient(MetadataProvider):
             if season_meta:
                 seasons.append(season_meta)
 
+        content_rating = self._parse_series_content_rating(
+            data.get("content_ratings", {}),
+        )
+
         return MediaMetadata(
             title=data.get("name", ""),
             original_title=data.get("original_name"),
@@ -211,6 +215,7 @@ class TmdbClient(MetadataProvider):
             genres=[g["name"] for g in data.get("genres", [])],
             tmdb_id=data["id"],
             imdb_id=data.get("external_ids", {}).get("imdb_id"),
+            content_rating=content_rating,
             seasons=seasons,
         )
 
@@ -297,6 +302,24 @@ class TmdbClient(MetadataProvider):
                 cert = str(rel.get("certification", "")).strip() if isinstance(rel, dict) else ""
                 if cert and iso not in ratings_by_country:
                     ratings_by_country[iso] = cert
+
+        return ratings_by_country.get("BR") or ratings_by_country.get("US") or None
+
+    @staticmethod
+    def _parse_series_content_rating(content_ratings: dict[str, object]) -> str | None:
+        """Extract content rating from TMDB series content_ratings, preferring BR then US."""
+        results = content_ratings.get("results", [])
+        if not isinstance(results, list):
+            return None
+
+        ratings_by_country: dict[str, str] = {}
+        for entry in results:
+            if not isinstance(entry, dict):
+                continue
+            iso = str(entry.get("iso_3166_1", ""))
+            rating = str(entry.get("rating", "")).strip()
+            if rating and iso not in ratings_by_country:
+                ratings_by_country[iso] = rating
 
         return ratings_by_country.get("BR") or ratings_by_country.get("US") or None
 

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -258,6 +258,7 @@ class SeriesMapper:
             poster_path=entity.poster_path.value if entity.poster_path else None,
             backdrop_path=entity.backdrop_path.value if entity.backdrop_path else None,
             genres=",".join(g.value for g in entity.genres) if entity.genres else None,
+            content_rating=entity.content_rating,
             localized=json.dumps(entity.localized, ensure_ascii=False)
             if entity.localized
             else None,
@@ -294,6 +295,7 @@ class SeriesMapper:
             poster_path=ImageUrl(model.poster_path) if model.poster_path else None,
             backdrop_path=ImageUrl(model.backdrop_path) if model.backdrop_path else None,
             genres=genre_list,
+            content_rating=model.content_rating,
             localized=json.loads(model.localized) if model.localized else {},
             tmdb_id=TmdbId(model.tmdb_id) if model.tmdb_id else None,
             imdb_id=ImdbId(model.imdb_id) if model.imdb_id else None,
@@ -321,6 +323,7 @@ class SeriesMapper:
         model.poster_path = entity.poster_path.value if entity.poster_path else None
         model.backdrop_path = entity.backdrop_path.value if entity.backdrop_path else None
         model.genres = ",".join(g.value for g in entity.genres) if entity.genres else None
+        model.content_rating = entity.content_rating
         model.localized = (
             json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None
         )

--- a/src/modules/media/infrastructure/persistence/models/series.py
+++ b/src/modules/media/infrastructure/persistence/models/series.py
@@ -44,6 +44,7 @@ class SeriesModel(Base):
 
     # Categorization
     genres: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    content_rating: Mapped[str | None] = mapped_column(String(20), nullable=True)
 
     # Localized metadata (JSON)
     localized: Mapped[str | None] = mapped_column(Text, nullable=True)


### PR DESCRIPTION
## Summary

- Add `content_rating` field to `FeaturedItemOutput` DTO
- Movies pass their content rating, series default to null
- Enables the hero banner to display the classification badge

## Test plan

- [ ] `GET /api/v1/featured` response includes `content_rating` field
- [ ] Movies with content rating return it (e.g. "14", "PG-13")
- [ ] Series return `content_rating: null`

## Summary by Sourcery

New Features:
- Add a nullable content_rating field to FeaturedItemOutput returned by the featured media endpoint, populated for movies and left null for series.