### PR TITLE
refactor(streaming): extract shared subprocess kwargs

### DIFF
--- a/src/modules/media/infrastructure/streaming/_subprocess.py
+++ b/src/modules/media/infrastructure/streaming/_subprocess.py
@@ -1,0 +1,16 @@
+"""Shared subprocess kwargs for ffprobe/ffmpeg calls.
+
+Centralises the encoding and output-capture settings so that every
+subprocess.run() call in the streaming package stays consistent.
+"""
+
+from typing import Any
+
+#: Common kwargs for ``subprocess.run`` calls that capture text output.
+#: Each call site should unpack this and add its own ``timeout``.
+SUBPROCESS_TEXT_KWARGS: dict[str, Any] = {
+    "capture_output": True,
+    "text": True,
+    "encoding": "utf-8",
+    "errors": "replace",
+}

--- a/src/modules/media/infrastructure/streaming/_subprocess.py
+++ b/src/modules/media/infrastructure/streaming/_subprocess.py
@@ -4,13 +4,16 @@ Centralises the encoding and output-capture settings so that every
 subprocess.run() call in the streaming package stays consistent.
 """
 
+from types import MappingProxyType
 from typing import Any
 
 #: Common kwargs for ``subprocess.run`` calls that capture text output.
 #: Each call site should unpack this and add its own ``timeout``.
-SUBPROCESS_TEXT_KWARGS: dict[str, Any] = {
-    "capture_output": True,
-    "text": True,
-    "encoding": "utf-8",
-    "errors": "replace",
-}
+SUBPROCESS_TEXT_KWARGS: MappingProxyType[str, Any] = MappingProxyType(
+    {
+        "capture_output": True,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+    }
+)

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -35,6 +35,7 @@ import threading
 from pathlib import Path
 from typing import Any
 
+from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
 from src.modules.media.infrastructure.streaming.media_probe_service import (
     MediaProbeResult,
     MediaProbeService,
@@ -365,10 +366,7 @@ class HlsService:
                     "default=noprint_wrappers=1:nokey=1",
                     file_path,
                 ],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
+                **SUBPROCESS_TEXT_KWARGS,
                 check=False,
                 timeout=10,
             )
@@ -499,10 +497,7 @@ class HlsService:
                         "-y",
                         str(vtt_path),
                     ],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
+                    **SUBPROCESS_TEXT_KWARGS,
                     check=False,
                     timeout=60,
                 )
@@ -535,10 +530,7 @@ class HlsService:
                         "-y",
                         str(vtt_path),
                     ],
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
-                    errors="replace",
+                    **SUBPROCESS_TEXT_KWARGS,
                     check=False,
                     timeout=60,
                 )

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
@@ -166,10 +167,7 @@ class MediaProbeService:
                     "json",
                     file_path,
                 ],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
+                **SUBPROCESS_TEXT_KWARGS,
                 check=False,
                 timeout=_FFPROBE_TIMEOUT,
             )


### PR DESCRIPTION
## Summary

- Extract repeated `encoding="utf-8"`, `errors="replace"`, `capture_output=True`, `text=True` kwargs into a `SUBPROCESS_TEXT_KWARGS` constant in `_subprocess.py`
- Replace inline kwargs in all 4 `subprocess.run` calls (1 in `media_probe_service.py`, 3 in `hls_service.py`)
- Keeps `check=False` and `timeout` explicit at each call site (required by ruff PLW1510 and varies per call)

Addresses Sourcery feedback from #74.

## Test plan

- [x] All 438 media module tests pass
- [x] ruff, ruff-format, mypy pass

## Summary by Sourcery

Refactor media streaming subprocess usage to centralize shared text-mode configuration for ffmpeg/ffprobe invocations.

Enhancements:
- Introduce a shared SUBPROCESS_TEXT_KWARGS constant for common text-mode subprocess.run parameters in the streaming infrastructure.
- Update ffprobe and HLS-related subprocess calls to use the shared subprocess kwargs while keeping check and timeout configured per call site.