### PR TITLE
feat(library): add scheduled scans via APScheduler

### DIFF
--- a/migrations/versions/2026_04_04_435d635e4b18_initial_schema.py
+++ b/migrations/versions/2026_04_04_435d635e4b18_initial_schema.py
@@ -30,6 +30,8 @@ def upgrade() -> None:
         sa.Column("poster_path", sa.String(length=1000), nullable=True),
         sa.Column("backdrop_path", sa.String(length=1000), nullable=True),
         sa.Column("genres", sa.String(length=500), nullable=True),
+        sa.Column("cast", sa.Text(), nullable=True),
+        sa.Column("directors", sa.Text(), nullable=True),
         sa.Column("file_path", sa.String(length=2000), nullable=True),
         sa.Column("file_size", sa.BigInteger(), nullable=True),
         sa.Column("resolution", sa.String(length=20), nullable=True),

--- a/migrations/versions/2026_04_13_add_libraries_table.py
+++ b/migrations/versions/2026_04_13_add_libraries_table.py
@@ -1,7 +1,7 @@
 """Add libraries table.
 
-Revision ID: a1b2c3d4e5f6
-Revises: 2026_04_12_add_fts5_search
+Revision ID: d4e5f6a7b8c9
+Revises: a1b2c3d4e5f6
 Create Date: 2026-04-13 10:00:00.000000
 
 """
@@ -12,8 +12,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
-down_revision: str | Sequence[str] | None = None
+revision: str = "d4e5f6a7b8c9"
+down_revision: str | Sequence[str] | None = "a1b2c3d4e5f6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/2026_04_13_add_preferences_table.py
+++ b/migrations/versions/2026_04_13_add_preferences_table.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "b2c3d4e5f6g7"
-down_revision: str | Sequence[str] | None = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "d4e5f6a7b8c9"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/2026_04_14_add_library_last_scan_at.py
+++ b/migrations/versions/2026_04_14_add_library_last_scan_at.py
@@ -1,0 +1,29 @@
+"""Add last_scan_at column to libraries table.
+
+Revision ID: c3d4e5f6g7h8
+Revises: b2c3d4e5f6g7
+Create Date: 2026-04-14 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3d4e5f6g7h8"
+down_revision: str | Sequence[str] | None = "b2c3d4e5f6g7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add last_scan_at column."""
+    with op.batch_alter_table("libraries", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("last_scan_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop last_scan_at column."""
+    with op.batch_alter_table("libraries", schema=None) as batch_op:
+        batch_op.drop_column("last_scan_at")

--- a/migrations/versions/2026_04_14_catch_up_schema.py
+++ b/migrations/versions/2026_04_14_catch_up_schema.py
@@ -1,0 +1,172 @@
+"""Catch up schema with columns and tables never migrated.
+
+Historically the project relied on SQLAlchemy ``create_all`` in dev
+mode, which kept the live DB in sync with the models but left the
+Alembic history behind. Four tables (``watch_progresses``,
+``custom_lists``, ``custom_list_items``, ``watchlist_items``) and
+several columns on ``movies`` / ``series`` were never turned into
+migrations. This revision brings the migration chain up to parity
+with the current model set so a fresh `alembic upgrade head` yields
+a fully functional schema.
+
+Revision ID: e5f6a7b8c9d0
+Revises: c3d4e5f6g7h8
+Create Date: 2026-04-14 22:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e5f6a7b8c9d0"
+down_revision: str | Sequence[str] | None = "c3d4e5f6g7h8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_COMMON_TIMESTAMPS = (
+    sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+    sa.Column("external_id", sa.String(length=50), nullable=False),
+    sa.Column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.text("(CURRENT_TIMESTAMP)"),
+        nullable=False,
+    ),
+    sa.Column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.text("(CURRENT_TIMESTAMP)"),
+        nullable=False,
+    ),
+    sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+)
+
+
+def upgrade() -> None:
+    """Add missing columns and tables to match current models."""
+    # ── movies: credits, classification, trailer, localized metadata ──
+    # IMPORTANT: use op.add_column (direct ALTER TABLE) rather than
+    # batch_alter_table here. batch_alter_table copies the table in
+    # SQLite, which silently breaks the external-content FTS5 link
+    # defined in the earlier migration and causes subsequent UPDATEs
+    # on movies to raise "database disk image is malformed".
+    op.add_column("movies", sa.Column("writers", sa.Text(), nullable=True))
+    op.add_column("movies", sa.Column("content_rating", sa.String(length=20), nullable=True))
+    op.add_column("movies", sa.Column("trailer_url", sa.String(length=500), nullable=True))
+    op.add_column("movies", sa.Column("localized", sa.Text(), nullable=True))
+
+    # ── series: classification, trailer, localized metadata ──
+    op.add_column("series", sa.Column("content_rating", sa.String(length=20), nullable=True))
+    op.add_column("series", sa.Column("trailer_url", sa.String(length=500), nullable=True))
+    op.add_column("series", sa.Column("localized", sa.Text(), nullable=True))
+
+    # ── watch_progresses ─────────────────────────────────────────────
+    op.create_table(
+        "watch_progresses",
+        sa.Column("media_id", sa.String(length=50), nullable=False),
+        sa.Column("media_type", sa.String(length=20), nullable=False),
+        sa.Column("position_seconds", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("duration_seconds", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="in_progress"),
+        sa.Column("audio_track", sa.Integer(), nullable=True),
+        sa.Column("subtitle_track", sa.Integer(), nullable=True),
+        sa.Column("last_watched_at", sa.DateTime(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        *_COMMON_TIMESTAMPS,
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("watch_progresses", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_watch_progresses_deleted_at"), ["deleted_at"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_watch_progresses_external_id"), ["external_id"], unique=True
+        )
+        batch_op.create_index(batch_op.f("ix_watch_progresses_media_id"), ["media_id"], unique=True)
+
+    # ── custom_lists ─────────────────────────────────────────────────
+    op.create_table(
+        "custom_lists",
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("item_count", sa.Integer(), nullable=False, server_default="0"),
+        *_COMMON_TIMESTAMPS,
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("custom_lists", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_custom_lists_deleted_at"), ["deleted_at"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_custom_lists_external_id"), ["external_id"], unique=True
+        )
+
+    # ── custom_list_items (FK → custom_lists) ────────────────────────
+    op.create_table(
+        "custom_list_items",
+        sa.Column("custom_list_id", sa.Integer(), nullable=False),
+        sa.Column("media_id", sa.String(length=50), nullable=False),
+        sa.Column("media_type", sa.String(length=20), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("added_at", sa.DateTime(), nullable=False),
+        *_COMMON_TIMESTAMPS,
+        sa.ForeignKeyConstraint(["custom_list_id"], ["custom_lists.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("custom_list_items", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_custom_list_items_custom_list_id"),
+            ["custom_list_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_custom_list_items_deleted_at"), ["deleted_at"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_custom_list_items_external_id"), ["external_id"], unique=True
+        )
+        batch_op.create_index(
+            batch_op.f("ix_custom_list_items_media_id"), ["media_id"], unique=False
+        )
+
+    # ── watchlist_items ──────────────────────────────────────────────
+    op.create_table(
+        "watchlist_items",
+        sa.Column("media_id", sa.String(length=50), nullable=False),
+        sa.Column("media_type", sa.String(length=20), nullable=False),
+        sa.Column("added_at", sa.DateTime(), nullable=False),
+        *_COMMON_TIMESTAMPS,
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("watchlist_items", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_watchlist_items_deleted_at"), ["deleted_at"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_watchlist_items_external_id"), ["external_id"], unique=True
+        )
+        batch_op.create_index(batch_op.f("ix_watchlist_items_media_id"), ["media_id"], unique=True)
+
+
+def downgrade() -> None:
+    """Drop the catch-up tables and columns."""
+    op.drop_table("watchlist_items")
+    op.drop_table("custom_list_items")
+    op.drop_table("custom_lists")
+    op.drop_table("watch_progresses")
+
+    # NOTE: Proper SQLite downgrade of DROP COLUMN requires
+    # batch_alter_table, which in turn would break the FTS5 external
+    # content link (see upgrade comment). If you need to downgrade,
+    # drop and recreate the FTS5 indexes around these calls. For v1
+    # this migration is one-way in practice.
+    op.drop_column("series", "localized")
+    op.drop_column("series", "trailer_url")
+    op.drop_column("series", "content_rating")
+
+    op.drop_column("movies", "localized")
+    op.drop_column("movies", "trailer_url")
+    op.drop_column("movies", "content_rating")
+    op.drop_column("movies", "writers")

--- a/migrations/versions/2026_04_14_catch_up_schema.py
+++ b/migrations/versions/2026_04_14_catch_up_schema.py
@@ -151,22 +151,21 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Drop the catch-up tables and columns."""
-    op.drop_table("watchlist_items")
-    op.drop_table("custom_list_items")
-    op.drop_table("custom_lists")
-    op.drop_table("watch_progresses")
+    """This migration is intentionally one-way.
 
-    # NOTE: Proper SQLite downgrade of DROP COLUMN requires
-    # batch_alter_table, which in turn would break the FTS5 external
-    # content link (see upgrade comment). If you need to downgrade,
-    # drop and recreate the FTS5 indexes around these calls. For v1
-    # this migration is one-way in practice.
-    op.drop_column("series", "localized")
-    op.drop_column("series", "trailer_url")
-    op.drop_column("series", "content_rating")
+    Reverting it on SQLite would require either ``op.drop_column``
+    (which fails on the SQLite versions that ship with most Python
+    distributions, since native ``ALTER TABLE ... DROP COLUMN`` only
+    landed in SQLite 3.35) or ``batch_alter_table`` (which would
+    silently break the FTS5 external-content link defined in the
+    earlier migration and corrupt subsequent UPDATEs).
 
-    op.drop_column("movies", "localized")
-    op.drop_column("movies", "trailer_url")
-    op.drop_column("movies", "content_rating")
-    op.drop_column("movies", "writers")
+    Rather than ship a downgrade that fails or corrupts the DB at the
+    worst possible moment, fail loudly here. To roll back, restore
+    the database from a backup taken before this revision was applied.
+    """
+    raise RuntimeError(
+        "Downgrade for revision 'e5f6a7b8c9d0' (catch-up schema) is "
+        "intentionally disabled. Restore from a pre-migration backup "
+        "instead — see the docstring for the reasoning."
+    )

--- a/migrations/versions/2026_04_14_fix_fts5_triggers.py
+++ b/migrations/versions/2026_04_14_fix_fts5_triggers.py
@@ -1,0 +1,184 @@
+"""Fix FTS5 sync triggers to use external-content-safe commands.
+
+The original triggers in revision ``a1b2c3d4e5f6`` used plain
+``DELETE FROM movies_fts WHERE rowid = OLD.id`` to remove rows from
+the FTS5 virtual table. That syntax is *not* valid for FTS5 tables
+declared with ``content='...'`` (external content mode) — the
+correct call is the special ``'delete'`` command that also tells
+FTS5 the full prior value of each indexed column:
+
+    INSERT INTO movies_fts(movies_fts, rowid, title, ...)
+        VALUES('delete', OLD.id, OLD.title, ...);
+
+Some SQLite builds (notably the ones shipping with Python on
+Windows) now reject the old syntax with
+``database disk image is malformed`` when the offending trigger
+fires — for example, every UPDATE on ``movies`` during metadata
+enrichment. This revision drops the broken triggers and recreates
+them with the correct external-content commands.
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-04-14 23:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "f6a7b8c9d0e1"
+down_revision: str | Sequence[str] | None = "e5f6a7b8c9d0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Replace the broken FTS5 sync triggers with correct ones."""
+    # ── Movies ───────────────────────────────────────────────────────
+    op.execute("DROP TRIGGER IF EXISTS movies_fts_update")
+    op.execute("DROP TRIGGER IF EXISTS movies_fts_delete")
+
+    op.execute(
+        """
+        CREATE TRIGGER movies_fts_update AFTER UPDATE ON movies BEGIN
+            INSERT INTO movies_fts(movies_fts, rowid, title, original_title,
+                                   synopsis, genres, "cast", directors)
+            VALUES ('delete',
+                    OLD.id,
+                    COALESCE(OLD.title, ''),
+                    COALESCE(OLD.original_title, ''),
+                    COALESCE(OLD.synopsis, ''),
+                    COALESCE(OLD.genres, ''),
+                    COALESCE(OLD."cast", ''),
+                    COALESCE(OLD.directors, ''));
+            INSERT INTO movies_fts(rowid, title, original_title,
+                                   synopsis, genres, "cast", directors)
+            SELECT NEW.id,
+                   COALESCE(NEW.title, ''),
+                   COALESCE(NEW.original_title, ''),
+                   COALESCE(NEW.synopsis, ''),
+                   COALESCE(NEW.genres, ''),
+                   COALESCE(NEW."cast", ''),
+                   COALESCE(NEW.directors, '')
+            WHERE NEW.deleted_at IS NULL;
+        END
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER movies_fts_delete AFTER DELETE ON movies BEGIN
+            INSERT INTO movies_fts(movies_fts, rowid, title, original_title,
+                                   synopsis, genres, "cast", directors)
+            VALUES ('delete',
+                    OLD.id,
+                    COALESCE(OLD.title, ''),
+                    COALESCE(OLD.original_title, ''),
+                    COALESCE(OLD.synopsis, ''),
+                    COALESCE(OLD.genres, ''),
+                    COALESCE(OLD."cast", ''),
+                    COALESCE(OLD.directors, ''));
+        END
+        """
+    )
+
+    # ── Series ───────────────────────────────────────────────────────
+    op.execute("DROP TRIGGER IF EXISTS series_fts_update")
+    op.execute("DROP TRIGGER IF EXISTS series_fts_delete")
+
+    op.execute(
+        """
+        CREATE TRIGGER series_fts_update AFTER UPDATE ON series BEGIN
+            INSERT INTO series_fts(series_fts, rowid, title, original_title,
+                                   synopsis, genres)
+            VALUES ('delete',
+                    OLD.id,
+                    COALESCE(OLD.title, ''),
+                    COALESCE(OLD.original_title, ''),
+                    COALESCE(OLD.synopsis, ''),
+                    COALESCE(OLD.genres, ''));
+            INSERT INTO series_fts(rowid, title, original_title,
+                                   synopsis, genres)
+            SELECT NEW.id,
+                   COALESCE(NEW.title, ''),
+                   COALESCE(NEW.original_title, ''),
+                   COALESCE(NEW.synopsis, ''),
+                   COALESCE(NEW.genres, '')
+            WHERE NEW.deleted_at IS NULL;
+        END
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER series_fts_delete AFTER DELETE ON series BEGIN
+            INSERT INTO series_fts(series_fts, rowid, title, original_title,
+                                   synopsis, genres)
+            VALUES ('delete',
+                    OLD.id,
+                    COALESCE(OLD.title, ''),
+                    COALESCE(OLD.original_title, ''),
+                    COALESCE(OLD.synopsis, ''),
+                    COALESCE(OLD.genres, ''));
+        END
+        """
+    )
+
+    # Rebuild the FTS5 indexes in case any stale deletes left orphaned
+    # rows that would confuse future queries.
+    op.execute("INSERT INTO movies_fts(movies_fts) VALUES('rebuild')")
+    op.execute("INSERT INTO series_fts(series_fts) VALUES('rebuild')")
+
+
+def downgrade() -> None:
+    """Restore the original (broken) triggers."""
+    op.execute("DROP TRIGGER IF EXISTS movies_fts_update")
+    op.execute("DROP TRIGGER IF EXISTS movies_fts_delete")
+    op.execute("DROP TRIGGER IF EXISTS series_fts_update")
+    op.execute("DROP TRIGGER IF EXISTS series_fts_delete")
+
+    op.execute(
+        """
+        CREATE TRIGGER movies_fts_update AFTER UPDATE ON movies BEGIN
+            DELETE FROM movies_fts WHERE rowid = OLD.id;
+            INSERT INTO movies_fts(rowid, title, original_title,
+                                   synopsis, genres, "cast", directors)
+            SELECT NEW.id,
+                   COALESCE(NEW.title, ''),
+                   COALESCE(NEW.original_title, ''),
+                   COALESCE(NEW.synopsis, ''),
+                   COALESCE(NEW.genres, ''),
+                   COALESCE(NEW."cast", ''),
+                   COALESCE(NEW.directors, '')
+            WHERE NEW.deleted_at IS NULL;
+        END
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER movies_fts_delete AFTER DELETE ON movies BEGIN
+            DELETE FROM movies_fts WHERE rowid = OLD.id;
+        END
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER series_fts_update AFTER UPDATE ON series BEGIN
+            DELETE FROM series_fts WHERE rowid = OLD.id;
+            INSERT INTO series_fts(rowid, title, original_title, synopsis, genres)
+            SELECT NEW.id,
+                   COALESCE(NEW.title, ''),
+                   COALESCE(NEW.original_title, ''),
+                   COALESCE(NEW.synopsis, ''),
+                   COALESCE(NEW.genres, '')
+            WHERE NEW.deleted_at IS NULL;
+        END
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER series_fts_delete AFTER DELETE ON series BEGIN
+            DELETE FROM series_fts WHERE rowid = OLD.id;
+        END
+        """
+    )

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,6 +68,34 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+description = "In-process task scheduler with Cron-like capabilities"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d"},
+    {file = "apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41"},
+]
+
+[package.dependencies]
+tzlocal = ">=3.0"
+
+[package.extras]
+doc = ["packaging", "sphinx", "sphinx-rtd-theme (>=1.3.0)"]
+etcd = ["etcd3", "protobuf (<=3.21.0)"]
+gevent = ["gevent"]
+mongodb = ["pymongo (>=3.0)"]
+redis = ["redis (>=3.0)"]
+rethinkdb = ["rethinkdb (>=2.4.0)"]
+sqlalchemy = ["sqlalchemy (>=1.4)"]
+test = ["APScheduler[etcd,mongodb,redis,rethinkdb,sqlalchemy,tornado,zookeeper]", "PySide6 ; platform_python_implementation == \"CPython\" and python_version < \"3.14\"", "anyio (>=4.5.2)", "gevent ; python_version < \"3.14\"", "pytest", "pytest-timeout", "pytz", "twisted ; python_version < \"3.14\""]
+tornado = ["tornado (>=4.3)"]
+twisted = ["twisted"]
+zookeeper = ["kazoo"]
+
+[[package]]
 name = "asyncpg"
 version = "0.29.0"
 description = "An asyncio PostgreSQL driver"
@@ -1964,12 +1992,30 @@ version = "2025.3"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["postgres"]
-markers = "sys_platform == \"win32\""
+groups = ["main", "postgres"]
 files = [
     {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
     {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
 ]
+markers = {main = "platform_system == \"Windows\"", postgres = "sys_platform == \"win32\""}
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+description = "tzinfo object for the local timezone"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d"},
+    {file = "tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+devenv = ["check-manifest", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
 [[package]]
 name = "uvicorn"
@@ -2279,4 +2325,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "168d274e20170c57d9d09294859126b2fea05a01b806e68229e029f4a2eba2e4"
+content-hash = "7270a22be48edc70cb6775af704b9cdcf414f0f4da3eb4feede85dfcfec3a0c0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependency-injector = "^4.41.0"
 python-multipart = "^0.0.6"
 python-jose = { extras = ["cryptography"], version = "^3.3.0" }
 structlog = "^24.1.0"
+apscheduler = "^3.10.4"
 
 [tool.poetry.group.dev.dependencies]
 # Testing
@@ -92,6 +93,10 @@ plugins = ["pydantic.mypy", "sqlalchemy.ext.mypy.plugin"]
 module = "tests.*"
 disallow_untyped_defs = false
 disallow_untyped_decorators = false
+
+[[tool.mypy.overrides]]
+module = ["apscheduler.*"]
+ignore_missing_imports = true
 
 # =============================================================================
 # Pytest

--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from src.building_blocks.infrastructure.in_process_event_bus import InProcessEventBus
 from src.config.persistence.session_manager import create_tracked_session
 from src.config.settings import Settings
+from src.infrastructure.scheduling import LibraryScanScheduler
 
 
 async def _init_engine(
@@ -72,3 +73,10 @@ class InfrastructureContainer(containers.DeclarativeContainer):  # type: ignore[
     )
 
     event_bus = providers.Singleton(InProcessEventBus)
+
+    library_scan_scheduler = providers.Singleton(
+        LibraryScanScheduler,
+        session_factory=session_factory,
+        event_bus=event_bus,
+        reconcile_interval_minutes=config.provided.scheduler_reconcile_interval_minutes,
+    )

--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -14,6 +14,8 @@ from src.building_blocks.infrastructure.in_process_event_bus import InProcessEve
 from src.config.persistence.session_manager import create_tracked_session
 from src.config.settings import Settings
 from src.infrastructure.scheduling import LibraryScanScheduler
+from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
+from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
 
 
 async def _init_engine(
@@ -74,9 +76,15 @@ class InfrastructureContainer(containers.DeclarativeContainer):  # type: ignore[
 
     event_bus = providers.Singleton(InProcessEventBus)
 
+    # Stateless services reused across requests and background jobs.
+    file_scanner = providers.Singleton(LocalFileSystemScanner)
+    variant_detector = providers.Singleton(VariantDetector)
+
     library_scan_scheduler = providers.Singleton(
         LibraryScanScheduler,
         session_factory=session_factory,
         event_bus=event_bus,
+        file_scanner=file_scanner,
+        variant_detector=variant_detector,
         reconcile_interval_minutes=config.provided.scheduler_reconcile_interval_minutes,
     )

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -116,6 +116,21 @@ class Settings(BaseSettings):  # type: ignore[misc]
     )
 
     # =========================================================================
+    # Scheduler
+    # =========================================================================
+
+    scheduler_enabled: bool = Field(
+        default=True,
+        description="Enable the background scheduler (library scans, etc.).",
+    )
+    scheduler_reconcile_interval_minutes: int = Field(
+        default=5,
+        ge=1,
+        description="How often the scheduler re-reads libraries from the "
+        "database to sync cron jobs with configured schedules.",
+    )
+
+    # =========================================================================
     # Internationalization
     # =========================================================================
 

--- a/src/infrastructure/scheduling/__init__.py
+++ b/src/infrastructure/scheduling/__init__.py
@@ -1,0 +1,11 @@
+"""Background scheduling infrastructure.
+
+The scheduler coordinates recurring work (library scans today;
+trickplay generation and periodic enrichment later) without
+coupling the domain or application layers to any specific
+scheduling backend.
+"""
+
+from src.infrastructure.scheduling.scheduler_service import LibraryScanScheduler
+
+__all__ = ["LibraryScanScheduler"]

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -1,0 +1,200 @@
+"""Scheduler service for recurring library scans.
+
+Wraps APScheduler with a domain-aware reconciliation loop.  The
+``Library`` entity stores its own cron expression; this service reads
+those rows periodically and mirrors them into the APScheduler job
+registry — adding new jobs, removing deleted ones, and replacing jobs
+whose cron changed.  Each scan opens a fresh DB session so background
+work never shares a request-scoped one.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
+    SqlAlchemyLibraryRepository,
+)
+from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
+from src.modules.media.application.use_cases.scan_media_directories import (
+    ScanMediaDirectoriesUseCase,
+)
+from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
+from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
+from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
+    SQLAlchemyMovieRepository,
+)
+from src.modules.media.infrastructure.persistence.repositories.series_repository import (
+    SQLAlchemySeriesRepository,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from src.building_blocks.application.event_bus import EventBus
+
+_logger = logging.getLogger(__name__)
+
+_RECONCILE_JOB_ID = "homeflix:reconcile-libraries"
+_LIBRARY_JOB_PREFIX = "library-scan:"
+
+
+def _job_id_for(library_id: str) -> str:
+    return f"{_LIBRARY_JOB_PREFIX}{library_id}"
+
+
+class LibraryScanScheduler:
+    """Coordinate cron-driven library scans.
+
+    Single source of truth for schedules is the ``Library`` table; this
+    service does not maintain its own job database.  Reconciliation
+    runs at startup and on a configurable interval so schedule edits
+    made through the REST API propagate without a restart.
+    """
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+        reconcile_interval_minutes: int,
+    ) -> None:
+        self._session_factory = session_factory
+        self._event_bus = event_bus
+        self._reconcile_interval_minutes = reconcile_interval_minutes
+        self._scheduler = AsyncIOScheduler(timezone="UTC")
+
+    async def start(self) -> None:
+        """Start the scheduler and register the reconcile + initial jobs."""
+        self._scheduler.start()
+        self._scheduler.add_job(
+            self._reconcile,
+            trigger="interval",
+            minutes=self._reconcile_interval_minutes,
+            id=_RECONCILE_JOB_ID,
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+        )
+        await self._reconcile()
+        _logger.info(
+            "[scheduler] Started; reconciling every %s minute(s)",
+            self._reconcile_interval_minutes,
+        )
+
+    async def stop(self) -> None:
+        """Shut the scheduler down, waiting for any in-flight jobs."""
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=True)
+            _logger.info("[scheduler] Stopped")
+
+    async def _reconcile(self) -> None:
+        """Sync APScheduler jobs with the current ``Library`` rows.
+
+        Adds a cron job for each library with a non-empty, valid
+        ``scan_schedule``; replaces an existing job whose cron changed;
+        removes jobs for libraries that vanished or lost their schedule.
+        Invalid crons are logged and skipped — we never crash startup
+        or reconciliation over a bad expression.
+        """
+        async with self._session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+            libraries = await repo.find_all()
+
+        desired: dict[str, tuple[str, str]] = {}  # job_id -> (library_id, cron)
+        for library in libraries:
+            if not library.scan_schedule or library.id is None:
+                continue
+            library_id = str(library.id)
+            desired[_job_id_for(library_id)] = (library_id, library.scan_schedule)
+
+        existing = {
+            job.id for job in self._scheduler.get_jobs() if job.id.startswith(_LIBRARY_JOB_PREFIX)
+        }
+
+        # Remove jobs no longer desired.
+        for job_id in existing - desired.keys():
+            self._scheduler.remove_job(job_id)
+            _logger.info("[scheduler] Removed job %s", job_id)
+
+        # Add or replace desired jobs.
+        for job_id, (library_id, cron) in desired.items():
+            try:
+                trigger = CronTrigger.from_crontab(cron, timezone="UTC")
+            except ValueError as exc:
+                _logger.warning(
+                    "[scheduler] Skipping library %s: invalid cron %r (%s)",
+                    library_id,
+                    cron,
+                    exc,
+                )
+                if job_id in existing:
+                    self._scheduler.remove_job(job_id)
+                continue
+
+            self._scheduler.add_job(
+                self._run_scan,
+                trigger=trigger,
+                args=[library_id],
+                id=job_id,
+                replace_existing=True,
+                max_instances=1,
+                coalesce=True,
+            )
+            _logger.info("[scheduler] Scheduled library %s with cron %r", library_id, cron)
+
+    async def _run_scan(self, library_id: str) -> None:
+        """Run a single library scan and record completion.
+
+        Opens a fresh session, loads the library, runs the scan use
+        case for its configured paths, and persists an updated
+        ``last_scan_at`` on success. Errors are logged — failure
+        tracking beyond logs is out of scope for v1.
+        """
+        _logger.info("[scheduler] Running scan for library %s", library_id)
+
+        async with self._session_factory() as session:
+            library_repo = SqlAlchemyLibraryRepository(session)
+            from src.modules.library.domain.value_objects.library_id import LibraryId
+
+            library = await library_repo.find_by_id(LibraryId(library_id))
+            if library is None:
+                _logger.warning("[scheduler] Library %s vanished before scan; skipping", library_id)
+                return
+
+            scan_input = ScanMediaInput(directories=list(library.paths))
+            use_case = ScanMediaDirectoriesUseCase(
+                file_scanner=LocalFileSystemScanner(),
+                variant_detector=VariantDetector(),
+                movie_repository=SQLAlchemyMovieRepository(session),
+                series_repository=SQLAlchemySeriesRepository(session),
+                event_bus=self._event_bus,
+            )
+
+            try:
+                result = await use_case.execute(scan_input)
+            except Exception:
+                _logger.exception("[scheduler] Scan failed for library %s", library_id)
+                await session.rollback()
+                return
+
+            updated = library.with_scan_completed(datetime.now(UTC))
+            await library_repo.save(updated)
+            await session.commit()
+
+        _logger.info(
+            "[scheduler] Library %s scan done: " "movies=%d/%d episodes=%d/%d errors=%d",
+            library_id,
+            result.movies_created,
+            result.movies_updated,
+            result.episodes_created,
+            result.episodes_updated,
+            len(result.errors),
+        )
+
+
+__all__ = ["LibraryScanScheduler"]

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -10,13 +10,13 @@ work never shares a request-scoped one.
 
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from src.config.logging import get_logger
 from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
     SqlAlchemyLibraryRepository,
 )
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
     from src.building_blocks.application.event_bus import EventBus
 
-_logger = logging.getLogger(__name__)
+_logger = get_logger()
 
 _RECONCILE_JOB_ID = "homeflix:reconcile-libraries"
 _LIBRARY_JOB_PREFIX = "library-scan:"
@@ -82,8 +82,8 @@ class LibraryScanScheduler:
         )
         await self._reconcile()
         _logger.info(
-            "[scheduler] Started; reconciling every %s minute(s)",
-            self._reconcile_interval_minutes,
+            "[scheduler] Started",
+            reconcile_interval_minutes=self._reconcile_interval_minutes,
         )
 
     async def stop(self) -> None:
@@ -119,7 +119,7 @@ class LibraryScanScheduler:
         # Remove jobs no longer desired.
         for job_id in existing - desired.keys():
             self._scheduler.remove_job(job_id)
-            _logger.info("[scheduler] Removed job %s", job_id)
+            _logger.info("[scheduler] Removed job", job_id=job_id)
 
         # Add or replace desired jobs.
         for job_id, (library_id, cron) in desired.items():
@@ -127,10 +127,10 @@ class LibraryScanScheduler:
                 trigger = CronTrigger.from_crontab(cron, timezone="UTC")
             except ValueError as exc:
                 _logger.warning(
-                    "[scheduler] Skipping library %s: invalid cron %r (%s)",
-                    library_id,
-                    cron,
-                    exc,
+                    "[scheduler] Skipping library: invalid cron",
+                    library_id=library_id,
+                    cron=cron,
+                    error=str(exc),
                 )
                 if job_id in existing:
                     self._scheduler.remove_job(job_id)
@@ -145,7 +145,11 @@ class LibraryScanScheduler:
                 max_instances=1,
                 coalesce=True,
             )
-            _logger.info("[scheduler] Scheduled library %s with cron %r", library_id, cron)
+            _logger.info(
+                "[scheduler] Scheduled library",
+                library_id=library_id,
+                cron=cron,
+            )
 
     async def _run_scan(self, library_id: str) -> None:
         """Run a single library scan and record completion.
@@ -155,7 +159,7 @@ class LibraryScanScheduler:
         ``last_scan_at`` on success. Errors are logged — failure
         tracking beyond logs is out of scope for v1.
         """
-        _logger.info("[scheduler] Running scan for library %s", library_id)
+        _logger.info("[scheduler] Running scan", library_id=library_id)
 
         async with self._session_factory() as session:
             library_repo = SqlAlchemyLibraryRepository(session)
@@ -163,7 +167,10 @@ class LibraryScanScheduler:
 
             library = await library_repo.find_by_id(LibraryId(library_id))
             if library is None:
-                _logger.warning("[scheduler] Library %s vanished before scan; skipping", library_id)
+                _logger.warning(
+                    "[scheduler] Library vanished before scan; skipping",
+                    library_id=library_id,
+                )
                 return
 
             scan_input = ScanMediaInput(directories=list(library.paths))
@@ -177,8 +184,13 @@ class LibraryScanScheduler:
 
             try:
                 result = await use_case.execute(scan_input)
-            except Exception:
-                _logger.exception("[scheduler] Scan failed for library %s", library_id)
+            except Exception as exc:
+                _logger.error(
+                    "[scheduler] Scan failed",
+                    library_id=library_id,
+                    error=str(exc),
+                    exc_info=True,
+                )
                 await session.rollback()
                 return
 
@@ -187,13 +199,13 @@ class LibraryScanScheduler:
             await session.commit()
 
         _logger.info(
-            "[scheduler] Library %s scan done: " "movies=%d/%d episodes=%d/%d errors=%d",
-            library_id,
-            result.movies_created,
-            result.movies_updated,
-            result.episodes_created,
-            result.episodes_updated,
-            len(result.errors),
+            "[scheduler] Scan done",
+            library_id=library_id,
+            movies_created=result.movies_created,
+            movies_updated=result.movies_updated,
+            episodes_created=result.episodes_created,
+            episodes_updated=result.episodes_updated,
+            errors=len(result.errors),
         )
 
 

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -24,8 +24,6 @@ from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
-from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
-from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
 from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
     SQLAlchemyMovieRepository,
 )
@@ -37,6 +35,10 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
     from src.building_blocks.application.event_bus import EventBus
+    from src.modules.media.application.ports import FileSystemScanner
+    from src.modules.media.infrastructure.file_system.variant_detector import (
+        VariantDetector,
+    )
 
 _logger = get_logger()
 
@@ -61,10 +63,14 @@ class LibraryScanScheduler:
         self,
         session_factory: async_sessionmaker[AsyncSession],
         event_bus: EventBus,
+        file_scanner: FileSystemScanner,
+        variant_detector: VariantDetector,
         reconcile_interval_minutes: int,
     ) -> None:
         self._session_factory = session_factory
         self._event_bus = event_bus
+        self._file_scanner = file_scanner
+        self._variant_detector = variant_detector
         self._reconcile_interval_minutes = reconcile_interval_minutes
         self._scheduler = AsyncIOScheduler(timezone="UTC")
 
@@ -175,8 +181,8 @@ class LibraryScanScheduler:
 
             scan_input = ScanMediaInput(directories=list(library.paths))
             use_case = ScanMediaDirectoriesUseCase(
-                file_scanner=LocalFileSystemScanner(),
-                variant_detector=VariantDetector(),
+                file_scanner=self._file_scanner,
+                variant_detector=self._variant_detector,
                 movie_repository=SQLAlchemyMovieRepository(session),
                 series_repository=SQLAlchemySeriesRepository(session),
                 event_bus=self._event_bus,

--- a/src/main.py
+++ b/src/main.py
@@ -91,12 +91,22 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Subscribe domain event handlers
     _subscribe_event_handlers(container)
 
+    # Start background scheduler (library scans).
+    # The provider depends on the session_factory Resource, so it
+    # resolves asynchronously — must be awaited.
+    if settings.scheduler_enabled:
+        scheduler = await container.infrastructure.library_scan_scheduler()
+        await scheduler.start()
+        app.state.scheduler = scheduler
+
     logger.info("Application ready")
 
     yield
 
     # Shutdown
     logger.info("Application shutting down")
+    if hasattr(app.state, "scheduler"):
+        await app.state.scheduler.stop()
     await container.infrastructure.shutdown_resources()
     logger.info("Application stopped")
 

--- a/src/main.py
+++ b/src/main.py
@@ -93,7 +93,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Start background scheduler (library scans).
     # The provider depends on the session_factory Resource, so it
-    # resolves asynchronously — must be awaited.
+    # resolves asynchronously — must be awaited. Always pin a slot on
+    # app.state so the shutdown handler can do a single truthy check.
+    app.state.scheduler = None
     if settings.scheduler_enabled:
         scheduler = await container.infrastructure.library_scan_scheduler()
         await scheduler.start()
@@ -105,7 +107,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Shutdown
     logger.info("Application shutting down")
-    if hasattr(app.state, "scheduler"):
+    if app.state.scheduler:
         await app.state.scheduler.stop()
     await container.infrastructure.shutdown_resources()
     logger.info("Application stopped")

--- a/src/modules/library/application/dtos/library_dtos.py
+++ b/src/modules/library/application/dtos/library_dtos.py
@@ -40,6 +40,7 @@ class LibraryOutput:
     language: str
     metadata_providers: list[MetadataProviderOutput]
     scan_schedule: str | None
+    last_scan_at: str | None
     settings: LibrarySettingsOutput
 
 

--- a/src/modules/library/application/use_cases/_to_output.py
+++ b/src/modules/library/application/use_cases/_to_output.py
@@ -25,6 +25,7 @@ def library_to_output(entity: Library) -> LibraryOutput:
             for p in entity.metadata_providers
         ],
         scan_schedule=entity.scan_schedule,
+        last_scan_at=entity.last_scan_at.isoformat() if entity.last_scan_at else None,
         settings=LibrarySettingsOutput(
             preferred_audio_language=entity.settings.preferred_audio_language.value,
             preferred_subtitle_language=(

--- a/src/modules/library/domain/entities/library.py
+++ b/src/modules/library/domain/entities/library.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime  # noqa: TCH003 - Pydantic needs this at runtime for field validation
 from typing import TYPE_CHECKING, Any, Self
 
 from pydantic import Field, field_validator, model_validator
@@ -64,6 +65,7 @@ class Library(AggregateRoot[LibraryId]):
         default=None,
         pattern=r"^(\S+\s+){4}\S+$",
     )
+    last_scan_at: datetime | None = None
 
     # Settings
     settings: LibrarySettings = Field(default_factory=LibrarySettings.default)
@@ -178,6 +180,17 @@ class Library(AggregateRoot[LibraryId]):
             )
 
         return self.with_updates(paths=[p for p in self.paths if p != path])
+
+    def with_scan_completed(self, at: datetime) -> Self:
+        """Return a copy with ``last_scan_at`` set to the given timestamp.
+
+        Args:
+            at: The timestamp to record as the most recent successful scan.
+
+        Returns:
+            A new Library with the timestamp recorded.
+        """
+        return self.with_updates(last_scan_at=at)
 
     def get_enabled_providers(self) -> list[MetadataProviderConfig]:
         """Get enabled metadata providers sorted by priority.

--- a/src/modules/library/infrastructure/persistence/mappers/library_mapper.py
+++ b/src/modules/library/infrastructure/persistence/mappers/library_mapper.py
@@ -58,6 +58,7 @@ class LibraryMapper:
                 ensure_ascii=False,
             ),
             scan_schedule=entity.scan_schedule,
+            last_scan_at=entity.last_scan_at,
             settings=json.dumps(
                 {
                     "preferred_audio_language": entity.settings.preferred_audio_language.value,
@@ -104,6 +105,7 @@ class LibraryMapper:
                 for p in providers_raw
             ],
             scan_schedule=model.scan_schedule,
+            last_scan_at=model.last_scan_at,
             settings=LibrarySettings(
                 preferred_audio_language=LanguageCode(
                     settings_raw.get("preferred_audio_language", "en"),
@@ -144,6 +146,7 @@ class LibraryMapper:
         model.language = fresh.language
         model.metadata_providers = fresh.metadata_providers
         model.scan_schedule = fresh.scan_schedule
+        model.last_scan_at = fresh.last_scan_at
         model.settings = fresh.settings
         return model
 

--- a/src/modules/library/infrastructure/persistence/mappers/library_mapper.py
+++ b/src/modules/library/infrastructure/persistence/mappers/library_mapper.py
@@ -1,6 +1,7 @@
 """Mapper between Library domain entity and LibraryModel ORM model."""
 
 import json
+from datetime import UTC, datetime
 from typing import Any
 
 from src.modules.library.domain.entities.library import Library
@@ -16,6 +17,21 @@ from src.modules.library.domain.value_objects.subtitle_mode import SubtitleMode
 from src.modules.library.infrastructure.persistence.models.library_model import LibraryModel
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
+
+
+def _ensure_utc(value: datetime | None) -> datetime | None:
+    """Attach UTC tzinfo to naive datetimes loaded from the DB.
+
+    SQLite stores datetimes without timezone info even when the column
+    is declared ``DateTime(timezone=True)``. Without this normalisation
+    the entity would round-trip a naive datetime, and JSON serialisers
+    would emit an ISO string with no offset — which JS clients then
+    interpret as local time, shifting the displayed timestamp by the
+    user's UTC offset.
+    """
+    if value is None:
+        return None
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
 
 
 class LibraryMapper:
@@ -105,7 +121,7 @@ class LibraryMapper:
                 for p in providers_raw
             ],
             scan_schedule=model.scan_schedule,
-            last_scan_at=model.last_scan_at,
+            last_scan_at=_ensure_utc(model.last_scan_at),
             settings=LibrarySettings(
                 preferred_audio_language=LanguageCode(
                     settings_raw.get("preferred_audio_language", "en"),

--- a/src/modules/library/infrastructure/persistence/models/library_model.py
+++ b/src/modules/library/infrastructure/persistence/models/library_model.py
@@ -1,6 +1,8 @@
 """Library ORM model."""
 
-from sqlalchemy import String, Text
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.config.persistence.base import Base
@@ -34,6 +36,7 @@ class LibraryModel(Base):
     language: Mapped[str] = mapped_column(String(10), nullable=False, default="en")
     metadata_providers: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
     scan_schedule: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    last_scan_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     settings: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
 
     def __repr__(self) -> str:

--- a/tests/infrastructure/scheduling/test_scheduler_service.py
+++ b/tests/infrastructure/scheduling/test_scheduler_service.py
@@ -76,6 +76,8 @@ def scheduler() -> LibraryScanScheduler:
     instance = LibraryScanScheduler(
         session_factory=MagicMock(),
         event_bus=MagicMock(),
+        file_scanner=MagicMock(),
+        variant_detector=MagicMock(),
         reconcile_interval_minutes=5,
     )
     instance._scheduler = _FakeScheduler()

--- a/tests/infrastructure/scheduling/test_scheduler_service.py
+++ b/tests/infrastructure/scheduling/test_scheduler_service.py
@@ -1,0 +1,263 @@
+"""Tests for LibraryScanScheduler.
+
+These tests exercise the reconciliation logic and job execution path
+without starting a real APScheduler — we swap the ``_scheduler``
+attribute for a lightweight fake that records add/remove calls.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.infrastructure.scheduling.scheduler_service import (
+    LibraryScanScheduler,
+    _job_id_for,
+)
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.library.domain.value_objects.library_type import LibraryType
+
+
+class _FakeJob:
+    def __init__(self, job_id: str) -> None:
+        self.id = job_id
+
+
+class _FakeScheduler:
+    """Minimal stand-in for APScheduler that records operations."""
+
+    def __init__(self) -> None:
+        self.running = False
+        self.jobs: dict[str, dict[str, object]] = {}
+
+    def start(self) -> None:
+        self.running = True
+
+    def shutdown(self, wait: bool = True) -> None:
+        _ = wait  # signature parity with APScheduler
+        self.running = False
+
+    def add_job(self, func: object, **kwargs: object) -> None:
+        key = str(kwargs["id"])
+        self.jobs[key] = {"func": func, **kwargs}
+
+    def remove_job(self, job_id: str) -> None:
+        self.jobs.pop(job_id, None)
+
+    def get_jobs(self) -> list[_FakeJob]:
+        return [_FakeJob(jid) for jid in self.jobs]
+
+
+def _make_library(name: str = "Test", schedule: str | None = "0 * * * *") -> Library:
+    return Library.create(
+        name=name,
+        library_type=LibraryType.MOVIES,
+        paths=["/media/test"],
+        scan_schedule=schedule,
+    )
+
+
+def _session_factory(session: object) -> object:
+    """Build a callable that yields ``session`` from an ``async with``."""
+
+    @asynccontextmanager
+    async def _factory():
+        yield session
+
+    return _factory
+
+
+@pytest.fixture
+def scheduler() -> LibraryScanScheduler:
+    instance = LibraryScanScheduler(
+        session_factory=MagicMock(),
+        event_bus=MagicMock(),
+        reconcile_interval_minutes=5,
+    )
+    instance._scheduler = _FakeScheduler()
+    return instance
+
+
+class TestReconcile:
+    @pytest.mark.asyncio
+    async def test_adds_job_for_each_library_with_schedule(
+        self, scheduler: LibraryScanScheduler
+    ) -> None:
+        lib_a = _make_library("A", "0 3 * * *")
+        lib_b = _make_library("B", "30 4 * * *")
+        lib_no_sched = _make_library("C", schedule=None)
+
+        repo = AsyncMock()
+        repo.find_all.return_value = [lib_a, lib_b, lib_no_sched]
+        scheduler._session_factory = _session_factory(MagicMock())  # type: ignore[assignment]
+
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
+            return_value=repo,
+        ):
+            await scheduler._reconcile()
+
+        fake: _FakeScheduler = scheduler._scheduler
+        assert _job_id_for(str(lib_a.id)) in fake.jobs
+        assert _job_id_for(str(lib_b.id)) in fake.jobs
+        assert _job_id_for(str(lib_no_sched.id)) not in fake.jobs
+
+    @pytest.mark.asyncio
+    async def test_removes_job_when_library_loses_schedule(
+        self, scheduler: LibraryScanScheduler
+    ) -> None:
+        lib = _make_library("A", "0 3 * * *")
+        job_id = _job_id_for(str(lib.id))
+        fake: _FakeScheduler = scheduler._scheduler
+        fake.jobs[job_id] = {"cron": "0 3 * * *"}
+
+        lib_cleared = lib.with_updates(scan_schedule=None)
+
+        repo = AsyncMock()
+        repo.find_all.return_value = [lib_cleared]
+        scheduler._session_factory = _session_factory(MagicMock())  # type: ignore[assignment]
+
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
+            return_value=repo,
+        ):
+            await scheduler._reconcile()
+
+        assert job_id not in fake.jobs
+
+    @pytest.mark.asyncio
+    async def test_replaces_job_when_cron_changes(self, scheduler: LibraryScanScheduler) -> None:
+        lib = _make_library("A", "0 3 * * *")
+        job_id = _job_id_for(str(lib.id))
+        fake: _FakeScheduler = scheduler._scheduler
+        fake.jobs[job_id] = {"existing": True}
+
+        lib_updated = lib.with_updates(scan_schedule="30 5 * * *")
+
+        repo = AsyncMock()
+        repo.find_all.return_value = [lib_updated]
+        scheduler._session_factory = _session_factory(MagicMock())  # type: ignore[assignment]
+
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
+            return_value=repo,
+        ):
+            await scheduler._reconcile()
+
+        assert job_id in fake.jobs
+        # The job got replaced — our fake's `existing` marker is gone.
+        assert "existing" not in fake.jobs[job_id]
+
+    @pytest.mark.asyncio
+    async def test_skips_invalid_cron_without_crashing(
+        self, scheduler: LibraryScanScheduler
+    ) -> None:
+        # Passes the entity-level regex but fails real cron parsing.
+        lib = _make_library("A", "99 99 * * *")
+
+        repo = AsyncMock()
+        repo.find_all.return_value = [lib]
+        scheduler._session_factory = _session_factory(MagicMock())  # type: ignore[assignment]
+
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
+            return_value=repo,
+        ):
+            await scheduler._reconcile()  # must not raise
+
+        fake: _FakeScheduler = scheduler._scheduler
+        assert _job_id_for(str(lib.id)) not in fake.jobs
+
+
+class TestRunScan:
+    @pytest.mark.asyncio
+    async def test_updates_last_scan_at_on_success(self, scheduler: LibraryScanScheduler) -> None:
+        lib = _make_library("A", "0 * * * *")
+        lib_id = str(lib.id)
+
+        library_repo = AsyncMock()
+        library_repo.find_by_id.return_value = lib
+        library_repo.save = AsyncMock()
+
+        session = AsyncMock()
+        scheduler._session_factory = _session_factory(session)  # type: ignore[assignment]
+
+        fake_use_case = AsyncMock()
+        fake_use_case.execute.return_value = MagicMock(
+            movies_created=1,
+            movies_updated=0,
+            episodes_created=0,
+            episodes_updated=0,
+            errors=[],
+        )
+
+        with (
+            patch(
+                "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
+                return_value=library_repo,
+            ),
+            patch(
+                "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
+                return_value=fake_use_case,
+            ),
+        ):
+            await scheduler._run_scan(lib_id)
+
+        library_repo.save.assert_awaited_once()
+        await_args = library_repo.save.await_args
+        assert await_args is not None
+        saved = await_args.args[0]
+        assert saved.last_scan_at is not None
+        assert saved.last_scan_at.tzinfo == UTC
+        assert saved.last_scan_at <= datetime.now(UTC)
+
+    @pytest.mark.asyncio
+    async def test_skips_when_library_deleted_mid_run(
+        self, scheduler: LibraryScanScheduler
+    ) -> None:
+        library_repo = AsyncMock()
+        library_repo.find_by_id.return_value = None
+        library_repo.save = AsyncMock()
+
+        session = AsyncMock()
+        scheduler._session_factory = _session_factory(session)  # type: ignore[assignment]
+
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
+            return_value=library_repo,
+        ):
+            await scheduler._run_scan(str(LibraryId.generate()))
+
+        library_repo.save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rolls_back_on_scan_failure(self, scheduler: LibraryScanScheduler) -> None:
+        lib = _make_library("A", "0 * * * *")
+        library_repo = AsyncMock()
+        library_repo.find_by_id.return_value = lib
+        library_repo.save = AsyncMock()
+
+        session = AsyncMock()
+        scheduler._session_factory = _session_factory(session)  # type: ignore[assignment]
+
+        fake_use_case = AsyncMock()
+        fake_use_case.execute.side_effect = RuntimeError("scan blew up")
+
+        with (
+            patch(
+                "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
+                return_value=library_repo,
+            ),
+            patch(
+                "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
+                return_value=fake_use_case,
+            ),
+        ):
+            await scheduler._run_scan(str(lib.id))
+
+        session.rollback.assert_awaited_once()
+        library_repo.save.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds a background scheduler that reads `scan_schedule` cron expressions from the libraries table and runs `ScanMediaDirectoriesUseCase` at the configured cadence. The scheduler reconciles against the DB every N minutes so API edits propagate without a restart. Each completed scan records `last_scan_at` on the library.

**New infrastructure**
- `LibraryScanScheduler` service wrapping APScheduler's `AsyncIOScheduler`
- Wired via `InfrastructureContainer` as a singleton, started/stopped in `main.py` lifespan
- Gated by `SCHEDULER_ENABLED` (default `True`) and configurable reconcile interval (`SCHEDULER_RECONCILE_INTERVAL_MINUTES`, default `5`)

**Domain change**
- `Library` gains a `last_scan_at: datetime | None` field and a `with_scan_completed()` convenience method
- Exposed via all library GET endpoints

**Migration cleanup (needed to make alembic actually work)**
- Renames the duplicate revision id on `add_libraries_table` so the chain is single-head
- Adds a catch-up migration for columns and tables that only ever existed via `create_all` (writers/content_rating/trailer_url/localized on movies+series, and the watch_progresses / custom_lists / custom_list_items / watchlist_items tables)
- Rewrites the FTS5 sync triggers to use the external-content-safe `'delete'` command instead of raw `DELETE FROM fts_table`, which some SQLite builds (notably Python-on-Windows) reject with `database disk image is malformed`

## Test plan

- [x] `poetry run pytest tests/` — 1502 passing (7 new scheduler tests)
- [x] `poetry run ruff check src/ tests/` — clean
- [x] `poetry run mypy` via pre-commit — clean
- [x] `alembic upgrade head` on a fresh SQLite DB — applies all 7 migrations cleanly
- [x] End-to-end: create a library with `scan_schedule="* * * * *"`, wait 1 min, confirm scan ran and `last_scan_at` updated

## Summary by Sourcery

Introduce a background scheduler service to run recurring library media scans based on cron expressions stored on libraries, and expose the timestamp of the last successful scan.

New Features:
- Add LibraryScanScheduler infrastructure service using APScheduler to run scheduled ScanMediaDirectoriesUseCase jobs per library scan_schedule.
- Expose a last_scan_at field on Library entities and API outputs to record the time of the most recent successful scan.

Bug Fixes:
- Fix FTS5 sync triggers for movies and series to use external-content-safe delete commands, preventing SQLite corruption errors on some platforms.

Enhancements:
- Add configuration flags to enable or disable the scheduler and control its library reconciliation interval.
- Wire the scheduler into the application lifespan and dependency-injection container as a singleton.
- Extend the movies and series schema with additional metadata fields and bring Alembic migrations up to date with the current ORM models.
- Add a library domain helper method to mark scans as completed and persist the timestamp.

Build:
- Add APScheduler as a runtime dependency and configure mypy to ignore its missing type hints.

Tests:
- Add unit tests covering scheduler reconciliation behavior and scan execution, including success, deletion, cron changes, invalid schedules, and failure rollback.

Chores:
- Repair and linearize the Alembic migration history, including catch-up migrations for previously unmigrated tables and columns.