### PR TITLE
feat(watch-progress): deduplicate series in continue watching

### DIFF
--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -1,16 +1,24 @@
 """GetContinueWatchingUseCase - List in-progress items with media details."""
 
-import logging
+from __future__ import annotations
 
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+import logging
+from typing import TYPE_CHECKING
+
 from src.modules.watch_progress.application.dtos import (
     ContinueWatchingItem,
     ContinueWatchingOutput,
     GetContinueWatchingInput,
 )
-from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 from src.shared_kernel.episode_composite_id import EpisodeCompositeId
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from src.modules.media.domain.entities import Series
+    from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+    from src.modules.watch_progress.domain.entities import WatchProgress
+    from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 
 _logger = logging.getLogger(__name__)
 
@@ -20,6 +28,10 @@ class GetContinueWatchingUseCase:
 
     Joins progress records with movie/series data to provide title and
     poster for the "Continue Watching" UI section.
+
+    For series, returns at most one item per series — the best episode
+    to resume. If no episode is in-progress but the series has unwatched
+    episodes after completed ones, the next unwatched episode is returned.
 
     Example:
         >>> use_case = GetContinueWatchingUseCase(progress_repo, movie_repo, series_repo)
@@ -52,85 +64,193 @@ class GetContinueWatchingUseCase:
         Returns:
             ContinueWatchingOutput with items including media metadata.
         """
-        progress_list = await self._progress_repo.list_in_progress(limit=input_dto.limit)
-        _logger.info("Found %d in-progress items", len(progress_list))
+        progress_list = await self._progress_repo.list_recently_watched(limit=input_dto.limit)
 
         items: list[ContinueWatchingItem] = []
+        seen_series: set[str] = set()
+
         for progress in progress_list:
-            _logger.info(
-                "Enriching progress: media_id=%s, media_type=%s",
-                progress.media_id,
-                progress.media_type,
-            )
-            item = await self._enrich_with_metadata(progress, input_dto.lang)
-            if item:
-                items.append(item)
-            else:
-                _logger.warning("Could not find media for progress: %s", progress.media_id)
+            if progress.media_type == "movie":
+                if progress.status != "in_progress":
+                    continue
+                item = await self._enrich_movie(progress, input_dto.lang)
+                if item:
+                    items.append(item)
+            elif progress.media_type == "episode":
+                parsed = EpisodeCompositeId.parse(progress.media_id)
+                if not parsed or parsed.series_id in seen_series:
+                    continue
+                seen_series.add(parsed.series_id)
+                item = await self._resolve_series_episode(
+                    parsed.series_id,
+                    input_dto.lang,
+                )
+                if item:
+                    items.append(item)
 
         return ContinueWatchingOutput(items=items)
 
-    async def _enrich_with_metadata(
+    async def _resolve_series_episode(
         self,
-        progress: WatchProgress,
+        series_id: str,
         lang: str,
     ) -> ContinueWatchingItem | None:
-        """Enrich a progress record with media metadata.
+        """Find the best episode to resume for a series.
+
+        Priority:
+        1. Highest-numbered in-progress episode
+        2. Next unwatched episode after the last completed one
 
         Args:
-            progress: The watch progress record.
+            series_id: External series ID.
             lang: Language code for localized metadata.
 
         Returns:
-            ContinueWatchingItem with metadata, or None if media not found.
+            ContinueWatchingItem for the best episode, or None.
         """
-        if progress.media_type == "movie":
-            return await self._enrich_movie(progress, lang)
-        if progress.media_type == "episode":
-            return await self._enrich_episode(progress, lang)
+        from src.modules.media.domain.value_objects import SeriesId
+
+        series = await self._series_repo.find_by_id(SeriesId(series_id))
+        if not series:
+            return None
+
+        # Build composite IDs for all episodes and fetch progress in batch
+        all_episodes = [
+            (s.season_number, ep.episode_number)
+            for s in sorted(series.seasons, key=lambda s: s.season_number)
+            for ep in sorted(s.episodes, key=lambda e: e.episode_number)
+        ]
+        if not all_episodes:
+            return None
+
+        composite_ids = [
+            EpisodeCompositeId.build(series_id, sn, en).media_id for sn, en in all_episodes
+        ]
+        progress_map = await self._progress_repo.find_by_media_ids(composite_ids)
+
+        best_in_progress, last_completed = self._scan_episode_progress(
+            series_id,
+            all_episodes,
+            progress_map,
+        )
+
+        target = best_in_progress or self._find_next_unwatched(
+            series_id, all_episodes, progress_map, last_completed
+        )
+        if not target:
+            return None
+
+        # Use the most recent last_watched_at from any episode in the series
+        # so the item sorts correctly even for "next unwatched" episodes
+        latest_watched_at = max(
+            (p.last_watched_at for p in progress_map.values()),
+            default=None,
+        )
+
+        return self._build_series_item(
+            series,
+            target,
+            progress_map,
+            lang,
+            fallback_last_watched=latest_watched_at,
+        )
+
+    @staticmethod
+    def _scan_episode_progress(
+        series_id: str,
+        all_episodes: list[tuple[int, int]],
+        progress_map: dict[str, WatchProgress],
+    ) -> tuple[tuple[int, int] | None, tuple[int, int] | None]:
+        """Scan episodes and return (highest in-progress, highest completed)."""
+        best_in_progress: tuple[int, int] | None = None
+        last_completed: tuple[int, int] | None = None
+        for season_num, ep_num in all_episodes:
+            key = EpisodeCompositeId.build(series_id, season_num, ep_num).media_id
+            progress = progress_map.get(key)
+            if not progress:
+                continue
+            coords = (season_num, ep_num)
+            if progress.status == "in_progress" and (
+                not best_in_progress or coords > best_in_progress
+            ):
+                best_in_progress = coords
+            elif progress.status == "completed" and (not last_completed or coords > last_completed):
+                last_completed = coords
+        return best_in_progress, last_completed
+
+    @staticmethod
+    def _find_next_unwatched(
+        series_id: str,
+        all_episodes: list[tuple[int, int]],
+        progress_map: dict[str, WatchProgress],
+        last_completed: tuple[int, int] | None,
+    ) -> tuple[int, int] | None:
+        """Find the next unwatched episode after the last completed one."""
+        if not last_completed:
+            return None
+        past_completed = False
+        for season_num, ep_num in all_episodes:
+            if (season_num, ep_num) == last_completed:
+                past_completed = True
+                continue
+            if past_completed:
+                key = EpisodeCompositeId.build(series_id, season_num, ep_num).media_id
+                if key not in progress_map:
+                    return (season_num, ep_num)
         return None
 
-    def _build_item(
+    def _build_series_item(
         self,
-        progress: WatchProgress,
-        *,
-        title: str,
-        poster_path: str | None,
-        backdrop_path: str | None,
-        series_id: str | None = None,
-        series_title: str | None = None,
-        season_number: int | None = None,
-        episode_number: int | None = None,
-    ) -> ContinueWatchingItem:
-        """Build a ContinueWatchingItem from progress and media metadata.
+        series: Series,
+        target: tuple[int, int],
+        progress_map: dict[str, WatchProgress],
+        lang: str,
+        fallback_last_watched: datetime | None = None,
+    ) -> ContinueWatchingItem | None:
+        """Build a ContinueWatchingItem for a specific series episode.
 
         Args:
-            progress: The watch progress record.
-            title: Display title.
-            poster_path: Poster image path.
-            backdrop_path: Backdrop image path.
-            series_id: Series external ID (episodes only).
-            series_title: Series title (episodes only).
-            season_number: Season number (episodes only).
-            episode_number: Episode number (episodes only).
+            series: The series entity.
+            target: Tuple of (season_number, episode_number).
+            progress_map: Map of composite IDs to progress.
+            lang: Language code.
+            fallback_last_watched: Fallback timestamp for unwatched episodes.
 
         Returns:
-            A fully populated ContinueWatchingItem.
+            ContinueWatchingItem or None if episode not found.
         """
+        season_num, ep_num = target
+        season = series.get_season(season_num)
+        if not season:
+            return None
+        episode = season.get_episode(ep_num)
+        if not episode:
+            return None
+
+        series_id = str(series.id)
+        composite_id = EpisodeCompositeId.build(series_id, season_num, ep_num).media_id
+        progress = progress_map.get(composite_id)
+
+        last_watched = (
+            progress.last_watched_at.isoformat()
+            if progress
+            else (fallback_last_watched.isoformat() if fallback_last_watched else "")
+        )
+
         return ContinueWatchingItem(
-            media_id=progress.media_id,
-            media_type=progress.media_type,
-            title=title,
-            poster_path=poster_path,
-            backdrop_path=backdrop_path,
-            position_seconds=progress.position_seconds,
-            duration_seconds=progress.duration_seconds,
-            percentage=progress.percentage,
-            last_watched_at=progress.last_watched_at.isoformat(),
+            media_id=composite_id,
+            media_type="episode",
+            title=episode.title.value,
+            poster_path=series.poster_path.value if series.poster_path else None,
+            backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+            position_seconds=progress.position_seconds if progress else 0,
+            duration_seconds=progress.duration_seconds if progress else episode.duration.value,
+            percentage=progress.percentage if progress else 0.0,
+            last_watched_at=last_watched,
             series_id=series_id,
-            series_title=series_title,
-            season_number=season_number,
-            episode_number=episode_number,
+            series_title=series.get_title(lang),
+            season_number=season_num,
+            episode_number=ep_num,
         )
 
     async def _enrich_movie(
@@ -144,50 +264,16 @@ class GetContinueWatchingUseCase:
         movie = await self._movie_repo.find_by_id(MovieId(progress.media_id))
         if not movie:
             return None
-        return self._build_item(
-            progress,
+        return ContinueWatchingItem(
+            media_id=progress.media_id,
+            media_type=progress.media_type,
             title=movie.get_title(lang),
             poster_path=movie.poster_path.value if movie.poster_path else None,
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
-        )
-
-    async def _enrich_episode(
-        self,
-        progress: WatchProgress,
-        lang: str,
-    ) -> ContinueWatchingItem | None:
-        """Enrich an episode progress record with series metadata.
-
-        Parses the composite media_id format (``epi_ser_XXX_S_E``)
-        to look up the series, season, and episode.
-        """
-        parsed = EpisodeCompositeId.parse(progress.media_id)
-        if not parsed:
-            return None
-
-        from src.modules.media.domain.value_objects import SeriesId
-
-        series = await self._series_repo.find_by_id(SeriesId(parsed.series_id))
-        if not series:
-            return None
-
-        season = series.get_season(parsed.season_number)
-        if not season:
-            return None
-
-        episode = season.get_episode(parsed.episode_number)
-        if not episode:
-            return None
-
-        return self._build_item(
-            progress,
-            title=episode.title.value,
-            poster_path=series.poster_path.value if series.poster_path else None,
-            backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-            series_id=str(series.id),
-            series_title=series.get_title(lang),
-            season_number=season.season_number,
-            episode_number=episode.episode_number,
+            position_seconds=progress.position_seconds,
+            duration_seconds=progress.duration_seconds,
+            percentage=progress.percentage,
+            last_watched_at=progress.last_watched_at.isoformat(),
         )
 
 

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from src.modules.watch_progress.application.dtos import (
@@ -21,6 +22,17 @@ if TYPE_CHECKING:
     from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 
 _logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EpisodeCandidate:
+    """An episode with its coordinates and optional progress."""
+
+    series_id: str
+    season_number: int
+    episode_number: int
+    media_id: str
+    progress: WatchProgress | None
 
 
 class GetContinueWatchingUseCase:
@@ -114,123 +126,120 @@ class GetContinueWatchingUseCase:
         if not series:
             return None
 
-        # Build composite IDs for all episodes and fetch progress in batch
-        all_episodes = [
-            (s.season_number, ep.episode_number)
-            for s in sorted(series.seasons, key=lambda s: s.season_number)
-            for ep in sorted(s.episodes, key=lambda e: e.episode_number)
-        ]
-        if not all_episodes:
+        candidates = await self._build_candidates(series_id, series)
+        if not candidates:
             return None
 
-        composite_ids = [
-            EpisodeCompositeId.build(series_id, sn, en).media_id for sn, en in all_episodes
-        ]
-        progress_map = await self._progress_repo.find_by_media_ids(composite_ids)
-
-        best_in_progress, last_completed = self._scan_episode_progress(
-            series_id,
-            all_episodes,
-            progress_map,
-        )
-
-        target = best_in_progress or self._find_next_unwatched(
-            series_id, all_episodes, progress_map, last_completed
-        )
-        if not target:
+        best, latest_watched_at = self._pick_series_episode(candidates)
+        if not best:
             return None
 
-        # Use the most recent last_watched_at from any episode in the series
-        # so the item sorts correctly even for "next unwatched" episodes
-        latest_watched_at = max(
-            (p.last_watched_at for p in progress_map.values()),
-            default=None,
-        )
+        return self._build_series_item(series, best, lang, latest_watched_at)
 
-        return self._build_series_item(
-            series,
-            target,
-            progress_map,
-            lang,
-            fallback_last_watched=latest_watched_at,
-        )
+    async def _build_candidates(
+        self,
+        series_id: str,
+        series: Series,
+    ) -> list[EpisodeCandidate]:
+        """Build EpisodeCandidate list with progress for all episodes."""
+        candidates: list[EpisodeCandidate] = []
+        media_ids: list[str] = []
+
+        for s in sorted(series.seasons, key=lambda s: s.season_number):
+            for ep in sorted(s.episodes, key=lambda e: e.episode_number):
+                mid = EpisodeCompositeId.build(
+                    series_id,
+                    s.season_number,
+                    ep.episode_number,
+                ).media_id
+                media_ids.append(mid)
+                candidates.append(
+                    EpisodeCandidate(
+                        series_id=series_id,
+                        season_number=s.season_number,
+                        episode_number=ep.episode_number,
+                        media_id=mid,
+                        progress=None,
+                    )
+                )
+
+        if not candidates:
+            return []
+
+        progress_map = await self._progress_repo.find_by_media_ids(media_ids)
+        for candidate in candidates:
+            candidate.progress = progress_map.get(candidate.media_id)
+
+        return candidates
 
     @staticmethod
-    def _scan_episode_progress(
-        series_id: str,
-        all_episodes: list[tuple[int, int]],
-        progress_map: dict[str, WatchProgress],
-    ) -> tuple[tuple[int, int] | None, tuple[int, int] | None]:
-        """Scan episodes and return (highest in-progress, highest completed)."""
-        best_in_progress: tuple[int, int] | None = None
-        last_completed: tuple[int, int] | None = None
-        for season_num, ep_num in all_episodes:
-            key = EpisodeCompositeId.build(series_id, season_num, ep_num).media_id
-            progress = progress_map.get(key)
-            if not progress:
-                continue
-            coords = (season_num, ep_num)
-            if progress.status == "in_progress" and (
-                not best_in_progress or coords > best_in_progress
-            ):
-                best_in_progress = coords
-            elif progress.status == "completed" and (not last_completed or coords > last_completed):
-                last_completed = coords
-        return best_in_progress, last_completed
+    def _pick_series_episode(
+        candidates: list[EpisodeCandidate],
+    ) -> tuple[EpisodeCandidate | None, datetime | None]:
+        """Pick the best episode to resume and the latest watched timestamp.
 
-    @staticmethod
-    def _find_next_unwatched(
-        series_id: str,
-        all_episodes: list[tuple[int, int]],
-        progress_map: dict[str, WatchProgress],
-        last_completed: tuple[int, int] | None,
-    ) -> tuple[int, int] | None:
-        """Find the next unwatched episode after the last completed one."""
-        if not last_completed:
-            return None
-        past_completed = False
-        for season_num, ep_num in all_episodes:
-            if (season_num, ep_num) == last_completed:
-                past_completed = True
+        Args:
+            candidates: Ordered list of episode candidates with progress.
+
+        Returns:
+            Tuple of (best candidate, latest last_watched_at).
+        """
+        best_in_progress: EpisodeCandidate | None = None
+        last_completed_idx: int | None = None
+        latest_watched_at: datetime | None = None
+
+        for idx, ep in enumerate(candidates):
+            if not ep.progress:
                 continue
-            if past_completed:
-                key = EpisodeCompositeId.build(series_id, season_num, ep_num).media_id
-                if key not in progress_map:
-                    return (season_num, ep_num)
-        return None
+            if not latest_watched_at or ep.progress.last_watched_at > latest_watched_at:
+                latest_watched_at = ep.progress.last_watched_at
+
+            if ep.progress.status == "in_progress":
+                coords = (ep.season_number, ep.episode_number)
+                if not best_in_progress or coords > (
+                    best_in_progress.season_number,
+                    best_in_progress.episode_number,
+                ):
+                    best_in_progress = ep
+            elif ep.progress.status == "completed":
+                last_completed_idx = max(last_completed_idx or -1, idx)
+
+        if best_in_progress:
+            return best_in_progress, latest_watched_at
+
+        if last_completed_idx is not None:
+            for ep in candidates[last_completed_idx + 1 :]:
+                if ep.progress is None:
+                    return ep, latest_watched_at
+
+        return None, latest_watched_at
 
     def _build_series_item(
         self,
         series: Series,
-        target: tuple[int, int],
-        progress_map: dict[str, WatchProgress],
+        candidate: EpisodeCandidate,
         lang: str,
         fallback_last_watched: datetime | None = None,
     ) -> ContinueWatchingItem | None:
-        """Build a ContinueWatchingItem for a specific series episode.
+        """Build a ContinueWatchingItem from a resolved candidate.
 
         Args:
             series: The series entity.
-            target: Tuple of (season_number, episode_number).
-            progress_map: Map of composite IDs to progress.
+            candidate: The selected episode candidate.
             lang: Language code.
             fallback_last_watched: Fallback timestamp for unwatched episodes.
 
         Returns:
-            ContinueWatchingItem or None if episode not found.
+            ContinueWatchingItem or None if episode not found in series.
         """
-        season_num, ep_num = target
-        season = series.get_season(season_num)
+        season = series.get_season(candidate.season_number)
         if not season:
             return None
-        episode = season.get_episode(ep_num)
+        episode = season.get_episode(candidate.episode_number)
         if not episode:
             return None
 
-        series_id = str(series.id)
-        composite_id = EpisodeCompositeId.build(series_id, season_num, ep_num).media_id
-        progress = progress_map.get(composite_id)
-
+        progress = candidate.progress
         last_watched = (
             progress.last_watched_at.isoformat()
             if progress
@@ -238,7 +247,7 @@ class GetContinueWatchingUseCase:
         )
 
         return ContinueWatchingItem(
-            media_id=composite_id,
+            media_id=candidate.media_id,
             media_type="episode",
             title=episode.title.value,
             poster_path=series.poster_path.value if series.poster_path else None,
@@ -247,10 +256,10 @@ class GetContinueWatchingUseCase:
             duration_seconds=progress.duration_seconds if progress else episode.duration.value,
             percentage=progress.percentage if progress else 0.0,
             last_watched_at=last_watched,
-            series_id=series_id,
+            series_id=str(series.id),
             series_title=series.get_title(lang),
-            season_number=season_num,
-            episode_number=ep_num,
+            season_number=candidate.season_number,
+            episode_number=candidate.episode_number,
         )
 
     async def _enrich_movie(

--- a/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
@@ -46,6 +46,17 @@ class WatchProgressRepository(ABC):
         """
 
     @abstractmethod
+    async def list_recently_watched(self, limit: int = 20) -> list[WatchProgress]:
+        """List recently watched items (in_progress + completed) ordered by last watched.
+
+        Args:
+            limit: Maximum number of items to return.
+
+        Returns:
+            List of WatchProgress with status "in_progress" or "completed".
+        """
+
+    @abstractmethod
     async def find_by_media_ids(self, media_ids: list[str]) -> dict[str, WatchProgress]:
         """Find progress for multiple media items in a single query.
 

--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -74,6 +74,20 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         result = await self._session.execute(stmt)
         return [WatchProgressMapper.to_entity(m) for m in result.scalars().all()]
 
+    async def list_recently_watched(self, limit: int = 20) -> list[WatchProgress]:
+        """List recently watched items (in_progress + completed)."""
+        stmt = (
+            select(WatchProgressModel)
+            .where(
+                WatchProgressModel.status.in_(["in_progress", "completed"]),
+                WatchProgressModel.deleted_at.is_(None),
+            )
+            .order_by(WatchProgressModel.last_watched_at.desc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [WatchProgressMapper.to_entity(m) for m in result.scalars().all()]
+
     async def find_by_media_ids(self, media_ids: list[str]) -> dict[str, WatchProgress]:
         """Find progress for multiple media items in a single query."""
         if not media_ids:

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -85,7 +85,10 @@ class TestEnrichEpisode:
         progress_repo, movie_repo, series_repo = repos
         series = _make_series_with_episode()
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_2")
-        progress_repo.list_in_progress.return_value = [progress]
+        progress_repo.list_recently_watched.return_value = [progress]
+        progress_repo.find_by_media_ids.return_value = {
+            "epi_ser_Hy9VjMfILYZe_3_2": progress,
+        }
         series_repo.find_by_id.return_value = series
 
         use_case = GetContinueWatchingUseCase(
@@ -110,7 +113,7 @@ class TestEnrichEpisode:
     async def test_enrich_returns_none_for_standard_episode_id(self, repos):
         progress_repo, movie_repo, series_repo = repos
         progress = _make_progress("epi_03ZzYaQ77FaB")
-        progress_repo.list_in_progress.return_value = [progress]
+        progress_repo.list_recently_watched.return_value = [progress]
 
         use_case = GetContinueWatchingUseCase(
             progress_repository=progress_repo,
@@ -126,7 +129,7 @@ class TestEnrichEpisode:
     async def test_enrich_returns_none_for_missing_series(self, repos):
         progress_repo, movie_repo, series_repo = repos
         progress = _make_progress("epi_ser_NotExists123_1_1")
-        progress_repo.list_in_progress.return_value = [progress]
+        progress_repo.list_recently_watched.return_value = [progress]
         series_repo.find_by_id.return_value = None
 
         use_case = GetContinueWatchingUseCase(
@@ -145,7 +148,10 @@ class TestEnrichEpisode:
         series = _make_series_with_episode()
         # Request season 99 which doesn't exist
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_99_1")
-        progress_repo.list_in_progress.return_value = [progress]
+        progress_repo.list_recently_watched.return_value = [progress]
+        progress_repo.find_by_media_ids.return_value = {
+            "epi_ser_Hy9VjMfILYZe_99_1": progress,
+        }
         series_repo.find_by_id.return_value = series
 
         use_case = GetContinueWatchingUseCase(
@@ -164,7 +170,10 @@ class TestEnrichEpisode:
         series = _make_series_with_episode()
         # Request episode 99 in season 3 which doesn't exist
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_99")
-        progress_repo.list_in_progress.return_value = [progress]
+        progress_repo.list_recently_watched.return_value = [progress]
+        progress_repo.find_by_media_ids.return_value = {
+            "epi_ser_Hy9VjMfILYZe_3_99": progress,
+        }
         series_repo.find_by_id.return_value = series
 
         use_case = GetContinueWatchingUseCase(
@@ -181,7 +190,7 @@ class TestEnrichEpisode:
     async def test_enrich_returns_none_for_malformed_media_id(self, repos):
         progress_repo, movie_repo, series_repo = repos
         progress = _make_progress("epi_ser_broken")
-        progress_repo.list_in_progress.return_value = [progress]
+        progress_repo.list_recently_watched.return_value = [progress]
 
         use_case = GetContinueWatchingUseCase(
             progress_repository=progress_repo,

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -1,4 +1,4 @@
-"""Tests for GetContinueWatchingUseCase - episode enrichment."""
+"""Tests for GetContinueWatchingUseCase - episode enrichment and deduplication."""
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
@@ -17,54 +17,78 @@ from src.modules.media.domain.value_objects import (
     SeriesId,
     Title,
 )
-from src.modules.watch_progress.application.dtos import ContinueWatchingItem
+from src.modules.watch_progress.application.dtos import (
+    ContinueWatchingItem,
+    GetContinueWatchingInput,
+)
 from src.modules.watch_progress.application.use_cases import GetContinueWatchingUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 
 
-def _make_progress(media_id: str, media_type: str = "episode") -> WatchProgress:
+def _make_progress(
+    media_id: str,
+    media_type: str = "episode",
+    *,
+    status: str = "in_progress",
+    position: int = 1800,
+    last_watched: datetime | None = None,
+) -> WatchProgress:
     """Create a WatchProgress entity for testing."""
     return WatchProgress(
         media_id=media_id,
         media_type=media_type,
-        position_seconds=1800,
+        position_seconds=position,
         duration_seconds=3600,
-        status="in_progress",
-        last_watched_at=datetime(2026, 4, 9, tzinfo=UTC),
+        status=status,
+        last_watched_at=last_watched or datetime(2026, 4, 9, tzinfo=UTC),
     )
 
 
-def _make_series_with_episode(
-    series_id: str = "ser_Hy9VjMfILYZe",
-) -> Series:
-    """Create a Series with one season and one episode for testing."""
-    series = Series.create(title="Test Series", start_year=2024)
-    # Override the generated ID
-    series = series.with_updates(id=SeriesId(series_id))
-    season = Season(
-        id=SeasonId.generate(),
-        series_id=series.id,
-        season_number=3,
-    )
-    episode = Episode(
+def _make_episode(series_id: SeriesId | None, season: int, ep: int, title: str = "") -> Episode:
+    """Create an Episode entity."""
+    return Episode(
         id=EpisodeId.generate(),
-        series_id=series.id,
-        season_number=3,
-        episode_number=2,
-        title=Title("The Episode"),
+        series_id=series_id,
+        season_number=season,
+        episode_number=ep,
+        title=Title(title or f"Episode {ep}"),
         duration=Duration(3600),
         files=[
             MediaFile(
-                file_path=FilePath("/series/test/s03e02.mkv"),
+                file_path=FilePath(f"/series/test/s{season:02d}e{ep:02d}.mkv"),
                 file_size=1_000_000,
                 resolution=Resolution("1080p"),
                 is_primary=True,
             ),
         ],
     )
-    season = season.with_episode(episode)
-    series = series.with_season(season)
+
+
+def _make_series(
+    series_id: str,
+    episodes_per_season: dict[int, list[int]],
+    title: str = "Test Series",
+) -> Series:
+    """Create a Series with specified seasons and episodes.
+
+    Args:
+        series_id: External series ID.
+        episodes_per_season: Mapping of season_number to list of episode_numbers.
+        title: Series title.
+    """
+    series = Series.create(title=title, start_year=2024)
+    series = series.with_updates(id=SeriesId(series_id))
+    for season_num, ep_nums in sorted(episodes_per_season.items()):
+        season = Season(
+            id=SeasonId.generate(),
+            series_id=series.id,
+            season_number=season_num,
+        )
+        for ep_num in sorted(ep_nums):
+            episode = _make_episode(series.id, season_num, ep_num)
+            season = season.with_episode(episode)
+        series = series.with_season(season)
     return series
 
 
@@ -77,13 +101,24 @@ def repos() -> tuple[AsyncMock, AsyncMock, AsyncMock]:
     return progress_repo, movie_repo, series_repo
 
 
+def _make_use_case(
+    repos: tuple[AsyncMock, AsyncMock, AsyncMock],
+) -> GetContinueWatchingUseCase:
+    progress_repo, movie_repo, series_repo = repos
+    return GetContinueWatchingUseCase(
+        progress_repository=progress_repo,
+        movie_repository=movie_repo,
+        series_repository=series_repo,
+    )
+
+
 class TestEnrichEpisode:
     """Tests for episode enrichment in continue watching."""
 
     @pytest.mark.asyncio
     async def test_enrich_valid_composite_episode(self, repos):
-        progress_repo, movie_repo, series_repo = repos
-        series = _make_series_with_episode()
+        progress_repo, _, series_repo = repos
+        series = _make_series("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_2")
         progress_repo.list_recently_watched.return_value = [progress]
         progress_repo.find_by_media_ids.return_value = {
@@ -91,14 +126,7 @@ class TestEnrichEpisode:
         }
         series_repo.find_by_id.return_value = series
 
-        use_case = GetContinueWatchingUseCase(
-            progress_repository=progress_repo,
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
-        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
-
-        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
 
         assert len(result.items) == 1
         item = result.items[0]
@@ -107,46 +135,32 @@ class TestEnrichEpisode:
         assert item.series_title == "Test Series"
         assert item.season_number == 3
         assert item.episode_number == 2
-        assert item.title == "The Episode"
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_standard_episode_id(self, repos):
-        progress_repo, movie_repo, series_repo = repos
-        progress = _make_progress("epi_03ZzYaQ77FaB")
-        progress_repo.list_recently_watched.return_value = [progress]
+        progress_repo, _, _ = repos
+        progress_repo.list_recently_watched.return_value = [
+            _make_progress("epi_03ZzYaQ77FaB"),
+        ]
 
-        use_case = GetContinueWatchingUseCase(
-            progress_repository=progress_repo,
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
-        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
-
-        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_series(self, repos):
-        progress_repo, movie_repo, series_repo = repos
-        progress = _make_progress("epi_ser_NotExists123_1_1")
-        progress_repo.list_recently_watched.return_value = [progress]
+        progress_repo, _, series_repo = repos
+        progress_repo.list_recently_watched.return_value = [
+            _make_progress("epi_ser_NotExists123_1_1"),
+        ]
         series_repo.find_by_id.return_value = None
 
-        use_case = GetContinueWatchingUseCase(
-            progress_repository=progress_repo,
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
-        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
-
-        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_season(self, repos):
-        progress_repo, movie_repo, series_repo = repos
-        series = _make_series_with_episode()
-        # Request season 99 which doesn't exist
+        progress_repo, _, series_repo = repos
+        series = _make_series("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_99_1")
         progress_repo.list_recently_watched.return_value = [progress]
         progress_repo.find_by_media_ids.return_value = {
@@ -154,21 +168,13 @@ class TestEnrichEpisode:
         }
         series_repo.find_by_id.return_value = series
 
-        use_case = GetContinueWatchingUseCase(
-            progress_repository=progress_repo,
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
-        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
-
-        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_episode(self, repos):
-        progress_repo, movie_repo, series_repo = repos
-        series = _make_series_with_episode()
-        # Request episode 99 in season 3 which doesn't exist
+        progress_repo, _, series_repo = repos
+        series = _make_series("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_99")
         progress_repo.list_recently_watched.return_value = [progress]
         progress_repo.find_by_media_ids.return_value = {
@@ -176,28 +182,192 @@ class TestEnrichEpisode:
         }
         series_repo.find_by_id.return_value = series
 
-        use_case = GetContinueWatchingUseCase(
-            progress_repository=progress_repo,
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
-        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
-
-        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_malformed_media_id(self, repos):
-        progress_repo, movie_repo, series_repo = repos
-        progress = _make_progress("epi_ser_broken")
-        progress_repo.list_recently_watched.return_value = [progress]
+        progress_repo, _, _ = repos
+        progress_repo.list_recently_watched.return_value = [
+            _make_progress("epi_ser_broken"),
+        ]
 
-        use_case = GetContinueWatchingUseCase(
-            progress_repository=progress_repo,
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
-        from src.modules.watch_progress.application.dtos import GetContinueWatchingInput
-
-        result = await use_case.execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
         assert len(result.items) == 0
+
+
+class TestSeriesDeduplication:
+    """Tests for series deduplication and episode selection."""
+
+    @pytest.mark.asyncio
+    async def test_multiple_episodes_same_series_returns_one_item(self, repos):
+        """Multiple in-progress episodes from same series → single item."""
+        progress_repo, _, series_repo = repos
+        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
+        series_repo.find_by_id.return_value = series
+
+        p1 = _make_progress("epi_ser_AAAAAAAAAAAA_1_1")
+        p2 = _make_progress("epi_ser_AAAAAAAAAAAA_1_2")
+        p3 = _make_progress("epi_ser_AAAAAAAAAAAA_1_3")
+        progress_repo.list_recently_watched.return_value = [p1, p2, p3]
+        progress_repo.find_by_media_ids.return_value = {
+            "epi_ser_AAAAAAAAAAAA_1_1": p1,
+            "epi_ser_AAAAAAAAAAAA_1_2": p2,
+            "epi_ser_AAAAAAAAAAAA_1_3": p3,
+        }
+
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+
+        assert len(result.items) == 1
+
+    @pytest.mark.asyncio
+    async def test_picks_highest_in_progress_episode(self, repos):
+        """Should pick the highest-numbered in-progress episode."""
+        progress_repo, _, series_repo = repos
+        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2, 3], 2: [1, 2]})
+        series_repo.find_by_id.return_value = series
+
+        progress_repo.list_recently_watched.return_value = [
+            _make_progress("epi_ser_AAAAAAAAAAAA_1_2"),
+        ]
+        progress_repo.find_by_media_ids.return_value = {
+            "epi_ser_AAAAAAAAAAAA_1_2": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_1_2",
+                status="completed",
+            ),
+            "epi_ser_AAAAAAAAAAAA_1_3": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_1_3",
+                status="in_progress",
+            ),
+            "epi_ser_AAAAAAAAAAAA_2_1": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_2_1",
+                status="in_progress",
+            ),
+        }
+
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+
+        assert len(result.items) == 1
+        assert result.items[0].season_number == 2
+        assert result.items[0].episode_number == 1
+
+    @pytest.mark.asyncio
+    async def test_picks_next_unwatched_when_all_completed(self, repos):
+        """Completed episodes + unwatched episodes → next unwatched."""
+        progress_repo, _, series_repo = repos
+        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
+        series_repo.find_by_id.return_value = series
+
+        progress_repo.list_recently_watched.return_value = [
+            _make_progress("epi_ser_AAAAAAAAAAAA_1_1", status="completed"),
+        ]
+        progress_repo.find_by_media_ids.return_value = {
+            "epi_ser_AAAAAAAAAAAA_1_1": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_1_1",
+                status="completed",
+            ),
+            "epi_ser_AAAAAAAAAAAA_1_2": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_1_2",
+                status="completed",
+            ),
+        }
+
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+
+        assert len(result.items) == 1
+        assert result.items[0].season_number == 1
+        assert result.items[0].episode_number == 3
+        assert result.items[0].percentage == 0.0
+
+    @pytest.mark.asyncio
+    async def test_returns_nothing_when_all_episodes_completed(self, repos):
+        """All episodes completed, none unwatched → no item."""
+        progress_repo, _, series_repo = repos
+        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2]})
+        series_repo.find_by_id.return_value = series
+
+        progress_repo.list_recently_watched.return_value = [
+            _make_progress("epi_ser_AAAAAAAAAAAA_1_1", status="completed"),
+        ]
+        progress_repo.find_by_media_ids.return_value = {
+            "epi_ser_AAAAAAAAAAAA_1_1": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_1_1",
+                status="completed",
+            ),
+            "epi_ser_AAAAAAAAAAAA_1_2": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_1_2",
+                status="completed",
+            ),
+        }
+
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        assert len(result.items) == 0
+
+    @pytest.mark.asyncio
+    async def test_two_series_return_one_item_each(self, repos):
+        """Two different series → two items, one per series."""
+        progress_repo, _, series_repo = repos
+        series_a = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2]}, title="Series A")
+        series_b = _make_series("ser_BBBBBBBBBBBB", {1: [1]}, title="Series B")
+
+        def find_by_id_side_effect(sid):
+            if str(sid) == "ser_AAAAAAAAAAAA":
+                return series_a
+            if str(sid) == "ser_BBBBBBBBBBBB":
+                return series_b
+            return None
+
+        series_repo.find_by_id.side_effect = find_by_id_side_effect
+
+        pa = _make_progress("epi_ser_AAAAAAAAAAAA_1_1")
+        pb = _make_progress("epi_ser_BBBBBBBBBBBB_1_1")
+        progress_repo.list_recently_watched.return_value = [pa, pb]
+
+        def find_by_media_ids_side_effect(ids):
+            result = {}
+            if "epi_ser_AAAAAAAAAAAA_1_1" in ids:
+                result["epi_ser_AAAAAAAAAAAA_1_1"] = pa
+            if "epi_ser_AAAAAAAAAAAA_1_2" in ids:
+                pass  # no progress
+            if "epi_ser_BBBBBBBBBBBB_1_1" in ids:
+                result["epi_ser_BBBBBBBBBBBB_1_1"] = pb
+            return result
+
+        progress_repo.find_by_media_ids.side_effect = find_by_media_ids_side_effect
+
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+
+        assert len(result.items) == 2
+        series_ids = {item.series_id for item in result.items}
+        assert series_ids == {"ser_AAAAAAAAAAAA", "ser_BBBBBBBBBBBB"}
+
+    @pytest.mark.asyncio
+    async def test_mixed_in_progress_and_completed_across_seasons(self, repos):
+        """S1 completed, S2E1 in-progress → picks S2E1."""
+        progress_repo, _, series_repo = repos
+        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2], 2: [1, 2]})
+        series_repo.find_by_id.return_value = series
+
+        progress_repo.list_recently_watched.return_value = [
+            _make_progress("epi_ser_AAAAAAAAAAAA_2_1"),
+        ]
+        progress_repo.find_by_media_ids.return_value = {
+            "epi_ser_AAAAAAAAAAAA_1_1": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_1_1",
+                status="completed",
+            ),
+            "epi_ser_AAAAAAAAAAAA_1_2": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_1_2",
+                status="completed",
+            ),
+            "epi_ser_AAAAAAAAAAAA_2_1": _make_progress(
+                "epi_ser_AAAAAAAAAAAA_2_1",
+                status="in_progress",
+            ),
+        }
+
+        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+
+        assert len(result.items) == 1
+        assert result.items[0].season_number == 2
+        assert result.items[0].episode_number == 1


### PR DESCRIPTION
## Summary

- Return at most one item per series in the continue watching list
- For each series, pick the highest-numbered in-progress episode
- If all watched episodes are completed but unwatched episodes remain, return the next unwatched episode (series considered "in progress")
- Add `list_recently_watched` repo method that includes both `in_progress` and `completed` records
- Extract `_scan_episode_progress` and `_find_next_unwatched` helpers to reduce method complexity
- Movies still only appear when `in_progress` (completed movies are excluded)

## Test plan

- [ ] Watch several episodes of a series — verify only one entry appears in continue watching
- [ ] Complete an episode, verify next unwatched episode is shown
- [ ] Complete all episodes — verify series disappears from continue watching
- [ ] Verify movies still only show when in-progress
- [ ] Run `make test` — 806 tests passing

## Summary by Sourcery

Deduplicate series entries in the continue watching feed by selecting a single best episode to resume per series while preserving existing movie behavior.

New Features:
- Add support for selecting a single resume episode per series based on recent watch activity, preferring the highest-numbered in-progress episode or the next unwatched after the last completed one.
- Expose a repository method to list recently watched items including both in-progress and completed watch progress records.

Enhancements:
- Refine the continue watching use case to operate on recently watched items and derive episode selection per series using batched progress lookup and helper methods.
- Adjust construction of continue watching items for series and movies to better align with episode and series metadata.