### PR TITLE
feat(preferences): add GET/PUT /api/v1/preferences

### DIFF
--- a/migrations/versions/2026_04_13_add_preferences_table.py
+++ b/migrations/versions/2026_04_13_add_preferences_table.py
@@ -1,0 +1,59 @@
+"""Add preferences table.
+
+Revision ID: b2c3d4e5f6g7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-13 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b2c3d4e5f6g7"
+down_revision: str | Sequence[str] | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create preferences table."""
+    op.create_table(
+        "preferences",
+        sa.Column("user_key", sa.String(length=50), nullable=False),
+        sa.Column("audio_lang", sa.String(length=10), nullable=False, server_default="pt-BR"),
+        sa.Column("subtitle_lang", sa.String(length=10), nullable=False, server_default="pt-BR"),
+        sa.Column(
+            "subtitle_mode", sa.String(length=20), nullable=False, server_default="foreignOnly"
+        ),
+        sa.Column("default_quality", sa.String(length=20), nullable=False, server_default="best"),
+        sa.Column("speed", sa.Float(), nullable=False, server_default="1.0"),
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("external_id", sa.String(length=50), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("preferences", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_preferences_deleted_at"), ["deleted_at"], unique=False)
+        batch_op.create_index(
+            batch_op.f("ix_preferences_external_id"), ["external_id"], unique=True
+        )
+        batch_op.create_index(batch_op.f("ix_preferences_user_key"), ["user_key"], unique=True)
+
+
+def downgrade() -> None:
+    """Drop preferences table."""
+    op.drop_table("preferences")

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -12,6 +12,7 @@ from src.config.containers.collections import CollectionsContainer
 from src.config.containers.infrastructure import InfrastructureContainer
 from src.config.containers.library import LibraryContainer
 from src.config.containers.media import MediaContainer
+from src.config.containers.preferences import PreferencesContainer
 from src.config.containers.watch_progress import WatchProgressContainer
 from src.config.settings import Settings
 
@@ -65,6 +66,11 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     library = providers.Container(
         LibraryContainer,
+        session=infrastructure.session,
+    )
+
+    preferences = providers.Container(
+        PreferencesContainer,
         session=infrastructure.session,
     )
 

--- a/src/config/containers/preferences.py
+++ b/src/config/containers/preferences.py
@@ -1,0 +1,34 @@
+"""Preferences bounded context dependency container."""
+
+from dependency_injector import containers, providers
+
+from src.modules.preferences.application.use_cases.get_preferences import (
+    GetPreferencesUseCase,
+)
+from src.modules.preferences.application.use_cases.update_preferences import (
+    UpdatePreferencesUseCase,
+)
+from src.modules.preferences.infrastructure.persistence.repositories.preferences_repository import (
+    PreferencesRepository,
+)
+
+
+class PreferencesContainer(containers.DeclarativeContainer):  # type: ignore[misc]
+    """Container for Preferences bounded context."""
+
+    session = providers.Dependency()
+
+    preferences_repository = providers.Factory(
+        PreferencesRepository,
+        session=session,
+    )
+
+    get_preferences = providers.Factory(
+        GetPreferencesUseCase,
+        preferences_repository=preferences_repository,
+    )
+
+    update_preferences = providers.Factory(
+        UpdatePreferencesUseCase,
+        preferences_repository=preferences_repository,
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,9 @@ from src.modules.media.presentation.routes import (
     series_router,
     stream_router,
 )
+from src.modules.preferences.presentation.routes.preferences_routes import (
+    router as preferences_router,
+)
 from src.modules.watch_progress.presentation.routes import progress_router
 
 
@@ -77,6 +80,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "src.modules.collections.presentation.routes.watchlist_routes",
             "src.modules.collections.presentation.routes.custom_list_routes",
             "src.modules.library.presentation.routes.library_routes",
+            "src.modules.preferences.presentation.routes.preferences_routes",
         ],
     )
     app.state.container = container
@@ -164,6 +168,7 @@ def create_app() -> FastAPI:
     app.include_router(watchlist_router)
     app.include_router(custom_list_router)
     app.include_router(library_router)
+    app.include_router(preferences_router)
 
     return app
 

--- a/src/modules/preferences/application/dtos/preferences_dtos.py
+++ b/src/modules/preferences/application/dtos/preferences_dtos.py
@@ -1,0 +1,30 @@
+"""DTOs for playback preferences."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PreferencesOutput:
+    """Current playback preferences for the user."""
+
+    audio_lang: str
+    subtitle_lang: str
+    subtitle_mode: str
+    default_quality: str
+    speed: float
+
+
+@dataclass(frozen=True)
+class UpdatePreferencesInput:
+    """Partial update — only non-``None`` fields are applied."""
+
+    audio_lang: str | None = None
+    subtitle_lang: str | None = None
+    subtitle_mode: str | None = None
+    default_quality: str | None = None
+    speed: float | None = None
+
+
+__all__ = ["PreferencesOutput", "UpdatePreferencesInput"]

--- a/src/modules/preferences/application/use_cases/get_preferences.py
+++ b/src/modules/preferences/application/use_cases/get_preferences.py
@@ -1,0 +1,40 @@
+"""GetPreferencesUseCase."""
+
+from src.modules.preferences.application.dtos.preferences_dtos import PreferencesOutput
+from src.modules.preferences.infrastructure.persistence.repositories.preferences_repository import (
+    PreferencesRepository,
+)
+
+
+class GetPreferencesUseCase:
+    """Return the current user's playback preferences.
+
+    If no row exists yet (first visit), returns the column defaults
+    baked into ``PreferencesModel``.
+    """
+
+    def __init__(self, preferences_repository: PreferencesRepository) -> None:
+        self._repo = preferences_repository
+
+    async def execute(self) -> PreferencesOutput:
+        """Fetch or default the user's playback preferences."""
+        model = await self._repo.get()
+        if model is None:
+            # Return defaults — first visit, no row yet.
+            return PreferencesOutput(
+                audio_lang="pt-BR",
+                subtitle_lang="pt-BR",
+                subtitle_mode="foreignOnly",
+                default_quality="best",
+                speed=1.0,
+            )
+        return PreferencesOutput(
+            audio_lang=model.audio_lang,
+            subtitle_lang=model.subtitle_lang,
+            subtitle_mode=model.subtitle_mode,
+            default_quality=model.default_quality,
+            speed=model.speed,
+        )
+
+
+__all__ = ["GetPreferencesUseCase"]

--- a/src/modules/preferences/application/use_cases/update_preferences.py
+++ b/src/modules/preferences/application/use_cases/update_preferences.py
@@ -1,0 +1,36 @@
+"""UpdatePreferencesUseCase."""
+
+from src.modules.preferences.application.dtos.preferences_dtos import (
+    PreferencesOutput,
+    UpdatePreferencesInput,
+)
+from src.modules.preferences.infrastructure.persistence.repositories.preferences_repository import (
+    PreferencesRepository,
+)
+
+
+class UpdatePreferencesUseCase:
+    """Partially update (or create) the user's playback preferences."""
+
+    def __init__(self, preferences_repository: PreferencesRepository) -> None:
+        self._repo = preferences_repository
+
+    async def execute(self, input_dto: UpdatePreferencesInput) -> PreferencesOutput:
+        """Upsert the user's playback preferences."""
+        model = await self._repo.upsert(
+            audio_lang=input_dto.audio_lang,
+            subtitle_lang=input_dto.subtitle_lang,
+            subtitle_mode=input_dto.subtitle_mode,
+            default_quality=input_dto.default_quality,
+            speed=input_dto.speed,
+        )
+        return PreferencesOutput(
+            audio_lang=model.audio_lang,
+            subtitle_lang=model.subtitle_lang,
+            subtitle_mode=model.subtitle_mode,
+            default_quality=model.default_quality,
+            speed=model.speed,
+        )
+
+
+__all__ = ["UpdatePreferencesUseCase"]

--- a/src/modules/preferences/infrastructure/persistence/models/preferences_model.py
+++ b/src/modules/preferences/infrastructure/persistence/models/preferences_model.py
@@ -1,0 +1,33 @@
+"""User preferences ORM model."""
+
+from sqlalchemy import Float, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.config.persistence.base import Base
+
+
+class PreferencesModel(Base):
+    """SQLAlchemy model for user playback preferences.
+
+    Singleton-per-user design: there's exactly one row per
+    ``user_key``. Until an auth system lands the only key is
+    ``"default"`` — all browser sessions share the same prefs.
+
+    Maps to the ``preferences`` table.
+    """
+
+    user_key: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        unique=True,
+        index=True,
+        default="default",
+    )
+    audio_lang: Mapped[str] = mapped_column(String(10), nullable=False, default="pt-BR")
+    subtitle_lang: Mapped[str] = mapped_column(String(10), nullable=False, default="pt-BR")
+    subtitle_mode: Mapped[str] = mapped_column(String(20), nullable=False, default="foreignOnly")
+    default_quality: Mapped[str] = mapped_column(String(20), nullable=False, default="best")
+    speed: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
+
+
+__all__ = ["PreferencesModel"]

--- a/src/modules/preferences/infrastructure/persistence/repositories/preferences_repository.py
+++ b/src/modules/preferences/infrastructure/persistence/repositories/preferences_repository.py
@@ -1,0 +1,76 @@
+"""SQLAlchemy repository for user preferences (singleton-per-user)."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.preferences.infrastructure.persistence.models.preferences_model import (
+    PreferencesModel,
+)
+
+DEFAULT_USER_KEY = "default"
+
+
+class PreferencesRepository:
+    """Read/upsert the preferences row for a given user key.
+
+    Until auth lands, every call uses ``DEFAULT_USER_KEY``.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get(self, user_key: str = DEFAULT_USER_KEY) -> PreferencesModel | None:
+        """Return the preferences row or ``None`` if none exists yet."""
+        stmt = select(PreferencesModel).where(
+            PreferencesModel.user_key == user_key,
+            PreferencesModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def upsert(
+        self,
+        *,
+        user_key: str = DEFAULT_USER_KEY,
+        audio_lang: str | None = None,
+        subtitle_lang: str | None = None,
+        subtitle_mode: str | None = None,
+        default_quality: str | None = None,
+        speed: float | None = None,
+    ) -> PreferencesModel:
+        """Create or update the preferences row.
+
+        Only non-``None`` fields are touched — callers can send a
+        partial update and the rest keeps its current value (or the
+        column default for a brand-new row).
+        """
+        model = await self.get(user_key)
+
+        if model is None:
+            model = PreferencesModel(
+                external_id=f"prf_{user_key}",
+                user_key=user_key,
+            )
+            self._session.add(model)
+
+        if audio_lang is not None:
+            model.audio_lang = audio_lang
+        if subtitle_lang is not None:
+            model.subtitle_lang = subtitle_lang
+        if subtitle_mode is not None:
+            model.subtitle_mode = subtitle_mode
+        if default_quality is not None:
+            model.default_quality = default_quality
+        if speed is not None:
+            model.speed = speed
+
+        await self._session.flush()
+        await self._session.commit()
+
+        # Re-read so we return server-generated timestamps.
+        refreshed = await self.get(user_key)
+        assert refreshed is not None
+        return refreshed
+
+
+__all__ = ["PreferencesRepository"]

--- a/src/modules/preferences/presentation/routes/preferences_routes.py
+++ b/src/modules/preferences/presentation/routes/preferences_routes.py
@@ -1,0 +1,59 @@
+"""Playback preferences REST API routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.config.containers import ApplicationContainer
+from src.modules.preferences.application.dtos.preferences_dtos import (
+    UpdatePreferencesInput,
+)
+from src.modules.preferences.application.use_cases.get_preferences import (
+    GetPreferencesUseCase,
+)
+from src.modules.preferences.application.use_cases.update_preferences import (
+    UpdatePreferencesUseCase,
+)
+from src.modules.preferences.presentation.schemas.preferences_schemas import (
+    UpdatePreferencesRequest,
+)
+
+router = APIRouter(prefix="/api/v1/preferences", tags=["Preferences"])
+
+
+@router.get("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_preferences(
+    use_case: GetPreferencesUseCase = Depends(
+        Provide[ApplicationContainer.preferences.get_preferences],
+    ),
+) -> dict[str, Any]:
+    """Return the current user's playback preferences."""
+    result = await use_case.execute()
+    return {"data": asdict(result)}
+
+
+@router.put("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def update_preferences(
+    body: UpdatePreferencesRequest,
+    use_case: UpdatePreferencesUseCase = Depends(
+        Provide[ApplicationContainer.preferences.update_preferences],
+    ),
+) -> dict[str, Any]:
+    """Partially update (or create) playback preferences."""
+    result = await use_case.execute(
+        UpdatePreferencesInput(
+            audio_lang=body.audio_lang,
+            subtitle_lang=body.subtitle_lang,
+            subtitle_mode=body.subtitle_mode,
+            default_quality=body.default_quality,
+            speed=body.speed,
+        )
+    )
+    return {"data": asdict(result)}
+
+
+__all__ = ["router"]

--- a/src/modules/preferences/presentation/schemas/preferences_schemas.py
+++ b/src/modules/preferences/presentation/schemas/preferences_schemas.py
@@ -1,0 +1,16 @@
+"""Pydantic schemas for preferences REST API."""
+
+from pydantic import BaseModel, Field
+
+
+class UpdatePreferencesRequest(BaseModel):
+    """PUT /api/v1/preferences body. All fields optional."""
+
+    audio_lang: str | None = None
+    subtitle_lang: str | None = None
+    subtitle_mode: str | None = None
+    default_quality: str | None = None
+    speed: float | None = Field(default=None, ge=0.25, le=4.0)
+
+
+__all__ = ["UpdatePreferencesRequest"]


### PR DESCRIPTION
## Summary

Phase 2 of #92 — user playback preferences persisted server-side.

- New \`preferences\` module with a singleton-per-user design (\`user_key = "default"\` until auth lands).
- **Model**: \`PreferencesModel\` — flat columns for \`audio_lang\`, \`subtitle_lang\`, \`subtitle_mode\`, \`default_quality\`, \`speed\`.
- **Repository**: \`PreferencesRepository\` — \`get()\` + \`upsert()\` (partial update, creates row on first write).
- **Use cases**: \`GetPreferencesUseCase\` (returns defaults if no row) + \`UpdatePreferencesUseCase\`.
- **Routes**: \`GET /api/v1/preferences\` + \`PUT /api/v1/preferences\` (partial body).
- **Migration**: \`preferences\` table with \`user_key\` unique index.
- **Container**: \`PreferencesContainer\` wired with session in main.

## Test plan

- [x] Import smoke test passes.
- [x] \`ruff\` + \`ruff format\` + \`mypy\` clean.
- [ ] Manual curl:
  - [ ] \`GET /preferences\` returns defaults on first call.
  - [ ] \`PUT /preferences { "speed": 1.5 }\` creates row, returns full prefs with speed=1.5.
  - [ ] \`PUT /preferences { "audio_lang": "en" }\` updates only audio_lang, rest unchanged.
  - [ ] \`GET /preferences\` reflects all changes.

## Related

Phase 2 of #92. Frontend integration in lucaschf/homeflix-web (pending PR).