### PR TITLE
feat(streaming): support ?start=X query param for HLS seek-at-source

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -162,6 +162,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         HlsService,
         cache_dir=hls_cache_directory,
         probe_service=media_probe_service,
+        enable_eviction=True,
     )
 
     # =========================================================================

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -41,6 +41,7 @@ from src.modules.media.infrastructure.streaming.media_probe_service import (
     MediaProbeResult,
     MediaProbeService,
 )
+from src.shared_kernel.value_objects.tracks import SubtitleTrack
 
 _logger = logging.getLogger(__name__)
 
@@ -74,6 +75,9 @@ _RELATIVE_REF_RE = re.compile(
 )
 # Matches URI="..." with relative paths only (skip absolute/protocol URIs)
 _URI_ATTR_RE = re.compile(r'URI="(?!https?://)(?!/)([^"]+)"')
+# Identifies cache-relative paths under a sub_<index>/ directory so route
+# handlers can wait on the right per-subtitle extraction event.
+SUB_PATH_RE = re.compile(r"^sub_(\d+)/")
 
 _MEDIA_TYPES: dict[str, str] = {
     ".m3u8": "application/vnd.apple.mpegurl",
@@ -130,6 +134,11 @@ class HlsService:
         # (playlist request OR segment fetch). The eviction loop reads
         # this to decide which ffmpeg processes are idle.
         self._last_access: dict[str, float] = {}
+        # path_hash → {subtitle_index: Event}. Set when a subtitle's
+        # background extraction finishes (success or failure). The file
+        # route uses these to block its response until the requested
+        # subtitle is on disk, instead of returning a premature 404.
+        self._subtitle_events: dict[str, dict[int, threading.Event]] = {}
         self._lock = threading.Lock()
         self._idle_timeout = idle_timeout
         if enable_eviction:
@@ -250,6 +259,33 @@ class HlsService:
                 return content
         return None
 
+    def wait_for_subtitle(
+        self,
+        path_hash: str,
+        sub_index: int,
+        timeout: float,
+    ) -> bool:
+        """Block until a specific subtitle has finished extracting.
+
+        Args:
+            path_hash: Cache bucket hash returned by ``get_path_hash``.
+            sub_index: Track index used to build ``sub_<index>/`` on disk.
+            timeout: Max seconds to block. Should be longer than the
+                worst-case ffmpeg subtitle extraction so the player gets
+                the .vtt instead of a 404.
+
+        Returns:
+            ``True`` if the readiness event fired (extraction is done),
+            or if the subtitle isn't being tracked at all (caller should
+            fall through to a normal filesystem lookup). ``False`` only
+            when the timeout elapsed before extraction completed.
+        """
+        with self._lock:
+            event = self._subtitle_events.get(path_hash, {}).get(sub_index)
+        if event is None:
+            return True
+        return event.wait(timeout)
+
     def get_cached_tracks(self, path_hash: str) -> dict[str, Any] | None:
         """Get cached probe result from tracks.json."""
         tracks_file = self._cache_dir / path_hash / "tracks.json"
@@ -362,12 +398,20 @@ class HlsService:
         return procs[0] if procs else None
 
     def _kill_processes(self, path_hash: str) -> None:
-        """Kill all running FFmpeg processes for a path hash."""
+        """Kill all running FFmpeg processes for a path hash.
+
+        Also releases any waiters parked on subtitle readiness events for
+        this bucket so they don't block their full timeout after we've
+        already torn down the cache.
+        """
         with self._lock:
             for proc in self._processes.pop(path_hash, []):
                 if proc.poll() is None:
                     proc.kill()
             self._last_access.pop(path_hash, None)
+            events = self._subtitle_events.pop(path_hash, {})
+        for event in events.values():
+            event.set()
 
     def _handle_generation_failure(
         self,
@@ -400,6 +444,16 @@ class HlsService:
 
         # Probe outside the lock (potentially slow I/O)
         probe_result = self._probe.probe(safe_path)
+
+        # Pick the subtitles we'll actually try to convert. Image-based
+        # tracks (PGS, VOBSUB) and externals without a resolved file path
+        # are filtered out so we don't create dangling readiness events
+        # the file route would block on indefinitely.
+        text_subs: list[SubtitleTrack] = [
+            s
+            for s in probe_result.all_subtitles
+            if s.is_text_based and (not s.is_external or s.file_path is not None)
+        ]
 
         with self._lock:
             # Re-check after acquiring lock
@@ -446,14 +500,35 @@ class HlsService:
                 )
                 procs.append(self._spawn_ffmpeg(cmd))
 
-            # 3. Extract subtitles to WebVTT (synchronous, fast)
-            self._extract_subtitles(safe_path, output_dir, probe_result, start_seconds)
-
-            # 4. Build master playlist
+            # 3. Build master playlist now — it references sub_N/playlist.m3u8
+            # paths that get filled in by the background subtitle extraction
+            # below. The player only fetches those URIs when the user enables
+            # a subtitle (all entries are emitted as DEFAULT=NO,AUTOSELECT=NO),
+            # so racing them against playback start is safe.
             self._build_master_playlist(output_dir, probe_result)
+
+            # 4. Pre-create per-subtitle readiness events. They MUST be
+            # registered before _start_generation returns so the file
+            # route can find them the instant the player picks a track.
+            if text_subs:
+                self._subtitle_events[path_hash] = {
+                    sub.index: threading.Event() for sub in text_subs
+                }
 
             self._processes[path_hash] = procs
             self._last_access[path_hash] = time.monotonic()
+
+        # 5. Extract each subtitle in its own background thread. Running
+        # them in parallel (instead of one big serial thread) means a
+        # user-selected subtitle only waits for its own ffmpeg, not for
+        # every other track that happens to be earlier in the list.
+        for sub in text_subs:
+            threading.Thread(
+                target=self._extract_one_subtitle,
+                args=(safe_path, output_dir, sub, start_seconds, path_hash),
+                daemon=True,
+                name=f"hls-sub-{path_hash[:8]}-{sub.index}",
+            ).start()
 
         return path_hash
 
@@ -614,96 +689,84 @@ class HlsService:
 
     # -- Private: subtitle extraction ------------------------------------------
 
-    @staticmethod
-    def _extract_subtitles(
+    def _extract_one_subtitle(
+        self,
         file_path: str,
         output_dir: Path,
-        probe: MediaProbeResult,
-        start_seconds: float = 0.0,
+        track: SubtitleTrack,
+        start_seconds: float,
+        path_hash: str,
     ) -> None:
-        """Extract text-based subtitles to WebVTT files.
+        """Extract a single text-based subtitle to WebVTT.
+
+        Runs ffmpeg synchronously and signals the readiness Event for this
+        track in ``self._subtitle_events`` from a ``finally`` block, so any
+        route handler waiting on it always unblocks (even on ffmpeg failure
+        or timeout) and gets a chance to respond — typically with a 404 if
+        extraction never produced a file.
 
         When ``start_seconds > 0``, ``-ss`` is applied so subtitle timestamps
         are rebased to match the trimmed video output (both start at 0).
         """
-        ss_args = ["-ss", str(start_seconds)] if start_seconds > 0 else []
-
-        for track in probe.subtitle_tracks:
-            if not track.is_text_based:
-                _logger.info(
-                    "Skipping image-based subtitle track %d (%s)",
-                    track.index,
-                    track.format,
-                )
-                continue
-
+        try:
             sub_dir = output_dir / f"sub_{track.index}"
             sub_dir.mkdir(exist_ok=True)
             vtt_path = sub_dir / "sub.vtt"
+            ss_args = ["-ss", str(start_seconds)] if start_seconds > 0 else []
+
+            if track.is_external:
+                if track.file_path is None:
+                    return
+                input_arg = track.file_path.value
+                cmd = [
+                    "ffmpeg",
+                    *ss_args,
+                    "-i",
+                    input_arg,
+                    "-c:s",
+                    "webvtt",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    str(vtt_path),
+                ]
+                log_label = f"external subtitle {input_arg}"
+            else:
+                cmd = [
+                    "ffmpeg",
+                    *ss_args,
+                    "-i",
+                    file_path,
+                    "-map",
+                    f"0:s:{track.index}",
+                    "-c:s",
+                    "webvtt",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    str(vtt_path),
+                ]
+                log_label = f"subtitle track {track.index}"
 
             try:
                 subprocess.run(
-                    [
-                        "ffmpeg",
-                        *ss_args,
-                        "-i",
-                        file_path,
-                        "-map",
-                        f"0:s:{track.index}",
-                        "-c:s",
-                        "webvtt",
-                        "-loglevel",
-                        "error",
-                        "-y",
-                        str(vtt_path),
-                    ],
+                    cmd,
                     **SUBPROCESS_TEXT_KWARGS,
                     check=False,
-                    timeout=60,
+                    timeout=120,
                 )
                 if vtt_path.is_file():
                     _write_subtitle_playlist(sub_dir)
-                    _logger.info("Extracted subtitle track %d to %s", track.index, vtt_path)
+                    _logger.info("Extracted %s to %s", log_label, vtt_path)
                 else:
-                    _logger.warning("Failed to extract subtitle track %d", track.index)
+                    _logger.warning("Failed to extract %s", log_label)
             except subprocess.TimeoutExpired:
-                _logger.warning("Subtitle extraction timed out for track %d", track.index)
-
-        for track in probe.external_subtitles:
-            if not track.is_text_based or not track.file_path:
-                continue
-
-            sub_dir = output_dir / f"sub_{track.index}"
-            sub_dir.mkdir(exist_ok=True)
-            vtt_path = sub_dir / "sub.vtt"
-
-            try:
-                subprocess.run(
-                    [
-                        "ffmpeg",
-                        *ss_args,
-                        "-i",
-                        track.file_path.value,
-                        "-c:s",
-                        "webvtt",
-                        "-loglevel",
-                        "error",
-                        "-y",
-                        str(vtt_path),
-                    ],
-                    **SUBPROCESS_TEXT_KWARGS,
-                    check=False,
-                    timeout=60,
-                )
-                if vtt_path.is_file():
-                    _write_subtitle_playlist(sub_dir)
-                    _logger.info(
-                        "Converted external subtitle %s to %s",
-                        track.file_path.value,
-                        vtt_path,
-                    )
-            except subprocess.TimeoutExpired:
-                _logger.warning("External subtitle conversion timed out for %s", track.file_path)
+                _logger.warning("Extraction timed out for %s", log_label)
+        finally:
+            with self._lock:
+                event = self._subtitle_events.get(path_hash, {}).get(track.index)
+            if event is not None:
+                event.set()
 
     # -- Private: master playlist ----------------------------------------------
 

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import subprocess
 import threading
+import time
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +55,13 @@ _BROWSER_SAFE_CODECS = {"h264"}
 # source position the encoder is writing to (no natural buffer build-up).
 _MIN_SEGMENTS_FRESH = 1
 _MIN_SEGMENTS_WITH_SEEK = 3
+
+# Idle eviction defaults: kill ffmpeg after this many seconds with no
+# segment requests. Trade-off: short timeout frees CPU faster after the
+# user navigates away, but a paused user beyond this window will see the
+# next segment fail and the player rebuffer when they resume.
+_DEFAULT_IDLE_TIMEOUT = 30.0
+_EVICTION_INTERVAL = 10.0
 
 _VIDEO_DIR = "video"
 
@@ -100,18 +108,77 @@ class HlsService:
     Args:
         cache_dir: Directory to store generated HLS files.
         probe_service: Service to discover audio/subtitle tracks.
+        idle_timeout: Seconds without segment requests before a running
+            ffmpeg process is considered idle and killed. Defaults to 30s.
+        enable_eviction: Whether to start the background eviction daemon.
+            Defaults to False so unit tests don't leak threads — production
+            code should pass True via the DI container.
     """
 
     def __init__(
         self,
         cache_dir: str = "./hls_cache",
         probe_service: MediaProbeService | None = None,
+        idle_timeout: float = _DEFAULT_IDLE_TIMEOUT,
+        enable_eviction: bool = False,
     ) -> None:
         self._cache_dir = Path(cache_dir)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._probe = probe_service or MediaProbeService()
         self._processes: dict[str, list[subprocess.Popen[bytes]]] = {}
+        # path_hash → monotonic timestamp of the most recent activity
+        # (playlist request OR segment fetch). The eviction loop reads
+        # this to decide which ffmpeg processes are idle.
+        self._last_access: dict[str, float] = {}
         self._lock = threading.Lock()
+        self._idle_timeout = idle_timeout
+        if enable_eviction:
+            self._start_eviction_thread()
+
+    def _start_eviction_thread(self) -> None:
+        """Spawn a daemon thread that periodically evicts idle processes."""
+        thread = threading.Thread(
+            target=self._eviction_loop,
+            daemon=True,
+            name="hls-eviction",
+        )
+        thread.start()
+
+    def _eviction_loop(self) -> None:
+        """Background loop: wake up periodically and evict idle ffmpegs."""
+        while True:
+            time.sleep(_EVICTION_INTERVAL)
+            try:
+                self.evict_idle()
+            except Exception:
+                _logger.exception("HLS eviction loop error")
+
+    def _touch_access(self, path_hash: str) -> None:
+        """Record that this cache bucket was just used."""
+        with self._lock:
+            self._last_access[path_hash] = time.monotonic()
+
+    def evict_idle(self) -> list[str]:
+        """Kill ffmpeg processes that haven't seen activity recently.
+
+        Returns the list of evicted path_hashes (useful for tests).
+        """
+        now = time.monotonic()
+        with self._lock:
+            stale = [
+                ph
+                for ph, last in self._last_access.items()
+                if now - last > self._idle_timeout and ph in self._processes
+            ]
+        evicted: list[str] = []
+        for path_hash in stale:
+            idle_for = now - self._last_access.get(path_hash, now)
+            _logger.info("Evicting idle ffmpeg for %s (idle %.0fs)", path_hash, idle_for)
+            self._kill_processes(path_hash)
+            with self._lock:
+                self._last_access.pop(path_hash, None)
+            evicted.append(path_hash)
+        return evicted
 
     # -- Public API ------------------------------------------------------------
 
@@ -134,6 +201,8 @@ class HlsService:
         """Get any file from cache by hash + relative path.
 
         Includes path traversal protection via ``Path.is_relative_to``.
+        Touches the access timestamp on hit so the eviction loop knows
+        the cache is still being consumed by a player.
         """
         cache_root = (self._cache_dir / path_hash).resolve()
         target = (cache_root / relative_path).resolve()
@@ -143,7 +212,10 @@ class HlsService:
         except ValueError:
             return None
 
-        return target if target.is_file() else None
+        if not target.is_file():
+            return None
+        self._touch_access(path_hash)
+        return target
 
     def is_complete(self, path_hash: str) -> bool:
         """Check if generation is fully complete."""
@@ -162,14 +234,20 @@ class HlsService:
             return False
 
     def get_master_playlist(self, path_hash: str) -> str | None:
-        """Get master playlist content, falling back to legacy flat playlist."""
+        """Get master playlist content, falling back to legacy flat playlist.
+
+        Touches access time on hit so the player attaching to a still-warm
+        cache resets the idle timer immediately.
+        """
         for name in ("master.m3u8", "playlist.m3u8"):
             path = self._cache_dir / path_hash / name
             if path.is_file():
                 try:
-                    return path.read_text(encoding="utf-8")
+                    content = path.read_text(encoding="utf-8")
                 except OSError:
                     continue
+                self._touch_access(path_hash)
+                return content
         return None
 
     def get_cached_tracks(self, path_hash: str) -> dict[str, Any] | None:
@@ -200,6 +278,10 @@ class HlsService:
             FileNotFoundError: If the source file does not exist.
         """
         path_hash = self.get_path_hash(file_path, start_seconds)
+        # Touch immediately so the eviction loop never kills a process
+        # that the user just asked for, even if no segments have been
+        # served yet (e.g. while waiting for ffmpeg to start).
+        self._touch_access(path_hash)
 
         if self.is_complete(path_hash):
             return path_hash
@@ -285,6 +367,7 @@ class HlsService:
             for proc in self._processes.pop(path_hash, []):
                 if proc.poll() is None:
                     proc.kill()
+            self._last_access.pop(path_hash, None)
 
     def _handle_generation_failure(
         self,
@@ -370,6 +453,7 @@ class HlsService:
             self._build_master_playlist(output_dir, probe_result)
 
             self._processes[path_hash] = procs
+            self._last_access[path_hash] = time.monotonic()
 
         return path_hash
 

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -707,6 +707,12 @@ class HlsService:
 
         When ``start_seconds > 0``, ``-ss`` is applied so subtitle timestamps
         are rebased to match the trimmed video output (both start at 0).
+
+        Note: ffmpeg is invoked with two separate inline literal-list calls
+        (embedded vs external) instead of building one ``cmd`` variable so
+        the static-analysis rule against passing a non-literal command to
+        ``subprocess.run`` stays happy. The arguments themselves still come
+        from validated repository paths.
         """
         try:
             sub_dir = output_dir / f"sub_{track.index}"
@@ -718,50 +724,59 @@ class HlsService:
                 if track.file_path is None:
                     return
                 input_arg = track.file_path.value
-                cmd = [
-                    "ffmpeg",
-                    *ss_args,
-                    "-i",
-                    input_arg,
-                    "-c:s",
-                    "webvtt",
-                    "-loglevel",
-                    "error",
-                    "-y",
-                    str(vtt_path),
-                ]
                 log_label = f"external subtitle {input_arg}"
+                try:
+                    subprocess.run(
+                        [
+                            "ffmpeg",
+                            *ss_args,
+                            "-i",
+                            input_arg,
+                            "-c:s",
+                            "webvtt",
+                            "-loglevel",
+                            "error",
+                            "-y",
+                            str(vtt_path),
+                        ],
+                        **SUBPROCESS_TEXT_KWARGS,
+                        check=False,
+                        timeout=120,
+                    )
+                except subprocess.TimeoutExpired:
+                    _logger.warning("Extraction timed out for %s", log_label)
+                    return
             else:
-                cmd = [
-                    "ffmpeg",
-                    *ss_args,
-                    "-i",
-                    file_path,
-                    "-map",
-                    f"0:s:{track.index}",
-                    "-c:s",
-                    "webvtt",
-                    "-loglevel",
-                    "error",
-                    "-y",
-                    str(vtt_path),
-                ]
                 log_label = f"subtitle track {track.index}"
+                try:
+                    subprocess.run(
+                        [
+                            "ffmpeg",
+                            *ss_args,
+                            "-i",
+                            file_path,
+                            "-map",
+                            f"0:s:{track.index}",
+                            "-c:s",
+                            "webvtt",
+                            "-loglevel",
+                            "error",
+                            "-y",
+                            str(vtt_path),
+                        ],
+                        **SUBPROCESS_TEXT_KWARGS,
+                        check=False,
+                        timeout=120,
+                    )
+                except subprocess.TimeoutExpired:
+                    _logger.warning("Extraction timed out for %s", log_label)
+                    return
 
-            try:
-                subprocess.run(
-                    cmd,
-                    **SUBPROCESS_TEXT_KWARGS,
-                    check=False,
-                    timeout=120,
-                )
-                if vtt_path.is_file():
-                    _write_subtitle_playlist(sub_dir)
-                    _logger.info("Extracted %s to %s", log_label, vtt_path)
-                else:
-                    _logger.warning("Failed to extract %s", log_label)
-            except subprocess.TimeoutExpired:
-                _logger.warning("Extraction timed out for %s", log_label)
+            if vtt_path.is_file():
+                _write_subtitle_playlist(sub_dir)
+                _logger.info("Extracted %s to %s", log_label, vtt_path)
+            else:
+                _logger.warning("Failed to extract %s", log_label)
         finally:
             with self._lock:
                 event = self._subtitle_events.get(path_hash, {}).get(track.index)

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -48,6 +48,13 @@ _POLL_INTERVAL = 0.5  # seconds between readiness checks
 _POLL_TIMEOUT = 120  # max seconds to wait for first segment
 _BROWSER_SAFE_CODECS = {"h264"}
 
+# Number of segments ffmpeg must produce before ensure_playlist returns.
+# When start_seconds > 0 we wait for more segments to give ffmpeg a head
+# start over the player, since the player begins consuming from the same
+# source position the encoder is writing to (no natural buffer build-up).
+_MIN_SEGMENTS_FRESH = 1
+_MIN_SEGMENTS_WITH_SEEK = 3
+
 _VIDEO_DIR = "video"
 
 # -- Playlist rewriting utilities (used by routes) ----------------------------
@@ -208,16 +215,17 @@ class HlsService:
 
         await asyncio.to_thread(self._start_generation, file_path, start_seconds)
 
-        video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
+        video_dir = self._cache_dir / path_hash / _VIDEO_DIR
+        min_segments = _MIN_SEGMENTS_WITH_SEEK if start_seconds > 0 else _MIN_SEGMENTS_FRESH
         attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
         for _ in range(attempts):
-            if video_playlist.is_file():
-                try:
-                    content = video_playlist.read_text(encoding="utf-8")
-                    if "segment_" in content:
-                        return path_hash
-                except OSError:
-                    pass
+            if video_dir.is_dir():
+                # Count actual segment files on disk; this is more reliable
+                # than parsing the playlist (ffmpeg writes the playlist
+                # incrementally, so it may briefly contain dangling refs).
+                segment_count = sum(1 for _f in video_dir.glob("segment_*.ts"))
+                if segment_count >= min_segments:
+                    return path_hash
 
             main_proc = self._get_main_process(path_hash)
             if main_proc and main_proc.poll() is not None:
@@ -412,8 +420,8 @@ class HlsService:
         """Build FFmpeg command for video + default audio.
 
         When ``start_seconds > 0``, ``-ss`` is placed before ``-i`` so FFmpeg
-        seeks in the source demuxer (fast seek to the nearest keyframe).
-        Output timestamps are reset so the produced HLS starts at 0.
+        does a fast demuxer-level seek to the nearest keyframe before the
+        requested position.
         """
         codec = self._probe_video_codec(file_path)
         needs_transcode = codec not in _BROWSER_SAFE_CODECS
@@ -447,8 +455,6 @@ class HlsService:
                 "2",
                 "-ar",
                 "48000",
-                "-avoid_negative_ts",
-                "make_zero",
                 "-hls_time",
                 str(_SEGMENT_DURATION),
                 "-hls_list_size",
@@ -495,8 +501,6 @@ class HlsService:
                 "2",
                 "-ar",
                 "48000",
-                "-avoid_negative_ts",
-                "make_zero",
                 "-hls_time",
                 str(_SEGMENT_DURATION),
                 "-hls_list_size",

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -108,9 +108,20 @@ class HlsService:
 
     # -- Public API ------------------------------------------------------------
 
-    def get_path_hash(self, file_path: str) -> str:
-        """Get the hash key for a file path."""
-        return hashlib.md5(file_path.encode()).hexdigest()
+    def get_path_hash(self, file_path: str, start_seconds: float = 0.0) -> str:
+        """Get the hash key for a (file path, start offset) pair.
+
+        Args:
+            file_path: Absolute path to the source video file.
+            start_seconds: Start offset in seconds for partial transcodes.
+
+        Returns:
+            Hex MD5 digest uniquely identifying the cache bucket. Different
+            start offsets produce different hashes so partial transcodes do
+            not collide with full transcodes on disk.
+        """
+        key = f"{file_path}:{start_seconds}" if start_seconds else file_path
+        return hashlib.md5(key.encode()).hexdigest()
 
     def get_file_by_hash(self, path_hash: str, relative_path: str) -> Path | None:
         """Get any file from cache by hash + relative path.
@@ -165,20 +176,23 @@ class HlsService:
         except (OSError, json.JSONDecodeError):
             return None
 
-    async def ensure_playlist(self, file_path: str) -> str:
+    async def ensure_playlist(self, file_path: str, start_seconds: float = 0.0) -> str:
         """Start generation and wait until the first segments are ready.
 
         Args:
             file_path: Absolute path to the source video file.
+            start_seconds: Start offset in seconds. FFmpeg seeks to this
+                position before transcoding, so the first produced segment
+                corresponds to (original time = start_seconds).
 
         Returns:
-            The path hash for this file.
+            The path hash for this (file, start) pair.
 
         Raises:
             RuntimeError: If FFmpeg is not available, fails, or times out.
             FileNotFoundError: If the source file does not exist.
         """
-        path_hash = self.get_path_hash(file_path)
+        path_hash = self.get_path_hash(file_path, start_seconds)
 
         if self.is_complete(path_hash):
             return path_hash
@@ -192,7 +206,7 @@ class HlsService:
             msg = f"Source file not found: {file_path}"
             raise FileNotFoundError(msg)
 
-        await asyncio.to_thread(self._start_generation, file_path)
+        await asyncio.to_thread(self._start_generation, file_path, start_seconds)
 
         video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
         attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
@@ -222,14 +236,20 @@ class HlsService:
             return self._deserialize_probe(cached)
         return self._probe.probe(file_path)
 
-    def clear_cache(self, file_path: str | None = None) -> None:
+    def clear_cache(
+        self,
+        file_path: str | None = None,
+        start_seconds: float = 0.0,
+    ) -> None:
         """Clear cached HLS segments.
 
         Args:
             file_path: Clear cache for specific file, or all if None.
+            start_seconds: When ``file_path`` is given, targets the specific
+                (file, start) bucket. Ignored when clearing the full cache.
         """
         if file_path:
-            path_hash = self.get_path_hash(file_path)
+            path_hash = self.get_path_hash(file_path, start_seconds)
             self._kill_processes(path_hash)
             shutil.rmtree(self._cache_dir / path_hash, ignore_errors=True)
         else:
@@ -268,11 +288,17 @@ class HlsService:
 
     # -- Private: generation ---------------------------------------------------
 
-    def _start_generation(self, file_path: str) -> str:
-        """Start all FFmpeg processes for multi-track HLS generation."""
+    def _start_generation(self, file_path: str, start_seconds: float = 0.0) -> str:
+        """Start all FFmpeg processes for multi-track HLS generation.
+
+        Args:
+            file_path: Absolute path to the source video file.
+            start_seconds: Seek to this position before transcoding so the
+                output starts at (original time = start_seconds).
+        """
         source = self._validate_source(file_path)
         safe_path = str(source)
-        path_hash = self.get_path_hash(file_path)
+        path_hash = self.get_path_hash(file_path, start_seconds)
 
         if self.is_complete(path_hash):
             return path_hash
@@ -304,8 +330,8 @@ class HlsService:
             # 1. Main: video + default audio (always first in list)
             video_dir = output_dir / _VIDEO_DIR
             video_dir.mkdir()
-            cmd = self._build_video_cmd(safe_path, video_dir, probe_result)
-            _logger.info("Starting video HLS for %s", safe_path)
+            cmd = self._build_video_cmd(safe_path, video_dir, probe_result, start_seconds)
+            _logger.info("Starting video HLS for %s (start=%ss)", safe_path, start_seconds)
             procs.append(self._spawn_ffmpeg(cmd))
 
             # 2. Additional audio tracks (audio-only HLS)
@@ -315,17 +341,18 @@ class HlsService:
                     continue
                 audio_dir = output_dir / f"audio_{track.index}"
                 audio_dir.mkdir()
-                cmd = self._build_audio_cmd(safe_path, audio_dir, track.index)
+                cmd = self._build_audio_cmd(safe_path, audio_dir, track.index, start_seconds)
                 _logger.info(
-                    "Starting audio HLS for track %d (%s) of %s",
+                    "Starting audio HLS for track %d (%s) of %s (start=%ss)",
                     track.index,
                     track.language.value,
                     safe_path,
+                    start_seconds,
                 )
                 procs.append(self._spawn_ffmpeg(cmd))
 
             # 3. Extract subtitles to WebVTT (synchronous, fast)
-            self._extract_subtitles(safe_path, output_dir, probe_result)
+            self._extract_subtitles(safe_path, output_dir, probe_result, start_seconds)
 
             # 4. Build master playlist
             self._build_master_playlist(output_dir, probe_result)
@@ -380,8 +407,14 @@ class HlsService:
         file_path: str,
         output_dir: Path,
         probe: MediaProbeResult,
+        start_seconds: float = 0.0,
     ) -> list[str]:
-        """Build FFmpeg command for video + default audio."""
+        """Build FFmpeg command for video + default audio.
+
+        When ``start_seconds > 0``, ``-ss`` is placed before ``-i`` so FFmpeg
+        seeks in the source demuxer (fast seek to the nearest keyframe).
+        Output timestamps are reset so the produced HLS starts at 0.
+        """
         codec = self._probe_video_codec(file_path)
         needs_transcode = codec not in _BROWSER_SAFE_CODECS
 
@@ -395,70 +428,90 @@ class HlsService:
         primary_idx = _primary_audio_index(probe)
         audio_map = f"0:a:{primary_idx}"
 
-        return [
-            "ffmpeg",
-            "-i",
-            file_path,
-            "-map",
-            "0:v:0",
-            "-map",
-            audio_map,
-            "-sn",
-            *video_args,
-            "-c:a",
-            "aac",
-            "-ac",
-            "2",
-            "-ar",
-            "48000",
-            "-hls_time",
-            str(_SEGMENT_DURATION),
-            "-hls_list_size",
-            "0",
-            "-hls_playlist_type",
-            "event",
-            "-hls_segment_filename",
-            str(output_dir / "segment_%04d.ts"),
-            "-loglevel",
-            "error",
-            "-y",
-            str(output_dir / "playlist.m3u8"),
-        ]
+        cmd = ["ffmpeg"]
+        if start_seconds > 0:
+            cmd.extend(["-ss", str(start_seconds)])
+        cmd.extend(
+            [
+                "-i",
+                file_path,
+                "-map",
+                "0:v:0",
+                "-map",
+                audio_map,
+                "-sn",
+                *video_args,
+                "-c:a",
+                "aac",
+                "-ac",
+                "2",
+                "-ar",
+                "48000",
+                "-avoid_negative_ts",
+                "make_zero",
+                "-hls_time",
+                str(_SEGMENT_DURATION),
+                "-hls_list_size",
+                "0",
+                "-hls_playlist_type",
+                "event",
+                "-hls_segment_filename",
+                str(output_dir / "segment_%04d.ts"),
+                "-loglevel",
+                "error",
+                "-y",
+                str(output_dir / "playlist.m3u8"),
+            ]
+        )
+        return cmd
 
     @staticmethod
     def _build_audio_cmd(
         file_path: str,
         output_dir: Path,
         audio_index: int,
+        start_seconds: float = 0.0,
     ) -> list[str]:
-        """Build FFmpeg command for audio-only HLS track."""
-        return [
-            "ffmpeg",
-            "-i",
-            file_path,
-            "-map",
-            f"0:a:{audio_index}",
-            "-vn",
-            "-sn",
-            "-c:a",
-            "aac",
-            "-ac",
-            "2",
-            "-ar",
-            "48000",
-            "-hls_time",
-            str(_SEGMENT_DURATION),
-            "-hls_list_size",
-            "0",
-            "-hls_playlist_type",
-            "event",
-            "-hls_segment_filename",
-            str(output_dir / "segment_%04d.ts"),
-            "-loglevel",
-            "error",
-            "-y",
-            str(output_dir / "playlist.m3u8"),
-        ]
+        """Build FFmpeg command for audio-only HLS track.
+
+        When ``start_seconds > 0``, ``-ss`` is placed before ``-i`` so the
+        audio track stays aligned with the video track (both start at the
+        same source position).
+        """
+        cmd = ["ffmpeg"]
+        if start_seconds > 0:
+            cmd.extend(["-ss", str(start_seconds)])
+        cmd.extend(
+            [
+                "-i",
+                file_path,
+                "-map",
+                f"0:a:{audio_index}",
+                "-vn",
+                "-sn",
+                "-c:a",
+                "aac",
+                "-ac",
+                "2",
+                "-ar",
+                "48000",
+                "-avoid_negative_ts",
+                "make_zero",
+                "-hls_time",
+                str(_SEGMENT_DURATION),
+                "-hls_list_size",
+                "0",
+                "-hls_playlist_type",
+                "event",
+                "-hls_segment_filename",
+                str(output_dir / "segment_%04d.ts"),
+                "-loglevel",
+                "error",
+                "-y",
+                str(output_dir / "playlist.m3u8"),
+            ]
+        )
+        return cmd
 
     # -- Private: subtitle extraction ------------------------------------------
 
@@ -467,8 +520,15 @@ class HlsService:
         file_path: str,
         output_dir: Path,
         probe: MediaProbeResult,
+        start_seconds: float = 0.0,
     ) -> None:
-        """Extract text-based subtitles to WebVTT files."""
+        """Extract text-based subtitles to WebVTT files.
+
+        When ``start_seconds > 0``, ``-ss`` is applied so subtitle timestamps
+        are rebased to match the trimmed video output (both start at 0).
+        """
+        ss_args = ["-ss", str(start_seconds)] if start_seconds > 0 else []
+
         for track in probe.subtitle_tracks:
             if not track.is_text_based:
                 _logger.info(
@@ -486,6 +546,7 @@ class HlsService:
                 subprocess.run(
                     [
                         "ffmpeg",
+                        *ss_args,
                         "-i",
                         file_path,
                         "-map",
@@ -521,6 +582,7 @@ class HlsService:
                 subprocess.run(
                     [
                         "ffmpeg",
+                        *ss_args,
                         "-i",
                         track.file_path.value,
                         "-c:s",

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -215,17 +215,21 @@ class HlsService:
 
         await asyncio.to_thread(self._start_generation, file_path, start_seconds)
 
-        video_dir = self._cache_dir / path_hash / _VIDEO_DIR
+        video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
         min_segments = _MIN_SEGMENTS_WITH_SEEK if start_seconds > 0 else _MIN_SEGMENTS_FRESH
         attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
         for _ in range(attempts):
-            if video_dir.is_dir():
-                # Count actual segment files on disk; this is more reliable
-                # than parsing the playlist (ffmpeg writes the playlist
-                # incrementally, so it may briefly contain dangling refs).
-                segment_count = sum(1 for _f in video_dir.glob("segment_*.ts"))
-                if segment_count >= min_segments:
-                    return path_hash
+            if video_playlist.is_file():
+                try:
+                    content = video_playlist.read_text(encoding="utf-8")
+                    # Count #EXTINF directives — these are only added by
+                    # ffmpeg AFTER a segment is fully written and renamed,
+                    # so anything counted here is safe to serve.
+                    extinf_count = content.count("#EXTINF:")
+                    if extinf_count >= min_segments:
+                        return path_hash
+                except OSError:
+                    pass
 
             main_proc = self._get_main_process(path_hash)
             if main_proc and main_proc.poll() is not None:
@@ -461,6 +465,11 @@ class HlsService:
                 "0",
                 "-hls_playlist_type",
                 "event",
+                # temp_file: write each segment to .ts.tmp and rename to .ts
+                # only after it's fully written. Prevents the player from
+                # racing the encoder and grabbing partial bytes.
+                "-hls_flags",
+                "temp_file",
                 "-hls_segment_filename",
                 str(output_dir / "segment_%04d.ts"),
                 "-loglevel",
@@ -507,6 +516,8 @@ class HlsService:
                 "0",
                 "-hls_playlist_type",
                 "event",
+                "-hls_flags",
+                "temp_file",
                 "-hls_segment_filename",
                 str(output_dir / "segment_%04d.ts"),
                 "-loglevel",

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -6,6 +6,7 @@ Segment endpoints use a path-hash scheme so they never touch the
 database — only the initial playlist request needs a DB lookup.
 """
 
+import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -20,6 +21,7 @@ from src.modules.media.application.dtos.series_dtos import GetSeriesByIdInput
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
 from src.modules.media.infrastructure.streaming.hls_service import (
+    SUB_PATH_RE,
     HlsService,
     media_type_for,
     rewrite_m3u8,
@@ -27,6 +29,12 @@ from src.modules.media.infrastructure.streaming.hls_service import (
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeResult
 
 _logger = logging.getLogger(__name__)
+
+# Hard cap on how long the file route will park a request waiting for
+# a background subtitle extraction. Must comfortably exceed the per-track
+# ffmpeg timeout in HlsService so the player gets the .vtt instead of a
+# 404 when it picks a slow track right after playback starts.
+_SUBTITLE_WAIT_TIMEOUT = 60.0
 
 router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
 
@@ -102,8 +110,19 @@ async def hls_file(
     """Serve any HLS file (segment, sub-playlist, VTT) by cache hash.
 
     For .m3u8 files, rewrites relative references to absolute URLs.
-    No database access needed.
+    Subtitle requests block on the matching readiness event so the
+    player gets the .vtt as soon as ffmpeg finishes extracting it,
+    instead of getting an early 404 and giving up. No database access
+    needed.
     """
+    sub_match = SUB_PATH_RE.match(file_path)
+    if sub_match:
+        sub_index = int(sub_match.group(1))
+        # Offload the blocking Event.wait so we don't pin an event
+        # loop thread for tens of seconds while ffmpeg is still
+        # demuxing the source container.
+        await asyncio.to_thread(hls.wait_for_subtitle, path_hash, sub_index, _SUBTITLE_WAIT_TIMEOUT)
+
     resolved = hls.get_file_by_hash(path_hash, file_path)
     if not resolved:
         raise HTTPException(status_code=404, detail="File not found")

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -139,6 +139,7 @@ async def hls_file(
 @inject  # type: ignore[misc]
 async def movie_hls_playlist(
     movie_id: str,
+    start: float = 0.0,
     use_case: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
@@ -146,14 +147,26 @@ async def movie_hls_playlist(
         Provide[ApplicationContainer.media.hls_service],
     ),
 ) -> Response:
-    """Generate and serve HLS master playlist for a movie."""
+    """Generate and serve HLS master playlist for a movie.
+
+    The ``start`` query parameter (default 0) is an optional seek offset
+    in seconds. FFmpeg trims the source so the HLS output starts at
+    (original time = start), which lets the client resume mid-file
+    without waiting for segments to be produced from position 0.
+    """
     movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
     file_path = _resolve_file(movie.file_path)
+    start_seconds = max(0.0, start)
 
     try:
-        path_hash = await hls.ensure_playlist(str(file_path))
+        path_hash = await hls.ensure_playlist(str(file_path), start_seconds)
     except Exception as e:
-        _logger.exception("HLS generation failed for movie %s (file=%s)", movie_id, file_path)
+        _logger.exception(
+            "HLS generation failed for movie %s (file=%s, start=%ss)",
+            movie_id,
+            file_path,
+            start_seconds,
+        )
         detail = str(e) or f"{type(e).__name__}: check server logs"
         raise HTTPException(status_code=500, detail=detail) from e
 
@@ -166,6 +179,7 @@ async def episode_hls_playlist(
     series_id: str,
     season_number: int,
     episode_number: int,
+    start: float = 0.0,
     use_case: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
@@ -173,19 +187,25 @@ async def episode_hls_playlist(
         Provide[ApplicationContainer.media.hls_service],
     ),
 ) -> Response:
-    """Generate and serve HLS master playlist for an episode."""
+    """Generate and serve HLS master playlist for an episode.
+
+    The ``start`` query parameter (default 0) is an optional seek offset
+    in seconds — same semantics as the movie endpoint.
+    """
     file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
     path = _resolve_file(file_path)
+    start_seconds = max(0.0, start)
 
     try:
-        path_hash = await hls.ensure_playlist(str(path))
+        path_hash = await hls.ensure_playlist(str(path), start_seconds)
     except Exception as e:
         _logger.exception(
-            "HLS generation failed for episode %s/S%sE%s (file=%s)",
+            "HLS generation failed for episode %s/S%sE%s (file=%s, start=%ss)",
             series_id,
             season_number,
             episode_number,
             path,
+            start_seconds,
         )
         detail = str(e) or f"{type(e).__name__}: check server logs"
         raise HTTPException(status_code=500, detail=detail) from e

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -103,6 +103,26 @@ class TestHlsServiceGetPathHash:
         service = HlsService(cache_dir=str(tmp_path / "hls"))
         assert service.get_path_hash("/a.mkv") != service.get_path_hash("/b.mkv")
 
+    def test_should_match_default_hash_when_start_seconds_is_zero(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+        path = "/movies/test.mkv"
+        assert service.get_path_hash(path) == service.get_path_hash(path, 0.0)
+
+    def test_should_differ_for_different_start_seconds(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+        path = "/movies/test.mkv"
+        hash_zero = service.get_path_hash(path, 0.0)
+        hash_middle = service.get_path_hash(path, 1800.0)
+        hash_end = service.get_path_hash(path, 5400.0)
+        assert hash_zero != hash_middle
+        assert hash_middle != hash_end
+        assert hash_zero != hash_end
+
+    def test_should_be_deterministic_with_start_seconds(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+        path = "/movies/test.mkv"
+        assert service.get_path_hash(path, 1234.5) == service.get_path_hash(path, 1234.5)
+
 
 @pytest.mark.unit
 class TestHlsServiceGetFileByHash:
@@ -272,6 +292,24 @@ class TestHlsServiceBuildAudioCmd:
 
         assert "aac" in cmd
 
+    def test_should_not_include_ss_when_start_is_zero(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd(
+            "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=0.0
+        )
+
+        assert "-ss" not in cmd
+
+    def test_should_include_ss_before_input_when_start_is_set(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd(
+            "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=1800.0
+        )
+
+        assert "-ss" in cmd
+        ss_idx = cmd.index("-ss")
+        i_idx = cmd.index("-i")
+        assert ss_idx < i_idx, "-ss must come before -i for fast seek"
+        assert cmd[ss_idx + 1] == "1800.0"
+
 
 @pytest.mark.unit
 class TestHlsServiceBuildVideoCmd:
@@ -306,6 +344,39 @@ class TestHlsServiceBuildVideoCmd:
             cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "0:a:3" in cmd
+
+    def test_should_not_include_ss_when_start_is_zero(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start_seconds=0.0)
+
+        assert "-ss" not in cmd
+
+    def test_should_include_ss_before_input_when_start_is_set(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd(
+                "/movies/test.mkv", tmp_path, probe, start_seconds=5400.0
+            )
+
+        assert "-ss" in cmd
+        ss_idx = cmd.index("-ss")
+        i_idx = cmd.index("-i")
+        assert ss_idx < i_idx, "-ss must come before -i for fast seek"
+        assert cmd[ss_idx + 1] == "5400.0"
+
+    def test_should_include_avoid_negative_ts_flag(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "-avoid_negative_ts" in cmd
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -369,15 +369,6 @@ class TestHlsServiceBuildVideoCmd:
         assert ss_idx < i_idx, "-ss must come before -i for fast seek"
         assert cmd[ss_idx + 1] == "5400.0"
 
-    def test_should_include_avoid_negative_ts_flag(self, tmp_path: Path) -> None:
-        service = HlsService(cache_dir=str(tmp_path / "cache"))
-        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
-
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
-
-        assert "-avoid_negative_ts" in cmd
-
 
 @pytest.mark.unit
 class TestHlsServiceBuildMasterPlaylist:

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -554,3 +554,101 @@ class TestHlsServiceValidateSource:
         result = HlsService._validate_source(str(source))
 
         assert result == source.resolve()
+
+
+@pytest.mark.unit
+class TestHlsServiceEvictIdle:
+    """Tests for the idle ffmpeg eviction logic."""
+
+    def _make_alive_proc(self) -> MagicMock:
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        return proc
+
+    def test_should_not_evict_when_no_processes(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path), idle_timeout=0.0)
+        evicted = service.evict_idle()
+        assert evicted == []
+
+    def test_should_evict_process_idle_longer_than_timeout(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path), idle_timeout=0.5)
+        proc = self._make_alive_proc()
+        service._processes["abc"] = [proc]
+        # Set last access far in the past
+        service._last_access["abc"] = 0.0  # epoch — definitely > 0.5s ago
+
+        evicted = service.evict_idle()
+
+        assert evicted == ["abc"]
+        proc.kill.assert_called_once()
+        assert "abc" not in service._processes
+        assert "abc" not in service._last_access
+
+    def test_should_not_evict_recently_accessed_process(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path), idle_timeout=60.0)
+        proc = self._make_alive_proc()
+        service._processes["abc"] = [proc]
+        # Touch with monotonic now — fresh
+        service._last_access["abc"] = service._last_access.get("abc", 0)
+        service._touch_access("abc")
+
+        evicted = service.evict_idle()
+
+        assert evicted == []
+        proc.kill.assert_not_called()
+        assert "abc" in service._processes
+
+    def test_should_evict_only_stale_entries(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path), idle_timeout=0.5)
+        stale_proc = self._make_alive_proc()
+        fresh_proc = self._make_alive_proc()
+        service._processes["stale"] = [stale_proc]
+        service._processes["fresh"] = [fresh_proc]
+        service._last_access["stale"] = 0.0  # ancient
+        service._touch_access("fresh")  # right now
+
+        evicted = service.evict_idle()
+
+        assert evicted == ["stale"]
+        stale_proc.kill.assert_called_once()
+        fresh_proc.kill.assert_not_called()
+        assert "fresh" in service._processes
+
+    def test_get_file_by_hash_should_touch_access_on_hit(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        cache_dir = tmp_path / "abc"
+        cache_dir.mkdir()
+        (cache_dir / "segment_0000.ts").write_text("data")
+
+        result = service.get_file_by_hash("abc", "segment_0000.ts")
+
+        assert result is not None
+        assert "abc" in service._last_access
+
+    def test_get_file_by_hash_should_not_touch_access_on_miss(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        result = service.get_file_by_hash("abc", "missing.ts")
+
+        assert result is None
+        assert "abc" not in service._last_access
+
+    def test_get_master_playlist_should_touch_access_on_hit(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        cache_dir = tmp_path / "abc"
+        cache_dir.mkdir()
+        (cache_dir / "master.m3u8").write_text("#EXTM3U")
+
+        result = service.get_master_playlist("abc")
+
+        assert result == "#EXTM3U"
+        assert "abc" in service._last_access
+
+    def test_kill_processes_should_remove_last_access_entry(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        service._processes["abc"] = [self._make_alive_proc()]
+        service._touch_access("abc")
+
+        service._kill_processes("abc")
+
+        assert "abc" not in service._processes
+        assert "abc" not in service._last_access

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import json
+import subprocess
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -652,3 +654,184 @@ class TestHlsServiceEvictIdle:
 
         assert "abc" not in service._processes
         assert "abc" not in service._last_access
+
+
+@pytest.mark.unit
+class TestHlsServiceWaitForSubtitle:
+    """Tests for the per-subtitle readiness wait."""
+
+    def test_should_return_true_immediately_when_no_event_registered(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+
+        # Untracked bucket → not being extracted → caller falls through
+        # to a normal filesystem lookup, so we report ready.
+        assert service.wait_for_subtitle("missing", 0, timeout=0.0) is True
+
+    def test_should_return_true_when_event_is_already_set(self, tmp_path: Path) -> None:
+        import threading
+
+        service = HlsService(cache_dir=str(tmp_path))
+        event = threading.Event()
+        event.set()
+        service._subtitle_events["abc"] = {2: event}
+
+        assert service.wait_for_subtitle("abc", 2, timeout=0.0) is True
+
+    def test_should_return_false_when_timeout_elapses(self, tmp_path: Path) -> None:
+        import threading
+
+        service = HlsService(cache_dir=str(tmp_path))
+        # Unset event — wait will time out
+        service._subtitle_events["abc"] = {0: threading.Event()}
+
+        assert service.wait_for_subtitle("abc", 0, timeout=0.05) is False
+
+    def test_should_unblock_after_event_is_set(self, tmp_path: Path) -> None:
+        import threading
+
+        service = HlsService(cache_dir=str(tmp_path))
+        event = threading.Event()
+        service._subtitle_events["abc"] = {0: event}
+
+        # Set the event from a worker after a tiny delay so the main
+        # thread has a chance to enter the wait first.
+        def _release() -> None:
+            time.sleep(0.05)
+            event.set()
+
+        worker = threading.Thread(target=_release, daemon=True)
+        worker.start()
+
+        assert service.wait_for_subtitle("abc", 0, timeout=2.0) is True
+        worker.join(timeout=1.0)
+
+
+@pytest.mark.unit
+class TestHlsServiceExtractOneSubtitle:
+    """Tests for the per-track subtitle extraction worker."""
+
+    def _make_service(self, tmp_path: Path) -> tuple[HlsService, Path]:
+        service = HlsService(cache_dir=str(tmp_path))
+        output_dir = tmp_path / "abc"
+        output_dir.mkdir()
+        return service, output_dir
+
+    def test_should_set_event_after_successful_embedded_extraction(self, tmp_path: Path) -> None:
+        import threading
+
+        service, output_dir = self._make_service(tmp_path)
+        event = threading.Event()
+        service._subtitle_events["abc"] = {3: event}
+
+        track = _make_subtitle_track(index=3, fmt="srt")
+
+        def _fake_run(cmd: list[str], **_: object) -> MagicMock:
+            # Simulate ffmpeg writing the .vtt before exiting
+            (output_dir / "sub_3" / "sub.vtt").write_text("WEBVTT\n")
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=_fake_run):
+            service._extract_one_subtitle(
+                file_path="/movies/test.mkv",
+                output_dir=output_dir,
+                track=track,
+                start_seconds=0.0,
+                path_hash="abc",
+            )
+
+        assert event.is_set()
+        assert (output_dir / "sub_3" / "sub.vtt").is_file()
+        # _write_subtitle_playlist should have been called
+        assert (output_dir / "sub_3" / "playlist.m3u8").is_file()
+
+    def test_should_set_event_even_when_ffmpeg_fails_to_write_vtt(self, tmp_path: Path) -> None:
+        import threading
+
+        service, output_dir = self._make_service(tmp_path)
+        event = threading.Event()
+        service._subtitle_events["abc"] = {0: event}
+
+        track = _make_subtitle_track(index=0, fmt="srt")
+
+        # ffmpeg "succeeds" but never produces the .vtt → route waiters
+        # must still wake up so they can fall through to a 404.
+        with patch("subprocess.run", return_value=MagicMock(returncode=1)):
+            service._extract_one_subtitle(
+                file_path="/movies/test.mkv",
+                output_dir=output_dir,
+                track=track,
+                start_seconds=0.0,
+                path_hash="abc",
+            )
+
+        assert event.is_set()
+        assert not (output_dir / "sub_0" / "sub.vtt").exists()
+        assert not (output_dir / "sub_0" / "playlist.m3u8").exists()
+
+    def test_should_set_event_on_subprocess_timeout(self, tmp_path: Path) -> None:
+        import threading
+
+        service, output_dir = self._make_service(tmp_path)
+        event = threading.Event()
+        service._subtitle_events["abc"] = {1: event}
+
+        track = _make_subtitle_track(index=1, fmt="srt")
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ffmpeg", timeout=120),
+        ):
+            service._extract_one_subtitle(
+                file_path="/movies/test.mkv",
+                output_dir=output_dir,
+                track=track,
+                start_seconds=0.0,
+                path_hash="abc",
+            )
+
+        assert event.is_set()
+
+    def test_should_pass_ss_args_when_start_seconds_is_positive(self, tmp_path: Path) -> None:
+        import threading
+
+        service, output_dir = self._make_service(tmp_path)
+        service._subtitle_events["abc"] = {0: threading.Event()}
+        track = _make_subtitle_track(index=0, fmt="srt")
+
+        captured: dict[str, list[str]] = {}
+
+        def _capture(cmd: list[str], **_: object) -> MagicMock:
+            captured["cmd"] = cmd
+            (output_dir / "sub_0" / "sub.vtt").write_text("WEBVTT\n")
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=_capture):
+            service._extract_one_subtitle(
+                file_path="/movies/test.mkv",
+                output_dir=output_dir,
+                track=track,
+                start_seconds=42.0,
+                path_hash="abc",
+            )
+
+        cmd = captured["cmd"]
+        assert "-ss" in cmd
+        ss_index = cmd.index("-ss")
+        assert cmd[ss_index + 1] == "42.0"
+        # -ss must come before -i for fast demuxer-level seek
+        assert cmd.index("-ss") < cmd.index("-i")
+
+    def test_kill_processes_should_release_subtitle_waiters(self, tmp_path: Path) -> None:
+        import threading
+
+        service = HlsService(cache_dir=str(tmp_path))
+        proc = MagicMock()
+        proc.poll.return_value = None
+        service._processes["abc"] = [proc]
+        event = threading.Event()
+        service._subtitle_events["abc"] = {0: event}
+
+        service._kill_processes("abc")
+
+        assert event.is_set()
+        assert "abc" not in service._subtitle_events


### PR DESCRIPTION
## Summary

Add a \`start\` query parameter (seconds, default 0) to the HLS playlist endpoints so clients can request a partial transcode starting at an arbitrary point in the source file. FFmpeg receives \`-ss\` before \`-i\` for source-level fast seek, making the first segment available within seconds regardless of where the user wants to resume.

## Why

The continue-watching flow was hanging the player on "preparing video" because:
1. Frontend fetches \`playlist.m3u8\` — backend returns after the first segment is ready
2. Frontend waits for the \`playing\` event, then seeks to the saved position (e.g., 1h30min)
3. FFmpeg produces segments sequentially from 0 — segment_0540.ts doesn't exist yet
4. HLS.js polls for the segment while ffmpeg catches up — often taking many minutes or never, depending on codec

With \`?start=X\`, ffmpeg seeks to the saved position first and segment_0000.ts corresponds to (original time = X). The player starts playback immediately.

## Changes

- \`HlsService.get_path_hash(file_path, start_seconds=0.0)\` — hash includes start so different offsets get isolated cache buckets
- \`ensure_playlist\`, \`_start_generation\`, \`_build_video_cmd\`, \`_build_audio_cmd\`, \`_extract_subtitles\` all accept \`start_seconds\`
- FFmpeg cmds place \`-ss\` **before** \`-i\` (demuxer-level fast seek to keyframe)
- Added \`-avoid_negative_ts make_zero\` to reset output PTS to 0
- \`stream_routes.py\` exposes \`start: float = 0.0\` on both movie and episode HLS playlist endpoints
- 8 new unit tests covering hash isolation, \`-ss\` placement, and \`-avoid_negative_ts\` flag

## Frontend coordination

This is the backend half. The frontend PR (in \`homeflix-web\`) needs to:
- Wait for saved progress to resolve before mounting HLS
- Pass \`?start=\${savedProgress.position_seconds ?? 0}\` to the playlist URL
- Display scrubber position as \`video.currentTime + startOffset\`
- Save progress as \`video.currentTime + startOffset\`

**Both PRs must ship together.** The backend alone works with \`start=0\` (original behavior), but doesn't fix the bug until the frontend is updated.

## Cache growth

Each unique \`(file, start)\` generates its own cache directory. For a personal media server this is acceptable short-term. Automatic eviction is tracked as a follow-up (see \`clear_cache()\` for manual cleanup in the meantime).

## Test plan

- [x] All 1319 tests pass (\`poetry run pytest\`)
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] Unit tests verify \`-ss\` placement before \`-i\`
- [x] Unit tests verify hash isolation between different start offsets
- [x] Default behavior (\`start=0\`) unchanged — all existing tests still pass

## Summary by Sourcery

Add support for starting HLS transcoding from an arbitrary offset in the source media so playback can resume mid-file without waiting for earlier segments to be generated.

New Features:
- Introduce an optional start time parameter to movie and episode HLS playlist endpoints to request playlists that begin at a given offset in seconds.
- Generate separate HLS cache buckets per (file, start offset) pair to isolate partial transcodes from full-file transcodes.

Enhancements:
- Propagate a start offset through HLS generation so FFmpeg seeks before input, resets timestamps, and keeps video, audio, and subtitle outputs aligned from the requested start time.

Tests:
- Add unit tests covering hash behavior with start offsets, FFmpeg command construction with -ss placement and timestamp flags, and default behavior when no start offset is provided.