### PR TITLE
feat(library): add Library CRUD persistence and REST API

### DIFF
--- a/migrations/versions/2026_04_13_add_libraries_table.py
+++ b/migrations/versions/2026_04_13_add_libraries_table.py
@@ -1,0 +1,59 @@
+"""Add libraries table.
+
+Revision ID: a1b2c3d4e5f6
+Revises: 2026_04_12_add_fts5_search
+Create Date: 2026-04-13 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create libraries table."""
+    op.create_table(
+        "libraries",
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("library_type", sa.String(length=20), nullable=False),
+        sa.Column("paths", sa.Text(), nullable=False),
+        sa.Column("language", sa.String(length=10), nullable=False),
+        sa.Column("metadata_providers", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("scan_schedule", sa.String(length=100), nullable=True),
+        sa.Column("settings", sa.Text(), nullable=False, server_default="{}"),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("external_id", sa.String(length=50), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("libraries", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_libraries_deleted_at"), ["deleted_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_libraries_external_id"), ["external_id"], unique=True)
+        batch_op.create_index(
+            batch_op.f("ix_libraries_library_type"), ["library_type"], unique=False
+        )
+
+
+def downgrade() -> None:
+    """Drop libraries table."""
+    op.drop_table("libraries")

--- a/src/config/containers/library.py
+++ b/src/config/containers/library.py
@@ -1,22 +1,71 @@
 """Library bounded context dependency container.
 
-Provides services for the Library module.
+Provides repositories, use cases, and domain services for the
+Library module.
 """
 
 from dependency_injector import containers, providers
 
+from src.modules.library.application.use_cases.create_library import CreateLibraryUseCase
+from src.modules.library.application.use_cases.delete_library import DeleteLibraryUseCase
+from src.modules.library.application.use_cases.get_library_by_id import GetLibraryByIdUseCase
+from src.modules.library.application.use_cases.list_libraries import ListLibrariesUseCase
+from src.modules.library.application.use_cases.update_library import UpdateLibraryUseCase
 from src.modules.library.domain.services.track_selector import TrackSelector
+from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
+    SqlAlchemyLibraryRepository,
+)
 
 
 class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Library bounded context dependencies.
 
     Provides:
+    - Repository implementation (SQLAlchemy)
+    - CRUD use cases
     - Domain services
-
-    A ``session`` dependency will be added here when library
-    persistence is implemented, wired from InfrastructureContainer.
     """
+
+    # Wired from InfrastructureContainer via main container.
+    session = providers.Dependency()
+
+    # =========================================================================
+    # Repositories
+    # =========================================================================
+
+    library_repository = providers.Factory(
+        SqlAlchemyLibraryRepository,
+        session=session,
+    )
+
+    # =========================================================================
+    # Use Cases
+    # =========================================================================
+
+    create_library = providers.Factory(
+        CreateLibraryUseCase,
+        library_repository=library_repository,
+    )
+
+    list_libraries = providers.Factory(
+        ListLibrariesUseCase,
+        library_repository=library_repository,
+    )
+
+    get_library_by_id = providers.Factory(
+        GetLibraryByIdUseCase,
+        library_repository=library_repository,
+    )
+
+    update_library = providers.Factory(
+        UpdateLibraryUseCase,
+        library_repository=library_repository,
+    )
+
+    delete_library = providers.Factory(
+        DeleteLibraryUseCase,
+        library_repository=library_repository,
+    )
 
     # =========================================================================
     # Domain Services

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -63,7 +63,10 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         hls_cache_max_size_mb=config.provided.hls_cache_max_size_mb,
     )
 
-    library = providers.Container(LibraryContainer)
+    library = providers.Container(
+        LibraryContainer,
+        session=infrastructure.session,
+    )
 
     watch_progress = providers.Container(
         WatchProgressContainer,

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,9 @@ from src.config.containers import ApplicationContainer
 from src.config.logging import get_logger, setup_logging
 from src.config.settings import get_settings
 from src.modules.collections.presentation.routes import custom_list_router, watchlist_router
+from src.modules.library.presentation.routes.library_routes import (
+    router as library_router,
+)
 from src.modules.media.presentation.routes import (
     catalog_router,
     enrichment_router,
@@ -73,6 +76,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "src.modules.watch_progress.presentation.routes.progress_routes",
             "src.modules.collections.presentation.routes.watchlist_routes",
             "src.modules.collections.presentation.routes.custom_list_routes",
+            "src.modules.library.presentation.routes.library_routes",
         ],
     )
     app.state.container = container
@@ -159,6 +163,7 @@ def create_app() -> FastAPI:
     app.include_router(progress_router)
     app.include_router(watchlist_router)
     app.include_router(custom_list_router)
+    app.include_router(library_router)
 
     return app
 

--- a/src/modules/library/application/dtos/library_dtos.py
+++ b/src/modules/library/application/dtos/library_dtos.py
@@ -1,0 +1,111 @@
+"""DTOs for Library CRUD use cases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# ── Shared output shapes ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class MetadataProviderOutput:
+    """One entry in the library's metadata-provider chain."""
+
+    provider: str
+    priority: int
+    enabled: bool
+
+
+@dataclass(frozen=True)
+class LibrarySettingsOutput:
+    """Flattened playback / scan settings for one library."""
+
+    preferred_audio_language: str
+    preferred_subtitle_language: str | None
+    subtitle_mode: str
+    generate_thumbnails: bool
+    detect_intros: bool
+    auto_refresh_metadata: bool
+
+
+@dataclass(frozen=True)
+class LibraryOutput:
+    """Full representation of a library — used by get, list, create, update."""
+
+    id: str
+    name: str
+    library_type: str
+    paths: list[str]
+    language: str
+    metadata_providers: list[MetadataProviderOutput]
+    scan_schedule: str | None
+    settings: LibrarySettingsOutput
+
+
+# ── Create ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CreateLibraryInput:
+    """Input for ``CreateLibraryUseCase``."""
+
+    name: str
+    library_type: str
+    paths: list[str]
+    language: str = "en"
+    metadata_providers: list[dict[str, Any]] = field(default_factory=list)
+    scan_schedule: str | None = None
+    settings: dict[str, Any] | None = None
+
+
+# ── Update ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class UpdateLibraryInput:
+    """Input for ``UpdateLibraryUseCase``.
+
+    All fields except ``library_id`` are optional — only supplied
+    fields are updated; omitted fields keep their current value.
+    """
+
+    library_id: str
+    name: str | None = None
+    library_type: str | None = None
+    paths: list[str] | None = None
+    language: str | None = None
+    metadata_providers: list[dict[str, Any]] | None = None
+    scan_schedule: str | None = None
+    settings: dict[str, Any] | None = None
+
+
+# ── Delete ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class DeleteLibraryInput:
+    """Input for ``DeleteLibraryUseCase``."""
+
+    library_id: str
+
+
+# ── Get by ID ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class GetLibraryByIdInput:
+    """Input for ``GetLibraryByIdUseCase``."""
+
+    library_id: str
+
+
+__all__ = [
+    "CreateLibraryInput",
+    "DeleteLibraryInput",
+    "GetLibraryByIdInput",
+    "LibraryOutput",
+    "LibrarySettingsOutput",
+    "MetadataProviderOutput",
+    "UpdateLibraryInput",
+]

--- a/src/modules/library/application/use_cases/_to_output.py
+++ b/src/modules/library/application/use_cases/_to_output.py
@@ -1,0 +1,43 @@
+"""Shared entity → output DTO converter for Library use cases."""
+
+from src.modules.library.application.dtos.library_dtos import (
+    LibraryOutput,
+    LibrarySettingsOutput,
+    MetadataProviderOutput,
+)
+from src.modules.library.domain.entities.library import Library
+
+
+def library_to_output(entity: Library) -> LibraryOutput:
+    """Convert a Library domain entity to its output DTO."""
+    return LibraryOutput(
+        id=str(entity.id),
+        name=entity.name.value,
+        library_type=entity.library_type.value,
+        paths=[p.value for p in entity.paths],
+        language=entity.language.value,
+        metadata_providers=[
+            MetadataProviderOutput(
+                provider=p.provider.value,
+                priority=p.priority,
+                enabled=p.enabled,
+            )
+            for p in entity.metadata_providers
+        ],
+        scan_schedule=entity.scan_schedule,
+        settings=LibrarySettingsOutput(
+            preferred_audio_language=entity.settings.preferred_audio_language.value,
+            preferred_subtitle_language=(
+                entity.settings.preferred_subtitle_language.value
+                if entity.settings.preferred_subtitle_language
+                else None
+            ),
+            subtitle_mode=entity.settings.subtitle_mode.value,
+            generate_thumbnails=entity.settings.generate_thumbnails,
+            detect_intros=entity.settings.detect_intros,
+            auto_refresh_metadata=entity.settings.auto_refresh_metadata,
+        ),
+    )
+
+
+__all__ = ["library_to_output"]

--- a/src/modules/library/application/use_cases/create_library.py
+++ b/src/modules/library/application/use_cases/create_library.py
@@ -1,0 +1,83 @@
+"""CreateLibraryUseCase."""
+
+from typing import Any
+
+from src.modules.library.application.dtos.library_dtos import (
+    CreateLibraryInput,
+    LibraryOutput,
+)
+from src.modules.library.application.use_cases._to_output import library_to_output
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.library.domain.value_objects.library_settings import LibrarySettings
+from src.modules.library.domain.value_objects.library_type import LibraryType
+from src.modules.library.domain.value_objects.metadata_provider import (
+    MetadataProvider,
+    MetadataProviderConfig,
+)
+from src.modules.library.domain.value_objects.subtitle_mode import SubtitleMode
+from src.shared_kernel.value_objects.language_code import LanguageCode
+
+
+class CreateLibraryUseCase:
+    """Create a new library and persist it."""
+
+    def __init__(self, library_repository: LibraryRepository) -> None:
+        self._repo = library_repository
+
+    async def execute(self, input_dto: CreateLibraryInput) -> LibraryOutput:
+        """Create and persist a new Library.
+
+        Args:
+            input_dto: Library creation parameters.
+
+        Returns:
+            The persisted library as a ``LibraryOutput``.
+        """
+        providers = [
+            MetadataProviderConfig(
+                provider=MetadataProvider(p["provider"]),
+                priority=p.get("priority", 1),
+                enabled=p.get("enabled", True),
+            )
+            for p in input_dto.metadata_providers
+        ]
+
+        settings = _build_settings(input_dto.settings) if input_dto.settings else None
+
+        library = Library.create(
+            name=input_dto.name,
+            library_type=LibraryType(input_dto.library_type),
+            paths=input_dto.paths,
+            language=input_dto.language,
+            metadata_providers=providers,
+            settings=settings,
+        )
+        if input_dto.scan_schedule:
+            library = library.with_updates(scan_schedule=input_dto.scan_schedule)
+
+        saved = await self._repo.save(library)
+        return library_to_output(saved)
+
+
+def _build_settings(raw: dict[str, Any]) -> LibrarySettings:
+    """Build a ``LibrarySettings`` VO from a raw dict.
+
+    Missing keys fall back to the VO's own defaults so callers can
+    pass a partial dict (e.g. ``{"subtitle_mode": "always"}``).
+    """
+    kwargs: dict[str, Any] = {}
+    if "preferred_audio_language" in raw:
+        kwargs["preferred_audio_language"] = LanguageCode(raw["preferred_audio_language"])
+    if "preferred_subtitle_language" in raw:
+        val = raw["preferred_subtitle_language"]
+        kwargs["preferred_subtitle_language"] = LanguageCode(val) if val else None
+    if "subtitle_mode" in raw:
+        kwargs["subtitle_mode"] = SubtitleMode(raw["subtitle_mode"])
+    for flag in ("generate_thumbnails", "detect_intros", "auto_refresh_metadata"):
+        if flag in raw:
+            kwargs[flag] = raw[flag]
+    return LibrarySettings(**kwargs)
+
+
+__all__ = ["CreateLibraryUseCase"]

--- a/src/modules/library/application/use_cases/delete_library.py
+++ b/src/modules/library/application/use_cases/delete_library.py
@@ -1,0 +1,34 @@
+"""DeleteLibraryUseCase."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.library.application.dtos.library_dtos import DeleteLibraryInput
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.library.domain.value_objects.library_id import LibraryId
+
+
+class DeleteLibraryUseCase:
+    """Soft-delete a library."""
+
+    def __init__(self, library_repository: LibraryRepository) -> None:
+        self._repo = library_repository
+
+    async def execute(self, input_dto: DeleteLibraryInput) -> None:
+        """Soft-delete a library by id.
+
+        Args:
+            input_dto: Carries the ``library_id``.
+
+        Raises:
+            ResourceNotFoundException: If no non-deleted library
+                matches the id.
+        """
+        library_id = LibraryId(input_dto.library_id)
+        deleted = await self._repo.delete(library_id)
+        if not deleted:
+            raise ResourceNotFoundException.for_resource(
+                "Library",
+                input_dto.library_id,
+            )
+
+
+__all__ = ["DeleteLibraryUseCase"]

--- a/src/modules/library/application/use_cases/get_library_by_id.py
+++ b/src/modules/library/application/use_cases/get_library_by_id.py
@@ -1,0 +1,42 @@
+"""GetLibraryByIdUseCase."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.library.application.dtos.library_dtos import (
+    GetLibraryByIdInput,
+    LibraryOutput,
+)
+from src.modules.library.application.use_cases._to_output import library_to_output
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.library.domain.value_objects.library_id import LibraryId
+
+
+class GetLibraryByIdUseCase:
+    """Fetch a single library by its external id."""
+
+    def __init__(self, library_repository: LibraryRepository) -> None:
+        self._repo = library_repository
+
+    async def execute(self, input_dto: GetLibraryByIdInput) -> LibraryOutput:
+        """Fetch a library or raise if not found.
+
+        Args:
+            input_dto: Carries the ``library_id``.
+
+        Returns:
+            The matching ``LibraryOutput``.
+
+        Raises:
+            ResourceNotFoundException: If the id doesn't match any
+                non-deleted library.
+        """
+        library_id = LibraryId(input_dto.library_id)
+        entity = await self._repo.find_by_id(library_id)
+        if entity is None:
+            raise ResourceNotFoundException.for_resource(
+                "Library",
+                input_dto.library_id,
+            )
+        return library_to_output(entity)
+
+
+__all__ = ["GetLibraryByIdUseCase"]

--- a/src/modules/library/application/use_cases/list_libraries.py
+++ b/src/modules/library/application/use_cases/list_libraries.py
@@ -1,0 +1,24 @@
+"""ListLibrariesUseCase."""
+
+from src.modules.library.application.dtos.library_dtos import LibraryOutput
+from src.modules.library.application.use_cases._to_output import library_to_output
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+
+
+class ListLibrariesUseCase:
+    """Return every non-deleted library."""
+
+    def __init__(self, library_repository: LibraryRepository) -> None:
+        self._repo = library_repository
+
+    async def execute(self) -> list[LibraryOutput]:
+        """List all libraries.
+
+        Returns:
+            List of ``LibraryOutput`` ordered by name.
+        """
+        entities = await self._repo.find_all()
+        return [library_to_output(e) for e in entities]
+
+
+__all__ = ["ListLibrariesUseCase"]

--- a/src/modules/library/application/use_cases/update_library.py
+++ b/src/modules/library/application/use_cases/update_library.py
@@ -1,0 +1,81 @@
+"""UpdateLibraryUseCase."""
+
+from typing import Any
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.library.application.dtos.library_dtos import (
+    LibraryOutput,
+    UpdateLibraryInput,
+)
+from src.modules.library.application.use_cases._to_output import library_to_output
+from src.modules.library.application.use_cases.create_library import _build_settings
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.library.domain.value_objects.library_name import LibraryName
+from src.modules.library.domain.value_objects.library_type import LibraryType
+from src.modules.library.domain.value_objects.metadata_provider import (
+    MetadataProvider,
+    MetadataProviderConfig,
+)
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+
+
+class UpdateLibraryUseCase:
+    """Partially update an existing library."""
+
+    def __init__(self, library_repository: LibraryRepository) -> None:
+        self._repo = library_repository
+
+    async def execute(self, input_dto: UpdateLibraryInput) -> LibraryOutput:
+        """Apply partial updates to a library.
+
+        Only fields present (not ``None``) in the input are changed;
+        the rest keep their current value via ``entity.with_updates``.
+
+        Args:
+            input_dto: The update payload.
+
+        Returns:
+            The updated ``LibraryOutput``.
+
+        Raises:
+            ResourceNotFoundException: If the library doesn't exist.
+        """
+        library_id = LibraryId(input_dto.library_id)
+        entity = await self._repo.find_by_id(library_id)
+        if entity is None:
+            raise ResourceNotFoundException.for_resource(
+                "Library",
+                input_dto.library_id,
+            )
+
+        updates: dict[str, Any] = {}
+        if input_dto.name is not None:
+            updates["name"] = LibraryName(input_dto.name)
+        if input_dto.library_type is not None:
+            updates["library_type"] = LibraryType(input_dto.library_type)
+        if input_dto.paths is not None:
+            updates["paths"] = [FilePath(p) for p in input_dto.paths]
+        if input_dto.language is not None:
+            updates["language"] = LanguageCode(input_dto.language)
+        if input_dto.metadata_providers is not None:
+            updates["metadata_providers"] = [
+                MetadataProviderConfig(
+                    provider=MetadataProvider(p["provider"]),
+                    priority=p.get("priority", 1),
+                    enabled=p.get("enabled", True),
+                )
+                for p in input_dto.metadata_providers
+            ]
+        if input_dto.scan_schedule is not None:
+            updates["scan_schedule"] = input_dto.scan_schedule
+        if input_dto.settings is not None:
+            updates["settings"] = _build_settings(input_dto.settings)
+
+        updated = entity.with_updates(**updates)
+        saved = await self._repo.save(updated)
+        return library_to_output(saved)
+
+
+__all__ = ["UpdateLibraryUseCase"]

--- a/src/modules/library/infrastructure/persistence/mappers/library_mapper.py
+++ b/src/modules/library/infrastructure/persistence/mappers/library_mapper.py
@@ -1,0 +1,151 @@
+"""Mapper between Library domain entity and LibraryModel ORM model."""
+
+import json
+from typing import Any
+
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.library.domain.value_objects.library_name import LibraryName
+from src.modules.library.domain.value_objects.library_settings import LibrarySettings
+from src.modules.library.domain.value_objects.library_type import LibraryType
+from src.modules.library.domain.value_objects.metadata_provider import (
+    MetadataProvider,
+    MetadataProviderConfig,
+)
+from src.modules.library.domain.value_objects.subtitle_mode import SubtitleMode
+from src.modules.library.infrastructure.persistence.models.library_model import LibraryModel
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+
+
+class LibraryMapper:
+    """Bidirectional mapper between Library entity and LibraryModel.
+
+    Complex nested value objects (paths, settings, metadata providers)
+    are serialized to JSON for the Text columns and reconstructed on
+    the way back.  All other fields map 1:1 through their VO's
+    ``.value`` property.
+    """
+
+    @staticmethod
+    def to_model(entity: Library) -> LibraryModel:
+        """Convert Library entity to LibraryModel for persistence.
+
+        Args:
+            entity: The domain Library entity (must have an id).
+
+        Returns:
+            SQLAlchemy LibraryModel ready for ``session.add()``.
+        """
+        if entity.id is None:
+            raise ValueError("Cannot map entity without ID to model")
+
+        return LibraryModel(
+            external_id=str(entity.id),
+            name=entity.name.value,
+            library_type=entity.library_type.value,
+            paths=json.dumps([p.value for p in entity.paths], ensure_ascii=False),
+            language=entity.language.value,
+            metadata_providers=json.dumps(
+                [
+                    {
+                        "provider": p.provider.value,
+                        "priority": p.priority,
+                        "enabled": p.enabled,
+                    }
+                    for p in entity.metadata_providers
+                ],
+                ensure_ascii=False,
+            ),
+            scan_schedule=entity.scan_schedule,
+            settings=json.dumps(
+                {
+                    "preferred_audio_language": entity.settings.preferred_audio_language.value,
+                    "preferred_subtitle_language": (
+                        entity.settings.preferred_subtitle_language.value
+                        if entity.settings.preferred_subtitle_language
+                        else None
+                    ),
+                    "subtitle_mode": entity.settings.subtitle_mode.value,
+                    "generate_thumbnails": entity.settings.generate_thumbnails,
+                    "detect_intros": entity.settings.detect_intros,
+                    "auto_refresh_metadata": entity.settings.auto_refresh_metadata,
+                },
+                ensure_ascii=False,
+            ),
+        )
+
+    @staticmethod
+    def to_entity(model: LibraryModel) -> Library:
+        """Convert LibraryModel to Library domain entity.
+
+        Args:
+            model: The SQLAlchemy LibraryModel.
+
+        Returns:
+            Domain Library entity with reconstructed value objects.
+        """
+        paths_raw: list[str] = json.loads(model.paths)
+        providers_raw: list[dict[str, Any]] = json.loads(model.metadata_providers)
+        settings_raw: dict[str, Any] = json.loads(model.settings)
+
+        return Library(
+            id=LibraryId(model.external_id),
+            name=LibraryName(model.name),
+            library_type=LibraryType(model.library_type),
+            paths=[FilePath(p) for p in paths_raw],
+            language=LanguageCode(model.language),
+            metadata_providers=[
+                MetadataProviderConfig(
+                    provider=MetadataProvider(p["provider"]),
+                    priority=p["priority"],
+                    enabled=p.get("enabled", True),
+                )
+                for p in providers_raw
+            ],
+            scan_schedule=model.scan_schedule,
+            settings=LibrarySettings(
+                preferred_audio_language=LanguageCode(
+                    settings_raw.get("preferred_audio_language", "en"),
+                ),
+                preferred_subtitle_language=(
+                    LanguageCode(settings_raw["preferred_subtitle_language"])
+                    if settings_raw.get("preferred_subtitle_language")
+                    else None
+                ),
+                subtitle_mode=SubtitleMode(
+                    settings_raw.get("subtitle_mode", SubtitleMode.FOREIGN_AUDIO_ONLY.value),
+                ),
+                generate_thumbnails=settings_raw.get("generate_thumbnails", True),
+                detect_intros=settings_raw.get("detect_intros", False),
+                auto_refresh_metadata=settings_raw.get("auto_refresh_metadata", False),
+            ),
+        )
+
+    @staticmethod
+    def update_model(model: LibraryModel, entity: Library) -> LibraryModel:
+        """Apply entity field values onto an existing model.
+
+        Used by ``save()`` when the library already exists in the DB
+        (update path). Only domain-owned fields are touched — the
+        base columns (id, created_at, etc.) stay unchanged.
+
+        Args:
+            model: The existing SQLAlchemy model to update in-place.
+            entity: The domain entity carrying the new state.
+
+        Returns:
+            The same ``model`` reference, mutated.
+        """
+        fresh = LibraryMapper.to_model(entity)
+        model.name = fresh.name
+        model.library_type = fresh.library_type
+        model.paths = fresh.paths
+        model.language = fresh.language
+        model.metadata_providers = fresh.metadata_providers
+        model.scan_schedule = fresh.scan_schedule
+        model.settings = fresh.settings
+        return model
+
+
+__all__ = ["LibraryMapper"]

--- a/src/modules/library/infrastructure/persistence/models/library_model.py
+++ b/src/modules/library/infrastructure/persistence/models/library_model.py
@@ -1,0 +1,47 @@
+"""Library ORM model."""
+
+from sqlalchemy import String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.config.persistence.base import Base
+
+
+class LibraryModel(Base):
+    """SQLAlchemy model for Library aggregate.
+
+    Maps to the 'libraries' table (auto-generated from class name via
+    ``Base.__tablename__``).  Complex nested fields (paths, settings,
+    metadata providers) are stored as JSON text columns — they're read
+    and written as a whole by the mapper, never queried individually,
+    so a JSON column is a better fit than a normalized join table.
+
+    Attributes:
+        name: User-friendly library name.
+        library_type: One of ``movies``, ``series``, ``mixed``.
+        paths: JSON array of directory paths included in this library.
+        language: ISO 639-1 language code for the library's primary
+            content language (e.g. ``en``, ``pt``).
+        metadata_providers: JSON array of
+            ``{provider, priority, enabled}`` objects.
+        scan_schedule: Optional 5-field cron pattern.
+        settings: JSON blob of ``LibrarySettings`` (preferred audio/sub
+            language, subtitle mode, thumbnails, etc.).
+    """
+
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    library_type: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    paths: Mapped[str] = mapped_column(Text, nullable=False)  # JSON array
+    language: Mapped[str] = mapped_column(String(10), nullable=False, default="en")
+    metadata_providers: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    scan_schedule: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    settings: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"<LibraryModel(id={self.id}, external_id={self.external_id!r}, "
+            f"name={self.name!r}, type={self.library_type!r})>"
+        )
+
+
+__all__ = ["LibraryModel"]

--- a/src/modules/library/infrastructure/persistence/repositories/sqlalchemy_library_repository.py
+++ b/src/modules/library/infrastructure/persistence/repositories/sqlalchemy_library_repository.py
@@ -1,0 +1,139 @@
+"""SQLAlchemy implementation of LibraryRepository."""
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.library.infrastructure.persistence.mappers.library_mapper import LibraryMapper
+from src.modules.library.infrastructure.persistence.models.library_model import LibraryModel
+
+
+class SqlAlchemyLibraryRepository(LibraryRepository):
+    """Async SQLAlchemy repository for Library aggregates.
+
+    Follows the same patterns as ``SQLAlchemyMovieRepository``:
+    soft-delete, flush + commit per write, reload after save.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def save(self, library: Library) -> Library:
+        """Persist a library (create or update).
+
+        Generates an external id if the entity doesn't have one yet.
+        On update, field values from the entity overwrite the model;
+        the mapper never touches base columns (id, created_at, etc.).
+
+        Args:
+            library: The Library to persist.
+
+        Returns:
+            The saved Library, re-read from the DB so the caller sees
+            any server-generated values (timestamps, auto-increment id).
+        """
+        library = library.with_updates(
+            id=LibraryId.generate_if_absent(library.id),
+        )
+
+        stmt = select(LibraryModel).where(
+            LibraryModel.external_id == str(library.id),
+        )
+        result = await self._session.execute(stmt)
+        existing = result.scalar_one_or_none()
+
+        if existing is not None and existing.is_deleted:
+            existing.restore()
+
+        if existing is not None:
+            LibraryMapper.update_model(existing, library)
+            await self._session.flush()
+        else:
+            model = LibraryMapper.to_model(library)
+            self._session.add(model)
+            await self._session.flush()
+
+        await self._session.commit()
+
+        assert library.id is not None
+        saved = await self.find_by_id(library.id)
+        assert saved is not None
+        return saved
+
+    async def find_by_id(self, library_id: LibraryId) -> Library | None:
+        """Find a library by its external id.
+
+        Args:
+            library_id: The library's external id (``lib_xxx``).
+
+        Returns:
+            The Library if found and not soft-deleted, ``None`` otherwise.
+        """
+        stmt = select(LibraryModel).where(
+            LibraryModel.external_id == str(library_id),
+            LibraryModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else LibraryMapper.to_entity(model)
+
+    async def find_all(self) -> Sequence[Library]:
+        """List all non-deleted libraries ordered by name.
+
+        Returns:
+            Sequence of libraries (may be empty).
+        """
+        stmt = (
+            select(LibraryModel)
+            .where(LibraryModel.deleted_at.is_(None))
+            .order_by(LibraryModel.name)
+        )
+        result = await self._session.execute(stmt)
+        models = result.scalars().all()
+        return [LibraryMapper.to_entity(m) for m in models]
+
+    async def delete(self, library_id: LibraryId) -> bool:
+        """Soft-delete a library.
+
+        Args:
+            library_id: The library's external id.
+
+        Returns:
+            ``True`` if the library was found and deleted, ``False``
+            if it didn't exist or was already deleted.
+        """
+        stmt = select(LibraryModel).where(
+            LibraryModel.external_id == str(library_id),
+            LibraryModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            return False
+        model.soft_delete()
+        await self._session.flush()
+        await self._session.commit()
+        return True
+
+    async def exists(self, library_id: LibraryId) -> bool:
+        """Check whether a non-deleted library with this id exists.
+
+        Args:
+            library_id: The library's external id.
+
+        Returns:
+            ``True`` if found and not soft-deleted.
+        """
+        stmt = select(LibraryModel.id).where(
+            LibraryModel.external_id == str(library_id),
+            LibraryModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none() is not None
+
+
+__all__ = ["SqlAlchemyLibraryRepository"]

--- a/src/modules/library/presentation/routes/library_routes.py
+++ b/src/modules/library/presentation/routes/library_routes.py
@@ -1,0 +1,121 @@
+"""Library CRUD REST API routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.config.containers import ApplicationContainer
+from src.modules.library.application.dtos.library_dtos import (
+    CreateLibraryInput,
+    DeleteLibraryInput,
+    GetLibraryByIdInput,
+    UpdateLibraryInput,
+)
+from src.modules.library.application.use_cases.create_library import CreateLibraryUseCase
+from src.modules.library.application.use_cases.delete_library import DeleteLibraryUseCase
+from src.modules.library.application.use_cases.get_library_by_id import GetLibraryByIdUseCase
+from src.modules.library.application.use_cases.list_libraries import ListLibrariesUseCase
+from src.modules.library.application.use_cases.update_library import UpdateLibraryUseCase
+from src.modules.library.presentation.schemas.library_schemas import (
+    CreateLibraryRequest,
+    UpdateLibraryRequest,
+)
+
+router = APIRouter(prefix="/api/v1/libraries", tags=["Libraries"])
+
+
+@router.post("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def create_library(
+    body: CreateLibraryRequest,
+    use_case: CreateLibraryUseCase = Depends(
+        Provide[ApplicationContainer.library.create_library],
+    ),
+) -> dict[str, Any]:
+    """Create a new media library."""
+    result = await use_case.execute(
+        CreateLibraryInput(
+            name=body.name,
+            library_type=body.library_type,
+            paths=body.paths,
+            language=body.language,
+            metadata_providers=[p.model_dump() for p in body.metadata_providers],
+            scan_schedule=body.scan_schedule,
+            settings=body.settings.model_dump() if body.settings else None,
+        )
+    )
+    return {"data": asdict(result)}
+
+
+@router.get("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_libraries(
+    use_case: ListLibrariesUseCase = Depends(
+        Provide[ApplicationContainer.library.list_libraries],
+    ),
+) -> dict[str, Any]:
+    """List all non-deleted libraries."""
+    result = await use_case.execute()
+    return {
+        "type": "list",
+        "data": [asdict(lib) for lib in result],
+    }
+
+
+@router.get("/{library_id}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_library(
+    library_id: str,
+    use_case: GetLibraryByIdUseCase = Depends(
+        Provide[ApplicationContainer.library.get_library_by_id],
+    ),
+) -> dict[str, Any]:
+    """Get a library by its external id."""
+    result = await use_case.execute(GetLibraryByIdInput(library_id=library_id))
+    return {"data": asdict(result)}
+
+
+@router.put("/{library_id}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def update_library(
+    library_id: str,
+    body: UpdateLibraryRequest,
+    use_case: UpdateLibraryUseCase = Depends(
+        Provide[ApplicationContainer.library.update_library],
+    ),
+) -> dict[str, Any]:
+    """Partially update a library."""
+    result = await use_case.execute(
+        UpdateLibraryInput(
+            library_id=library_id,
+            name=body.name,
+            library_type=body.library_type,
+            paths=body.paths,
+            language=body.language,
+            metadata_providers=(
+                [p.model_dump() for p in body.metadata_providers]
+                if body.metadata_providers is not None
+                else None
+            ),
+            scan_schedule=body.scan_schedule,
+            settings=body.settings.model_dump() if body.settings else None,
+        )
+    )
+    return {"data": asdict(result)}
+
+
+@router.delete("/{library_id}", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def delete_library(
+    library_id: str,
+    use_case: DeleteLibraryUseCase = Depends(
+        Provide[ApplicationContainer.library.delete_library],
+    ),
+) -> None:
+    """Soft-delete a library."""
+    await use_case.execute(DeleteLibraryInput(library_id=library_id))
+
+
+__all__ = ["router"]

--- a/src/modules/library/presentation/schemas/library_schemas.py
+++ b/src/modules/library/presentation/schemas/library_schemas.py
@@ -1,0 +1,57 @@
+"""Pydantic schemas for Library REST API request/response validation."""
+
+from pydantic import BaseModel, Field
+
+
+class MetadataProviderSchema(BaseModel):
+    """One entry in the metadata-provider chain."""
+
+    provider: str = Field(description="Provider name: tmdb, omdb, or tvdb")
+    priority: int = Field(ge=1, le=10, default=1)
+    enabled: bool = True
+
+
+class LibrarySettingsSchema(BaseModel):
+    """Playback / scan settings for a library."""
+
+    preferred_audio_language: str = "en"
+    preferred_subtitle_language: str | None = None
+    subtitle_mode: str = "foreign"
+    generate_thumbnails: bool = True
+    detect_intros: bool = False
+    auto_refresh_metadata: bool = False
+
+
+class CreateLibraryRequest(BaseModel):
+    """POST /api/v1/libraries body."""
+
+    name: str = Field(min_length=1, max_length=200)
+    library_type: str = Field(description="movies, series, or mixed")
+    paths: list[str] = Field(min_length=1)
+    language: str = "en"
+    metadata_providers: list[MetadataProviderSchema] = Field(default_factory=list)
+    scan_schedule: str | None = None
+    settings: LibrarySettingsSchema | None = None
+
+
+class UpdateLibraryRequest(BaseModel):
+    """PUT /api/v1/libraries/{library_id} body.
+
+    All fields are optional — only supplied fields are updated.
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    library_type: str | None = None
+    paths: list[str] | None = None
+    language: str | None = None
+    metadata_providers: list[MetadataProviderSchema] | None = None
+    scan_schedule: str | None = None
+    settings: LibrarySettingsSchema | None = None
+
+
+__all__ = [
+    "CreateLibraryRequest",
+    "LibrarySettingsSchema",
+    "MetadataProviderSchema",
+    "UpdateLibraryRequest",
+]

--- a/tests/modules/library/unit/application/use_cases/test_create_library.py
+++ b/tests/modules/library/unit/application/use_cases/test_create_library.py
@@ -1,0 +1,84 @@
+"""Tests for CreateLibraryUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.library.application.dtos.library_dtos import CreateLibraryInput
+from src.modules.library.application.use_cases.create_library import CreateLibraryUseCase
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+
+
+def _make_repo() -> AsyncMock:
+    repo = AsyncMock(spec=LibraryRepository)
+    # save echoes back whatever it receives
+    repo.save.side_effect = lambda lib: lib
+    return repo
+
+
+@pytest.mark.unit
+class TestCreateLibraryUseCase:
+    """Unit tests for library creation."""
+
+    @pytest.mark.asyncio
+    async def test_should_create_library_with_generated_id(self) -> None:
+        repo = _make_repo()
+        use_case = CreateLibraryUseCase(repo)
+
+        result = await use_case.execute(
+            CreateLibraryInput(
+                name="Movies",
+                library_type="movies",
+                paths=["/media/movies"],
+            )
+        )
+
+        assert result.name == "Movies"
+        assert result.library_type == "movies"
+        assert result.paths == ["/media/movies"]
+        assert result.id.startswith("lib_")
+        repo.save.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_should_pass_settings_through(self) -> None:
+        repo = _make_repo()
+        use_case = CreateLibraryUseCase(repo)
+
+        result = await use_case.execute(
+            CreateLibraryInput(
+                name="Anime",
+                library_type="series",
+                paths=["/media/anime"],
+                language="ja",
+                settings={
+                    "preferred_audio_language": "ja",
+                    "preferred_subtitle_language": "en",
+                    "subtitle_mode": "always",
+                },
+            )
+        )
+
+        assert result.settings.preferred_audio_language == "ja"
+        assert result.settings.preferred_subtitle_language == "en"
+        assert result.settings.subtitle_mode == "always"
+
+    @pytest.mark.asyncio
+    async def test_should_pass_metadata_providers(self) -> None:
+        repo = _make_repo()
+        use_case = CreateLibraryUseCase(repo)
+
+        result = await use_case.execute(
+            CreateLibraryInput(
+                name="Movies",
+                library_type="movies",
+                paths=["/media/movies"],
+                metadata_providers=[
+                    {"provider": "tmdb", "priority": 1},
+                    {"provider": "omdb", "priority": 2, "enabled": False},
+                ],
+            )
+        )
+
+        assert len(result.metadata_providers) == 2
+        assert result.metadata_providers[0].provider == "tmdb"
+        assert result.metadata_providers[1].enabled is False

--- a/tests/modules/library/unit/application/use_cases/test_delete_library.py
+++ b/tests/modules/library/unit/application/use_cases/test_delete_library.py
@@ -1,0 +1,37 @@
+"""Tests for DeleteLibraryUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.library.application.dtos.library_dtos import DeleteLibraryInput
+from src.modules.library.application.use_cases.delete_library import DeleteLibraryUseCase
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.library.domain.value_objects.library_id import LibraryId
+
+
+@pytest.mark.unit
+class TestDeleteLibraryUseCase:
+    """Unit tests for deleting a library."""
+
+    @pytest.mark.asyncio
+    async def test_should_delete_when_found(self) -> None:
+        repo = AsyncMock(spec=LibraryRepository)
+        repo.delete.return_value = True
+        use_case = DeleteLibraryUseCase(repo)
+        lib_id = str(LibraryId.generate())
+
+        await use_case.execute(DeleteLibraryInput(library_id=lib_id))
+
+        repo.delete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_not_found(self) -> None:
+        repo = AsyncMock(spec=LibraryRepository)
+        repo.delete.return_value = False
+        use_case = DeleteLibraryUseCase(repo)
+        lib_id = str(LibraryId.generate())
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(DeleteLibraryInput(library_id=lib_id))

--- a/tests/modules/library/unit/application/use_cases/test_get_library_by_id.py
+++ b/tests/modules/library/unit/application/use_cases/test_get_library_by_id.py
@@ -1,0 +1,44 @@
+"""Tests for GetLibraryByIdUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.library.application.dtos.library_dtos import GetLibraryByIdInput
+from src.modules.library.application.use_cases.get_library_by_id import (
+    GetLibraryByIdUseCase,
+)
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.library.domain.value_objects.library_id import LibraryId
+
+
+@pytest.mark.unit
+class TestGetLibraryByIdUseCase:
+    """Unit tests for fetching a library by id."""
+
+    @pytest.mark.asyncio
+    async def test_should_return_library_when_found(self) -> None:
+        lib = Library.create(name="Movies", library_type="movies", paths=["/m"])
+        repo = AsyncMock(spec=LibraryRepository)
+        repo.find_by_id.return_value = lib
+        use_case = GetLibraryByIdUseCase(repo)
+
+        result = await use_case.execute(
+            GetLibraryByIdInput(library_id=str(lib.id)),
+        )
+
+        assert result.name == "Movies"
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_not_found(self) -> None:
+        repo = AsyncMock(spec=LibraryRepository)
+        repo.find_by_id.return_value = None
+        use_case = GetLibraryByIdUseCase(repo)
+        lib_id = str(LibraryId.generate())
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                GetLibraryByIdInput(library_id=lib_id),
+            )

--- a/tests/modules/library/unit/application/use_cases/test_list_libraries.py
+++ b/tests/modules/library/unit/application/use_cases/test_list_libraries.py
@@ -1,0 +1,39 @@
+"""Tests for ListLibrariesUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.library.application.use_cases.list_libraries import ListLibrariesUseCase
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+
+
+@pytest.mark.unit
+class TestListLibrariesUseCase:
+    """Unit tests for listing libraries."""
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_list_when_no_libraries(self) -> None:
+        repo = AsyncMock(spec=LibraryRepository)
+        repo.find_all.return_value = []
+        use_case = ListLibrariesUseCase(repo)
+
+        result = await use_case.execute()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_should_return_all_libraries(self) -> None:
+        repo = AsyncMock(spec=LibraryRepository)
+        repo.find_all.return_value = [
+            Library.create(name="Movies", library_type="movies", paths=["/m"]),
+            Library.create(name="Series", library_type="series", paths=["/s"]),
+        ]
+        use_case = ListLibrariesUseCase(repo)
+
+        result = await use_case.execute()
+
+        assert len(result) == 2
+        assert result[0].name == "Movies"
+        assert result[1].name == "Series"


### PR DESCRIPTION
## Summary

Phase 1 of #92 — wire the Library bounded context end-to-end from persistence through presentation. The domain layer (entity, VOs, repository interface, TrackSelector) already existed; this PR adds everything from infrastructure down to routes.

### New files (16)
- **Model**: `LibraryModel` (SQLAlchemy) — JSON columns for paths, settings, metadata_providers.
- **Migration**: `2026_04_13_add_libraries_table.py` — creates `libraries` table with `external_id`, `library_type`, and `deleted_at` indexes.
- **Mapper**: `LibraryMapper` — `to_model` / `to_entity` / `update_model` with JSON ↔ VO conversion.
- **Repository**: `SqlAlchemyLibraryRepository` — implements all 5 interface methods (save, find_by_id, find_all, delete, exists) with soft-delete.
- **DTOs**: `library_dtos.py` — `CreateLibraryInput`, `UpdateLibraryInput`, `DeleteLibraryInput`, `GetLibraryByIdInput`, `LibraryOutput`, `LibrarySettingsOutput`, `MetadataProviderOutput`.
- **Use cases**: `CreateLibrary`, `ListLibraries`, `GetLibraryById`, `UpdateLibrary`, `DeleteLibrary` — each with constructor-injected repo, async `execute`.
- **Schemas**: `CreateLibraryRequest`, `UpdateLibraryRequest` (Pydantic v2, separate file per project convention).
- **Routes**: `GET/POST/PUT/DELETE /api/v1/libraries` and `GET /api/v1/libraries/{library_id}`.
- **Helper**: `_to_output.py` — shared `library_to_output(entity)` converter.

### Modified files (4)
- `config/containers/library.py` — wired `session`, `library_repository`, 5 use case factories.
- `config/containers/main.py` — passes `session` to `LibraryContainer`.
- `main.py` — registers library routes + wiring module.

## Test plan

- [x] 102 library tests passing (93 existing domain + 9 new application use-case tests).
- [x] `ruff check` + `ruff format` + `mypy` clean.
- [x] Import smoke test: `from src.config.containers.main import ApplicationContainer; ApplicationContainer()` succeeds.
- [ ] Manual curl after deploy:
  - [ ] `POST /api/v1/libraries` creates a library, returns `lib_xxx` id.
  - [ ] `GET /api/v1/libraries` lists all.
  - [ ] `GET /api/v1/libraries/{id}` returns single.
  - [ ] `PUT /api/v1/libraries/{id}` partial update.
  - [ ] `DELETE /api/v1/libraries/{id}` returns 204, subsequent GET returns 404.

## Related issues

Part of #92 (Phase 1). Phases 2 (user preferences) and 3 (HLS TrackSelector integration) remain open.