### PR TITLE
feat(docker): add multi-stage Dockerfile and compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Git
+.git
+.github
+.gitignore
+.gitattributes
+
+# Python
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.egg-info
+.pytest_cache
+.mypy_cache
+.ruff_cache
+htmlcov
+.coverage
+coverage.xml
+
+# Environment — template is kept, real values never shipped
+.env
+.env.*
+!.env.example
+
+# Runtime data directories (bind-mounted at run time)
+data/
+hls_cache/
+thumbnails/
+*.db
+*.sqlite
+*.sqlite3
+
+# Docs / dev assets not needed at runtime
+docs/
+tests/
+Makefile
+.pre-commit-config.yaml
+
+# IDE / OS clutter
+.vscode
+.idea
+.DS_Store
+Thumbs.db
+
+# Node (in case the frontend repo ever lands here)
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ temp/
 CLAUDE.md
 hls_cache/
 
+# Docker bind-mount directories
+/data/
+
 # Specs and evidence (local references only)
 specs/
 evidence/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1.7
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder
+# ---------------------------------------------------------------------------
+# Installs Poetry, exports resolved production deps to requirements.txt,
+# then builds a clean virtualenv with only those deps. The runtime stage
+# copies /opt/venv from here — keeping Poetry and build tools out of the
+# final image.
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim AS builder
+
+WORKDIR /build
+
+ENV POETRY_VERSION=1.8.3 \
+    POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_CREATE=false \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+RUN pip install "poetry==${POETRY_VERSION}" poetry-plugin-export
+
+COPY pyproject.toml poetry.lock ./
+
+RUN poetry export --without dev --format requirements.txt --output requirements.txt
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+RUN pip install -r requirements.txt
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime
+# ---------------------------------------------------------------------------
+# Slim runtime with Python + ffmpeg + curl (for healthcheck). App code
+# runs as a non-root user.
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --uid 1000 homeflix
+
+WORKDIR /app
+
+COPY --from=builder /opt/venv /opt/venv
+
+COPY --chown=homeflix:homeflix src/ ./src/
+COPY --chown=homeflix:homeflix migrations/ ./migrations/
+COPY --chown=homeflix:homeflix alembic.ini ./
+COPY --chown=homeflix:homeflix docker/entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+USER homeflix
+
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    HOST=0.0.0.0 \
+    PORT=8005
+
+EXPOSE 8005
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -fsS http://localhost:8005/health || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install dev test lint format migrate migration clean
+.PHONY: help install dev test lint format migrate migration clean docker-build docker-up docker-down docker-logs
 
 # Default target
 help:
@@ -26,6 +26,12 @@ help:
 	@echo "Database:"
 	@echo "  make migrate       Apply all migrations"
 	@echo "  make migration     Create new migration (use: make migration message='description')"
+	@echo ""
+	@echo "Docker:"
+	@echo "  make docker-build  Build the backend image"
+	@echo "  make docker-up     Start the stack in the background"
+	@echo "  make docker-down   Stop and remove the stack"
+	@echo "  make docker-logs   Tail backend logs"
 	@echo ""
 	@echo "Cleanup:"
 	@echo "  make clean         Remove generated files"
@@ -92,6 +98,22 @@ migrate:
 
 migration:
 	poetry run alembic revision --autogenerate -m "$(message)"
+
+# =============================================================================
+# Docker
+# =============================================================================
+
+docker-build:
+	docker compose build
+
+docker-up:
+	docker compose up -d
+
+docker-down:
+	docker compose down
+
+docker-logs:
+	docker compose logs -f backend
 
 # =============================================================================
 # Cleanup

--- a/README.md
+++ b/README.md
@@ -115,6 +115,29 @@ make migrate
 make dev
 ```
 
+### Docker
+
+For a one-command self-contained setup:
+
+```bash
+cp .env.example .env           # edit TMDB_API_KEY and media paths
+docker compose up --build
+```
+
+The backend serves at http://localhost:8005. Migrations run
+automatically on startup. Before shipping media, edit
+`docker-compose.yml` to bind-mount your directories onto
+`/media/movies` and `/media/series`:
+
+```yaml
+volumes:
+  - /your/movies:/media/movies:ro
+  - /your/series:/media/series:ro
+```
+
+Data, HLS cache, and thumbnails persist under `./data`, `./hls_cache`,
+and `./thumbnails` on the host.
+
 ### Configuration
 
 Copy the example environment file and configure:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  backend:
+    build: .
+    container_name: homeflix-backend
+    ports:
+      - "8005:8005"
+    environment:
+      APP_ENV: production
+      DEBUG: "false"
+      LOG_LEVEL: INFO
+      DATABASE_URL: sqlite+aiosqlite:////app/data/homeflix.db
+      MEDIA_DIRECTORIES: /media/movies,/media/series
+      THUMBNAILS_DIRECTORY: /app/thumbnails
+      HLS_CACHE_DIRECTORY: /app/hls_cache
+      HLS_CACHE_MAX_SIZE_MB: "20000"
+      TMDB_API_KEY: "${TMDB_API_KEY:-}"
+      TMDB_BASE_URL: "${TMDB_BASE_URL:-https://api.themoviedb.org/3}"
+      OMDB_API_KEY: "${OMDB_API_KEY:-}"
+      ALLOWED_ORIGINS: "${ALLOWED_ORIGINS:-http://localhost:5173}"
+      DEFAULT_LOCALE: "${DEFAULT_LOCALE:-en}"
+      SUPPORTED_LOCALES: "${SUPPORTED_LOCALES:-en,pt-BR}"
+    volumes:
+      - ./data:/app/data
+      - ./hls_cache:/app/hls_cache
+      - ./thumbnails:/app/thumbnails
+      # Customize these to point at your actual media:
+      # - /path/to/movies:/media/movies:ro
+      # - /path/to/series:/media/series:ro
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8005/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # Opt-in PostgreSQL profile — enable with:
+  #   docker compose --profile postgres up
+  # postgres:
+  #   image: postgres:16-alpine
+  #   container_name: homeflix-postgres
+  #   profiles: [postgres]
+  #   environment:
+  #     POSTGRES_USER: homeflix
+  #     POSTGRES_PASSWORD: homeflix
+  #     POSTGRES_DB: homeflix
+  #   volumes:
+  #     - ./data/postgres:/var/lib/postgresql/data
+  #   restart: unless-stopped

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Container entrypoint — runs pending database migrations, then starts
+# the FastAPI server. Migrations are safe to re-run on every boot.
+#
+set -euo pipefail
+
+echo "[entrypoint] Running database migrations..."
+alembic upgrade head
+
+echo "[entrypoint] Starting HomeFlix API on ${HOST}:${PORT}..."
+exec uvicorn src.main:app --host "${HOST}" --port "${PORT}"


### PR DESCRIPTION
## Summary

Package the backend as a reproducible container. This kicks off Phase 2 of the roadmap and unblocks reproducible deployment, CI image targets, and future items like GPU passthrough for hardware transcoding.

**What's new**
- `Dockerfile` — multi-stage: Poetry-based builder exports production deps to a venv, slim runtime copies the venv plus ffmpeg/curl and runs as non-root
- `docker-compose.yml` — single backend service with volumes, env vars, healthcheck; commented PostgreSQL profile for opt-in later
- `docker/entrypoint.sh` — runs `alembic upgrade head` then `exec uvicorn`
- `.dockerignore` — excludes tests, caches, local data dirs, real `.env`
- Makefile `docker-build`, `docker-up`, `docker-down`, `docker-logs` targets
- README ``Docker`` section under Quick Start

**Volumes**
- `./data` → `/app/data` (SQLite DB)
- `./hls_cache` → `/app/hls_cache`
- `./thumbnails` → `/app/thumbnails`
- Media bind mounts documented as commented examples in compose

## Test plan

- [x] `bash -n docker/entrypoint.sh` — syntax valid
- [x] `docker-compose.yml` parses as valid YAML with `backend` service
- [x] `alembic upgrade head` works against the existing migrations (entrypoint command)
- [ ] `docker compose build` — run locally (Docker isn't available in my WSL shell)
- [ ] `docker compose up -d` — confirm container reaches healthy state
- [ ] `curl http://localhost:8005/health` returns healthy
- [ ] `./data/homeflix.db` gets created on first run

## Summary by Sourcery

Containerize the backend with a multi-stage Docker image and docker-compose setup for reproducible local and production-like deployments.

New Features:
- Provide a multi-stage Dockerfile that builds a production virtualenv with Poetry and runs the app in a slim non-root runtime image with health checks.
- Introduce a docker-compose configuration for the backend service with persisted data/cache volumes and configurable environment variables.
- Add a container entrypoint script that applies database migrations before starting the FastAPI server via Uvicorn.

Enhancements:
- Extend the Makefile with convenience targets for building, running, stopping, and tailing logs of the Docker stack.
- Document a Docker-based quick start workflow in the README, including media volume configuration and persistence paths.

Build:
- Add a .dockerignore file to exclude tests, caches, local data, and non-essential files from the Docker build context.