### PR TITLE
feat(streaming): add LRU disk eviction to HLS cache

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -60,6 +60,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         event_bus=infrastructure.event_bus,
         tmdb_api_key=config.provided.tmdb_api_key,
         hls_cache_directory=config.provided.hls_cache_directory,
+        hls_cache_max_size_mb=config.provided.hls_cache_max_size_mb,
     )
 
     library = providers.Container(LibraryContainer)

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -65,8 +65,9 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     session = providers.Dependency()
     event_bus = providers.Dependency()
 
-    # Must be wired from parent container (Settings.hls_cache_directory)
+    # Must be wired from parent container (Settings.hls_cache_directory / hls_cache_max_size_mb)
     hls_cache_directory = providers.Dependency(default="./hls_cache")
+    hls_cache_max_size_mb = providers.Dependency(default=5120)
 
     # =========================================================================
     # Repositories
@@ -188,6 +189,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         cache_dir=hls_cache_directory,
         probe_service=media_probe_service,
         enable_eviction=True,
+        max_cache_size_mb=hls_cache_max_size_mb,
     )
 
     # =========================================================================

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -82,6 +82,12 @@ class Settings(BaseSettings):  # type: ignore[misc]
         default="./hls_cache",
         description="Directory to store cached HLS segments",
     )
+    hls_cache_max_size_mb: int = Field(
+        default=5120,
+        description="Maximum HLS cache size in megabytes. When exceeded, "
+        "the least-recently-accessed buckets are deleted until the "
+        "cache fits. Default 5 GB.",
+    )
 
     @field_validator("media_directories", mode="before")
     @classmethod

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -125,10 +125,12 @@ class HlsService:
         probe_service: MediaProbeService | None = None,
         idle_timeout: float = _DEFAULT_IDLE_TIMEOUT,
         enable_eviction: bool = False,
+        max_cache_size_mb: int = 5120,
     ) -> None:
         self._cache_dir = Path(cache_dir)
         self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._probe = probe_service or MediaProbeService()
+        self._max_cache_bytes = max_cache_size_mb * 1024 * 1024
         self._processes: dict[str, list[subprocess.Popen[bytes]]] = {}
         # path_hash → monotonic timestamp of the most recent activity
         # (playlist request OR segment fetch). The eviction loop reads
@@ -154,11 +156,12 @@ class HlsService:
         thread.start()
 
     def _eviction_loop(self) -> None:
-        """Background loop: wake up periodically and evict idle ffmpegs."""
+        """Background loop: wake up periodically and evict idle ffmpegs + LRU cache."""
         while True:
             time.sleep(_EVICTION_INTERVAL)
             try:
                 self.evict_idle()
+                self.evict_lru()
             except Exception:
                 _logger.exception("HLS eviction loop error")
 
@@ -186,6 +189,63 @@ class HlsService:
             self._kill_processes(path_hash)
             with self._lock:
                 self._last_access.pop(path_hash, None)
+            evicted.append(path_hash)
+        return evicted
+
+    def evict_lru(self) -> list[str]:
+        """Delete the least-recently-used cache buckets until total size is within the limit.
+
+        Scans all subdirectories under ``cache_dir``, sums their sizes,
+        and deletes the ones with the oldest ``_last_access`` timestamp
+        (or oldest filesystem mtime if the hash isn't tracked in memory)
+        until the total drops below ``max_cache_size_mb``.
+
+        Active buckets (those with running ffmpeg processes) are skipped
+        to avoid deleting segments a player is currently reading.
+
+        Returns the list of evicted path_hashes (useful for tests).
+        """
+        if self._max_cache_bytes <= 0:
+            return []
+
+        # Scan disk: collect (path_hash, size_bytes, last_access_time)
+        buckets: list[tuple[str, int, float]] = []
+        total_size = 0
+        for entry in self._cache_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            path_hash = entry.name
+            size = sum(f.stat().st_size for f in entry.rglob("*") if f.is_file())
+            total_size += size
+            # Prefer in-memory access time; fall back to directory mtime
+            with self._lock:
+                access_time = self._last_access.get(path_hash, entry.stat().st_mtime)
+            buckets.append((path_hash, size, access_time))
+
+        if total_size <= self._max_cache_bytes:
+            return []
+
+        # Sort by access time ascending — oldest first
+        buckets.sort(key=lambda b: b[2])
+
+        evicted: list[str] = []
+        for path_hash, size, _ in buckets:
+            if total_size <= self._max_cache_bytes:
+                break
+            # Don't evict buckets with active ffmpeg processes
+            with self._lock:
+                if path_hash in self._processes:
+                    continue
+            bucket_path = self._cache_dir / path_hash
+            _logger.info(
+                "LRU evicting cache bucket %s (%.1f MB)",
+                path_hash,
+                size / (1024 * 1024),
+            )
+            shutil.rmtree(bucket_path, ignore_errors=True)
+            with self._lock:
+                self._last_access.pop(path_hash, None)
+            total_size -= size
             evicted.append(path_hash)
         return evicted
 

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -835,3 +835,90 @@ class TestHlsServiceExtractOneSubtitle:
 
         assert event.is_set()
         assert "abc" not in service._subtitle_events
+
+
+@pytest.mark.unit
+class TestEvictLru:
+    """LRU disk eviction behavior."""
+
+    def test_should_delete_oldest_bucket_when_over_limit(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path), max_cache_size_mb=0)
+
+        # Create two buckets: "old" (1 MB, accessed first) and "new" (1 MB, accessed later)
+        old_dir = tmp_path / "old_hash"
+        old_dir.mkdir()
+        (old_dir / "segment.ts").write_bytes(b"\x00" * 1_000_000)
+
+        new_dir = tmp_path / "new_hash"
+        new_dir.mkdir()
+        (new_dir / "segment.ts").write_bytes(b"\x00" * 1_000_000)
+
+        # Simulate access order: old first, new later
+        service._last_access["old_hash"] = 100.0
+        service._last_access["new_hash"] = 200.0
+        # max_cache_size_mb=0 means everything is over limit
+        service._max_cache_bytes = 1_500_000  # 1.5 MB — only room for one
+
+        evicted = service.evict_lru()
+
+        assert "old_hash" in evicted
+        assert not old_dir.exists()
+        assert new_dir.exists()
+
+    def test_should_not_evict_buckets_with_active_processes(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path), max_cache_size_mb=0)
+
+        active_dir = tmp_path / "active"
+        active_dir.mkdir()
+        (active_dir / "segment.ts").write_bytes(b"\x00" * 1_000_000)
+
+        idle_dir = tmp_path / "idle"
+        idle_dir.mkdir()
+        (idle_dir / "segment.ts").write_bytes(b"\x00" * 1_000_000)
+
+        service._last_access["active"] = 100.0
+        service._last_access["idle"] = 200.0
+        # Mark "active" as having running ffmpeg — should be skipped
+        service._processes["active"] = [MagicMock()]
+        service._max_cache_bytes = 1_500_000
+
+        evicted = service.evict_lru()
+
+        # "active" is oldest but has processes — skipped
+        # "idle" is newer but evicted because active can't be
+        assert "active" not in evicted
+        assert active_dir.exists()
+
+    def test_should_not_evict_when_under_limit(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path), max_cache_size_mb=100)
+
+        bucket = tmp_path / "small"
+        bucket.mkdir()
+        (bucket / "segment.ts").write_bytes(b"\x00" * 1000)
+
+        evicted = service.evict_lru()
+
+        assert evicted == []
+        assert bucket.exists()
+
+    def test_should_use_mtime_for_untracked_buckets(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path), max_cache_size_mb=0)
+
+        # Create a bucket NOT in _last_access — should use mtime
+        bucket = tmp_path / "untracked"
+        bucket.mkdir()
+        (bucket / "segment.ts").write_bytes(b"\x00" * 1_000_000)
+        service._max_cache_bytes = 1  # Everything over limit
+
+        evicted = service.evict_lru()
+
+        assert "untracked" in evicted
+        assert not bucket.exists()
+
+    def test_should_return_empty_when_max_size_is_zero_or_negative(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        service._max_cache_bytes = -1
+
+        evicted = service.evict_lru()
+
+        assert evicted == []


### PR DESCRIPTION
## Summary

The HLS segment cache grew unbounded — each \`(file, start_offset)\` pair created a separate bucket that was never cleaned up. Over time this fills the disk, especially with the \`?start=X\` seek feature that multiplies cache entries per media file.

### Changes
- **\`evict_lru()\`** on \`HlsService\` — scans every subdirectory under \`cache_dir\`, sums their sizes, and deletes the least-recently-accessed ones until the total drops below the configured limit.
  - Active buckets (those with running ffmpeg processes) are **skipped** so a currently-playing stream doesn't lose its segments.
  - Untracked buckets (from a previous server session, not in the in-memory \`_last_access\` dict) fall back to filesystem \`mtime\` for access ordering.
- **Daemon integration** — \`evict_lru()\` runs alongside the existing \`evict_idle()\` in the background eviction thread (every 10s).
- **New setting**: \`HLS_CACHE_MAX_SIZE_MB\` (default 5120 = 5 GB). Wired through \`Settings\` → \`ApplicationContainer\` → \`MediaContainer\` → \`HlsService\`.

### Design notes
- The eviction is **synchronous** and runs on the daemon thread. \`shutil.rmtree\` is called with \`ignore_errors=True\` so a locked file (e.g. a segment being read by the HTTP response) doesn't crash the loop.
- The 10-second interval is shared with idle-process eviction — cheap enough because the scan is just \`iterdir() + rglob("*").stat()\` which is O(n) in the number of cached files, bounded by the max cache size.
- Setting \`max_cache_size_mb <= 0\` disables LRU eviction entirely (only idle-process eviction runs).

## Test plan

- [x] 5 new unit tests in \`TestEvictLru\`:
  - Oldest bucket deleted when over limit.
  - Active-process buckets skipped.
  - Under-limit → no eviction.
  - Untracked buckets use mtime fallback.
  - Negative/zero max size disables eviction.
- [x] Full media suite: 777 passed (+5 new).
- [x] \`ruff\` + \`mypy\` clean.

## Related issues

Closes #91.