### PR TITLE
feat(media): add domain events with auto-enrich on scan

### DIFF
--- a/src/building_blocks/application/event_bus.py
+++ b/src/building_blocks/application/event_bus.py
@@ -1,0 +1,41 @@
+"""Event bus and handler abstractions for the application layer."""
+
+from abc import ABC, abstractmethod
+
+from src.building_blocks.domain.events import DomainEvent
+
+
+class EventHandler(ABC):
+    """Abstract handler for a specific domain event type."""
+
+    @abstractmethod
+    async def handle(self, event: DomainEvent) -> None:
+        """Handle a domain event.
+
+        Args:
+            event: The domain event to handle.
+        """
+
+
+class EventBus(ABC):
+    """Abstract event bus for publishing and subscribing to domain events."""
+
+    @abstractmethod
+    def subscribe(self, event_type: type[DomainEvent], handler: EventHandler) -> None:
+        """Register a handler for a specific event type.
+
+        Args:
+            event_type: The class of the event to listen for.
+            handler: The handler to invoke when the event is published.
+        """
+
+    @abstractmethod
+    async def publish(self, event: DomainEvent) -> None:
+        """Publish an event to all registered handlers.
+
+        Args:
+            event: The domain event to publish.
+        """
+
+
+__all__ = ["EventBus", "EventHandler"]

--- a/src/building_blocks/domain/__init__.py
+++ b/src/building_blocks/domain/__init__.py
@@ -12,6 +12,7 @@ from src.building_blocks.domain.errors import (
     ExceptionDetail,
     Severity,
 )
+from src.building_blocks.domain.events import DomainEvent, MediaCreatedEvent
 from src.building_blocks.domain.external_id import (
     BASE62_ALPHABET,
     RANDOM_PART_LENGTH,
@@ -36,6 +37,7 @@ __all__ = [
     "DateValueObject",
     "DomainConflictException",
     "DomainEntity",
+    "DomainEvent",
     "DomainException",
     "DomainModel",
     "DomainNotFoundException",
@@ -44,6 +46,7 @@ __all__ = [
     "ExternalId",
     "FloatValueObject",
     "IntValueObject",
+    "MediaCreatedEvent",
     "RANDOM_PART_LENGTH",
     "Severity",
     "StringValueObject",

--- a/src/building_blocks/domain/entity.py
+++ b/src/building_blocks/domain/entity.py
@@ -96,5 +96,15 @@ class AggregateRoot(DomainEntity[IdT]):
         """Return True if there are pending domain events."""
         return len(self._events) > 0
 
+    def with_updates(self, **kwargs: Any) -> Self:
+        """Create a new instance with updates, propagating pending events.
+
+        Overrides DomainEntity.with_updates to ensure domain events
+        survive immutable model transitions.
+        """
+        new_instance = super().with_updates(**kwargs)
+        new_instance._events = self._events[:]
+        return new_instance
+
 
 __all__ = ["AggregateRoot", "DomainEntity", "utc_now"]

--- a/src/building_blocks/domain/entity.py
+++ b/src/building_blocks/domain/entity.py
@@ -1,7 +1,12 @@
 """Base classes for Domain Entities and Aggregate Roots."""
 
+from __future__ import annotations
+
 from datetime import UTC, datetime
-from typing import Any, ClassVar, Generic, Self, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, Self, TypeVar
+
+if TYPE_CHECKING:
+    from src.building_blocks.domain.events import DomainEvent
 
 from pydantic import ConfigDict, Field, PrivateAttr, ValidationError
 
@@ -75,13 +80,13 @@ class AggregateRoot(DomainEntity[IdT]):
     Includes domain events collection.
     """
 
-    _events: list[Any] = PrivateAttr(default_factory=list)
+    _events: list[DomainEvent] = PrivateAttr(default_factory=list)
 
-    def add_event(self, event: Any) -> None:
+    def add_event(self, event: DomainEvent) -> None:
         """Add a domain event."""
         self._events.append(event)
 
-    def pull_events(self) -> list[Any]:
+    def pull_events(self) -> list[DomainEvent]:
         """Retrieve and clear all pending domain events."""
         events = self._events[:]
         self._events.clear()
@@ -97,13 +102,16 @@ class AggregateRoot(DomainEntity[IdT]):
         return len(self._events) > 0
 
     def with_updates(self, **kwargs: Any) -> Self:
-        """Create a new instance with updates, propagating pending events.
+        """Create a new instance with updates, moving pending events.
 
         Overrides DomainEntity.with_updates to ensure domain events
-        survive immutable model transitions.
+        survive immutable model transitions. Events are moved (not copied)
+        to the new instance — the old instance is cleared to prevent
+        double-dispatch if it is accidentally retained.
         """
         new_instance = super().with_updates(**kwargs)
         new_instance._events = self._events[:]
+        self._events.clear()
         return new_instance
 
 

--- a/src/building_blocks/domain/events.py
+++ b/src/building_blocks/domain/events.py
@@ -1,0 +1,31 @@
+"""Base domain event and media-specific events."""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+
+@dataclass(frozen=True)
+class DomainEvent:
+    """Base class for all domain events.
+
+    Attributes:
+        occurred_at: UTC timestamp when the event occurred.
+    """
+
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+
+@dataclass(frozen=True)
+class MediaCreatedEvent(DomainEvent):
+    """Emitted when a new movie or series is created.
+
+    Attributes:
+        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_type: Type of media ("movie" or "series").
+    """
+
+    media_id: str = ""
+    media_type: str = ""
+
+
+__all__ = ["DomainEvent", "MediaCreatedEvent"]

--- a/src/building_blocks/infrastructure/in_process_event_bus.py
+++ b/src/building_blocks/infrastructure/in_process_event_bus.py
@@ -1,0 +1,54 @@
+"""In-process event bus implementation."""
+
+import logging
+from collections import defaultdict
+
+from src.building_blocks.application.event_bus import EventBus, EventHandler
+from src.building_blocks.domain.events import DomainEvent
+
+_logger = logging.getLogger(__name__)
+
+
+class InProcessEventBus(EventBus):
+    """Simple in-process event bus using a dict of handlers.
+
+    Handlers are invoked sequentially. Exceptions are logged
+    but do not propagate, so a failing handler never breaks
+    the publisher.
+
+    Example:
+        >>> bus = InProcessEventBus()
+        >>> bus.subscribe(MediaCreatedEvent, my_handler)
+        >>> await bus.publish(MediaCreatedEvent(media_id="mov_abc", media_type="movie"))
+    """
+
+    def __init__(self) -> None:
+        """Initialize with empty handler registry."""
+        self._handlers: dict[type[DomainEvent], list[EventHandler]] = defaultdict(list)
+
+    def subscribe(self, event_type: type[DomainEvent], handler: EventHandler) -> None:
+        """Register a handler for a specific event type."""
+        self._handlers[event_type].append(handler)
+        _logger.info(
+            "Subscribed %s to %s",
+            handler.__class__.__name__,
+            event_type.__name__,
+        )
+
+    async def publish(self, event: DomainEvent) -> None:
+        """Publish an event to all registered handlers."""
+        event_type = type(event)
+        handlers = self._handlers.get(event_type, [])
+
+        for handler in handlers:
+            try:
+                await handler.handle(event)
+            except Exception:
+                _logger.exception(
+                    "Handler %s failed for event %s",
+                    handler.__class__.__name__,
+                    event_type.__name__,
+                )
+
+
+__all__ = ["InProcessEventBus"]

--- a/src/building_blocks/infrastructure/in_process_event_bus.py
+++ b/src/building_blocks/infrastructure/in_process_event_bus.py
@@ -36,7 +36,11 @@ class InProcessEventBus(EventBus):
         )
 
     async def publish(self, event: DomainEvent) -> None:
-        """Publish an event to all registered handlers."""
+        """Publish an event to all registered handlers.
+
+        Dispatch is by exact concrete type — handlers registered for a
+        base class will not receive subclass events.
+        """
         event_type = type(event)
         handlers = self._handlers.get(event_type, [])
 

--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -10,6 +10,7 @@ from dependency_injector import containers, providers
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from src.building_blocks.infrastructure.in_process_event_bus import InProcessEventBus
 from src.config.settings import Settings
 
 
@@ -68,3 +69,5 @@ class InfrastructureContainer(containers.DeclarativeContainer):  # type: ignore[
         lambda factory: factory(),
         factory=session_factory,
     )
+
+    event_bus = providers.Singleton(InProcessEventBus)

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -57,6 +57,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     media = providers.Container(
         MediaContainer,
         session=infrastructure.session,
+        event_bus=infrastructure.event_bus,
         tmdb_api_key=config.provided.tmdb_api_key,
         hls_cache_directory=config.provided.hls_cache_directory,
     )

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -5,6 +5,7 @@ Provides repositories and use cases for the Media module.
 
 from dependency_injector import containers, providers
 
+from src.modules.media.application.event_handlers import OnMediaCreatedHandler
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
 from src.modules.media.application.use_cases.bulk_enrich_metadata import (
     BulkEnrichMetadataUseCase,
@@ -54,8 +55,9 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         >>> use_case = container.get_movie_by_id()
     """
 
-    # Must be wired from InfrastructureContainer.session
+    # Must be wired from InfrastructureContainer
     session = providers.Dependency()
+    event_bus = providers.Dependency()
 
     # Must be wired from parent container (Settings.hls_cache_directory)
     hls_cache_directory = providers.Dependency(default="./hls_cache")
@@ -163,6 +165,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         variant_detector=variant_detector,
         movie_repository=movie_repository,
         series_repository=series_repository,
+        event_bus=event_bus,
     )
 
     # =========================================================================
@@ -196,4 +199,14 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         enrich_series=enrich_series_metadata,
         movie_repository=movie_repository,
         series_repository=series_repository,
+    )
+
+    # =========================================================================
+    # Event Handlers
+    # =========================================================================
+
+    on_media_created_handler = providers.Singleton(
+        OnMediaCreatedHandler,
+        enrich_movie=enrich_movie_metadata,
+        enrich_series=enrich_series_metadata,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -77,15 +77,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await container.infrastructure.init_resources()
 
     # Subscribe domain event handlers
-    from src.building_blocks.domain.events import MediaCreatedEvent
-    from src.modules.media.application.event_handlers import OnMediaCreatedHandler
-
-    event_bus = container.infrastructure.event_bus()
-    handler = OnMediaCreatedHandler(
-        enrich_movie_factory=container.media.enrich_movie_metadata,
-        enrich_series_factory=container.media.enrich_series_metadata,
-    )
-    event_bus.subscribe(MediaCreatedEvent, handler)
+    _subscribe_event_handlers(container)
 
     logger.info("Application ready")
 
@@ -95,6 +87,23 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.info("Application shutting down")
     await container.infrastructure.shutdown_resources()
     logger.info("Application stopped")
+
+
+def _subscribe_event_handlers(container: ApplicationContainer) -> None:
+    """Wire domain event handlers to the event bus.
+
+    Centralises event handler registration so it stays alongside
+    the rest of the container configuration.
+    """
+    from src.building_blocks.domain.events import MediaCreatedEvent
+    from src.modules.media.application.event_handlers import OnMediaCreatedHandler
+
+    event_bus = container.infrastructure.event_bus()
+    handler = OnMediaCreatedHandler(
+        enrich_movie_factory=container.media.enrich_movie_metadata,
+        enrich_series_factory=container.media.enrich_series_metadata,
+    )
+    event_bus.subscribe(MediaCreatedEvent, handler)
 
 
 def create_app() -> FastAPI:

--- a/src/main.py
+++ b/src/main.py
@@ -78,9 +78,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Subscribe domain event handlers
     from src.building_blocks.domain.events import MediaCreatedEvent
+    from src.modules.media.application.event_handlers import OnMediaCreatedHandler
 
     event_bus = container.infrastructure.event_bus()
-    event_bus.subscribe(MediaCreatedEvent, container.media.on_media_created_handler())
+    handler = OnMediaCreatedHandler(
+        enrich_movie=container.media.enrich_movie_metadata(),
+        enrich_series=container.media.enrich_series_metadata(),
+    )
+    event_bus.subscribe(MediaCreatedEvent, handler)
 
     logger.info("Application ready")
 

--- a/src/main.py
+++ b/src/main.py
@@ -82,8 +82,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     event_bus = container.infrastructure.event_bus()
     handler = OnMediaCreatedHandler(
-        enrich_movie=container.media.enrich_movie_metadata(),
-        enrich_series=container.media.enrich_series_metadata(),
+        enrich_movie_factory=container.media.enrich_movie_metadata,
+        enrich_series_factory=container.media.enrich_series_metadata,
     )
     event_bus.subscribe(MediaCreatedEvent, handler)
 

--- a/src/main.py
+++ b/src/main.py
@@ -76,6 +76,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Initialize database
     await container.infrastructure.init_resources()
 
+    # Subscribe domain event handlers
+    from src.building_blocks.domain.events import MediaCreatedEvent
+
+    event_bus = container.infrastructure.event_bus()
+    event_bus.subscribe(MediaCreatedEvent, container.media.on_media_created_handler())
+
     logger.info("Application ready")
 
     yield

--- a/src/modules/media/application/event_handlers/__init__.py
+++ b/src/modules/media/application/event_handlers/__init__.py
@@ -1,0 +1,7 @@
+"""Media event handlers."""
+
+from src.modules.media.application.event_handlers.on_media_created import (
+    OnMediaCreatedHandler,
+)
+
+__all__ = ["OnMediaCreatedHandler"]

--- a/src/modules/media/application/event_handlers/on_media_created.py
+++ b/src/modules/media/application/event_handlers/on_media_created.py
@@ -1,0 +1,76 @@
+"""Handler that auto-enriches media when created."""
+
+import logging
+
+from src.building_blocks.application.event_bus import EventHandler
+from src.building_blocks.domain.events import DomainEvent, MediaCreatedEvent
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
+from src.modules.media.application.use_cases.enrich_movie_metadata import (
+    EnrichMovieMetadataUseCase,
+)
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class OnMediaCreatedHandler(EventHandler):
+    """Auto-enrich movies and series when they are first created.
+
+    Listens to MediaCreatedEvent and dispatches to the appropriate
+    enrich use case. Failures are logged but never raised.
+
+    Example:
+        >>> handler = OnMediaCreatedHandler(enrich_movie, enrich_series)
+        >>> await handler.handle(MediaCreatedEvent(media_id="mov_abc", media_type="movie"))
+    """
+
+    def __init__(
+        self,
+        enrich_movie: EnrichMovieMetadataUseCase,
+        enrich_series: EnrichSeriesMetadataUseCase,
+    ) -> None:
+        """Initialize the handler.
+
+        Args:
+            enrich_movie: Use case for enriching movie metadata.
+            enrich_series: Use case for enriching series metadata.
+        """
+        self._enrich_movie = enrich_movie
+        self._enrich_series = enrich_series
+
+    async def handle(self, event: DomainEvent) -> None:
+        """Handle a MediaCreatedEvent by enriching the media.
+
+        Args:
+            event: The domain event (expected to be MediaCreatedEvent).
+        """
+        if not isinstance(event, MediaCreatedEvent):
+            return
+
+        _logger.info(
+            "Auto-enriching %s %s",
+            event.media_type,
+            event.media_id,
+        )
+
+        input_dto = EnrichMediaInput(media_id=event.media_id, force=False)
+
+        if event.media_type == "movie":
+            result = await self._enrich_movie.execute(input_dto)
+        elif event.media_type == "series":
+            result = await self._enrich_series.execute(input_dto)
+        else:
+            _logger.warning("Unknown media type: %s", event.media_type)
+            return
+
+        if result.enriched:
+            _logger.info("Enriched %s %s via %s", event.media_type, event.media_id, result.provider)
+        elif result.error:
+            _logger.warning(
+                "Failed to enrich %s %s: %s", event.media_type, event.media_id, result.error
+            )
+
+
+__all__ = ["OnMediaCreatedHandler"]

--- a/src/modules/media/application/event_handlers/on_media_created.py
+++ b/src/modules/media/application/event_handlers/on_media_created.py
@@ -1,6 +1,7 @@
 """Handler that auto-enriches media when created."""
 
 import logging
+from collections.abc import Awaitable, Callable
 
 from src.building_blocks.application.event_bus import EventHandler
 from src.building_blocks.domain.events import DomainEvent, MediaCreatedEvent
@@ -18,27 +19,27 @@ _logger = logging.getLogger(__name__)
 class OnMediaCreatedHandler(EventHandler):
     """Auto-enrich movies and series when they are first created.
 
-    Listens to MediaCreatedEvent and dispatches to the appropriate
-    enrich use case. Failures are logged but never raised.
+    Receives use case factories (callables) instead of instances to
+    ensure each invocation gets a fresh use case with its own DB session.
 
     Example:
-        >>> handler = OnMediaCreatedHandler(enrich_movie, enrich_series)
+        >>> handler = OnMediaCreatedHandler(movie_uc_factory, series_uc_factory)
         >>> await handler.handle(MediaCreatedEvent(media_id="mov_abc", media_type="movie"))
     """
 
     def __init__(
         self,
-        enrich_movie: EnrichMovieMetadataUseCase,
-        enrich_series: EnrichSeriesMetadataUseCase,
+        enrich_movie_factory: Callable[[], Awaitable[EnrichMovieMetadataUseCase]],
+        enrich_series_factory: Callable[[], Awaitable[EnrichSeriesMetadataUseCase]],
     ) -> None:
         """Initialize the handler.
 
         Args:
-            enrich_movie: Use case for enriching movie metadata.
-            enrich_series: Use case for enriching series metadata.
+            enrich_movie_factory: Factory that creates EnrichMovieMetadataUseCase.
+            enrich_series_factory: Factory that creates EnrichSeriesMetadataUseCase.
         """
-        self._enrich_movie = enrich_movie
-        self._enrich_series = enrich_series
+        self._enrich_movie_factory = enrich_movie_factory
+        self._enrich_series_factory = enrich_series_factory
 
     async def handle(self, event: DomainEvent) -> None:
         """Handle a MediaCreatedEvent by enriching the media.
@@ -49,18 +50,16 @@ class OnMediaCreatedHandler(EventHandler):
         if not isinstance(event, MediaCreatedEvent):
             return
 
-        _logger.info(
-            "Auto-enriching %s %s",
-            event.media_type,
-            event.media_id,
-        )
+        _logger.info("Auto-enriching %s %s", event.media_type, event.media_id)
 
         input_dto = EnrichMediaInput(media_id=event.media_id, force=False)
 
         if event.media_type == "movie":
-            result = await self._enrich_movie.execute(input_dto)
+            movie_uc = await self._enrich_movie_factory()
+            result = await movie_uc.execute(input_dto)
         elif event.media_type == "series":
-            result = await self._enrich_series.execute(input_dto)
+            series_uc = await self._enrich_series_factory()
+            result = await series_uc.execute(input_dto)
         else:
             _logger.warning("Unknown media type: %s", event.media_type)
             return
@@ -69,7 +68,10 @@ class OnMediaCreatedHandler(EventHandler):
             _logger.info("Enriched %s %s via %s", event.media_type, event.media_id, result.provider)
         elif result.error:
             _logger.warning(
-                "Failed to enrich %s %s: %s", event.media_type, event.media_id, result.error
+                "Failed to enrich %s %s: %s",
+                event.media_type,
+                event.media_id,
+                result.error,
             )
 
 

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 
+from src.building_blocks.application.event_bus import EventBus
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput, ScanMediaOutput
 from src.modules.media.application.ports import FileSystemScanner, MediaType, ScannedFile
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
@@ -34,11 +35,13 @@ class ScanMediaDirectoriesUseCase:
         variant_detector: VariantDetector,
         movie_repository: MovieRepository,
         series_repository: SeriesRepository,
+        event_bus: EventBus | None = None,
     ) -> None:
         self._file_scanner = file_scanner
         self._variant_detector = variant_detector
         self._movie_repository = movie_repository
         self._series_repository = series_repository
+        self._event_bus = event_bus
 
     async def execute(self, input_dto: ScanMediaInput) -> ScanMediaOutput:
         """Execute the media scan.
@@ -66,6 +69,13 @@ class ScanMediaDirectoriesUseCase:
             episodes_updated=episodes_updated,
             errors=[*movie_errors, *episode_errors],
         )
+
+    async def _dispatch_events(self, events: list[object]) -> None:
+        """Dispatch domain events via the event bus, if available."""
+        if not self._event_bus:
+            return
+        for event in events:
+            await self._event_bus.publish(event)  # type: ignore[arg-type]
 
     async def _process_movies(
         self,
@@ -147,7 +157,9 @@ class ScanMediaDirectoriesUseCase:
         )
         for path in paths[1:]:
             movie = movie.with_file(_build_media_file(by_path[path], is_primary=False))
+        events = movie.pull_events()
         await self._movie_repository.save(movie)
+        await self._dispatch_events(events)
         return 1, 0
 
     async def _process_episodes(
@@ -198,7 +210,9 @@ class ScanMediaDirectoriesUseCase:
             created += c
             updated += u
 
+        events = series.pull_events()
         await self._series_repository.save(series)
+        await self._dispatch_events(events)
         return created, updated
 
 

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 
 from src.building_blocks.application.event_bus import EventBus
+from src.building_blocks.domain.events import DomainEvent
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput, ScanMediaOutput
 from src.modules.media.application.ports import FileSystemScanner, MediaType, ScannedFile
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
@@ -70,12 +71,12 @@ class ScanMediaDirectoriesUseCase:
             errors=[*movie_errors, *episode_errors],
         )
 
-    async def _dispatch_events(self, events: list[object]) -> None:
+    async def _dispatch_events(self, events: list[DomainEvent]) -> None:
         """Dispatch domain events via the event bus, if available."""
         if not self._event_bus:
             return
         for event in events:
-            await self._event_bus.publish(event)  # type: ignore[arg-type]
+            await self._event_bus.publish(event)
 
     async def _process_movies(
         self,

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -7,6 +7,7 @@ from typing import Any, Self
 from pydantic import Field, field_validator
 
 from src.building_blocks.domain import AggregateRoot
+from src.building_blocks.domain.events import MediaCreatedEvent
 from src.modules.media.domain.entities.file_variant_mixin import FileVariantMixin
 from src.modules.media.domain.value_objects import (
     Duration,
@@ -178,7 +179,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
             is_primary=True,
         )
 
-        return cls(
+        movie = cls(
             id=movie_id,
             title=title,
             year=year,
@@ -186,6 +187,8 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
             files=[file],
             **kwargs,
         )
+        movie.add_event(MediaCreatedEvent(media_id=str(movie_id), media_type="movie"))
+        return movie
 
 
 __all__ = ["Movie"]

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -8,6 +8,7 @@ from pydantic import Field, field_validator, model_validator
 
 from src.building_blocks.domain import AggregateRoot
 from src.building_blocks.domain.errors import BusinessRuleViolationException
+from src.building_blocks.domain.events import MediaCreatedEvent
 from src.modules.media.domain.rule_codes import MediaRuleCodes
 from src.modules.media.domain.value_objects import (
     Genre,
@@ -188,12 +189,14 @@ class Series(AggregateRoot[SeriesId]):
         if isinstance(start_year, int):
             start_year = Year(start_year)
 
-        return cls(
+        series = cls(
             id=series_id,
             title=title,
             start_year=start_year,
             **kwargs,
         )
+        series.add_event(MediaCreatedEvent(media_id=str(series_id), media_type="series"))
+        return series
 
 
 __all__ = ["Series"]

--- a/tests/modules/media/unit/domain/entities/test_movie.py
+++ b/tests/modules/media/unit/domain/entities/test_movie.py
@@ -405,6 +405,29 @@ class TestMovieEquality:
 class TestMovieEvents:
     """Tests for Movie domain events."""
 
+    def test_should_emit_media_created_event_on_create(self):
+        from src.building_blocks.domain.events import MediaCreatedEvent
+        from src.modules.media.domain.entities import Movie
+
+        movie = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+
+        assert movie.has_pending_events is True
+
+        events = movie.pull_events()
+
+        assert len(events) == 1
+        assert isinstance(events[0], MediaCreatedEvent)
+        assert events[0].media_id == str(movie.id)
+        assert events[0].media_type == "movie"
+        assert movie.has_pending_events is False
+
     def test_should_add_and_pull_events(self):
         from src.modules.media.domain.entities import Movie
 
@@ -417,14 +440,35 @@ class TestMovieEvents:
             resolution="1080p",
         )
 
-        movie.add_event({"type": "MovieCreated", "movie_id": str(movie.id)})
-
-        assert movie.has_pending_events is True
+        movie.add_event({"type": "CustomEvent", "movie_id": str(movie.id)})
 
         events = movie.pull_events()
 
-        assert len(events) == 1
+        # MediaCreatedEvent from create() + the custom event
+        assert len(events) == 2
         assert movie.has_pending_events is False
+
+    def test_events_survive_with_updates(self):
+        from src.building_blocks.domain.events import MediaCreatedEvent
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import Year
+
+        movie = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+
+        # Events from create() should survive with_updates()
+        updated = movie.with_updates(year=Year(2011))
+
+        assert updated.has_pending_events is True
+        events = updated.pull_events()
+        assert len(events) == 1
+        assert isinstance(events[0], MediaCreatedEvent)
 
 
 class TestMovieImmutability:

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -166,18 +166,33 @@ class TestSeriesEquality:
 class TestSeriesEvents:
     """Tests for Series domain events."""
 
-    def test_should_add_and_pull_events(self):
+    def test_should_emit_media_created_event_on_create(self):
+        from src.building_blocks.domain.events import MediaCreatedEvent
         from src.modules.media.domain.entities import Series
 
         series = Series.create(title="Breaking Bad", start_year=2008)
-
-        series.add_event({"type": "SeriesCreated", "series_id": str(series.id)})
 
         assert series.has_pending_events is True
 
         events = series.pull_events()
 
         assert len(events) == 1
+        assert isinstance(events[0], MediaCreatedEvent)
+        assert events[0].media_id == str(series.id)
+        assert events[0].media_type == "series"
+        assert series.has_pending_events is False
+
+    def test_should_add_and_pull_events(self):
+        from src.modules.media.domain.entities import Series
+
+        series = Series.create(title="Breaking Bad", start_year=2008)
+
+        series.add_event({"type": "CustomEvent", "series_id": str(series.id)})
+
+        events = series.pull_events()
+
+        # MediaCreatedEvent from create() + the custom event
+        assert len(events) == 2
         assert series.has_pending_events is False
 
 


### PR DESCRIPTION
## Summary

- Fix `AggregateRoot.with_updates()` to propagate `_events` to new instances — events now survive immutable model transitions
- Add `DomainEvent` base class and `MediaCreatedEvent` in building blocks
- Add `EventBus` / `EventHandler` abstractions with `InProcessEventBus` implementation (fire-and-forget, logs failures)
- `Movie.create()` and `Series.create()` now emit `MediaCreatedEvent` from the domain layer
- Add `OnMediaCreatedHandler` that auto-enriches media via TMDB when created
- Inject `EventBus` into `ScanMediaDirectoriesUseCase` — events dispatched after save
- Wire event bus as singleton in infrastructure container, subscribe handler at app startup

## Architecture

```
Movie.create() → add_event(MediaCreatedEvent)
    ↓ (survives with_updates/with_file)
ScanUseCase → pull_events() → save() → event_bus.publish()
    ↓
OnMediaCreatedHandler → EnrichMovieMetadataUseCase.execute()
```

## Test plan

- [ ] All 786 tests pass (3 new: event emission, propagation through with_updates)
- [ ] Scan a new movie → auto-enriches with TMDB metadata
- [ ] Scan a new series → auto-enriches with TMDB metadata
- [ ] Enrichment failure doesn't break the scan (logged only)
- [ ] Adding file variants to existing media doesn't trigger re-enrichment

## Summary by Sourcery

Introduce domain event infrastructure for media creation and wire it into media scanning and application startup to enable automatic metadata enrichment.

New Features:
- Emit MediaCreatedEvent domain events from Movie and Series aggregates when new media is created.
- Add DomainEvent base type and media-specific MediaCreatedEvent to the domain building blocks.
- Introduce EventBus and EventHandler abstractions with an in-process event bus implementation for publishing domain events.
- Add OnMediaCreatedHandler that enriches movies and series metadata when MediaCreatedEvent is published.

Enhancements:
- Ensure aggregate with_updates propagates pending domain events across immutable entity instances.
- Inject the event bus into ScanMediaDirectoriesUseCase to publish media domain events after persistence.
- Wire event bus and media event handler singletons into the dependency injection containers and subscribe handlers at application startup.

Tests:
- Extend movie and series domain tests to cover MediaCreatedEvent emission, custom event accumulation, and event persistence through with_updates transitions.