### PR TITLE
test(media): improve coverage for low-coverage use cases

### DIFF
--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -1,14 +1,20 @@
 """Tests for EnrichMovieMetadataUseCase."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
-from src.modules.media.application.ports import MediaMetadata, MetadataProvider
+from src.modules.media.application.ports import (
+    CreditPerson,
+    LocalizedFields,
+    MediaMetadata,
+    MetadataProvider,
+)
 from src.modules.media.application.use_cases.enrich_movie_metadata import (
     EnrichMovieMetadataUseCase,
+    _clean_title,
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
@@ -149,3 +155,192 @@ class TestEnrichMovieMetadata:
         fake_id = str(MovieId.generate())
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(EnrichMediaInput(media_id=fake_id))
+
+    @pytest.mark.asyncio
+    async def test_should_use_localized_metadata_when_available(self) -> None:
+        movie = _make_movie()
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+
+        # Provider with get_movie_localized method
+        provider = MagicMock(spec=["search_movie", "get_movie_by_id", "get_movie_localized"])
+        provider.search_movie = AsyncMock(return_value=_make_metadata())
+        localized_meta = MediaMetadata(
+            title="A Origem",
+            tmdb_id=27205,
+            localized={
+                "pt-BR": LocalizedFields(title="A Origem", synopsis="Trama mental"),
+            },
+        )
+        provider.get_movie_localized = AsyncMock(return_value=localized_meta)
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is True
+        provider.get_movie_localized.assert_awaited_once_with(27205)
+        saved = repo.save.call_args[0][0]
+        assert "pt-BR" in saved.localized
+
+    @pytest.mark.asyncio
+    async def test_should_retry_with_cleaned_title(self) -> None:
+        movie = Movie.create(
+            title="Inception 1080p BluRay x264",
+            year=2010,
+            duration=0,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+
+        provider = AsyncMock(spec=MetadataProvider)
+
+        # First call (with year): None. Second call (cleaned title): success
+        provider.search_movie.side_effect = [None, _make_metadata()]
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is True
+        # Two attempts: with year, then cleaned
+        assert provider.search_movie.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_should_retry_with_title_only_when_year_search_fails(self) -> None:
+        movie = _make_movie()
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+
+        provider = AsyncMock(spec=MetadataProvider)
+        # All searches return None except the title-only one
+        provider.search_movie.side_effect = [None, _make_metadata()]
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is True
+
+
+@pytest.mark.unit
+class TestCleanTitle:
+    """Tests for the _clean_title helper."""
+
+    def test_should_remove_resolution_tags(self) -> None:
+        assert _clean_title("Inception 1080p").strip() == "Inception"
+
+    def test_should_remove_codec_tags(self) -> None:
+        assert _clean_title("Inception x264 AAC").strip() == "Inception"
+
+    def test_should_remove_quality_tags(self) -> None:
+        assert _clean_title("Inception BluRay HDR").strip() == "Inception"
+
+    def test_should_remove_brackets(self) -> None:
+        assert _clean_title("Inception [2010]").strip() == "Inception"
+
+    def test_should_remove_parentheses(self) -> None:
+        assert _clean_title("Inception (2010)").strip() == "Inception"
+
+    def test_should_remove_audio_channels(self) -> None:
+        assert _clean_title("Inception 5.1").strip() == "Inception"
+
+    def test_should_remove_release_group_tags(self) -> None:
+        assert _clean_title("Inception YIFY").strip() == "Inception"
+
+    def test_should_preserve_clean_title(self) -> None:
+        assert _clean_title("Inception").strip() == "Inception"
+
+
+@pytest.mark.unit
+class TestApplyMetadataFields:
+    """Tests verifying _apply_movie_metadata applies all relevant fields."""
+
+    @pytest.mark.asyncio
+    async def test_should_apply_synopsis_when_missing(self) -> None:
+        movie = _make_movie()
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = _make_metadata()
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        saved = repo.save.call_args[0][0]
+        assert saved.synopsis == "A mind-bending thriller."
+
+    @pytest.mark.asyncio
+    async def test_should_apply_genres_when_missing(self) -> None:
+        movie = _make_movie()
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = _make_metadata()
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        saved = repo.save.call_args[0][0]
+        assert {g.value for g in saved.genres} == {"Sci-Fi", "Action"}
+
+    @pytest.mark.asyncio
+    async def test_should_apply_cast_directors_writers(self) -> None:
+        movie = _make_movie()
+        metadata = MediaMetadata(
+            title="Inception",
+            tmdb_id=27205,
+            cast=[CreditPerson(name="Leonardo DiCaprio")],
+            directors=[CreditPerson(name="Christopher Nolan")],
+            writers=[CreditPerson(name="Christopher Nolan")],
+            content_rating="PG-13",
+            trailer_url="https://youtube.com/abc",
+        )
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = metadata
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        saved = repo.save.call_args[0][0]
+        assert saved.cast == ["Leonardo DiCaprio"]
+        assert saved.directors == ["Christopher Nolan"]
+        assert saved.writers == ["Christopher Nolan"]
+        assert saved.content_rating == "PG-13"
+        assert saved.trailer_url == "https://youtube.com/abc"
+
+    @pytest.mark.asyncio
+    async def test_should_apply_localized_fields(self) -> None:
+        movie = _make_movie()
+        metadata = MediaMetadata(
+            title="Inception",
+            tmdb_id=27205,
+            localized={
+                "pt-BR": LocalizedFields(
+                    title="A Origem",
+                    synopsis="Sonho dentro do sonho.",
+                    genres=["Ficção Científica"],
+                ),
+            },
+        )
+        repo = AsyncMock(spec=MovieRepository)
+        repo.find_by_id.return_value = movie
+        repo.save.side_effect = lambda m: m
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = metadata
+
+        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        saved = repo.save.call_args[0][0]
+        assert saved.localized["pt-BR"]["title"] == "A Origem"
+        assert saved.localized["pt-BR"]["synopsis"] == "Sonho dentro do sonho."
+        assert saved.localized["pt-BR"]["genres"] == ["Ficção Científica"]

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -1,6 +1,6 @@
 """Tests for EnrichSeriesMetadataUseCase."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -8,13 +8,16 @@ from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
 from src.modules.media.application.ports import (
     EpisodeMetadata,
+    LocalizedFields,
     MediaMetadata,
     MetadataProvider,
     SeasonMetadata,
 )
 from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
+    _clean_series_title,
     _detect_multi_episode,
+    _parse_date,
 )
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
@@ -312,3 +315,212 @@ class TestDetectMultiEpisode:
 
     def test_empty_title(self):
         assert _detect_multi_episode("") == 1
+
+
+@pytest.mark.unit
+class TestCleanSeriesTitle:
+    """Tests for the _clean_series_title helper."""
+
+    def test_should_remove_quality_tags(self):
+        assert _clean_series_title("Breaking Bad BluRay").strip() == "Breaking Bad"
+
+    def test_should_remove_codec_tags(self):
+        assert _clean_series_title("Breaking Bad x264 AAC").strip() == "Breaking Bad"
+
+    def test_should_remove_brackets(self):
+        assert _clean_series_title("Breaking Bad [2008]").strip() == "Breaking Bad"
+
+    def test_should_preserve_clean_title(self):
+        assert _clean_series_title("Breaking Bad").strip() == "Breaking Bad"
+
+    def test_should_fallback_to_original_when_empty(self):
+        assert _clean_series_title("[2008]").strip() == "[2008]"
+
+
+@pytest.mark.unit
+class TestParseDate:
+    """Tests for the _parse_date helper."""
+
+    def test_should_parse_iso_date(self):
+        from datetime import date
+
+        result = _parse_date("2008-01-20")
+        assert result == date(2008, 1, 20)
+
+    def test_should_return_none_on_invalid_date(self):
+        assert _parse_date("not-a-date") is None
+
+    def test_should_return_none_on_empty(self):
+        assert _parse_date("") is None
+
+
+@pytest.mark.unit
+class TestEnrichSeriesByTmdbId:
+    """Tests for fetching series metadata by existing TMDB ID."""
+
+    @pytest.mark.asyncio
+    async def test_should_fetch_by_tmdb_id_when_force(self) -> None:
+        series = _make_series().with_updates(tmdb_id=TmdbId(1396))
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+        repo.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_by_id.return_value = _make_metadata()
+
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id), force=True))
+
+        assert result.enriched is True
+        provider.get_series_by_id.assert_awaited_once_with(1396)
+
+    @pytest.mark.asyncio
+    async def test_should_retry_with_cleaned_title(self) -> None:
+        series = Series.create(title="Breaking Bad 1080p BluRay", start_year=2008)
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+        repo.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        # First call (with year): None. Second call (cleaned): success
+        provider.search_series.side_effect = [None, _make_metadata()]
+
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        assert result.enriched is True
+        assert provider.search_series.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_should_use_fallback_when_primary_fails(self) -> None:
+        series = _make_series()
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+        repo.save.side_effect = lambda s: s
+
+        primary = AsyncMock(spec=MetadataProvider)
+        primary.search_series.return_value = None
+
+        fallback = AsyncMock(spec=MetadataProvider)
+        fallback.search_series.return_value = _make_metadata()
+
+        use_case = EnrichSeriesMetadataUseCase(
+            series_repository=repo,
+            primary_provider=primary,
+            fallback_provider=fallback,
+        )
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        assert result.enriched is True
+        assert result.provider == "omdb"
+
+    @pytest.mark.asyncio
+    async def test_should_return_error_when_no_metadata_found(self) -> None:
+        series = _make_series()
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = None
+
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        assert result.enriched is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_should_use_localized_metadata_when_available(self) -> None:
+        series = _make_series()
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+        repo.save.side_effect = lambda s: s
+
+        provider = MagicMock(spec=["search_series", "get_series_by_id", "get_series_localized"])
+        provider.search_series = AsyncMock(return_value=_make_metadata())
+        localized_meta = MediaMetadata(
+            title="Breaking Bad",
+            tmdb_id=1396,
+            localized={
+                "pt-BR": LocalizedFields(title="Breaking Bad", synopsis="Sinopse pt-BR"),
+            },
+        )
+        provider.get_series_localized = AsyncMock(return_value=localized_meta)
+
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        assert result.enriched is True
+        provider.get_series_localized.assert_awaited_once_with(1396)
+        saved = repo.save.call_args[0][0]
+        assert "pt-BR" in saved.localized
+
+
+@pytest.mark.unit
+class TestApplySeriesFields:
+    """Tests verifying _apply_series_metadata covers all field branches."""
+
+    @pytest.mark.asyncio
+    async def test_should_apply_all_top_level_fields(self) -> None:
+        series = _make_series()
+        metadata = MediaMetadata(
+            title="Breaking Bad",
+            original_title="Breaking Bad",
+            year=2008,
+            end_year=2013,
+            synopsis="Crime drama.",
+            genres=["Drama"],
+            tmdb_id=1396,
+            imdb_id="tt0903747",
+            poster_url="https://image.tmdb.org/poster.jpg",
+            backdrop_url="https://image.tmdb.org/backdrop.jpg",
+            content_rating="TV-MA",
+            trailer_url="https://youtube.com/abc",
+        )
+
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+        repo.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        saved = repo.save.call_args[0][0]
+        assert saved.tmdb_id == TmdbId(1396)
+        assert saved.end_year is not None
+        assert saved.synopsis == "Crime drama."
+        assert saved.poster_path is not None
+        assert saved.backdrop_path is not None
+        assert saved.content_rating == "TV-MA"
+        assert saved.trailer_url == "https://youtube.com/abc"
+
+    @pytest.mark.asyncio
+    async def test_should_apply_localized_series_fields(self) -> None:
+        series = _make_series()
+        metadata = MediaMetadata(
+            title="Breaking Bad",
+            tmdb_id=1396,
+            localized={
+                "pt-BR": LocalizedFields(
+                    title="Breaking Bad",
+                    synopsis="Drama de crime.",
+                    genres=["Drama"],
+                ),
+            },
+        )
+
+        repo = AsyncMock(spec=SeriesRepository)
+        repo.find_by_id.return_value = series
+        repo.save.side_effect = lambda s: s
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        saved = repo.save.call_args[0][0]
+        assert "pt-BR" in saved.localized
+        assert saved.localized["pt-BR"]["synopsis"] == "Drama de crime."

--- a/tests/modules/media/unit/application/use_cases/test_get_featured_media.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_featured_media.py
@@ -1,0 +1,190 @@
+"""Tests for GetFeaturedMediaUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.application.dtos.featured_dtos import (
+    FeaturedItemOutput,
+    GetFeaturedInput,
+)
+from src.modules.media.application.use_cases.get_featured_media import (
+    GetFeaturedMediaUseCase,
+)
+from src.modules.media.domain.entities import Movie, Series
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.value_objects import ImageUrl
+
+
+def _make_movie(title: str = "Inception") -> Movie:
+    movie = Movie.create(
+        title=title,
+        year=2010,
+        duration=8880,
+        file_path=f"/movies/{title.lower()}.mkv",
+        file_size=4_000_000_000,
+        resolution="1080p",
+    )
+    return movie.with_updates(
+        backdrop_path=ImageUrl("https://image.tmdb.org/backdrop.jpg"),
+    )
+
+
+def _make_series(title: str = "Breaking Bad") -> Series:
+    series = Series.create(title=title, start_year=2008)
+    return series.with_updates(
+        backdrop_path=ImageUrl("https://image.tmdb.org/series_backdrop.jpg"),
+    )
+
+
+@pytest.mark.unit
+class TestGetFeaturedMediaUseCase:
+    """Tests for GetFeaturedMediaUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_return_movies_only(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_random.return_value = [_make_movie("Inception")]
+        series_repo = AsyncMock(spec=SeriesRepository)
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=10))
+
+        assert len(result) == 1
+        assert isinstance(result[0], FeaturedItemOutput)
+        assert result[0].type == "movie"
+        assert result[0].title == "Inception"
+        series_repo.find_random.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_return_series_only(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.find_random.return_value = [_make_series("Breaking Bad")]
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        result = await use_case.execute(GetFeaturedInput(media_type="series", limit=10))
+
+        assert len(result) == 1
+        assert result[0].type == "series"
+        assert result[0].title == "Breaking Bad"
+        movie_repo.find_random.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_return_both_movies_and_series_when_all(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_random.return_value = [_make_movie("Inception")]
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.find_random.return_value = [_make_series("Breaking Bad")]
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        result = await use_case.execute(GetFeaturedInput(media_type="all", limit=10))
+
+        assert len(result) == 2
+        types = {item.type for item in result}
+        assert types == {"movie", "series"}
+
+    @pytest.mark.asyncio
+    async def test_should_truncate_to_limit(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_random.return_value = [_make_movie(f"Movie{i}") for i in range(5)]
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.find_random.return_value = [_make_series(f"Series{i}") for i in range(5)]
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        result = await use_case.execute(GetFeaturedInput(media_type="all", limit=4))
+
+        assert len(result) == 4
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_when_no_results(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_random.return_value = []
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.find_random.return_value = []
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        result = await use_case.execute(GetFeaturedInput(media_type="all", limit=10))
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_should_filter_with_backdrop(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_random.return_value = []
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.find_random.return_value = []
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        await use_case.execute(GetFeaturedInput(media_type="movie", limit=5))
+
+        movie_repo.find_random.assert_called_once_with(5, with_backdrop=True)
+
+    @pytest.mark.asyncio
+    async def test_should_pass_language_to_movie_outputs(self) -> None:
+        movie = _make_movie("Inception")
+        movie = movie.with_updates(
+            localized={"pt-BR": {"title": "A Origem"}},
+        )
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_random.return_value = [movie]
+        series_repo = AsyncMock(spec=SeriesRepository)
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=1, lang="pt-BR"))
+
+        assert result[0].title == "A Origem"
+
+    @pytest.mark.asyncio
+    async def test_movie_output_should_include_backdrop_and_genres(self) -> None:
+        movie = _make_movie("Inception")
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_random.return_value = [movie]
+        series_repo = AsyncMock(spec=SeriesRepository)
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=1))
+
+        assert result[0].backdrop_path == "https://image.tmdb.org/backdrop.jpg"
+        assert result[0].year == 2010
+        assert result[0].duration_formatted is not None
+
+    @pytest.mark.asyncio
+    async def test_series_output_should_have_no_duration(self) -> None:
+        series = _make_series("Breaking Bad")
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.find_random.return_value = [series]
+        use_case = GetFeaturedMediaUseCase(
+            movie_repository=movie_repo,
+            series_repository=series_repo,
+        )
+
+        result = await use_case.execute(GetFeaturedInput(media_type="series", limit=1))
+
+        assert result[0].duration_formatted is None
+        assert result[0].year == 2008

--- a/tests/modules/media/unit/application/use_cases/test_set_primary_file.py
+++ b/tests/modules/media/unit/application/use_cases/test_set_primary_file.py
@@ -7,9 +7,15 @@ import pytest
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos import SetPrimaryFileInput
 from src.modules.media.application.use_cases import SetPrimaryFileUseCase
-from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
-from src.modules.media.domain.value_objects import MediaFile, Resolution
+from src.modules.media.domain.value_objects import (
+    Duration,
+    EpisodeId,
+    MediaFile,
+    Resolution,
+    Title,
+)
 from src.shared_kernel.value_objects.file_path import FilePath
 
 
@@ -30,6 +36,38 @@ def _create_movie_with_variants() -> Movie:
             resolution=Resolution("4K"),
         ),
     )
+
+
+def _create_series_with_episode_variants() -> Series:
+    """Create a series with one episode that has multiple file variants."""
+    series = Series.create(title="Breaking Bad", start_year=2008)
+    assert series.id is not None
+    episode_id = EpisodeId.generate()
+    episode = Episode(
+        id=episode_id,
+        series_id=series.id,
+        season_number=1,
+        episode_number=1,
+        title=Title("Pilot"),
+        duration=Duration(2820),
+        files=[
+            MediaFile(
+                file_path=FilePath("/series/bb/s01e01_1080p.mkv"),
+                file_size=2_000_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+            MediaFile(
+                file_path=FilePath("/series/bb/s01e01_4k.mkv"),
+                file_size=8_000_000_000,
+                resolution=Resolution("4K"),
+                is_primary=False,
+            ),
+        ],
+    )
+    season = Season(series_id=series.id, season_number=1)
+    season = season.with_episode(episode)
+    return series.with_season(season)
 
 
 @pytest.mark.unit
@@ -104,3 +142,120 @@ class TestSetPrimaryFileUseCase:
                     file_path="/movies/test.mkv",
                 ),
             )
+
+    @pytest.mark.asyncio
+    async def test_should_raise_for_invalid_media_id_prefix(self):
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        use_case = SetPrimaryFileUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                SetPrimaryFileInput(
+                    media_id="ssn_invalidprefix",
+                    file_path="/series/test.mkv",
+                ),
+            )
+
+        assert exc_info.value.resource_type == "Media"
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_media_id_has_no_underscore(self):
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        use_case = SetPrimaryFileUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                SetPrimaryFileInput(
+                    media_id="invalidformat",
+                    file_path="/movies/test.mkv",
+                ),
+            )
+
+
+@pytest.mark.unit
+class TestSetPrimaryFileForEpisode:
+    """Tests for setting primary file on episode variants."""
+
+    @pytest.mark.asyncio
+    async def test_should_switch_primary_for_episode(self) -> None:
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+
+        series = _create_series_with_episode_variants()
+        episode = series.seasons[0].episodes[0]
+        mock_series_repo.find_by_episode_id.return_value = series
+        mock_series_repo.save.return_value = series
+
+        use_case = SetPrimaryFileUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        result = await use_case.execute(
+            SetPrimaryFileInput(
+                media_id=str(episode.id),
+                file_path="/series/bb/s01e01_4k.mkv",
+            ),
+        )
+
+        # Verify save was called with the updated series
+        saved_series = mock_series_repo.save.call_args[0][0]
+        saved_episode = saved_series.seasons[0].episodes[0]
+        primary = next(f for f in saved_episode.files if f.is_primary)
+        assert primary.file_path == FilePath("/series/bb/s01e01_4k.mkv")
+
+        # Verify return value contains the updated files
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_episode_not_found(self) -> None:
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        mock_series_repo.find_by_episode_id.return_value = None
+
+        use_case = SetPrimaryFileUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                SetPrimaryFileInput(
+                    media_id=str(EpisodeId.generate()),
+                    file_path="/series/test.mkv",
+                ),
+            )
+
+        assert exc_info.value.resource_type == "Episode"
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_episode_file_path_missing(self) -> None:
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+
+        series = _create_series_with_episode_variants()
+        episode = series.seasons[0].episodes[0]
+        mock_series_repo.find_by_episode_id.return_value = series
+
+        use_case = SetPrimaryFileUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                SetPrimaryFileInput(
+                    media_id=str(episode.id),
+                    file_path="/series/bb/nonexistent.mkv",
+                ),
+            )
+
+        assert exc_info.value.resource_type == "FileVariant"


### PR DESCRIPTION
## Summary

- Add `test_get_featured_media.py` from scratch (9 tests, **100% coverage**)
- Extend `test_set_primary_file.py` with episode path and invalid-prefix handling (52% → **97%**, 5 new tests)
- Extend `test_enrich_movie_metadata.py` with localized fetch, clean_title retry, and full _apply_movie_metadata field coverage (65% → **92%**, 15 new tests)
- Extend `test_enrich_series_metadata.py` with localized fetch, get_series_by_id, fallback provider, _clean_series_title, and _parse_date helpers (67% → **90%**, 15 new tests)
- Total new tests: 44. Total tests: 1014 (all passing)

## Coverage improvements

| File | Before | After |
|---|---|---|
| `get_featured_media.py` | 34% | **100%** |
| `set_primary_file.py` | 52% | **97%** |
| `enrich_movie_metadata.py` | 65% | **92%** |
| `enrich_series_metadata.py` | 67% | **90%** |

## Test plan

- [x] All 1014 tests pass (`poetry run pytest`)
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] Coverage verified per file via `pytest --cov-report=term-missing`

## Summary by Sourcery

Increase test coverage for media metadata enrichment, featured media retrieval, and primary file selection across movies, series, and episodes.

Tests:
- Add comprehensive unit tests for GetFeaturedMediaUseCase covering media type filtering, limits, localization, and output fields.
- Extend movie metadata enrichment tests to cover localized metadata usage, title-cleaning retries, and full application of metadata and localized fields.
- Extend series metadata enrichment tests to cover title cleaning, date parsing helpers, fetching by TMDB ID, fallback providers, localization, and full application of metadata fields.
- Add tests for SetPrimaryFileUseCase to cover invalid media IDs and episode-level primary file switching and error handling.