### PR TITLE
feat(watch-progress): add episode progress to series detail and continue watching

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -68,6 +68,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         WatchProgressContainer,
         session=infrastructure.session,
         movie_repository=media.movie_repository,
+        series_repository=media.series_repository,
     )
 
     collections = providers.Container(

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -38,6 +38,9 @@ from src.modules.media.infrastructure.persistence.repositories.series_repository
     SQLAlchemySeriesRepository,
 )
 from src.modules.media.infrastructure.streaming import HlsService, MediaProbeService
+from src.modules.watch_progress.infrastructure.persistence.repositories import (
+    SQLAlchemyWatchProgressRepository,
+)
 
 
 class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
@@ -76,6 +79,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         session=session,
     )
 
+    progress_repository = providers.Factory(
+        SQLAlchemyWatchProgressRepository,
+        session=session,
+    )
+
     # =========================================================================
     # Use Cases — Query
     # =========================================================================
@@ -104,6 +112,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     get_series_by_id = providers.Factory(
         GetSeriesByIdUseCase,
         series_repository=series_repository,
+        progress_repository=progress_repository,
     )
 
     list_series = providers.Factory(

--- a/src/config/containers/watch_progress.py
+++ b/src/config/containers/watch_progress.py
@@ -22,6 +22,7 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
 
     session = providers.Dependency()
     movie_repository = providers.Dependency()
+    series_repository = providers.Dependency()
 
     # =========================================================================
     # Repositories
@@ -50,6 +51,7 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
         GetContinueWatchingUseCase,
         progress_repository=progress_repository,
         movie_repository=movie_repository,
+        series_repository=series_repository,
     )
 
     clear_progress = providers.Factory(

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -39,6 +39,10 @@ class EpisodeOutput:
     files: list[MediaFileOutput]
     thumbnail_path: str | None
     air_date: str | None
+    progress_percentage: float | None = None
+    position_seconds: int | None = None
+    watch_status: str | None = None
+    last_watched_at: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -15,6 +15,7 @@ from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import SeriesId
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.shared_kernel.episode_composite_id import EpisodeCompositeId
 
 
 class GetSeriesByIdUseCase:
@@ -64,28 +65,35 @@ class GetSeriesByIdUseCase:
         if series is None:
             raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
 
-        return await self._to_output(series, input_dto.lang)
-
-    async def _to_output(self, series: Series, lang: str = "en") -> SeriesOutput:
-        """Convert Series entity to output DTO.
-
-        Args:
-            series: The Series entity to convert.
-            lang: Language code for localized fields.
-
-        Returns:
-            SeriesOutput with all fields and nested seasons/episodes.
-        """
-        series_id = str(series.id)
+        series_id_str = str(series.id)
         composite_ids = [
-            f"epi_{series_id}_{s.season_number}_{ep.episode_number}"
+            EpisodeCompositeId.build(series_id_str, s.season_number, ep.episode_number).media_id
             for s in series.seasons
             for ep in s.episodes
         ]
         progress_map = await self._progress_repo.find_by_media_ids(composite_ids)
 
+        return self._to_output(series, input_dto.lang, progress_map)
+
+    def _to_output(
+        self,
+        series: Series,
+        lang: str,
+        progress_map: dict[str, WatchProgress],
+    ) -> SeriesOutput:
+        """Convert Series entity to output DTO.
+
+        Args:
+            series: The Series entity to convert.
+            lang: Language code for localized fields.
+            progress_map: Map of composite media_id to watch progress.
+
+        Returns:
+            SeriesOutput with all fields and nested seasons/episodes.
+        """
+        series_id = str(series.id)
         return SeriesOutput(
-            id=str(series.id),
+            id=series_id,
             title=series.get_title(lang),
             original_title=series.original_title.value if series.original_title else None,
             start_year=series.start_year.value,
@@ -106,8 +114,8 @@ class GetSeriesByIdUseCase:
             updated_at=series.updated_at.isoformat(),
         )
 
+    @staticmethod
     def _to_season_output(
-        self,
         season: Season,
         series_id: str,
         progress_map: dict[str, WatchProgress],
@@ -131,7 +139,12 @@ class GetSeriesByIdUseCase:
             air_date=season.air_date.value.isoformat() if season.air_date else None,
             episode_count=season.episode_count,
             episodes=[
-                self._to_episode_output(e, series_id, season.season_number, progress_map)
+                GetSeriesByIdUseCase._to_episode_output(
+                    e,
+                    series_id,
+                    season.season_number,
+                    progress_map,
+                )
                 for e in season.episodes
             ],
         )
@@ -155,7 +168,11 @@ class GetSeriesByIdUseCase:
             EpisodeOutput with all fields including progress.
         """
         primary = episode.primary_file
-        composite_key = f"epi_{series_id}_{season_number}_{episode.episode_number}"
+        composite_key = EpisodeCompositeId.build(
+            series_id,
+            season_number,
+            episode.episode_number,
+        ).media_id
         progress = progress_map.get(composite_key)
         return EpisodeOutput(
             id=str(episode.id) if episode.id else None,

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -76,8 +76,13 @@ class GetSeriesByIdUseCase:
         Returns:
             SeriesOutput with all fields and nested seasons/episodes.
         """
-        episode_ids = [str(ep.id) for s in series.seasons for ep in s.episodes if ep.id]
-        progress_map = await self._progress_repo.find_by_media_ids(episode_ids)
+        series_id = str(series.id)
+        composite_ids = [
+            f"epi_{series_id}_{s.season_number}_{ep.episode_number}"
+            for s in series.seasons
+            for ep in s.episodes
+        ]
+        progress_map = await self._progress_repo.find_by_media_ids(composite_ids)
 
         return SeriesOutput(
             id=str(series.id),
@@ -96,7 +101,7 @@ class GetSeriesByIdUseCase:
             imdb_id=series.imdb_id.value if series.imdb_id else None,
             season_count=series.season_count,
             total_episodes=series.total_episodes,
-            seasons=[self._to_season_output(s, progress_map) for s in series.seasons],
+            seasons=[self._to_season_output(s, series_id, progress_map) for s in series.seasons],
             created_at=series.created_at.isoformat(),
             updated_at=series.updated_at.isoformat(),
         )
@@ -104,13 +109,15 @@ class GetSeriesByIdUseCase:
     def _to_season_output(
         self,
         season: Season,
+        series_id: str,
         progress_map: dict[str, WatchProgress],
     ) -> SeasonOutput:
         """Convert Season entity to output DTO.
 
         Args:
             season: The Season entity to convert.
-            progress_map: Map of episode ID to watch progress.
+            series_id: External series ID for composite key lookup.
+            progress_map: Map of composite media_id to watch progress.
 
         Returns:
             SeasonOutput with episode list.
@@ -123,25 +130,33 @@ class GetSeriesByIdUseCase:
             poster_path=season.poster_path.value if season.poster_path else None,
             air_date=season.air_date.value.isoformat() if season.air_date else None,
             episode_count=season.episode_count,
-            episodes=[self._to_episode_output(e, progress_map) for e in season.episodes],
+            episodes=[
+                self._to_episode_output(e, series_id, season.season_number, progress_map)
+                for e in season.episodes
+            ],
         )
 
     @staticmethod
     def _to_episode_output(
         episode: Episode,
+        series_id: str,
+        season_number: int,
         progress_map: dict[str, WatchProgress],
     ) -> EpisodeOutput:
         """Convert Episode entity to output DTO.
 
         Args:
             episode: The Episode entity to convert.
-            progress_map: Map of episode ID to watch progress.
+            series_id: External series ID for composite key lookup.
+            season_number: Season number for composite key lookup.
+            progress_map: Map of composite media_id to watch progress.
 
         Returns:
             EpisodeOutput with all fields including progress.
         """
         primary = episode.primary_file
-        progress = progress_map.get(str(episode.id)) if episode.id else None
+        composite_key = f"epi_{series_id}_{season_number}_{episode.episode_number}"
+        progress = progress_map.get(composite_key)
         return EpisodeOutput(
             id=str(episode.id) if episode.id else None,
             episode_number=episode.episode_number,

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -13,15 +13,18 @@ from src.modules.media.application.use_cases._media_file_helpers import (
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import SeriesId
+from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 
 
 class GetSeriesByIdUseCase:
     """Retrieve a series with all seasons and episodes.
 
-    This use case fetches a complete series hierarchy from the repository.
+    This use case fetches a complete series hierarchy from the repository,
+    enriching each episode with watch progress data when available.
 
     Example:
-        >>> use_case = GetSeriesByIdUseCase(series_repository)
+        >>> use_case = GetSeriesByIdUseCase(series_repository, progress_repository)
         >>> result = await use_case.execute(GetSeriesByIdInput("ser_abc123"))
         >>> result.title
         'Breaking Bad'
@@ -29,13 +32,19 @@ class GetSeriesByIdUseCase:
         5
     """
 
-    def __init__(self, series_repository: SeriesRepository) -> None:
+    def __init__(
+        self,
+        series_repository: SeriesRepository,
+        progress_repository: WatchProgressRepository,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             series_repository: Repository for series persistence.
+            progress_repository: Repository for watch progress.
         """
         self._series_repository = series_repository
+        self._progress_repo = progress_repository
 
     async def execute(self, input_dto: GetSeriesByIdInput) -> SeriesOutput:
         """Execute the use case.
@@ -55,9 +64,9 @@ class GetSeriesByIdUseCase:
         if series is None:
             raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
 
-        return self._to_output(series, input_dto.lang)
+        return await self._to_output(series, input_dto.lang)
 
-    def _to_output(self, series: Series, lang: str = "en") -> SeriesOutput:
+    async def _to_output(self, series: Series, lang: str = "en") -> SeriesOutput:
         """Convert Series entity to output DTO.
 
         Args:
@@ -67,6 +76,9 @@ class GetSeriesByIdUseCase:
         Returns:
             SeriesOutput with all fields and nested seasons/episodes.
         """
+        episode_ids = [str(ep.id) for s in series.seasons for ep in s.episodes if ep.id]
+        progress_map = await self._progress_repo.find_by_media_ids(episode_ids)
+
         return SeriesOutput(
             id=str(series.id),
             title=series.get_title(lang),
@@ -84,16 +96,21 @@ class GetSeriesByIdUseCase:
             imdb_id=series.imdb_id.value if series.imdb_id else None,
             season_count=series.season_count,
             total_episodes=series.total_episodes,
-            seasons=[self._to_season_output(s) for s in series.seasons],
+            seasons=[self._to_season_output(s, progress_map) for s in series.seasons],
             created_at=series.created_at.isoformat(),
             updated_at=series.updated_at.isoformat(),
         )
 
-    def _to_season_output(self, season: Season) -> SeasonOutput:
+    def _to_season_output(
+        self,
+        season: Season,
+        progress_map: dict[str, WatchProgress],
+    ) -> SeasonOutput:
         """Convert Season entity to output DTO.
 
         Args:
             season: The Season entity to convert.
+            progress_map: Map of episode ID to watch progress.
 
         Returns:
             SeasonOutput with episode list.
@@ -106,20 +123,25 @@ class GetSeriesByIdUseCase:
             poster_path=season.poster_path.value if season.poster_path else None,
             air_date=season.air_date.value.isoformat() if season.air_date else None,
             episode_count=season.episode_count,
-            episodes=[self._to_episode_output(e) for e in season.episodes],
+            episodes=[self._to_episode_output(e, progress_map) for e in season.episodes],
         )
 
     @staticmethod
-    def _to_episode_output(episode: Episode) -> EpisodeOutput:
+    def _to_episode_output(
+        episode: Episode,
+        progress_map: dict[str, WatchProgress],
+    ) -> EpisodeOutput:
         """Convert Episode entity to output DTO.
 
         Args:
             episode: The Episode entity to convert.
+            progress_map: Map of episode ID to watch progress.
 
         Returns:
-            EpisodeOutput with all fields.
+            EpisodeOutput with all fields including progress.
         """
         primary = episode.primary_file
+        progress = progress_map.get(str(episode.id)) if episode.id else None
         return EpisodeOutput(
             id=str(episode.id) if episode.id else None,
             episode_number=episode.episode_number,
@@ -133,6 +155,10 @@ class GetSeriesByIdUseCase:
             files=[to_media_file_output(f) for f in episode.files],
             thumbnail_path=episode.thumbnail_path.value if episode.thumbnail_path else None,
             air_date=episode.air_date.value.isoformat() if episode.air_date else None,
+            progress_percentage=progress.percentage if progress else None,
+            position_seconds=progress.position_seconds if progress else None,
+            watch_status=progress.status if progress else None,
+            last_watched_at=progress.last_watched_at.isoformat() if progress else None,
         )
 
 

--- a/src/modules/watch_progress/application/dtos/progress_dtos.py
+++ b/src/modules/watch_progress/application/dtos/progress_dtos.py
@@ -120,6 +120,10 @@ class ContinueWatchingItem:
     duration_seconds: int
     percentage: float
     last_watched_at: str
+    series_id: str | None = None
+    series_title: str | None = None
+    season_number: int | None = None
+    episode_number: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -117,32 +117,71 @@ class GetContinueWatchingUseCase:
         progress: WatchProgress,
         lang: str,
     ) -> ContinueWatchingItem | None:
-        """Enrich an episode progress record with series metadata."""
-        from src.modules.media.domain.value_objects import EpisodeId
+        """Enrich an episode progress record with series metadata.
 
-        series = await self._series_repo.find_by_episode_id(EpisodeId(progress.media_id))
+        Supports two media_id formats:
+        - Standard EpisodeId: ``epi_<12chars>``
+        - Composite key: ``epi_<series_id>_<season>_<episode>``
+        """
+        parsed = self._parse_episode_media_id(progress.media_id)
+        if not parsed:
+            return None
+
+        series_id_str, season_num, episode_num = parsed
+
+        from src.modules.media.domain.value_objects import SeriesId
+
+        series = await self._series_repo.find_by_id(SeriesId(series_id_str))
         if not series:
             return None
 
-        for season in series.seasons:
-            for episode in season.episodes:
-                if str(episode.id) == progress.media_id:
-                    return ContinueWatchingItem(
-                        media_id=progress.media_id,
-                        media_type=progress.media_type,
-                        title=episode.title.value,
-                        poster_path=series.poster_path.value if series.poster_path else None,
-                        backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-                        position_seconds=progress.position_seconds,
-                        duration_seconds=progress.duration_seconds,
-                        percentage=progress.percentage,
-                        last_watched_at=progress.last_watched_at.isoformat(),
-                        series_id=str(series.id),
-                        series_title=series.get_title(lang),
-                        season_number=season.season_number,
-                        episode_number=episode.episode_number,
-                    )
-        return None
+        season = series.get_season(season_num)
+        if not season:
+            return None
+
+        episode = season.get_episode(episode_num)
+        if not episode:
+            return None
+
+        return ContinueWatchingItem(
+            media_id=progress.media_id,
+            media_type=progress.media_type,
+            title=episode.title.value,
+            poster_path=series.poster_path.value if series.poster_path else None,
+            backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+            position_seconds=progress.position_seconds,
+            duration_seconds=progress.duration_seconds,
+            percentage=progress.percentage,
+            last_watched_at=progress.last_watched_at.isoformat(),
+            series_id=str(series.id),
+            series_title=series.get_title(lang),
+            season_number=season.season_number,
+            episode_number=episode.episode_number,
+        )
+
+    @staticmethod
+    def _parse_episode_media_id(
+        media_id: str,
+    ) -> tuple[str, int, int] | None:
+        """Parse an episode media_id into (series_id, season, episode).
+
+        Handles composite format ``epi_ser_XXXX_S_E``.
+
+        Returns:
+            Tuple of (series_id, season_number, episode_number) or None.
+        """
+        if not media_id.startswith("epi_ser_"):
+            return None
+        # epi_ser_Hy9VjMfILYZe_3_2 → parts after "epi_" = "ser_Hy9VjMfILYZe_3_2"
+        rest = media_id[4:]  # "ser_Hy9VjMfILYZe_3_2"
+        parts = rest.rsplit("_", 2)
+        if len(parts) != 3:
+            return None
+        series_id_str, season_str, episode_str = parts
+        try:
+            return series_id_str, int(season_str), int(episode_str)
+        except ValueError:
+            return None
 
 
 __all__ = ["GetContinueWatchingUseCase"]

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -10,6 +10,7 @@ from src.modules.watch_progress.application.dtos import (
 )
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.shared_kernel.episode_composite_id import EpisodeCompositeId
 
 _logger = logging.getLogger(__name__)
 
@@ -17,11 +18,11 @@ _logger = logging.getLogger(__name__)
 class GetContinueWatchingUseCase:
     """List in-progress media items with display metadata.
 
-    Joins progress records with movie data to provide title and
+    Joins progress records with movie/series data to provide title and
     poster for the "Continue Watching" UI section.
 
     Example:
-        >>> use_case = GetContinueWatchingUseCase(progress_repo, movie_repo)
+        >>> use_case = GetContinueWatchingUseCase(progress_repo, movie_repo, series_repo)
         >>> result = await use_case.execute(GetContinueWatchingInput(limit=10))
     """
 
@@ -89,6 +90,49 @@ class GetContinueWatchingUseCase:
             return await self._enrich_episode(progress, lang)
         return None
 
+    def _build_item(
+        self,
+        progress: WatchProgress,
+        *,
+        title: str,
+        poster_path: str | None,
+        backdrop_path: str | None,
+        series_id: str | None = None,
+        series_title: str | None = None,
+        season_number: int | None = None,
+        episode_number: int | None = None,
+    ) -> ContinueWatchingItem:
+        """Build a ContinueWatchingItem from progress and media metadata.
+
+        Args:
+            progress: The watch progress record.
+            title: Display title.
+            poster_path: Poster image path.
+            backdrop_path: Backdrop image path.
+            series_id: Series external ID (episodes only).
+            series_title: Series title (episodes only).
+            season_number: Season number (episodes only).
+            episode_number: Episode number (episodes only).
+
+        Returns:
+            A fully populated ContinueWatchingItem.
+        """
+        return ContinueWatchingItem(
+            media_id=progress.media_id,
+            media_type=progress.media_type,
+            title=title,
+            poster_path=poster_path,
+            backdrop_path=backdrop_path,
+            position_seconds=progress.position_seconds,
+            duration_seconds=progress.duration_seconds,
+            percentage=progress.percentage,
+            last_watched_at=progress.last_watched_at.isoformat(),
+            series_id=series_id,
+            series_title=series_title,
+            season_number=season_number,
+            episode_number=episode_number,
+        )
+
     async def _enrich_movie(
         self,
         progress: WatchProgress,
@@ -100,16 +144,11 @@ class GetContinueWatchingUseCase:
         movie = await self._movie_repo.find_by_id(MovieId(progress.media_id))
         if not movie:
             return None
-        return ContinueWatchingItem(
-            media_id=progress.media_id,
-            media_type=progress.media_type,
+        return self._build_item(
+            progress,
             title=movie.get_title(lang),
             poster_path=movie.poster_path.value if movie.poster_path else None,
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
-            position_seconds=progress.position_seconds,
-            duration_seconds=progress.duration_seconds,
-            percentage=progress.percentage,
-            last_watched_at=progress.last_watched_at.isoformat(),
         )
 
     async def _enrich_episode(
@@ -119,69 +158,37 @@ class GetContinueWatchingUseCase:
     ) -> ContinueWatchingItem | None:
         """Enrich an episode progress record with series metadata.
 
-        Supports two media_id formats:
-        - Standard EpisodeId: ``epi_<12chars>``
-        - Composite key: ``epi_<series_id>_<season>_<episode>``
+        Parses the composite media_id format (``epi_ser_XXX_S_E``)
+        to look up the series, season, and episode.
         """
-        parsed = self._parse_episode_media_id(progress.media_id)
+        parsed = EpisodeCompositeId.parse(progress.media_id)
         if not parsed:
             return None
 
-        series_id_str, season_num, episode_num = parsed
-
         from src.modules.media.domain.value_objects import SeriesId
 
-        series = await self._series_repo.find_by_id(SeriesId(series_id_str))
+        series = await self._series_repo.find_by_id(SeriesId(parsed.series_id))
         if not series:
             return None
 
-        season = series.get_season(season_num)
+        season = series.get_season(parsed.season_number)
         if not season:
             return None
 
-        episode = season.get_episode(episode_num)
+        episode = season.get_episode(parsed.episode_number)
         if not episode:
             return None
 
-        return ContinueWatchingItem(
-            media_id=progress.media_id,
-            media_type=progress.media_type,
+        return self._build_item(
+            progress,
             title=episode.title.value,
             poster_path=series.poster_path.value if series.poster_path else None,
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-            position_seconds=progress.position_seconds,
-            duration_seconds=progress.duration_seconds,
-            percentage=progress.percentage,
-            last_watched_at=progress.last_watched_at.isoformat(),
             series_id=str(series.id),
             series_title=series.get_title(lang),
             season_number=season.season_number,
             episode_number=episode.episode_number,
         )
-
-    @staticmethod
-    def _parse_episode_media_id(
-        media_id: str,
-    ) -> tuple[str, int, int] | None:
-        """Parse an episode media_id into (series_id, season, episode).
-
-        Handles composite format ``epi_ser_XXXX_S_E``.
-
-        Returns:
-            Tuple of (series_id, season_number, episode_number) or None.
-        """
-        if not media_id.startswith("epi_ser_"):
-            return None
-        # epi_ser_Hy9VjMfILYZe_3_2 → parts after "epi_" = "ser_Hy9VjMfILYZe_3_2"
-        rest = media_id[4:]  # "ser_Hy9VjMfILYZe_3_2"
-        parts = rest.rsplit("_", 2)
-        if len(parts) != 3:
-            return None
-        series_id_str, season_str, episode_str = parts
-        try:
-            return series_id_str, int(season_str), int(episode_str)
-        except ValueError:
-            return None
 
 
 __all__ = ["GetContinueWatchingUseCase"]

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from src.modules.media.domain.repositories import MovieRepository
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.watch_progress.application.dtos import (
     ContinueWatchingItem,
     ContinueWatchingOutput,
@@ -29,15 +29,18 @@ class GetContinueWatchingUseCase:
         self,
         progress_repository: WatchProgressRepository,
         movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
     ) -> None:
         """Initialize the use case.
 
         Args:
             progress_repository: Repository for watch progress.
             movie_repository: Repository for movie metadata.
+            series_repository: Repository for series metadata.
         """
         self._progress_repo = progress_repository
         self._movie_repo = movie_repository
+        self._series_repo = series_repository
 
     async def execute(self, input_dto: GetContinueWatchingInput) -> ContinueWatchingOutput:
         """Execute the use case.
@@ -81,24 +84,64 @@ class GetContinueWatchingUseCase:
             ContinueWatchingItem with metadata, or None if media not found.
         """
         if progress.media_type == "movie":
-            from src.modules.media.domain.value_objects import MovieId
+            return await self._enrich_movie(progress, lang)
+        if progress.media_type == "episode":
+            return await self._enrich_episode(progress, lang)
+        return None
 
-            movie = await self._movie_repo.find_by_id(MovieId(progress.media_id))
-            if not movie:
-                return None
-            return ContinueWatchingItem(
-                media_id=progress.media_id,
-                media_type=progress.media_type,
-                title=movie.get_title(lang),
-                poster_path=movie.poster_path.value if movie.poster_path else None,
-                backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
-                position_seconds=progress.position_seconds,
-                duration_seconds=progress.duration_seconds,
-                percentage=progress.percentage,
-                last_watched_at=progress.last_watched_at.isoformat(),
-            )
+    async def _enrich_movie(
+        self,
+        progress: WatchProgress,
+        lang: str,
+    ) -> ContinueWatchingItem | None:
+        """Enrich a movie progress record with metadata."""
+        from src.modules.media.domain.value_objects import MovieId
 
-        # TODO: episode support (requires series repo lookup)
+        movie = await self._movie_repo.find_by_id(MovieId(progress.media_id))
+        if not movie:
+            return None
+        return ContinueWatchingItem(
+            media_id=progress.media_id,
+            media_type=progress.media_type,
+            title=movie.get_title(lang),
+            poster_path=movie.poster_path.value if movie.poster_path else None,
+            backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+            position_seconds=progress.position_seconds,
+            duration_seconds=progress.duration_seconds,
+            percentage=progress.percentage,
+            last_watched_at=progress.last_watched_at.isoformat(),
+        )
+
+    async def _enrich_episode(
+        self,
+        progress: WatchProgress,
+        lang: str,
+    ) -> ContinueWatchingItem | None:
+        """Enrich an episode progress record with series metadata."""
+        from src.modules.media.domain.value_objects import EpisodeId
+
+        series = await self._series_repo.find_by_episode_id(EpisodeId(progress.media_id))
+        if not series:
+            return None
+
+        for season in series.seasons:
+            for episode in season.episodes:
+                if str(episode.id) == progress.media_id:
+                    return ContinueWatchingItem(
+                        media_id=progress.media_id,
+                        media_type=progress.media_type,
+                        title=episode.title.value,
+                        poster_path=series.poster_path.value if series.poster_path else None,
+                        backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+                        position_seconds=progress.position_seconds,
+                        duration_seconds=progress.duration_seconds,
+                        percentage=progress.percentage,
+                        last_watched_at=progress.last_watched_at.isoformat(),
+                        series_id=str(series.id),
+                        series_title=series.get_title(lang),
+                        season_number=season.season_number,
+                        episode_number=episode.episode_number,
+                    )
         return None
 
 

--- a/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
@@ -46,6 +46,17 @@ class WatchProgressRepository(ABC):
         """
 
     @abstractmethod
+    async def find_by_media_ids(self, media_ids: list[str]) -> dict[str, WatchProgress]:
+        """Find progress for multiple media items in a single query.
+
+        Args:
+            media_ids: List of external media IDs.
+
+        Returns:
+            Dict mapping media_id to WatchProgress for found records.
+        """
+
+    @abstractmethod
     async def delete(self, media_id: str) -> bool:
         """Soft-delete progress for a media item.
 

--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -74,6 +74,17 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         result = await self._session.execute(stmt)
         return [WatchProgressMapper.to_entity(m) for m in result.scalars().all()]
 
+    async def find_by_media_ids(self, media_ids: list[str]) -> dict[str, WatchProgress]:
+        """Find progress for multiple media items in a single query."""
+        if not media_ids:
+            return {}
+        stmt = select(WatchProgressModel).where(
+            WatchProgressModel.media_id.in_(media_ids),
+            WatchProgressModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        return {m.media_id: WatchProgressMapper.to_entity(m) for m in result.scalars().all()}
+
     async def delete(self, media_id: str) -> bool:
         """Soft-delete progress for a media item."""
         stmt = select(WatchProgressModel).where(

--- a/src/shared_kernel/episode_composite_id.py
+++ b/src/shared_kernel/episode_composite_id.py
@@ -1,0 +1,86 @@
+"""Shared helper for composite episode media IDs.
+
+The frontend identifies episodes using composite keys in the format
+``epi_{series_id}_{season_number}_{episode_number}`` (e.g.
+``epi_ser_Hy9VjMfILYZe_3_2``). This module provides build/parse
+utilities so the format is defined in a single place.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EpisodeCompositeId:
+    """Composite episode identifier used by the frontend.
+
+    Attributes:
+        series_id: External series ID (``ser_xxx`` format).
+        season_number: Season number.
+        episode_number: Episode number within the season.
+
+    Example:
+        >>> eid = EpisodeCompositeId.build("ser_Hy9VjMfILYZe", 3, 2)
+        >>> eid.media_id
+        'epi_ser_Hy9VjMfILYZe_3_2'
+        >>> EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_3_2")
+        EpisodeCompositeId(series_id='ser_Hy9VjMfILYZe', season_number=3, episode_number=2)
+    """
+
+    series_id: str
+    season_number: int
+    episode_number: int
+
+    @property
+    def media_id(self) -> str:
+        """Build the composite media_id string."""
+        return f"epi_{self.series_id}_{self.season_number}_{self.episode_number}"
+
+    @classmethod
+    def build(cls, series_id: str, season_number: int, episode_number: int) -> EpisodeCompositeId:
+        """Create from individual components.
+
+        Args:
+            series_id: External series ID.
+            season_number: Season number.
+            episode_number: Episode number.
+
+        Returns:
+            A new EpisodeCompositeId instance.
+        """
+        return cls(
+            series_id=series_id,
+            season_number=season_number,
+            episode_number=episode_number,
+        )
+
+    @classmethod
+    def parse(cls, media_id: str) -> EpisodeCompositeId | None:
+        """Parse a composite media_id string.
+
+        Args:
+            media_id: The composite media_id (e.g. ``epi_ser_XXX_S_E``).
+
+        Returns:
+            EpisodeCompositeId if valid, None otherwise.
+        """
+        if not media_id.startswith("epi_ser_"):
+            return None
+        # epi_ser_Hy9VjMfILYZe_3_2 → strip "epi_" → "ser_Hy9VjMfILYZe_3_2"
+        rest = media_id[4:]
+        parts = rest.rsplit("_", 2)
+        if len(parts) != 3:
+            return None
+        series_id_str, season_str, episode_str = parts
+        try:
+            return cls(
+                series_id=series_id_str,
+                season_number=int(season_str),
+                episode_number=int(episode_str),
+            )
+        except ValueError:
+            return None
+
+
+__all__ = ["EpisodeCompositeId"]

--- a/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
@@ -18,20 +18,32 @@ from src.modules.media.domain.value_objects import (
     SeasonId,
     Title,
 )
+from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+
+
+@pytest.fixture()
+def mock_progress_repo() -> AsyncMock:
+    """Create a mock WatchProgressRepository with empty results."""
+    repo = AsyncMock(spec=WatchProgressRepository)
+    repo.find_by_media_ids.return_value = {}
+    return repo
 
 
 class TestGetSeriesByIdUseCase:
     """Tests for GetSeriesByIdUseCase."""
 
     @pytest.mark.asyncio
-    async def test_should_return_series_when_found(self):
+    async def test_should_return_series_when_found(self, mock_progress_repo):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Breaking Bad",
             start_year=2008,
         )
         mock_repo.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
+        use_case = GetSeriesByIdUseCase(
+            series_repository=mock_repo,
+            progress_repository=mock_progress_repo,
+        )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
 
@@ -41,7 +53,7 @@ class TestGetSeriesByIdUseCase:
         assert result.is_ongoing is True
 
     @pytest.mark.asyncio
-    async def test_should_return_series_with_seasons(self):
+    async def test_should_return_series_with_seasons(self, mock_progress_repo):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Breaking Bad",
@@ -55,7 +67,10 @@ class TestGetSeriesByIdUseCase:
         )
         series = series.with_season(season)
         mock_repo.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
+        use_case = GetSeriesByIdUseCase(
+            series_repository=mock_repo,
+            progress_repository=mock_progress_repo,
+        )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
 
@@ -64,7 +79,7 @@ class TestGetSeriesByIdUseCase:
         assert result.seasons[0].season_number == 1
 
     @pytest.mark.asyncio
-    async def test_should_return_series_with_episodes(self):
+    async def test_should_return_series_with_episodes(self, mock_progress_repo):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Breaking Bad",
@@ -94,7 +109,10 @@ class TestGetSeriesByIdUseCase:
         season = season.with_episode(episode)
         series = series.with_season(season)
         mock_repo.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
+        use_case = GetSeriesByIdUseCase(
+            series_repository=mock_repo,
+            progress_repository=mock_progress_repo,
+        )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
 
@@ -106,14 +124,17 @@ class TestGetSeriesByIdUseCase:
         assert episode_output.duration_formatted == "01:00:00"
 
     @pytest.mark.asyncio
-    async def test_should_return_ongoing_status(self):
+    async def test_should_return_ongoing_status(self, mock_progress_repo):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Ongoing Show",
             start_year=2020,
         )
         mock_repo.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
+        use_case = GetSeriesByIdUseCase(
+            series_repository=mock_repo,
+            progress_repository=mock_progress_repo,
+        )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
 
@@ -121,7 +142,7 @@ class TestGetSeriesByIdUseCase:
         assert result.end_year is None
 
     @pytest.mark.asyncio
-    async def test_should_return_completed_status(self):
+    async def test_should_return_completed_status(self, mock_progress_repo):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Completed Show",
@@ -129,7 +150,10 @@ class TestGetSeriesByIdUseCase:
             end_year=2015,
         )
         mock_repo.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
+        use_case = GetSeriesByIdUseCase(
+            series_repository=mock_repo,
+            progress_repository=mock_progress_repo,
+        )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
 
@@ -137,10 +161,13 @@ class TestGetSeriesByIdUseCase:
         assert result.end_year == 2015
 
     @pytest.mark.asyncio
-    async def test_should_raise_not_found_when_series_missing(self):
+    async def test_should_raise_not_found_when_series_missing(self, mock_progress_repo):
         mock_repo = AsyncMock(spec=SeriesRepository)
         mock_repo.find_by_id.return_value = None
-        use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
+        use_case = GetSeriesByIdUseCase(
+            series_repository=mock_repo,
+            progress_repository=mock_progress_repo,
+        )
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(GetSeriesByIdInput(series_id="ser_nonexistent1"))
@@ -149,14 +176,17 @@ class TestGetSeriesByIdUseCase:
         assert exc_info.value.resource_id == "ser_nonexistent1"
 
     @pytest.mark.asyncio
-    async def test_should_handle_series_with_no_seasons(self):
+    async def test_should_handle_series_with_no_seasons(self, mock_progress_repo):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="New Show",
             start_year=2024,
         )
         mock_repo.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
+        use_case = GetSeriesByIdUseCase(
+            series_repository=mock_repo,
+            progress_repository=mock_progress_repo,
+        )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
 
@@ -165,7 +195,7 @@ class TestGetSeriesByIdUseCase:
         assert result.seasons == []
 
     @pytest.mark.asyncio
-    async def test_should_return_genres_as_strings(self):
+    async def test_should_return_genres_as_strings(self, mock_progress_repo):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Drama Show",
@@ -173,7 +203,10 @@ class TestGetSeriesByIdUseCase:
             genres=["Drama", "Thriller"],
         )
         mock_repo.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(series_repository=mock_repo)
+        use_case = GetSeriesByIdUseCase(
+            series_repository=mock_repo,
+            progress_repository=mock_progress_repo,
+        )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
 

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -1,0 +1,194 @@
+"""Tests for GetContinueWatchingUseCase - episode enrichment."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.domain.entities import Episode, Season, Series
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.value_objects import (
+    Duration,
+    EpisodeId,
+    FilePath,
+    MediaFile,
+    Resolution,
+    SeasonId,
+    SeriesId,
+    Title,
+)
+from src.modules.watch_progress.application.dtos import ContinueWatchingItem
+from src.modules.watch_progress.application.use_cases import GetContinueWatchingUseCase
+from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+
+
+def _make_progress(media_id: str, media_type: str = "episode") -> WatchProgress:
+    """Create a WatchProgress entity for testing."""
+    return WatchProgress(
+        media_id=media_id,
+        media_type=media_type,
+        position_seconds=1800,
+        duration_seconds=3600,
+        status="in_progress",
+        last_watched_at=datetime(2026, 4, 9, tzinfo=UTC),
+    )
+
+
+def _make_series_with_episode(
+    series_id: str = "ser_Hy9VjMfILYZe",
+) -> Series:
+    """Create a Series with one season and one episode for testing."""
+    series = Series.create(title="Test Series", start_year=2024)
+    # Override the generated ID
+    series = series.with_updates(id=SeriesId(series_id))
+    season = Season(
+        id=SeasonId.generate(),
+        series_id=series.id,
+        season_number=3,
+    )
+    episode = Episode(
+        id=EpisodeId.generate(),
+        series_id=series.id,
+        season_number=3,
+        episode_number=2,
+        title=Title("The Episode"),
+        duration=Duration(3600),
+        files=[
+            MediaFile(
+                file_path=FilePath("/series/test/s03e02.mkv"),
+                file_size=1_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+        ],
+    )
+    season = season.with_episode(episode)
+    series = series.with_season(season)
+    return series
+
+
+@pytest.fixture()
+def repos() -> tuple[AsyncMock, AsyncMock, AsyncMock]:
+    """Create mock repositories."""
+    progress_repo = AsyncMock(spec=WatchProgressRepository)
+    movie_repo = AsyncMock(spec=MovieRepository)
+    series_repo = AsyncMock(spec=SeriesRepository)
+    return progress_repo, movie_repo, series_repo
+
+
+class TestEnrichEpisode:
+    """Tests for episode enrichment in continue watching."""
+
+    @pytest.mark.asyncio
+    async def test_enrich_valid_composite_episode(self, repos):
+        progress_repo, movie_repo, series_repo = repos
+        series = _make_series_with_episode()
+        progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_2")
+        progress_repo.list_in_progress.return_value = [progress]
+        series_repo.find_by_id.return_value = series
+
+        use_case = GetContinueWatchingUseCase(
+            progress_repository=progress_repo,
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
+
+        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+
+        assert len(result.items) == 1
+        item = result.items[0]
+        assert isinstance(item, ContinueWatchingItem)
+        assert item.series_id == "ser_Hy9VjMfILYZe"
+        assert item.series_title == "Test Series"
+        assert item.season_number == 3
+        assert item.episode_number == 2
+        assert item.title == "The Episode"
+
+    @pytest.mark.asyncio
+    async def test_enrich_returns_none_for_standard_episode_id(self, repos):
+        progress_repo, movie_repo, series_repo = repos
+        progress = _make_progress("epi_03ZzYaQ77FaB")
+        progress_repo.list_in_progress.return_value = [progress]
+
+        use_case = GetContinueWatchingUseCase(
+            progress_repository=progress_repo,
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
+
+        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        assert len(result.items) == 0
+
+    @pytest.mark.asyncio
+    async def test_enrich_returns_none_for_missing_series(self, repos):
+        progress_repo, movie_repo, series_repo = repos
+        progress = _make_progress("epi_ser_NotExists123_1_1")
+        progress_repo.list_in_progress.return_value = [progress]
+        series_repo.find_by_id.return_value = None
+
+        use_case = GetContinueWatchingUseCase(
+            progress_repository=progress_repo,
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
+
+        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        assert len(result.items) == 0
+
+    @pytest.mark.asyncio
+    async def test_enrich_returns_none_for_missing_season(self, repos):
+        progress_repo, movie_repo, series_repo = repos
+        series = _make_series_with_episode()
+        # Request season 99 which doesn't exist
+        progress = _make_progress("epi_ser_Hy9VjMfILYZe_99_1")
+        progress_repo.list_in_progress.return_value = [progress]
+        series_repo.find_by_id.return_value = series
+
+        use_case = GetContinueWatchingUseCase(
+            progress_repository=progress_repo,
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
+
+        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        assert len(result.items) == 0
+
+    @pytest.mark.asyncio
+    async def test_enrich_returns_none_for_missing_episode(self, repos):
+        progress_repo, movie_repo, series_repo = repos
+        series = _make_series_with_episode()
+        # Request episode 99 in season 3 which doesn't exist
+        progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_99")
+        progress_repo.list_in_progress.return_value = [progress]
+        series_repo.find_by_id.return_value = series
+
+        use_case = GetContinueWatchingUseCase(
+            progress_repository=progress_repo,
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
+
+        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        assert len(result.items) == 0
+
+    @pytest.mark.asyncio
+    async def test_enrich_returns_none_for_malformed_media_id(self, repos):
+        progress_repo, movie_repo, series_repo = repos
+        progress = _make_progress("epi_ser_broken")
+        progress_repo.list_in_progress.return_value = [progress]
+
+        use_case = GetContinueWatchingUseCase(
+            progress_repository=progress_repo,
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
+
+        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        assert len(result.items) == 0

--- a/tests/shared_kernel/unit/test_episode_composite_id.py
+++ b/tests/shared_kernel/unit/test_episode_composite_id.py
@@ -1,0 +1,75 @@
+"""Tests for EpisodeCompositeId."""
+
+import pytest
+
+from src.shared_kernel.episode_composite_id import EpisodeCompositeId
+
+
+class TestEpisodeCompositeIdBuild:
+    """Tests for building composite IDs."""
+
+    def test_build_creates_correct_media_id(self):
+        eid = EpisodeCompositeId.build("ser_Hy9VjMfILYZe", 3, 2)
+        assert eid.media_id == "epi_ser_Hy9VjMfILYZe_3_2"
+
+    def test_build_stores_components(self):
+        eid = EpisodeCompositeId.build("ser_abc123def456", 1, 5)
+        assert eid.series_id == "ser_abc123def456"
+        assert eid.season_number == 1
+        assert eid.episode_number == 5
+
+    def test_build_with_large_numbers(self):
+        eid = EpisodeCompositeId.build("ser_XXXXXXXXXXXX", 25, 100)
+        assert eid.media_id == "epi_ser_XXXXXXXXXXXX_25_100"
+
+
+class TestEpisodeCompositeIdParse:
+    """Tests for parsing composite IDs."""
+
+    def test_parse_valid_composite_id(self):
+        eid = EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_3_2")
+        assert eid is not None
+        assert eid.series_id == "ser_Hy9VjMfILYZe"
+        assert eid.season_number == 3
+        assert eid.episode_number == 2
+
+    def test_parse_returns_none_for_standard_episode_id(self):
+        assert EpisodeCompositeId.parse("epi_03ZzYaQ77FaB") is None
+
+    def test_parse_returns_none_for_movie_id(self):
+        assert EpisodeCompositeId.parse("mov_abc123def456") is None
+
+    def test_parse_returns_none_for_empty_string(self):
+        assert EpisodeCompositeId.parse("") is None
+
+    def test_parse_returns_none_for_non_numeric_season(self):
+        assert EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_abc_2") is None
+
+    def test_parse_returns_none_for_non_numeric_episode(self):
+        assert EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_3_abc") is None
+
+    def test_parse_returns_none_for_missing_segments(self):
+        assert EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe") is None
+
+    def test_parse_returns_none_for_wrong_prefix(self):
+        assert EpisodeCompositeId.parse("epi_mov_something_1_2") is None
+
+
+class TestEpisodeCompositeIdRoundTrip:
+    """Tests for build/parse symmetry."""
+
+    @pytest.mark.parametrize(
+        ("series_id", "season", "episode"),
+        [
+            ("ser_Hy9VjMfILYZe", 3, 2),
+            ("ser_abc123def456", 1, 1),
+            ("ser_XXXXXXXXXXXX", 10, 25),
+        ],
+    )
+    def test_round_trip(self, series_id: str, season: int, episode: int) -> None:
+        built = EpisodeCompositeId.build(series_id, season, episode)
+        parsed = EpisodeCompositeId.parse(built.media_id)
+        assert parsed is not None
+        assert parsed.series_id == series_id
+        assert parsed.season_number == season
+        assert parsed.episode_number == episode


### PR DESCRIPTION
## Summary

- Add episode support to `GetContinueWatchingUseCase` by parsing composite media IDs (`epi_ser_XXX_S_E`) and looking up series metadata
- Enrich `EpisodeOutput` with watch progress fields (`progress_percentage`, `position_seconds`, `watch_status`, `last_watched_at`) in `GetSeriesByIdUseCase`
- Add `find_by_media_ids` batch method to `WatchProgressRepository` for efficient progress lookup
- Wire `SeriesRepository` into watch progress container and `WatchProgressRepository` into media container

## Test plan

- [ ] Verify continue watching section shows episodes with series title
- [ ] Verify clicking episode in continue watching starts playback
- [ ] Verify series detail page shows progress bars on watched episodes
- [ ] Verify resume button picks up the correct in-progress episode
- [ ] Run `make test` — 786 tests passing

## Summary by Sourcery

Add watch progress integration for series and episodes across continue-watching and series detail flows.

New Features:
- Surface episode watch progress and related metadata in the continue watching feed, including series context.
- Expose per-episode watch progress fields on the series detail endpoint output.

Enhancements:
- Batch load watch progress for all episodes in a series to avoid per-episode queries.
- Inject watch progress and series repositories into existing media and watch-progress containers for dependency wiring.

Tests:
- Extend GetSeriesByIdUseCase unit tests to work with a mocked WatchProgressRepository.