### PR TITLE
refactor(media): move MediaCreatedEvent to media bounded context

### DIFF
--- a/src/building_blocks/domain/__init__.py
+++ b/src/building_blocks/domain/__init__.py
@@ -12,7 +12,7 @@ from src.building_blocks.domain.errors import (
     ExceptionDetail,
     Severity,
 )
-from src.building_blocks.domain.events import DomainEvent, MediaCreatedEvent
+from src.building_blocks.domain.events import DomainEvent
 from src.building_blocks.domain.external_id import (
     BASE62_ALPHABET,
     RANDOM_PART_LENGTH,
@@ -46,7 +46,6 @@ __all__ = [
     "ExternalId",
     "FloatValueObject",
     "IntValueObject",
-    "MediaCreatedEvent",
     "RANDOM_PART_LENGTH",
     "Severity",
     "StringValueObject",

--- a/src/building_blocks/domain/events.py
+++ b/src/building_blocks/domain/events.py
@@ -1,4 +1,4 @@
-"""Base domain event and media-specific events."""
+"""Base domain event."""
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -15,17 +15,4 @@ class DomainEvent:
     occurred_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 
 
-@dataclass(frozen=True)
-class MediaCreatedEvent(DomainEvent):
-    """Emitted when a new movie or series is created.
-
-    Attributes:
-        media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media ("movie" or "series").
-    """
-
-    media_id: str = ""
-    media_type: str = ""
-
-
-__all__ = ["DomainEvent", "MediaCreatedEvent"]
+__all__ = ["DomainEvent"]

--- a/src/building_blocks/infrastructure/in_process_event_bus.py
+++ b/src/building_blocks/infrastructure/in_process_event_bus.py
@@ -18,8 +18,8 @@ class InProcessEventBus(EventBus):
 
     Example:
         >>> bus = InProcessEventBus()
-        >>> bus.subscribe(MediaCreatedEvent, my_handler)
-        >>> await bus.publish(MediaCreatedEvent(media_id="mov_abc", media_type="movie"))
+        >>> bus.subscribe(MyEvent, my_handler)
+        >>> await bus.publish(MyEvent())
     """
 
     def __init__(self) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -95,8 +95,8 @@ def _subscribe_event_handlers(container: ApplicationContainer) -> None:
     Centralises event handler registration so it stays alongside
     the rest of the container configuration.
     """
-    from src.building_blocks.domain.events import MediaCreatedEvent
     from src.modules.media.application.event_handlers import OnMediaCreatedHandler
+    from src.modules.media.domain.events import MediaCreatedEvent
 
     event_bus = container.infrastructure.event_bus()
     handler = OnMediaCreatedHandler(

--- a/src/modules/media/application/event_handlers/on_media_created.py
+++ b/src/modules/media/application/event_handlers/on_media_created.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Awaitable, Callable
 
 from src.building_blocks.application.event_bus import EventHandler
-from src.building_blocks.domain.events import DomainEvent, MediaCreatedEvent
+from src.building_blocks.domain.events import DomainEvent
 from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
 from src.modules.media.application.use_cases.enrich_movie_metadata import (
     EnrichMovieMetadataUseCase,
@@ -12,6 +12,7 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
 from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
 )
+from src.modules.media.domain.events import MediaCreatedEvent
 
 _logger = logging.getLogger(__name__)
 

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -7,8 +7,8 @@ from typing import Any, Self
 from pydantic import Field, field_validator
 
 from src.building_blocks.domain import AggregateRoot
-from src.building_blocks.domain.events import MediaCreatedEvent
 from src.modules.media.domain.entities.file_variant_mixin import FileVariantMixin
+from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.value_objects import (
     Duration,
     FilePath,

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -8,7 +8,7 @@ from pydantic import Field, field_validator, model_validator
 
 from src.building_blocks.domain import AggregateRoot
 from src.building_blocks.domain.errors import BusinessRuleViolationException
-from src.building_blocks.domain.events import MediaCreatedEvent
+from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.rule_codes import MediaRuleCodes
 from src.modules.media.domain.value_objects import (
     Genre,

--- a/src/modules/media/domain/events.py
+++ b/src/modules/media/domain/events.py
@@ -1,0 +1,21 @@
+"""Domain events for the Media bounded context."""
+
+from dataclasses import dataclass
+
+from src.building_blocks.domain.events import DomainEvent
+
+
+@dataclass(frozen=True)
+class MediaCreatedEvent(DomainEvent):
+    """Emitted when a new movie or series is created.
+
+    Attributes:
+        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_type: Type of media ("movie" or "series").
+    """
+
+    media_id: str = ""
+    media_type: str = ""
+
+
+__all__ = ["MediaCreatedEvent"]

--- a/tests/modules/media/unit/domain/entities/test_movie.py
+++ b/tests/modules/media/unit/domain/entities/test_movie.py
@@ -406,8 +406,8 @@ class TestMovieEvents:
     """Tests for Movie domain events."""
 
     def test_should_emit_media_created_event_on_create(self):
-        from src.building_blocks.domain.events import MediaCreatedEvent
         from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.events import MediaCreatedEvent
 
         movie = Movie.create(
             title="Inception",
@@ -440,7 +440,9 @@ class TestMovieEvents:
             resolution="1080p",
         )
 
-        movie.add_event({"type": "CustomEvent", "movie_id": str(movie.id)})
+        from src.building_blocks.domain.events import DomainEvent
+
+        movie.add_event(DomainEvent())
 
         events = movie.pull_events()
 
@@ -449,8 +451,8 @@ class TestMovieEvents:
         assert movie.has_pending_events is False
 
     def test_events_survive_with_updates(self):
-        from src.building_blocks.domain.events import MediaCreatedEvent
         from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.events import MediaCreatedEvent
         from src.modules.media.domain.value_objects import Year
 
         movie = Movie.create(

--- a/tests/modules/media/unit/domain/entities/test_movie.py
+++ b/tests/modules/media/unit/domain/entities/test_movie.py
@@ -440,9 +440,15 @@ class TestMovieEvents:
             resolution="1080p",
         )
 
+        from dataclasses import dataclass
+
         from src.building_blocks.domain.events import DomainEvent
 
-        movie.add_event(DomainEvent())
+        @dataclass(frozen=True)
+        class _FakeEvent(DomainEvent):
+            pass
+
+        movie.add_event(_FakeEvent())
 
         events = movie.pull_events()
 

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -187,9 +187,15 @@ class TestSeriesEvents:
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
+        from dataclasses import dataclass
+
         from src.building_blocks.domain.events import DomainEvent
 
-        series.add_event(DomainEvent())
+        @dataclass(frozen=True)
+        class _FakeEvent(DomainEvent):
+            pass
+
+        series.add_event(_FakeEvent())
 
         events = series.pull_events()
 

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -167,8 +167,8 @@ class TestSeriesEvents:
     """Tests for Series domain events."""
 
     def test_should_emit_media_created_event_on_create(self):
-        from src.building_blocks.domain.events import MediaCreatedEvent
         from src.modules.media.domain.entities import Series
+        from src.modules.media.domain.events import MediaCreatedEvent
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
@@ -187,7 +187,9 @@ class TestSeriesEvents:
 
         series = Series.create(title="Breaking Bad", start_year=2008)
 
-        series.add_event({"type": "CustomEvent", "series_id": str(series.id)})
+        from src.building_blocks.domain.events import DomainEvent
+
+        series.add_event(DomainEvent())
 
         events = series.pull_events()
 


### PR DESCRIPTION
## Summary

- Move `MediaCreatedEvent` from `building_blocks/domain/events.py` to `modules/media/domain/events.py`
- `building_blocks` should be domain-agnostic — only the base `DomainEvent` class belongs there
- Update all imports across entities, event handlers, main.py, and tests
- Fix test type errors where `add_event()` received a dict instead of `DomainEvent`

## Test plan

- [ ] Run `make test` — 806 tests passing
- [ ] Verify media scan still triggers auto-enrichment via domain events

## Summary by Sourcery

Move the media-specific domain event into the media bounded context and align usages accordingly.

Enhancements:
- Relocate MediaCreatedEvent from the shared building_blocks domain to src.modules.media.domain.events to keep building_blocks domain-agnostic.
- Adjust event bus documentation example to use a generic event instead of MediaCreatedEvent.
- Remove MediaCreatedEvent from the public exports of the building_blocks.domain package.

Tests:
- Update media domain entity tests to import MediaCreatedEvent from the media module and to add only DomainEvent instances to aggregates' event lists.