### PR TITLE
feat(catalog): add ?type= filter to genres and by-genre endpoints

### DIFF
--- a/src/modules/media/application/dtos/catalog_dtos.py
+++ b/src/modules/media/application/dtos/catalog_dtos.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
+
+# Canonical media-type filter shared by the catalog inputs. ``None``
+# means "no filter — aggregate both movies and series". Kept as a
+# module-level alias so the use cases, the routes, and the tests all
+# agree on the exact literal values without copy-pasting the shape.
+MediaTypeFilter = Literal["movie", "series"]
 
 
 @dataclass(frozen=True)
@@ -35,9 +42,14 @@ class ListGenresInput:
     Attributes:
         lang: Language code used to resolve the localized display
             name for each canonical genre.
+        media_type: Optional filter — when set to ``"movie"`` or
+            ``"series"`` the use case only aggregates genres from
+            the matching repository, so the resulting counts reflect
+            that media type alone. ``None`` (default) aggregates both.
     """
 
     lang: str = "en"
+    media_type: MediaTypeFilter | None = None
 
 
 @dataclass(frozen=True)
@@ -94,12 +106,16 @@ class ListByGenreInput:
             ``None`` for the first page.
         limit: Page size. Routes clamp to ``[1, MAX_PAGE_SIZE]``.
         lang: Language for localized titles / synopses / genres.
+        media_type: Optional filter — when set the use case only
+            pulls from the matching stream (movie or series). ``None``
+            (default) merges both streams as usual.
     """
 
     genre: str
     cursor: str | None = None
     limit: int = DEFAULT_PAGE_SIZE
     lang: str = "en"
+    media_type: MediaTypeFilter | None = None
 
 
 @dataclass(frozen=True)
@@ -126,4 +142,5 @@ __all__ = [
     "ListByGenreOutput",
     "ListGenresInput",
     "ListGenresOutput",
+    "MediaTypeFilter",
 ]

--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -2,10 +2,12 @@
 
 import asyncio
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, TypeVar
 
 from src.building_blocks.application.pagination import (
+    DualCursorValue,
     PaginatedResult,
+    Pagination,
     decode_dual_cursor,
     encode_dual_cursor,
 )
@@ -17,6 +19,25 @@ from src.modules.media.application.dtos.catalog_dtos import (
 from src.modules.media.domain.entities import Movie, Series
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import Genre
+
+_T = TypeVar("_T")
+
+
+def _empty_page(_element_type: type[_T]) -> PaginatedResult[_T]:
+    """Build a no-op ``PaginatedResult`` for a stream that was skipped.
+
+    Used when the media-type filter excludes one side of the merge —
+    the missing stream is replaced by an empty page so the sort and
+    cursor-advancement logic below stays linear instead of sprouting
+    a second code path for the "only one stream" case. The
+    ``_element_type`` argument is present only so mypy can bind the
+    generic parameter at the call site — it's not used at runtime.
+    """
+    return PaginatedResult(
+        items=[],
+        pagination=Pagination(next_cursor=None, has_more=False),
+        item_cursors=[],
+    )
 
 
 @dataclass(frozen=True)
@@ -92,17 +113,16 @@ class ListByGenreUseCase:
         # serializing them. The DI container hands each repository
         # its own AsyncSession (Factory provider), so there's no
         # session contention to worry about.
-        movies_page, series_page = await asyncio.gather(
-            self._movie_repository.list_paginated_by_genre(
-                genre=genre,
-                cursor=decoded.movies,
-                limit=input_dto.limit,
-            ),
-            self._series_repository.list_paginated_by_genre(
-                genre=genre,
-                cursor=decoded.series,
-                limit=input_dto.limit,
-            ),
+        #
+        # When ``media_type`` restricts the stream to one side, the
+        # excluded repo is skipped entirely and a synthetic empty
+        # page stands in for it so the merge / cursor logic below
+        # stays unchanged.
+        movies_page, series_page = await self._fetch_pages(
+            genre=genre,
+            decoded=decoded,
+            limit=input_dto.limit,
+            media_type=input_dto.media_type,
         )
 
         # Tag each entity with its source stream and its source-page
@@ -155,6 +175,51 @@ class ListByGenreUseCase:
             items=[self._to_output(mi.kind, mi.entity, input_dto.lang) for mi in page_items],
             next_cursor=next_cursor,
             has_more=has_more,
+        )
+
+    async def _fetch_pages(
+        self,
+        *,
+        genre: Genre,
+        decoded: DualCursorValue,
+        limit: int,
+        media_type: Literal["movie", "series"] | None,
+    ) -> tuple[PaginatedResult[Movie], PaginatedResult[Series]]:
+        """Fetch the movie and series pages, honoring the media-type filter.
+
+        Both repos are awaited concurrently via ``asyncio.gather``
+        when no filter is active. When ``media_type`` excludes a
+        stream, only the surviving repo is called and an empty
+        ``PaginatedResult`` stands in for the other — preserving the
+        caller's ``(movies, series)`` tuple shape and the "previous
+        cursor stays put if nothing is consumed" semantics of the
+        merge sort.
+        """
+        if media_type == "movie":
+            movies_page = await self._movie_repository.list_paginated_by_genre(
+                genre=genre,
+                cursor=decoded.movies,
+                limit=limit,
+            )
+            return movies_page, _empty_page(Series)
+        if media_type == "series":
+            series_page = await self._series_repository.list_paginated_by_genre(
+                genre=genre,
+                cursor=decoded.series,
+                limit=limit,
+            )
+            return _empty_page(Movie), series_page
+        return await asyncio.gather(
+            self._movie_repository.list_paginated_by_genre(
+                genre=genre,
+                cursor=decoded.movies,
+                limit=limit,
+            ),
+            self._series_repository.list_paginated_by_genre(
+                genre=genre,
+                cursor=decoded.series,
+                limit=limit,
+            ),
         )
 
     @staticmethod

--- a/src/modules/media/application/use_cases/list_genres.py
+++ b/src/modules/media/application/use_cases/list_genres.py
@@ -53,14 +53,29 @@ class ListGenresUseCase:
         """Execute the use case.
 
         Args:
-            input_dto: Carries the requested ``lang``.
+            input_dto: Carries the requested ``lang`` and optional
+                ``media_type`` filter.
 
         Returns:
             ``ListGenresOutput`` with one ``GenreOutput`` per unique
-            canonical genre present in the library.
+            canonical genre present in the library (restricted to the
+            selected media type when ``media_type`` is set).
         """
-        movie_rows = await self._movie_repository.list_genre_rows(input_dto.lang)
-        series_rows = await self._series_repository.list_genre_rows(input_dto.lang)
+        # Skip the repo call for the excluded media type when a
+        # filter is active. The Movies and Series tabs on the frontend
+        # use this to get counts scoped to just their half of the
+        # catalog, so e.g. a genre that only tags series shouldn't
+        # appear on the Movies tab.
+        movie_rows = (
+            await self._movie_repository.list_genre_rows(input_dto.lang)
+            if input_dto.media_type != "series"
+            else []
+        )
+        series_rows = (
+            await self._series_repository.list_genre_rows(input_dto.lang)
+            if input_dto.media_type != "movie"
+            else []
+        )
 
         counts: dict[str, int] = {}
         localized_label: dict[str, str] = {}

--- a/src/modules/media/presentation/routes/catalog_routes.py
+++ b/src/modules/media/presentation/routes/catalog_routes.py
@@ -1,27 +1,40 @@
 """Catalog (cross-cutting movies + series) REST API routes."""
 
 from dataclasses import asdict
-from typing import Any
+from typing import Any, Literal
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.catalog_dtos import (
     ListByGenreInput,
     ListGenresInput,
+    MediaTypeFilter,
 )
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
 
 router = APIRouter(prefix="/api/v1/catalog", tags=["Catalog"])
 
+# Shared OpenAPI/validation config for the `?type=` query param. Kept
+# as a module-level constant so both routes stay identical and changes
+# to the description show up in a single place.
+_MEDIA_TYPE_QUERY: MediaTypeFilter | None = Query(
+    default=None,
+    description=(
+        "Optional filter — restrict the result to a single media type. "
+        "Accepts 'movie' or 'series'; omit to aggregate both."
+    ),
+)
+
 
 @router.get("/genres")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_genres(
     lang: str = "en",
+    type: Literal["movie", "series"] | None = _MEDIA_TYPE_QUERY,
     use_case: ListGenresUseCase = Depends(
         Provide[ApplicationContainer.media.list_genres],
     ),
@@ -36,8 +49,15 @@ async def list_genres(
 
     Sorted by count descending, then alphabetically by display name —
     most-populated carousels surface first on the Home page.
+
+    Query params:
+        lang: Language code for localized genre names.
+        type: Optional ``"movie"`` or ``"series"`` filter. When set,
+            counts only reflect the matching media type so the Movies
+            and Series tabs can skip genres that exist only on the
+            other side.
     """
-    result = await use_case.execute(ListGenresInput(lang=lang))
+    result = await use_case.execute(ListGenresInput(lang=lang, media_type=type))
     return {
         "type": "list",
         "data": [asdict(g) for g in result.genres],
@@ -51,6 +71,7 @@ async def list_by_genre(
     cursor: str | None = None,
     limit: int = DEFAULT_PAGE_SIZE,
     lang: str = "en",
+    type: Literal["movie", "series"] | None = _MEDIA_TYPE_QUERY,
     use_case: ListByGenreUseCase = Depends(
         Provide[ApplicationContainer.media.list_by_genre],
     ),
@@ -70,6 +91,10 @@ async def list_by_genre(
         limit: Page size, clamped to ``[1, MAX_PAGE_SIZE]``.
         lang: Language code for localized titles, synopses, and
             genre names returned in each item.
+        type: Optional ``"movie"`` or ``"series"`` filter. When set,
+            only the matching stream is queried so the Movies and
+            Series tabs can show a genre restricted to their side of
+            the catalog without mixing in the other.
     """
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
@@ -78,6 +103,7 @@ async def list_by_genre(
             cursor=cursor,
             limit=clamped_limit,
             lang=lang,
+            media_type=type,
         )
     )
     return {

--- a/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
@@ -209,6 +209,74 @@ class TestListByGenreUseCase:
         assert result.next_cursor is None
 
     @pytest.mark.asyncio
+    async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
+        # media_type="movie" restricts the merge to the movie stream
+        # — series repo stays silent so the output is a pure movies
+        # listing for the Movies tab.
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Avatar"), _movie("Cyrano")]
+        )
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListByGenreInput(genre="Action", media_type="movie"))
+
+        movie_repo.list_paginated_by_genre.assert_awaited_once()
+        series_repo.list_paginated_by_genre.assert_not_awaited()
+        assert [item.type for item in result.items] == ["movie", "movie"]
+        assert [item.title for item in result.items] == ["Avatar", "Cyrano"]
+
+    @pytest.mark.asyncio
+    async def test_should_skip_movie_repo_when_filtered_to_series(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.list_paginated_by_genre.return_value = _series_page(
+            [_series("Breaking Bad"), _series("Dark")]
+        )
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListByGenreInput(genre="Action", media_type="series"))
+
+        series_repo.list_paginated_by_genre.assert_awaited_once()
+        movie_repo.list_paginated_by_genre.assert_not_awaited()
+        assert [item.type for item in result.items] == ["series", "series"]
+        assert [item.title for item in result.items] == ["Breaking Bad", "Dark"]
+
+    @pytest.mark.asyncio
+    async def test_should_advance_only_filtered_stream_cursor_when_filtered(
+        self,
+    ) -> None:
+        # Under a media-type filter only the surviving stream's
+        # cursor should advance — the skipped stream's slot in the
+        # dual cursor must round-trip unchanged so a later unfiltered
+        # request doesn't have to start from scratch.
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Apple"), _movie("Banana")],
+            has_more=True,
+        )
+        use_case = ListByGenreUseCase(movie_repo, series_repo)
+
+        from src.building_blocks.application.pagination import encode_dual_cursor
+
+        previous_cursor = encode_dual_cursor(None, "untouched-series-cursor")
+        result = await use_case.execute(
+            ListByGenreInput(
+                genre="Action",
+                cursor=previous_cursor,
+                limit=2,
+                media_type="movie",
+            )
+        )
+
+        assert result.has_more is True
+        decoded = decode_dual_cursor(result.next_cursor)
+        assert decoded.movies == "m-cursor-1"
+        assert decoded.series == "untouched-series-cursor"
+
+    @pytest.mark.asyncio
     async def test_catalog_item_output_carries_required_fields(self) -> None:
         movie_repo = AsyncMock(spec=MovieRepository)
         series_repo = AsyncMock(spec=SeriesRepository)

--- a/tests/modules/media/unit/application/use_cases/test_list_genres.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_genres.py
@@ -133,3 +133,37 @@ class TestListGenresUseCase:
 
         movie_repo.list_genre_rows.assert_awaited_once_with("pt-BR")
         series_repo.list_genre_rows.assert_awaited_once_with("pt-BR")
+
+    @pytest.mark.asyncio
+    async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
+        # media_type="movie" restricts the aggregation to the movie
+        # repo — the series repo must not be called at all so the
+        # counts reflect movies only (and the Movies tab on the
+        # frontend doesn't surface series-only genres).
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_genre_rows.return_value = [_row(["Action"]), _row(["Comedy"])]
+        series_repo.list_genre_rows.return_value = [_row(["Drama"])]
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListGenresInput(media_type="movie"))
+
+        movie_repo.list_genre_rows.assert_awaited_once()
+        series_repo.list_genre_rows.assert_not_awaited()
+        assert {g.id for g in result.genres} == {"Action", "Comedy"}
+
+    @pytest.mark.asyncio
+    async def test_should_skip_movie_repo_when_filtered_to_series(self) -> None:
+        # Mirror of the previous test — Series tab should only hit
+        # the series repo.
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.list_genre_rows.return_value = [_row(["Action"])]
+        series_repo.list_genre_rows.return_value = [_row(["Drama"]), _row(["Thriller"])]
+        use_case = ListGenresUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(ListGenresInput(media_type="series"))
+
+        series_repo.list_genre_rows.assert_awaited_once()
+        movie_repo.list_genre_rows.assert_not_awaited()
+        assert {g.id for g in result.genres} == {"Drama", "Thriller"}


### PR DESCRIPTION
## Summary
- Add optional `?type=movie|series` to `GET /catalog/genres` and `GET /catalog/by-genre/{genre}` so the Movies and Series tabs on the frontend can scope their carousel layout to a single media type.
- `ListGenresUseCase` and `ListByGenreUseCase` honor the new `media_type` input by skipping the excluded repo entirely — the dual-cursor logic falls back to an empty page on the skipped side so cursor-advancement semantics stay unchanged.
- Routes use `Literal["movie", "series"] | None`, so invalid values return a 422 instead of silently being ignored.

## Test plan
- [x] `pytest tests/modules/media/unit/application/use_cases/test_list_genres.py tests/modules/media/unit/application/use_cases/test_list_by_genre.py` — 20 passing (4 new cases covering type filter, cursor preservation, and skipped-repo assertions).
- [x] Full media suite green: `pytest tests/modules/media/` — 756 passing.
- [x] `mypy` clean on touched application/DTO files.
- [x] Manual curl against a running backend:
  - `GET /catalog/genres?type=movie` → movie-only counts (e.g. Comedy 32 instead of 37).
  - `GET /catalog/genres?type=series` → series-only genres surface (Kids, Sci-Fi & Fantasy).
  - `GET /catalog/by-genre/Comedy?type=series` → only series rows.
  - `GET /catalog/genres?type=both` → HTTP 422.

## Related issues
- Unblocks lucaschf/homeflix-web#... — Movies/Series tabs on the frontend had been mixing both sides since the per-genre refactor.