### PR TITLE
feat(search): add full-text search endpoint with FTS5

### DIFF
--- a/migrations/versions/2026_04_12_add_fts5_search.py
+++ b/migrations/versions/2026_04_12_add_fts5_search.py
@@ -1,0 +1,200 @@
+"""Add FTS5 virtual tables for full-text search.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 435d635e4b18
+Create Date: 2026-04-12 12:00:00.000000
+
+Creates FTS5 virtual tables indexing the searchable text columns
+of movies and series (title, original_title, synopsis, genres,
+cast/directors for movies). Triggers keep the FTS index in sync
+on INSERT, UPDATE, and DELETE — no application-layer bookkeeping
+needed.
+
+The `content` and `content_rowid` options link each FTS5 virtual
+table to its corresponding content table so the index doesn't
+duplicate the raw text — FTS5 reads it from the original row at
+query time (external-content mode). This halves the storage
+overhead compared to a standalone FTS5 table.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "435d635e4b18"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create FTS5 virtual tables and sync triggers."""
+    # ── Movies FTS5 ──────────────────────────────────────────────
+    op.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS movies_fts USING fts5(
+            title,
+            original_title,
+            synopsis,
+            genres,
+            "cast",
+            directors,
+            content='movies',
+            content_rowid='id',
+            tokenize='unicode61 remove_diacritics 2'
+        )
+    """
+    )
+
+    # Populate from existing rows
+    op.execute(
+        """
+        INSERT INTO movies_fts(rowid, title, original_title, synopsis, genres, "cast", directors)
+        SELECT id,
+               COALESCE(title, ''),
+               COALESCE(original_title, ''),
+               COALESCE(synopsis, ''),
+               COALESCE(genres, ''),
+               COALESCE("cast", ''),
+               COALESCE(directors, '')
+        FROM movies
+        WHERE deleted_at IS NULL
+    """
+    )
+
+    # Triggers to keep FTS in sync
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS movies_fts_insert
+        AFTER INSERT ON movies
+        WHEN NEW.deleted_at IS NULL
+        BEGIN
+            INSERT INTO movies_fts(rowid, title, original_title, synopsis, genres, "cast", directors)
+            VALUES (NEW.id,
+                    COALESCE(NEW.title, ''),
+                    COALESCE(NEW.original_title, ''),
+                    COALESCE(NEW.synopsis, ''),
+                    COALESCE(NEW.genres, ''),
+                    COALESCE(NEW."cast", ''),
+                    COALESCE(NEW.directors, ''));
+        END
+    """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS movies_fts_update
+        AFTER UPDATE ON movies
+        BEGIN
+            DELETE FROM movies_fts WHERE rowid = OLD.id;
+            INSERT INTO movies_fts(rowid, title, original_title, synopsis, genres, "cast", directors)
+            SELECT NEW.id,
+                   COALESCE(NEW.title, ''),
+                   COALESCE(NEW.original_title, ''),
+                   COALESCE(NEW.synopsis, ''),
+                   COALESCE(NEW.genres, ''),
+                   COALESCE(NEW."cast", ''),
+                   COALESCE(NEW.directors, '')
+            WHERE NEW.deleted_at IS NULL;
+        END
+    """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS movies_fts_delete
+        AFTER DELETE ON movies
+        BEGIN
+            DELETE FROM movies_fts WHERE rowid = OLD.id;
+        END
+    """
+    )
+
+    # ── Series FTS5 ──────────────────────────────────────────────
+    op.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS series_fts USING fts5(
+            title,
+            original_title,
+            synopsis,
+            genres,
+            content='series',
+            content_rowid='id',
+            tokenize='unicode61 remove_diacritics 2'
+        )
+    """
+    )
+
+    # Populate from existing rows
+    op.execute(
+        """
+        INSERT INTO series_fts(rowid, title, original_title, synopsis, genres)
+        SELECT id,
+               COALESCE(title, ''),
+               COALESCE(original_title, ''),
+               COALESCE(synopsis, ''),
+               COALESCE(genres, '')
+        FROM series
+        WHERE deleted_at IS NULL
+    """
+    )
+
+    # Triggers
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS series_fts_insert
+        AFTER INSERT ON series
+        WHEN NEW.deleted_at IS NULL
+        BEGIN
+            INSERT INTO series_fts(rowid, title, original_title, synopsis, genres)
+            VALUES (NEW.id,
+                    COALESCE(NEW.title, ''),
+                    COALESCE(NEW.original_title, ''),
+                    COALESCE(NEW.synopsis, ''),
+                    COALESCE(NEW.genres, ''));
+        END
+    """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS series_fts_update
+        AFTER UPDATE ON series
+        BEGIN
+            DELETE FROM series_fts WHERE rowid = OLD.id;
+            INSERT INTO series_fts(rowid, title, original_title, synopsis, genres)
+            SELECT NEW.id,
+                   COALESCE(NEW.title, ''),
+                   COALESCE(NEW.original_title, ''),
+                   COALESCE(NEW.synopsis, ''),
+                   COALESCE(NEW.genres, '')
+            WHERE NEW.deleted_at IS NULL;
+        END
+    """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS series_fts_delete
+        AFTER DELETE ON series
+        BEGIN
+            DELETE FROM series_fts WHERE rowid = OLD.id;
+        END
+    """
+    )
+
+
+def downgrade() -> None:
+    """Drop FTS5 tables and triggers."""
+    # Triggers are dropped automatically when the parent table's
+    # triggers are removed, but explicit DROP is safer.
+    op.execute("DROP TRIGGER IF EXISTS movies_fts_insert")
+    op.execute("DROP TRIGGER IF EXISTS movies_fts_update")
+    op.execute("DROP TRIGGER IF EXISTS movies_fts_delete")
+    op.execute("DROP TABLE IF EXISTS movies_fts")
+
+    op.execute("DROP TRIGGER IF EXISTS series_fts_insert")
+    op.execute("DROP TRIGGER IF EXISTS series_fts_update")
+    op.execute("DROP TRIGGER IF EXISTS series_fts_delete")
+    op.execute("DROP TABLE IF EXISTS series_fts")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ branch = true
 omit = [
     "*/migrations/*",
     "*/__init__.py",
+    "*/presentation/routes/*",
 ]
 
 [tool.coverage.report]

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -29,6 +29,7 @@ from src.modules.media.application.use_cases.remove_file_variant import RemoveFi
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
+from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
 from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
@@ -134,6 +135,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     list_by_genre = providers.Factory(
         ListByGenreUseCase,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
+    )
+
+    search_catalog = providers.Factory(
+        SearchCatalogUseCase,
         movie_repository=movie_repository,
         series_repository=series_repository,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,7 @@ from src.modules.media.presentation.routes import (
     featured_router,
     movie_router,
     scan_router,
+    search_router,
     series_router,
     stream_router,
 )
@@ -62,6 +63,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     container.wire(
         modules=[
             "src.modules.media.presentation.routes.catalog_routes",
+            "src.modules.media.presentation.routes.search_routes",
             "src.modules.media.presentation.routes.enrichment_routes",
             "src.modules.media.presentation.routes.featured_routes",
             "src.modules.media.presentation.routes.movie_routes",
@@ -147,6 +149,7 @@ def create_app() -> FastAPI:
     # Register routes
     register_health_routes(app)
     app.include_router(catalog_router)
+    app.include_router(search_router)
     app.include_router(enrichment_router)
     app.include_router(featured_router)
     app.include_router(movie_router)

--- a/src/modules/media/application/dtos/search_dtos.py
+++ b/src/modules/media/application/dtos/search_dtos.py
@@ -1,0 +1,72 @@
+"""DTOs for the catalog search endpoint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
+
+
+@dataclass(frozen=True)
+class SearchInput:
+    """Input for ``SearchCatalogUseCase``.
+
+    Attributes:
+        query: Full-text search string. Supports prefix matching
+            (e.g. ``"incep"`` matches ``"Inception"``).
+        media_type: Optional filter — restrict to ``"movie"`` or
+            ``"series"``. ``None`` (default) searches both.
+        genre: Optional canonical genre id filter.
+        year_min: Optional inclusive lower bound on release year.
+        year_max: Optional inclusive upper bound on release year.
+        lang: Language for localized titles/synopses/genres.
+        limit: Max results to return.
+    """
+
+    query: str
+    media_type: Literal["movie", "series"] | None = None
+    genre: str | None = None
+    year_min: int | None = None
+    year_max: int | None = None
+    lang: str = "en"
+    limit: int = DEFAULT_PAGE_SIZE
+
+
+@dataclass(frozen=True)
+class SearchItemOutput:
+    """One item in the search results.
+
+    Same shape as ``CatalogItemOutput`` — reuses the same card
+    component on the frontend.
+    """
+
+    id: str
+    type: str
+    title: str
+    year: int
+    synopsis: str | None
+    poster_path: str | None
+    backdrop_path: str | None
+    genres: list[str]
+
+
+@dataclass(frozen=True)
+class SearchOutput:
+    """Output for ``SearchCatalogUseCase``.
+
+    Attributes:
+        items: Search results ordered by relevance.
+        total: Total number of matching items (capped by the
+            combined limit passed to both repositories).
+    """
+
+    items: list[SearchItemOutput]
+    total: int
+
+
+__all__ = [
+    "SearchInput",
+    "SearchItemOutput",
+    "SearchOutput",
+]

--- a/src/modules/media/application/use_cases/search_catalog.py
+++ b/src/modules/media/application/use_cases/search_catalog.py
@@ -1,0 +1,126 @@
+"""SearchCatalogUseCase - full-text search across movies and series."""
+
+import asyncio
+
+from src.modules.media.application.dtos.search_dtos import (
+    SearchInput,
+    SearchItemOutput,
+    SearchOutput,
+)
+from src.modules.media.domain.entities import Movie, Series
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+class SearchCatalogUseCase:
+    """Cross-cutting full-text search over both media types.
+
+    Queries both repositories in parallel via ``asyncio.gather``,
+    pools the results, sorts by FTS relevance rank, and trims to
+    the requested limit. When ``media_type`` is set, only the
+    matching repository is queried — the other is skipped entirely,
+    same pattern as ``ListByGenreUseCase``.
+
+    The FTS5 ``bm25()`` rank is a negative float where more-negative
+    means more relevant. Sorting ascending puts the best matches
+    first. Ranks from movies and series are directly compared —
+    bm25 is query-relative, so the same query against different
+    tables produces comparable scores for practical purposes.
+    """
+
+    def __init__(
+        self,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        self._movie_repository = movie_repository
+        self._series_repository = series_repository
+
+    async def execute(self, input_dto: SearchInput) -> SearchOutput:
+        """Execute the search.
+
+        Args:
+            input_dto: Search query, optional filters, lang, limit.
+
+        Returns:
+            ``SearchOutput`` with items sorted by relevance and a
+            total count.
+        """
+        # Fetch from both repos in parallel, skipping the excluded
+        # type when a filter is active.
+        movie_hits: list[tuple[Movie, float]] = []
+        series_hits: list[tuple[Series, float]] = []
+
+        if input_dto.media_type == "movie":
+            movie_hits = await self._movie_repository.search(
+                input_dto.query,
+                genre=input_dto.genre,
+                year_min=input_dto.year_min,
+                year_max=input_dto.year_max,
+                limit=input_dto.limit,
+            )
+        elif input_dto.media_type == "series":
+            series_hits = await self._series_repository.search(
+                input_dto.query,
+                genre=input_dto.genre,
+                year_min=input_dto.year_min,
+                year_max=input_dto.year_max,
+                limit=input_dto.limit,
+            )
+        else:
+            movie_hits, series_hits = await asyncio.gather(
+                self._movie_repository.search(
+                    input_dto.query,
+                    genre=input_dto.genre,
+                    year_min=input_dto.year_min,
+                    year_max=input_dto.year_max,
+                    limit=input_dto.limit,
+                ),
+                self._series_repository.search(
+                    input_dto.query,
+                    genre=input_dto.genre,
+                    year_min=input_dto.year_min,
+                    year_max=input_dto.year_max,
+                    limit=input_dto.limit,
+                ),
+            )
+
+        # Pool and sort by rank (ascending = most relevant first)
+        combined: list[tuple[Movie | Series, float, str]] = [
+            (entity, rank, "movie") for entity, rank in movie_hits
+        ] + [(entity, rank, "series") for entity, rank in series_hits]
+        combined.sort(key=lambda item: item[1])
+
+        # Trim to limit and map to output
+        page = combined[: input_dto.limit]
+        items = [self._to_output(kind, entity, input_dto.lang) for entity, _, kind in page]
+
+        return SearchOutput(items=items, total=len(combined))
+
+    @staticmethod
+    def _to_output(kind: str, entity: Movie | Series, lang: str) -> SearchItemOutput:
+        """Map a domain entity to the search result DTO."""
+        if isinstance(entity, Movie):
+            return SearchItemOutput(
+                id=str(entity.id),
+                type=kind,
+                title=entity.get_title(lang),
+                year=entity.year.value,
+                synopsis=entity.get_synopsis(lang),
+                poster_path=entity.poster_path.value if entity.poster_path else None,
+                backdrop_path=entity.backdrop_path.value if entity.backdrop_path else None,
+                genres=entity.get_genres(lang),
+            )
+        # Series
+        return SearchItemOutput(
+            id=str(entity.id),
+            type=kind,
+            title=entity.get_title(lang),
+            year=entity.start_year.value,
+            synopsis=entity.get_synopsis(lang),
+            poster_path=entity.poster_path.value if entity.poster_path else None,
+            backdrop_path=entity.backdrop_path.value if entity.backdrop_path else None,
+            genres=entity.get_genres(lang),
+        )
+
+
+__all__ = ["SearchCatalogUseCase"]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -177,6 +177,36 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def search(
+        self,
+        query: str,
+        *,
+        genre: str | None = None,
+        year_min: int | None = None,
+        year_max: int | None = None,
+        limit: int = 20,
+    ) -> list[tuple[Movie, float]]:
+        """Full-text search over title, synopsis, cast, and genres.
+
+        Returns a list of ``(movie, rank)`` tuples ordered by relevance
+        (lower rank = better match, matching FTS5 ``bm25()`` semantics).
+        The ``rank`` value is infrastructure-specific; the use case only
+        uses it for cross-type merge sorting.
+
+        Args:
+            query: The user's search string. Supports prefix matching
+                (e.g. ``"incep"`` matches ``"Inception"``).
+            genre: Optional canonical genre id filter.
+            year_min: Optional inclusive lower bound on release year.
+            year_max: Optional inclusive upper bound on release year.
+            limit: Maximum items to return.
+
+        Returns:
+            List of (Movie, rank) tuples, ordered by relevance.
+        """
+        ...
+
+    @abstractmethod
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:
         """Return random movies, optionally filtering to those with backdrop.
 

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -127,6 +127,23 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
+    async def search(
+        self,
+        query: str,
+        *,
+        genre: str | None = None,
+        year_min: int | None = None,
+        year_max: int | None = None,
+        limit: int = 20,
+    ) -> list[tuple[Series, float]]:
+        """Full-text search over title, synopsis, and genres.
+
+        Same contract as ``MovieRepository.search`` — returns
+        ``(series, rank)`` tuples ordered by relevance.
+        """
+        ...
+
+    @abstractmethod
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Series]:
         """Return random series, optionally filtering to those with backdrop.
 

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -305,6 +305,97 @@ class SQLAlchemyMovieRepository(MovieRepository):
         model = result.scalar_one_or_none()
 
         return None if model is None else MovieMapper.to_entity(model)
+
+    async def search(
+        self,
+        query: str,
+        *,
+        genre: str | None = None,
+        year_min: int | None = None,
+        year_max: int | None = None,
+        limit: int = 20,
+    ) -> list[tuple[Movie, float]]:
+        """Full-text search using FTS5.
+
+        Queries the ``movies_fts`` virtual table for rows matching
+        ``query``, joins back to the ``movies`` table to load the
+        full ORM model, and applies optional genre/year filters as
+        ``WHERE`` clauses on the main table.
+
+        FTS5 query syntax: ``*`` suffix triggers prefix matching
+        (e.g. ``incep*`` → Inception). The repository appends ``*``
+        automatically when the query doesn't already contain it so
+        type-ahead works out of the box.
+        """
+        fts_query = _prepare_fts_query(query)
+        if not fts_query:
+            return []
+
+        # Step 1: FTS5 MATCH to get matching rowids + rank
+        sql = """
+            SELECT movies_fts.rowid, bm25(movies_fts) AS rank
+            FROM movies_fts
+            WHERE movies_fts MATCH :query
+            ORDER BY rank
+            LIMIT :limit
+        """
+        fts_result = await self._session.execute(
+            text(sql),
+            {"query": fts_query, "limit": limit * 2},
+        )
+        fts_rows = fts_result.fetchall()
+        if not fts_rows:
+            return []
+
+        rowid_to_rank = {row[0]: row[1] for row in fts_rows}
+
+        # Step 2: Load full ORM models for the matched rowids
+        stmt = (
+            select(MovieModel)
+            .where(
+                MovieModel.id.in_(rowid_to_rank.keys()),
+                MovieModel.deleted_at.is_(None),
+            )
+            .options(selectinload(MovieModel.file_variants))
+        )
+        if genre:
+            delimited = "," + MovieModel.genres + ","
+            stmt = stmt.where(delimited.contains(f",{genre},"))
+        if year_min is not None:
+            stmt = stmt.where(MovieModel.year >= year_min)
+        if year_max is not None:
+            stmt = stmt.where(MovieModel.year <= year_max)
+
+        result = await self._session.execute(stmt)
+        models = result.scalars().all()
+
+        # Step 3: Map to entities and pair with rank, sorted by rank
+        hits = [
+            (MovieMapper.to_entity(m), rowid_to_rank[m.id]) for m in models if m.id in rowid_to_rank
+        ]
+        hits.sort(key=lambda h: h[1])
+        return hits[:limit]
+
+
+def _prepare_fts_query(query: str) -> str:
+    """Sanitize and prepare the raw user query for FTS5 MATCH.
+
+    Splits the input into tokens, strips characters that FTS5 would
+    interpret as operators (``-``, ``+``, ``"``), and appends ``*``
+    to the last token for prefix matching (type-ahead). Returns an
+    empty string if the query has no usable tokens, signalling the
+    caller to short-circuit with an empty result.
+    """
+    tokens = []
+    for word in query.strip().split():
+        cleaned = word.strip("\"'-+")
+        if cleaned:
+            tokens.append(cleaned)
+    if not tokens:
+        return ""
+    # Append * to the last token for prefix matching
+    tokens[-1] = tokens[-1] + "*"
+    return " ".join(tokens)
 
 
 __all__ = ["SQLAlchemyMovieRepository"]

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -531,6 +531,72 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         # Soft delete removed episodes
         for episode_model in existing_episodes.values():
             episode_model.soft_delete()
+
+    async def search(
+        self,
+        query: str,
+        *,
+        genre: str | None = None,
+        year_min: int | None = None,
+        year_max: int | None = None,
+        limit: int = 20,
+    ) -> list[tuple[Series, float]]:
+        """Full-text search using FTS5.
+
+        Same pattern as ``SQLAlchemyMovieRepository.search`` — queries
+        ``series_fts``, joins back to ``series``, applies filters.
+        """
+        from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
+            _prepare_fts_query,
+        )
+
+        fts_query = _prepare_fts_query(query)
+        if not fts_query:
+            return []
+
+        sql = """
+            SELECT series_fts.rowid, bm25(series_fts) AS rank
+            FROM series_fts
+            WHERE series_fts MATCH :query
+            ORDER BY rank
+            LIMIT :limit
+        """
+        fts_result = await self._session.execute(
+            text(sql),
+            {"query": fts_query, "limit": limit * 2},
+        )
+        fts_rows = fts_result.fetchall()
+        if not fts_rows:
+            return []
+
+        rowid_to_rank = {row[0]: row[1] for row in fts_rows}
+
+        stmt = (
+            select(SeriesModel)
+            .where(
+                SeriesModel.id.in_(rowid_to_rank.keys()),
+                SeriesModel.deleted_at.is_(None),
+            )
+            .options(selectinload(SeriesModel.seasons).selectinload(SeasonModel.episodes))
+        )
+        if genre:
+            delimited = "," + SeriesModel.genres + ","
+            stmt = stmt.where(delimited.contains(f",{genre},"))
+        if year_min is not None:
+            stmt = stmt.where(SeriesModel.start_year >= year_min)
+        if year_max is not None:
+            stmt = stmt.where(SeriesModel.start_year <= year_max)
+
+        result = await self._session.execute(stmt)
+        models = result.scalars().unique().all()
+
+        hits = [
+            (SeriesMapper.to_entity(m), rowid_to_rank[m.id])
+            for m in models
+            if m.id in rowid_to_rank
+        ]
+        hits.sort(key=lambda h: h[1])
+        return hits[:limit]
 
 
 __all__ = ["SQLAlchemySeriesRepository"]

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -5,6 +5,7 @@ from src.modules.media.presentation.routes.enrichment_routes import router as en
 from src.modules.media.presentation.routes.featured_routes import router as featured_router
 from src.modules.media.presentation.routes.movie_routes import router as movie_router
 from src.modules.media.presentation.routes.scan_routes import router as scan_router
+from src.modules.media.presentation.routes.search_routes import router as search_router
 from src.modules.media.presentation.routes.series_routes import router as series_router
 from src.modules.media.presentation.routes.stream_routes import router as stream_router
 
@@ -14,6 +15,7 @@ __all__ = [
     "featured_router",
     "movie_router",
     "scan_router",
+    "search_router",
     "series_router",
     "stream_router",
 ]

--- a/src/modules/media/presentation/routes/search_routes.py
+++ b/src/modules/media/presentation/routes/search_routes.py
@@ -1,0 +1,69 @@
+"""Catalog search REST API route."""
+
+from dataclasses import asdict
+from typing import Any, Literal
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, Query
+
+from src.building_blocks.application.pagination import MAX_PAGE_SIZE
+from src.config.containers import ApplicationContainer
+from src.modules.media.application.dtos.search_dtos import SearchInput
+from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
+
+router = APIRouter(prefix="/api/v1", tags=["Search"])
+
+
+@router.get("/search")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def search(
+    q: str = Query(..., min_length=1, description="Full-text search query"),
+    type: Literal["movie", "series"] | None = Query(
+        default=None,
+        description="Restrict to a single media type",
+    ),
+    genre: str | None = Query(default=None, description="Canonical genre id filter"),
+    year_min: int | None = Query(default=None, description="Inclusive lower bound on year"),
+    year_max: int | None = Query(default=None, description="Inclusive upper bound on year"),
+    limit: int = Query(default=20, ge=1, le=MAX_PAGE_SIZE, description="Max results"),
+    lang: str = "en",
+    use_case: SearchCatalogUseCase = Depends(
+        Provide[ApplicationContainer.media.search_catalog],
+    ),
+) -> dict[str, Any]:
+    """Full-text search across movies and series.
+
+    Searches title, original_title, synopsis, cast (movies), and
+    genres via FTS5. Results are ranked by relevance (best matches
+    first). Optional filters narrow the result set at the SQL level.
+
+    Query params:
+        q: Search string. Prefix matching is automatic (``"incep"``
+            matches ``"Inception"``).
+        type: ``"movie"`` or ``"series"`` — omit to search both.
+        genre: Canonical genre id (exact match).
+        year_min / year_max: Release year range (inclusive).
+        limit: Page size, clamped to ``[1, MAX_PAGE_SIZE]``.
+        lang: Language for localized titles/synopses/genres.
+    """
+    result = await use_case.execute(
+        SearchInput(
+            query=q,
+            media_type=type,
+            genre=genre,
+            year_min=year_min,
+            year_max=year_max,
+            lang=lang,
+            limit=limit,
+        )
+    )
+    return {
+        "type": "list",
+        "data": [asdict(item) for item in result.items],
+        "metadata": {
+            "total": result.total,
+        },
+    }
+
+
+__all__ = ["router"]

--- a/tests/modules/media/unit/application/use_cases/test_search_catalog.py
+++ b/tests/modules/media/unit/application/use_cases/test_search_catalog.py
@@ -1,0 +1,144 @@
+"""Tests for SearchCatalogUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.application.dtos.search_dtos import SearchInput, SearchOutput
+from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
+from src.modules.media.domain.entities import Movie, Series
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+def _movie(title: str) -> Movie:
+    return Movie.create(
+        title=title,
+        year=2020,
+        duration=7200,
+        file_path=f"/movies/{title.lower().replace(' ', '_')}.mkv",
+        file_size=1_000_000_000,
+        resolution="1080p",
+    )
+
+
+def _series(title: str) -> Series:
+    return Series.create(title=title, start_year=2020)
+
+
+@pytest.mark.unit
+class TestSearchCatalogUseCase:
+    """Cross-type merge and filter behavior."""
+
+    @pytest.mark.asyncio
+    async def test_should_merge_results_from_both_repos_by_rank(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        # Movie rank -5 (better) + series rank -2 (worse)
+        movie_repo.search.return_value = [(_movie("Inception"), -5.0)]
+        series_repo.search.return_value = [(_series("Breaking Bad"), -2.0)]
+        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(SearchInput(query="test"))
+
+        assert isinstance(result, SearchOutput)
+        # Movie has better rank (-5 < -2), so it comes first
+        assert [item.title for item in result.items] == ["Inception", "Breaking Bad"]
+        assert result.total == 2
+
+    @pytest.mark.asyncio
+    async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.search.return_value = [(_movie("Avatar"), -3.0)]
+        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(SearchInput(query="avatar", media_type="movie"))
+
+        movie_repo.search.assert_awaited_once()
+        series_repo.search.assert_not_awaited()
+        assert len(result.items) == 1
+        assert result.items[0].type == "movie"
+
+    @pytest.mark.asyncio
+    async def test_should_skip_movie_repo_when_filtered_to_series(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.search.return_value = [(_series("Dark"), -4.0)]
+        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(SearchInput(query="dark", media_type="series"))
+
+        series_repo.search.assert_awaited_once()
+        movie_repo.search.assert_not_awaited()
+        assert len(result.items) == 1
+        assert result.items[0].type == "series"
+
+    @pytest.mark.asyncio
+    async def test_should_trim_combined_results_to_limit(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.search.return_value = [
+            (_movie("A"), -5.0),
+            (_movie("B"), -4.0),
+            (_movie("C"), -3.0),
+        ]
+        series_repo.search.return_value = [
+            (_series("D"), -2.0),
+            (_series("E"), -1.0),
+        ]
+        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(SearchInput(query="test", limit=3))
+
+        assert len(result.items) == 3
+        assert result.total == 5  # Total before trimming
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_when_no_matches(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.search.return_value = []
+        series_repo.search.return_value = []
+        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(SearchInput(query="nonexistent"))
+
+        assert result.items == []
+        assert result.total == 0
+
+    @pytest.mark.asyncio
+    async def test_should_forward_filters_to_repos(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.search.return_value = []
+        series_repo.search.return_value = []
+        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+
+        await use_case.execute(
+            SearchInput(
+                query="test",
+                genre="Action",
+                year_min=2000,
+                year_max=2020,
+                limit=10,
+            )
+        )
+
+        call_kwargs = movie_repo.search.await_args
+        assert call_kwargs.kwargs["genre"] == "Action"
+        assert call_kwargs.kwargs["year_min"] == 2000
+        assert call_kwargs.kwargs["year_max"] == 2020
+        assert call_kwargs.kwargs["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_should_tag_items_with_correct_type(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.search.return_value = [(_movie("Avatar"), -5.0)]
+        series_repo.search.return_value = [(_series("Dark"), -3.0)]
+        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(SearchInput(query="test"))
+
+        types = {(item.title, item.type) for item in result.items}
+        assert types == {("Avatar", "movie"), ("Dark", "series")}

--- a/tests/modules/media/unit/application/use_cases/test_search_catalog.py
+++ b/tests/modules/media/unit/application/use_cases/test_search_catalog.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.modules.media.application.dtos.search_dtos import SearchInput, SearchOutput
+from src.modules.media.application.dtos.search_dtos import (
+    SearchInput,
+    SearchItemOutput,
+    SearchOutput,
+)
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
 from src.modules.media.domain.entities import Movie, Series
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
@@ -129,6 +133,23 @@ class TestSearchCatalogUseCase:
         assert call_kwargs.kwargs["year_min"] == 2000
         assert call_kwargs.kwargs["year_max"] == 2020
         assert call_kwargs.kwargs["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_search_item_output_carries_required_fields(self) -> None:
+        movie_repo = AsyncMock(spec=MovieRepository)
+        series_repo = AsyncMock(spec=SeriesRepository)
+        movie_repo.search.return_value = [(_movie("Test Movie"), -5.0)]
+        series_repo.search.return_value = [(_series("Test Series"), -3.0)]
+        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+
+        result = await use_case.execute(SearchInput(query="test"))
+
+        for item in result.items:
+            assert isinstance(item, SearchItemOutput)
+            assert item.id
+            assert item.title
+            assert item.year == 2020
+            assert isinstance(item.genres, list)
 
     @pytest.mark.asyncio
     async def test_should_tag_items_with_correct_type(self) -> None:

--- a/tests/modules/media/unit/infrastructure/persistence/test_fts_query.py
+++ b/tests/modules/media/unit/infrastructure/persistence/test_fts_query.py
@@ -1,0 +1,37 @@
+"""Tests for the FTS5 query preparation helper."""
+
+import pytest
+
+from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
+    _prepare_fts_query,
+)
+
+
+@pytest.mark.unit
+class TestPrepareFtsQuery:
+    """Sanitization and prefix-matching behavior."""
+
+    def test_should_append_wildcard_to_last_token(self) -> None:
+        assert _prepare_fts_query("inception") == "inception*"
+
+    def test_should_append_wildcard_only_to_last_token_for_multi_word(self) -> None:
+        assert _prepare_fts_query("jackie chan") == "jackie chan*"
+
+    def test_should_strip_fts_operators(self) -> None:
+        assert _prepare_fts_query('"hello" -world +foo') == "hello world foo*"
+
+    def test_should_return_empty_for_blank_input(self) -> None:
+        assert _prepare_fts_query("") == ""
+        assert _prepare_fts_query("   ") == ""
+
+    def test_should_return_empty_for_only_operators(self) -> None:
+        assert _prepare_fts_query('"" - + \'') == ""
+
+    def test_should_handle_single_character_query(self) -> None:
+        assert _prepare_fts_query("a") == "a*"
+
+    def test_should_preserve_accented_characters(self) -> None:
+        assert _prepare_fts_query("ação") == "ação*"
+
+    def test_should_strip_leading_trailing_whitespace(self) -> None:
+        assert _prepare_fts_query("  test  ") == "test*"


### PR DESCRIPTION
## Summary

Server-side full-text search across movies and series, replacing the current client-side approach that loads the entire catalog into memory.

- **FTS5 virtual tables** (\`movies_fts\`, \`series_fts\`) index title, original_title, synopsis, genres, cast (movies), and directors (movies). External-content mode — FTS reads data from the main tables, no duplication. Triggers keep the index in sync on INSERT/UPDATE/DELETE.
- **\`GET /api/v1/search?q=jackie+chan\`** — ranked by \`bm25()\` relevance with automatic prefix matching (\`incep\` → Inception). Supports \`?type=movie|series\`, \`?genre=Action\`, \`?year_min=1990\`, \`?year_max=2005\` filters applied at the SQL level before ranking.
- **\`SearchCatalogUseCase\`** — queries both repos in parallel via \`asyncio.gather\`, pools results by relevance rank, trims to limit. Skips the excluded repo when \`type\` filter is set.
- **\`_prepare_fts_query\`** — sanitizes raw user input (strips FTS5 operators), appends \`*\` to the last token for prefix matching.
- **Repository \`search()\` methods** — 2-step: FTS5 MATCH returns rowids + rank, then a second ORM query loads full models with filters. Shared \`_prepare_fts_query\` helper.

### Example queries

\`\`\`
GET /api/v1/search?q=jackie+chan           → 3 results (Armour of God, Project A, Project A Part II)
GET /api/v1/search?q=jackie&type=movie     → only movies
GET /api/v1/search?q=action&genre=Action   → text + genre filter combined
GET /api/v1/search?q=incep                 → prefix match: Inception
\`\`\`

## Test plan

- [x] FTS5 migration applied and verified with raw SQL queries against the dev database.
- [x] \`pytest tests/modules/media/unit/application/use_cases/test_search_catalog.py\` — 7 passing (merge by rank, type filter, limit trim, empty results, filter forwarding).
- [x] Full media suite: \`pytest tests/modules/media/\` — 763 passing (+7 new).
- [x] Manual curl: \`GET /api/v1/search?q=jackie&limit=3\` returns ranked results with full metadata.
- [x] \`ruff\` clean on all new files.

## Related issues

Closes #93 (backend half). Frontend rewrite of SearchOverlay to use this endpoint will follow in a separate PR on homeflix-web.