### PR TITLE
feat(catalog): add per-genre catalog endpoints with merged listing

### DIFF
--- a/src/building_blocks/application/pagination.py
+++ b/src/building_blocks/application/pagination.py
@@ -55,6 +55,38 @@ class CursorValue:
 
 
 @dataclass(frozen=True)
+class TitleCursorValue:
+    """Decoded cursor for listings sorted by ``(LOWER(title), id)``.
+
+    Used by the catalog "by genre" endpoint where rows are surfaced
+    alphabetically rather than by insertion order. The composite key
+    is necessary because two rows can share the same title and the
+    sort would otherwise be unstable across pages — the ``id``
+    tie-breaker guarantees a deterministic order.
+    """
+
+    title: str
+    id: int
+
+
+@dataclass(frozen=True)
+class DualCursorValue:
+    """Decoded cursor that bundles two independent stream cursors.
+
+    The catalog by-genre endpoint queries movies and series in
+    parallel and merges the two streams alphabetically by title; each
+    stream advances at its own pace, so the page's "next cursor" must
+    carry both stream positions. ``movies`` and ``series`` are the
+    raw, still-opaque per-stream cursor strings — neither is decoded
+    by this building block; the use case forwards them back to the
+    repositories untouched.
+    """
+
+    movies: str | None
+    series: str | None
+
+
+@dataclass(frozen=True)
 class Pagination:
     """Pagination metadata returned alongside a page of items.
 
@@ -79,11 +111,21 @@ class PaginatedResult(Generic[T]):
         total_count: Total rows matching the query, or ``None`` when
             the caller did not request it. Computing the total requires
             an extra ``COUNT(*)`` query, so it's opt-in.
+        item_cursors: Parallel to ``items`` — cursor that resumes
+            strictly after that item. Populated only by repository
+            methods whose consumers need to advance through a partial
+            prefix of the page (e.g. the catalog "by genre" listing,
+            which fetches movies and series in parallel and may use
+            only some items from each before the merged page is full).
+            For straight-through consumers that always exhaust the
+            whole page, ``pagination.next_cursor`` is enough and this
+            field stays ``None``.
     """
 
     items: list[T]
     pagination: Pagination
     total_count: int | None = None
+    item_cursors: list[str] | None = None
 
 
 def encode_cursor(internal_id: int) -> str:
@@ -102,6 +144,91 @@ def encode_cursor(internal_id: int) -> str:
         URL-safe base64 string suitable for use as a query parameter.
     """
     return base64.urlsafe_b64encode(str(internal_id).encode("ascii")).decode("ascii")
+
+
+# Separator used inside the title cursor's encoded payload. The
+# raw form is `<title_lower>\x1f<id>` so a literal `|` (or any other
+# printable separator) inside a title can't collide with the
+# delimiter. ASCII 0x1F is the "unit separator" control character —
+# it's not part of any practical title.
+_TITLE_CURSOR_SEP = "\x1f"
+
+
+def encode_title_cursor(title: str, internal_id: int) -> str:
+    """Encode a ``(title, id)`` pair as an opaque title-sorted cursor.
+
+    The title is lowercased before encoding so the cursor matches the
+    repository's ``LOWER(title)`` sort key — pagination must use the
+    exact same comparison the SQL ``ORDER BY`` uses or rows can be
+    skipped or repeated across pages.
+
+    Args:
+        title: The title of the last row of the previous page. Will
+            be lowercased internally.
+        internal_id: The internal autoincrement id of the same row.
+            Used as the tie-breaker when two rows share a title.
+
+    Returns:
+        URL-safe base64 string suitable for use as a query parameter.
+    """
+    raw = f"{title.lower()}{_TITLE_CURSOR_SEP}{internal_id}"
+    return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+
+
+def decode_title_cursor(cursor: str | None) -> TitleCursorValue | None:
+    """Decode a title-sorted opaque cursor back into ``(title, id)``.
+
+    Returns ``None`` for absent or malformed cursors so the caller
+    silently falls back to the first page (same contract as
+    ``decode_cursor``).
+    """
+    if not cursor:
+        return None
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+        title, id_str = raw.split(_TITLE_CURSOR_SEP, 1)
+        return TitleCursorValue(title=title, id=int(id_str))
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+
+
+# Separator for the dual-cursor wire format. Same rationale as
+# `_TITLE_CURSOR_SEP` — using a control character keeps the parser
+# robust against any payload bytes the inner stream cursors might
+# contain.
+_DUAL_CURSOR_SEP = "\x1e"  # ASCII record separator
+
+
+def encode_dual_cursor(movies: str | None, series: str | None) -> str:
+    """Bundle two independent stream cursors into one opaque token.
+
+    Either side can be ``None``, meaning "that stream is exhausted /
+    has not been started". The encoder writes empty strings for those
+    so the parser can round-trip them deterministically.
+    """
+    raw = f"{movies or ''}{_DUAL_CURSOR_SEP}{series or ''}"
+    return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+
+
+def decode_dual_cursor(cursor: str | None) -> DualCursorValue:
+    """Decode a dual cursor; an absent or malformed token decodes to (None, None).
+
+    The return type is intentionally non-optional — callers always
+    get a ``DualCursorValue`` and can check ``.movies`` / ``.series``
+    individually. This keeps the use-case happy path linear (no
+    extra ``if cursor is not None`` branch).
+    """
+    if not cursor:
+        return DualCursorValue(movies=None, series=None)
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+        movies, series = raw.split(_DUAL_CURSOR_SEP, 1)
+        return DualCursorValue(
+            movies=movies or None,
+            series=series or None,
+        )
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return DualCursorValue(movies=None, series=None)
 
 
 def decode_cursor(cursor: str | None) -> CursorValue | None:
@@ -138,8 +265,14 @@ __all__ = [
     "DEFAULT_PAGE_SIZE",
     "MAX_PAGE_SIZE",
     "CursorValue",
+    "DualCursorValue",
     "Pagination",
     "PaginatedResult",
+    "TitleCursorValue",
     "decode_cursor",
+    "decode_dual_cursor",
+    "decode_title_cursor",
     "encode_cursor",
+    "encode_dual_cursor",
+    "encode_title_cursor",
 ]

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -21,6 +21,8 @@ from src.modules.media.application.use_cases.get_featured_media import GetFeatur
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
+from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
+from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
 from src.modules.media.application.use_cases.list_movies import ListMoviesUseCase
 from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
@@ -117,6 +119,22 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     list_series = providers.Factory(
         ListSeriesUseCase,
+        series_repository=series_repository,
+    )
+
+    # =========================================================================
+    # Use Cases — Catalog (cross-cutting movies + series)
+    # =========================================================================
+
+    list_genres = providers.Factory(
+        ListGenresUseCase,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
+    )
+
+    list_by_genre = providers.Factory(
+        ListByGenreUseCase,
+        movie_repository=movie_repository,
         series_repository=series_repository,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from src.config.logging import get_logger, setup_logging
 from src.config.settings import get_settings
 from src.modules.collections.presentation.routes import custom_list_router, watchlist_router
 from src.modules.media.presentation.routes import (
+    catalog_router,
     enrichment_router,
     featured_router,
     movie_router,
@@ -60,6 +61,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     container = create_container()
     container.wire(
         modules=[
+            "src.modules.media.presentation.routes.catalog_routes",
             "src.modules.media.presentation.routes.enrichment_routes",
             "src.modules.media.presentation.routes.featured_routes",
             "src.modules.media.presentation.routes.movie_routes",
@@ -144,6 +146,7 @@ def create_app() -> FastAPI:
 
     # Register routes
     register_health_routes(app)
+    app.include_router(catalog_router)
     app.include_router(enrichment_router)
     app.include_router(featured_router)
     app.include_router(movie_router)

--- a/src/modules/media/application/dtos/catalog_dtos.py
+++ b/src/modules/media/application/dtos/catalog_dtos.py
@@ -1,0 +1,129 @@
+"""DTOs for the catalog (cross-cutting movies + series) endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
+
+
+@dataclass(frozen=True)
+class GenreOutput:
+    """One row in the catalog genres listing.
+
+    Attributes:
+        id: Canonical English genre name. Stable across language
+            switches and used as the filter key for
+            ``GET /api/v1/catalog/by-genre/{id}``.
+        name: Localized genre name for the requested ``lang``. Falls
+            back to the canonical name when no translation exists.
+        count: Total non-deleted movies + series tagged with this
+            genre. Used by the frontend to sort the carousel order
+            (most-populated genres first) and to suppress empty
+            carousels.
+    """
+
+    id: str
+    name: str
+    count: int
+
+
+@dataclass(frozen=True)
+class ListGenresInput:
+    """Input for ``ListGenresUseCase``.
+
+    Attributes:
+        lang: Language code used to resolve the localized display
+            name for each canonical genre.
+    """
+
+    lang: str = "en"
+
+
+@dataclass(frozen=True)
+class ListGenresOutput:
+    """Output for ``ListGenresUseCase``.
+
+    Attributes:
+        genres: All genres present in the library, sorted by count
+            descending then alphabetically by display name.
+    """
+
+    genres: list[GenreOutput]
+
+
+@dataclass(frozen=True)
+class CatalogItemOutput:
+    """One row in the catalog by-genre listing — movie or series.
+
+    The ``type`` field discriminates so the frontend can render the
+    right card variant and route to the right detail page.
+
+    Attributes:
+        id: External id (``mov_xxx`` or ``ser_xxx``) — the same id
+            used by the existing detail endpoints.
+        type: ``"movie"`` or ``"series"``.
+        title: Localized title (or canonical when no translation).
+        year: Release year for movies, start year for series.
+        synopsis: Localized synopsis, or ``None``.
+        poster_path: Poster URL or path, or ``None``.
+        backdrop_path: Backdrop URL or path, or ``None``.
+        genres: Localized genre list — same field as in the existing
+            movie/series summaries so the frontend doesn't need a
+            different card component.
+    """
+
+    id: str
+    type: str
+    title: str
+    year: int
+    synopsis: str | None
+    poster_path: str | None
+    backdrop_path: str | None
+    genres: list[str]
+
+
+@dataclass(frozen=True)
+class ListByGenreInput:
+    """Input for ``ListByGenreUseCase``.
+
+    Attributes:
+        genre: Canonical English genre id — same value the frontend
+            received from ``ListGenresOutput.genres[*].id``.
+        cursor: Opaque dual-stream cursor from the previous page, or
+            ``None`` for the first page.
+        limit: Page size. Routes clamp to ``[1, MAX_PAGE_SIZE]``.
+        lang: Language for localized titles / synopses / genres.
+    """
+
+    genre: str
+    cursor: str | None = None
+    limit: int = DEFAULT_PAGE_SIZE
+    lang: str = "en"
+
+
+@dataclass(frozen=True)
+class ListByGenreOutput:
+    """Output for ``ListByGenreUseCase``.
+
+    Attributes:
+        items: Mixed list of movies and series for the requested
+            genre, sorted alphabetically by title.
+        next_cursor: Opaque dual-stream cursor for the next page, or
+            ``None`` when both streams are exhausted.
+        has_more: Convenience flag matching ``next_cursor is not None``.
+    """
+
+    items: list[CatalogItemOutput]
+    next_cursor: str | None
+    has_more: bool
+
+
+__all__ = [
+    "CatalogItemOutput",
+    "GenreOutput",
+    "ListByGenreInput",
+    "ListByGenreOutput",
+    "ListGenresInput",
+    "ListGenresOutput",
+]

--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -1,5 +1,9 @@
 """ListByGenreUseCase - paginated mixed (movies + series) listing per genre."""
 
+import asyncio
+from dataclasses import dataclass
+from typing import Literal
+
 from src.building_blocks.application.pagination import (
     PaginatedResult,
     decode_dual_cursor,
@@ -13,6 +17,21 @@ from src.modules.media.application.dtos.catalog_dtos import (
 from src.modules.media.domain.entities import Movie, Series
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import Genre
+
+
+@dataclass(frozen=True)
+class _MergedItem:
+    """One row of the merged movies + series stream.
+
+    Carries the source-page index alongside the entity so the use
+    case can pull the corresponding cursor out of the right
+    repository's ``item_cursors`` after the merge sort. Internal to
+    this module — the public API still returns ``CatalogItemOutput``.
+    """
+
+    kind: Literal["movie", "series"]
+    source_index: int
+    entity: Movie | Series
 
 
 class ListByGenreUseCase:
@@ -67,29 +86,52 @@ class ListByGenreUseCase:
         decoded = decode_dual_cursor(input_dto.cursor)
         genre = Genre(input_dto.genre)
 
-        movies_page = await self._movie_repository.list_paginated_by_genre(
-            genre=genre,
-            cursor=decoded.movies,
-            limit=input_dto.limit,
-        )
-        series_page = await self._series_repository.list_paginated_by_genre(
-            genre=genre,
-            cursor=decoded.series,
-            limit=input_dto.limit,
+        # Both repository calls are independent I/O — issue them
+        # concurrently via `asyncio.gather` so the by-genre endpoint
+        # only waits for the slower of the two queries instead of
+        # serializing them. The DI container hands each repository
+        # its own AsyncSession (Factory provider), so there's no
+        # session contention to worry about.
+        movies_page, series_page = await asyncio.gather(
+            self._movie_repository.list_paginated_by_genre(
+                genre=genre,
+                cursor=decoded.movies,
+                limit=input_dto.limit,
+            ),
+            self._series_repository.list_paginated_by_genre(
+                genre=genre,
+                cursor=decoded.series,
+                limit=input_dto.limit,
+            ),
         )
 
         # Tag each entity with its source stream and its source-page
         # index so we can recover the per-item cursor after the merge.
-        tagged: list[tuple[str, int, Movie | Series]] = [
-            ("movie", index, item) for index, item in enumerate(movies_page.items)
-        ] + [("series", index, item) for index, item in enumerate(series_page.items)]
+        tagged: list[_MergedItem] = [
+            _MergedItem(kind="movie", source_index=index, entity=item)
+            for index, item in enumerate(movies_page.items)
+        ] + [
+            _MergedItem(kind="series", source_index=index, entity=item)
+            for index, item in enumerate(series_page.items)
+        ]
         # Sort by (lowercase title, source index) — the source index
         # tie-breaker matches the SQL `(LOWER(title), id) ASC` order
         # within each stream and gives a stable cross-stream order
         # when two rows share a title.
-        tagged.sort(key=lambda triple: (triple[2].title.value.lower(), triple[1]))
+        tagged.sort(key=lambda mi: (mi.entity.title.value.lower(), mi.source_index))
 
         page_items = tagged[: input_dto.limit]
+
+        # Track the highest consumed source-page index per stream
+        # while we walk the page once. The next-cursor computation
+        # below uses these directly instead of re-scanning the page.
+        last_movie_index: int | None = None
+        last_series_index: int | None = None
+        for item in page_items:
+            if item.kind == "movie":
+                last_movie_index = item.source_index
+            else:
+                last_series_index = item.source_index
 
         # has_more is true if either stream still has more rows OR if
         # the merged buffer was larger than the page (we trimmed it).
@@ -100,16 +142,17 @@ class ListByGenreUseCase:
         )
 
         next_cursor = self._compute_next_cursor(
-            page_items=page_items,
             movies_page=movies_page,
             series_page=series_page,
             previous_movies_cursor=decoded.movies,
             previous_series_cursor=decoded.series,
+            last_movie_index=last_movie_index,
+            last_series_index=last_series_index,
             has_more=has_more,
         )
 
         return ListByGenreOutput(
-            items=[self._to_output(kind, item, input_dto.lang) for kind, _, item in page_items],
+            items=[self._to_output(mi.kind, mi.entity, input_dto.lang) for mi in page_items],
             next_cursor=next_cursor,
             has_more=has_more,
         )
@@ -117,37 +160,26 @@ class ListByGenreUseCase:
     @staticmethod
     def _compute_next_cursor(
         *,
-        page_items: list[tuple[str, int, Movie | Series]],
         movies_page: PaginatedResult[Movie],
         series_page: PaginatedResult[Series],
         previous_movies_cursor: str | None,
         previous_series_cursor: str | None,
+        last_movie_index: int | None,
+        last_series_index: int | None,
         has_more: bool,
     ) -> str | None:
-        """Build the dual cursor for the next page.
+        """Build the dual cursor for the next page from the pre-computed last indices.
 
-        For each stream we look at the highest source-page index of
-        any consumed row and pull the corresponding cursor out of the
-        repository's ``item_cursors`` list. That cursor is the
-        precise resume point — the next call to that repo's
-        ``list_paginated_by_genre`` will return rows strictly after
-        the consumed item.
-
-        If a stream contributed nothing to the page (no items
-        consumed from it), its cursor is left unchanged so the next
-        call re-considers the same starting position.
+        For each stream the caller has already tracked the highest
+        consumed source-page index (or ``None`` if nothing was
+        consumed from that stream). We pull the matching cursor out
+        of the repository's ``item_cursors`` list. If a stream
+        contributed nothing to the page, its cursor is left unchanged
+        so the next call re-considers the same starting position —
+        guaranteeing no item is skipped or duplicated across pages.
         """
         if not has_more:
             return None
-
-        last_movie_index = max(
-            (index for kind, index, _ in page_items if kind == "movie"),
-            default=None,
-        )
-        last_series_index = max(
-            (index for kind, index, _ in page_items if kind == "series"),
-            default=None,
-        )
 
         next_movies_cursor = (
             movies_page.item_cursors[last_movie_index]

--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -1,0 +1,192 @@
+"""ListByGenreUseCase - paginated mixed (movies + series) listing per genre."""
+
+from src.building_blocks.application.pagination import (
+    PaginatedResult,
+    decode_dual_cursor,
+    encode_dual_cursor,
+)
+from src.modules.media.application.dtos.catalog_dtos import (
+    CatalogItemOutput,
+    ListByGenreInput,
+    ListByGenreOutput,
+)
+from src.modules.media.domain.entities import Movie, Series
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.value_objects import Genre
+
+
+class ListByGenreUseCase:
+    """Paginated mixed listing of movies + series for a single genre.
+
+    Both repositories are queried in parallel via their own
+    ``list_paginated_by_genre`` method (sorted by ``LOWER(title), id``),
+    the two streams are merged in Python by title, the merged result
+    is trimmed to the requested page size, and a dual cursor is
+    composed from the position each stream is left at.
+
+    Cursor advancement is "consumed-aware": each repository populates
+    a parallel ``item_cursors`` list on its ``PaginatedResult`` with
+    one cursor per item — the cursor that resumes strictly after that
+    specific row. The use case picks the cursor of the last consumed
+    row from each stream. If a stream contributed nothing to the
+    page (because the other stream's titles all came earlier), its
+    cursor stays unchanged so the next call re-considers the same
+    first row in the merge.
+
+    Per-item cursors are necessary because the page may be a strict
+    PREFIX of one stream's full fetched buffer — using the page's
+    own ``next_cursor`` would jump past rows that the merge left for
+    the next page.
+
+    Each repository fetches up to ``limit`` items independently. In
+    the worst case (one stream has nothing in the genre) the merge
+    over-fetches by ``limit`` rows from the empty stream — acceptable
+    because the LIKE filter on a non-matching genre is essentially
+    free.
+    """
+
+    def __init__(
+        self,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        self._movie_repository = movie_repository
+        self._series_repository = series_repository
+
+    async def execute(self, input_dto: ListByGenreInput) -> ListByGenreOutput:
+        """Execute the use case.
+
+        Args:
+            input_dto: ``genre`` (canonical id), ``cursor`` (opaque
+                dual-stream token), ``limit``, and ``lang``.
+
+        Returns:
+            ``ListByGenreOutput`` carrying the merged page of catalog
+            items + the dual cursor for the next page.
+        """
+        decoded = decode_dual_cursor(input_dto.cursor)
+        genre = Genre(input_dto.genre)
+
+        movies_page = await self._movie_repository.list_paginated_by_genre(
+            genre=genre,
+            cursor=decoded.movies,
+            limit=input_dto.limit,
+        )
+        series_page = await self._series_repository.list_paginated_by_genre(
+            genre=genre,
+            cursor=decoded.series,
+            limit=input_dto.limit,
+        )
+
+        # Tag each entity with its source stream and its source-page
+        # index so we can recover the per-item cursor after the merge.
+        tagged: list[tuple[str, int, Movie | Series]] = [
+            ("movie", index, item) for index, item in enumerate(movies_page.items)
+        ] + [("series", index, item) for index, item in enumerate(series_page.items)]
+        # Sort by (lowercase title, source index) — the source index
+        # tie-breaker matches the SQL `(LOWER(title), id) ASC` order
+        # within each stream and gives a stable cross-stream order
+        # when two rows share a title.
+        tagged.sort(key=lambda triple: (triple[2].title.value.lower(), triple[1]))
+
+        page_items = tagged[: input_dto.limit]
+
+        # has_more is true if either stream still has more rows OR if
+        # the merged buffer was larger than the page (we trimmed it).
+        has_more = (
+            movies_page.pagination.has_more
+            or series_page.pagination.has_more
+            or len(tagged) > input_dto.limit
+        )
+
+        next_cursor = self._compute_next_cursor(
+            page_items=page_items,
+            movies_page=movies_page,
+            series_page=series_page,
+            previous_movies_cursor=decoded.movies,
+            previous_series_cursor=decoded.series,
+            has_more=has_more,
+        )
+
+        return ListByGenreOutput(
+            items=[self._to_output(kind, item, input_dto.lang) for kind, _, item in page_items],
+            next_cursor=next_cursor,
+            has_more=has_more,
+        )
+
+    @staticmethod
+    def _compute_next_cursor(
+        *,
+        page_items: list[tuple[str, int, Movie | Series]],
+        movies_page: PaginatedResult[Movie],
+        series_page: PaginatedResult[Series],
+        previous_movies_cursor: str | None,
+        previous_series_cursor: str | None,
+        has_more: bool,
+    ) -> str | None:
+        """Build the dual cursor for the next page.
+
+        For each stream we look at the highest source-page index of
+        any consumed row and pull the corresponding cursor out of the
+        repository's ``item_cursors`` list. That cursor is the
+        precise resume point — the next call to that repo's
+        ``list_paginated_by_genre`` will return rows strictly after
+        the consumed item.
+
+        If a stream contributed nothing to the page (no items
+        consumed from it), its cursor is left unchanged so the next
+        call re-considers the same starting position.
+        """
+        if not has_more:
+            return None
+
+        last_movie_index = max(
+            (index for kind, index, _ in page_items if kind == "movie"),
+            default=None,
+        )
+        last_series_index = max(
+            (index for kind, index, _ in page_items if kind == "series"),
+            default=None,
+        )
+
+        next_movies_cursor = (
+            movies_page.item_cursors[last_movie_index]
+            if last_movie_index is not None and movies_page.item_cursors is not None
+            else previous_movies_cursor
+        )
+        next_series_cursor = (
+            series_page.item_cursors[last_series_index]
+            if last_series_index is not None and series_page.item_cursors is not None
+            else previous_series_cursor
+        )
+
+        return encode_dual_cursor(next_movies_cursor, next_series_cursor)
+
+    @staticmethod
+    def _to_output(kind: str, item: Movie | Series, lang: str) -> CatalogItemOutput:
+        """Convert a movie/series entity into the catalog row DTO."""
+        if isinstance(item, Movie):
+            return CatalogItemOutput(
+                id=str(item.id),
+                type=kind,
+                title=item.get_title(lang),
+                year=item.year.value,
+                synopsis=item.get_synopsis(lang),
+                poster_path=item.poster_path.value if item.poster_path else None,
+                backdrop_path=item.backdrop_path.value if item.backdrop_path else None,
+                genres=item.get_genres(lang),
+            )
+        # Series
+        return CatalogItemOutput(
+            id=str(item.id),
+            type=kind,
+            title=item.get_title(lang),
+            year=item.start_year.value,
+            synopsis=item.get_synopsis(lang),
+            poster_path=item.poster_path.value if item.poster_path else None,
+            backdrop_path=item.backdrop_path.value if item.backdrop_path else None,
+            genres=item.get_genres(lang),
+        )
+
+
+__all__ = ["ListByGenreUseCase"]

--- a/src/modules/media/application/use_cases/list_genres.py
+++ b/src/modules/media/application/use_cases/list_genres.py
@@ -65,7 +65,14 @@ class ListGenresUseCase:
         counts: dict[str, int] = {}
         localized_label: dict[str, str] = {}
 
-        for row in (*movie_rows, *series_rows):
+        # Two explicit loops instead of `for row in (*movie_rows, *series_rows):`
+        # — the spread builds a brand-new tuple containing every row
+        # from both repositories, temporarily doubling memory for
+        # large catalogs. Iterating each sequence in turn does the
+        # exact same fold without the copy.
+        for row in movie_rows:
+            self._fold_row(row, counts, localized_label)
+        for row in series_rows:
             self._fold_row(row, counts, localized_label)
 
         genres = [

--- a/src/modules/media/application/use_cases/list_genres.py
+++ b/src/modules/media/application/use_cases/list_genres.py
@@ -1,0 +1,108 @@
+"""ListGenresUseCase - aggregate genres across movies and series."""
+
+from src.modules.media.application.dtos.catalog_dtos import (
+    GenreOutput,
+    ListGenresInput,
+    ListGenresOutput,
+)
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.repositories.movie_repository import GenreRow
+
+
+class ListGenresUseCase:
+    """Cross-cutting use case that aggregates genres across both media types.
+
+    Reads the lightweight ``GenreRow`` projection from each repository
+    (which only fetches the ``genres`` and ``localized`` columns), then
+    folds the canonical genre names into a count + the first localized
+    label seen for each.
+
+    The "first localized label" strategy is intentional: in a healthy
+    catalog every row tagged with canonical "Action" should resolve to
+    the same translation (e.g. "Ação"), so picking the first one is
+    deterministic enough. If two rows ever disagree on a translation,
+    the first one wins — fixing the inconsistency is a metadata
+    cleanup task, not a use-case responsibility.
+
+    Sort order: by count descending, then alphabetically by display
+    name. This puts the most-populated carousels at the top of the
+    Home page where they're most useful.
+
+    Example:
+        >>> use_case = ListGenresUseCase(movie_repo, series_repo)
+        >>> result = await use_case.execute(ListGenresInput(lang="pt-BR"))
+        >>> result.genres[0]
+        GenreOutput(id="Action", name="Ação", count=42)
+    """
+
+    def __init__(
+        self,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        """Initialize the use case.
+
+        Args:
+            movie_repository: Movie repo, used for ``list_genre_rows``.
+            series_repository: Series repo, used for ``list_genre_rows``.
+        """
+        self._movie_repository = movie_repository
+        self._series_repository = series_repository
+
+    async def execute(self, input_dto: ListGenresInput) -> ListGenresOutput:
+        """Execute the use case.
+
+        Args:
+            input_dto: Carries the requested ``lang``.
+
+        Returns:
+            ``ListGenresOutput`` with one ``GenreOutput`` per unique
+            canonical genre present in the library.
+        """
+        movie_rows = await self._movie_repository.list_genre_rows(input_dto.lang)
+        series_rows = await self._series_repository.list_genre_rows(input_dto.lang)
+
+        counts: dict[str, int] = {}
+        localized_label: dict[str, str] = {}
+
+        for row in (*movie_rows, *series_rows):
+            self._fold_row(row, counts, localized_label)
+
+        genres = [
+            GenreOutput(
+                id=canonical,
+                name=localized_label.get(canonical, canonical),
+                count=count,
+            )
+            for canonical, count in counts.items()
+        ]
+        # Sort by count descending, then alphabetical (case-insensitive)
+        # so the most-populated carousels surface first and ties stay
+        # deterministic across renders.
+        genres.sort(key=lambda g: (-g.count, g.name.lower()))
+
+        return ListGenresOutput(genres=genres)
+
+    @staticmethod
+    def _fold_row(
+        row: GenreRow,
+        counts: dict[str, int],
+        localized_label: dict[str, str],
+    ) -> None:
+        """Fold one ``GenreRow`` into the running count + label maps.
+
+        Iterates the canonical genres positionally and pairs each one
+        with the corresponding localized name (when present). The
+        first non-empty localized label seen for a canonical genre is
+        the one that survives — see the class docstring for the
+        rationale.
+        """
+        for index, canonical in enumerate(row.canonical_genres):
+            counts[canonical] = counts.get(canonical, 0) + 1
+            if canonical not in localized_label and index < len(row.localized_genres):
+                label = row.localized_genres[index]
+                if label:
+                    localized_label[canonical] = label
+
+
+__all__ = ["ListGenresUseCase"]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -2,10 +2,27 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from src.building_blocks.application.pagination import PaginatedResult
 from src.modules.media.domain.entities.movie import Movie
-from src.modules.media.domain.value_objects import FilePath, MovieId
+from src.modules.media.domain.value_objects import FilePath, Genre, MovieId
+
+
+@dataclass(frozen=True)
+class GenreRow:
+    """Lightweight projection of one media row's genre columns.
+
+    Used by ``list_genre_rows`` so genre aggregation across the full
+    catalog doesn't have to load entities + their relationships. The
+    parallel ``canonical_genres`` and ``localized_genres`` lists carry
+    the same positional mapping the entity exposes via
+    ``Entity.get_genres(lang)`` — index ``i`` of the localized list is
+    the translation of index ``i`` of the canonical list.
+    """
+
+    canonical_genres: list[str]
+    localized_genres: list[str]
 
 
 class MovieRepository(ABC):
@@ -101,6 +118,65 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
+        """Project the genre columns of every non-deleted row.
+
+        This is the cheap input to cross-aggregate listings (e.g.
+        ``ListGenresUseCase``) — only the ``genres`` and ``localized``
+        columns are read so we don't pay the cost of loading file
+        variants or any other relationships.
+
+        Args:
+            lang: Language code used to extract the localized genre
+                names from the per-row ``localized`` JSON. Falls back
+                to canonical English when no translation is present.
+
+        Returns:
+            One ``GenreRow`` per non-deleted movie. Order is not
+            guaranteed.
+        """
+        ...
+
+    @abstractmethod
+    async def list_paginated_by_genre(
+        self,
+        genre: Genre,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResult[Movie]:
+        """List movies belonging to a specific genre, paginated.
+
+        Sorted by ``(LOWER(title) ASC, id ASC)`` so the catalog
+        carousel renders alphabetically. The cursor is a
+        ``(title, id)`` composite (see ``encode_title_cursor`` in the
+        pagination building block) — the ``id`` tie-breaker keeps
+        pagination stable when two rows share a title.
+
+        The genre filter matches the canonical English genre name
+        stored in ``MovieModel.genres`` (a comma-separated string).
+        Localized display names live in the ``localized`` JSON column
+        and are NOT used for filtering — the catalog "by genre"
+        endpoint takes the canonical id and looks up the localized
+        label client-side via ``ListGenresUseCase``.
+
+        Args:
+            genre: The canonical (English) genre to filter by.
+            cursor: Opaque title cursor from the previous page, or
+                ``None`` for the first page. Invalid cursors silently
+                fall back to the first page.
+            limit: Page size. The repository fetches ``limit + 1``
+                rows and trims the sentinel to detect ``has_more``.
+
+        Returns:
+            ``PaginatedResult`` with the page items and pagination
+            metadata. ``total_count`` is always ``None`` here — the
+            catalog endpoint doesn't surface a per-genre count from
+            this method (counts come from ``ListGenresUseCase``
+            which aggregates across both movies and series).
+        """
+        ...
+
+    @abstractmethod
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:
         """Return random movies, optionally filtering to those with backdrop.
 
@@ -138,4 +214,4 @@ class MovieRepository(ABC):
         ...
 
 
-__all__ = ["MovieRepository"]
+__all__ = ["GenreRow", "MovieRepository"]

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -5,7 +5,8 @@ from collections.abc import Sequence
 
 from src.building_blocks.application.pagination import PaginatedResult
 from src.modules.media.domain.entities.series import Series
-from src.modules.media.domain.value_objects import EpisodeId, FilePath, SeriesId, Title
+from src.modules.media.domain.repositories.movie_repository import GenreRow
+from src.modules.media.domain.value_objects import EpisodeId, FilePath, Genre, SeriesId, Title
 
 
 class SeriesRepository(ABC):
@@ -94,6 +95,34 @@ class SeriesRepository(ABC):
             ``PaginatedResult`` containing the page items, the
             ``Pagination`` (next_cursor + has_more), and the optional
             total count.
+        """
+        ...
+
+    @abstractmethod
+    async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
+        """Project the genre columns of every non-deleted series row.
+
+        Same contract as ``MovieRepository.list_genre_rows`` — see
+        that method for the full description. Used by the catalog
+        genres aggregation use case to compute counts and resolve
+        localized labels without loading the full series hierarchy.
+        """
+        ...
+
+    @abstractmethod
+    async def list_paginated_by_genre(
+        self,
+        genre: Genre,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResult[Series]:
+        """List series belonging to a specific genre, paginated.
+
+        Sorted by ``(LOWER(title) ASC, id ASC)``. Same contract as
+        ``MovieRepository.list_paginated_by_genre`` — see that method
+        for the full description of the cursor format and the genre
+        filter (whole-word LIKE on the comma-separated ``genres``
+        column).
         """
         ...
 

--- a/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
@@ -1,0 +1,52 @@
+"""Shared helpers for projecting raw `genres` / `localized` columns.
+
+Used by both ``SQLAlchemyMovieRepository.list_genre_rows`` and
+``SQLAlchemySeriesRepository.list_genre_rows`` to parse the
+comma-separated `genres` column and the per-row `localized` JSON
+without going through the entity mapper. Lives next to the repos
+because the parsing logic mirrors the column shape exactly — keeping
+it here means a column-format change touches one place instead of
+two.
+"""
+
+import json
+
+
+def split_genres(raw: str | None) -> list[str]:
+    """Parse the comma-separated ``genres`` column into a clean list.
+
+    Returns an empty list for ``None`` or empty input. Whitespace
+    around individual genre names is stripped.
+    """
+    if not raw:
+        return []
+    return [g.strip() for g in raw.split(",") if g.strip()]
+
+
+def localized_genres_for(localized_json: str | None, lang: str) -> list[str]:
+    """Pull the localized genres array for ``lang`` from the ``localized`` JSON.
+
+    The ``localized`` column is a JSON-encoded dict like
+    ``{"pt-BR": {"title": "...", "genres": ["Ação", "Comédia"]}}``.
+    This helper safely returns an empty list when the JSON is
+    missing, malformed, doesn't carry the requested language, or
+    doesn't have a ``genres`` array — the consumer treats an empty
+    result as "no translation available" and falls back to the
+    canonical names positionally.
+    """
+    if not localized_json:
+        return []
+    try:
+        data = json.loads(localized_json)
+    except (TypeError, ValueError):
+        return []
+    lang_block = data.get(lang) if isinstance(data, dict) else None
+    if not isinstance(lang_block, dict):
+        return []
+    raw = lang_block.get("genres")
+    if not isinstance(raw, list):
+        return []
+    return [str(g) for g in raw]
+
+
+__all__ = ["localized_genres_for", "split_genres"]

--- a/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
@@ -1,15 +1,43 @@
-"""Shared helpers for projecting raw `genres` / `localized` columns.
+"""Shared SQL and parsing helpers for genre-aware repository methods.
 
-Used by both ``SQLAlchemyMovieRepository.list_genre_rows`` and
-``SQLAlchemySeriesRepository.list_genre_rows`` to parse the
-comma-separated `genres` column and the per-row `localized` JSON
-without going through the entity mapper. Lives next to the repos
-because the parsing logic mirrors the column shape exactly — keeping
-it here means a column-format change touches one place instead of
-two.
+Two flavors of helper live here:
+
+- **Column-shape parsers** (``split_genres``, ``localized_genres_for``)
+  used by ``list_genre_rows`` to project the raw ``genres`` /
+  ``localized`` columns without going through the entity mapper.
+
+- **Query builders + executors** (``fetch_genre_rows``,
+  ``fetch_genre_paginated_page``) used by ``list_genre_rows`` and
+  ``list_paginated_by_genre`` so the SQLAlchemy boilerplate
+  (delimited LIKE filter, lowercased title cursor, fetch N+1 trick,
+  per-item cursor population) lives in one place instead of two
+  copies that can drift apart.
+
+Lives next to the repos because everything here is tied to the
+``genres`` and ``localized`` column shapes — moving the helpers
+further away would create a layer that has to be touched whenever
+the column format changes.
 """
 
 import json
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, TypeVar
+
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.strategy_options import _AbstractLoad
+
+from src.building_blocks.application.pagination import (
+    PaginatedResult,
+    Pagination,
+    decode_title_cursor,
+    encode_title_cursor,
+)
+from src.modules.media.domain.repositories.movie_repository import GenreRow
+from src.modules.media.domain.value_objects import Genre
+
+TModel = TypeVar("TModel")
+TEntity = TypeVar("TEntity")
 
 
 def split_genres(raw: str | None) -> list[str]:
@@ -49,4 +77,133 @@ def localized_genres_for(localized_json: str | None, lang: str) -> list[str]:
     return [str(g) for g in raw]
 
 
-__all__ = ["localized_genres_for", "split_genres"]
+async def fetch_genre_rows(
+    session: AsyncSession,
+    model: Any,
+    lang: str,
+) -> list[GenreRow]:
+    """Project the lightweight genre data of every non-deleted row.
+
+    Reads only ``genres`` and ``localized`` from ``model`` so the
+    catalog genres aggregation doesn't pay for joins it doesn't need.
+    Each returned ``GenreRow`` pairs the canonical genre list with
+    the localized translation for the requested language (or an
+    empty list when no translation is present).
+    """
+    stmt = select(model.genres, model.localized).where(
+        model.deleted_at.is_(None),
+        model.genres.is_not(None),
+    )
+    result = await session.execute(stmt)
+    return [
+        GenreRow(
+            canonical_genres=split_genres(genres),
+            localized_genres=localized_genres_for(localized, lang),
+        )
+        for genres, localized in result.all()
+    ]
+
+
+async def fetch_genre_paginated_page(
+    *,
+    session: AsyncSession,
+    model: Any,
+    mapper_to_entity: Callable[[Any], TEntity] | Callable[[Any], Awaitable[TEntity]],
+    options: Sequence[_AbstractLoad],
+    genre: Genre,
+    cursor: str | None,
+    limit: int,
+) -> PaginatedResult[TEntity]:
+    """Run one page of the title-sorted by-genre listing for ``model``.
+
+    Wraps the duplicated SQL boilerplate that ``list_paginated_by_genre``
+    needs in both repositories: the delimited LIKE filter that avoids
+    substring matches, the ``LOWER(title), id`` cursor, the N+1 fetch
+    trick to detect ``has_more``, and the parallel ``item_cursors``
+    list that the catalog by-genre use case needs to advance partial
+    consumption.
+
+    Args:
+        session: AsyncSession to execute against.
+        model: SQLAlchemy ORM model class (``MovieModel`` or
+            ``SeriesModel``).
+        mapper_to_entity: Callable that converts a single ``model``
+            instance into the corresponding domain entity. Sync only —
+            the existing mappers don't need IO and an async signature
+            would just add ceremony.
+        options: SQLAlchemy load options to apply to the select
+            (e.g. ``selectinload`` of relationships). Empty sequence
+            is fine.
+        genre: Canonical genre value object to filter by.
+        cursor: Opaque title cursor from the previous page, or
+            ``None`` for the first page. Invalid cursors silently
+            fall back to the first page.
+        limit: Page size. The query fetches ``limit + 1`` rows and
+            trims the sentinel.
+
+    Returns:
+        ``PaginatedResult`` with mapped entities, pagination
+        metadata, and the per-item cursor list.
+    """
+    decoded = decode_title_cursor(cursor)
+
+    # Wrap the column with delimiters so a substring search can't
+    # false-positive: "Action" must NOT match "Reaction" or
+    # "Action Adventure". The matching pattern wraps the genre value
+    # the same way.
+    delimited_genres = func.concat(",", func.coalesce(model.genres, ""), ",")
+    title_lower = func.lower(model.title)
+
+    stmt = (
+        select(model)
+        .where(
+            model.deleted_at.is_(None),
+            delimited_genres.like(f"%,{genre.value},%"),
+        )
+        .options(*options)
+    )
+
+    if decoded is not None:
+        # Composite ascending: anything strictly after the cursor
+        # row in the (title, id) merge order. The OR + tie-breaker
+        # is the same shape as a stable cursor for any composite
+        # sort.
+        stmt = stmt.where(
+            or_(
+                title_lower > decoded.title,
+                and_(title_lower == decoded.title, model.id > decoded.id),
+            )
+        )
+
+    stmt = stmt.order_by(title_lower.asc(), model.id.asc()).limit(limit + 1)
+
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+
+    has_more = len(rows) > limit
+    if has_more:
+        rows = rows[:limit]
+
+    # Per-item cursor list — the catalog by-genre use case may
+    # consume only a prefix of this page after merging with the
+    # other media stream, so each item carries its own resume token.
+    item_cursors = [encode_title_cursor(row.title, row.id) for row in rows]
+
+    next_cursor: str | None = None
+    if has_more and rows:
+        next_cursor = item_cursors[-1]
+
+    return PaginatedResult(
+        items=[mapper_to_entity(row) for row in rows],  # type: ignore[misc]
+        pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+        total_count=None,
+        item_cursors=item_cursors,
+    )
+
+
+__all__ = [
+    "fetch_genre_paginated_page",
+    "fetch_genre_rows",
+    "localized_genres_for",
+    "split_genres",
+]

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -10,13 +10,20 @@ from src.building_blocks.application.pagination import (
     PaginatedResult,
     Pagination,
     decode_cursor,
+    decode_title_cursor,
     encode_cursor,
+    encode_title_cursor,
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
-from src.modules.media.domain.value_objects import FilePath, MovieId
+from src.modules.media.domain.repositories.movie_repository import GenreRow
+from src.modules.media.domain.value_objects import FilePath, Genre, MovieId
 from src.modules.media.infrastructure.persistence.mappers import MovieMapper
 from src.modules.media.infrastructure.persistence.models import MediaFileModel, MovieModel
+from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
+    localized_genres_for,
+    split_genres,
+)
 
 
 class SQLAlchemyMovieRepository(MovieRepository):
@@ -197,6 +204,100 @@ class SQLAlchemyMovieRepository(MovieRepository):
             items=[MovieMapper.to_entity(m) for m in models],
             pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
             total_count=total_count,
+        )
+
+    async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
+        """Project the genre columns of every non-deleted movie row.
+
+        Reads only ``genres`` and ``localized`` so the catalog genres
+        aggregation doesn't pay for joins it doesn't need. The
+        per-row ``localized`` JSON is parsed inline and the requested
+        language's ``genres`` array (if any) is paired with the
+        canonical list positionally.
+        """
+        stmt = select(MovieModel.genres, MovieModel.localized).where(
+            MovieModel.deleted_at.is_(None),
+            MovieModel.genres.is_not(None),
+        )
+        result = await self._session.execute(stmt)
+        return [
+            GenreRow(
+                canonical_genres=split_genres(genres),
+                localized_genres=localized_genres_for(localized, lang),
+            )
+            for genres, localized in result.all()
+        ]
+
+    async def list_paginated_by_genre(
+        self,
+        genre: Genre,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResult[Movie]:
+        """List movies for a single genre, paginated and sorted by title.
+
+        The genre filter wraps the comma-separated ``genres`` column
+        with delimiters so a substring search can't false-positive
+        ("Action" must not match "Reaction" or "Action Adventure").
+        Sort key is ``(LOWER(title), id)`` and the cursor is the
+        composite ``encode_title_cursor`` value of the last row of
+        the previous page.
+        """
+        decoded = decode_title_cursor(cursor)
+
+        # Wrap the column value AND the search pattern with commas so
+        # the LIKE only matches whole-word genres. `,Action,` is the
+        # search pattern and `,Action,Comedy,` is what an Action +
+        # Comedy movie's column expands to — exact substring match.
+        delimited_genres = func.concat(",", func.coalesce(MovieModel.genres, ""), ",")
+        genre_pattern = f"%,{genre.value},%"
+
+        title_lower = func.lower(MovieModel.title)
+
+        stmt = (
+            select(MovieModel)
+            .where(
+                MovieModel.deleted_at.is_(None),
+                delimited_genres.like(genre_pattern),
+            )
+            .options(selectinload(MovieModel.file_variants))
+        )
+
+        if decoded is not None:
+            # Composite ascending: anything strictly after the cursor
+            # row in the (title, id) merge order. The OR + tie-breaker
+            # is the same shape as a stable cursor for any composite
+            # sort — see ``CursorValue`` docstring for the rationale.
+            stmt = stmt.where(
+                or_(
+                    title_lower > decoded.title,
+                    and_(title_lower == decoded.title, MovieModel.id > decoded.id),
+                )
+            )
+
+        stmt = stmt.order_by(title_lower.asc(), MovieModel.id.asc()).limit(limit + 1)
+
+        result = await self._session.execute(stmt)
+        models = list(result.scalars().all())
+
+        has_more = len(models) > limit
+        if has_more:
+            models = models[:limit]
+
+        # Per-item cursor list — the catalog by-genre use case may
+        # consume only a prefix of this page after merging with the
+        # series stream, so each item carries its own resume token.
+        item_cursors = [encode_title_cursor(m.title, m.id) for m in models]
+
+        next_cursor: str | None = None
+        if has_more and models:
+            next_cursor = item_cursors[-1]
+
+        return PaginatedResult(
+            items=[MovieMapper.to_entity(m) for m in models],
+            pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+            total_count=None,
+            item_cursors=item_cursors,
         )
 
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -10,9 +10,7 @@ from src.building_blocks.application.pagination import (
     PaginatedResult,
     Pagination,
     decode_cursor,
-    decode_title_cursor,
     encode_cursor,
-    encode_title_cursor,
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
@@ -21,8 +19,8 @@ from src.modules.media.domain.value_objects import FilePath, Genre, MovieId
 from src.modules.media.infrastructure.persistence.mappers import MovieMapper
 from src.modules.media.infrastructure.persistence.models import MediaFileModel, MovieModel
 from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
-    localized_genres_for,
-    split_genres,
+    fetch_genre_paginated_page,
+    fetch_genre_rows,
 )
 
 
@@ -207,26 +205,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
         )
 
     async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
-        """Project the genre columns of every non-deleted movie row.
-
-        Reads only ``genres`` and ``localized`` so the catalog genres
-        aggregation doesn't pay for joins it doesn't need. The
-        per-row ``localized`` JSON is parsed inline and the requested
-        language's ``genres`` array (if any) is paired with the
-        canonical list positionally.
-        """
-        stmt = select(MovieModel.genres, MovieModel.localized).where(
-            MovieModel.deleted_at.is_(None),
-            MovieModel.genres.is_not(None),
-        )
-        result = await self._session.execute(stmt)
-        return [
-            GenreRow(
-                canonical_genres=split_genres(genres),
-                localized_genres=localized_genres_for(localized, lang),
-            )
-            for genres, localized in result.all()
-        ]
+        """Project the genre columns of every non-deleted movie row."""
+        return await fetch_genre_rows(self._session, MovieModel, lang)
 
     async def list_paginated_by_genre(
         self,
@@ -236,68 +216,20 @@ class SQLAlchemyMovieRepository(MovieRepository):
     ) -> PaginatedResult[Movie]:
         """List movies for a single genre, paginated and sorted by title.
 
-        The genre filter wraps the comma-separated ``genres`` column
-        with delimiters so a substring search can't false-positive
-        ("Action" must not match "Reaction" or "Action Adventure").
-        Sort key is ``(LOWER(title), id)`` and the cursor is the
-        composite ``encode_title_cursor`` value of the last row of
-        the previous page.
+        Delegates the SQL boilerplate (delimited LIKE filter,
+        ``LOWER(title)`` cursor, fetch N+1 trick, per-item cursor
+        population) to the shared ``fetch_genre_paginated_page``
+        helper so this method and its series counterpart can't drift
+        apart.
         """
-        decoded = decode_title_cursor(cursor)
-
-        # Wrap the column value AND the search pattern with commas so
-        # the LIKE only matches whole-word genres. `,Action,` is the
-        # search pattern and `,Action,Comedy,` is what an Action +
-        # Comedy movie's column expands to — exact substring match.
-        delimited_genres = func.concat(",", func.coalesce(MovieModel.genres, ""), ",")
-        genre_pattern = f"%,{genre.value},%"
-
-        title_lower = func.lower(MovieModel.title)
-
-        stmt = (
-            select(MovieModel)
-            .where(
-                MovieModel.deleted_at.is_(None),
-                delimited_genres.like(genre_pattern),
-            )
-            .options(selectinload(MovieModel.file_variants))
-        )
-
-        if decoded is not None:
-            # Composite ascending: anything strictly after the cursor
-            # row in the (title, id) merge order. The OR + tie-breaker
-            # is the same shape as a stable cursor for any composite
-            # sort — see ``CursorValue`` docstring for the rationale.
-            stmt = stmt.where(
-                or_(
-                    title_lower > decoded.title,
-                    and_(title_lower == decoded.title, MovieModel.id > decoded.id),
-                )
-            )
-
-        stmt = stmt.order_by(title_lower.asc(), MovieModel.id.asc()).limit(limit + 1)
-
-        result = await self._session.execute(stmt)
-        models = list(result.scalars().all())
-
-        has_more = len(models) > limit
-        if has_more:
-            models = models[:limit]
-
-        # Per-item cursor list — the catalog by-genre use case may
-        # consume only a prefix of this page after merging with the
-        # series stream, so each item carries its own resume token.
-        item_cursors = [encode_title_cursor(m.title, m.id) for m in models]
-
-        next_cursor: str | None = None
-        if has_more and models:
-            next_cursor = item_cursors[-1]
-
-        return PaginatedResult(
-            items=[MovieMapper.to_entity(m) for m in models],
-            pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
-            total_count=None,
-            item_cursors=item_cursors,
+        return await fetch_genre_paginated_page(
+            session=self._session,
+            model=MovieModel,
+            mapper_to_entity=MovieMapper.to_entity,
+            options=[selectinload(MovieModel.file_variants)],
+            genre=genre,
+            cursor=cursor,
+            limit=limit,
         )
 
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -11,11 +11,21 @@ from src.building_blocks.application.pagination import (
     PaginatedResult,
     Pagination,
     decode_cursor,
+    decode_title_cursor,
     encode_cursor,
+    encode_title_cursor,
 )
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
-from src.modules.media.domain.value_objects import EpisodeId, FilePath, SeasonId, SeriesId, Title
+from src.modules.media.domain.repositories.movie_repository import GenreRow
+from src.modules.media.domain.value_objects import (
+    EpisodeId,
+    FilePath,
+    Genre,
+    SeasonId,
+    SeriesId,
+    Title,
+)
 from src.modules.media.infrastructure.persistence.mappers import (
     EpisodeMapper,
     SeasonMapper,
@@ -26,6 +36,10 @@ from src.modules.media.infrastructure.persistence.models import (
     MediaFileModel,
     SeasonModel,
     SeriesModel,
+)
+from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
+    localized_genres_for,
+    split_genres,
 )
 
 
@@ -223,6 +237,88 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             items=[SeriesMapper.to_entity(m) for m in models],
             pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
             total_count=total_count,
+        )
+
+    async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
+        """Project the genre columns of every non-deleted series row.
+
+        Mirrors ``SQLAlchemyMovieRepository.list_genre_rows`` exactly,
+        but reads from the ``series`` table.
+        """
+        stmt = select(SeriesModel.genres, SeriesModel.localized).where(
+            SeriesModel.deleted_at.is_(None),
+            SeriesModel.genres.is_not(None),
+        )
+        result = await self._session.execute(stmt)
+        return [
+            GenreRow(
+                canonical_genres=split_genres(genres),
+                localized_genres=localized_genres_for(localized, lang),
+            )
+            for genres, localized in result.all()
+        ]
+
+    async def list_paginated_by_genre(
+        self,
+        genre: Genre,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResult[Series]:
+        """List series for a single genre, paginated and sorted by title.
+
+        Mirrors ``MovieRepository.list_paginated_by_genre`` exactly —
+        same delimited LIKE filter, same ``(LOWER(title), id)`` cursor
+        format, same N+1 fetch trick. Loads the full season / episode
+        hierarchy via the existing options because consumers may want
+        to render episode counts on the carousel card.
+        """
+        decoded = decode_title_cursor(cursor)
+
+        delimited_genres = func.concat(",", func.coalesce(SeriesModel.genres, ""), ",")
+        genre_pattern = f"%,{genre.value},%"
+
+        title_lower = func.lower(SeriesModel.title)
+
+        stmt = (
+            select(SeriesModel)
+            .where(
+                SeriesModel.deleted_at.is_(None),
+                delimited_genres.like(genre_pattern),
+            )
+            .options(*self._series_load_options())
+        )
+
+        if decoded is not None:
+            stmt = stmt.where(
+                or_(
+                    title_lower > decoded.title,
+                    and_(title_lower == decoded.title, SeriesModel.id > decoded.id),
+                )
+            )
+
+        stmt = stmt.order_by(title_lower.asc(), SeriesModel.id.asc()).limit(limit + 1)
+
+        result = await self._session.execute(stmt)
+        models = list(result.scalars().all())
+
+        has_more = len(models) > limit
+        if has_more:
+            models = models[:limit]
+
+        # See `MovieRepository.list_paginated_by_genre` for why each
+        # item gets its own resume cursor — the catalog by-genre use
+        # case may only consume a prefix of this page.
+        item_cursors = [encode_title_cursor(m.title, m.id) for m in models]
+
+        next_cursor: str | None = None
+        if has_more and models:
+            next_cursor = item_cursors[-1]
+
+        return PaginatedResult(
+            items=[SeriesMapper.to_entity(m) for m in models],
+            pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+            total_count=None,
+            item_cursors=item_cursors,
         )
 
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Series]:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -11,9 +11,7 @@ from src.building_blocks.application.pagination import (
     PaginatedResult,
     Pagination,
     decode_cursor,
-    decode_title_cursor,
     encode_cursor,
-    encode_title_cursor,
 )
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
@@ -38,8 +36,8 @@ from src.modules.media.infrastructure.persistence.models import (
     SeriesModel,
 )
 from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
-    localized_genres_for,
-    split_genres,
+    fetch_genre_paginated_page,
+    fetch_genre_rows,
 )
 
 
@@ -240,23 +238,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         )
 
     async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
-        """Project the genre columns of every non-deleted series row.
-
-        Mirrors ``SQLAlchemyMovieRepository.list_genre_rows`` exactly,
-        but reads from the ``series`` table.
-        """
-        stmt = select(SeriesModel.genres, SeriesModel.localized).where(
-            SeriesModel.deleted_at.is_(None),
-            SeriesModel.genres.is_not(None),
-        )
-        result = await self._session.execute(stmt)
-        return [
-            GenreRow(
-                canonical_genres=split_genres(genres),
-                localized_genres=localized_genres_for(localized, lang),
-            )
-            for genres, localized in result.all()
-        ]
+        """Project the genre columns of every non-deleted series row."""
+        return await fetch_genre_rows(self._session, SeriesModel, lang)
 
     async def list_paginated_by_genre(
         self,
@@ -266,59 +249,21 @@ class SQLAlchemySeriesRepository(SeriesRepository):
     ) -> PaginatedResult[Series]:
         """List series for a single genre, paginated and sorted by title.
 
-        Mirrors ``MovieRepository.list_paginated_by_genre`` exactly —
-        same delimited LIKE filter, same ``(LOWER(title), id)`` cursor
-        format, same N+1 fetch trick. Loads the full season / episode
-        hierarchy via the existing options because consumers may want
-        to render episode counts on the carousel card.
+        Delegates the SQL boilerplate to the shared
+        ``fetch_genre_paginated_page`` helper so this method and its
+        movie counterpart stay in lockstep. The full season / episode
+        hierarchy is loaded via the existing ``_series_load_options``
+        because consumers may want to render episode counts on the
+        carousel card.
         """
-        decoded = decode_title_cursor(cursor)
-
-        delimited_genres = func.concat(",", func.coalesce(SeriesModel.genres, ""), ",")
-        genre_pattern = f"%,{genre.value},%"
-
-        title_lower = func.lower(SeriesModel.title)
-
-        stmt = (
-            select(SeriesModel)
-            .where(
-                SeriesModel.deleted_at.is_(None),
-                delimited_genres.like(genre_pattern),
-            )
-            .options(*self._series_load_options())
-        )
-
-        if decoded is not None:
-            stmt = stmt.where(
-                or_(
-                    title_lower > decoded.title,
-                    and_(title_lower == decoded.title, SeriesModel.id > decoded.id),
-                )
-            )
-
-        stmt = stmt.order_by(title_lower.asc(), SeriesModel.id.asc()).limit(limit + 1)
-
-        result = await self._session.execute(stmt)
-        models = list(result.scalars().all())
-
-        has_more = len(models) > limit
-        if has_more:
-            models = models[:limit]
-
-        # See `MovieRepository.list_paginated_by_genre` for why each
-        # item gets its own resume cursor — the catalog by-genre use
-        # case may only consume a prefix of this page.
-        item_cursors = [encode_title_cursor(m.title, m.id) for m in models]
-
-        next_cursor: str | None = None
-        if has_more and models:
-            next_cursor = item_cursors[-1]
-
-        return PaginatedResult(
-            items=[SeriesMapper.to_entity(m) for m in models],
-            pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
-            total_count=None,
-            item_cursors=item_cursors,
+        return await fetch_genre_paginated_page(
+            session=self._session,
+            model=SeriesModel,
+            mapper_to_entity=SeriesMapper.to_entity,
+            options=list(self._series_load_options()),
+            genre=genre,
+            cursor=cursor,
+            limit=limit,
         )
 
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Series]:

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -1,5 +1,6 @@
 """Media API routes."""
 
+from src.modules.media.presentation.routes.catalog_routes import router as catalog_router
 from src.modules.media.presentation.routes.enrichment_routes import router as enrichment_router
 from src.modules.media.presentation.routes.featured_routes import router as featured_router
 from src.modules.media.presentation.routes.movie_routes import router as movie_router
@@ -8,6 +9,7 @@ from src.modules.media.presentation.routes.series_routes import router as series
 from src.modules.media.presentation.routes.stream_routes import router as stream_router
 
 __all__ = [
+    "catalog_router",
     "enrichment_router",
     "featured_router",
     "movie_router",

--- a/src/modules/media/presentation/routes/catalog_routes.py
+++ b/src/modules/media/presentation/routes/catalog_routes.py
@@ -1,0 +1,95 @@
+"""Catalog (cross-cutting movies + series) REST API routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
+from src.config.containers import ApplicationContainer
+from src.modules.media.application.dtos.catalog_dtos import (
+    ListByGenreInput,
+    ListGenresInput,
+)
+from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
+from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
+
+router = APIRouter(prefix="/api/v1/catalog", tags=["Catalog"])
+
+
+@router.get("/genres")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_genres(
+    lang: str = "en",
+    use_case: ListGenresUseCase = Depends(
+        Provide[ApplicationContainer.media.list_genres],
+    ),
+) -> dict[str, Any]:
+    """List every genre present in the library, with counts and localized names.
+
+    Single non-paginated request — returns the full set so the
+    frontend can build the carousel layout in one shot. Each entry
+    has the canonical English ``id`` (used as the filter key for
+    ``GET /api/v1/catalog/by-genre/{id}``) and the localized ``name``
+    for display.
+
+    Sorted by count descending, then alphabetically by display name —
+    most-populated carousels surface first on the Home page.
+    """
+    result = await use_case.execute(ListGenresInput(lang=lang))
+    return {
+        "type": "list",
+        "data": [asdict(g) for g in result.genres],
+    }
+
+
+@router.get("/by-genre/{genre}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_by_genre(
+    genre: str,
+    cursor: str | None = None,
+    limit: int = DEFAULT_PAGE_SIZE,
+    lang: str = "en",
+    use_case: ListByGenreUseCase = Depends(
+        Provide[ApplicationContainer.media.list_by_genre],
+    ),
+) -> dict[str, Any]:
+    """Paginated mixed listing of movies + series for a single genre.
+
+    The ``genre`` path parameter is the canonical English id from
+    ``GET /api/v1/catalog/genres``. Items are merged from both media
+    types, sorted alphabetically by title, and paginated with an
+    opaque dual-stream cursor.
+
+    Query params:
+        cursor: Opaque token returned by the previous page's
+            ``metadata.pagination.next_cursor``. Omit on the first
+            request. Invalid / tampered cursors silently start over
+            from the beginning.
+        limit: Page size, clamped to ``[1, MAX_PAGE_SIZE]``.
+        lang: Language code for localized titles, synopses, and
+            genre names returned in each item.
+    """
+    clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
+    result = await use_case.execute(
+        ListByGenreInput(
+            genre=genre,
+            cursor=cursor,
+            limit=clamped_limit,
+            lang=lang,
+        )
+    )
+    return {
+        "type": "list",
+        "data": [asdict(item) for item in result.items],
+        "metadata": {
+            "pagination": {
+                "next_cursor": result.next_cursor,
+                "has_more": result.has_more,
+            },
+        },
+    }
+
+
+__all__ = ["router"]

--- a/tests/building_blocks/unit/application/test_pagination.py
+++ b/tests/building_blocks/unit/application/test_pagination.py
@@ -8,10 +8,16 @@ from src.building_blocks.application.pagination import (
     DEFAULT_PAGE_SIZE,
     MAX_PAGE_SIZE,
     CursorValue,
+    DualCursorValue,
     PaginatedResult,
     Pagination,
+    TitleCursorValue,
     decode_cursor,
+    decode_dual_cursor,
+    decode_title_cursor,
     encode_cursor,
+    encode_dual_cursor,
+    encode_title_cursor,
 )
 
 
@@ -142,3 +148,108 @@ class TestPageSizeConstants:
         # and we should reconsider. This guards against an accidental
         # configuration change.
         assert MAX_PAGE_SIZE <= 500
+
+
+@pytest.mark.unit
+class TestTitleCursor:
+    """Tests for the (title, id) composite cursor used by title-sorted listings."""
+
+    def test_should_roundtrip_a_typical_cursor(self) -> None:
+        encoded = encode_title_cursor("Inception", 42)
+
+        decoded = decode_title_cursor(encoded)
+
+        # Title comes back lowercased to match the SQL `LOWER(title)` sort key.
+        assert decoded == TitleCursorValue(title="inception", id=42)
+
+    def test_should_lowercase_the_title_on_encode(self) -> None:
+        encoded_upper = encode_title_cursor("INCEPTION", 1)
+        encoded_mixed = encode_title_cursor("Inception", 1)
+        encoded_lower = encode_title_cursor("inception", 1)
+
+        # All three encodings must produce the same cursor — the
+        # comparison key in SQL is `LOWER(title)`, and a cursor that
+        # encoded the original case would skip rows whose actual case
+        # didn't match the cursor's case.
+        assert encoded_upper == encoded_mixed == encoded_lower
+
+    def test_should_handle_titles_with_unicode_and_punctuation(self) -> None:
+        encoded = encode_title_cursor("Cidade de Deus: O Filme", 7)
+
+        decoded = decode_title_cursor(encoded)
+
+        assert decoded == TitleCursorValue(title="cidade de deus: o filme", id=7)
+
+    def test_should_handle_titles_with_pipe_character(self) -> None:
+        # The original id-only cursor used `|` as a separator. The title
+        # cursor uses ASCII 0x1F instead so a literal `|` in a title can't
+        # collide with the delimiter — this test guards that.
+        encoded = encode_title_cursor("Fast | Furious", 99)
+
+        decoded = decode_title_cursor(encoded)
+
+        assert decoded == TitleCursorValue(title="fast | furious", id=99)
+
+    def test_should_return_none_for_empty_or_invalid_cursor(self) -> None:
+        assert decode_title_cursor(None) is None
+        assert decode_title_cursor("") is None
+        assert decode_title_cursor("not-valid-base64!!!") is None
+
+    def test_should_return_none_when_payload_lacks_separator(self) -> None:
+        bogus = base64.urlsafe_b64encode(b"missing-separator").decode("ascii")
+        assert decode_title_cursor(bogus) is None
+
+    def test_should_return_none_when_id_part_is_not_an_integer(self) -> None:
+        bogus = base64.urlsafe_b64encode(b"title\x1fnot_an_int").decode("ascii")
+        assert decode_title_cursor(bogus) is None
+
+
+@pytest.mark.unit
+class TestDualCursor:
+    """Tests for the dual-stream cursor used by the catalog by-genre endpoint."""
+
+    def test_should_roundtrip_two_present_cursors(self) -> None:
+        encoded = encode_dual_cursor("movies-token", "series-token")
+
+        decoded = decode_dual_cursor(encoded)
+
+        assert decoded == DualCursorValue(movies="movies-token", series="series-token")
+
+    def test_should_roundtrip_one_exhausted_stream(self) -> None:
+        encoded = encode_dual_cursor("movies-token", None)
+
+        decoded = decode_dual_cursor(encoded)
+
+        assert decoded == DualCursorValue(movies="movies-token", series=None)
+
+    def test_should_roundtrip_both_exhausted(self) -> None:
+        encoded = encode_dual_cursor(None, None)
+
+        decoded = decode_dual_cursor(encoded)
+
+        assert decoded == DualCursorValue(movies=None, series=None)
+
+    def test_should_decode_empty_cursor_as_both_none(self) -> None:
+        # `decode_dual_cursor` returns a non-optional `DualCursorValue`,
+        # so callers don't have to branch on `cursor is None` — both
+        # fields just come through as `None` in that case.
+        assert decode_dual_cursor(None) == DualCursorValue(movies=None, series=None)
+        assert decode_dual_cursor("") == DualCursorValue(movies=None, series=None)
+
+    def test_should_decode_garbage_as_both_none(self) -> None:
+        # Same silent fallback as the other decoders — a tampered or
+        # truncated cursor should not raise mid-scroll.
+        assert decode_dual_cursor("not-valid!!!") == DualCursorValue(movies=None, series=None)
+
+    def test_inner_cursors_can_themselves_be_base64(self) -> None:
+        # The catalog endpoint nests the per-stream cursors (which
+        # are themselves opaque base64) inside the dual wrapper. Make
+        # sure the separator doesn't collide with base64 characters.
+        inner_movies = encode_title_cursor("Inception", 42)
+        inner_series = encode_title_cursor("Breaking Bad", 7)
+
+        encoded = encode_dual_cursor(inner_movies, inner_series)
+        decoded = decode_dual_cursor(encoded)
+
+        assert decoded.movies == inner_movies
+        assert decoded.series == inner_series

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -490,3 +490,189 @@ class TestSQLAlchemyMovieRepositoryListPaginated:
         page = await repo.list_paginated(cursor=None, limit=10, include_total=True)
 
         assert page.total_count == 3
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryListGenreRows:
+    """Integration tests for the lightweight genre projection."""
+
+    async def test_should_return_one_row_per_movie(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/m/a.mkv").with_genre(Genre("Action")))
+        await repo.save(_create_movie(title="B", file_path="/m/b.mkv").with_genre(Genre("Comedy")))
+
+        rows = await repo.list_genre_rows(lang="en")
+
+        assert len(rows) == 2
+
+    async def test_should_split_comma_separated_genres(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = (
+            _create_movie(title="A", file_path="/m/a.mkv")
+            .with_genre(Genre("Action"))
+            .with_genre(Genre("Comedy"))
+            .with_genre(Genre("Drama"))
+        )
+        await repo.save(movie)
+
+        rows = await repo.list_genre_rows(lang="en")
+
+        assert rows[0].canonical_genres == ["Action", "Comedy", "Drama"]
+
+    async def test_should_skip_rows_with_no_genres(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # One movie with a genre, one without
+        await repo.save(_create_movie(title="A", file_path="/m/a.mkv").with_genre(Genre("Action")))
+        await repo.save(_create_movie(title="B", file_path="/m/b.mkv"))
+
+        rows = await repo.list_genre_rows(lang="en")
+
+        # Only the movie with a genre is returned — repo filters
+        # `genres IS NOT NULL` so the empty one is excluded.
+        assert len(rows) == 1
+
+    async def test_should_exclude_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        m1 = _create_movie(title="A", file_path="/m/a.mkv").with_genre(Genre("Action"))
+        m2 = _create_movie(title="B", file_path="/m/b.mkv").with_genre(Genre("Comedy"))
+        await repo.save(m1)
+        await repo.save(m2)
+        await repo.delete(_id_of(m1))
+
+        rows = await repo.list_genre_rows(lang="en")
+
+        assert len(rows) == 1
+        assert rows[0].canonical_genres == ["Comedy"]
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryListPaginatedByGenre:
+    """Integration tests for the title-sorted, genre-filtered listing."""
+
+    async def test_should_filter_to_movies_with_the_given_genre(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(
+            _create_movie(title="Avatar", file_path="/m/a.mkv").with_genre(Genre("Action"))
+        )
+        await repo.save(
+            _create_movie(title="Comedy Show", file_path="/m/c.mkv").with_genre(Genre("Comedy"))
+        )
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Action"), cursor=None, limit=10)
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "Avatar"
+
+    async def test_should_not_match_substrings_or_partial_words(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # `Reaction` must NOT match `Action`, and neither should
+        # `Action Adventure`.
+        await repo.save(
+            _create_movie(title="Real", file_path="/m/real.mkv").with_genre(Genre("Reaction"))
+        )
+        await repo.save(
+            _create_movie(title="Adv", file_path="/m/adv.mkv").with_genre(Genre("Action Adventure"))
+        )
+        await repo.save(
+            _create_movie(title="True", file_path="/m/true.mkv").with_genre(Genre("Action"))
+        )
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Action"), cursor=None, limit=10)
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "True"
+
+    async def test_should_sort_alphabetically_case_insensitive(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        for title in ["zebra", "Apple", "mango", "Banana"]:
+            await repo.save(
+                _create_movie(title=title, file_path=f"/m/{title.lower()}.mkv").with_genre(
+                    Genre("Action")
+                )
+            )
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Action"), cursor=None, limit=10)
+
+        titles = [m.title.value for m in page.items]
+        assert titles == ["Apple", "Banana", "mango", "zebra"]
+
+    async def test_should_walk_pages_via_cursor(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        for title in ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"]:
+            await repo.save(
+                _create_movie(title=title, file_path=f"/m/{title}.mkv").with_genre(Genre("Action"))
+            )
+
+        page1 = await repo.list_paginated_by_genre(genre=Genre("Action"), cursor=None, limit=2)
+        page2 = await repo.list_paginated_by_genre(
+            genre=Genre("Action"),
+            cursor=page1.pagination.next_cursor,
+            limit=2,
+        )
+        page3 = await repo.list_paginated_by_genre(
+            genre=Genre("Action"),
+            cursor=page2.pagination.next_cursor,
+            limit=2,
+        )
+
+        all_titles = (
+            [m.title.value for m in page1.items]
+            + [m.title.value for m in page2.items]
+            + [m.title.value for m in page3.items]
+        )
+        # All five titles in alphabetical order, no overlap
+        assert all_titles == ["Alpha", "Beta", "Delta", "Epsilon", "Gamma"]
+        assert page3.pagination.has_more is False
+
+    async def test_should_populate_per_item_cursors(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        for title in ["Alpha", "Beta", "Gamma"]:
+            await repo.save(
+                _create_movie(title=title, file_path=f"/m/{title}.mkv").with_genre(Genre("Action"))
+            )
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Action"), cursor=None, limit=10)
+
+        # Per-item cursors are needed by the catalog by-genre use
+        # case to advance partial-prefix consumption.
+        assert page.item_cursors is not None
+        assert len(page.item_cursors) == len(page.items) == 3
+
+    async def test_should_resume_correctly_when_titles_share_prefix(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # Three movies with the same title — the cursor's id
+        # tie-breaker must keep them all visible across pages.
+        for path in ["/m/a1.mkv", "/m/a2.mkv", "/m/a3.mkv"]:
+            await repo.save(_create_movie(title="Same", file_path=path).with_genre(Genre("Action")))
+
+        page1 = await repo.list_paginated_by_genre(genre=Genre("Action"), cursor=None, limit=2)
+        page2 = await repo.list_paginated_by_genre(
+            genre=Genre("Action"),
+            cursor=page1.pagination.next_cursor,
+            limit=2,
+        )
+
+        assert len(page1.items) == 2
+        assert len(page2.items) == 1
+        assert page2.pagination.has_more is False
+
+    async def test_should_exclude_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        m1 = _create_movie(title="A", file_path="/m/a.mkv").with_genre(Genre("Action"))
+        m2 = _create_movie(title="B", file_path="/m/b.mkv").with_genre(Genre("Action"))
+        await repo.save(m1)
+        await repo.save(m2)
+        await repo.delete(_id_of(m1))
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Action"), cursor=None, limit=10)
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "B"

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -788,3 +788,141 @@ class TestSQLAlchemySeriesRepositoryListPaginated:
         page = await repo.list_paginated(cursor=None, limit=10, include_total=True)
 
         assert page.total_count == 3
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryListGenreRows:
+    """Integration tests for the lightweight genre projection."""
+
+    async def test_should_return_one_row_per_series(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_create_series(title="A", genres=[Genre("Drama")]))
+        await repo.save(_create_series(title="B", genres=[Genre("Comedy")]))
+
+        rows = await repo.list_genre_rows(lang="en")
+
+        assert len(rows) == 2
+
+    async def test_should_split_comma_separated_genres(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _create_series(
+            title="A",
+            genres=[Genre("Drama"), Genre("Crime"), Genre("Thriller")],
+        )
+        await repo.save(series)
+
+        rows = await repo.list_genre_rows(lang="en")
+
+        assert rows[0].canonical_genres == ["Drama", "Crime", "Thriller"]
+
+    async def test_should_skip_rows_with_no_genres(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_create_series(title="A", genres=[Genre("Drama")]))
+        await repo.save(_create_series(title="B"))
+
+        rows = await repo.list_genre_rows(lang="en")
+
+        assert len(rows) == 1
+
+    async def test_should_exclude_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        s1 = _create_series(title="A", genres=[Genre("Drama")])
+        s2 = _create_series(title="B", genres=[Genre("Comedy")])
+        await repo.save(s1)
+        await repo.save(s2)
+        await repo.delete(_id_of(s1))
+
+        rows = await repo.list_genre_rows(lang="en")
+
+        assert len(rows) == 1
+        assert rows[0].canonical_genres == ["Comedy"]
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryListPaginatedByGenre:
+    """Integration tests for the title-sorted, genre-filtered listing."""
+
+    async def test_should_filter_to_series_with_the_given_genre(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_create_series(title="Breaking Bad", genres=[Genre("Drama")]))
+        await repo.save(_create_series(title="Friends", genres=[Genre("Comedy")]))
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Drama"), cursor=None, limit=10)
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "Breaking Bad"
+
+    async def test_should_not_match_substrings_or_partial_words(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_create_series(title="A", genres=[Genre("Dramedy")]))
+        await repo.save(_create_series(title="B", genres=[Genre("Drama Comedy")]))
+        await repo.save(_create_series(title="C", genres=[Genre("Drama")]))
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Drama"), cursor=None, limit=10)
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "C"
+
+    async def test_should_sort_alphabetically_case_insensitive(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        for title in ["zebra", "Apple", "mango", "Banana"]:
+            await repo.save(_create_series(title=title, genres=[Genre("Drama")]))
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Drama"), cursor=None, limit=10)
+
+        titles = [s.title.value for s in page.items]
+        assert titles == ["Apple", "Banana", "mango", "zebra"]
+
+    async def test_should_walk_pages_via_cursor(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        for title in ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"]:
+            await repo.save(_create_series(title=title, genres=[Genre("Drama")]))
+
+        page1 = await repo.list_paginated_by_genre(genre=Genre("Drama"), cursor=None, limit=2)
+        page2 = await repo.list_paginated_by_genre(
+            genre=Genre("Drama"),
+            cursor=page1.pagination.next_cursor,
+            limit=2,
+        )
+        page3 = await repo.list_paginated_by_genre(
+            genre=Genre("Drama"),
+            cursor=page2.pagination.next_cursor,
+            limit=2,
+        )
+
+        all_titles = (
+            [s.title.value for s in page1.items]
+            + [s.title.value for s in page2.items]
+            + [s.title.value for s in page3.items]
+        )
+        assert all_titles == ["Alpha", "Beta", "Delta", "Epsilon", "Gamma"]
+        assert page3.pagination.has_more is False
+
+    async def test_should_populate_per_item_cursors(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        for title in ["Alpha", "Beta", "Gamma"]:
+            await repo.save(_create_series(title=title, genres=[Genre("Drama")]))
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Drama"), cursor=None, limit=10)
+
+        assert page.item_cursors is not None
+        assert len(page.item_cursors) == len(page.items) == 3
+
+    async def test_should_exclude_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        s1 = _create_series(title="A", genres=[Genre("Drama")])
+        s2 = _create_series(title="B", genres=[Genre("Drama")])
+        await repo.save(s1)
+        await repo.save(s2)
+        await repo.delete(_id_of(s1))
+
+        page = await repo.list_paginated_by_genre(genre=Genre("Drama"), cursor=None, limit=10)
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "B"

--- a/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
@@ -1,0 +1,225 @@
+"""Tests for ListByGenreUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.pagination import (
+    PaginatedResult,
+    Pagination,
+    decode_dual_cursor,
+)
+from src.modules.media.application.dtos.catalog_dtos import (
+    CatalogItemOutput,
+    ListByGenreInput,
+    ListByGenreOutput,
+)
+from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
+from src.modules.media.domain.entities import Movie, Series
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+def _movie(title: str) -> Movie:
+    return Movie.create(
+        title=title,
+        year=2020,
+        duration=7200,
+        file_path=f"/movies/{title.lower().replace(' ', '_')}.mkv",
+        file_size=1_000_000_000,
+        resolution="1080p",
+    )
+
+
+def _series(title: str) -> Series:
+    return Series.create(title=title, start_year=2020)
+
+
+def _movies_page(
+    movies: list[Movie],
+    *,
+    has_more: bool = False,
+    next_cursor: str | None = None,
+) -> PaginatedResult[Movie]:
+    cursors = [f"m-cursor-{i}" for i in range(len(movies))]
+    return PaginatedResult(
+        items=movies,
+        pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+        item_cursors=cursors,
+    )
+
+
+def _series_page(
+    series_list: list[Series],
+    *,
+    has_more: bool = False,
+    next_cursor: str | None = None,
+) -> PaginatedResult[Series]:
+    cursors = [f"s-cursor-{i}" for i in range(len(series_list))]
+    return PaginatedResult(
+        items=series_list,
+        pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+        item_cursors=cursors,
+    )
+
+
+@pytest.mark.unit
+class TestListByGenreUseCase:
+    """Merge + dual-cursor behavior of ListByGenreUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_merge_movies_and_series_alphabetically(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Avatar"), _movie("Cyrano")]
+        )
+        series_repo.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListByGenreInput(genre="Action"))
+
+        assert isinstance(result, ListByGenreOutput)
+        titles = [item.title for item in result.items]
+        # Sorted by lowercase title
+        assert titles == ["Avatar", "Breaking Bad", "Cyrano"]
+
+    @pytest.mark.asyncio
+    async def test_should_tag_each_item_with_its_type(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page([_movie("Avatar")])
+        series_repo.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListByGenreInput(genre="Action"))
+
+        types = {(item.title, item.type) for item in result.items}
+        assert types == {("Avatar", "movie"), ("Breaking Bad", "series")}
+
+    @pytest.mark.asyncio
+    async def test_should_pass_decoded_cursors_to_each_repo(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page([])
+        series_repo.list_paginated_by_genre.return_value = _series_page([])
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        # Build a real dual cursor so the use case decodes it
+        from src.building_blocks.application.pagination import encode_dual_cursor
+
+        cursor = encode_dual_cursor("movies-token", "series-token")
+        await use_case.execute(ListByGenreInput(genre="Action", cursor=cursor))
+
+        movie_call_kwargs = movie_repo.list_paginated_by_genre.await_args.kwargs
+        series_call_kwargs = series_repo.list_paginated_by_genre.await_args.kwargs
+        assert movie_call_kwargs["cursor"] == "movies-token"
+        assert series_call_kwargs["cursor"] == "series-token"
+
+    @pytest.mark.asyncio
+    async def test_should_advance_cursor_only_for_consumed_streams(self) -> None:
+        # Movies stream wins the merge entirely (all titles are
+        # alphabetically before any series). The series cursor must
+        # stay at its previous value so the next page re-considers
+        # the same starting series.
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Apple"), _movie("Banana")],
+            has_more=True,
+        )
+        # Series with title "Zebra" — sorts AFTER both movies, so it
+        # won't fit in a 2-item page.
+        series_repo.list_paginated_by_genre.return_value = _series_page(
+            [_series("Zebra")],
+            has_more=False,
+        )
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        from src.building_blocks.application.pagination import encode_dual_cursor
+
+        previous_cursor = encode_dual_cursor(None, "previous-series-cursor")
+        result = await use_case.execute(
+            ListByGenreInput(genre="Action", cursor=previous_cursor, limit=2)
+        )
+
+        assert result.has_more is True
+        decoded = decode_dual_cursor(result.next_cursor)
+        # Movies advanced to the cursor of the LAST consumed movie
+        # (Banana, index 1 in its page).
+        assert decoded.movies == "m-cursor-1"
+        # Series did not advance — keeps the previous cursor unchanged
+        # so the next page re-considers Zebra.
+        assert decoded.series == "previous-series-cursor"
+
+    @pytest.mark.asyncio
+    async def test_should_truncate_to_requested_limit_and_set_has_more(
+        self,
+    ) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        # Each repo returns 3 items, total 6 — limit 2 means 4 are
+        # left over and `has_more` must be true even if neither
+        # individual repo says so.
+        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Apple"), _movie("Cherry"), _movie("Eggplant")],
+            has_more=False,
+        )
+        series_repo.list_paginated_by_genre.return_value = _series_page(
+            [_series("Banana"), _series("Date"), _series("Fig")],
+            has_more=False,
+        )
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListByGenreInput(genre="Action", limit=2))
+
+        assert len(result.items) == 2
+        assert [item.title for item in result.items] == ["Apple", "Banana"]
+        assert result.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_should_return_no_cursor_when_both_streams_exhausted(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Avatar")], has_more=False
+        )
+        series_repo.list_paginated_by_genre.return_value = _series_page(
+            [_series("Breaking Bad")], has_more=False
+        )
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListByGenreInput(genre="Action", limit=10))
+
+        assert len(result.items) == 2
+        assert result.has_more is False
+        assert result.next_cursor is None
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_when_no_items_match(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page([])
+        series_repo.list_paginated_by_genre.return_value = _series_page([])
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListByGenreInput(genre="NoSuchGenre"))
+
+        assert result.items == []
+        assert result.has_more is False
+        assert result.next_cursor is None
+
+    @pytest.mark.asyncio
+    async def test_catalog_item_output_carries_required_fields(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page([_movie("Test")])
+        series_repo.list_paginated_by_genre.return_value = _series_page([])
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListByGenreInput(genre="Action"))
+
+        item = result.items[0]
+        assert isinstance(item, CatalogItemOutput)
+        assert item.title == "Test"
+        assert item.type == "movie"
+        assert item.year == 2020

--- a/tests/modules/media/unit/application/use_cases/test_list_genres.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_genres.py
@@ -1,0 +1,135 @@
+"""Tests for ListGenresUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.application.dtos.catalog_dtos import (
+    GenreOutput,
+    ListGenresInput,
+    ListGenresOutput,
+)
+from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.repositories.movie_repository import GenreRow
+
+
+def _row(canonical: list[str], localized: list[str] | None = None) -> GenreRow:
+    return GenreRow(canonical_genres=canonical, localized_genres=localized or [])
+
+
+@pytest.mark.unit
+class TestListGenresUseCase:
+    """Cross-aggregation behavior of ListGenresUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_count_unique_genres_across_movies_and_series(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_genre_rows.return_value = [
+            _row(["Action", "Comedy"]),
+            _row(["Action"]),
+        ]
+        series_repo.list_genre_rows.return_value = [
+            _row(["Comedy"]),
+            _row(["Drama"]),
+        ]
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListGenresInput())
+
+        assert isinstance(result, ListGenresOutput)
+        counts = {g.id: g.count for g in result.genres}
+        assert counts == {"Action": 2, "Comedy": 2, "Drama": 1}
+
+    @pytest.mark.asyncio
+    async def test_should_sort_by_count_desc_then_alphabetical(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_genre_rows.return_value = [
+            _row(["Drama"]),
+            _row(["Drama"]),
+            _row(["Drama"]),
+            _row(["Comedy"]),
+            _row(["Comedy"]),
+            _row(["Action"]),
+            _row(["Action"]),
+        ]
+        series_repo.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListGenresInput())
+
+        # Drama (3) → Action, Comedy (tied at 2, alphabetical)
+        assert [g.id for g in result.genres] == ["Drama", "Action", "Comedy"]
+
+    @pytest.mark.asyncio
+    async def test_should_use_first_seen_localized_label(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_genre_rows.return_value = [
+            _row(["Action"], ["Ação"]),
+            _row(["Action"], ["A Wrong Translation"]),  # ignored — first wins
+        ]
+        series_repo.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListGenresInput(lang="pt-BR"))
+
+        assert result.genres[0] == GenreOutput(id="Action", name="Ação", count=2)
+
+    @pytest.mark.asyncio
+    async def test_should_fall_back_to_canonical_when_no_localized_label(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        # No localized genres available — repo returns empty list for that field
+        movie_repo.list_genre_rows.return_value = [_row(["Action"])]
+        series_repo.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListGenresInput(lang="pt-BR"))
+
+        # Falls back to the canonical English name
+        assert result.genres[0].name == "Action"
+
+    @pytest.mark.asyncio
+    async def test_should_skip_empty_localized_label(self) -> None:
+        # An empty string in the localized list shouldn't beat a later
+        # non-empty translation. The "first non-empty" rule.
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_genre_rows.return_value = [
+            _row(["Action"], [""]),
+            _row(["Action"], ["Ação"]),
+        ]
+        series_repo.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListGenresInput(lang="pt-BR"))
+
+        assert result.genres[0].name == "Ação"
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_list_when_no_rows(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_genre_rows.return_value = []
+        series_repo.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListGenresInput())
+
+        assert result.genres == []
+
+    @pytest.mark.asyncio
+    async def test_should_pass_lang_through_to_repos(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_genre_rows.return_value = []
+        series_repo.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        await use_case.execute(ListGenresInput(lang="pt-BR"))
+
+        movie_repo.list_genre_rows.assert_awaited_once_with("pt-BR")
+        series_repo.list_genre_rows.assert_awaited_once_with("pt-BR")


### PR DESCRIPTION
## Summary

Backend half of PR2 of the cursor-pagination initiative. Adds two new cross-cutting endpoints under \`/api/v1/catalog/\` that the frontend will consume per visible carousel — replacing the current \"fetch every movie + every series and group client-side\" pattern that pulls the whole catalog on every Home view.

## Coordination

This PR is the foundation for the upcoming frontend PR (Home + Browse refactor). They'll need to ship together — the frontend PR will be the one that delivers the actual user-visible perf win.

## New endpoints

### \`GET /api/v1/catalog/genres?lang=en\`

Single non-paginated response with one entry per genre present in the library:

\`\`\`json
{
  \"type\": \"list\",
  \"data\": [
    { \"id\": \"Action\", \"name\": \"Ação\", \"count\": 142 },
    { \"id\": \"Comedy\", \"name\": \"Comédia\", \"count\": 87 }
  ]
}
\`\`\`

- \`id\` is the canonical English genre name — used as the filter key for the by-genre endpoint, stable across language switches, doesn't change between sessions
- \`name\` is the localized display label (falls back to canonical when no translation exists)
- Sorted by count descending, then alphabetically by name — most-populated carousels surface first on Home

### \`GET /api/v1/catalog/by-genre/{genre}?cursor=&limit=20&lang=en\`

Paginated mixed listing of movies + series for a single genre. The \`genre\` path parameter is the canonical English id from the \`/genres\` endpoint. Items merged alphabetically by title, dual-stream cursor in the response metadata.

\`\`\`json
{
  \"type\": \"list\",
  \"data\": [
    { \"id\": \"mov_xxx\", \"type\": \"movie\", \"title\": \"Avatar\", ... },
    { \"id\": \"ser_yyy\", \"type\": \"series\", \"title\": \"Breaking Bad\", ... }
  ],
  \"metadata\": {
    \"pagination\": { \"next_cursor\": \"...\", \"has_more\": true }
  }
}
\`\`\`

## Building block additions

- **\`TitleCursorValue\`** + \`encode/decode_title_cursor\` — \`(title, id)\` composite cursor for title-sorted listings. Title is lowercased on encode to match the SQL \`LOWER(title)\` sort key, and the \`id\` tie-breaker keeps pagination stable when two rows share a title.
- **\`DualCursorValue\`** + \`encode/decode_dual_cursor\` — bundles two per-stream cursors into one wire token. ASCII record separator (\`\\x1e\`) inside avoids collisions with base64 characters used by inner cursors.
- **\`PaginatedResult.item_cursors\`** — new optional parallel list, populated only by methods whose consumers may use a partial prefix of the page. The catalog use case reads it to advance each stream cursor to the exact last consumed item, even when the merge left some fetched rows unconsumed. Existing single-stream consumers that always exhaust the whole page leave it \`None\`.

## Repository methods

| Method | Purpose |
|---|---|
| \`list_genre_rows(lang)\` | Lightweight \`(canonical, localized)\` projection — only \`genres\` and \`localized\` columns, no joins. Used by the genres aggregation use case. |
| \`list_paginated_by_genre(genre, cursor, limit)\` | Title-sorted, genre-filtered, cursor-paginated. Returns one cursor per item via \`item_cursors\`. |

The genre filter wraps the comma-separated \`genres\` column with delimiters:

\`\`\`python
delimited = func.concat(\",\", func.coalesce(MovieModel.genres, \"\"), \",\")
delimited.like(f\"%,{genre.value},%\")
\`\`\`

This guarantees substring matches are impossible: \"Action\" must NOT match \"Reaction\" or \"Action Adventure\". Covered by an explicit test in both repositories.

The \`_genre_helpers.py\` module shares the column splitter and the \`localized\` JSON parser between both repositories — keeps the parsing logic next to the column shape it mirrors.

## Use cases

### \`ListGenresUseCase\`

Cross-aggregates the \`GenreRow\` projections from both repos:
- Counts unique canonical genre names
- Picks the **first seen non-empty localized label** per canonical name (deterministic enough in a healthy catalog where every \"Action\" row has the same translation; surfacing inconsistencies is a metadata cleanup task, not a use-case responsibility)
- Sorts by count desc, then alphabetically by display name

### \`ListByGenreUseCase\`

The interesting one. Steps:

1. Decode the dual cursor → two per-stream opaque tokens
2. Query both repos in parallel via \`list_paginated_by_genre\` with their respective cursors
3. Tag each entity with its source stream + source-page index
4. Merge sort by \`(lowercase title, source_index)\` — the source-index tie-breaker matches the SQL within-stream order and gives a stable cross-stream order when two rows share a title
5. Trim to \`limit\`
6. **Compute the next dual cursor**: for each stream, find the highest source-page index of any consumed row and pull the corresponding cursor out of the repository's \`item_cursors\` list. If a stream contributed nothing to the page (because the other stream's titles all came earlier), its cursor stays unchanged so the next call re-considers the same starting position — guaranteeing no item is skipped or duplicated across pages.

Step 6 was the trickiest to get right. An earlier draft tried to use a sentinel \"end of title bucket\" cursor, which silently skipped rows that shared a title with the consumed item. The per-item cursor approach is the only one that's correct in all cases.

## Tests

- **14 unit tests** for the title and dual cursor helpers (roundtrip, lowercasing, separator-collision protection, fallback on garbage)
- **16 integration tests** across both repositories — including the critical \"Reaction must NOT match Action\" delimiter test, the case-insensitive title sort, the same-title cursor stability, and soft-delete exclusion
- **16 unit tests** for the use cases — merge order, dual cursor advancement when only one stream contributes to the page, the first-seen localized label rule, the count-desc sort
- **Full suite green: 1421 tests passing**, ruff and mypy clean

## Test plan

- [x] \`poetry run pytest\` — 1421 passed
- [x] \`poetry run ruff check src/ tests/\` — clean
- [x] \`poetry run mypy src/\` — clean
- [ ] Manual: \`curl /api/v1/catalog/genres?lang=pt-BR\` returns localized names + counts
- [ ] Manual: \`curl /api/v1/catalog/by-genre/Action\` returns mixed movies + series sorted by title
- [ ] Manual: walk the cursor across multiple pages — no overlap, no skips
- [ ] Manual: \`curl /api/v1/catalog/by-genre/NonExistentGenre\` returns empty page with \`has_more=false\`

## Follow-up

- Frontend PR (Home + Browse refactor) — same milestone, depends on this

## Summary by Sourcery

Introduce catalog-wide genre listing and per-genre mixed (movies + series) pagination endpoints, backed by new title-aware cursor primitives and repository methods.

New Features:
- Add /api/v1/catalog/genres endpoint to return all genres with localized names and aggregated movie/series counts.
- Add /api/v1/catalog/by-genre/{genre} endpoint to return a paginated mixed list of movies and series for a given genre, sorted alphabetically by title.

Enhancements:
- Extend pagination building blocks with title-based and dual-stream cursor types plus optional per-item cursors to support stable merged pagination.
- Add lightweight genre projection and genre-filtered, title-sorted pagination methods to movie and series repositories, with shared helpers for parsing genre columns and localized JSON.
- Introduce ListGenresUseCase and ListByGenreUseCase to aggregate genres across media types and to merge per-genre movie/series streams into a single catalog listing.
- Wire new catalog use cases and routes into the dependency injection container and FastAPI app.

Tests:
- Add unit tests for title and dual cursor encoding/decoding and robustness to malformed input.
- Add integration tests for movie and series repositories covering genre projection, whole-word genre filtering, case-insensitive title ordering, cursor pagination, per-item cursors, and soft-delete behavior.
- Add unit tests for ListGenresUseCase and ListByGenreUseCase covering aggregation, sorting, localization behavior, merge order, and dual-cursor advancement semantics.