### PR TITLE
refactor(domain): extract value objects from domain primitives

### DIFF
--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -11,6 +11,7 @@ from src.modules.media.application.ports import MediaMetadata, MetadataProvider
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
 from src.modules.media.domain.value_objects import (
+    ContentRating,
     Duration,
     Genre,
     ImageUrl,
@@ -199,7 +200,7 @@ def _apply_credits(
     if metadata.writers and not movie.writers:
         updates["writers"] = [p.name for p in metadata.writers]
     if metadata.content_rating and not movie.content_rating:
-        updates["content_rating"] = metadata.content_rating
+        updates["content_rating"] = ContentRating(metadata.content_rating)
     if metadata.trailer_url and not movie.trailer_url:
         updates["trailer_url"] = metadata.trailer_url
     if metadata.localized:

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -20,6 +20,7 @@ from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import (
     AirDate,
+    ContentRating,
     Duration,
     Genre,
     ImageUrl,
@@ -192,7 +193,7 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
             "genres": ("genres", lambda v: [Genre(g) for g in v]),
             "poster_url": ("poster_path", ImageUrl),
             "backdrop_url": ("backdrop_path", ImageUrl),
-            "content_rating": ("content_rating", None),
+            "content_rating": ("content_rating", ContentRating),
             "trailer_url": ("trailer_url", None),
         },
     )
@@ -211,11 +212,11 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
 
 def _enrich_seasons(series: Series, season_metas: list[SeasonMetadata]) -> Series:
     """Enrich existing seasons with metadata."""
-    meta_by_num = {s.season_number: s for s in season_metas}
+    meta_by_num = {s.season_number: s for s in season_metas}  # int keys from API
 
     new_seasons = []
     for season in series.seasons:
-        meta = meta_by_num.get(season.season_number)
+        meta = meta_by_num.get(season.season_number.value)
         enriched = _apply_season_metadata(season, meta) if meta else season
         new_seasons.append(enriched)
 
@@ -240,8 +241,8 @@ def _apply_season_metadata(season: Season, meta: SeasonMetadata) -> Season:
 
     # Enrich episodes — track TMDB index separately to handle multi-segment files
     if meta.episodes:
-        ep_by_num = {e.episode_number: e for e in meta.episodes}
-        sorted_episodes = sorted(season.episodes, key=lambda e: e.episode_number)
+        ep_by_num = {e.episode_number: e for e in meta.episodes}  # int keys from API
+        sorted_episodes = sorted(season.episodes, key=lambda e: e.episode_number.value)
         tmdb_idx = 1  # TMDB episode numbering starts at 1
         new_episodes = []
         for ep in sorted_episodes:
@@ -294,7 +295,7 @@ def _apply_multi_episode_metadata(
         segment_count: Number of TMDB episodes in this file.
         tmdb_start: Starting TMDB episode number (if None, uses episode.episode_number).
     """
-    start = tmdb_start if tmdb_start is not None else episode.episode_number
+    start = tmdb_start if tmdb_start is not None else episode.episode_number.value
     metas = [ep_by_num.get(start + i) for i in range(segment_count)]
     present = [m for m in metas if m is not None]
 

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -74,7 +74,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=movie.duration.format_hms(),
             genres=movie.get_genres(lang),
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
-            content_rating=movie.content_rating,
+            content_rating=movie.content_rating.value if movie.content_rating else None,
             trailer_url=movie.trailer_url,
         )
 
@@ -90,7 +90,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=None,
             genres=series.get_genres(lang),
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-            content_rating=series.content_rating,
+            content_rating=series.content_rating.value if series.content_rating else None,
             trailer_url=series.trailer_url,
         )
 

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -77,7 +77,7 @@ class GetMovieByIdUseCase:
             cast=movie.cast,
             directors=movie.directors,
             writers=movie.writers,
-            content_rating=movie.content_rating,
+            content_rating=movie.content_rating.value if movie.content_rating else None,
             trailer_url=movie.trailer_url,
             file_path=primary.file_path.value if primary else None,
             file_size=primary.file_size if primary else None,

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -67,7 +67,9 @@ class GetSeriesByIdUseCase:
 
         series_id_str = str(series.id)
         composite_ids = [
-            EpisodeCompositeId.build(series_id_str, s.season_number, ep.episode_number).media_id
+            EpisodeCompositeId.build(
+                series_id_str, s.season_number.value, ep.episode_number.value
+            ).media_id
             for s in series.seasons
             for ep in s.episodes
         ]
@@ -103,7 +105,7 @@ class GetSeriesByIdUseCase:
             poster_path=series.poster_path.value if series.poster_path else None,
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
             genres=series.get_genres(lang),
-            content_rating=series.content_rating,
+            content_rating=series.content_rating.value if series.content_rating else None,
             trailer_url=series.trailer_url,
             tmdb_id=series.tmdb_id.value if series.tmdb_id else None,
             imdb_id=series.imdb_id.value if series.imdb_id else None,
@@ -132,7 +134,7 @@ class GetSeriesByIdUseCase:
         """
         return SeasonOutput(
             id=str(season.id) if season.id else None,
-            season_number=season.season_number,
+            season_number=season.season_number.value,
             title=season.title.value if season.title else None,
             synopsis=season.synopsis,
             poster_path=season.poster_path.value if season.poster_path else None,
@@ -142,7 +144,7 @@ class GetSeriesByIdUseCase:
                 GetSeriesByIdUseCase._to_episode_output(
                     e,
                     series_id,
-                    season.season_number,
+                    season.season_number.value,
                     progress_map,
                 )
                 for e in season.episodes
@@ -171,12 +173,12 @@ class GetSeriesByIdUseCase:
         composite_key = EpisodeCompositeId.build(
             series_id,
             season_number,
-            episode.episode_number,
+            episode.episode_number.value,
         ).media_id
         progress = progress_map.get(composite_key)
         return EpisodeOutput(
             id=str(episode.id) if episode.id else None,
-            episode_number=episode.episode_number,
+            episode_number=episode.episode_number.value,
             title=episode.title.value,
             synopsis=episode.synopsis,
             duration_seconds=episode.duration.value,

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -10,8 +10,10 @@ from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import (
     Duration,
+    EpisodeNumber,
     MediaFile,
     Resolution,
+    SeasonNumber,
     Title,
 )
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
@@ -227,7 +229,7 @@ def _process_episode_group(
     season = series.get_season(season_num)
     if not season:
         assert series.id is not None
-        season = Season(series_id=series.id, season_number=season_num)
+        season = Season(series_id=series.id, season_number=SeasonNumber(season_num))
         series = series.with_season(season)
 
     episode = season.get_episode(episode_num)
@@ -256,8 +258,8 @@ def _create_episode(
     ep_title = first.episode_title or f"Episode {episode_num}"
     episode = Episode(
         series_id=series.id,
-        season_number=season_num,
-        episode_number=episode_num,
+        season_number=SeasonNumber(season_num),
+        episode_number=EpisodeNumber(episode_num),
         title=Title(ep_title),
         duration=Duration(0),
         files=[_build_media_file(first, is_primary=True)],

--- a/src/modules/media/domain/entities/episode.py
+++ b/src/modules/media/domain/entities/episode.py
@@ -10,8 +10,10 @@ from src.modules.media.domain.value_objects import (
     AirDate,
     Duration,
     EpisodeId,
+    EpisodeNumber,
     ImageUrl,
     MediaFile,
+    SeasonNumber,
     SeriesId,
     Title,
 )
@@ -44,8 +46,8 @@ class Episode(FileVariantMixin, DomainEntity[EpisodeId]):
 
     # Relationship
     series_id: SeriesId
-    season_number: int = Field(ge=0)  # 0 for specials
-    episode_number: int = Field(ge=1)
+    season_number: SeasonNumber
+    episode_number: EpisodeNumber
 
     # Content info
     title: Title

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -10,6 +10,7 @@ from src.building_blocks.domain import AggregateRoot
 from src.modules.media.domain.entities.file_variant_mixin import FileVariantMixin
 from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.value_objects import (
+    ContentRating,
     Duration,
     FilePath,
     Genre,
@@ -67,7 +68,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
     writers: list[str] = Field(default_factory=list)
 
     # Classification
-    content_rating: str | None = None
+    content_rating: ContentRating | None = None
 
     # Trailer
     trailer_url: str | None = None

--- a/src/modules/media/domain/entities/season.py
+++ b/src/modules/media/domain/entities/season.py
@@ -9,7 +9,15 @@ from pydantic import Field, field_validator
 from src.building_blocks.domain import DomainEntity
 from src.building_blocks.domain.errors import BusinessRuleViolationException
 from src.modules.media.domain.rule_codes import MediaRuleCodes
-from src.modules.media.domain.value_objects import AirDate, ImageUrl, SeasonId, SeriesId, Title
+from src.modules.media.domain.value_objects import (
+    AirDate,
+    EpisodeNumber,
+    ImageUrl,
+    SeasonId,
+    SeasonNumber,
+    SeriesId,
+    Title,
+)
 
 if TYPE_CHECKING:
     from src.modules.media.domain.entities.episode import Episode
@@ -34,7 +42,7 @@ class Season(DomainEntity[SeasonId]):
 
     # Relationship
     series_id: SeriesId
-    season_number: int = Field(ge=0)  # 0 for specials
+    season_number: SeasonNumber
 
     # Content info
     title: Title | None = None
@@ -91,7 +99,7 @@ class Season(DomainEntity[SeasonId]):
             return self
         return self.with_updates(episodes=[*self.episodes, episode])
 
-    def get_episode(self, episode_number: int) -> Episode | None:
+    def get_episode(self, episode_number: EpisodeNumber | int) -> Episode | None:
         """Find an episode by its number.
 
         Args:
@@ -100,8 +108,13 @@ class Season(DomainEntity[SeasonId]):
         Returns:
             The Episode if found, None otherwise.
         """
+        needle = (
+            episode_number
+            if isinstance(episode_number, EpisodeNumber)
+            else EpisodeNumber(episode_number)
+        )
         return next(
-            (ep for ep in self.episodes if ep.episode_number == episode_number),
+            (ep for ep in self.episodes if ep.episode_number == needle),
             None,
         )
 

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -11,9 +11,11 @@ from src.building_blocks.domain.errors import BusinessRuleViolationException
 from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.rule_codes import MediaRuleCodes
 from src.modules.media.domain.value_objects import (
+    ContentRating,
     Genre,
     ImageUrl,
     ImdbId,
+    SeasonNumber,
     SeriesId,
     Title,
     TmdbId,
@@ -53,7 +55,7 @@ class Series(AggregateRoot[SeriesId]):
 
     # Categorization
     genres: list[Genre] = Field(default_factory=list)
-    content_rating: str | None = None
+    content_rating: ContentRating | None = None
     trailer_url: str | None = None
 
     # Localized metadata
@@ -151,7 +153,7 @@ class Series(AggregateRoot[SeriesId]):
             return self
         return self.with_updates(seasons=[*self.seasons, season])
 
-    def get_season(self, season_number: int) -> Season | None:
+    def get_season(self, season_number: SeasonNumber | int) -> Season | None:
         """Find a season by its number.
 
         Args:
@@ -160,8 +162,13 @@ class Series(AggregateRoot[SeriesId]):
         Returns:
             The Season if found, None otherwise.
         """
+        needle = (
+            season_number
+            if isinstance(season_number, SeasonNumber)
+            else SeasonNumber(season_number)
+        )
         return next(
-            (season for season in self.seasons if season.season_number == season_number),
+            (season for season in self.seasons if season.season_number == needle),
             None,
         )
 

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -1,7 +1,9 @@
 """Media domain value objects."""
 
 from src.modules.media.domain.value_objects.air_date import AirDate
+from src.modules.media.domain.value_objects.content_rating import ContentRating
 from src.modules.media.domain.value_objects.duration import Duration
+from src.modules.media.domain.value_objects.episode_number import EpisodeNumber
 from src.modules.media.domain.value_objects.genre import Genre
 from src.modules.media.domain.value_objects.hdr_format import HdrFormat
 from src.modules.media.domain.value_objects.imdb_id import ImdbId
@@ -15,6 +17,7 @@ from src.modules.media.domain.value_objects.media_id import (
     parse_media_id,
 )
 from src.modules.media.domain.value_objects.resolution import Resolution
+from src.modules.media.domain.value_objects.season_number import SeasonNumber
 from src.modules.media.domain.value_objects.title import Title
 from src.modules.media.domain.value_objects.tmdb_id import TmdbId
 from src.modules.media.domain.value_objects.video_codec import VideoCodec
@@ -26,8 +29,10 @@ from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 __all__ = [
     "AirDate",
     "AudioTrack",
+    "ContentRating",
     "Duration",
     "EpisodeId",
+    "EpisodeNumber",
     "FilePath",
     "Genre",
     "ImageUrl",
@@ -38,6 +43,7 @@ __all__ = [
     "MovieId",
     "Resolution",
     "SeasonId",
+    "SeasonNumber",
     "SeriesId",
     "SubtitleTrack",
     "Title",

--- a/src/modules/media/domain/value_objects/content_rating.py
+++ b/src/modules/media/domain/value_objects/content_rating.py
@@ -1,0 +1,42 @@
+"""Content rating value object for media content."""
+
+from typing import ClassVar
+
+from pydantic import model_validator
+
+from src.building_blocks.domain import StringValueObject
+
+
+class ContentRating(StringValueObject):
+    """Content rating classification for movies and series.
+
+    Represents age/content classification labels such as G, PG, PG-13,
+    R, NC-17, TV-MA, etc. Validates non-empty and max 20 characters.
+
+    Example:
+        >>> rating = ContentRating("PG-13")
+        >>> rating.value
+        'PG-13'
+    """
+
+    MAX_LENGTH: ClassVar[int] = 20
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_content_rating(cls, value: str) -> str:
+        """Validate the content rating string."""
+        if not isinstance(value, str):
+            raise ValueError("Content rating must be a string")
+
+        value = value.strip()
+
+        if not value:
+            raise ValueError("Content rating cannot be empty")
+
+        if len(value) > cls.MAX_LENGTH:
+            raise ValueError(f"Content rating cannot exceed {cls.MAX_LENGTH} characters")
+
+        return value
+
+
+__all__ = ["ContentRating"]

--- a/src/modules/media/domain/value_objects/episode_number.py
+++ b/src/modules/media/domain/value_objects/episode_number.py
@@ -1,0 +1,32 @@
+"""Episode number value object for media content."""
+
+from pydantic import model_validator
+
+from src.building_blocks.domain import IntValueObject
+
+
+class EpisodeNumber(IntValueObject):
+    """Episode number within a season.
+
+    Must be positive (>= 1).
+
+    Example:
+        >>> episode = EpisodeNumber(1)
+        >>> episode.value
+        1
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_positive(cls, value: int) -> int:
+        """Validate that episode number is positive."""
+        if not isinstance(value, int):
+            raise ValueError("Episode number must be an integer")
+
+        if value < 1:
+            raise ValueError("Episode number must be at least 1")
+
+        return value
+
+
+__all__ = ["EpisodeNumber"]

--- a/src/modules/media/domain/value_objects/season_number.py
+++ b/src/modules/media/domain/value_objects/season_number.py
@@ -1,0 +1,35 @@
+"""Season number value object for media content."""
+
+from pydantic import model_validator
+
+from src.building_blocks.domain import IntValueObject
+
+
+class SeasonNumber(IntValueObject):
+    """Season number within a series.
+
+    Must be non-negative (>= 0). Season 0 represents specials.
+
+    Example:
+        >>> season = SeasonNumber(1)
+        >>> season.value
+        1
+        >>> specials = SeasonNumber(0)
+        >>> specials.value
+        0
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_non_negative(cls, value: int) -> int:
+        """Validate that season number is non-negative."""
+        if not isinstance(value, int):
+            raise ValueError("Season number must be an integer")
+
+        if value < 0:
+            raise ValueError("Season number must be non-negative")
+
+        return value
+
+
+__all__ = ["SeasonNumber"]

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -10,6 +10,7 @@ from src.modules.media.application.ports import (
     MetadataProvider,
     SeasonMetadata,
 )
+from src.modules.media.domain.value_objects import ContentRating
 
 _MAX_CAST = 15
 
@@ -173,7 +174,7 @@ class TmdbClient(MetadataProvider):
             cast=cast,
             directors=directors,
             writers=writers,
-            content_rating=content_rating,
+            content_rating=content_rating.value if content_rating else None,
             trailer_url=trailer_url,
         )
 
@@ -219,7 +220,7 @@ class TmdbClient(MetadataProvider):
             genres=[g["name"] for g in data.get("genres", [])],
             tmdb_id=data["id"],
             imdb_id=data.get("external_ids", {}).get("imdb_id"),
-            content_rating=content_rating,
+            content_rating=content_rating.value if content_rating else None,
             trailer_url=self._parse_trailer(data.get("videos", {})),
             seasons=seasons,
         )
@@ -291,7 +292,7 @@ class TmdbClient(MetadataProvider):
         return directors, writers
 
     @staticmethod
-    def _parse_content_rating(release_dates: dict[str, object]) -> str | None:
+    def _parse_content_rating(release_dates: dict[str, object]) -> ContentRating | None:
         """Extract content rating from TMDB release_dates, preferring BR then US."""
         results = release_dates.get("results", [])
         if not isinstance(results, list):
@@ -308,7 +309,8 @@ class TmdbClient(MetadataProvider):
                 if cert and iso not in ratings_by_country:
                     ratings_by_country[iso] = cert
 
-        return ratings_by_country.get("BR") or ratings_by_country.get("US") or None
+        selected = ratings_by_country.get("BR") or ratings_by_country.get("US")
+        return ContentRating(selected) if selected else None
 
     @staticmethod
     def _parse_trailer(videos: dict[str, object]) -> str | None:
@@ -349,7 +351,7 @@ class TmdbClient(MetadataProvider):
         return f"https://www.youtube.com/watch?v={best['key']}"
 
     @staticmethod
-    def _parse_series_content_rating(content_ratings: dict[str, object]) -> str | None:
+    def _parse_series_content_rating(content_ratings: dict[str, object]) -> ContentRating | None:
         """Extract content rating from TMDB series content_ratings, preferring BR then US."""
         results = content_ratings.get("results", [])
         if not isinstance(results, list):
@@ -364,7 +366,8 @@ class TmdbClient(MetadataProvider):
             if rating and iso not in ratings_by_country:
                 ratings_by_country[iso] = rating
 
-        return ratings_by_country.get("BR") or ratings_by_country.get("US") or None
+        selected = ratings_by_country.get("BR") or ratings_by_country.get("US")
+        return ContentRating(selected) if selected else None
 
     def _to_credit_person(self, data: dict[str, object], role_key: str) -> CreditPerson:
         """Convert a TMDB cast/crew dict to a CreditPerson."""

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -4,6 +4,7 @@ import json
 
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
+    ContentRating,
     Duration,
     FilePath,
     Genre,
@@ -68,7 +69,7 @@ class MovieMapper:
             if entity.directors
             else None,
             writers=json.dumps(entity.writers, ensure_ascii=False) if entity.writers else None,
-            content_rating=entity.content_rating,
+            content_rating=entity.content_rating.value if entity.content_rating else None,
             trailer_url=entity.trailer_url,
             localized=json.dumps(entity.localized, ensure_ascii=False)
             if entity.localized
@@ -130,7 +131,7 @@ class MovieMapper:
             cast=json.loads(model.cast) if model.cast else [],
             directors=json.loads(model.directors) if model.directors else [],
             writers=json.loads(model.writers) if model.writers else [],
-            content_rating=model.content_rating,
+            content_rating=ContentRating(model.content_rating) if model.content_rating else None,
             trailer_url=model.trailer_url,
             localized=json.loads(model.localized) if model.localized else {},
             files=files,
@@ -168,7 +169,7 @@ class MovieMapper:
             json.dumps(entity.directors, ensure_ascii=False) if entity.directors else None
         )
         model.writers = json.dumps(entity.writers, ensure_ascii=False) if entity.writers else None
-        model.content_rating = entity.content_rating
+        model.content_rating = entity.content_rating.value if entity.content_rating else None
         model.trailer_url = entity.trailer_url
         model.localized = (
             json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -5,8 +5,10 @@ import json
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
     AirDate,
+    ContentRating,
     Duration,
     EpisodeId,
+    EpisodeNumber,
     FilePath,
     Genre,
     ImageUrl,
@@ -14,6 +16,7 @@ from src.modules.media.domain.value_objects import (
     MediaFile,
     Resolution,
     SeasonId,
+    SeasonNumber,
     SeriesId,
     Title,
     TmdbId,
@@ -58,8 +61,8 @@ class EpisodeMapper:
             external_id=str(entity.id),
             season_id=season_id,
             series_external_id=str(entity.series_id),
-            season_number=entity.season_number,
-            episode_number=entity.episode_number,
+            season_number=entity.season_number.value,
+            episode_number=entity.episode_number.value,
             title=entity.title.value,
             synopsis=entity.synopsis,
             duration=entity.duration.value,
@@ -106,8 +109,8 @@ class EpisodeMapper:
         return Episode(
             id=EpisodeId(model.external_id),
             series_id=SeriesId(model.series_external_id),
-            season_number=model.season_number,
-            episode_number=model.episode_number,
+            season_number=SeasonNumber(model.season_number),
+            episode_number=EpisodeNumber(model.episode_number),
             title=Title(model.title),
             synopsis=model.synopsis,
             duration=Duration(model.duration),
@@ -132,8 +135,8 @@ class EpisodeMapper:
             The updated EpisodeModel.
         """
         primary = entity.primary_file
-        model.season_number = entity.season_number
-        model.episode_number = entity.episode_number
+        model.season_number = entity.season_number.value
+        model.episode_number = entity.episode_number.value
         model.title = entity.title.value
         model.synopsis = entity.synopsis
         model.duration = entity.duration.value
@@ -172,7 +175,7 @@ class SeasonMapper:
             external_id=str(entity.id),
             series_id=series_db_id,
             series_external_id=str(entity.series_id),
-            season_number=entity.season_number,
+            season_number=entity.season_number.value,
             title=entity.title.value if entity.title else None,
             synopsis=entity.synopsis,
             poster_path=entity.poster_path.value if entity.poster_path else None,
@@ -199,7 +202,7 @@ class SeasonMapper:
         return Season(
             id=SeasonId(model.external_id),
             series_id=SeriesId(model.series_external_id),
-            season_number=model.season_number,
+            season_number=SeasonNumber(model.season_number),
             title=Title(model.title) if model.title else None,
             synopsis=model.synopsis,
             poster_path=ImageUrl(model.poster_path) if model.poster_path else None,
@@ -220,7 +223,7 @@ class SeasonMapper:
         Returns:
             The updated SeasonModel.
         """
-        model.season_number = entity.season_number
+        model.season_number = entity.season_number.value
         model.title = entity.title.value if entity.title else None
         model.synopsis = entity.synopsis
         model.poster_path = entity.poster_path.value if entity.poster_path else None
@@ -258,7 +261,7 @@ class SeriesMapper:
             poster_path=entity.poster_path.value if entity.poster_path else None,
             backdrop_path=entity.backdrop_path.value if entity.backdrop_path else None,
             genres=",".join(g.value for g in entity.genres) if entity.genres else None,
-            content_rating=entity.content_rating,
+            content_rating=entity.content_rating.value if entity.content_rating else None,
             trailer_url=entity.trailer_url,
             localized=json.dumps(entity.localized, ensure_ascii=False)
             if entity.localized
@@ -296,7 +299,7 @@ class SeriesMapper:
             poster_path=ImageUrl(model.poster_path) if model.poster_path else None,
             backdrop_path=ImageUrl(model.backdrop_path) if model.backdrop_path else None,
             genres=genre_list,
-            content_rating=model.content_rating,
+            content_rating=ContentRating(model.content_rating) if model.content_rating else None,
             trailer_url=model.trailer_url,
             localized=json.loads(model.localized) if model.localized else {},
             tmdb_id=TmdbId(model.tmdb_id) if model.tmdb_id else None,
@@ -325,7 +328,7 @@ class SeriesMapper:
         model.poster_path = entity.poster_path.value if entity.poster_path else None
         model.backdrop_path = entity.backdrop_path.value if entity.backdrop_path else None
         model.genres = ",".join(g.value for g in entity.genres) if entity.genres else None
-        model.content_rating = entity.content_rating
+        model.content_rating = entity.content_rating.value if entity.content_rating else None
         model.trailer_url = entity.trailer_url
         model.localized = (
             json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -11,6 +11,7 @@ from src.modules.watch_progress.application.dtos import (
     ContinueWatchingOutput,
     GetContinueWatchingInput,
 )
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType, WatchStatus
 from src.shared_kernel.episode_composite_id import EpisodeCompositeId
 
 if TYPE_CHECKING:
@@ -82,13 +83,13 @@ class GetContinueWatchingUseCase:
         seen_series: set[str] = set()
 
         for progress in progress_list:
-            if progress.media_type == "movie":
-                if progress.status != "in_progress":
+            if progress.media_type == WatchableMediaType.MOVIE:
+                if progress.status != WatchStatus.IN_PROGRESS:
                     continue
                 item = await self._enrich_movie(progress, input_dto.lang)
                 if item:
                     items.append(item)
-            elif progress.media_type == "episode":
+            elif progress.media_type == WatchableMediaType.EPISODE:
                 parsed = EpisodeCompositeId.parse(progress.media_id)
                 if not parsed or parsed.series_id in seen_series:
                     continue
@@ -145,19 +146,19 @@ class GetContinueWatchingUseCase:
         candidates: list[EpisodeCandidate] = []
         media_ids: list[str] = []
 
-        for s in sorted(series.seasons, key=lambda s: s.season_number):
-            for ep in sorted(s.episodes, key=lambda e: e.episode_number):
+        for s in sorted(series.seasons, key=lambda s: s.season_number.value):
+            for ep in sorted(s.episodes, key=lambda e: e.episode_number.value):
                 mid = EpisodeCompositeId.build(
                     series_id,
-                    s.season_number,
-                    ep.episode_number,
+                    s.season_number.value,
+                    ep.episode_number.value,
                 ).media_id
                 media_ids.append(mid)
                 candidates.append(
                     EpisodeCandidate(
                         series_id=series_id,
-                        season_number=s.season_number,
-                        episode_number=ep.episode_number,
+                        season_number=s.season_number.value,
+                        episode_number=ep.episode_number.value,
                         media_id=mid,
                         progress=None,
                     )
@@ -194,14 +195,14 @@ class GetContinueWatchingUseCase:
             if not latest_watched_at or ep.progress.last_watched_at > latest_watched_at:
                 latest_watched_at = ep.progress.last_watched_at
 
-            if ep.progress.status == "in_progress":
+            if ep.progress.status == WatchStatus.IN_PROGRESS:
                 coords = (ep.season_number, ep.episode_number)
                 if not best_in_progress or coords > (
                     best_in_progress.season_number,
                     best_in_progress.episode_number,
                 ):
                     best_in_progress = ep
-            elif ep.progress.status == "completed":
+            elif ep.progress.status == WatchStatus.COMPLETED:
                 last_completed_idx = max(last_completed_idx or -1, idx)
 
         if best_in_progress:
@@ -248,7 +249,7 @@ class GetContinueWatchingUseCase:
 
         return ContinueWatchingItem(
             media_id=candidate.media_id,
-            media_type="episode",
+            media_type=WatchableMediaType.EPISODE,
             title=episode.title.value,
             poster_path=series.poster_path.value if series.poster_path else None,
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,

--- a/src/modules/watch_progress/application/use_cases/save_progress.py
+++ b/src/modules/watch_progress/application/use_cases/save_progress.py
@@ -3,6 +3,7 @@
 from src.modules.watch_progress.application.dtos import ProgressOutput, SaveProgressInput
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType
 
 
 class SaveProgressUseCase:
@@ -50,7 +51,7 @@ class SaveProgressUseCase:
         else:
             progress = WatchProgress.create(
                 media_id=input_dto.media_id,
-                media_type=input_dto.media_type,
+                media_type=WatchableMediaType(input_dto.media_type),
                 position_seconds=input_dto.position_seconds,
                 duration_seconds=input_dto.duration_seconds,
                 audio_track=input_dto.audio_track,

--- a/src/modules/watch_progress/domain/entities/watch_progress.py
+++ b/src/modules/watch_progress/domain/entities/watch_progress.py
@@ -8,7 +8,11 @@ from typing import Self
 from pydantic import Field
 
 from src.building_blocks.domain import AggregateRoot
-from src.modules.watch_progress.domain.value_objects import ProgressId
+from src.modules.watch_progress.domain.value_objects import (
+    ProgressId,
+    WatchableMediaType,
+    WatchStatus,
+)
 
 _COMPLETION_THRESHOLD = 0.9
 
@@ -34,12 +38,12 @@ class WatchProgress(AggregateRoot[ProgressId]):
 
     # What is being watched
     media_id: str
-    media_type: str  # "movie" or "episode"
+    media_type: WatchableMediaType
 
     # Position tracking
     position_seconds: int = Field(ge=0)
     duration_seconds: int = Field(gt=0)
-    status: str = Field(default="in_progress")  # "in_progress" or "completed"
+    status: WatchStatus = Field(default=WatchStatus.IN_PROGRESS)
 
     # Track preferences
     audio_track: int | None = None
@@ -59,7 +63,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
     @property
     def is_completed(self) -> bool:
         """Check if the media has been fully watched."""
-        return self.status == "completed"
+        return self.status == WatchStatus.COMPLETED
 
     def update_position(
         self,
@@ -99,7 +103,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
             updates["subtitle_track"] = subtitle_track
 
         if is_complete and not self.is_completed:
-            updates["status"] = "completed"
+            updates["status"] = WatchStatus.COMPLETED
             updates["completed_at"] = now
 
         return self.with_updates(**updates)
@@ -108,7 +112,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
     def create(
         cls,
         media_id: str,
-        media_type: str,
+        media_type: WatchableMediaType,
         position_seconds: int,
         duration_seconds: int,
         audio_track: int | None = None,
@@ -137,7 +141,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
             media_type=media_type,
             position_seconds=position_seconds,
             duration_seconds=duration_seconds,
-            status="completed" if is_complete else "in_progress",
+            status=WatchStatus.COMPLETED if is_complete else WatchStatus.IN_PROGRESS,
             audio_track=audio_track,
             subtitle_track=subtitle_track,
             last_watched_at=now,

--- a/src/modules/watch_progress/domain/value_objects/__init__.py
+++ b/src/modules/watch_progress/domain/value_objects/__init__.py
@@ -1,5 +1,9 @@
 """Watch Progress value objects."""
 
 from src.modules.watch_progress.domain.value_objects.progress_id import ProgressId
+from src.modules.watch_progress.domain.value_objects.watch_status import WatchStatus
+from src.modules.watch_progress.domain.value_objects.watchable_media_type import (
+    WatchableMediaType,
+)
 
-__all__ = ["ProgressId"]
+__all__ = ["ProgressId", "WatchStatus", "WatchableMediaType"]

--- a/src/modules/watch_progress/domain/value_objects/watch_status.py
+++ b/src/modules/watch_progress/domain/value_objects/watch_status.py
@@ -1,0 +1,24 @@
+"""Watch progress status enum."""
+
+from enum import StrEnum
+
+
+class WatchStatus(StrEnum):
+    """Status of a watch progress record.
+
+    Attributes:
+        IN_PROGRESS: Media is partially watched.
+        COMPLETED: Media has been watched past the completion threshold.
+
+    Example:
+        >>> WatchStatus.IN_PROGRESS
+        'in_progress'
+        >>> WatchStatus("completed") == "completed"
+        True
+    """
+
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+__all__ = ["WatchStatus"]

--- a/src/modules/watch_progress/domain/value_objects/watchable_media_type.py
+++ b/src/modules/watch_progress/domain/value_objects/watchable_media_type.py
@@ -1,0 +1,24 @@
+"""Media type enum for watchable content."""
+
+from enum import StrEnum
+
+
+class WatchableMediaType(StrEnum):
+    """Type of media that can have watch progress tracked.
+
+    Attributes:
+        MOVIE: A standalone movie.
+        EPISODE: An episode within a series.
+
+    Example:
+        >>> WatchableMediaType.MOVIE
+        'movie'
+        >>> WatchableMediaType("episode") == "episode"
+        True
+    """
+
+    MOVIE = "movie"
+    EPISODE = "episode"
+
+
+__all__ = ["WatchableMediaType"]

--- a/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
+++ b/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
@@ -1,7 +1,11 @@
 """Mapper between WatchProgress entity and WatchProgressModel."""
 
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import ProgressId
+from src.modules.watch_progress.domain.value_objects import (
+    ProgressId,
+    WatchableMediaType,
+    WatchStatus,
+)
 from src.modules.watch_progress.infrastructure.persistence.models import (
     WatchProgressModel,
 )
@@ -55,10 +59,10 @@ class WatchProgressMapper:
         return WatchProgress(
             id=ProgressId(model.external_id),
             media_id=model.media_id,
-            media_type=model.media_type,
+            media_type=WatchableMediaType(model.media_type),
             position_seconds=model.position_seconds,
             duration_seconds=model.duration_seconds,
-            status=model.status,
+            status=WatchStatus(model.status),
             audio_track=model.audio_track,
             subtitle_track=model.subtitle_track,
             last_watched_at=model.last_watched_at,

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -14,6 +14,7 @@ from src.modules.media.domain.value_objects import (
     MediaFile,
     Resolution,
     SeasonId,
+    SeasonNumber,
     SeriesId,
     Title,
     TmdbId,
@@ -130,8 +131,8 @@ class TestSQLAlchemySeriesRepository:
         saved = await repo.save(series)
 
         assert saved.season_count == 2
-        assert saved.seasons[0].season_number == 1
-        assert saved.seasons[1].season_number == 2
+        assert saved.seasons[0].season_number == SeasonNumber(1)
+        assert saved.seasons[1].season_number == SeasonNumber(2)
 
     async def test_save_creates_series_with_episodes(
         self,
@@ -350,7 +351,7 @@ class TestSQLAlchemySeriesRepository:
         saved = await repo.save(updated_series)
 
         assert saved.season_count == 2
-        assert saved.seasons[1].season_number == 2
+        assert saved.seasons[1].season_number == SeasonNumber(2)
 
     async def test_update_removes_season(self, db_session: AsyncSession) -> None:
         """Test that updating a series can remove a season."""

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -18,7 +18,7 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
-from src.modules.media.domain.value_objects import TmdbId
+from src.modules.media.domain.value_objects import ContentRating, TmdbId
 
 
 def _make_movie() -> Movie:
@@ -314,7 +314,7 @@ class TestApplyMetadataFields:
         assert saved.cast == ["Leonardo DiCaprio"]
         assert saved.directors == ["Christopher Nolan"]
         assert saved.writers == ["Christopher Nolan"]
-        assert saved.content_rating == "PG-13"
+        assert saved.content_rating == ContentRating("PG-13")
         assert saved.trailer_url == "https://youtube.com/abc"
 
     @pytest.mark.asyncio

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -22,6 +22,7 @@ from src.modules.media.application.use_cases.enrich_series_metadata import (
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import (
+    ContentRating,
     Duration,
     FilePath,
     MediaFile,
@@ -494,7 +495,7 @@ class TestApplySeriesFields:
         assert saved.synopsis == "Crime drama."
         assert saved.poster_path is not None
         assert saved.backdrop_path is not None
-        assert saved.content_rating == "TV-MA"
+        assert saved.content_rating == ContentRating("TV-MA")
         assert saved.trailer_url == "https://youtube.com/abc"
 
     @pytest.mark.asyncio

--- a/tests/modules/media/unit/domain/entities/test_episode.py
+++ b/tests/modules/media/unit/domain/entities/test_episode.py
@@ -5,7 +5,13 @@ from datetime import date
 import pytest
 
 from src.building_blocks.domain.errors import DomainValidationException
-from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
+from src.modules.media.domain.value_objects import (
+    EpisodeNumber,
+    FilePath,
+    MediaFile,
+    Resolution,
+    SeasonNumber,
+)
 
 
 def _make_file(**overrides: object) -> MediaFile:
@@ -41,7 +47,7 @@ class TestEpisodeCreation:
         )
 
         assert episode.id is None
-        assert episode.episode_number == 1
+        assert episode.episode_number == EpisodeNumber(1)
         assert episode.title.value == "Pilot"
 
     def test_should_create_with_explicit_id(self):
@@ -115,7 +121,7 @@ class TestEpisodeCreation:
             ],
         )
 
-        assert episode.season_number == 0
+        assert episode.season_number == SeasonNumber(0)
 
     def test_should_raise_error_for_negative_episode_number(self):
         from src.modules.media.domain.entities import Episode
@@ -412,4 +418,4 @@ class TestEpisodeTimestamps:
         )
 
         with pytest.raises(DomainValidationException):
-            episode.season_number = 2  # type: ignore[misc]
+            episode.season_number = 2  # type: ignore[assignment,misc]

--- a/tests/modules/media/unit/domain/entities/test_season.py
+++ b/tests/modules/media/unit/domain/entities/test_season.py
@@ -15,6 +15,7 @@ from src.modules.media.domain.value_objects import (
     FilePath,
     MediaFile,
     Resolution,
+    SeasonNumber,
     SeriesId,
     Title,
 )
@@ -60,7 +61,7 @@ class TestSeasonCreation:
 
         assert season.id is None
         assert season.series_id == series_id
-        assert season.season_number == 1
+        assert season.season_number == SeasonNumber(1)
         assert season.episodes == []
 
     def test_should_create_with_explicit_id(self):
@@ -98,7 +99,7 @@ class TestSeasonCreation:
             season_number=0,
         )
 
-        assert season.season_number == 0
+        assert season.season_number == SeasonNumber(0)
 
     def test_should_raise_error_for_negative_season_number(self):
         from src.modules.media.domain.entities import Season
@@ -293,7 +294,7 @@ class TestSeasonImmutability:
         )
 
         with pytest.raises(DomainValidationException):
-            season.season_number = 2  # type: ignore[misc]
+            season.season_number = 2  # type: ignore[assignment,misc]
 
     def test_with_episode_should_return_new_instance(self):
         from src.modules.media.domain.entities import Season

--- a/tests/modules/media/unit/domain/value_objects/test_content_rating.py
+++ b/tests/modules/media/unit/domain/value_objects/test_content_rating.py
@@ -1,0 +1,87 @@
+"""Tests for ContentRating value object."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+
+
+class TestContentRatingCreation:
+    """Tests for ContentRating instantiation."""
+
+    def test_should_create_with_valid_rating(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        rating = ContentRating("PG-13")
+
+        assert rating.value == "PG-13"
+
+    def test_should_strip_whitespace(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        rating = ContentRating("  R  ")
+
+        assert rating.value == "R"
+
+    def test_should_raise_error_for_empty_string(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        with pytest.raises(DomainValidationException, match="cannot be empty"):
+            ContentRating("")
+
+    def test_should_raise_error_for_whitespace_only(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        with pytest.raises(DomainValidationException, match="cannot be empty"):
+            ContentRating("   ")
+
+    def test_should_raise_error_when_exceeds_max_length(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        with pytest.raises(DomainValidationException, match="20"):
+            ContentRating("A" * 21)
+
+    def test_should_accept_rating_at_max_length(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        rating = ContentRating("A" * 20)
+
+        assert len(rating.value) == 20
+
+    def test_should_raise_error_for_non_string_input(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        with pytest.raises(DomainValidationException):
+            ContentRating(123)  # type: ignore[arg-type]
+
+
+class TestContentRatingEquality:
+    """Tests for ContentRating equality and hashing."""
+
+    def test_should_be_equal_when_same_value(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        assert ContentRating("PG-13") == ContentRating("PG-13")
+
+    def test_should_not_be_equal_when_different_value(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        assert ContentRating("PG-13") != ContentRating("R")
+
+    def test_should_be_hashable(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        rating = ContentRating("R")
+
+        assert rating in {rating}
+
+
+class TestContentRatingImmutability:
+    """Tests for ContentRating immutability."""
+
+    def test_should_be_immutable(self):
+        from src.modules.media.domain.value_objects import ContentRating
+
+        rating = ContentRating("PG-13")
+
+        with pytest.raises(DomainValidationException):
+            rating.root = "R"  # type: ignore[misc]

--- a/tests/modules/media/unit/domain/value_objects/test_episode_number.py
+++ b/tests/modules/media/unit/domain/value_objects/test_episode_number.py
@@ -1,0 +1,67 @@
+"""Tests for EpisodeNumber value object."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+
+
+class TestEpisodeNumberCreation:
+    """Tests for EpisodeNumber instantiation."""
+
+    def test_should_create_with_valid_number(self):
+        from src.modules.media.domain.value_objects import EpisodeNumber
+
+        episode = EpisodeNumber(1)
+
+        assert episode.value == 1
+
+    def test_should_raise_error_for_zero(self):
+        from src.modules.media.domain.value_objects import EpisodeNumber
+
+        with pytest.raises(DomainValidationException, match="at least 1"):
+            EpisodeNumber(0)
+
+    def test_should_raise_error_for_negative_number(self):
+        from src.modules.media.domain.value_objects import EpisodeNumber
+
+        with pytest.raises(DomainValidationException, match="at least 1"):
+            EpisodeNumber(-1)
+
+    def test_should_raise_error_for_non_integer(self):
+        from src.modules.media.domain.value_objects import EpisodeNumber
+
+        with pytest.raises(DomainValidationException):
+            EpisodeNumber("1")  # type: ignore[arg-type]
+
+
+class TestEpisodeNumberComparison:
+    """Tests for EpisodeNumber comparison operators."""
+
+    def test_should_compare_equal(self):
+        from src.modules.media.domain.value_objects import EpisodeNumber
+
+        assert EpisodeNumber(1) == EpisodeNumber(1)
+
+    def test_should_compare_less_than(self):
+        from src.modules.media.domain.value_objects import EpisodeNumber
+
+        assert EpisodeNumber(1) < EpisodeNumber(2)
+
+    def test_should_be_hashable(self):
+        from src.modules.media.domain.value_objects import EpisodeNumber
+
+        episode = EpisodeNumber(3)
+
+        assert episode in {episode}
+
+
+class TestEpisodeNumberImmutability:
+    """Tests for EpisodeNumber immutability."""
+
+    def test_should_be_immutable(self):
+        from src.modules.media.domain.value_objects import EpisodeNumber
+
+        episode = EpisodeNumber(1)
+
+        with pytest.raises(DomainValidationException):
+            episode.root = 2  # type: ignore[misc]

--- a/tests/modules/media/unit/domain/value_objects/test_season_number.py
+++ b/tests/modules/media/unit/domain/value_objects/test_season_number.py
@@ -1,0 +1,73 @@
+"""Tests for SeasonNumber value object."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+
+
+class TestSeasonNumberCreation:
+    """Tests for SeasonNumber instantiation."""
+
+    def test_should_create_with_positive_number(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        season = SeasonNumber(1)
+
+        assert season.value == 1
+
+    def test_should_accept_zero_for_specials(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        specials = SeasonNumber(0)
+
+        assert specials.value == 0
+
+    def test_should_raise_error_for_negative_number(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        with pytest.raises(DomainValidationException, match="non-negative"):
+            SeasonNumber(-1)
+
+    def test_should_raise_error_for_non_integer(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        with pytest.raises(DomainValidationException):
+            SeasonNumber("1")  # type: ignore[arg-type]
+
+
+class TestSeasonNumberComparison:
+    """Tests for SeasonNumber comparison operators."""
+
+    def test_should_compare_equal(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        assert SeasonNumber(1) == SeasonNumber(1)
+
+    def test_should_compare_less_than(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        assert SeasonNumber(1) < SeasonNumber(2)
+
+    def test_should_compare_greater_than(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        assert SeasonNumber(2) > SeasonNumber(1)
+
+    def test_should_be_hashable(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        season = SeasonNumber(3)
+
+        assert season in {season}
+
+
+class TestSeasonNumberImmutability:
+    """Tests for SeasonNumber immutability."""
+
+    def test_should_be_immutable(self):
+        from src.modules.media.domain.value_objects import SeasonNumber
+
+        season = SeasonNumber(1)
+
+        with pytest.raises(DomainValidationException):
+            season.root = 2  # type: ignore[misc]

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
+from src.modules.media.domain.value_objects import ContentRating
 from src.modules.media.infrastructure.metadata.tmdb_client import (
     TmdbClient,
     _safe_int,
@@ -193,7 +194,7 @@ class TestParseContentRating:
                 },
             ],
         }
-        assert TmdbClient._parse_content_rating(data) == "14"
+        assert TmdbClient._parse_content_rating(data) == ContentRating("14")
 
     def test_should_fallback_to_us(self) -> None:
         data: dict[str, Any] = {
@@ -204,7 +205,7 @@ class TestParseContentRating:
                 },
             ],
         }
-        assert TmdbClient._parse_content_rating(data) == "PG-13"
+        assert TmdbClient._parse_content_rating(data) == ContentRating("PG-13")
 
     def test_should_return_none_when_empty(self) -> None:
         assert TmdbClient._parse_content_rating({"results": []}) is None
@@ -228,7 +229,7 @@ class TestParseContentRating:
                 },
             ],
         }
-        assert TmdbClient._parse_content_rating(data) == "R"
+        assert TmdbClient._parse_content_rating(data) == ContentRating("R")
 
 
 @pytest.mark.unit
@@ -242,11 +243,11 @@ class TestParseSeriesContentRating:
                 {"iso_3166_1": "BR", "rating": "18"},
             ],
         }
-        assert TmdbClient._parse_series_content_rating(data) == "18"
+        assert TmdbClient._parse_series_content_rating(data) == ContentRating("18")
 
     def test_should_fallback_to_us(self) -> None:
         data: dict[str, Any] = {"results": [{"iso_3166_1": "US", "rating": "TV-14"}]}
-        assert TmdbClient._parse_series_content_rating(data) == "TV-14"
+        assert TmdbClient._parse_series_content_rating(data) == ContentRating("TV-14")
 
     def test_should_return_none_when_empty(self) -> None:
         assert TmdbClient._parse_series_content_rating({}) is None

--- a/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
+++ b/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType
 from src.modules.watch_progress.infrastructure.persistence.repositories import (
     SQLAlchemyWatchProgressRepository,
 )
@@ -15,7 +16,7 @@ MISSING_MEDIA_ID = "mov_missing00000"
 
 def _create_progress(
     media_id: str = SAMPLE_MOVIE_ID,
-    media_type: str = "movie",
+    media_type: WatchableMediaType = WatchableMediaType.MOVIE,
     position: int = 1800,
     duration: int = 7200,
 ) -> WatchProgress:
@@ -57,7 +58,7 @@ class TestSQLAlchemyWatchProgressRepositorySave:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         progress = WatchProgress.create(
             media_id=SAMPLE_MOVIE_ID,
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=6500,
             duration_seconds=7200,
         )
@@ -94,7 +95,7 @@ class TestSQLAlchemyWatchProgressRepositoryFind:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         await repo.save(_create_progress(media_id=SAMPLE_MOVIE_ID))
         await repo.save(
-            _create_progress(media_id=SAMPLE_EPISODE_ID, media_type="episode"),
+            _create_progress(media_id=SAMPLE_EPISODE_ID, media_type=WatchableMediaType.EPISODE),
         )
 
         result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, SAMPLE_EPISODE_ID])
@@ -133,7 +134,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         await repo.save(
             WatchProgress.create(
                 media_id="mov_bbbbbbbbbbbb",
-                media_type="movie",
+                media_type=WatchableMediaType.MOVIE,
                 position_seconds=7200,
                 duration_seconds=7200,
             ),
@@ -178,7 +179,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         await repo.save(
             WatchProgress.create(
                 media_id="mov_bbbbbbbbbbbb",
-                media_type="movie",
+                media_type=WatchableMediaType.MOVIE,
                 position_seconds=7200,
                 duration_seconds=7200,
             ),

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -24,11 +24,12 @@ from src.modules.watch_progress.application.dtos import (
 from src.modules.watch_progress.application.use_cases import GetContinueWatchingUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType
 
 
 def _make_progress(
     media_id: str,
-    media_type: str = "episode",
+    media_type: WatchableMediaType = WatchableMediaType.EPISODE,
     *,
     status: str = "in_progress",
     position: int = 1800,

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_progress.py
@@ -8,6 +8,7 @@ from src.modules.watch_progress.application.dtos import GetProgressInput, Progre
 from src.modules.watch_progress.application.use_cases import GetProgressUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType
 
 
 class TestGetProgressUseCase:
@@ -17,7 +18,7 @@ class TestGetProgressUseCase:
     async def test_returns_progress_when_found(self):
         existing = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=1800,
             duration_seconds=7200,
         )

--- a/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
@@ -8,6 +8,7 @@ from src.modules.watch_progress.application.dtos import ProgressOutput, SaveProg
 from src.modules.watch_progress.application.use_cases import SaveProgressUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType
 
 
 class TestSaveProgressUseCase:
@@ -39,7 +40,7 @@ class TestSaveProgressUseCase:
     async def test_updates_existing_progress(self):
         existing = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=1000,
             duration_seconds=7200,
         )

--- a/tests/modules/watch_progress/unit/domain/entities/test_watch_progress.py
+++ b/tests/modules/watch_progress/unit/domain/entities/test_watch_progress.py
@@ -2,6 +2,7 @@
 
 
 from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType
 
 
 class TestWatchProgress:
@@ -10,7 +11,7 @@ class TestWatchProgress:
     def test_create_sets_in_progress_status(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=1800,
             duration_seconds=7200,
         )
@@ -21,7 +22,7 @@ class TestWatchProgress:
     def test_create_auto_completes_at_90_percent(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=6500,
             duration_seconds=7200,
         )
@@ -31,7 +32,7 @@ class TestWatchProgress:
     def test_percentage_calculation(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=3600,
             duration_seconds=7200,
         )
@@ -40,7 +41,7 @@ class TestWatchProgress:
     def test_percentage_zero_position(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=0,
             duration_seconds=7200,
         )
@@ -49,7 +50,7 @@ class TestWatchProgress:
     def test_percentage_capped_at_100(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=8000,
             duration_seconds=7200,
         )
@@ -58,7 +59,7 @@ class TestWatchProgress:
     def test_update_position_preserves_identity(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
             duration_seconds=7200,
         )
@@ -70,7 +71,7 @@ class TestWatchProgress:
     def test_update_position_auto_completes(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
             duration_seconds=7200,
         )
@@ -83,7 +84,7 @@ class TestWatchProgress:
     def test_update_position_saves_audio_track(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
             duration_seconds=7200,
         )
@@ -93,7 +94,7 @@ class TestWatchProgress:
     def test_update_position_saves_subtitle_track(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
             duration_seconds=7200,
         )
@@ -103,7 +104,7 @@ class TestWatchProgress:
     def test_is_completed_property(self):
         progress = WatchProgress.create(
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
             duration_seconds=7200,
         )
@@ -115,7 +116,7 @@ class TestWatchProgress:
     def test_create_with_episode(self):
         progress = WatchProgress.create(
             media_id="epi_abc123def456",
-            media_type="episode",
+            media_type=WatchableMediaType.EPISODE,
             position_seconds=300,
             duration_seconds=2700,
         )

--- a/tests/modules/watch_progress/unit/domain/value_objects/test_watch_status.py
+++ b/tests/modules/watch_progress/unit/domain/value_objects/test_watch_status.py
@@ -1,0 +1,36 @@
+"""Tests for WatchStatus enum."""
+
+import pytest
+
+
+class TestWatchStatusValues:
+    """Tests for WatchStatus enum members."""
+
+    def test_should_have_in_progress_member(self):
+        from src.modules.watch_progress.domain.value_objects import WatchStatus
+
+        assert WatchStatus.IN_PROGRESS.value == "in_progress"
+
+    def test_should_have_completed_member(self):
+        from src.modules.watch_progress.domain.value_objects import WatchStatus
+
+        assert WatchStatus.COMPLETED.value == "completed"
+
+    def test_should_construct_from_string(self):
+        from src.modules.watch_progress.domain.value_objects import WatchStatus
+
+        assert WatchStatus("in_progress") == WatchStatus.IN_PROGRESS
+        assert WatchStatus("completed") == WatchStatus.COMPLETED
+
+    def test_should_raise_for_invalid_value(self):
+        from src.modules.watch_progress.domain.value_objects import WatchStatus
+
+        with pytest.raises(ValueError):
+            WatchStatus("invalid")
+
+    def test_should_behave_as_string(self):
+        """StrEnum inherits from str, so string comparisons work."""
+        from src.modules.watch_progress.domain.value_objects import WatchStatus
+
+        assert WatchStatus.IN_PROGRESS.value == "in_progress"
+        assert isinstance(WatchStatus.IN_PROGRESS, str)

--- a/tests/modules/watch_progress/unit/domain/value_objects/test_watchable_media_type.py
+++ b/tests/modules/watch_progress/unit/domain/value_objects/test_watchable_media_type.py
@@ -1,0 +1,36 @@
+"""Tests for WatchableMediaType enum."""
+
+import pytest
+
+
+class TestWatchableMediaTypeValues:
+    """Tests for WatchableMediaType enum members."""
+
+    def test_should_have_movie_member(self):
+        from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+
+        assert WatchableMediaType.MOVIE.value == "movie"
+
+    def test_should_have_episode_member(self):
+        from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+
+        assert WatchableMediaType.EPISODE.value == "episode"
+
+    def test_should_construct_from_string(self):
+        from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+
+        assert WatchableMediaType("movie") == WatchableMediaType.MOVIE
+        assert WatchableMediaType("episode") == WatchableMediaType.EPISODE
+
+    def test_should_raise_for_invalid_value(self):
+        from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+
+        with pytest.raises(ValueError):
+            WatchableMediaType("invalid")
+
+    def test_should_behave_as_string(self):
+        """StrEnum inherits from str, so string comparisons work."""
+        from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+
+        assert WatchableMediaType.MOVIE.value == "movie"
+        assert isinstance(WatchableMediaType.MOVIE, str)

--- a/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
+++ b/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 import pytest
 
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import ProgressId
+from src.modules.watch_progress.domain.value_objects import ProgressId, WatchableMediaType
 from src.modules.watch_progress.infrastructure.persistence.mappers import (
     WatchProgressMapper,
 )
@@ -16,7 +16,7 @@ from src.modules.watch_progress.infrastructure.persistence.models import (
 
 def _make_progress(
     media_id: str = "mov_abc123def456",
-    media_type: str = "movie",
+    media_type: WatchableMediaType = WatchableMediaType.MOVIE,
     position: int = 1800,
     duration: int = 7200,
     progress_id: ProgressId | None = None,
@@ -38,7 +38,7 @@ class TestWatchProgressMapperToModel:
         progress = WatchProgress(
             id=None,
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
             duration_seconds=7200,
         )
@@ -63,7 +63,7 @@ class TestWatchProgressMapperToModel:
         progress = WatchProgress(
             id=ProgressId.generate(),
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
             duration_seconds=7200,
             audio_track=1,
@@ -80,7 +80,7 @@ class TestWatchProgressMapperToModel:
         progress = WatchProgress(
             id=ProgressId.generate(),
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=7200,
             duration_seconds=7200,
             status="completed",
@@ -164,7 +164,7 @@ class TestWatchProgressMapperUpdateModel:
         updated = WatchProgress(
             id=progress_id,
             media_id="mov_abc123def456",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=6500,
             duration_seconds=7200,
             status="completed",
@@ -198,7 +198,7 @@ class TestWatchProgressMapperUpdateModel:
         updated = WatchProgress(
             id=progress_id,
             media_id="mov_different000",
-            media_type="movie",
+            media_type=WatchableMediaType.MOVIE,
             position_seconds=200,
             duration_seconds=7200,
         )


### PR DESCRIPTION
## Summary

Replace raw `str` and `int` fields with dedicated Value Objects for semantically meaningful domain concepts. Addresses primitive obsession in the highest-impact cases identified in a recent audit.

**New value objects:**
- `WatchableMediaType` (StrEnum) — watch_progress: ``movie`` / ``episode``
- `WatchStatus` (StrEnum) — watch_progress: ``in_progress`` / ``completed``
- `ContentRating` (StringValueObject) — media: PG-13, R, etc.
- `SeasonNumber` (IntValueObject, >= 0) — media
- `EpisodeNumber` (IntValueObject, >= 1) — media

**Boundaries preserved:**
- DTOs remain primitive (`str`, `int`) at the application boundary
- ORM models remain primitive at the infrastructure boundary
- `EpisodeCompositeId` (shared_kernel) remains primitive; callers extract `.value`
- Mappers handle the conversion between layers

**Scope:** 31 production files, 6 test files updated, 5 new VO test files. 1 495 tests passing (was 1 457; +38 new VO tests).

## Test plan

- [x] Full test suite passes (`poetry run pytest tests/ -x -q`)
- [x] mypy passes (`poetry run mypy src/`)
- [x] ruff passes (`poetry run ruff check src/ tests/`)
- [x] Pre-commit hooks pass