### PR TITLE
fix(streaming): use accurate seek for subtitle extraction

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -806,19 +806,27 @@ class HlsService:
         or timeout) and gets a chance to respond — typically with a 404 if
         extraction never produced a file.
 
-        When ``start_seconds > 0``, ``-ss`` is applied so subtitle timestamps
-        are rebased to match the trimmed video output (both start at 0).
+        When ``start_seconds > 0``, ``-ss`` is placed **after** ``-i``
+        (accurate decoder-level seek) so subtitle timestamps are
+        frame-accurate with the video. Unlike video/audio, subtitle
+        extraction is a one-shot background operation with negligible
+        data to decode, so accurate seek has no measurable cost.
 
-        Note: ffmpeg is invoked with two separate inline literal-list calls
-        (embedded vs external) instead of building one ``cmd`` variable so
-        the static-analysis rule against passing a non-literal command to
-        ``subprocess.run`` stays happy. The arguments themselves still come
-        from validated repository paths.
+        The old code placed ``-ss`` before ``-i`` (fast demuxer seek)
+        which landed on the nearest keyframe — typically 1-5 seconds
+        off — causing subtitles to be out of sync with the video.
+
+        Note: ffmpeg is invoked with two separate inline literal-list
+        calls (embedded vs external) instead of building one ``cmd``
+        variable so the static-analysis rule against passing a
+        non-literal command to ``subprocess.run`` stays happy.
         """
         try:
             sub_dir = output_dir / f"sub_{track.index}"
             sub_dir.mkdir(exist_ok=True)
             vtt_path = sub_dir / "sub.vtt"
+            # Accurate seek: -ss AFTER -i so the decoder processes
+            # from the start and trims precisely at the target second.
             ss_args = ["-ss", str(start_seconds)] if start_seconds > 0 else []
 
             if track.is_external:
@@ -830,9 +838,9 @@ class HlsService:
                     subprocess.run(
                         [
                             "ffmpeg",
-                            *ss_args,
                             "-i",
                             input_arg,
+                            *ss_args,
                             "-c:s",
                             "webvtt",
                             "-loglevel",
@@ -853,9 +861,9 @@ class HlsService:
                     subprocess.run(
                         [
                             "ffmpeg",
-                            *ss_args,
                             "-i",
                             file_path,
+                            *ss_args,
                             "-map",
                             f"0:s:{track.index}",
                             "-c:s",

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -839,8 +839,10 @@ class TestHlsServiceExtractOneSubtitle:
         assert "-ss" in cmd
         ss_index = cmd.index("-ss")
         assert cmd[ss_index + 1] == "42.0"
-        # -ss must come before -i for fast demuxer-level seek
-        assert cmd.index("-ss") < cmd.index("-i")
+        # -ss must come AFTER -i for accurate decoder-level seek
+        # (subtitles are text — accurate seek has negligible cost
+        # and keeps subs in sync with the two-pass video seek)
+        assert cmd.index("-ss") > cmd.index("-i")
 
     def test_kill_processes_should_release_subtitle_waiters(self, tmp_path: Path) -> None:
         import threading


### PR DESCRIPTION
## Summary

Subtitles were out of sync with video on resume playback. The subtitle extraction used fast seek (\`-ss\` before \`-i\`) which lands on the nearest keyframe — typically 1-5 seconds off. Meanwhile, video/audio now use two-pass accurate seek (PR #99), so the offset between them was noticeable.

### Fix

Moved \`-ss\` from **before** \`-i\` to **after** \`-i\` in both the embedded and external subtitle extraction paths. This makes FFmpeg do an accurate decoder-level seek instead of a fast demuxer-level seek.

\`\`\`
Before: ffmpeg -ss 1800 -i input -c:s webvtt output.vtt  (fast, ~1-5s off)
After:  ffmpeg -i input -ss 1800 -c:s webvtt output.vtt  (accurate, frame-exact)
\`\`\`

### Performance

Zero concern — subtitle extraction is:
- Text-only data (no video/audio to decode)
- Run in a background thread (doesn't block playback)
- A one-shot operation (not streaming segments)

FFmpeg can seek through text tracks essentially instantly even in accurate mode.

## Test plan

- [x] 128 streaming tests passing (1 test updated for new \`-ss\` position).
- [x] \`ruff\` + \`mypy\` clean.
- [ ] Manual test: resume a movie with subtitles enabled — subs should be in sync from the first line. **Remember to clear the HLS cache** so the new extraction runs.