### PR TITLE
test(streaming): add unit tests for streaming infrastructure

### DIFF
--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -1,0 +1,494 @@
+"""Tests for HlsService."""
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.modules.media.infrastructure.streaming.hls_service import (
+    HlsService,
+    _primary_audio_index,
+)
+from src.modules.media.infrastructure.streaming.media_probe_service import (
+    MediaProbeResult,
+    MediaProbeService,
+)
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+
+def _make_audio_track(
+    index: int = 0,
+    lang: str = "en",
+    codec: str = "aac",
+    channels: int = 2,
+    is_default: bool = True,
+    title: str | None = None,
+) -> AudioTrack:
+    return AudioTrack(
+        index=index,
+        language=LanguageCode(lang),
+        codec=codec,
+        channels=channels,
+        is_default=is_default,
+        title=title,
+    )
+
+
+def _make_subtitle_track(
+    index: int = 0,
+    lang: str = "en",
+    fmt: str = "srt",
+    is_forced: bool = False,
+) -> SubtitleTrack:
+    return SubtitleTrack(
+        index=index,
+        language=LanguageCode(lang),
+        format=fmt,
+        is_forced=is_forced,
+    )
+
+
+@pytest.mark.unit
+class TestPrimaryAudioIndex:
+    """Tests for the _primary_audio_index helper."""
+
+    def test_should_return_first_track_index(self) -> None:
+        probe = MediaProbeResult(
+            audio_tracks=[_make_audio_track(index=2), _make_audio_track(index=5)],
+        )
+        assert _primary_audio_index(probe) == 2
+
+    def test_should_return_zero_when_no_tracks(self) -> None:
+        probe = MediaProbeResult(audio_tracks=[])
+        assert _primary_audio_index(probe) == 0
+
+
+@pytest.mark.unit
+class TestHlsServiceInit:
+    """Tests for HlsService initialization."""
+
+    def test_should_create_cache_directory(self, tmp_path: Path) -> None:
+        cache = tmp_path / "hls"
+        HlsService(cache_dir=str(cache))
+        assert cache.is_dir()
+
+    def test_should_accept_custom_probe_service(self, tmp_path: Path) -> None:
+        custom_probe = MagicMock(spec=MediaProbeService)
+        service = HlsService(cache_dir=str(tmp_path / "hls"), probe_service=custom_probe)
+        assert service._probe is custom_probe
+
+
+@pytest.mark.unit
+class TestHlsServiceGetPathHash:
+    """Tests for get_path_hash."""
+
+    def test_should_return_md5_hash(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+        file_path = "/movies/inception.mkv"
+
+        result = service.get_path_hash(file_path)
+
+        expected = hashlib.md5(file_path.encode()).hexdigest()
+        assert result == expected
+
+    def test_should_be_deterministic(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+        path = "/movies/test.mkv"
+        assert service.get_path_hash(path) == service.get_path_hash(path)
+
+    def test_should_differ_for_different_paths(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+        assert service.get_path_hash("/a.mkv") != service.get_path_hash("/b.mkv")
+
+
+@pytest.mark.unit
+class TestHlsServiceGetFileByHash:
+    """Tests for get_file_by_hash with path traversal protection."""
+
+    def test_should_return_file_when_exists(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        hash_dir = tmp_path / "abc123"
+        hash_dir.mkdir()
+        target = hash_dir / "segment_0000.ts"
+        target.write_text("data")
+
+        result = service.get_file_by_hash("abc123", "segment_0000.ts")
+
+        assert result == target
+
+    def test_should_return_none_when_file_missing(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        (tmp_path / "abc123").mkdir()
+
+        result = service.get_file_by_hash("abc123", "missing.ts")
+
+        assert result is None
+
+    def test_should_block_path_traversal(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        (tmp_path / "abc123").mkdir()
+        secret = tmp_path / "secret.txt"
+        secret.write_text("secret")
+
+        result = service.get_file_by_hash("abc123", "../secret.txt")
+
+        assert result is None
+
+    def test_should_return_nested_file(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        nested = tmp_path / "abc" / "video"
+        nested.mkdir(parents=True)
+        target = nested / "playlist.m3u8"
+        target.write_text("#EXTM3U")
+
+        result = service.get_file_by_hash("abc", "video/playlist.m3u8")
+
+        assert result == target
+
+
+@pytest.mark.unit
+class TestHlsServiceIsComplete:
+    """Tests for is_complete."""
+
+    def test_should_return_false_when_playlist_missing(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+
+        assert service.is_complete("abc123") is False
+
+    def test_should_return_true_when_endlist_marker_present(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        video_dir = tmp_path / "abc123" / "video"
+        video_dir.mkdir(parents=True)
+        (video_dir / "playlist.m3u8").write_text(
+            "#EXTM3U\n#EXTINF:10,\nsegment_0000.ts\n#EXT-X-ENDLIST\n"
+        )
+
+        assert service.is_complete("abc123") is True
+
+    def test_should_return_false_when_endlist_marker_missing(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        video_dir = tmp_path / "abc123" / "video"
+        video_dir.mkdir(parents=True)
+        (video_dir / "playlist.m3u8").write_text("#EXTM3U\n#EXTINF:10,\nsegment_0000.ts\n")
+
+        assert service.is_complete("abc123") is False
+
+    def test_should_fallback_to_flat_playlist(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        hash_dir = tmp_path / "abc123"
+        hash_dir.mkdir()
+        (hash_dir / "playlist.m3u8").write_text(
+            "#EXTM3U\n#EXTINF:10,\nsegment_0000.ts\n#EXT-X-ENDLIST\n"
+        )
+
+        assert service.is_complete("abc123") is True
+
+
+@pytest.mark.unit
+class TestHlsServiceGetMasterPlaylist:
+    """Tests for get_master_playlist."""
+
+    def test_should_return_master_playlist_content(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        hash_dir = tmp_path / "abc"
+        hash_dir.mkdir()
+        content = "#EXTM3U\n#EXT-X-VERSION:3\n"
+        (hash_dir / "master.m3u8").write_text(content)
+
+        result = service.get_master_playlist("abc")
+
+        assert result == content
+
+    def test_should_fallback_to_legacy_playlist(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        hash_dir = tmp_path / "abc"
+        hash_dir.mkdir()
+        content = "#EXTM3U\n#EXT-X-VERSION:3\n"
+        (hash_dir / "playlist.m3u8").write_text(content)
+
+        result = service.get_master_playlist("abc")
+
+        assert result == content
+
+    def test_should_return_none_when_missing(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        assert service.get_master_playlist("missing") is None
+
+
+@pytest.mark.unit
+class TestHlsServiceGetCachedTracks:
+    """Tests for get_cached_tracks."""
+
+    def test_should_return_parsed_json(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        hash_dir = tmp_path / "abc"
+        hash_dir.mkdir()
+        data = {"audio_tracks": [{"index": 0, "language": "en"}]}
+        (hash_dir / "tracks.json").write_text(json.dumps(data))
+
+        result = service.get_cached_tracks("abc")
+
+        assert result == data
+
+    def test_should_return_none_when_file_missing(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        assert service.get_cached_tracks("missing") is None
+
+    def test_should_return_none_on_invalid_json(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        hash_dir = tmp_path / "abc"
+        hash_dir.mkdir()
+        (hash_dir / "tracks.json").write_text("not json")
+
+        assert service.get_cached_tracks("abc") is None
+
+
+@pytest.mark.unit
+class TestHlsServiceBuildAudioCmd:
+    """Tests for _build_audio_cmd."""
+
+    def test_should_include_input_file(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=1)
+
+        assert "-i" in cmd
+        assert "/movies/test.mkv" in cmd
+
+    def test_should_map_to_correct_audio_stream(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=2)
+
+        assert "0:a:2" in cmd
+
+    def test_should_disable_video_and_subtitle(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
+
+        assert "-vn" in cmd
+        assert "-sn" in cmd
+
+    def test_should_use_aac_codec(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
+
+        assert "aac" in cmd
+
+
+@pytest.mark.unit
+class TestHlsServiceBuildVideoCmd:
+    """Tests for _build_video_cmd with mocked codec probe."""
+
+    def test_should_copy_video_for_h264(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "copy" in cmd
+        assert "libx264" not in cmd
+
+    def test_should_transcode_non_h264(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="hevc"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "libx264" in cmd
+
+    def test_should_map_primary_audio_track(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = MediaProbeResult(
+            audio_tracks=[_make_audio_track(index=3)],
+        )
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "0:a:3" in cmd
+
+
+@pytest.mark.unit
+class TestHlsServiceBuildMasterPlaylist:
+    """Tests for _build_master_playlist."""
+
+    def test_should_write_master_m3u8(self, tmp_path: Path) -> None:
+        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+
+        HlsService._build_master_playlist(tmp_path, probe)
+
+        master = tmp_path / "master.m3u8"
+        assert master.is_file()
+        content = master.read_text()
+        assert "#EXTM3U" in content
+        assert "video/playlist.m3u8" in content
+
+    def test_should_include_ext_media_for_alt_audio(self, tmp_path: Path) -> None:
+        probe = MediaProbeResult(
+            audio_tracks=[
+                _make_audio_track(index=0, lang="en", is_default=True),
+                _make_audio_track(index=1, lang="pt", is_default=False),
+            ],
+        )
+
+        HlsService._build_master_playlist(tmp_path, probe)
+
+        content = (tmp_path / "master.m3u8").read_text()
+        assert "#EXT-X-MEDIA:TYPE=AUDIO" in content
+        assert 'LANGUAGE="en"' in content
+        assert 'LANGUAGE="pt"' in content
+        assert 'URI="audio_1/playlist.m3u8"' in content
+
+    def test_should_include_ext_media_for_subtitles(self, tmp_path: Path) -> None:
+        probe = MediaProbeResult(
+            audio_tracks=[_make_audio_track()],
+            subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="srt")],
+        )
+
+        HlsService._build_master_playlist(tmp_path, probe)
+
+        content = (tmp_path / "master.m3u8").read_text()
+        assert "#EXT-X-MEDIA:TYPE=SUBTITLES" in content
+        assert 'URI="sub_0/playlist.m3u8"' in content
+
+    def test_should_skip_image_based_subtitles(self, tmp_path: Path) -> None:
+        probe = MediaProbeResult(
+            audio_tracks=[_make_audio_track()],
+            subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="pgs")],
+        )
+
+        HlsService._build_master_playlist(tmp_path, probe)
+
+        content = (tmp_path / "master.m3u8").read_text()
+        assert 'URI="sub_0/playlist.m3u8"' not in content
+
+    def test_should_mark_forced_subtitles(self, tmp_path: Path) -> None:
+        probe = MediaProbeResult(
+            audio_tracks=[_make_audio_track()],
+            subtitle_tracks=[
+                _make_subtitle_track(index=0, lang="en", fmt="srt", is_forced=True),
+            ],
+        )
+
+        HlsService._build_master_playlist(tmp_path, probe)
+
+        content = (tmp_path / "master.m3u8").read_text()
+        assert "FORCED=YES" in content
+
+
+@pytest.mark.unit
+class TestHlsServiceSaveAndDeserializeProbe:
+    """Tests for probe cache serialization round-trip."""
+
+    def test_should_save_probe_as_json(self, tmp_path: Path) -> None:
+        probe = MediaProbeResult(
+            audio_tracks=[_make_audio_track(index=0, lang="en", codec="aac")],
+            subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="srt")],
+        )
+
+        HlsService._save_probe_cache(tmp_path, probe)
+
+        tracks_file = tmp_path / "tracks.json"
+        assert tracks_file.is_file()
+        data = json.loads(tracks_file.read_text())
+        assert len(data["audio_tracks"]) == 1
+        assert data["audio_tracks"][0]["language"] == "en"
+
+    def test_should_round_trip_probe_cache(self, tmp_path: Path) -> None:
+        probe = MediaProbeResult(
+            audio_tracks=[
+                _make_audio_track(index=0, lang="en", codec="aac", title="English"),
+                _make_audio_track(index=1, lang="pt", codec="ac3", channels=6),
+            ],
+            subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="srt")],
+        )
+
+        HlsService._save_probe_cache(tmp_path, probe)
+        data = json.loads((tmp_path / "tracks.json").read_text())
+        result = HlsService._deserialize_probe(data)
+
+        assert len(result.audio_tracks) == 2
+        assert result.audio_tracks[0].title == "English"
+        assert result.audio_tracks[1].channels == 6
+        assert len(result.subtitle_tracks) == 1
+
+
+@pytest.mark.unit
+class TestHlsServiceProbeTracks:
+    """Tests for probe_tracks using cache."""
+
+    def test_should_return_cached_tracks_when_available(self, tmp_path: Path) -> None:
+        probe_mock = MagicMock(spec=MediaProbeService)
+        service = HlsService(cache_dir=str(tmp_path), probe_service=probe_mock)
+
+        file_path = "/movies/test.mkv"
+        path_hash = service.get_path_hash(file_path)
+        hash_dir = tmp_path / path_hash
+        hash_dir.mkdir()
+        (hash_dir / "tracks.json").write_text(
+            json.dumps({"audio_tracks": [], "subtitle_tracks": []})
+        )
+
+        result = service.probe_tracks(file_path)
+
+        assert result.audio_tracks == []
+        probe_mock.probe.assert_not_called()
+
+    def test_should_call_probe_service_when_no_cache(self, tmp_path: Path) -> None:
+        probe_mock = MagicMock(spec=MediaProbeService)
+        probe_mock.probe.return_value = MediaProbeResult(audio_tracks=[_make_audio_track()])
+        service = HlsService(cache_dir=str(tmp_path), probe_service=probe_mock)
+
+        result = service.probe_tracks("/movies/test.mkv")
+
+        probe_mock.probe.assert_called_once_with("/movies/test.mkv")
+        assert len(result.audio_tracks) == 1
+
+
+@pytest.mark.unit
+class TestHlsServiceClearCache:
+    """Tests for clear_cache."""
+
+    def test_should_clear_specific_file_cache(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        file_path = "/movies/test.mkv"
+        path_hash = service.get_path_hash(file_path)
+        (tmp_path / path_hash).mkdir()
+        (tmp_path / path_hash / "master.m3u8").write_text("#EXTM3U")
+
+        service.clear_cache(file_path)
+
+        assert not (tmp_path / path_hash).exists()
+
+    def test_should_clear_all_cache_when_no_file(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        (tmp_path / "hash1").mkdir()
+        (tmp_path / "hash2").mkdir()
+
+        service.clear_cache()
+
+        assert tmp_path.exists()  # Recreated
+        assert list(tmp_path.iterdir()) == []
+
+    def test_should_not_fail_when_cache_missing(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        # Should not raise
+        service.clear_cache("/nonexistent.mkv")
+
+
+@pytest.mark.unit
+class TestHlsServiceValidateSource:
+    """Tests for _validate_source."""
+
+    def test_should_raise_when_file_missing(self, tmp_path: Path) -> None:
+        missing = tmp_path / "missing.mkv"
+        with pytest.raises(FileNotFoundError, match="Source file not found"):
+            HlsService._validate_source(str(missing))
+
+    def test_should_return_resolved_path(self, tmp_path: Path) -> None:
+        source = tmp_path / "movie.mkv"
+        source.write_text("fake")
+
+        result = HlsService._validate_source(str(source))
+
+        assert result == source.resolve()

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -1,0 +1,425 @@
+"""Tests for MediaProbeService."""
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.modules.media.infrastructure.streaming.media_probe_service import (
+    MediaProbeResult,
+    MediaProbeService,
+)
+
+
+def _ffprobe_stream(
+    codec_type: str = "audio",
+    codec_name: str = "aac",
+    language: str = "en",
+    channels: int = 2,
+    default: bool = False,
+    forced: bool = False,
+    title: str | None = None,
+    bit_rate: str | None = None,
+) -> dict[str, Any]:
+    stream: dict[str, Any] = {
+        "codec_type": codec_type,
+        "codec_name": codec_name,
+        "channels": channels,
+        "disposition": {"default": 1 if default else 0, "forced": 1 if forced else 0},
+        "tags": {},
+    }
+    if language:
+        stream["tags"]["language"] = language
+    if title:
+        stream["tags"]["title"] = title
+    if bit_rate is not None:
+        stream["bit_rate"] = bit_rate
+    return stream
+
+
+@pytest.mark.unit
+class TestExtractLanguage:
+    """Tests for MediaProbeService._extract_language."""
+
+    def test_should_extract_2_letter_code(self) -> None:
+        stream = {"tags": {"language": "en"}}
+        assert MediaProbeService._extract_language(stream) == "en"
+
+    def test_should_truncate_3_letter_code(self) -> None:
+        stream = {"tags": {"language": "eng"}}
+        assert MediaProbeService._extract_language(stream) == "en"
+
+    def test_should_handle_uppercase(self) -> None:
+        stream = {"tags": {"LANGUAGE": "EN"}}
+        assert MediaProbeService._extract_language(stream) == "en"
+
+    def test_should_return_un_for_und(self) -> None:
+        stream = {"tags": {"language": "und"}}
+        assert MediaProbeService._extract_language(stream) == "un"
+
+    def test_should_return_un_for_invalid(self) -> None:
+        stream = {"tags": {"language": "123"}}
+        assert MediaProbeService._extract_language(stream) == "un"
+
+    def test_should_return_un_when_no_tags(self) -> None:
+        stream: dict[str, Any] = {}
+        assert MediaProbeService._extract_language(stream) == "un"
+
+
+@pytest.mark.unit
+class TestParseAudioTracks:
+    """Tests for MediaProbeService._parse_audio_tracks."""
+
+    def test_should_parse_single_audio_track(self) -> None:
+        streams = [_ffprobe_stream(codec_name="aac", language="en", channels=2)]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        assert len(tracks) == 1
+        assert tracks[0].codec == "aac"
+        assert tracks[0].language.value == "en"
+        assert tracks[0].channels == 2
+
+    def test_should_skip_non_audio_streams(self) -> None:
+        streams = [
+            _ffprobe_stream(codec_type="video"),
+            _ffprobe_stream(codec_type="subtitle"),
+            _ffprobe_stream(codec_type="audio", codec_name="aac"),
+        ]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        assert len(tracks) == 1
+        assert tracks[0].codec == "aac"
+
+    def test_should_parse_multiple_audio_tracks(self) -> None:
+        streams = [
+            _ffprobe_stream(codec_name="aac", language="en", default=True),
+            _ffprobe_stream(codec_name="ac3", language="pt", channels=6),
+        ]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        assert len(tracks) == 2
+        assert tracks[0].is_default is True
+        assert tracks[1].codec == "ac3"
+        assert tracks[1].channels == 6
+
+    def test_should_ensure_default_track_when_none_marked(self) -> None:
+        streams = [
+            _ffprobe_stream(codec_name="aac", language="en", default=False),
+            _ffprobe_stream(codec_name="ac3", language="pt", default=False),
+        ]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        # First track should be forced to default
+        assert tracks[0].is_default is True
+        assert tracks[1].is_default is False
+
+    def test_should_parse_bitrate(self) -> None:
+        streams = [_ffprobe_stream(codec_name="aac", bit_rate="192000")]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        assert tracks[0].bitrate == 192  # kbps
+
+    def test_should_parse_title(self) -> None:
+        streams = [_ffprobe_stream(codec_name="aac", title="English Stereo")]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        assert tracks[0].title == "English Stereo"
+
+    def test_should_cap_channels_at_16(self) -> None:
+        streams = [_ffprobe_stream(codec_name="aac", channels=20)]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        assert tracks[0].channels == 16
+
+    def test_should_return_empty_for_no_audio(self) -> None:
+        tracks = MediaProbeService._parse_audio_tracks([])
+        assert tracks == []
+
+
+@pytest.mark.unit
+class TestParseSubtitleTracks:
+    """Tests for MediaProbeService._parse_subtitle_tracks."""
+
+    def test_should_parse_embedded_subrip(self) -> None:
+        streams = [
+            {
+                "codec_type": "subtitle",
+                "codec_name": "subrip",
+                "disposition": {"default": 1},
+                "tags": {"language": "en"},
+            }
+        ]
+
+        tracks = MediaProbeService._parse_subtitle_tracks(streams)
+
+        assert len(tracks) == 1
+        assert tracks[0].format == "srt"
+        assert tracks[0].is_default is True
+        assert tracks[0].is_external is False
+
+    def test_should_map_codec_names(self) -> None:
+        streams = [
+            {
+                "codec_type": "subtitle",
+                "codec_name": "webvtt",
+                "disposition": {},
+                "tags": {"language": "en"},
+            },
+            {
+                "codec_type": "subtitle",
+                "codec_name": "hdmv_pgs_subtitle",
+                "disposition": {},
+                "tags": {"language": "pt"},
+            },
+        ]
+
+        tracks = MediaProbeService._parse_subtitle_tracks(streams)
+
+        assert tracks[0].format == "vtt"
+        assert tracks[1].format == "pgs"
+
+    def test_should_mark_forced_subtitles(self) -> None:
+        streams = [
+            {
+                "codec_type": "subtitle",
+                "codec_name": "subrip",
+                "disposition": {"forced": 1},
+                "tags": {"language": "en"},
+            }
+        ]
+
+        tracks = MediaProbeService._parse_subtitle_tracks(streams)
+
+        assert tracks[0].is_forced is True
+
+    def test_should_skip_non_subtitle_streams(self) -> None:
+        streams = [
+            {"codec_type": "audio"},
+            {"codec_type": "video"},
+        ]
+
+        tracks = MediaProbeService._parse_subtitle_tracks(streams)
+
+        assert tracks == []
+
+    def test_should_use_raw_codec_when_unknown(self) -> None:
+        streams = [
+            {
+                "codec_type": "subtitle",
+                "codec_name": "unknown_format",
+                "disposition": {},
+                "tags": {"language": "en"},
+            }
+        ]
+
+        tracks = MediaProbeService._parse_subtitle_tracks(streams)
+
+        assert tracks[0].format == "unknown_format"
+
+
+@pytest.mark.unit
+class TestDetectSubtitleLanguage:
+    """Tests for MediaProbeService._detect_subtitle_language."""
+
+    def test_should_detect_iso_code(self) -> None:
+        assert MediaProbeService._detect_subtitle_language("Movie.en.srt") == "en"
+
+    def test_should_detect_pt_br(self) -> None:
+        assert MediaProbeService._detect_subtitle_language("Movie.pt-BR.srt") == "pt"
+
+    def test_should_detect_full_english(self) -> None:
+        assert MediaProbeService._detect_subtitle_language("Movie.English.srt") == "en"
+
+    def test_should_detect_full_portuguese(self) -> None:
+        assert MediaProbeService._detect_subtitle_language("Movie.Portuguese.srt") == "pt"
+
+    def test_should_detect_full_japanese(self) -> None:
+        assert MediaProbeService._detect_subtitle_language("Movie.Japanese.srt") == "ja"
+
+    def test_should_return_un_for_unknown(self) -> None:
+        assert MediaProbeService._detect_subtitle_language("Movie.srt") == "un"
+
+    def test_should_handle_ass_format(self) -> None:
+        assert MediaProbeService._detect_subtitle_language("Movie.en.ass") == "en"
+
+
+@pytest.mark.unit
+class TestScanExternalSubtitles:
+    """Tests for MediaProbeService._scan_external_subtitles."""
+
+    def test_should_find_matching_subtitle_files(self, tmp_path: Path) -> None:
+        video = tmp_path / "Movie.mkv"
+        video.touch()
+        (tmp_path / "Movie.en.srt").touch()
+        (tmp_path / "Movie.pt.srt").touch()
+
+        tracks = MediaProbeService._scan_external_subtitles(video, start_index=0)
+
+        assert len(tracks) == 2
+        langs = {t.language.value for t in tracks}
+        assert langs == {"en", "pt"}
+
+    def test_should_skip_non_matching_files(self, tmp_path: Path) -> None:
+        video = tmp_path / "Movie.mkv"
+        video.touch()
+        (tmp_path / "Other.en.srt").touch()
+
+        tracks = MediaProbeService._scan_external_subtitles(video, start_index=0)
+
+        assert tracks == []
+
+    def test_should_skip_files_with_wrong_extension(self, tmp_path: Path) -> None:
+        video = tmp_path / "Movie.mkv"
+        video.touch()
+        (tmp_path / "Movie.en.txt").touch()
+
+        tracks = MediaProbeService._scan_external_subtitles(video, start_index=0)
+
+        assert tracks == []
+
+    def test_should_start_indexing_from_given_index(self, tmp_path: Path) -> None:
+        video = tmp_path / "Movie.mkv"
+        video.touch()
+        (tmp_path / "Movie.en.srt").touch()
+
+        tracks = MediaProbeService._scan_external_subtitles(video, start_index=5)
+
+        assert tracks[0].index == 5
+
+    def test_should_return_empty_when_directory_missing(self, tmp_path: Path) -> None:
+        # Point to a non-existent directory
+        video = tmp_path / "missing" / "Movie.mkv"
+
+        tracks = MediaProbeService._scan_external_subtitles(video, start_index=0)
+
+        assert tracks == []
+
+    def test_should_normalize_ssa_to_ass(self, tmp_path: Path) -> None:
+        video = tmp_path / "Movie.mkv"
+        video.touch()
+        (tmp_path / "Movie.en.ssa").touch()
+
+        tracks = MediaProbeService._scan_external_subtitles(video, start_index=0)
+
+        assert tracks[0].format == "ass"
+
+
+@pytest.mark.unit
+class TestMediaProbeResult:
+    """Tests for MediaProbeResult properties."""
+
+    def test_all_subtitles_should_combine_embedded_and_external(self) -> None:
+        from src.shared_kernel.value_objects.file_path import FilePath
+        from src.shared_kernel.value_objects.language_code import LanguageCode
+        from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+        embedded = SubtitleTrack(
+            index=0, language=LanguageCode("en"), format="srt", is_external=False
+        )
+        external = SubtitleTrack(
+            index=1,
+            language=LanguageCode("pt"),
+            format="srt",
+            is_external=True,
+            file_path=FilePath("/movies/Movie.pt.srt"),
+        )
+        result = MediaProbeResult(
+            subtitle_tracks=[embedded],
+            external_subtitles=[external],
+        )
+
+        assert len(result.all_subtitles) == 2
+
+    def test_text_subtitles_should_exclude_image_based(self) -> None:
+        from src.shared_kernel.value_objects.language_code import LanguageCode
+        from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+        text = SubtitleTrack(index=0, language=LanguageCode("en"), format="srt")
+        image = SubtitleTrack(index=1, language=LanguageCode("en"), format="pgs")
+
+        result = MediaProbeResult(subtitle_tracks=[text, image])
+
+        assert len(result.text_subtitles) == 1
+        assert result.text_subtitles[0].format == "srt"
+
+
+@pytest.mark.unit
+class TestMediaProbeServiceRunFfprobe:
+    """Tests for MediaProbeService._run_ffprobe with mocked subprocess."""
+
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value=None,
+    )
+    def test_should_return_empty_when_ffprobe_missing(self, _which: MagicMock) -> None:
+        result = MediaProbeService._run_ffprobe("/path/to/movie.mkv")
+        assert result == []
+
+    @patch("src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run")
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value="/usr/bin/ffprobe",
+    )
+    def test_should_return_streams_on_success(self, _which: MagicMock, mock_run: MagicMock) -> None:
+        streams = [{"codec_type": "audio", "codec_name": "aac"}]
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"streams": streams})
+        mock_run.return_value = mock_result
+
+        result = MediaProbeService._run_ffprobe("/path/to/movie.mkv")
+
+        assert result == streams
+
+    @patch("src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run")
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value="/usr/bin/ffprobe",
+    )
+    def test_should_return_empty_on_non_zero_exit(
+        self, _which: MagicMock, mock_run: MagicMock
+    ) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "error"
+        mock_run.return_value = mock_result
+
+        result = MediaProbeService._run_ffprobe("/path/to/movie.mkv")
+
+        assert result == []
+
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run",
+        side_effect=OSError("failed"),
+    )
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value="/usr/bin/ffprobe",
+    )
+    def test_should_return_empty_on_os_error(self, _which: MagicMock, _run: MagicMock) -> None:
+        result = MediaProbeService._run_ffprobe("/path/to/movie.mkv")
+        assert result == []
+
+
+@pytest.mark.unit
+class TestMediaProbeServiceProbe:
+    """Tests for the top-level probe method."""
+
+    def test_should_return_empty_for_missing_file(self, tmp_path: Path) -> None:
+        service = MediaProbeService()
+        missing = tmp_path / "missing.mkv"
+
+        result = service.probe(str(missing))
+
+        assert result.audio_tracks == []
+        assert result.subtitle_tracks == []
+        assert result.external_subtitles == []

--- a/tests/modules/media/unit/infrastructure/streaming/test_subprocess_helpers.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_subprocess_helpers.py
@@ -1,0 +1,103 @@
+"""Tests for streaming subprocess helpers and HLS utility functions."""
+
+import pytest
+
+from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
+from src.modules.media.infrastructure.streaming.hls_service import (
+    media_type_for,
+    rewrite_m3u8,
+)
+
+
+@pytest.mark.unit
+class TestSubprocessTextKwargs:
+    """Tests for the shared SUBPROCESS_TEXT_KWARGS mapping."""
+
+    def test_should_capture_output(self) -> None:
+        assert SUBPROCESS_TEXT_KWARGS["capture_output"] is True
+
+    def test_should_use_text_mode(self) -> None:
+        assert SUBPROCESS_TEXT_KWARGS["text"] is True
+
+    def test_should_use_utf8_encoding(self) -> None:
+        assert SUBPROCESS_TEXT_KWARGS["encoding"] == "utf-8"
+
+    def test_should_replace_decoding_errors(self) -> None:
+        assert SUBPROCESS_TEXT_KWARGS["errors"] == "replace"
+
+    def test_should_be_immutable(self) -> None:
+        with pytest.raises(TypeError):
+            SUBPROCESS_TEXT_KWARGS["capture_output"] = False  # type: ignore[index]
+
+
+@pytest.mark.unit
+class TestMediaTypeFor:
+    """Tests for media_type_for content-type detection."""
+
+    def test_should_return_hls_playlist_type_for_m3u8(self) -> None:
+        assert media_type_for("playlist.m3u8") == "application/vnd.apple.mpegurl"
+
+    def test_should_return_video_mp2t_for_ts(self) -> None:
+        assert media_type_for("segment_0001.ts") == "video/mp2t"
+
+    def test_should_return_text_vtt_for_vtt(self) -> None:
+        assert media_type_for("subtitle.vtt") == "text/vtt"
+
+    def test_should_handle_uppercase_extension(self) -> None:
+        assert media_type_for("PLAYLIST.M3U8") == "application/vnd.apple.mpegurl"
+
+    def test_should_return_octet_stream_for_unknown(self) -> None:
+        assert media_type_for("file.xyz") == "application/octet-stream"
+
+    def test_should_handle_path_with_directory(self) -> None:
+        assert media_type_for("/cache/abc/video/segment.ts") == "video/mp2t"
+
+
+@pytest.mark.unit
+class TestRewriteM3u8:
+    """Tests for rewriting relative references in M3U8 playlists."""
+
+    def test_should_prefix_relative_segment_references(self) -> None:
+        playlist = "#EXTM3U\n#EXTINF:10,\nsegment_0000.ts\n"
+
+        result = rewrite_m3u8(playlist, "https://example.com/hls/abc")
+
+        assert "https://example.com/hls/abc/segment_0000.ts" in result
+
+    def test_should_prefix_uri_attributes(self) -> None:
+        playlist = '#EXT-X-MEDIA:TYPE=AUDIO,URI="audio_1/playlist.m3u8"\n'
+
+        result = rewrite_m3u8(playlist, "https://example.com/hls/abc")
+
+        assert 'URI="https://example.com/hls/abc/audio_1/playlist.m3u8"' in result
+
+    def test_should_preserve_comment_lines(self) -> None:
+        playlist = "#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:10,\nsegment.ts\n"
+
+        result = rewrite_m3u8(playlist, "https://example.com/x")
+
+        assert "#EXTM3U" in result
+        assert "#EXT-X-VERSION:3" in result
+
+    def test_should_not_rewrite_absolute_urls(self) -> None:
+        playlist = "#EXTM3U\nhttps://other.com/segment.ts\n"
+
+        result = rewrite_m3u8(playlist, "https://example.com/x")
+
+        assert "https://other.com/segment.ts" in result
+        assert "https://example.com/x/https://other.com/segment.ts" not in result
+
+    def test_should_not_rewrite_root_relative_paths(self) -> None:
+        playlist = "#EXTM3U\n/some/path/segment.ts\n"
+
+        result = rewrite_m3u8(playlist, "https://example.com/x")
+
+        assert "/some/path/segment.ts" in result
+        assert "https://example.com/x//some/path/segment.ts" not in result
+
+    def test_should_not_rewrite_absolute_uri_attributes(self) -> None:
+        playlist = '#EXT-X-MEDIA:URI="https://other.com/playlist.m3u8"\n'
+
+        result = rewrite_m3u8(playlist, "https://example.com/x")
+
+        assert 'URI="https://other.com/playlist.m3u8"' in result


### PR DESCRIPTION
## Summary

- Add unit tests for `HlsService` — pure methods, playlist build, cache management, path traversal protection (0% → **55%**, 42 tests)
- Add unit tests for `MediaProbeService` — ffprobe parsing, language detection, external subtitle scan (0% → **96%**, 39 tests)
- Add unit tests for subprocess helpers — SUBPROCESS_TEXT_KWARGS, rewrite_m3u8, media_type_for (0% → **100%**, 17 tests)
- Total new tests: 98. Total tests: **1112** (all passing)

## Coverage improvements

| File | Before | After |
|---|---|---|
| `_subprocess.py` | 0% | **100%** |
| `media_probe_service.py` | 0% | **96%** |
| `hls_service.py` | 0% | **55%** |

## Scope note

Async/subprocess flows in `HlsService` (`ensure_playlist`, `_start_generation`, `_extract_subtitles`, `_handle_generation_failure`) are intentionally left untested — they require deep mocking of ffmpeg/ffprobe processes and thread state, which adds little confidence compared to integration tests. The tested 55% covers all pure logic, cache management, path security, and command building.

## Test plan

- [x] All 1112 tests pass (\`poetry run pytest\`)
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] Path traversal attack blocked (\`../secret.txt\`)
- [x] Master playlist correctly built for multi-audio and subtitle tracks
- [x] Probe cache round-trip serialization validated

## Summary by Sourcery

Add comprehensive unit test coverage for the media streaming infrastructure, focusing on HLS handling, media probing, and subprocess utilities.

Tests:
- Add unit tests for HlsService covering path hashing, cache access, playlist completeness, master playlist retrieval, probe caching, and cache clearing behaviors.
- Add unit tests for MediaProbeService covering ffprobe output parsing, language detection, embedded and external subtitle discovery, and ffprobe subprocess execution paths.
- Add unit tests for streaming subprocess helpers and HLS utilities, including subprocess text kwargs immutability, media content-type detection, and M3U8 URL rewriting.