### PR TITLE
test(media): close coverage gaps in repos and remove_file_variant (80% milestone)

### DIFF
--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -230,3 +230,135 @@ class TestSQLAlchemyMovieRepository:
         assert "Horror" in genre_values
         assert "Thriller" in genre_values
         assert "Mystery" in genre_values
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryFindRandom:
+    """Tests for find_random."""
+
+    async def test_find_random_should_return_requested_limit(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        for i in range(5):
+            await repo.save(
+                _create_movie(
+                    title=f"Movie {i}",
+                    file_path=f"/movies/movie_{i}.mkv",
+                ),
+            )
+
+        result = await repo.find_random(limit=3)
+
+        assert len(result) == 3
+
+    async def test_find_random_should_return_all_when_limit_exceeds_total(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/movies/a.mkv"))
+        await repo.save(_create_movie(title="B", file_path="/movies/b.mkv"))
+
+        result = await repo.find_random(limit=10)
+
+        assert len(result) == 2
+
+    async def test_find_random_with_backdrop_should_filter_without_backdrop(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(
+            _create_movie(
+                title="With Backdrop",
+                file_path="/movies/with.mkv",
+                backdrop_path=ImageUrl("https://image.tmdb.org/backdrop.jpg"),
+            ),
+        )
+        await repo.save(_create_movie(title="No Backdrop", file_path="/movies/no.mkv"))
+
+        result = await repo.find_random(limit=10, with_backdrop=True)
+
+        assert len(result) == 1
+        assert result[0].title.value == "With Backdrop"
+
+    async def test_find_random_should_exclude_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        kept = _create_movie(title="Kept", file_path="/movies/kept.mkv")
+        deleted = _create_movie(title="Deleted", file_path="/movies/deleted.mkv")
+        await repo.save(kept)
+        await repo.save(deleted)
+        await repo.delete(deleted.id)  # type: ignore[arg-type]
+
+        result = await repo.find_random(limit=10)
+
+        assert len(result) == 1
+        assert result[0].title.value == "Kept"
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryFindByIds:
+    """Tests for find_by_ids."""
+
+    async def test_find_by_ids_should_return_empty_dict_for_empty_input(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+
+        result = await repo.find_by_ids([])
+
+        assert result == {}
+
+    async def test_find_by_ids_should_return_mapping_by_external_id(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie_a = _create_movie(title="A", file_path="/movies/a.mkv")
+        movie_b = _create_movie(title="B", file_path="/movies/b.mkv")
+        await repo.save(movie_a)
+        await repo.save(movie_b)
+
+        result = await repo.find_by_ids([movie_a.id, movie_b.id])  # type: ignore[list-item]
+
+        assert len(result) == 2
+        assert str(movie_a.id) in result
+        assert str(movie_b.id) in result
+
+    async def test_find_by_ids_should_skip_missing(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _create_movie(title="Exists", file_path="/movies/exists.mkv")
+        await repo.save(movie)
+        missing_id = MovieId.generate()
+
+        result = await repo.find_by_ids([movie.id, missing_id])  # type: ignore[list-item]
+
+        assert len(result) == 1
+        assert str(movie.id) in result
+
+    async def test_find_by_ids_should_exclude_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _create_movie(title="Deleted", file_path="/movies/del.mkv")
+        await repo.save(movie)
+        await repo.delete(movie.id)  # type: ignore[arg-type]
+
+        result = await repo.find_by_ids([movie.id])  # type: ignore[list-item]
+
+        assert result == {}
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositorySaveRestore:
+    """Tests for save restoring soft-deleted records."""
+
+    async def test_save_should_restore_soft_deleted_movie(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _create_movie(title="Restored", file_path="/movies/r.mkv")
+        await repo.save(movie)
+        await repo.delete(movie.id)  # type: ignore[arg-type]
+
+        # Re-save the same entity
+        restored = await repo.save(movie)
+
+        assert restored.id == movie.id
+        found = await repo.find_by_id(movie.id)  # type: ignore[arg-type]
+        assert found is not None
+        assert found.title.value == "Restored"

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -48,6 +48,22 @@ def _create_movie(
     )
 
 
+def _id_of(movie: Movie) -> MovieId:
+    """Return the movie's ID, asserting it is set (narrows the type)."""
+    assert movie.id is not None
+    return movie.id
+
+
+async def _seed_movies(repo: SQLAlchemyMovieRepository, count: int) -> list[Movie]:
+    """Save ``count`` movies with sequential titles and file paths."""
+    movies = [
+        _create_movie(title=f"Movie {i}", file_path=f"/movies/movie_{i}.mkv") for i in range(count)
+    ]
+    for movie in movies:
+        await repo.save(movie)
+    return movies
+
+
 @pytest.mark.integration
 class TestSQLAlchemyMovieRepository:
     """Integration tests for movie repository operations."""
@@ -240,13 +256,7 @@ class TestSQLAlchemyMovieRepositoryFindRandom:
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemyMovieRepository(db_session)
-        for i in range(5):
-            await repo.save(
-                _create_movie(
-                    title=f"Movie {i}",
-                    file_path=f"/movies/movie_{i}.mkv",
-                ),
-            )
+        await _seed_movies(repo, count=5)
 
         result = await repo.find_random(limit=3)
 
@@ -256,8 +266,7 @@ class TestSQLAlchemyMovieRepositoryFindRandom:
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemyMovieRepository(db_session)
-        await repo.save(_create_movie(title="A", file_path="/movies/a.mkv"))
-        await repo.save(_create_movie(title="B", file_path="/movies/b.mkv"))
+        await _seed_movies(repo, count=2)
 
         result = await repo.find_random(limit=10)
 
@@ -287,7 +296,7 @@ class TestSQLAlchemyMovieRepositoryFindRandom:
         deleted = _create_movie(title="Deleted", file_path="/movies/deleted.mkv")
         await repo.save(kept)
         await repo.save(deleted)
-        await repo.delete(deleted.id)  # type: ignore[arg-type]
+        await repo.delete(_id_of(deleted))
 
         result = await repo.find_random(limit=10)
 
@@ -312,24 +321,21 @@ class TestSQLAlchemyMovieRepositoryFindByIds:
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemyMovieRepository(db_session)
-        movie_a = _create_movie(title="A", file_path="/movies/a.mkv")
-        movie_b = _create_movie(title="B", file_path="/movies/b.mkv")
-        await repo.save(movie_a)
-        await repo.save(movie_b)
+        movies = await _seed_movies(repo, count=2)
+        ids = [_id_of(m) for m in movies]
 
-        result = await repo.find_by_ids([movie_a.id, movie_b.id])  # type: ignore[list-item]
+        result = await repo.find_by_ids(ids)
 
         assert len(result) == 2
-        assert str(movie_a.id) in result
-        assert str(movie_b.id) in result
+        for movie_id in ids:
+            assert str(movie_id) in result
 
     async def test_find_by_ids_should_skip_missing(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyMovieRepository(db_session)
         movie = _create_movie(title="Exists", file_path="/movies/exists.mkv")
         await repo.save(movie)
-        missing_id = MovieId.generate()
 
-        result = await repo.find_by_ids([movie.id, missing_id])  # type: ignore[list-item]
+        result = await repo.find_by_ids([_id_of(movie), MovieId.generate()])
 
         assert len(result) == 1
         assert str(movie.id) in result
@@ -338,9 +344,10 @@ class TestSQLAlchemyMovieRepositoryFindByIds:
         repo = SQLAlchemyMovieRepository(db_session)
         movie = _create_movie(title="Deleted", file_path="/movies/del.mkv")
         await repo.save(movie)
-        await repo.delete(movie.id)  # type: ignore[arg-type]
+        movie_id = _id_of(movie)
+        await repo.delete(movie_id)
 
-        result = await repo.find_by_ids([movie.id])  # type: ignore[list-item]
+        result = await repo.find_by_ids([movie_id])
 
         assert result == {}
 
@@ -353,12 +360,13 @@ class TestSQLAlchemyMovieRepositorySaveRestore:
         repo = SQLAlchemyMovieRepository(db_session)
         movie = _create_movie(title="Restored", file_path="/movies/r.mkv")
         await repo.save(movie)
-        await repo.delete(movie.id)  # type: ignore[arg-type]
+        movie_id = _id_of(movie)
+        await repo.delete(movie_id)
 
         # Re-save the same entity
         restored = await repo.save(movie)
 
         assert restored.id == movie.id
-        found = await repo.find_by_id(movie.id)  # type: ignore[arg-type]
+        found = await repo.find_by_id(movie_id)
         assert found is not None
         assert found.title.value == "Restored"

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -486,3 +486,181 @@ class TestSQLAlchemySeriesRepository:
         result = await repo.save(updated_series)
 
         assert result.seasons[0].episodes[0].title.value == "Updated Episode Title"
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryFindRandom:
+    """Tests for find_random."""
+
+    async def test_find_random_should_return_requested_limit(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        for i in range(5):
+            await repo.save(_create_series(title=f"Series {i}"))
+
+        result = await repo.find_random(limit=3)
+
+        assert len(result) == 3
+
+    async def test_find_random_with_backdrop_should_filter(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(
+            _create_series(
+                title="With Backdrop",
+                backdrop_path=ImageUrl("https://image.tmdb.org/backdrop.jpg"),
+            ),
+        )
+        await repo.save(_create_series(title="No Backdrop"))
+
+        result = await repo.find_random(limit=10, with_backdrop=True)
+
+        assert len(result) == 1
+        assert result[0].title.value == "With Backdrop"
+
+    async def test_find_random_should_exclude_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        kept = _create_series(title="Kept")
+        deleted = _create_series(title="Deleted")
+        await repo.save(kept)
+        await repo.save(deleted)
+        await repo.delete(deleted.id)  # type: ignore[arg-type]
+
+        result = await repo.find_random(limit=10)
+
+        assert len(result) == 1
+        assert result[0].title.value == "Kept"
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryFindByIds:
+    """Tests for find_by_ids."""
+
+    async def test_find_by_ids_should_return_empty_dict_for_empty_input(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+
+        result = await repo.find_by_ids([])
+
+        assert result == {}
+
+    async def test_find_by_ids_should_return_mapping_by_external_id(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series_a = _create_series(title="A")
+        series_b = _create_series(title="B")
+        await repo.save(series_a)
+        await repo.save(series_b)
+
+        result = await repo.find_by_ids([series_a.id, series_b.id])  # type: ignore[list-item]
+
+        assert len(result) == 2
+        assert str(series_a.id) in result
+        assert str(series_b.id) in result
+
+    async def test_find_by_ids_should_skip_missing(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _create_series(title="Exists")
+        await repo.save(series)
+        missing = SeriesId.generate()
+
+        result = await repo.find_by_ids([series.id, missing])  # type: ignore[list-item]
+
+        assert len(result) == 1
+        assert str(series.id) in result
+
+    async def test_find_by_ids_should_exclude_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _create_series(title="Deleted")
+        await repo.save(series)
+        await repo.delete(series.id)  # type: ignore[arg-type]
+
+        result = await repo.find_by_ids([series.id])  # type: ignore[list-item]
+
+        assert result == {}
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryFindByTitle:
+    """Tests for find_by_title."""
+
+    async def test_find_by_title_should_return_series(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_create_series(title="Breaking Bad"))
+
+        result = await repo.find_by_title(Title("Breaking Bad"))
+
+        assert result is not None
+        assert result.title.value == "Breaking Bad"
+
+    async def test_find_by_title_should_be_case_insensitive(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_create_series(title="Breaking Bad"))
+
+        result = await repo.find_by_title(Title("breaking bad"))
+
+        assert result is not None
+
+    async def test_find_by_title_should_return_none_when_missing(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+
+        result = await repo.find_by_title(Title("Nonexistent"))
+
+        assert result is None
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryFindByEpisodeId:
+    """Tests for find_by_episode_id."""
+
+    async def test_find_by_episode_id_should_return_series(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _create_series(
+            title="With Episodes",
+            season_count=1,
+            episodes_per_season=2,
+        )
+        await repo.save(series)
+        episode_id = series.seasons[0].episodes[0].id
+        assert episode_id is not None
+
+        result = await repo.find_by_episode_id(episode_id)
+
+        assert result is not None
+        assert result.id == series.id
+
+    async def test_find_by_episode_id_should_return_none_when_missing(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+
+        result = await repo.find_by_episode_id(EpisodeId.generate())
+
+        assert result is None
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositorySaveRestore:
+    """Tests for save restoring soft-deleted records."""
+
+    async def test_save_should_restore_soft_deleted_series(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _create_series(
+            title="Restored",
+            season_count=1,
+            episodes_per_season=1,
+        )
+        await repo.save(series)
+        await repo.delete(series.id)  # type: ignore[arg-type]
+
+        # Re-save to restore
+        restored = await repo.save(series)
+
+        assert restored.id == series.id
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert found is not None
+        assert found.title.value == "Restored"

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -86,6 +86,20 @@ def _create_series(
     )
 
 
+def _id_of(series: Series) -> SeriesId:
+    """Return the series' ID, asserting it is set (narrows the type)."""
+    assert series.id is not None
+    return series.id
+
+
+async def _seed_series(repo: SQLAlchemySeriesRepository, count: int) -> list[Series]:
+    """Save ``count`` series with sequential titles."""
+    series_list = [_create_series(title=f"Series {i}") for i in range(count)]
+    for series in series_list:
+        await repo.save(series)
+    return series_list
+
+
 @pytest.mark.integration
 class TestSQLAlchemySeriesRepository:
     """Integration tests for series repository operations."""
@@ -496,8 +510,7 @@ class TestSQLAlchemySeriesRepositoryFindRandom:
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemySeriesRepository(db_session)
-        for i in range(5):
-            await repo.save(_create_series(title=f"Series {i}"))
+        await _seed_series(repo, count=5)
 
         result = await repo.find_random(limit=3)
 
@@ -524,7 +537,7 @@ class TestSQLAlchemySeriesRepositoryFindRandom:
         deleted = _create_series(title="Deleted")
         await repo.save(kept)
         await repo.save(deleted)
-        await repo.delete(deleted.id)  # type: ignore[arg-type]
+        await repo.delete(_id_of(deleted))
 
         result = await repo.find_random(limit=10)
 
@@ -549,24 +562,21 @@ class TestSQLAlchemySeriesRepositoryFindByIds:
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemySeriesRepository(db_session)
-        series_a = _create_series(title="A")
-        series_b = _create_series(title="B")
-        await repo.save(series_a)
-        await repo.save(series_b)
+        seeded = await _seed_series(repo, count=2)
+        ids = [_id_of(s) for s in seeded]
 
-        result = await repo.find_by_ids([series_a.id, series_b.id])  # type: ignore[list-item]
+        result = await repo.find_by_ids(ids)
 
         assert len(result) == 2
-        assert str(series_a.id) in result
-        assert str(series_b.id) in result
+        for series_id in ids:
+            assert str(series_id) in result
 
     async def test_find_by_ids_should_skip_missing(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemySeriesRepository(db_session)
         series = _create_series(title="Exists")
         await repo.save(series)
-        missing = SeriesId.generate()
 
-        result = await repo.find_by_ids([series.id, missing])  # type: ignore[list-item]
+        result = await repo.find_by_ids([_id_of(series), SeriesId.generate()])
 
         assert len(result) == 1
         assert str(series.id) in result
@@ -575,9 +585,10 @@ class TestSQLAlchemySeriesRepositoryFindByIds:
         repo = SQLAlchemySeriesRepository(db_session)
         series = _create_series(title="Deleted")
         await repo.save(series)
-        await repo.delete(series.id)  # type: ignore[arg-type]
+        series_id = _id_of(series)
+        await repo.delete(series_id)
 
-        result = await repo.find_by_ids([series.id])  # type: ignore[list-item]
+        result = await repo.find_by_ids([series_id])
 
         assert result == {}
 
@@ -655,12 +666,13 @@ class TestSQLAlchemySeriesRepositorySaveRestore:
             episodes_per_season=1,
         )
         await repo.save(series)
-        await repo.delete(series.id)  # type: ignore[arg-type]
+        series_id = _id_of(series)
+        await repo.delete(series_id)
 
         # Re-save to restore
         restored = await repo.save(series)
 
         assert restored.id == series.id
-        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        found = await repo.find_by_id(series_id)
         assert found is not None
         assert found.title.value == "Restored"

--- a/tests/modules/media/unit/application/use_cases/test_remove_file_variant.py
+++ b/tests/modules/media/unit/application/use_cases/test_remove_file_variant.py
@@ -10,9 +10,15 @@ from src.building_blocks.application.errors import (
 )
 from src.modules.media.application.dtos import RemoveFileVariantInput
 from src.modules.media.application.use_cases import RemoveFileVariantUseCase
-from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
-from src.modules.media.domain.value_objects import MediaFile, Resolution
+from src.modules.media.domain.value_objects import (
+    Duration,
+    EpisodeId,
+    MediaFile,
+    Resolution,
+    Title,
+)
 from src.shared_kernel.value_objects.file_path import FilePath
 
 
@@ -138,3 +144,174 @@ class TestRemoveFileVariantUseCase:
                     file_path="/movies/nonexistent.mkv",
                 ),
             )
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_movie_not_found(self):
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        mock_movie_repo.find_by_id.return_value = None
+
+        use_case = RemoveFileVariantUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                RemoveFileVariantInput(
+                    media_id="mov_nonexistent1",
+                    file_path="/movies/test.mkv",
+                ),
+            )
+
+        assert exc_info.value.resource_type == "Movie"
+
+    @pytest.mark.asyncio
+    async def test_should_raise_for_invalid_media_id_prefix(self):
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+
+        use_case = RemoveFileVariantUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                RemoveFileVariantInput(
+                    media_id="ssn_invalidprefix",
+                    file_path="/series/test.mkv",
+                ),
+            )
+
+        assert exc_info.value.resource_type == "Media"
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_media_id_has_no_underscore(self):
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+
+        use_case = RemoveFileVariantUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                RemoveFileVariantInput(
+                    media_id="invalidformat",
+                    file_path="/movies/test.mkv",
+                ),
+            )
+
+
+def _create_series_with_episode_variants() -> Series:
+    """Create a series with one episode that has two file variants."""
+    series = Series.create(title="Breaking Bad", start_year=2008)
+    assert series.id is not None
+    episode = Episode(
+        id=EpisodeId.generate(),
+        series_id=series.id,
+        season_number=1,
+        episode_number=1,
+        title=Title("Pilot"),
+        duration=Duration(2820),
+        files=[
+            MediaFile(
+                file_path=FilePath("/series/bb/s01e01_1080p.mkv"),
+                file_size=2_000_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+            MediaFile(
+                file_path=FilePath("/series/bb/s01e01_4k.mkv"),
+                file_size=8_000_000_000,
+                resolution=Resolution("4K"),
+                is_primary=False,
+            ),
+        ],
+    )
+    season = Season(series_id=series.id, season_number=1)
+    season = season.with_episode(episode)
+    return series.with_season(season)
+
+
+@pytest.mark.unit
+class TestRemoveFileVariantFromEpisode:
+    """Tests for removing a file variant from an episode."""
+
+    @pytest.mark.asyncio
+    async def test_should_remove_variant_from_episode(self) -> None:
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+
+        series = _create_series_with_episode_variants()
+        episode = series.seasons[0].episodes[0]
+        mock_series_repo.find_by_episode_id.return_value = series
+        mock_series_repo.save.return_value = series
+
+        use_case = RemoveFileVariantUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        await use_case.execute(
+            RemoveFileVariantInput(
+                media_id=str(episode.id),
+                file_path="/series/bb/s01e01_4k.mkv",
+            ),
+        )
+
+        saved_series = mock_series_repo.save.call_args[0][0]
+        saved_episode = saved_series.seasons[0].episodes[0]
+        assert len(saved_episode.files) == 1
+        assert saved_episode.files[0].file_path == FilePath("/series/bb/s01e01_1080p.mkv")
+
+    @pytest.mark.asyncio
+    async def test_should_promote_best_when_removing_primary_from_episode(self) -> None:
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+
+        series = _create_series_with_episode_variants()
+        episode = series.seasons[0].episodes[0]
+        mock_series_repo.find_by_episode_id.return_value = series
+        mock_series_repo.save.return_value = series
+
+        use_case = RemoveFileVariantUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        await use_case.execute(
+            RemoveFileVariantInput(
+                media_id=str(episode.id),
+                file_path="/series/bb/s01e01_1080p.mkv",
+            ),
+        )
+
+        saved_series = mock_series_repo.save.call_args[0][0]
+        saved_episode = saved_series.seasons[0].episodes[0]
+        assert len(saved_episode.files) == 1
+        assert saved_episode.files[0].is_primary is True
+        assert saved_episode.files[0].file_path == FilePath("/series/bb/s01e01_4k.mkv")
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_episode_not_found(self) -> None:
+        mock_movie_repo = AsyncMock(spec=MovieRepository)
+        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        mock_series_repo.find_by_episode_id.return_value = None
+
+        use_case = RemoveFileVariantUseCase(
+            movie_repository=mock_movie_repo,
+            series_repository=mock_series_repo,
+        )
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                RemoveFileVariantInput(
+                    media_id=str(EpisodeId.generate()),
+                    file_path="/series/test.mkv",
+                ),
+            )
+
+        assert exc_info.value.resource_type == "Episode"


### PR DESCRIPTION
## Summary

Reach the **80% global coverage milestone** by closing the three biggest remaining gaps:

- Extend \`test_remove_file_variant.py\` to cover the episode path and invalid media_id handling (4 new tests)
- Add \`find_random\`, \`find_by_ids\`, and save restore-on-readd tests for \`SQLAlchemyMovieRepository\` (9 new tests)
- Add \`find_random\`, \`find_by_ids\`, \`find_by_title\`, \`find_by_episode_id\`, and save restore-on-readd tests for \`SQLAlchemySeriesRepository\` (13 new tests)
- Total new tests: **28**. Total tests: **1311** (all passing)

## Coverage improvements

| File | Before | After |
|---|---|---|
| \`remove_file_variant.py\` | 59% | **97%** |
| \`movie_repository.py\` | 78% | **100%** |
| \`series_repository.py\` | 80% | **99%** |
| **Global** | **78.86%** | **80.08%** 🎯 |

## Test plan

- [x] All 1311 tests pass (\`poetry run pytest\`)
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] Coverage check passes: \`pytest --cov-fail-under=80\`
- [x] Episode removal correctly promotes best variant when primary is removed
- [x] Soft-deleted records excluded from all list/find queries
- [x] Save correctly restores soft-deleted entities on re-save

## Milestone

This PR crosses the **80% coverage threshold** after 10 phases of incremental test additions. Starting from 54.56% with 812 tests, the suite now covers **80.08%** with **1311 tests**.

## Summary by Sourcery

Expand media repository and file-variant removal test coverage to validate random retrieval, ID/title/episode lookups, soft-delete behavior, and episode file variant handling.

Tests:
- Add SQLAlchemyMovieRepository integration tests for find_random, find_by_ids, and restoring soft-deleted movies via save.
- Add SQLAlchemySeriesRepository integration tests for find_random, find_by_ids, find_by_title, find_by_episode_id, and restoring soft-deleted series via save.
- Extend remove_file_variant unit tests to cover invalid media IDs, missing movies/episodes, and episode-level variant removal and primary promotion.