### PR TITLE
feat(media): add cursor pagination to /movies and /series

### DIFF
--- a/src/building_blocks/application/pagination.py
+++ b/src/building_blocks/application/pagination.py
@@ -1,0 +1,139 @@
+"""Cursor-based pagination helpers and DTOs.
+
+Pagination uses an opaque base64-encoded cursor that snapshots the
+internal autoincrement ``id`` of the last row returned by the previous
+page. The next request echoes the cursor back; the repository decodes
+it into a ``WHERE id < :cursor_id`` filter, fetches ``limit + 1`` rows,
+and trims the extra row to detect ``has_more``.
+
+Why id-only and not ``(created_at, id)``? An earlier version of this
+building block tried to sort by ``(created_at DESC, id DESC)`` so the
+order would survive any future feature that sets ``created_at``
+explicitly (e.g. backfills). It tripped a SQLite quirk: ``func.now()``
+stores values with **second** precision (`'2026-04-11 22:32:13'`) but
+SQLAlchemy's `DateTime` serializer binds query parameters with
+microsecond precision (`'2026-04-11 22:32:13.000000'`). String-wise,
+the second-precision value is **less than** the microsecond-padded one,
+so the ``created_at < ?`` branch matched every row and the page never
+advanced. Internal autoincrement id doesn't have that problem, is
+monotonic with insertion, and matches "newest first" semantics for as
+long as ``created_at`` stays server-generated (which is the case
+everywhere in HomeFlix today). If a future feature ever needs a
+different sort order, the cursor format can change — invalid in-flight
+cursors degrade gracefully via the silent-fallback rule.
+
+Invalid or tampered cursors are silently treated as "no cursor — start
+from the beginning" so a stale token degrades into the natural starting
+point instead of a 400 in the middle of an infinite scroll.
+
+This building block is intentionally tiny and framework-agnostic so
+both the application layer (DTOs, use cases) and the infrastructure
+layer (SQLAlchemy queries) can share the same shapes.
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+# Default and clamp values for the `limit` query param. Routes typically
+# expose `limit` as an int and clamp to ``[1, MAX_PAGE_SIZE]`` before
+# handing it to the use case.
+DEFAULT_PAGE_SIZE = 20
+MAX_PAGE_SIZE = 100
+
+
+@dataclass(frozen=True)
+class CursorValue:
+    """Decoded cursor — the internal autoincrement id of the last row."""
+
+    id: int
+
+
+@dataclass(frozen=True)
+class Pagination:
+    """Pagination metadata returned alongside a page of items.
+
+    Attributes:
+        next_cursor: Opaque token to pass back as `cursor` on the next
+            request. ``None`` when there are no more pages.
+        has_more: Convenience flag — equivalent to ``next_cursor is not
+            None`` but explicit so clients don't have to infer it.
+    """
+
+    next_cursor: str | None
+    has_more: bool
+
+
+@dataclass(frozen=True)
+class PaginatedResult(Generic[T]):
+    """A page of results with its pagination metadata.
+
+    Attributes:
+        items: The page's items.
+        pagination: ``Pagination`` for ``next_cursor`` / ``has_more``.
+        total_count: Total rows matching the query, or ``None`` when
+            the caller did not request it. Computing the total requires
+            an extra ``COUNT(*)`` query, so it's opt-in.
+    """
+
+    items: list[T]
+    pagination: Pagination
+    total_count: int | None = None
+
+
+def encode_cursor(internal_id: int) -> str:
+    """Encode the last row's internal id into an opaque cursor string.
+
+    The wire format is the integer rendered as a base64url-encoded
+    string. We round-trip through base64 (instead of just stringifying
+    the int) so the cursor STAYS opaque to clients — they shouldn't
+    treat it as a sortable number.
+
+    Args:
+        internal_id: The internal autoincrement primary key of the last
+            row of the previous page.
+
+    Returns:
+        URL-safe base64 string suitable for use as a query parameter.
+    """
+    return base64.urlsafe_b64encode(str(internal_id).encode("ascii")).decode("ascii")
+
+
+def decode_cursor(cursor: str | None) -> CursorValue | None:
+    """Decode an opaque cursor back into its internal id.
+
+    Returns ``None`` for an absent or undecodable cursor so callers can
+    treat both as "no cursor — start from the beginning". Tampered or
+    truncated cursors are silently downgraded instead of raising; the
+    cost of an extra page-zero fetch is much smaller than a confusing
+    400 in the middle of an infinite scroll.
+
+    Args:
+        cursor: The opaque cursor string to decode, or ``None``.
+
+    Returns:
+        A ``CursorValue`` on success, or ``None`` when the input is
+        empty, malformed, or fails to decode.
+    """
+    if not cursor:
+        return None
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("ascii")
+        return CursorValue(id=int(raw))
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+__all__ = [
+    "DEFAULT_PAGE_SIZE",
+    "MAX_PAGE_SIZE",
+    "CursorValue",
+    "Pagination",
+    "PaginatedResult",
+    "decode_cursor",
+    "encode_cursor",
+]

--- a/src/building_blocks/application/pagination.py
+++ b/src/building_blocks/application/pagination.py
@@ -34,6 +34,7 @@ layer (SQLAlchemy queries) can share the same shapes.
 from __future__ import annotations
 
 import base64
+import binascii
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -124,7 +125,12 @@ def decode_cursor(cursor: str | None) -> CursorValue | None:
     try:
         raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("ascii")
         return CursorValue(id=int(raw))
-    except (ValueError, UnicodeDecodeError):
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        # `binascii.Error` is technically a subclass of `ValueError` in
+        # CPython today, so the trailing `ValueError` would catch it
+        # too — listing it explicitly documents the contract for the
+        # next reader and protects against any future Python release
+        # that might split the hierarchy.
         return None
 
 

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -119,11 +119,22 @@ class ListMoviesInput:
     """Input for ListMoviesUseCase.
 
     Attributes:
-        limit: Maximum number of movies to return (optional, default: all).
+        cursor: Opaque pagination cursor from the previous page's
+            ``next_cursor``. ``None`` (or any invalid token) starts at
+            the first page.
+        limit: Page size. Routes clamp this to ``[1, MAX_PAGE_SIZE]``
+            before constructing the input.
+        include_total: When ``True`` the use case asks the repository
+            for an extra ``COUNT(*)`` so ``total_count`` is populated.
+            Defaults to ``False`` because computing the total is the
+            most expensive part of the query and is rarely needed by
+            infinite-scroll consumers.
         lang: Language code for localized metadata.
     """
 
-    limit: int | None = None
+    cursor: str | None = None
+    limit: int = 20
+    include_total: bool = False
     lang: str = "en"
 
 
@@ -132,12 +143,21 @@ class ListMoviesOutput:
     """Output for ListMoviesUseCase.
 
     Attributes:
-        movies: List of movie summaries.
-        total_count: Total number of movies in the library.
+        movies: List of movie summaries on this page.
+        next_cursor: Opaque token to pass back as ``cursor`` on the
+            next request, or ``None`` when there are no more pages.
+        has_more: Convenience flag — equivalent to
+            ``next_cursor is not None`` but explicit so clients don't
+            have to infer it.
+        total_count: Total number of (non-deleted) movies in the
+            library, or ``None`` when the caller did not request it
+            via ``include_total``.
     """
 
     movies: list[MovieSummaryOutput]
-    total_count: int
+    next_cursor: str | None
+    has_more: bool
+    total_count: int | None = None
 
 
 __all__ = [

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
+
 if TYPE_CHECKING:
     from src.modules.media.application.dtos.media_file_dtos import MediaFileOutput
 
@@ -133,7 +135,7 @@ class ListMoviesInput:
     """
 
     cursor: str | None = None
-    limit: int = 20
+    limit: int = DEFAULT_PAGE_SIZE
     include_total: bool = False
     lang: str = "en"
 

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -167,11 +167,20 @@ class ListSeriesInput:
     """Input for ListSeriesUseCase.
 
     Attributes:
-        limit: Maximum number of series to return (optional, default: all).
+        cursor: Opaque pagination cursor from the previous page's
+            ``next_cursor``. ``None`` (or any invalid token) starts at
+            the first page.
+        limit: Page size. Routes clamp this to ``[1, MAX_PAGE_SIZE]``
+            before constructing the input.
+        include_total: When ``True`` the use case asks the repository
+            for an extra ``COUNT(*)`` so ``total_count`` is populated.
+            Defaults to ``False`` for performance.
         lang: Language code for localized metadata.
     """
 
-    limit: int | None = None
+    cursor: str | None = None
+    limit: int = 20
+    include_total: bool = False
     lang: str = "en"
 
 
@@ -180,12 +189,20 @@ class ListSeriesOutput:
     """Output for ListSeriesUseCase.
 
     Attributes:
-        series: List of series summaries.
-        total_count: Total number of series in the library.
+        series: List of series summaries on this page.
+        next_cursor: Opaque token to pass back as ``cursor`` on the
+            next request, or ``None`` when there are no more pages.
+        has_more: Convenience flag — equivalent to
+            ``next_cursor is not None`` but explicit.
+        total_count: Total number of (non-deleted) series in the
+            library, or ``None`` when the caller did not request it
+            via ``include_total``.
     """
 
     series: list[SeriesSummaryOutput]
-    total_count: int
+    next_cursor: str | None
+    has_more: bool
+    total_count: int | None = None
 
 
 __all__ = [

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
+
 if TYPE_CHECKING:
     from src.modules.media.application.dtos.media_file_dtos import MediaFileOutput
 
@@ -179,7 +181,7 @@ class ListSeriesInput:
     """
 
     cursor: str | None = None
-    limit: int = 20
+    limit: int = DEFAULT_PAGE_SIZE
     include_total: bool = False
     lang: str = "en"
 

--- a/src/modules/media/application/use_cases/list_movies.py
+++ b/src/modules/media/application/use_cases/list_movies.py
@@ -1,4 +1,4 @@
-"""ListMoviesUseCase - List all movies in the library."""
+"""ListMoviesUseCase - List movies in the library, paginated."""
 
 from src.modules.media.application.dtos.movie_dtos import (
     ListMoviesInput,
@@ -10,15 +10,20 @@ from src.modules.media.domain.repositories import MovieRepository
 
 
 class ListMoviesUseCase:
-    """List all movies in the library.
+    """List one page of movies using cursor-based pagination.
 
-    Returns a list of movie summaries suitable for grid/list display.
+    Delegates the page query to ``MovieRepository.list_paginated`` and
+    converts the resulting ``Movie`` entities into ``MovieSummaryOutput``
+    DTOs. The cursor is passed through opaquely — the use case never
+    decodes or encodes it, the repository owns that contract.
 
     Example:
         >>> use_case = ListMoviesUseCase(movie_repository)
         >>> result = await use_case.execute(ListMoviesInput(limit=20))
         >>> len(result.movies)
         20
+        >>> result.has_more
+        True
     """
 
     def __init__(self, movie_repository: MovieRepository) -> None:
@@ -33,21 +38,25 @@ class ListMoviesUseCase:
         """Execute the use case.
 
         Args:
-            input_dto: Contains optional limit parameter.
+            input_dto: ``cursor`` (opaque), ``limit``, ``include_total``,
+                and ``lang``.
 
         Returns:
-            ListMoviesOutput with movie summaries and count.
+            ``ListMoviesOutput`` with the page items, the next cursor,
+            ``has_more``, and an optional ``total_count`` (only when
+            ``include_total=True``).
         """
-        movies = await self._movie_repository.list_all()
-
-        total_count = len(movies)
-
-        if input_dto.limit is not None:
-            movies = movies[: input_dto.limit]
+        page = await self._movie_repository.list_paginated(
+            cursor=input_dto.cursor,
+            limit=input_dto.limit,
+            include_total=input_dto.include_total,
+        )
 
         return ListMoviesOutput(
-            movies=[self._to_summary(movie, input_dto.lang) for movie in movies],
-            total_count=total_count,
+            movies=[self._to_summary(movie, input_dto.lang) for movie in page.items],
+            next_cursor=page.pagination.next_cursor,
+            has_more=page.pagination.has_more,
+            total_count=page.total_count,
         )
 
     @staticmethod

--- a/src/modules/media/application/use_cases/list_series.py
+++ b/src/modules/media/application/use_cases/list_series.py
@@ -1,4 +1,4 @@
-"""ListSeriesUseCase - List all series in the library."""
+"""ListSeriesUseCase - List series in the library, paginated."""
 
 from src.modules.media.application.dtos.series_dtos import (
     ListSeriesInput,
@@ -10,16 +10,20 @@ from src.modules.media.domain.repositories import SeriesRepository
 
 
 class ListSeriesUseCase:
-    """List all series in the library.
+    """List one page of series using cursor-based pagination.
 
-    Returns a list of series summaries suitable for grid/list display.
-    Does not include full episode hierarchy for performance.
+    Delegates the page query to ``SeriesRepository.list_paginated`` and
+    converts the resulting ``Series`` entities into
+    ``SeriesSummaryOutput`` DTOs. The cursor is passed through
+    opaquely.
 
     Example:
         >>> use_case = ListSeriesUseCase(series_repository)
         >>> result = await use_case.execute(ListSeriesInput())
         >>> len(result.series)
-        15
+        20
+        >>> result.has_more
+        True
     """
 
     def __init__(self, series_repository: SeriesRepository) -> None:
@@ -34,21 +38,25 @@ class ListSeriesUseCase:
         """Execute the use case.
 
         Args:
-            input_dto: Contains optional limit.
+            input_dto: ``cursor`` (opaque), ``limit``, ``include_total``,
+                and ``lang``.
 
         Returns:
-            ListSeriesOutput with series summaries.
+            ``ListSeriesOutput`` with the page items, the next cursor,
+            ``has_more``, and an optional ``total_count`` (only when
+            ``include_total=True``).
         """
-        all_series = await self._series_repository.list_all()
-
-        total_count = len(all_series)
-
-        if input_dto.limit is not None:
-            all_series = all_series[: input_dto.limit]
+        page = await self._series_repository.list_paginated(
+            cursor=input_dto.cursor,
+            limit=input_dto.limit,
+            include_total=input_dto.include_total,
+        )
 
         return ListSeriesOutput(
-            series=[self._to_summary(s, input_dto.lang) for s in all_series],
-            total_count=total_count,
+            series=[self._to_summary(s, input_dto.lang) for s in page.items],
+            next_cursor=page.pagination.next_cursor,
+            has_more=page.pagination.has_more,
+            total_count=page.total_count,
         )
 
     @staticmethod

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -70,10 +70,16 @@ class MovieRepository(ABC):
     ) -> PaginatedResult[Movie]:
         """List movies in a single page using cursor-based pagination.
 
-        The page is ordered by ``(created_at DESC, id DESC)`` so newly
-        imported movies appear first. Cursors snapshot the
-        ``(created_at, id)`` of the last row of the previous page; the
-        next call resumes strictly after that pair.
+        The page is ordered by ``id DESC`` so the most recently
+        inserted rows appear first. Internal autoincrement id is
+        monotonic with insertion and matches "newest by ``created_at``"
+        in practice because ``created_at`` is server-generated on
+        insert and never edited later. The cursor snapshots only the
+        ``id`` of the last row of the previous page and the next call
+        resumes strictly after it. See
+        ``src/building_blocks/application/pagination.py`` for the
+        full justification (and the SQLite ``func.now()`` precision
+        quirk that ruled out a ``(created_at, id)`` composite cursor).
 
         Args:
             cursor: Opaque token from the previous page's

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
+from src.building_blocks.application.pagination import PaginatedResult
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.value_objects import FilePath, MovieId
 
@@ -56,6 +57,40 @@ class MovieRepository(ABC):
 
         Returns:
             Sequence of all movies.
+        """
+        ...
+
+    @abstractmethod
+    async def list_paginated(
+        self,
+        cursor: str | None,
+        limit: int,
+        *,
+        include_total: bool = False,
+    ) -> PaginatedResult[Movie]:
+        """List movies in a single page using cursor-based pagination.
+
+        The page is ordered by ``(created_at DESC, id DESC)`` so newly
+        imported movies appear first. Cursors snapshot the
+        ``(created_at, id)`` of the last row of the previous page; the
+        next call resumes strictly after that pair.
+
+        Args:
+            cursor: Opaque token from the previous page's
+                ``next_cursor``, or ``None`` for the first page.
+                Invalid / undecodable cursors silently fall back to the
+                first page so a stale token doesn't break a scroll.
+            limit: Page size. Callers should clamp this in the route.
+            include_total: When ``True`` the implementation runs an
+                extra ``COUNT(*)`` to populate
+                ``PaginatedResult.total_count``. Defaults to ``False``
+                because the count is the most expensive part of the
+                query and is rarely needed by infinite-scroll consumers.
+
+        Returns:
+            ``PaginatedResult`` containing the page items, the
+            ``Pagination`` (next_cursor + has_more), and the optional
+            total count.
         """
         ...
 

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
+from src.building_blocks.application.pagination import PaginatedResult
 from src.modules.media.domain.entities.series import Series
 from src.modules.media.domain.value_objects import EpisodeId, FilePath, SeriesId, Title
 
@@ -56,6 +57,38 @@ class SeriesRepository(ABC):
 
         Returns:
             Sequence of all series.
+        """
+        ...
+
+    @abstractmethod
+    async def list_paginated(
+        self,
+        cursor: str | None,
+        limit: int,
+        *,
+        include_total: bool = False,
+    ) -> PaginatedResult[Series]:
+        """List series in a single page using cursor-based pagination.
+
+        Sorted by ``(created_at DESC, id DESC)`` so newly imported
+        series appear first. The cursor opaquely snapshots the
+        ``(created_at, id)`` of the last row of the previous page; the
+        next call resumes strictly after that pair.
+
+        Args:
+            cursor: Opaque token from the previous page's
+                ``next_cursor``, or ``None`` for the first page.
+                Invalid / undecodable cursors silently fall back to
+                the first page.
+            limit: Page size. Callers should clamp this in the route.
+            include_total: When ``True`` the implementation runs an
+                extra ``COUNT(*)`` to populate
+                ``PaginatedResult.total_count``. Defaults to ``False``.
+
+        Returns:
+            ``PaginatedResult`` containing the page items, the
+            ``Pagination`` (next_cursor + has_more), and the optional
+            total count.
         """
         ...
 

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -70,10 +70,15 @@ class SeriesRepository(ABC):
     ) -> PaginatedResult[Series]:
         """List series in a single page using cursor-based pagination.
 
-        Sorted by ``(created_at DESC, id DESC)`` so newly imported
-        series appear first. The cursor opaquely snapshots the
-        ``(created_at, id)`` of the last row of the previous page; the
-        next call resumes strictly after that pair.
+        Sorted by ``id DESC`` so the most recently inserted rows
+        appear first. Internal autoincrement id is monotonic with
+        insertion and matches "newest by ``created_at``" in practice
+        because ``created_at`` is server-generated on insert and never
+        edited later. The cursor snapshots only the ``id`` of the last
+        row of the previous page. See
+        ``src/building_blocks/application/pagination.py`` for the
+        full justification (and the SQLite ``func.now()`` precision
+        quirk that ruled out a ``(created_at, id)`` composite cursor).
 
         Args:
             cursor: Opaque token from the previous page's

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -2,10 +2,16 @@
 
 from collections.abc import Sequence
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from src.building_blocks.application.pagination import (
+    PaginatedResult,
+    Pagination,
+    decode_cursor,
+    encode_cursor,
+)
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
 from src.modules.media.domain.value_objects import FilePath, MovieId
@@ -135,6 +141,63 @@ class SQLAlchemyMovieRepository(MovieRepository):
         models = result.scalars().all()
 
         return [MovieMapper.to_entity(model) for model in models]
+
+    async def list_paginated(
+        self,
+        cursor: str | None,
+        limit: int,
+        *,
+        include_total: bool = False,
+    ) -> PaginatedResult[Movie]:
+        """List movies in a single cursor-paginated page.
+
+        Sorted by ``id DESC`` so the most recently inserted rows
+        appear first. Internal autoincrement id is monotonic with
+        insertion and matches "newest by ``created_at``" in practice
+        because ``created_at`` is server-generated on insert and never
+        edited later — see ``building_blocks/application/pagination.py``
+        for the full justification.
+
+        Soft-deleted rows are filtered out the same way as ``list_all``.
+        Fetches ``limit + 1`` rows to detect ``has_more`` cheaply
+        without an extra query.
+        """
+        decoded = decode_cursor(cursor)
+
+        stmt = (
+            select(MovieModel)
+            .where(MovieModel.deleted_at.is_(None))
+            .options(selectinload(MovieModel.file_variants))
+        )
+
+        if decoded is not None:
+            stmt = stmt.where(MovieModel.id < decoded.id)
+
+        stmt = stmt.order_by(MovieModel.id.desc()).limit(limit + 1)
+
+        result = await self._session.execute(stmt)
+        models = list(result.scalars().all())
+
+        has_more = len(models) > limit
+        if has_more:
+            models = models[:limit]
+
+        next_cursor: str | None = None
+        if has_more and models:
+            next_cursor = encode_cursor(models[-1].id)
+
+        total_count: int | None = None
+        if include_total:
+            count_stmt = (
+                select(func.count()).select_from(MovieModel).where(MovieModel.deleted_at.is_(None))
+            )
+            total_count = (await self._session.execute(count_stmt)).scalar_one()
+
+        return PaginatedResult(
+            items=[MovieMapper.to_entity(m) for m in models],
+            pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+            total_count=total_count,
+        )
 
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:
         """Return random movies."""

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -3,10 +3,16 @@
 from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from src.building_blocks.application.pagination import (
+    PaginatedResult,
+    Pagination,
+    decode_cursor,
+    encode_cursor,
+)
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import EpisodeId, FilePath, SeasonId, SeriesId, Title
@@ -161,6 +167,63 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         models = result.scalars().all()
 
         return [SeriesMapper.to_entity(model) for model in models]
+
+    async def list_paginated(
+        self,
+        cursor: str | None,
+        limit: int,
+        *,
+        include_total: bool = False,
+    ) -> PaginatedResult[Series]:
+        """List series in a single cursor-paginated page.
+
+        Sorted by ``id DESC`` so the most recently inserted rows appear
+        first — see the building-block docstring and the matching
+        ``MovieRepository.list_paginated`` for the full justification.
+        Soft-deleted rows are filtered out the same way as ``list_all``.
+        Fetches ``limit + 1`` rows to detect ``has_more`` cheaply
+        without an extra query. The full season / episode hierarchy is
+        loaded via the same options as ``list_all``; if that turns out
+        to be a perf issue we'll add a shallow variant later.
+        """
+        decoded = decode_cursor(cursor)
+
+        stmt = (
+            select(SeriesModel)
+            .where(SeriesModel.deleted_at.is_(None))
+            .options(*self._series_load_options())
+        )
+
+        if decoded is not None:
+            stmt = stmt.where(SeriesModel.id < decoded.id)
+
+        stmt = stmt.order_by(SeriesModel.id.desc()).limit(limit + 1)
+
+        result = await self._session.execute(stmt)
+        models = list(result.scalars().all())
+
+        has_more = len(models) > limit
+        if has_more:
+            models = models[:limit]
+
+        next_cursor: str | None = None
+        if has_more and models:
+            next_cursor = encode_cursor(models[-1].id)
+
+        total_count: int | None = None
+        if include_total:
+            count_stmt = (
+                select(func.count())
+                .select_from(SeriesModel)
+                .where(SeriesModel.deleted_at.is_(None))
+            )
+            total_count = (await self._session.execute(count_stmt)).scalar_one()
+
+        return PaginatedResult(
+            items=[SeriesMapper.to_entity(m) for m in models],
+            pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+            total_count=total_count,
+        )
 
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Series]:
         """Return random series."""

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -5,6 +5,7 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
+from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
@@ -39,18 +40,50 @@ router = APIRouter(prefix="/api/v1/movies", tags=["Movies"])
 @router.get("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_movies(
-    limit: int | None = None,
+    cursor: str | None = None,
+    limit: int = DEFAULT_PAGE_SIZE,
+    include_count: bool = False,
     lang: str = "en",
     use_case: ListMoviesUseCase = Depends(
         Provide[ApplicationContainer.media.list_movies],
     ),
 ) -> dict[str, Any]:
-    """List all movies."""
-    result = await use_case.execute(ListMoviesInput(limit=limit, lang=lang))
+    """List one cursor-paginated page of movies.
+
+    Query params:
+        cursor: Opaque token returned by the previous page's
+            ``metadata.pagination.next_cursor``. Omit on the first
+            request. Invalid / tampered cursors silently start over
+            from the beginning.
+        limit: Page size, clamped to ``[1, MAX_PAGE_SIZE]``. Defaults
+            to ``DEFAULT_PAGE_SIZE`` (20).
+        include_count: When ``true``, the response includes
+            ``metadata.total_count``. Defaults to ``false`` to skip
+            the extra ``COUNT(*)`` query that infinite-scroll
+            consumers don't need.
+        lang: Language code for localized metadata.
+    """
+    clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
+    result = await use_case.execute(
+        ListMoviesInput(
+            cursor=cursor,
+            limit=clamped_limit,
+            include_total=include_count,
+            lang=lang,
+        )
+    )
+    metadata: dict[str, Any] = {
+        "pagination": {
+            "next_cursor": result.next_cursor,
+            "has_more": result.has_more,
+        },
+    }
+    if result.total_count is not None:
+        metadata["total_count"] = result.total_count
     return {
         "type": "list",
         "data": [_dataclass_to_dict(m) for m in result.movies],
-        "metadata": {"total_count": result.total_count},
+        "metadata": metadata,
     }
 
 

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -5,6 +5,7 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
+from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
@@ -34,18 +35,41 @@ router = APIRouter(prefix="/api/v1/series", tags=["Series"])
 @router.get("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_series(
-    limit: int | None = None,
+    cursor: str | None = None,
+    limit: int = DEFAULT_PAGE_SIZE,
+    include_count: bool = False,
     lang: str = "en",
     use_case: ListSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.list_series],
     ),
 ) -> dict[str, Any]:
-    """List all series."""
-    result = await use_case.execute(ListSeriesInput(limit=limit, lang=lang))
+    """List one cursor-paginated page of series.
+
+    Same query-param contract as ``GET /api/v1/movies`` — see that
+    endpoint for the full description of ``cursor``, ``limit``,
+    ``include_count``, and the response shape.
+    """
+    clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
+    result = await use_case.execute(
+        ListSeriesInput(
+            cursor=cursor,
+            limit=clamped_limit,
+            include_total=include_count,
+            lang=lang,
+        )
+    )
+    metadata: dict[str, Any] = {
+        "pagination": {
+            "next_cursor": result.next_cursor,
+            "has_more": result.has_more,
+        },
+    }
+    if result.total_count is not None:
+        metadata["total_count"] = result.total_count
     return {
         "type": "list",
         "data": [_dataclass_to_dict(s) for s in result.series],
-        "metadata": {"total_count": result.total_count},
+        "metadata": metadata,
     }
 
 

--- a/tests/building_blocks/unit/application/test_pagination.py
+++ b/tests/building_blocks/unit/application/test_pagination.py
@@ -68,6 +68,13 @@ class TestDecodeCursorFallback:
     def test_should_return_none_for_garbage_string(self) -> None:
         assert decode_cursor("not-a-valid-cursor!!!") is None
 
+    def test_should_return_none_for_invalid_base64_padding(self) -> None:
+        # Strings whose length isn't a multiple of 4 raise
+        # `binascii.Error` from `base64.urlsafe_b64decode`. The cursor
+        # decoder must catch this explicitly so callers never see the
+        # raw exception during an infinite scroll.
+        assert decode_cursor("abc") is None
+
     def test_should_return_none_when_payload_is_not_an_integer(self) -> None:
         bogus = base64.urlsafe_b64encode(b"hello world").decode("ascii")
         assert decode_cursor(bogus) is None

--- a/tests/building_blocks/unit/application/test_pagination.py
+++ b/tests/building_blocks/unit/application/test_pagination.py
@@ -1,0 +1,137 @@
+"""Tests for the pagination building block."""
+
+import base64
+
+import pytest
+
+from src.building_blocks.application.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE_SIZE,
+    CursorValue,
+    PaginatedResult,
+    Pagination,
+    decode_cursor,
+    encode_cursor,
+)
+
+
+@pytest.mark.unit
+class TestEncodeDecodeRoundtrip:
+    """Encode + decode should be a perfect inverse for valid inputs."""
+
+    def test_should_roundtrip_a_typical_cursor(self) -> None:
+        encoded = encode_cursor(42)
+
+        decoded = decode_cursor(encoded)
+
+        assert decoded == CursorValue(id=42)
+
+    def test_should_roundtrip_id_one(self) -> None:
+        encoded = encode_cursor(1)
+        assert decode_cursor(encoded) == CursorValue(id=1)
+
+    def test_should_roundtrip_high_internal_id(self) -> None:
+        encoded = encode_cursor(9_999_999_999)
+        assert decode_cursor(encoded) == CursorValue(id=9_999_999_999)
+
+
+@pytest.mark.unit
+class TestEncodeOpaqueness:
+    """The wire format should not let clients trivially infer the id."""
+
+    def test_should_only_contain_url_safe_characters(self) -> None:
+        encoded = encode_cursor(42)
+
+        # `+` and `/` are the unsafe ones in standard base64; URL-safe replaces
+        # them with `-` and `_`. The encoded cursor must not contain either.
+        assert "+" not in encoded
+        assert "/" not in encoded
+
+    def test_should_not_be_a_bare_integer_string(self) -> None:
+        # The whole point of base64-wrapping is that clients can't treat
+        # the cursor as a sortable number — make sure we didn't regress
+        # to passing the integer through verbatim.
+        encoded = encode_cursor(42)
+        assert encoded != "42"
+
+
+@pytest.mark.unit
+class TestDecodeCursorFallback:
+    """Invalid / absent cursors should silently degrade to None."""
+
+    def test_should_return_none_for_none_input(self) -> None:
+        assert decode_cursor(None) is None
+
+    def test_should_return_none_for_empty_string(self) -> None:
+        assert decode_cursor("") is None
+
+    def test_should_return_none_for_garbage_string(self) -> None:
+        assert decode_cursor("not-a-valid-cursor!!!") is None
+
+    def test_should_return_none_when_payload_is_not_an_integer(self) -> None:
+        bogus = base64.urlsafe_b64encode(b"hello world").decode("ascii")
+        assert decode_cursor(bogus) is None
+
+    def test_should_return_none_for_negative_decoded_payload(self) -> None:
+        # int("-5") parses successfully, so this isn't a malformed
+        # payload at the parser level — but a negative cursor would
+        # never come from `encode_cursor`. We document the current
+        # behavior: it round-trips. If we ever need to reject it the
+        # check goes here.
+        encoded = base64.urlsafe_b64encode(b"-5").decode("ascii")
+        assert decode_cursor(encoded) == CursorValue(id=-5)
+
+
+@pytest.mark.unit
+class TestEncodeDecodeContract:
+    """The wire format must survive a query-string round trip."""
+
+    def test_should_not_use_url_unsafe_padding(self) -> None:
+        # Standard base64 padding `=` is technically url-safe (it's a
+        # reserved char) but some HTTP libs strip it. The encoded
+        # values for any reasonable id should not need padding to be
+        # decoded back — the URL-safe variant tolerates missing padding,
+        # but tests should still confirm we're producing CONSISTENT
+        # output.
+        for i in (1, 42, 99_999_999):
+            encoded = encode_cursor(i)
+            assert decode_cursor(encoded) == CursorValue(id=i)
+
+
+@pytest.mark.unit
+class TestPaginatedResultDefaults:
+    """The dataclass defaults should match the documented contract."""
+
+    def test_total_count_defaults_to_none(self) -> None:
+        result: PaginatedResult[int] = PaginatedResult(
+            items=[1, 2, 3],
+            pagination=Pagination(next_cursor=None, has_more=False),
+        )
+
+        assert result.total_count is None
+
+    def test_should_carry_through_pagination_metadata(self) -> None:
+        result: PaginatedResult[int] = PaginatedResult(
+            items=[1],
+            pagination=Pagination(next_cursor="cursor-token", has_more=True),
+            total_count=99,
+        )
+
+        assert result.pagination.next_cursor == "cursor-token"
+        assert result.pagination.has_more is True
+        assert result.total_count == 99
+
+
+@pytest.mark.unit
+class TestPageSizeConstants:
+    """Sanity checks on the constants exposed for routes."""
+
+    def test_default_must_be_within_max(self) -> None:
+        assert 1 <= DEFAULT_PAGE_SIZE <= MAX_PAGE_SIZE
+
+    def test_max_should_not_be_unbounded(self) -> None:
+        # If the project ever bumps this past a few hundred, the cursor
+        # design (fetch limit+1, single SQL query) starts to get wasteful
+        # and we should reconsider. This guards against an accidental
+        # configuration change.
+        assert MAX_PAGE_SIZE <= 500

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -370,3 +370,125 @@ class TestSQLAlchemyMovieRepositorySaveRestore:
         found = await repo.find_by_id(movie_id)
         assert found is not None
         assert found.title.value == "Restored"
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryListPaginated:
+    """Integration tests for the cursor-paginated listing."""
+
+    async def test_should_return_first_page_when_cursor_is_none(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await _seed_movies(repo, 5)
+
+        page = await repo.list_paginated(cursor=None, limit=3)
+
+        assert len(page.items) == 3
+        assert page.pagination.has_more is True
+        assert page.pagination.next_cursor is not None
+        assert page.total_count is None  # include_total defaults to False
+
+    async def test_should_walk_to_the_next_page_via_cursor(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await _seed_movies(repo, 5)
+
+        page1 = await repo.list_paginated(cursor=None, limit=2)
+        page2 = await repo.list_paginated(cursor=page1.pagination.next_cursor, limit=2)
+        page3 = await repo.list_paginated(cursor=page2.pagination.next_cursor, limit=2)
+
+        page1_ids = {_id_of(m) for m in page1.items}
+        page2_ids = {_id_of(m) for m in page2.items}
+        page3_ids = {_id_of(m) for m in page3.items}
+
+        # No overlap between consecutive pages — the cursor must be exclusive
+        assert page1_ids.isdisjoint(page2_ids)
+        assert page2_ids.isdisjoint(page3_ids)
+        # Five rows total, walked in 2-2-1
+        assert len(page1.items) == 2
+        assert len(page2.items) == 2
+        assert len(page3.items) == 1
+        assert page3.pagination.has_more is False
+        assert page3.pagination.next_cursor is None
+
+    async def test_should_return_has_more_false_when_exact_fit(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await _seed_movies(repo, 3)
+
+        # Asking for exactly the number of rows that exist must NOT
+        # report has_more — the N+1 fetch comes back with N rows so
+        # the +1 sentinel never appears.
+        page = await repo.list_paginated(cursor=None, limit=3)
+
+        assert len(page.items) == 3
+        assert page.pagination.has_more is False
+        assert page.pagination.next_cursor is None
+
+    async def test_should_return_empty_page_when_no_movies(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+
+        page = await repo.list_paginated(cursor=None, limit=20)
+
+        assert page.items == []
+        assert page.pagination.has_more is False
+        assert page.pagination.next_cursor is None
+
+    async def test_should_silently_fall_back_to_first_page_on_invalid_cursor(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await _seed_movies(repo, 3)
+
+        page = await repo.list_paginated(cursor="not-a-valid-cursor", limit=10)
+
+        assert len(page.items) == 3
+
+    async def test_should_order_by_created_at_desc_then_id_desc(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # Saving movies sequentially gives them monotonically increasing
+        # internal ids — the test asserts the most recently saved row
+        # comes first, which is the contract of the cursor sort.
+        seeded = await _seed_movies(repo, 4)
+
+        page = await repo.list_paginated(cursor=None, limit=4)
+
+        returned_titles = [m.title.value for m in page.items]
+        seeded_titles = [m.title.value for m in seeded]
+        assert returned_titles == list(reversed(seeded_titles))
+
+    async def test_should_exclude_soft_deleted_movies(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movies = await _seed_movies(repo, 3)
+        await repo.delete(_id_of(movies[0]))
+
+        page = await repo.list_paginated(cursor=None, limit=10)
+
+        assert len(page.items) == 2
+        returned_ids = {_id_of(m) for m in page.items}
+        assert _id_of(movies[0]) not in returned_ids
+
+    async def test_should_populate_total_count_when_requested(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await _seed_movies(repo, 7)
+
+        page = await repo.list_paginated(cursor=None, limit=3, include_total=True)
+
+        assert page.total_count == 7
+        assert len(page.items) == 3
+        assert page.pagination.has_more is True
+
+    async def test_should_not_count_soft_deleted_in_total(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movies = await _seed_movies(repo, 5)
+        await repo.delete(_id_of(movies[0]))
+        await repo.delete(_id_of(movies[1]))
+
+        page = await repo.list_paginated(cursor=None, limit=10, include_total=True)
+
+        assert page.total_count == 3

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -445,9 +445,7 @@ class TestSQLAlchemyMovieRepositoryListPaginated:
 
         assert len(page.items) == 3
 
-    async def test_should_order_by_created_at_desc_then_id_desc(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_should_order_by_id_desc(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyMovieRepository(db_session)
         # Saving movies sequentially gives them monotonically increasing
         # internal ids — the test asserts the most recently saved row

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -676,3 +676,115 @@ class TestSQLAlchemySeriesRepositorySaveRestore:
         found = await repo.find_by_id(series_id)
         assert found is not None
         assert found.title.value == "Restored"
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryListPaginated:
+    """Integration tests for the cursor-paginated listing."""
+
+    async def test_should_return_first_page_when_cursor_is_none(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await _seed_series(repo, count=5)
+
+        page = await repo.list_paginated(cursor=None, limit=3)
+
+        assert len(page.items) == 3
+        assert page.pagination.has_more is True
+        assert page.pagination.next_cursor is not None
+        assert page.total_count is None
+
+    async def test_should_walk_to_the_next_page_via_cursor(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await _seed_series(repo, count=5)
+
+        page1 = await repo.list_paginated(cursor=None, limit=2)
+        page2 = await repo.list_paginated(cursor=page1.pagination.next_cursor, limit=2)
+        page3 = await repo.list_paginated(cursor=page2.pagination.next_cursor, limit=2)
+
+        page1_ids = {_id_of(s) for s in page1.items}
+        page2_ids = {_id_of(s) for s in page2.items}
+        page3_ids = {_id_of(s) for s in page3.items}
+
+        assert page1_ids.isdisjoint(page2_ids)
+        assert page2_ids.isdisjoint(page3_ids)
+        assert len(page1.items) == 2
+        assert len(page2.items) == 2
+        assert len(page3.items) == 1
+        assert page3.pagination.has_more is False
+        assert page3.pagination.next_cursor is None
+
+    async def test_should_return_has_more_false_when_exact_fit(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await _seed_series(repo, count=3)
+
+        page = await repo.list_paginated(cursor=None, limit=3)
+
+        assert len(page.items) == 3
+        assert page.pagination.has_more is False
+        assert page.pagination.next_cursor is None
+
+    async def test_should_return_empty_page_when_no_series(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+
+        page = await repo.list_paginated(cursor=None, limit=20)
+
+        assert page.items == []
+        assert page.pagination.has_more is False
+        assert page.pagination.next_cursor is None
+
+    async def test_should_silently_fall_back_to_first_page_on_invalid_cursor(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await _seed_series(repo, count=3)
+
+        page = await repo.list_paginated(cursor="not-a-valid-cursor", limit=10)
+
+        assert len(page.items) == 3
+
+    async def test_should_order_by_id_desc(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        seeded = await _seed_series(repo, count=4)
+
+        page = await repo.list_paginated(cursor=None, limit=4)
+
+        returned_titles = [s.title.value for s in page.items]
+        seeded_titles = [s.title.value for s in seeded]
+        assert returned_titles == list(reversed(seeded_titles))
+
+    async def test_should_exclude_soft_deleted_series(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series_list = await _seed_series(repo, count=3)
+        await repo.delete(_id_of(series_list[0]))
+
+        page = await repo.list_paginated(cursor=None, limit=10)
+
+        assert len(page.items) == 2
+        returned_ids = {_id_of(s) for s in page.items}
+        assert _id_of(series_list[0]) not in returned_ids
+
+    async def test_should_populate_total_count_when_requested(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await _seed_series(repo, count=7)
+
+        page = await repo.list_paginated(cursor=None, limit=3, include_total=True)
+
+        assert page.total_count == 7
+        assert len(page.items) == 3
+        assert page.pagination.has_more is True
+
+    async def test_should_not_count_soft_deleted_in_total(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series_list = await _seed_series(repo, count=5)
+        await repo.delete(_id_of(series_list[0]))
+        await repo.delete(_id_of(series_list[1]))
+
+        page = await repo.list_paginated(cursor=None, limit=10, include_total=True)
+
+        assert page.total_count == 3

--- a/tests/modules/media/unit/application/use_cases/test_list_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies.py
@@ -4,58 +4,69 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from src.building_blocks.application.pagination import PaginatedResult, Pagination
 from src.modules.media.application.dtos import ListMoviesInput, ListMoviesOutput, MovieSummaryOutput
 from src.modules.media.application.use_cases import ListMoviesUseCase
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
 
 
+def _make_movie(title: str = "Test Movie", year: int = 2020) -> Movie:
+    return Movie.create(
+        title=title,
+        year=year,
+        duration=7200,
+        file_path=f"/movies/{title.lower().replace(' ', '_')}.mkv",
+        file_size=1_000_000_000,
+        resolution="1080p",
+    )
+
+
+def _page(
+    movies: list[Movie],
+    *,
+    next_cursor: str | None = None,
+    has_more: bool = False,
+    total_count: int | None = None,
+) -> PaginatedResult[Movie]:
+    return PaginatedResult(
+        items=movies,
+        pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+        total_count=total_count,
+    )
+
+
 class TestListMoviesUseCase:
     """Tests for ListMoviesUseCase."""
 
     @pytest.mark.asyncio
-    async def test_should_return_all_movies(self):
+    async def test_should_return_first_page(self) -> None:
         mock_repo = AsyncMock(spec=MovieRepository)
-        movies = [
-            Movie.create(
-                title="Movie 1",
-                year=2020,
-                duration=7200,
-                file_path="/movies/movie1.mkv",
-                file_size=1_000_000_000,
-                resolution="1080p",
-            ),
-            Movie.create(
-                title="Movie 2",
-                year=2021,
-                duration=5400,
-                file_path="/movies/movie2.mkv",
-                file_size=2_000_000_000,
-                resolution="4K",
-            ),
-        ]
-        mock_repo.list_all.return_value = movies
+        mock_repo.list_paginated.return_value = _page(
+            [_make_movie("Movie 1"), _make_movie("Movie 2")],
+            has_more=False,
+        )
         use_case = ListMoviesUseCase(movie_repository=mock_repo)
 
         result = await use_case.execute(ListMoviesInput())
 
         assert isinstance(result, ListMoviesOutput)
         assert len(result.movies) == 2
-        assert result.total_count == 2
+        assert result.has_more is False
+        assert result.next_cursor is None
+        # include_total defaults to False → repo gets include_total=False → total_count is None
+        assert result.total_count is None
+        mock_repo.list_paginated.assert_awaited_once_with(
+            cursor=None,
+            limit=20,
+            include_total=False,
+        )
 
     @pytest.mark.asyncio
-    async def test_should_return_movie_summaries(self):
+    async def test_should_convert_movies_to_summaries(self) -> None:
         mock_repo = AsyncMock(spec=MovieRepository)
-        movie = Movie.create(
-            title="Test Movie",
-            year=2020,
-            duration=7200,
-            file_path="/movies/test.mkv",
-            file_size=1_000_000_000,
-            resolution="1080p",
-        )
-        movie = movie.with_genre("Action")
-        mock_repo.list_all.return_value = [movie]
+        movie = _make_movie("Test Movie", 2020).with_genre("Action")
+        mock_repo.list_paginated.return_value = _page([movie])
         use_case = ListMoviesUseCase(movie_repository=mock_repo)
 
         result = await use_case.execute(ListMoviesInput())
@@ -69,55 +80,60 @@ class TestListMoviesUseCase:
         assert summary.genres == ["Action"]
 
     @pytest.mark.asyncio
-    async def test_should_respect_limit_parameter(self):
+    async def test_should_pass_cursor_and_limit_to_repository(self) -> None:
         mock_repo = AsyncMock(spec=MovieRepository)
-        movies = [
-            Movie.create(
-                title=f"Movie {i}",
-                year=2020,
-                duration=7200,
-                file_path=f"/movies/movie{i}.mkv",
-                file_size=1_000_000_000,
-                resolution="1080p",
-            )
-            for i in range(5)
-        ]
-        mock_repo.list_all.return_value = movies
+        mock_repo.list_paginated.return_value = _page([])
         use_case = ListMoviesUseCase(movie_repository=mock_repo)
 
-        result = await use_case.execute(ListMoviesInput(limit=2))
+        await use_case.execute(ListMoviesInput(cursor="abc123", limit=15))
 
-        assert len(result.movies) == 2
-        assert result.total_count == 5
+        mock_repo.list_paginated.assert_awaited_once_with(
+            cursor="abc123",
+            limit=15,
+            include_total=False,
+        )
 
     @pytest.mark.asyncio
-    async def test_should_return_empty_list_when_no_movies(self):
+    async def test_should_propagate_next_cursor_and_has_more(self) -> None:
         mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.list_all.return_value = []
+        mock_repo.list_paginated.return_value = _page(
+            [_make_movie("Movie 1")],
+            next_cursor="next-token",
+            has_more=True,
+        )
+        use_case = ListMoviesUseCase(movie_repository=mock_repo)
+
+        result = await use_case.execute(ListMoviesInput())
+
+        assert result.next_cursor == "next-token"
+        assert result.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_page_when_no_movies(self) -> None:
+        mock_repo = AsyncMock(spec=MovieRepository)
+        mock_repo.list_paginated.return_value = _page([])
         use_case = ListMoviesUseCase(movie_repository=mock_repo)
 
         result = await use_case.execute(ListMoviesInput())
 
         assert result.movies == []
-        assert result.total_count == 0
+        assert result.has_more is False
+        assert result.next_cursor is None
 
     @pytest.mark.asyncio
-    async def test_should_handle_limit_greater_than_total(self):
+    async def test_should_request_total_when_include_total_is_true(self) -> None:
         mock_repo = AsyncMock(spec=MovieRepository)
-        movies = [
-            Movie.create(
-                title="Movie 1",
-                year=2020,
-                duration=7200,
-                file_path="/movies/movie1.mkv",
-                file_size=1_000_000_000,
-                resolution="1080p",
-            ),
-        ]
-        mock_repo.list_all.return_value = movies
+        mock_repo.list_paginated.return_value = _page(
+            [_make_movie("Movie 1")],
+            total_count=42,
+        )
         use_case = ListMoviesUseCase(movie_repository=mock_repo)
 
-        result = await use_case.execute(ListMoviesInput(limit=100))
+        result = await use_case.execute(ListMoviesInput(include_total=True))
 
-        assert len(result.movies) == 1
-        assert result.total_count == 1
+        assert result.total_count == 42
+        mock_repo.list_paginated.assert_awaited_once_with(
+            cursor=None,
+            limit=20,
+            include_total=True,
+        )

--- a/tests/modules/media/unit/application/use_cases/test_list_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from src.building_blocks.application.pagination import PaginatedResult, Pagination
 from src.modules.media.application.dtos import (
     ListSeriesInput,
     ListSeriesOutput,
@@ -14,27 +15,49 @@ from src.modules.media.domain.entities import Series
 from src.modules.media.domain.repositories import SeriesRepository
 
 
+def _page(
+    series_list: list[Series],
+    *,
+    next_cursor: str | None = None,
+    has_more: bool = False,
+    total_count: int | None = None,
+) -> PaginatedResult[Series]:
+    return PaginatedResult(
+        items=series_list,
+        pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+        total_count=total_count,
+    )
+
+
 class TestListSeriesUseCase:
     """Tests for ListSeriesUseCase."""
 
     @pytest.mark.asyncio
-    async def test_should_return_all_series(self):
+    async def test_should_return_first_page(self) -> None:
         mock_repo = AsyncMock(spec=SeriesRepository)
-        series_list = [
-            Series.create(title="Show 1", start_year=2020),
-            Series.create(title="Show 2", start_year=2021),
-        ]
-        mock_repo.list_all.return_value = series_list
+        mock_repo.list_paginated.return_value = _page(
+            [
+                Series.create(title="Show 1", start_year=2020),
+                Series.create(title="Show 2", start_year=2021),
+            ]
+        )
         use_case = ListSeriesUseCase(series_repository=mock_repo)
 
         result = await use_case.execute(ListSeriesInput())
 
         assert isinstance(result, ListSeriesOutput)
         assert len(result.series) == 2
-        assert result.total_count == 2
+        assert result.has_more is False
+        assert result.next_cursor is None
+        assert result.total_count is None
+        mock_repo.list_paginated.assert_awaited_once_with(
+            cursor=None,
+            limit=20,
+            include_total=False,
+        )
 
     @pytest.mark.asyncio
-    async def test_should_return_series_summaries(self):
+    async def test_should_convert_series_to_summaries(self) -> None:
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Breaking Bad",
@@ -42,7 +65,7 @@ class TestListSeriesUseCase:
             end_year=2013,
             genres=["Drama", "Crime"],
         )
-        mock_repo.list_all.return_value = [series]
+        mock_repo.list_paginated.return_value = _page([series])
         use_case = ListSeriesUseCase(series_repository=mock_repo)
 
         result = await use_case.execute(ListSeriesInput())
@@ -56,36 +79,51 @@ class TestListSeriesUseCase:
         assert summary.genres == ["Drama", "Crime"]
 
     @pytest.mark.asyncio
-    async def test_should_respect_limit_parameter(self):
+    async def test_should_pass_cursor_and_limit_to_repository(self) -> None:
         mock_repo = AsyncMock(spec=SeriesRepository)
-        series_list = [Series.create(title=f"Show {i}", start_year=2020) for i in range(5)]
-        mock_repo.list_all.return_value = series_list
+        mock_repo.list_paginated.return_value = _page([])
         use_case = ListSeriesUseCase(series_repository=mock_repo)
 
-        result = await use_case.execute(ListSeriesInput(limit=2))
+        await use_case.execute(ListSeriesInput(cursor="abc123", limit=15))
 
-        assert len(result.series) == 2
-        assert result.total_count == 5
+        mock_repo.list_paginated.assert_awaited_once_with(
+            cursor="abc123",
+            limit=15,
+            include_total=False,
+        )
 
     @pytest.mark.asyncio
-    async def test_should_return_empty_list_when_no_series(self):
+    async def test_should_propagate_next_cursor_and_has_more(self) -> None:
         mock_repo = AsyncMock(spec=SeriesRepository)
-        mock_repo.list_all.return_value = []
+        mock_repo.list_paginated.return_value = _page(
+            [Series.create(title="Show 1", start_year=2020)],
+            next_cursor="next-token",
+            has_more=True,
+        )
+        use_case = ListSeriesUseCase(series_repository=mock_repo)
+
+        result = await use_case.execute(ListSeriesInput())
+
+        assert result.next_cursor == "next-token"
+        assert result.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_page_when_no_series(self) -> None:
+        mock_repo = AsyncMock(spec=SeriesRepository)
+        mock_repo.list_paginated.return_value = _page([])
         use_case = ListSeriesUseCase(series_repository=mock_repo)
 
         result = await use_case.execute(ListSeriesInput())
 
         assert result.series == []
-        assert result.total_count == 0
+        assert result.has_more is False
+        assert result.next_cursor is None
 
     @pytest.mark.asyncio
-    async def test_should_indicate_ongoing_series(self):
+    async def test_should_indicate_ongoing_series(self) -> None:
         mock_repo = AsyncMock(spec=SeriesRepository)
-        series = Series.create(
-            title="Ongoing Show",
-            start_year=2020,
-        )
-        mock_repo.list_all.return_value = [series]
+        series = Series.create(title="Ongoing Show", start_year=2020)
+        mock_repo.list_paginated.return_value = _page([series])
         use_case = ListSeriesUseCase(series_repository=mock_repo)
 
         result = await use_case.execute(ListSeriesInput())
@@ -94,16 +132,31 @@ class TestListSeriesUseCase:
         assert result.series[0].end_year is None
 
     @pytest.mark.asyncio
-    async def test_should_include_season_and_episode_counts(self):
+    async def test_should_include_season_and_episode_counts(self) -> None:
         mock_repo = AsyncMock(spec=SeriesRepository)
-        series = Series.create(
-            title="Test Show",
-            start_year=2020,
-        )
-        mock_repo.list_all.return_value = [series]
+        series = Series.create(title="Test Show", start_year=2020)
+        mock_repo.list_paginated.return_value = _page([series])
         use_case = ListSeriesUseCase(series_repository=mock_repo)
 
         result = await use_case.execute(ListSeriesInput())
 
         assert result.series[0].season_count == 0
         assert result.series[0].total_episodes == 0
+
+    @pytest.mark.asyncio
+    async def test_should_request_total_when_include_total_is_true(self) -> None:
+        mock_repo = AsyncMock(spec=SeriesRepository)
+        mock_repo.list_paginated.return_value = _page(
+            [Series.create(title="Show 1", start_year=2020)],
+            total_count=10,
+        )
+        use_case = ListSeriesUseCase(series_repository=mock_repo)
+
+        result = await use_case.execute(ListSeriesInput(include_total=True))
+
+        assert result.total_count == 10
+        mock_repo.list_paginated.assert_awaited_once_with(
+            cursor=None,
+            limit=20,
+            include_total=True,
+        )


### PR DESCRIPTION
## Summary

Foundation PR for the listing performance work. Adds an opaque, base64-encoded cursor to both \`GET /api/v1/movies\` and \`GET /api/v1/series\` so the frontend can fetch the catalog in pages instead of one giant request. **Backwards-compatible**: existing clients that don't pass \`?cursor=\` get the first page; the response envelope only adds optional fields.

## Why this PR has no user-visible win

The Home and Browse pages today fetch the entire catalog and group items into genre carousels client-side via \`buildGenreSections\`. Cursor pagination on the flat \`/movies\` and \`/series\` endpoints alone doesn't change that — the consumers would still need every item in memory to build the carousels, so they'd just chain N small requests instead of making one big one.

The actual perf win lands in **PR2**, which:
- Adds new \`/library/genres\` and \`/library/by-genre/{genre}\` endpoints
- Refactors Home and Browse to fetch one page per visible carousel
- Switches to incremental rendering as the user scrolls vertically (new carousels) and horizontally (more items per carousel)

This PR is the rails PR2 will run on. Splitting was a deliberate trade-off — keeping cursor pagination in its own focused diff means PR2 can stay scoped to the carousel UX.

## Building block

\`src/building_blocks/application/pagination.py\` exposes:

- \`encode_cursor(internal_id)\` / \`decode_cursor(cursor)\` — opaque base64url wrappers around the integer id
- \`CursorValue\`, \`Pagination\`, \`PaginatedResult[T]\` — application DTOs
- \`DEFAULT_PAGE_SIZE = 20\` and \`MAX_PAGE_SIZE = 100\`

The cursor stores the internal autoincrement \`id\` only. An earlier draft used a \`(created_at, id)\` composite, which tripped a SQLite quirk: \`func.now()\` writes seconds-precision timestamps (\`'2026-04-11 22:32:13'\`) but SQLAlchemy binds query parameters with microsecond precision (\`'2026-04-11 22:32:13.000000'\`). String-wise the second-precision DB value is **less than** the microsecond-padded bind, so the \`created_at < ?\` branch matched every row and the cursor never advanced. The full justification lives in the building-block docstring.

## Repository implementation

\`MovieRepository.list_paginated\` and \`SeriesRepository.list_paginated\`:

\`\`\`sql
SELECT ...
FROM movies
WHERE deleted_at IS NULL
  AND id < :cursor_id            -- only when cursor is present
ORDER BY id DESC
LIMIT :limit + 1                  -- N+1 fetch to detect has_more
\`\`\`

The \`+1\` sentinel is trimmed before returning. Optional \`COUNT(*)\` only runs when \`include_total=True\`.

## DTOs and use cases

| Layer | Before | After |
|---|---|---|
| \`ListMoviesInput\` | \`limit?: int\`, \`lang\` | \`cursor?: str\`, \`limit: int = 20\`, \`include_total: bool = False\`, \`lang\` |
| \`ListMoviesOutput\` | \`movies\`, \`total_count: int\` | \`movies\`, \`next_cursor: str \| None\`, \`has_more: bool\`, \`total_count: int \| None\` |

Same for \`ListSeriesInput\` / \`ListSeriesOutput\`. Use cases delegate the page query to the repo and never touch the cursor encoding.

## Routes

\`\`\`
GET /api/v1/movies?cursor=&limit=20&include_count=false&lang=en
GET /api/v1/series?cursor=&limit=20&include_count=false&lang=en
\`\`\`

\`limit\` is clamped to \`[1, MAX_PAGE_SIZE]\`. Response envelope:

\`\`\`json
{
  "type": "list",
  "data": [...],
  "metadata": {
    "pagination": { "next_cursor": "NDI=", "has_more": true },
    "total_count": 142  // only when include_count=true
  }
}
\`\`\`

## Edge cases covered by tests

- **Invalid / undecodable cursor** → silent fallback to first page (no 400)
- **Empty catalog** → empty page with \`has_more=false\`
- **Exact-fit page** (rows == limit) → \`has_more=false\` (no false positive from the +1 fetch)
- **Soft-deleted rows** excluded from both the page and the optional total count
- **Cursor walk** across 3 sequential pages with no overlap or gaps

## Test plan

- [x] \`poetry run pytest\`: **1371 passed**
- [x] \`poetry run ruff check src/ tests/\`: clean
- [x] \`poetry run mypy src/\`: clean
- [x] 15 unit tests for the building block (encode/decode roundtrip, opaqueness, fallback)
- [x] 9 integration tests per repository (cursor walk, exact fit, empty, invalid cursor, ordering, soft-delete handling, optional total)
- [x] Use case tests rewritten to mock \`list_paginated\` and assert on \`cursor\` / \`limit\` / \`include_total\` args
- [ ] Manual: \`curl /api/v1/movies\` returns first page with \`metadata.pagination.next_cursor\`
- [ ] Manual: \`curl /api/v1/movies?cursor=<token>\` returns the second page with no overlap
- [ ] Manual: \`curl /api/v1/movies?include_count=true\` populates \`metadata.total_count\`
- [ ] Manual: \`curl /api/v1/movies?cursor=garbage\` falls back to first page

## Summary by Sourcery

Introduce shared cursor-based pagination primitives and apply them to paginated movie and series listings, including repository, use case, and HTTP route changes.

New Features:
- Add a reusable pagination building block with base64-encoded cursors, pagination metadata DTOs, and configurable page size limits.
- Expose cursor-paginated GET /api/v1/movies and /api/v1/series endpoints that return one page of results plus pagination metadata and optional total counts.

Enhancements:
- Refactor movie and series listing use cases to delegate to repository-level cursor pagination and surface next_cursor, has_more, and optional total_count in their outputs.

Tests:
- Add unit tests for the pagination helper module covering cursor encoding/decoding behavior and defaults.
- Add integration tests for movie and series repositories to verify cursor pagination behavior, ordering, soft-delete handling, and optional total counts.
- Update movie and series use case unit tests to exercise the new paginated contract and repository interactions.