### PR TITLE
test(shared-kernel): close coverage gaps in value objects

### DIFF
--- a/tests/shared_kernel/unit/value_objects/test_file_path.py
+++ b/tests/shared_kernel/unit/value_objects/test_file_path.py
@@ -4,6 +4,7 @@
 import pytest
 
 from src.building_blocks.domain.errors import DomainValidationException
+from src.shared_kernel.value_objects import FilePath
 
 
 class TestFilePathCreation:
@@ -114,28 +115,42 @@ class TestFilePathProperties:
         # Platform-independent check
         assert file_path.directory.endswith("action") or "movies" in file_path.directory
 
-    def test_filename_should_work_with_windows_path(self):
-        from src.modules.media.domain.value_objects import FilePath
+    @pytest.mark.parametrize(
+        ("path", "expected_filename", "expected_extension", "directory_contains"),
+        [
+            (
+                "C:\\Movies\\action\\inception.mkv",
+                "inception.mkv",
+                ".mkv",
+                ["action", "Movies"],
+            ),
+            (
+                "D:\\Media\\series\\show.mp4",
+                "show.mp4",
+                ".mp4",
+                ["series", "Media"],
+            ),
+            (
+                "C:\\Movies\\no_extension",
+                "no_extension",
+                "",
+                ["Movies"],
+            ),
+        ],
+    )
+    def test_windows_path_properties(
+        self,
+        path: str,
+        expected_filename: str,
+        expected_extension: str,
+        directory_contains: list[str],
+    ) -> None:
+        file_path = FilePath(path)
 
-        file_path = FilePath("C:\\Movies\\action\\inception.mkv")
-
-        assert file_path.filename == "inception.mkv"
-
-    def test_extension_should_work_with_windows_path(self):
-        from src.modules.media.domain.value_objects import FilePath
-
-        file_path = FilePath("C:\\Movies\\inception.mkv")
-
-        assert file_path.extension == ".mkv"
-
-    def test_directory_should_work_with_windows_path(self):
-        from src.modules.media.domain.value_objects import FilePath
-
-        file_path = FilePath("C:\\Movies\\action\\inception.mkv")
-
-        # PureWindowsPath parent for this path is C:\Movies\action
-        assert "action" in file_path.directory
-        assert "Movies" in file_path.directory
+        assert file_path.filename == expected_filename
+        assert file_path.extension == expected_extension
+        for segment in directory_contains:
+            assert segment in file_path.directory
 
 
 class TestFilePathEquality:

--- a/tests/shared_kernel/unit/value_objects/test_file_path.py
+++ b/tests/shared_kernel/unit/value_objects/test_file_path.py
@@ -114,6 +114,29 @@ class TestFilePathProperties:
         # Platform-independent check
         assert file_path.directory.endswith("action") or "movies" in file_path.directory
 
+    def test_filename_should_work_with_windows_path(self):
+        from src.modules.media.domain.value_objects import FilePath
+
+        file_path = FilePath("C:\\Movies\\action\\inception.mkv")
+
+        assert file_path.filename == "inception.mkv"
+
+    def test_extension_should_work_with_windows_path(self):
+        from src.modules.media.domain.value_objects import FilePath
+
+        file_path = FilePath("C:\\Movies\\inception.mkv")
+
+        assert file_path.extension == ".mkv"
+
+    def test_directory_should_work_with_windows_path(self):
+        from src.modules.media.domain.value_objects import FilePath
+
+        file_path = FilePath("C:\\Movies\\action\\inception.mkv")
+
+        # PureWindowsPath parent for this path is C:\Movies\action
+        assert "action" in file_path.directory
+        assert "Movies" in file_path.directory
+
 
 class TestFilePathEquality:
     """Tests for FilePath equality and hashing."""

--- a/tests/shared_kernel/unit/value_objects/test_image_url.py
+++ b/tests/shared_kernel/unit/value_objects/test_image_url.py
@@ -37,6 +37,10 @@ class TestImageUrlCreation:
         with pytest.raises(DomainValidationException):
             ImageUrl("not a url or path")
 
+    def test_should_raise_for_non_string_input(self):
+        with pytest.raises(DomainValidationException, match="must be a string"):
+            ImageUrl(123)  # type: ignore[arg-type]
+
 
 class TestImageUrlBehavior:
     """Tests for ImageUrl behavior."""

--- a/tests/shared_kernel/unit/value_objects/test_language_code.py
+++ b/tests/shared_kernel/unit/value_objects/test_language_code.py
@@ -51,6 +51,10 @@ class TestLanguageCodeValidation:
         with pytest.raises(DomainValidationException, match="ISO 639-1"):
             LanguageCode("")
 
+    def test_should_raise_error_for_non_string_input(self):
+        with pytest.raises(DomainValidationException, match="must be a string"):
+            LanguageCode(123)  # type: ignore[arg-type]
+
 
 class TestLanguageCodeFactories:
     """Tests for LanguageCode factory methods."""


### PR DESCRIPTION
## Summary

- Add tests for non-string input validation in \`ImageUrl\` and \`LanguageCode\` (previously uncovered branches)
- Add tests for \`FilePath\` computed properties (filename, extension, directory) with Windows paths — exercises \`PureWindowsPath\` branch in \`_get_path()\`
- Note: \`media_type.py\` and \`tracks.py\` were already at 100% coverage before this PR

## Coverage improvements

| File | Before | After |
|---|---|---|
| \`image_url.py\` | 94% | **100%** |
| \`language_code.py\` | 94% | **100%** |
| \`file_path.py\` | 92% | **96%** |
| **shared_kernel total** | **96%** | **99%** |

## Note on file_path.py line 69

One line remains uncovered: the defensive post-normalization traversal check at \`file_path.py:69\`. This is effectively unreachable dead code because \`PurePath\` normalization does not introduce \`..\` characters, and the pre-normalization check at line 51 catches any input containing \`..\`. Properly covering it would require a \`# pragma: no cover\` annotation in the source — out of scope for this PR.

## Test plan

- [x] All 1258 tests pass (\`poetry run pytest\`)
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] Coverage verified per file via \`pytest --cov-report=term-missing\`

## Coverage journey

With this PR, the full test suite has grown from 812 tests (54.56% coverage) to **1258 tests (77.46% coverage)** across 8 phases of test additions focused on collections domain, application, infrastructure, media use cases, streaming, TMDB client, building blocks, and shared kernel gaps.

## Summary by Sourcery

Increase shared-kernel value object test coverage, especially around edge-case validation and Windows path handling.

Tests:
- Add tests for FilePath filename, extension, and directory properties using Windows-style paths.
- Add validation tests ensuring ImageUrl and LanguageCode reject non-string inputs with appropriate errors.