### PR TITLE
test(watch-progress): add infrastructure tests for mapper and repository

### DIFF
--- a/tests/modules/watch_progress/integration/conftest.py
+++ b/tests/modules/watch_progress/integration/conftest.py
@@ -1,0 +1,41 @@
+"""Integration test fixtures for watch_progress database operations."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.config.persistence import Base
+
+
+@pytest.fixture(scope="function")
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Create an in-memory SQLite database session for testing.
+
+    Creates fresh tables for each test function and tears them down after.
+
+    Yields:
+        AsyncSession: A database session connected to an in-memory SQLite database.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+    async with session_factory() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()

--- a/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
+++ b/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
@@ -1,0 +1,248 @@
+"""Integration tests for SQLAlchemyWatchProgressRepository."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.infrastructure.persistence.repositories import (
+    SQLAlchemyWatchProgressRepository,
+)
+
+SAMPLE_MOVIE_ID = "mov_abc123def456"
+SAMPLE_EPISODE_ID = "epi_xyz789abc123"
+MISSING_MEDIA_ID = "mov_missing00000"
+
+
+def _create_progress(
+    media_id: str = SAMPLE_MOVIE_ID,
+    media_type: str = "movie",
+    position: int = 1800,
+    duration: int = 7200,
+) -> WatchProgress:
+    return WatchProgress.create(
+        media_id=media_id,
+        media_type=media_type,
+        position_seconds=position,
+        duration_seconds=duration,
+    )
+
+
+@pytest.mark.integration
+class TestSQLAlchemyWatchProgressRepositorySave:
+    """Tests for save (insert + update)."""
+
+    async def test_save_should_insert_new_progress(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        progress = _create_progress()
+
+        saved = await repo.save(progress)
+
+        assert saved.media_id == SAMPLE_MOVIE_ID
+        assert saved.position_seconds == 1800
+        assert saved.status == "in_progress"
+
+    async def test_save_should_update_existing_progress(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        original = _create_progress(position=1000)
+        await repo.save(original)
+
+        updated_entity = original.update_position(position_seconds=3000)
+        await repo.save(updated_entity)
+
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        assert found is not None
+        assert found.position_seconds == 3000
+
+    async def test_save_should_auto_complete_at_90_percent(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        progress = WatchProgress.create(
+            media_id=SAMPLE_MOVIE_ID,
+            media_type="movie",
+            position_seconds=6500,
+            duration_seconds=7200,
+        )
+
+        saved = await repo.save(progress)
+
+        assert saved.status == "completed"
+        assert saved.completed_at is not None
+
+
+@pytest.mark.integration
+class TestSQLAlchemyWatchProgressRepositoryFind:
+    """Tests for find operations."""
+
+    async def test_find_by_media_id_should_return_progress(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress())
+
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+
+        assert found is not None
+        assert found.media_id == SAMPLE_MOVIE_ID
+
+    async def test_find_by_media_id_should_return_none_when_absent(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+
+        found = await repo.find_by_media_id(MISSING_MEDIA_ID)
+
+        assert found is None
+
+    async def test_find_by_media_ids_should_return_mapping(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress(media_id=SAMPLE_MOVIE_ID))
+        await repo.save(
+            _create_progress(media_id=SAMPLE_EPISODE_ID, media_type="episode"),
+        )
+
+        result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, SAMPLE_EPISODE_ID])
+
+        assert len(result) == 2
+        assert SAMPLE_MOVIE_ID in result
+        assert SAMPLE_EPISODE_ID in result
+
+    async def test_find_by_media_ids_should_return_empty_for_empty_input(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+
+        result = await repo.find_by_media_ids([])
+
+        assert result == {}
+
+    async def test_find_by_media_ids_should_skip_missing(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress(media_id=SAMPLE_MOVIE_ID))
+
+        result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, MISSING_MEDIA_ID])
+
+        assert list(result.keys()) == [SAMPLE_MOVIE_ID]
+
+
+@pytest.mark.integration
+class TestSQLAlchemyWatchProgressRepositoryList:
+    """Tests for list operations."""
+
+    async def test_list_in_progress_should_exclude_completed(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress(media_id="mov_aaaaaaaaaaaa"))
+        await repo.save(
+            WatchProgress.create(
+                media_id="mov_bbbbbbbbbbbb",
+                media_type="movie",
+                position_seconds=7200,
+                duration_seconds=7200,
+            ),
+        )
+
+        result = await repo.list_in_progress()
+
+        assert len(result) == 1
+        assert result[0].media_id == "mov_aaaaaaaaaaaa"
+
+    async def test_list_in_progress_should_order_by_last_watched_desc(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        # Save in a specific order; last saved should appear first
+        await repo.save(_create_progress(media_id="mov_first0000000"))
+        await repo.save(_create_progress(media_id="mov_second000000"))
+        await repo.save(_create_progress(media_id="mov_third0000000"))
+
+        result = await repo.list_in_progress()
+
+        assert [p.media_id for p in result] == [
+            "mov_third0000000",
+            "mov_second000000",
+            "mov_first0000000",
+        ]
+
+    async def test_list_in_progress_should_respect_limit(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        for i in range(5):
+            await repo.save(_create_progress(media_id=f"mov_{i}aaaaaaaaaaa"))
+
+        result = await repo.list_in_progress(limit=2)
+
+        assert len(result) == 2
+
+    async def test_list_recently_watched_should_include_completed(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress(media_id="mov_aaaaaaaaaaaa"))
+        await repo.save(
+            WatchProgress.create(
+                media_id="mov_bbbbbbbbbbbb",
+                media_type="movie",
+                position_seconds=7200,
+                duration_seconds=7200,
+            ),
+        )
+
+        result = await repo.list_recently_watched()
+
+        assert len(result) == 2
+
+    async def test_list_recently_watched_should_exclude_deleted(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress(media_id="mov_kept000000000"))
+        await repo.save(_create_progress(media_id="mov_deleted000000"))
+        await repo.delete("mov_deleted000000")
+
+        result = await repo.list_recently_watched()
+
+        assert len(result) == 1
+        assert result[0].media_id == "mov_kept000000000"
+
+    async def test_list_recently_watched_should_respect_limit(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        for i in range(5):
+            await repo.save(_create_progress(media_id=f"mov_{i}aaaaaaaaaaa"))
+
+        result = await repo.list_recently_watched(limit=3)
+
+        assert len(result) == 3
+
+
+@pytest.mark.integration
+class TestSQLAlchemyWatchProgressRepositoryDelete:
+    """Tests for delete."""
+
+    async def test_delete_should_soft_delete_progress(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress())
+
+        deleted = await repo.delete(SAMPLE_MOVIE_ID)
+
+        assert deleted is True
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        assert found is None
+
+    async def test_delete_should_return_false_when_not_found(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+
+        deleted = await repo.delete(MISSING_MEDIA_ID)
+
+        assert deleted is False
+
+    async def test_delete_should_exclude_from_in_progress_list(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress(media_id=SAMPLE_MOVIE_ID))
+        await repo.delete(SAMPLE_MOVIE_ID)
+
+        result = await repo.list_in_progress()
+
+        assert result == []

--- a/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
+++ b/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
@@ -1,0 +1,210 @@
+"""Unit tests for WatchProgressMapper."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.value_objects import ProgressId
+from src.modules.watch_progress.infrastructure.persistence.mappers import (
+    WatchProgressMapper,
+)
+from src.modules.watch_progress.infrastructure.persistence.models import (
+    WatchProgressModel,
+)
+
+
+def _make_progress(
+    media_id: str = "mov_abc123def456",
+    media_type: str = "movie",
+    position: int = 1800,
+    duration: int = 7200,
+    progress_id: ProgressId | None = None,
+) -> WatchProgress:
+    return WatchProgress(
+        id=progress_id or ProgressId.generate(),
+        media_id=media_id,
+        media_type=media_type,
+        position_seconds=position,
+        duration_seconds=duration,
+    )
+
+
+@pytest.mark.unit
+class TestWatchProgressMapperToModel:
+    """Tests for WatchProgressMapper.to_model."""
+
+    def test_should_raise_when_id_is_none(self) -> None:
+        progress = WatchProgress(
+            id=None,
+            media_id="mov_abc123def456",
+            media_type="movie",
+            position_seconds=100,
+            duration_seconds=7200,
+        )
+
+        with pytest.raises(ValueError, match="Cannot map entity without ID"):
+            WatchProgressMapper.to_model(progress)
+
+    def test_should_convert_entity_correctly(self) -> None:
+        progress_id = ProgressId.generate()
+        progress = _make_progress(progress_id=progress_id)
+
+        model = WatchProgressMapper.to_model(progress)
+
+        assert model.external_id == str(progress_id)
+        assert model.media_id == "mov_abc123def456"
+        assert model.media_type == "movie"
+        assert model.position_seconds == 1800
+        assert model.duration_seconds == 7200
+        assert model.status == "in_progress"
+
+    def test_should_preserve_optional_tracks(self) -> None:
+        progress = WatchProgress(
+            id=ProgressId.generate(),
+            media_id="mov_abc123def456",
+            media_type="movie",
+            position_seconds=100,
+            duration_seconds=7200,
+            audio_track=1,
+            subtitle_track=2,
+        )
+
+        model = WatchProgressMapper.to_model(progress)
+
+        assert model.audio_track == 1
+        assert model.subtitle_track == 2
+
+    def test_should_preserve_completed_status(self) -> None:
+        now = datetime.now(UTC)
+        progress = WatchProgress(
+            id=ProgressId.generate(),
+            media_id="mov_abc123def456",
+            media_type="movie",
+            position_seconds=7200,
+            duration_seconds=7200,
+            status="completed",
+            completed_at=now,
+        )
+
+        model = WatchProgressMapper.to_model(progress)
+
+        assert model.status == "completed"
+        assert model.completed_at == now
+
+
+@pytest.mark.unit
+class TestWatchProgressMapperToEntity:
+    """Tests for WatchProgressMapper.to_entity."""
+
+    def test_should_convert_model_correctly(self) -> None:
+        progress_id = ProgressId.generate()
+        now = datetime.now(UTC)
+        model = WatchProgressModel(
+            external_id=str(progress_id),
+            media_id="epi_xyz789abc123",
+            media_type="episode",
+            position_seconds=900,
+            duration_seconds=3600,
+            status="in_progress",
+            audio_track=0,
+            subtitle_track=1,
+            last_watched_at=now,
+            completed_at=None,
+        )
+        model.created_at = now
+        model.updated_at = now
+
+        entity = WatchProgressMapper.to_entity(model)
+
+        assert entity.id == progress_id
+        assert entity.media_id == "epi_xyz789abc123"
+        assert entity.media_type == "episode"
+        assert entity.position_seconds == 900
+        assert entity.status == "in_progress"
+        assert entity.audio_track == 0
+        assert entity.subtitle_track == 1
+
+    def test_round_trip_should_preserve_fields(self) -> None:
+        progress_id = ProgressId.generate()
+        original = _make_progress(progress_id=progress_id)
+
+        model = WatchProgressMapper.to_model(original)
+        model.created_at = original.created_at
+        model.updated_at = original.updated_at
+        result = WatchProgressMapper.to_entity(model)
+
+        assert result.id == original.id
+        assert result.media_id == original.media_id
+        assert result.position_seconds == original.position_seconds
+        assert result.duration_seconds == original.duration_seconds
+
+
+@pytest.mark.unit
+class TestWatchProgressMapperUpdateModel:
+    """Tests for WatchProgressMapper.update_model."""
+
+    def test_should_update_mutable_fields(self) -> None:
+        progress_id = ProgressId.generate()
+        now = datetime.now(UTC)
+        model = WatchProgressModel(
+            external_id=str(progress_id),
+            media_id="mov_abc123def456",
+            media_type="movie",
+            position_seconds=100,
+            duration_seconds=7200,
+            status="in_progress",
+            audio_track=None,
+            subtitle_track=None,
+            last_watched_at=now,
+            completed_at=None,
+        )
+
+        later = datetime.now(UTC)
+        updated = WatchProgress(
+            id=progress_id,
+            media_id="mov_abc123def456",
+            media_type="movie",
+            position_seconds=6500,
+            duration_seconds=7200,
+            status="completed",
+            audio_track=1,
+            subtitle_track=2,
+            last_watched_at=later,
+            completed_at=later,
+        )
+
+        result = WatchProgressMapper.update_model(model, updated)
+
+        assert result.position_seconds == 6500
+        assert result.status == "completed"
+        assert result.audio_track == 1
+        assert result.subtitle_track == 2
+        assert result.last_watched_at == later
+        assert result.completed_at == later
+
+    def test_should_not_change_external_id_or_media_id(self) -> None:
+        progress_id = ProgressId.generate()
+        model = WatchProgressModel(
+            external_id=str(progress_id),
+            media_id="mov_original00000",
+            media_type="movie",
+            position_seconds=100,
+            duration_seconds=7200,
+            status="in_progress",
+            last_watched_at=datetime.now(UTC),
+        )
+
+        updated = WatchProgress(
+            id=progress_id,
+            media_id="mov_different000",
+            media_type="movie",
+            position_seconds=200,
+            duration_seconds=7200,
+        )
+
+        result = WatchProgressMapper.update_model(model, updated)
+
+        # media_id and external_id are not touched by update_model
+        assert result.external_id == str(progress_id)
+        assert result.media_id == "mov_original00000"


### PR DESCRIPTION
## Summary

- Add 8 unit tests for \`WatchProgressMapper\` covering \`to_model\` (id required, field conversion, optional tracks, completed status), \`to_entity\` (conversion + round-trip), and \`update_model\` (mutable fields vs immutable identity)
- Add 17 integration tests for \`SQLAlchemyWatchProgressRepository\` covering \`save\` (insert + update + auto-complete at 90%), \`find_by_media_id\`, \`find_by_media_ids\` (empty + missing), \`list_in_progress\` (excludes completed, orders by last_watched), \`list_recently_watched\` (includes completed, excludes soft-deleted), and \`delete\` (soft-delete)
- Total tests: **1283** (all passing)

## Coverage improvements

| File | Before | After |
|---|---|---|
| \`watch_progress_mapper.py\` | 0% | **100%** |
| \`watch_progress_model.py\` | 0% | **100%** |
| \`watch_progress_repository.py\` | 0% | **100%** |
| **Global** | **77.46%** | **78.86%** |

## Test plan

- [x] All 1283 tests pass (\`poetry run pytest\`)
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] Save correctly handles insert (new) and update (existing) paths
- [x] Auto-completion at 90% threshold validated end-to-end through save
- [x] Soft-deleted records excluded from all list queries

## Summary by Sourcery

Add comprehensive tests for watch progress persistence, covering mapper conversions and repository behavior against a real database.

Tests:
- Add unit tests for WatchProgressMapper covering model/entity conversion, optional fields, and update semantics.
- Add integration tests for SQLAlchemyWatchProgressRepository covering save/update behavior, auto-completion threshold, querying APIs, and soft deletion semantics.
- Introduce a shared async in-memory SQLite session fixture for watch_progress integration tests.