### PR TITLE
docs: add project roadmap and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ HomeFlix is a self-hosted media server that allows you to:
 | Layer | Technology |
 |-------|------------|
 | Backend | Python 3.12+, FastAPI, SQLAlchemy 2.0, Pydantic v2 |
-| Frontend | React 18+, TypeScript, TanStack Query, Video.js |
+| Frontend | React 18+, TypeScript, TanStack Query, MUI, hls.js |
 | Database | SQLite (dev) / PostgreSQL (prod) |
 | External APIs | TMDB, OMDb |
 
@@ -49,8 +49,15 @@ src/
 │   │   ├── application/
 │   │   ├── infrastructure/
 │   │   └── presentation/
-│   └── library/          # Bounded Context: Library Configuration
-│       └── domain/
+│   ├── library/          # Bounded Context: Library Configuration
+│   │   ├── domain/
+│   │   ├── application/
+│   │   ├── infrastructure/
+│   │   └── presentation/
+│   └── preferences/      # Bounded Context: Playback Preferences
+│       ├── application/
+│       ├── infrastructure/
+│       └── presentation/
 ├── infrastructure/       # Shared infra (database, Base model)
 ├── config/               # Settings, DI containers
 └── main.py
@@ -171,45 +178,43 @@ Commit messages follow [Conventional Commits](https://www.conventionalcommits.or
 ## Documentation
 
 - [Requirements](docs/homeflix-requirements.md) - Full feature specifications
+- [Roadmap](docs/roadmap.md) - Feature prioritization and next steps
 - [ADRs](docs/adr/) - Architecture Decision Records
 - [API Standards](docs/standards/) - Response format, exceptions, i18n
 
 ## Project Status
 
-🚧 **Phase 1: Foundation** - In Progress
+**Phase 1: Foundation** — Complete
 
-### Completed
+- 52 REST API endpoints across 5 bounded contexts
+- 1 450+ tests
+- Responsive React frontend with HLS player
 
-- [x] Project structure with Screaming Architecture (ADR-008)
-- [x] Building blocks (DomainModel, Entity, AggregateRoot, ValueObject, error hierarchy)
-- [x] Domain events and in-process event bus
-- [x] Dependency injection with `dependency-injector` (ADR-004)
-- [x] Pre-commit hooks (ruff, mypy, conventional commits)
-- [x] CI pipeline
-- [x] Database migrations (Alembic)
-- [x] **Media Catalog** module
-  - [x] Entities: Movie, Series, Season, Episode with FileVariantMixin
-  - [x] MediaFile variants with multiple resolutions (ADR-006)
-  - [x] Filesystem scanning and media discovery
-  - [x] TMDB/OMDb metadata enrichment (auto-enrich via domain events)
-  - [x] REST API: CRUD, scan, enrichment, streaming, featured content
-  - [x] HLS streaming with multi-audio/subtitle support
-- [x] **Collections** module
-  - [x] Watchlist (toggle, check, list)
-  - [x] Custom lists (create, rename, delete, add/remove items)
-- [x] **Watch Progress** module
-  - [x] Save/get/clear progress
-  - [x] Continue watching
-- [x] **Library** module (domain layer only, ADR-005)
-  - [x] Library entity, settings, TrackSelector service
+### Modules
 
-### Next Steps
+| Module | Scope | Highlights |
+|--------|-------|------------|
+| **Media Catalog** | Movies, Series, Seasons, Episodes | File variants (ADR-006), HLS streaming, multi-audio/subtitle, FTS5 search, TMDB enrichment, filesystem scanner |
+| **Library** | Media source configuration | CRUD, metadata providers, scan settings, TrackSelector service (ADR-005) |
+| **Watch Progress** | Playback tracking | Save/resume, continue watching, auto-complete at 90% |
+| **Collections** | Watchlist & Custom Lists | Toggle watchlist, up to 10 custom lists with ordering |
+| **Preferences** | Playback settings | Audio/subtitle language, subtitle mode, quality, speed |
 
-- [ ] Frontend (React + TypeScript)
-- [ ] User authentication
-- [ ] Full-text search
+### Frontend ([homeflix-web](https://github.com/lucaschf/homeflix-web))
 
-See [homeflix-requirements.md](docs/homeflix-requirements.md) for the complete roadmap.
+- Hero carousel, genre browsing, full-text search with recent history
+- HLS player: multi-audio, multi-subtitle with smart modes, quality selector, playback speed, keyboard shortcuts, auto-advance
+- Continue watching, watchlist, custom lists, settings
+- i18n (pt-BR + en), responsive mobile-first design
+
+### What's Next
+
+See [docs/roadmap.md](docs/roadmap.md) for the full roadmap. Up next:
+
+- **Phase 2**: Docker, primitive obsession cleanup, scheduled scan, subtitle appearance fix
+- **Phase 3**: Trickplay thumbnails, hardware transcoding, skip intro detection
+- **Phase 4**: Multi-user authentication and permissions
+- **Phase 5**: Webhooks and observability
 
 ## License
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,176 @@
+# HomeFlix — Roadmap
+
+> Last updated: 2026-04-13
+
+This roadmap captures **what comes next** after the Phase 1 foundation.
+Items are ordered so each tier builds on the previous one — both in
+infrastructure (later items reuse plumbing from earlier ones) and in
+the architectural patterns they exercise.
+
+The guiding principle: HomeFlix is a **learning lab** first and a
+**personal tool** second. Features are selected when they score high
+on at least one axis — ideally both. Features that would turn the
+project into a feature-replication exercise without teaching new
+patterns are explicitly excluded.
+
+---
+
+## Current state (Phase 1 — Foundation)
+
+Completed:
+
+- Media catalog (Movie, Series, Season, Episode) with Clean Architecture
+- Library CRUD with metadata provider config and scan settings
+- HLS streaming with FFmpeg (multi-audio, multi-subtitle, resume)
+- Watch progress tracking and "Continue Watching"
+- Collections (Watchlist + Custom Lists up to 10)
+- Playback preferences API (audio/subtitle lang, mode, quality, speed)
+- Full-text search (FTS5 with BM25 ranking)
+- Genre browsing with cursor pagination
+- TMDB metadata enrichment (single + bulk)
+- Media file variants (multiple resolutions per media)
+- Responsive React frontend with MUI, TanStack Query, hls.js player
+- i18n (pt-BR + en)
+- 52 REST API endpoints, 1 450+ tests
+
+---
+
+## Phase 2 — Hardening & Infrastructure
+
+Focus: solidify what exists, build shared infrastructure that later
+features depend on.
+
+### 2.1 Docker & Compose
+
+| | |
+|---|---|
+| **Teaches** | Multi-stage builds, containerization, infra as code |
+| **Unlocks** | Reproducible dev env, CI pipeline, easy deployment |
+| **Scope** | Dockerfile (backend), docker-compose with SQLite volume, optional PostgreSQL profile |
+
+### 2.2 Primitive Obsession Cleanup
+
+| | |
+|---|---|
+| **Teaches** | Value Object design, domain modeling discipline |
+| **Unlocks** | Stronger type safety, self-documenting domain |
+| **Scope** | Audit codebase for raw `str`, `int`, `float` that carry domain meaning; extract to Value Objects in `shared_kernel` or module-level `value_objects` |
+
+### 2.3 Scheduled Scan (Background Jobs)
+
+| | |
+|---|---|
+| **Teaches** | Task scheduling, background workers, async job lifecycle |
+| **Unlocks** | Foundation for trickplay generation, auto-enrichment, any future async pipeline |
+| **Scope** | Cron-like scheduler (APScheduler or similar), library scan on configurable interval, job status endpoint |
+
+### 2.4 Subtitle Appearance (fix)
+
+| | |
+|---|---|
+| **Teaches** | Browser text rendering pipeline, WebVTT spec, HLS.js internals |
+| **Unlocks** | Readable subtitles with user-chosen colors/size |
+| **Scope** | Investigate why `::cue` and custom overlay both failed; likely requires understanding HLS.js text track lifecycle in depth |
+
+---
+
+## Phase 3 — Player & Streaming Evolution
+
+Focus: bring the playback experience closer to commercial quality.
+
+### 3.1 Trickplay (Thumbnail Scrub)
+
+| | |
+|---|---|
+| **Teaches** | Heavy async processing pipeline, sprite sheet generation, FFmpeg image extraction, BIF/WebVTT-thumbnails spec |
+| **Unlocks** | Visual seek — the single biggest UX gap in the player |
+| **Scope** | Background job generates thumbnail grid per media file; player shows thumbnails on hover over seek bar |
+| **Depends on** | 2.3 (background jobs) |
+
+### 3.2 Hardware Transcoding (VAAPI / NVENC)
+
+| | |
+|---|---|
+| **Teaches** | FFmpeg hardware acceleration, capability detection, fallback chains |
+| **Unlocks** | 4K HEVC playback without melting the CPU |
+| **Scope** | Detect available HW encoders at startup, prefer HW pipeline in HLS generation, graceful fallback to software |
+| **Depends on** | 2.1 (Docker — GPU passthrough config) |
+
+### 3.3 Skip Intro Detection
+
+| | |
+|---|---|
+| **Teaches** | Audio fingerprinting (Chromaprint), cross-episode matching algorithms |
+| **Unlocks** | "Skip Intro" button during playback |
+| **Scope** | Analyze first 5 min of each episode in a season, find common audio segment, store start/end timestamps, player shows skip button |
+| **Depends on** | 2.3 (background jobs) |
+
+---
+
+## Phase 4 — Multi-User & Access Control
+
+Focus: make HomeFlix usable by more than one person on the network.
+
+### 4.1 Authentication (JWT)
+
+| | |
+|---|---|
+| **Teaches** | JWT lifecycle, refresh tokens, middleware auth, secure password storage |
+| **Unlocks** | Per-user state isolation |
+| **Scope** | Register/login endpoints, JWT access + refresh tokens, auth middleware, per-user preferences and progress |
+
+### 4.2 User Profiles & Permissions
+
+| | |
+|---|---|
+| **Teaches** | Row-level filtering, RBAC, multi-tenant patterns |
+| **Unlocks** | Parental controls, library-level access |
+| **Scope** | Admin vs. regular user roles, library visibility per user, content rating restrictions |
+
+---
+
+## Phase 5 — Observability & Resilience
+
+Focus: production-grade operational visibility.
+
+### 5.1 Webhooks & Notifications
+
+| | |
+|---|---|
+| **Teaches** | Event-driven architecture, outbox pattern, external integrations |
+| **Unlocks** | "Scan complete" notifications, integration with Telegram/Discord bots |
+| **Scope** | Domain events → outbox table → webhook dispatcher; configurable endpoints per event type |
+
+### 5.2 Structured Logging & Metrics
+
+| | |
+|---|---|
+| **Teaches** | Correlation IDs, structured JSON logs, Prometheus metrics |
+| **Unlocks** | Debugging production issues, performance monitoring |
+| **Scope** | Request-scoped correlation ID, structured log format, basic Prometheus endpoint (request count, latency, transcoding queue) |
+
+---
+
+## Explicitly excluded
+
+These features were evaluated and intentionally left out:
+
+| Feature | Reason |
+|---|---|
+| Live TV & DVR | Completely different domain, enormous complexity, low personal utility |
+| Music / Photos / Books | Scope creep — better served by Navidrome, Immich, Kavita respectively |
+| Plugin system | Over-engineering for a personal project; high maintenance cost for low return |
+| Native mobile/TV apps | Disproportionate investment — responsive web already covers the use case |
+| DLNA | Legacy protocol with poor UX; Chromecast superseded it |
+| SSO / LDAP | Enterprise-scale concern; overkill for a home server |
+| Remote streaming (WAN) | Reverse proxy is an infra concern, not an app feature; can be added externally |
+
+---
+
+## How to read this document
+
+- **Phases are sequential** but items within a phase can be parallelized.
+- **"Depends on"** links indicate hard prerequisites.
+- **"Teaches"** captures the architectural learning objective.
+- **"Unlocks"** captures the user-facing or infra value.
+- This document is updated as items are completed or re-prioritized.


### PR DESCRIPTION
## Summary

- Add `docs/roadmap.md` with phased feature plan (phases 2-5) prioritizing learning value and user impact
- Update README to reflect current project state — Phase 1 is complete with 52 endpoints, 1 450+ tests, and a responsive frontend
- Add roadmap reference to documentation table

## Test plan

- [x] Verify roadmap renders correctly on GitHub
- [x] Verify README links resolve
- [x] No code changes — documentation only

## Summary by Sourcery

Document the current Phase 1 project status and introduce a structured roadmap for future phases.

Documentation:
- Add a detailed roadmap document outlining post-Phase 1 priorities and learning goals.
- Update README to reflect completed Phase 1 functionality, modules, and frontend capabilities, and to reference the new roadmap.
- Refresh technology stack and bounded context descriptions in the README to match the current architecture.