### PR TITLE
ci: enforce 80% test coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,14 @@ jobs:
         run: poetry install --with dev --no-interaction
 
       - name: Run tests with coverage
+        # Coverage threshold (fail_under = 80) is enforced via
+        # [tool.coverage.report] in pyproject.toml.
         run: |
           poetry run pytest tests/ \
             -v \
             --cov=src \
             --cov-report=xml \
-            --cov-report=term-missing \
-            --cov-fail-under=50
+            --cov-report=term-missing
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Summary

- Remove \`--cov-fail-under=50\` CLI override from the \`test\` job in \`.github/workflows/ci.yml\`
- Coverage gate now respects the \`fail_under = 80\` setting already defined in \`pyproject.toml\` under \`[tool.coverage.report]\`
- CI will now fail the \`test\` job (and therefore block the PR via \`ci-success\`) if coverage drops below 80%

## Context

The 80% threshold was already configured in \`pyproject.toml\`, but the CI was passing \`--cov-fail-under=50\` on the command line, which overrode it. Now that the project is at 80.08% coverage, this gate makes the threshold effective.

## Test plan

- [x] Local \`poetry run pytest tests/ --cov=src\` reports "Required test coverage of 80.0% reached. Total coverage: 80.08%"
- [x] No other CI jobs affected
- [x] Single source of truth: threshold lives only in \`pyproject.toml\`; CI yaml has a comment pointing to it

## Summary by Sourcery

Align CI test coverage enforcement with the project’s configured threshold in pyproject.toml.

CI:
- Remove the hardcoded --cov-fail-under override from the test job so CI uses the 80% coverage threshold defined in pyproject.toml.
- Document in the workflow that coverage gates are configured via [tool.coverage.report] in pyproject.toml.