### PR TITLE
fix(streaming): use UTF-8 encoding for ffprobe/ffmpeg subprocess calls

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -367,6 +367,8 @@ class HlsService:
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
                 timeout=10,
             )
@@ -499,6 +501,8 @@ class HlsService:
                     ],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     check=False,
                     timeout=60,
                 )
@@ -533,6 +537,8 @@ class HlsService:
                     ],
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     check=False,
                     timeout=60,
                 )

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -168,6 +168,8 @@ class MediaProbeService:
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
                 timeout=_FFPROBE_TIMEOUT,
             )


### PR DESCRIPTION
## Summary

- Force `encoding="utf-8"` and `errors="replace"` on all `subprocess.run` calls to ffprobe/ffmpeg
- On Windows the default cp1252 encoding fails on media files with non-ASCII metadata bytes, causing `UnicodeDecodeError` in the reader thread and `None` stdout
- Affects `MediaProbeService._run_ffprobe` and three calls in `HlsService`

## Test plan

- [ ] Play a movie with non-ASCII metadata (e.g. accented characters in tags) — should stream without 500 error
- [ ] Run `make test` — 812 tests passing

## Summary by Sourcery

Bug Fixes:
- Prevent UnicodeDecodeError and missing stdout when probing or processing media with non-ASCII metadata by forcing UTF-8 decoding for ffprobe/ffmpeg subprocess output in streaming services.