### PR TITLE
feat(progress): add bulk series progress dismiss endpoint

### DIFF
--- a/src/config/containers/watch_progress.py
+++ b/src/config/containers/watch_progress.py
@@ -8,6 +8,9 @@ from src.modules.watch_progress.application.use_cases import (
     GetProgressUseCase,
     SaveProgressUseCase,
 )
+from src.modules.watch_progress.application.use_cases.clear_series_progress import (
+    ClearSeriesProgressUseCase,
+)
 from src.modules.watch_progress.infrastructure.persistence.repositories import (
     SQLAlchemyWatchProgressRepository,
 )
@@ -56,5 +59,10 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
 
     clear_progress = providers.Factory(
         ClearProgressUseCase,
+        progress_repository=progress_repository,
+    )
+
+    clear_series_progress = providers.Factory(
+        ClearSeriesProgressUseCase,
         progress_repository=progress_repository,
     )

--- a/src/modules/watch_progress/application/use_cases/clear_series_progress.py
+++ b/src/modules/watch_progress/application/use_cases/clear_series_progress.py
@@ -1,0 +1,43 @@
+"""ClearSeriesProgressUseCase - Clear all episode progress for a series."""
+
+from dataclasses import dataclass
+
+from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+
+
+@dataclass(frozen=True)
+class ClearSeriesProgressInput:
+    """Input for ClearSeriesProgressUseCase.
+
+    Attributes:
+        series_id: External series ID (``ser_xxx`` format).
+    """
+
+    series_id: str
+
+
+class ClearSeriesProgressUseCase:
+    """Soft-delete all episode progress entries for a series.
+
+    Used by the "dismiss from Continue Watching" action so that
+    removing a series clears ALL its episode progress at once —
+    otherwise deleting one episode's progress just surfaces the
+    next in-progress episode and the series reappears.
+    """
+
+    def __init__(self, progress_repository: WatchProgressRepository) -> None:
+        self._repo = progress_repository
+
+    async def execute(self, input_dto: ClearSeriesProgressInput) -> int:
+        """Execute the use case.
+
+        Args:
+            input_dto: Contains the series_id.
+
+        Returns:
+            Number of episode progress records soft-deleted.
+        """
+        return await self._repo.delete_by_series(input_dto.series_id)
+
+
+__all__ = ["ClearSeriesProgressUseCase"]

--- a/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
@@ -78,5 +78,20 @@ class WatchProgressRepository(ABC):
             True if deleted, False if not found.
         """
 
+    @abstractmethod
+    async def delete_by_series(self, series_id: str) -> int:
+        """Soft-delete all episode progress for a series.
+
+        Matches every row whose ``media_id`` starts with
+        ``epi_{series_id}_``, which is the composite-id format
+        produced by ``EpisodeCompositeId.build()``.
+
+        Args:
+            series_id: External series ID (``ser_xxx`` format).
+
+        Returns:
+            Number of rows soft-deleted.
+        """
+
 
 __all__ = ["WatchProgressRepository"]

--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -115,5 +115,20 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         await self._session.commit()
         return True
 
+    async def delete_by_series(self, series_id: str) -> int:
+        """Soft-delete all episode progress for a series."""
+        prefix = f"epi_{series_id}_"
+        stmt = select(WatchProgressModel).where(
+            WatchProgressModel.media_id.startswith(prefix),
+            WatchProgressModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        models = result.scalars().all()
+        for model in models:
+            model.soft_delete()
+        if models:
+            await self._session.commit()
+        return len(models)
+
 
 __all__ = ["SQLAlchemyWatchProgressRepository"]

--- a/src/modules/watch_progress/presentation/routes/progress_routes.py
+++ b/src/modules/watch_progress/presentation/routes/progress_routes.py
@@ -23,6 +23,10 @@ from src.modules.watch_progress.application.use_cases import (
 from src.modules.watch_progress.application.use_cases.clear_progress import (
     ClearProgressInput,
 )
+from src.modules.watch_progress.application.use_cases.clear_series_progress import (
+    ClearSeriesProgressInput,
+    ClearSeriesProgressUseCase,
+)
 
 router = APIRouter(prefix="/api/v1/progress", tags=["Watch Progress"])
 
@@ -96,6 +100,24 @@ async def get_progress(
     if result is None:
         return {"type": "progress", "data": None}
     return {"type": "progress", "data": asdict(result)}
+
+
+@router.delete("/series/{series_id}", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def clear_series_progress(
+    series_id: str,
+    use_case: ClearSeriesProgressUseCase = Depends(
+        Provide[ApplicationContainer.watch_progress.clear_series_progress],
+    ),
+) -> Response:
+    """Clear all episode progress for a series.
+
+    Used by the "dismiss from Continue Watching" action so removing
+    a series clears ALL its episode progress at once — otherwise
+    deleting one episode's progress just surfaces the next.
+    """
+    await use_case.execute(ClearSeriesProgressInput(series_id=series_id))
+    return Response(status_code=204)
 
 
 @router.delete("/{media_id}", status_code=204)  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- Add \`DELETE /api/v1/progress/series/{series_id}\` — bulk soft-deletes all episode progress for a series.
- New \`delete_by_series(series_id)\` method on \`WatchProgressRepository\` — matches rows whose \`media_id\` starts with \`epi_{series_id}_\`.
- New \`ClearSeriesProgressUseCase\`.
- Route registered BEFORE \`DELETE /progress/{media_id}\` so FastAPI doesn't match \`series\` as a media_id path param.

## Why
Dismissing a series from "Continue Watching" was deleting only the shown episode's progress — the next in-progress episode would surface and the series reappeared. This endpoint clears ALL episode progress at once.

## Test plan
- [x] \`ruff\` + \`mypy\` clean.
- [x] Manual test: dismiss series from continue watching — series disappears, doesn't reappear.
- [x] Movie dismiss still works (uses the existing single-item endpoint).