### PR TITLE
fix(infra): close database sessions per request to prevent connection leaks

### DIFF
--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -11,6 +11,7 @@ from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from src.building_blocks.infrastructure.in_process_event_bus import InProcessEventBus
+from src.config.persistence.session_manager import create_tracked_session
 from src.config.settings import Settings
 
 
@@ -66,7 +67,7 @@ class InfrastructureContainer(containers.DeclarativeContainer):  # type: ignore[
     )
 
     session = providers.Factory(
-        lambda factory: factory(),
+        create_tracked_session,
         factory=session_factory,
     )
 

--- a/src/config/persistence/session_manager.py
+++ b/src/config/persistence/session_manager.py
@@ -1,0 +1,56 @@
+"""Per-request session lifecycle management.
+
+Tracks AsyncSession instances created during a request and ensures
+they are closed when the request finishes, preventing connection leaks.
+"""
+
+from contextvars import ContextVar
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+_request_sessions: ContextVar[list[AsyncSession]] = ContextVar(
+    "_request_sessions",
+    default=[],
+)
+
+
+def create_tracked_session(factory: async_sessionmaker[AsyncSession]) -> AsyncSession:
+    """Create a session and register it for cleanup at request end.
+
+    Args:
+        factory: The async_sessionmaker to create the session from.
+
+    Returns:
+        A new AsyncSession that will be closed automatically.
+    """
+    session = factory()
+    try:
+        sessions = _request_sessions.get()
+    except LookupError:
+        # No request context (e.g. startup code) — session is untracked
+        return session
+    sessions.append(session)
+    return session
+
+
+class SessionCleanupMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
+    """Middleware that closes all tracked sessions after each request."""
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        """Run the request and close tracked sessions afterwards."""
+        sessions: list[AsyncSession] = []
+        token = _request_sessions.set(sessions)
+        try:
+            response = await call_next(request)
+            return response
+        finally:
+            for session in sessions:
+                await session.close()
+            _request_sessions.reset(token)

--- a/src/config/persistence/session_manager.py
+++ b/src/config/persistence/session_manager.py
@@ -4,6 +4,7 @@ Tracks AsyncSession instances created during a request and ensures
 they are closed when the request finishes, preventing connection leaks.
 """
 
+import logging
 from contextvars import ContextVar
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -11,9 +12,9 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 
-_request_sessions: ContextVar[list[AsyncSession]] = ContextVar(
+_request_sessions: ContextVar[list[AsyncSession] | None] = ContextVar(
     "_request_sessions",
-    default=[],
+    default=None,
 )
 
 
@@ -27,12 +28,9 @@ def create_tracked_session(factory: async_sessionmaker[AsyncSession]) -> AsyncSe
         A new AsyncSession that will be closed automatically.
     """
     session = factory()
-    try:
-        sessions = _request_sessions.get()
-    except LookupError:
-        # No request context (e.g. startup code) — session is untracked
-        return session
-    sessions.append(session)
+    sessions = _request_sessions.get()
+    if sessions is not None:
+        sessions.append(session)
     return session
 
 
@@ -52,5 +50,11 @@ class SessionCleanupMiddleware(BaseHTTPMiddleware):  # type: ignore[misc]
             return response
         finally:
             for session in sessions:
-                await session.close()
+                try:
+                    await session.close()
+                except Exception:
+                    logging.getLogger(__name__).debug(
+                        "Failed to close session",
+                        exc_info=True,
+                    )
             _request_sessions.reset(token)

--- a/src/main.py
+++ b/src/main.py
@@ -128,6 +128,11 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
+    # Session cleanup middleware (must be added before CORS)
+    from src.config.persistence.session_manager import SessionCleanupMiddleware
+
+    app.add_middleware(SessionCleanupMiddleware)
+
     # CORS middleware
     app.add_middleware(
         CORSMiddleware,


### PR DESCRIPTION
## Summary

- Add `SessionCleanupMiddleware` that tracks `AsyncSession` instances via `contextvars` and closes them when each request finishes
- Replace bare `factory()` call in DI container with `create_tracked_session()` that registers sessions for automatic cleanup
- Prevents SQLAlchemy "garbage collector cleaning up non-checked-in connection" warnings during concurrent requests

## Test plan

- [ ] Start dev server and trigger concurrent requests (e.g. home page load with many watchlist checks)
- [ ] Verify no "garbage collector cleaning up non-checked-in connection" warnings appear
- [ ] Run `make test` — 806 tests passing

## Summary by Sourcery

Ensure database sessions created during a request are tracked and cleaned up at the end of the request to prevent connection leaks.

Enhancements:
- Add per-request session tracking and cleanup via SessionCleanupMiddleware to automatically close AsyncSession instances.
- Update the infrastructure DI container to create tracked sessions instead of bare factory sessions for safer connection management.