### PR TITLE
fix(streaming): eliminate audio silence on resume playback

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -57,6 +57,15 @@ _BROWSER_SAFE_CODECS = {"h264"}
 _MIN_SEGMENTS_FRESH = 1
 _MIN_SEGMENTS_WITH_SEEK = 3
 
+# Seconds of decoded runway before the target position when using
+# the two-pass seek strategy (-ss before -i + -ss after -i). The
+# outer seek jumps cheaply to `start - runway`; the inner seek
+# decodes `runway` seconds so the audio codec is fully primed.
+# 5 seconds is enough for AAC initialization and safely within the
+# typical GOP size. Clamped to start_seconds at the call site so
+# we never seek to a negative position.
+_SEEK_RUNWAY = 5.0
+
 # Idle eviction defaults: kill ffmpeg after this many seconds with no
 # segment requests. Trade-off: short timeout frees CPU faster after the
 # user navigates away, but a paused user beyond this window will see the
@@ -660,12 +669,28 @@ class HlsService:
         audio_map = f"0:a:{primary_idx}"
 
         cmd = ["ffmpeg"]
+        # Two-pass seek: fast (demuxer) + accurate (decoder).
+        # The outer -ss jumps cheaply to a keyframe a few seconds
+        # before the target; the inner -ss (after -i) decodes that
+        # small runway so the AAC encoder has a full codec context
+        # and produces valid audio from frame 0. Without the
+        # runway the first ~2-3 seconds of a resumed playback are
+        # silent because the decoder discards partial packets.
         if start_seconds > 0:
-            cmd.extend(["-ss", str(start_seconds)])
+            runway = min(start_seconds, _SEEK_RUNWAY)
+            cmd.extend(["-ss", str(start_seconds - runway)])
+        cmd.extend(["-i", file_path])
+        if start_seconds > 0:
+            cmd.extend(
+                [
+                    "-ss",
+                    str(runway),
+                    "-avoid_negative_ts",
+                    "make_zero",
+                ]
+            )
         cmd.extend(
             [
-                "-i",
-                file_path,
                 "-map",
                 "0:v:0",
                 "-map",
@@ -708,17 +733,26 @@ class HlsService:
     ) -> list[str]:
         """Build FFmpeg command for audio-only HLS track.
 
-        When ``start_seconds > 0``, ``-ss`` is placed before ``-i`` so the
-        audio track stays aligned with the video track (both start at the
-        same source position).
+        When ``start_seconds > 0``, uses the same two-pass seek
+        strategy as ``_build_video_cmd`` so the audio track starts
+        with a full codec context and stays aligned with the video.
         """
         cmd = ["ffmpeg"]
         if start_seconds > 0:
-            cmd.extend(["-ss", str(start_seconds)])
+            runway = min(start_seconds, _SEEK_RUNWAY)
+            cmd.extend(["-ss", str(start_seconds - runway)])
+        cmd.extend(["-i", file_path])
+        if start_seconds > 0:
+            cmd.extend(
+                [
+                    "-ss",
+                    str(runway),
+                    "-avoid_negative_ts",
+                    "make_zero",
+                ]
+            )
         cmd.extend(
             [
-                "-i",
-                file_path,
                 "-map",
                 f"0:a:{audio_index}",
                 "-vn",

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -73,6 +73,44 @@ _SEEK_RUNWAY = 5.0
 _DEFAULT_IDLE_TIMEOUT = 30.0
 _EVICTION_INTERVAL = 10.0
 
+
+def _build_two_pass_seek_args(
+    start_seconds: float,
+    file_path: str,
+) -> list[str]:
+    """Return FFmpeg args for the two-pass seek strategy.
+
+    When ``start_seconds > 0``:
+      * outer ``-ss`` (before ``-i``): fast demuxer seek to a keyframe
+        a few seconds before the target.
+      * inner ``-ss`` (after ``-i``): accurate decoder seek over the
+        short runway so the AAC encoder has a full codec context.
+      * ``-avoid_negative_ts make_zero``: rebase PTS so both streams
+        start at exactly 0.
+
+    When ``start_seconds <= 0`` (fresh play from the beginning),
+    returns just ``["-i", file_path]`` with no seek flags.
+
+    Shared by both ``_build_video_cmd`` and ``_build_audio_cmd`` so
+    the seek behaviour stays consistent and changes only need to
+    happen in one place.
+    """
+    if start_seconds <= 0:
+        return ["-i", file_path]
+
+    runway = min(start_seconds, _SEEK_RUNWAY)
+    return [
+        "-ss",
+        str(start_seconds - runway),
+        "-i",
+        file_path,
+        "-ss",
+        str(runway),
+        "-avoid_negative_ts",
+        "make_zero",
+    ]
+
+
 _VIDEO_DIR = "video"
 
 # -- Playlist rewriting utilities (used by routes) ----------------------------
@@ -669,26 +707,7 @@ class HlsService:
         audio_map = f"0:a:{primary_idx}"
 
         cmd = ["ffmpeg"]
-        # Two-pass seek: fast (demuxer) + accurate (decoder).
-        # The outer -ss jumps cheaply to a keyframe a few seconds
-        # before the target; the inner -ss (after -i) decodes that
-        # small runway so the AAC encoder has a full codec context
-        # and produces valid audio from frame 0. Without the
-        # runway the first ~2-3 seconds of a resumed playback are
-        # silent because the decoder discards partial packets.
-        if start_seconds > 0:
-            runway = min(start_seconds, _SEEK_RUNWAY)
-            cmd.extend(["-ss", str(start_seconds - runway)])
-        cmd.extend(["-i", file_path])
-        if start_seconds > 0:
-            cmd.extend(
-                [
-                    "-ss",
-                    str(runway),
-                    "-avoid_negative_ts",
-                    "make_zero",
-                ]
-            )
+        cmd.extend(_build_two_pass_seek_args(start_seconds, file_path))
         cmd.extend(
             [
                 "-map",
@@ -738,19 +757,7 @@ class HlsService:
         with a full codec context and stays aligned with the video.
         """
         cmd = ["ffmpeg"]
-        if start_seconds > 0:
-            runway = min(start_seconds, _SEEK_RUNWAY)
-            cmd.extend(["-ss", str(start_seconds - runway)])
-        cmd.extend(["-i", file_path])
-        if start_seconds > 0:
-            cmd.extend(
-                [
-                    "-ss",
-                    str(runway),
-                    "-avoid_negative_ts",
-                    "make_zero",
-                ]
-            )
+        cmd.extend(_build_two_pass_seek_args(start_seconds, file_path))
         cmd.extend(
             [
                 "-map",

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -301,16 +301,19 @@ class TestHlsServiceBuildAudioCmd:
 
         assert "-ss" not in cmd
 
-    def test_should_include_ss_before_input_when_start_is_set(self, tmp_path: Path) -> None:
+    def test_should_use_two_pass_seek_when_start_is_set(self, tmp_path: Path) -> None:
         cmd = HlsService._build_audio_cmd(
             "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=1800.0
         )
 
-        assert "-ss" in cmd
-        ss_idx = cmd.index("-ss")
+        # Outer -ss (fast, before -i): start - runway
+        ss_positions = [i for i, v in enumerate(cmd) if v == "-ss"]
+        assert len(ss_positions) == 2, "Expected two -ss flags (fast + accurate)"
         i_idx = cmd.index("-i")
-        assert ss_idx < i_idx, "-ss must come before -i for fast seek"
-        assert cmd[ss_idx + 1] == "1800.0"
+        assert ss_positions[0] < i_idx, "First -ss must come before -i"
+        assert ss_positions[1] > i_idx, "Second -ss must come after -i"
+        assert cmd[ss_positions[0] + 1] == "1795.0"  # 1800 - 5 runway
+        assert cmd[ss_positions[1] + 1] == "5.0"  # runway
 
 
 @pytest.mark.unit
@@ -356,7 +359,7 @@ class TestHlsServiceBuildVideoCmd:
 
         assert "-ss" not in cmd
 
-    def test_should_include_ss_before_input_when_start_is_set(self, tmp_path: Path) -> None:
+    def test_should_use_two_pass_seek_when_start_is_set(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path / "cache"))
         probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
 
@@ -365,11 +368,13 @@ class TestHlsServiceBuildVideoCmd:
                 "/movies/test.mkv", tmp_path, probe, start_seconds=5400.0
             )
 
-        assert "-ss" in cmd
-        ss_idx = cmd.index("-ss")
+        ss_positions = [i for i, v in enumerate(cmd) if v == "-ss"]
+        assert len(ss_positions) == 2, "Expected two -ss flags (fast + accurate)"
         i_idx = cmd.index("-i")
-        assert ss_idx < i_idx, "-ss must come before -i for fast seek"
-        assert cmd[ss_idx + 1] == "5400.0"
+        assert ss_positions[0] < i_idx, "First -ss must come before -i"
+        assert ss_positions[1] > i_idx, "Second -ss must come after -i"
+        assert cmd[ss_positions[0] + 1] == "5395.0"  # 5400 - 5 runway
+        assert cmd[ss_positions[1] + 1] == "5.0"  # runway
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -306,7 +306,6 @@ class TestHlsServiceBuildAudioCmd:
             "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=1800.0
         )
 
-        # Outer -ss (fast, before -i): start - runway
         ss_positions = [i for i, v in enumerate(cmd) if v == "-ss"]
         assert len(ss_positions) == 2, "Expected two -ss flags (fast + accurate)"
         i_idx = cmd.index("-i")
@@ -314,6 +313,21 @@ class TestHlsServiceBuildAudioCmd:
         assert ss_positions[1] > i_idx, "Second -ss must come after -i"
         assert cmd[ss_positions[0] + 1] == "1795.0"  # 1800 - 5 runway
         assert cmd[ss_positions[1] + 1] == "5.0"  # runway
+        assert "-avoid_negative_ts" in cmd
+        assert cmd[cmd.index("-avoid_negative_ts") + 1] == "make_zero"
+
+    def test_should_clamp_runway_when_start_is_less_than_runway(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd(
+            "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=2.0
+        )
+
+        ss_positions = [i for i, v in enumerate(cmd) if v == "-ss"]
+        assert len(ss_positions) == 2
+        # Outer seek is clamped to 0 so we never seek to a negative position
+        assert cmd[ss_positions[0] + 1] == "0.0"
+        # Inner seek equals the full start_seconds (runway == start)
+        assert cmd[ss_positions[1] + 1] == "2.0"
+        assert "-avoid_negative_ts" in cmd
 
 
 @pytest.mark.unit
@@ -375,6 +389,8 @@ class TestHlsServiceBuildVideoCmd:
         assert ss_positions[1] > i_idx, "Second -ss must come after -i"
         assert cmd[ss_positions[0] + 1] == "5395.0"  # 5400 - 5 runway
         assert cmd[ss_positions[1] + 1] == "5.0"  # runway
+        assert "-avoid_negative_ts" in cmd
+        assert cmd[cmd.index("-avoid_negative_ts") + 1] == "make_zero"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

When resuming playback via \`?start=X\`, the first ~2-3 seconds of audio were silent. The root cause: the single \`-ss\` before \`-i\` (fast demuxer seek) jumps to the nearest video keyframe, but the AAC decoder lacks the codec initialization context from earlier in the stream, so it discards the first few audio packets.

### Fix

Replaced the single-pass fast seek with the standard **two-pass seek** strategy:

\`\`\`
Before: ffmpeg -ss 1800 -i input ...
After:  ffmpeg -ss 1795 -i input -ss 5 -avoid_negative_ts make_zero ...
\`\`\`

1. **Outer \`-ss 1795\`** (before \`-i\`): cheap demuxer-level seek to 5 seconds before the target.
2. **Inner \`-ss 5\`** (after \`-i\`): accurate decode of the 5-second runway, giving the AAC encoder a full codec context.
3. **\`-avoid_negative_ts make_zero\`**: rebases PTS so both streams start at exactly 0.

The 5-second runway (\`_SEEK_RUNWAY\`) is enough for AAC initialization and safely within a typical GOP. Clamped to \`start_seconds\` so we never seek to a negative position. Applied to both the video+audio command and the audio-only command.

### Performance impact

Negligible — decoding 5 extra seconds of content is imperceptible even on low-end hardware. The outer seek still does the heavy lifting.

## Test plan

- [x] 127 streaming unit tests passing (2 tests updated for two-pass seek assertions).
- [x] \`ruff\` + \`ruff format\` + \`mypy\` clean.
- [ ] Manual test: resume a movie from watch progress — audio should start immediately, no silence gap.
- [ ] Verify no regression on fresh play from the beginning (\`start=0\` → single-pass, no runway).

## Summary by Sourcery

Implement two-pass FFmpeg seeking for resumed HLS playback to ensure immediate audio output after seeks while keeping audio and video aligned.

Bug Fixes:
- Resolve initial 2–3 seconds of silence when resuming playback from a non-zero start time in HLS streams.

Enhancements:
- Introduce a configurable seek runway constant used to prime audio codecs during resumed playback.
- Align audio-only HLS commands with video commands by using a shared two-pass seek strategy with PTS rebasing.

Tests:
- Update streaming HLS unit tests to validate the two-pass seek behavior and argument ordering in generated FFmpeg commands.