### PR TITLE
feat(library): include movie and series counts in API responses

### DIFF
--- a/src/config/containers/library.py
+++ b/src/config/containers/library.py
@@ -28,6 +28,11 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     # Wired from InfrastructureContainer via main container.
     session = providers.Dependency()
+    # Media repositories come from MediaContainer — library responses
+    # include per-library movie/series counts, so the library use
+    # cases need to query those tables too.
+    movie_repository = providers.Dependency()
+    series_repository = providers.Dependency()
 
     # =========================================================================
     # Repositories
@@ -45,21 +50,29 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     create_library = providers.Factory(
         CreateLibraryUseCase,
         library_repository=library_repository,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
     )
 
     list_libraries = providers.Factory(
         ListLibrariesUseCase,
         library_repository=library_repository,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
     )
 
     get_library_by_id = providers.Factory(
         GetLibraryByIdUseCase,
         library_repository=library_repository,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
     )
 
     update_library = providers.Factory(
         UpdateLibraryUseCase,
         library_repository=library_repository,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
     )
 
     delete_library = providers.Factory(

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -67,6 +67,8 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     library = providers.Container(
         LibraryContainer,
         session=infrastructure.session,
+        movie_repository=media.movie_repository,
+        series_repository=media.series_repository,
     )
 
     preferences = providers.Container(

--- a/src/modules/library/application/dtos/library_dtos.py
+++ b/src/modules/library/application/dtos/library_dtos.py
@@ -41,6 +41,8 @@ class LibraryOutput:
     metadata_providers: list[MetadataProviderOutput]
     scan_schedule: str | None
     last_scan_at: str | None
+    movie_count: int
+    series_count: int
     settings: LibrarySettingsOutput
 
 

--- a/src/modules/library/application/use_cases/_to_output.py
+++ b/src/modules/library/application/use_cases/_to_output.py
@@ -6,15 +6,29 @@ from src.modules.library.application.dtos.library_dtos import (
     MetadataProviderOutput,
 )
 from src.modules.library.domain.entities.library import Library
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
-def library_to_output(entity: Library) -> LibraryOutput:
-    """Convert a Library domain entity to its output DTO."""
+async def library_to_output(
+    entity: Library,
+    movie_repository: MovieRepository,
+    series_repository: SeriesRepository,
+) -> LibraryOutput:
+    """Convert a Library domain entity to its output DTO.
+
+    The movie/series counts are computed inline from the media repos
+    — two ``COUNT(*)`` style queries per library. This is fine for
+    tens of libraries; batching across libraries would only matter
+    at a scale we don't have today.
+    """
+    paths = [p.value for p in entity.paths]
+    movie_count = await movie_repository.count_under_paths(paths)
+    series_count = await series_repository.count_under_paths(paths)
     return LibraryOutput(
         id=str(entity.id),
         name=entity.name.value,
         library_type=entity.library_type.value,
-        paths=[p.value for p in entity.paths],
+        paths=paths,
         language=entity.language.value,
         metadata_providers=[
             MetadataProviderOutput(
@@ -26,6 +40,8 @@ def library_to_output(entity: Library) -> LibraryOutput:
         ],
         scan_schedule=entity.scan_schedule,
         last_scan_at=entity.last_scan_at.isoformat() if entity.last_scan_at else None,
+        movie_count=movie_count,
+        series_count=series_count,
         settings=LibrarySettingsOutput(
             preferred_audio_language=entity.settings.preferred_audio_language.value,
             preferred_subtitle_language=(

--- a/src/modules/library/application/use_cases/create_library.py
+++ b/src/modules/library/application/use_cases/create_library.py
@@ -16,14 +16,22 @@ from src.modules.library.domain.value_objects.metadata_provider import (
     MetadataProviderConfig,
 )
 from src.modules.library.domain.value_objects.subtitle_mode import SubtitleMode
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.shared_kernel.value_objects.language_code import LanguageCode
 
 
 class CreateLibraryUseCase:
     """Create a new library and persist it."""
 
-    def __init__(self, library_repository: LibraryRepository) -> None:
+    def __init__(
+        self,
+        library_repository: LibraryRepository,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
         self._repo = library_repository
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
 
     async def execute(self, input_dto: CreateLibraryInput) -> LibraryOutput:
         """Create and persist a new Library.
@@ -57,7 +65,7 @@ class CreateLibraryUseCase:
             library = library.with_updates(scan_schedule=input_dto.scan_schedule)
 
         saved = await self._repo.save(library)
-        return library_to_output(saved)
+        return await library_to_output(saved, self._movie_repo, self._series_repo)
 
 
 def _build_settings(raw: dict[str, Any]) -> LibrarySettings:

--- a/src/modules/library/application/use_cases/get_library_by_id.py
+++ b/src/modules/library/application/use_cases/get_library_by_id.py
@@ -8,13 +8,21 @@ from src.modules.library.application.dtos.library_dtos import (
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 class GetLibraryByIdUseCase:
     """Fetch a single library by its external id."""
 
-    def __init__(self, library_repository: LibraryRepository) -> None:
+    def __init__(
+        self,
+        library_repository: LibraryRepository,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
         self._repo = library_repository
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
 
     async def execute(self, input_dto: GetLibraryByIdInput) -> LibraryOutput:
         """Fetch a library or raise if not found.
@@ -36,7 +44,7 @@ class GetLibraryByIdUseCase:
                 "Library",
                 input_dto.library_id,
             )
-        return library_to_output(entity)
+        return await library_to_output(entity, self._movie_repo, self._series_repo)
 
 
 __all__ = ["GetLibraryByIdUseCase"]

--- a/src/modules/library/application/use_cases/list_libraries.py
+++ b/src/modules/library/application/use_cases/list_libraries.py
@@ -3,13 +3,21 @@
 from src.modules.library.application.dtos.library_dtos import LibraryOutput
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 class ListLibrariesUseCase:
     """Return every non-deleted library."""
 
-    def __init__(self, library_repository: LibraryRepository) -> None:
+    def __init__(
+        self,
+        library_repository: LibraryRepository,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
         self._repo = library_repository
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
 
     async def execute(self) -> list[LibraryOutput]:
         """List all libraries.
@@ -18,7 +26,7 @@ class ListLibrariesUseCase:
             List of ``LibraryOutput`` ordered by name.
         """
         entities = await self._repo.find_all()
-        return [library_to_output(e) for e in entities]
+        return [await library_to_output(e, self._movie_repo, self._series_repo) for e in entities]
 
 
 __all__ = ["ListLibrariesUseCase"]

--- a/src/modules/library/application/use_cases/update_library.py
+++ b/src/modules/library/application/use_cases/update_library.py
@@ -17,6 +17,7 @@ from src.modules.library.domain.value_objects.metadata_provider import (
     MetadataProvider,
     MetadataProviderConfig,
 )
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
 
@@ -24,8 +25,15 @@ from src.shared_kernel.value_objects.language_code import LanguageCode
 class UpdateLibraryUseCase:
     """Partially update an existing library."""
 
-    def __init__(self, library_repository: LibraryRepository) -> None:
+    def __init__(
+        self,
+        library_repository: LibraryRepository,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
         self._repo = library_repository
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
 
     async def execute(self, input_dto: UpdateLibraryInput) -> LibraryOutput:
         """Apply partial updates to a library.
@@ -75,7 +83,7 @@ class UpdateLibraryUseCase:
 
         updated = entity.with_updates(**updates)
         saved = await self._repo.save(updated)
-        return library_to_output(saved)
+        return await library_to_output(saved, self._movie_repo, self._series_repo)
 
 
 __all__ = ["UpdateLibraryUseCase"]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -243,5 +243,25 @@ class MovieRepository(ABC):
         """
         ...
 
+    @abstractmethod
+    async def count_under_paths(self, paths: Sequence[str]) -> int:
+        """Count non-deleted movies whose file_path sits under any of ``paths``.
+
+        Used to show per-library totals on the Libraries UI without an
+        explicit ``library_id`` column — the association is implicit
+        through the path prefix.
+
+        Args:
+            paths: Absolute directory paths to include. Matching is a
+                string-prefix + separator check; both backslash and
+                forward-slash variants are considered so the query
+                works regardless of the OS the row was written on.
+
+        Returns:
+            Count of distinct movies whose primary file_path is under
+            one of the supplied directories. ``0`` for an empty list.
+        """
+        ...
+
 
 __all__ = ["GenreRow", "MovieRepository"]

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -204,5 +204,24 @@ class SeriesRepository(ABC):
         """
         ...
 
+    @abstractmethod
+    async def count_under_paths(self, paths: Sequence[str]) -> int:
+        """Count distinct series with at least one episode under ``paths``.
+
+        The "series belongs to library X" relationship is implicit
+        through its episode file paths. A series that happens to
+        straddle two libraries counts once per library it touches.
+
+        Args:
+            paths: Absolute directory paths to include. Matching is a
+                string-prefix + separator check that handles both
+                backslash and forward-slash styles.
+
+        Returns:
+            Distinct count of series meeting the condition. ``0`` for
+            an empty list.
+        """
+        ...
+
 
 __all__ = ["SeriesRepository"]

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 
-from sqlalchemy import func, select, text
+from sqlalchemy import func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -305,6 +305,36 @@ class SQLAlchemyMovieRepository(MovieRepository):
         model = result.scalar_one_or_none()
 
         return None if model is None else MovieMapper.to_entity(model)
+
+    async def count_under_paths(self, paths: Sequence[str]) -> int:
+        r"""Count non-deleted movies whose ``file_path`` is under any of ``paths``.
+
+        Matches both ``\`` and ``/`` separators so the query is
+        cross-platform — a library row written on Linux still matches
+        a filter coming from a Windows client and vice versa.
+        """
+        if not paths:
+            return 0
+        prefix_filters = []
+        for path in paths:
+            # LIKE is safe here: library paths come from our own DB and
+            # the user is the only one who can write them via the
+            # Libraries API. We still add explicit separator patterns
+            # rather than "{path}%" to avoid matching sibling dirs
+            # (e.g. ``/media/movies`` matching ``/media/movies-extra``).
+            prefix_filters.append(MovieModel.file_path.like(f"{path}\\%"))
+            prefix_filters.append(MovieModel.file_path.like(f"{path}/%"))
+        stmt = (
+            select(func.count())
+            .select_from(MovieModel)
+            .where(
+                MovieModel.deleted_at.is_(None),
+                MovieModel.file_path.is_not(None),
+                or_(*prefix_filters),
+            )
+        )
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
 
     async def search(
         self,

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -3,7 +3,7 @@
 from collections.abc import Sequence
 from typing import Any
 
-from sqlalchemy import func, select, text
+from sqlalchemy import distinct, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -386,6 +386,29 @@ class SQLAlchemySeriesRepository(SeriesRepository):
 
         # Load the full series
         return await self.find_by_id(SeriesId(episode_model.series_external_id))
+
+    async def count_under_paths(self, paths: Sequence[str]) -> int:
+        """Count distinct series with at least one episode under ``paths``.
+
+        One SELECT against ``episodes``, DISTINCT by ``series_id`` so a
+        series with ten matching episodes still counts as one.
+        """
+        if not paths:
+            return 0
+        prefix_filters = []
+        for path in paths:
+            prefix_filters.append(EpisodeModel.file_path.like(f"{path}\\%"))
+            prefix_filters.append(EpisodeModel.file_path.like(f"{path}/%"))
+        # DISTINCT on series_external_id (not series_id — episodes
+        # reference the series via the public external id, not the
+        # internal autoincrement pk).
+        stmt = select(func.count(distinct(EpisodeModel.series_external_id))).where(
+            EpisodeModel.deleted_at.is_(None),
+            EpisodeModel.file_path.is_not(None),
+            or_(*prefix_filters),
+        )
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
 
     def _ensure_ids(self, series: Series) -> Series:
         """Ensure all entities have IDs, generating them if needed.

--- a/tests/modules/library/unit/application/use_cases/test_create_library.py
+++ b/tests/modules/library/unit/application/use_cases/test_create_library.py
@@ -7,6 +7,7 @@ import pytest
 from src.modules.library.application.dtos.library_dtos import CreateLibraryInput
 from src.modules.library.application.use_cases.create_library import CreateLibraryUseCase
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 def _make_repo() -> AsyncMock:
@@ -16,6 +17,14 @@ def _make_repo() -> AsyncMock:
     return repo
 
 
+def _make_media_repos() -> tuple[AsyncMock, AsyncMock]:
+    movie_repo = AsyncMock(spec=MovieRepository)
+    movie_repo.count_under_paths.return_value = 0
+    series_repo = AsyncMock(spec=SeriesRepository)
+    series_repo.count_under_paths.return_value = 0
+    return movie_repo, series_repo
+
+
 @pytest.mark.unit
 class TestCreateLibraryUseCase:
     """Unit tests for library creation."""
@@ -23,7 +32,8 @@ class TestCreateLibraryUseCase:
     @pytest.mark.asyncio
     async def test_should_create_library_with_generated_id(self) -> None:
         repo = _make_repo()
-        use_case = CreateLibraryUseCase(repo)
+        movie_repo, series_repo = _make_media_repos()
+        use_case = CreateLibraryUseCase(repo, movie_repo, series_repo)
 
         result = await use_case.execute(
             CreateLibraryInput(
@@ -42,7 +52,8 @@ class TestCreateLibraryUseCase:
     @pytest.mark.asyncio
     async def test_should_pass_settings_through(self) -> None:
         repo = _make_repo()
-        use_case = CreateLibraryUseCase(repo)
+        movie_repo, series_repo = _make_media_repos()
+        use_case = CreateLibraryUseCase(repo, movie_repo, series_repo)
 
         result = await use_case.execute(
             CreateLibraryInput(
@@ -65,7 +76,8 @@ class TestCreateLibraryUseCase:
     @pytest.mark.asyncio
     async def test_should_pass_metadata_providers(self) -> None:
         repo = _make_repo()
-        use_case = CreateLibraryUseCase(repo)
+        movie_repo, series_repo = _make_media_repos()
+        use_case = CreateLibraryUseCase(repo, movie_repo, series_repo)
 
         result = await use_case.execute(
             CreateLibraryInput(

--- a/tests/modules/library/unit/application/use_cases/test_get_library_by_id.py
+++ b/tests/modules/library/unit/application/use_cases/test_get_library_by_id.py
@@ -12,6 +12,15 @@ from src.modules.library.application.use_cases.get_library_by_id import (
 from src.modules.library.domain.entities.library import Library
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+def _make_media_repos() -> tuple[AsyncMock, AsyncMock]:
+    movie_repo = AsyncMock(spec=MovieRepository)
+    movie_repo.count_under_paths.return_value = 0
+    series_repo = AsyncMock(spec=SeriesRepository)
+    series_repo.count_under_paths.return_value = 0
+    return movie_repo, series_repo
 
 
 @pytest.mark.unit
@@ -23,7 +32,8 @@ class TestGetLibraryByIdUseCase:
         lib = Library.create(name="Movies", library_type="movies", paths=["/m"])
         repo = AsyncMock(spec=LibraryRepository)
         repo.find_by_id.return_value = lib
-        use_case = GetLibraryByIdUseCase(repo)
+        movie_repo, series_repo = _make_media_repos()
+        use_case = GetLibraryByIdUseCase(repo, movie_repo, series_repo)
 
         result = await use_case.execute(
             GetLibraryByIdInput(library_id=str(lib.id)),
@@ -35,7 +45,8 @@ class TestGetLibraryByIdUseCase:
     async def test_should_raise_when_not_found(self) -> None:
         repo = AsyncMock(spec=LibraryRepository)
         repo.find_by_id.return_value = None
-        use_case = GetLibraryByIdUseCase(repo)
+        movie_repo, series_repo = _make_media_repos()
+        use_case = GetLibraryByIdUseCase(repo, movie_repo, series_repo)
         lib_id = str(LibraryId.generate())
 
         with pytest.raises(ResourceNotFoundException):

--- a/tests/modules/library/unit/application/use_cases/test_list_libraries.py
+++ b/tests/modules/library/unit/application/use_cases/test_list_libraries.py
@@ -7,6 +7,15 @@ import pytest
 from src.modules.library.application.use_cases.list_libraries import ListLibrariesUseCase
 from src.modules.library.domain.entities.library import Library
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+def _make_media_repos() -> tuple[AsyncMock, AsyncMock]:
+    movie_repo = AsyncMock(spec=MovieRepository)
+    movie_repo.count_under_paths.return_value = 0
+    series_repo = AsyncMock(spec=SeriesRepository)
+    series_repo.count_under_paths.return_value = 0
+    return movie_repo, series_repo
 
 
 @pytest.mark.unit
@@ -17,7 +26,8 @@ class TestListLibrariesUseCase:
     async def test_should_return_empty_list_when_no_libraries(self) -> None:
         repo = AsyncMock(spec=LibraryRepository)
         repo.find_all.return_value = []
-        use_case = ListLibrariesUseCase(repo)
+        movie_repo, series_repo = _make_media_repos()
+        use_case = ListLibrariesUseCase(repo, movie_repo, series_repo)
 
         result = await use_case.execute()
 
@@ -30,7 +40,8 @@ class TestListLibrariesUseCase:
             Library.create(name="Movies", library_type="movies", paths=["/m"]),
             Library.create(name="Series", library_type="series", paths=["/s"]),
         ]
-        use_case = ListLibrariesUseCase(repo)
+        movie_repo, series_repo = _make_media_repos()
+        use_case = ListLibrariesUseCase(repo, movie_repo, series_repo)
 
         result = await use_case.execute()
 

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -676,3 +676,56 @@ class TestSQLAlchemyMovieRepositoryListPaginatedByGenre:
 
         assert len(page.items) == 1
         assert page.items[0].title.value == "B"
+
+
+@pytest.mark.integration
+class TestCountUnderPaths:
+    """Integration tests for ``count_under_paths``."""
+
+    async def test_returns_zero_for_empty_paths(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(file_path="/media/movies/a.mkv"))
+
+        assert await repo.count_under_paths([]) == 0
+
+    async def test_matches_posix_prefix(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/media/movies/a.mkv"))
+        await repo.save(_create_movie(title="B", file_path="/media/movies/nested/b.mkv"))
+        await repo.save(_create_movie(title="Other", file_path="/elsewhere/c.mkv"))
+
+        assert await repo.count_under_paths(["/media/movies"]) == 2
+
+    async def test_matches_windows_prefix(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="W1", file_path=r"D:\homeflix\movie1.mkv"))
+        await repo.save(_create_movie(title="W2", file_path=r"D:\homeflix\sub\movie2.mkv"))
+        await repo.save(_create_movie(title="Other", file_path=r"E:\other\x.mkv"))
+
+        assert await repo.count_under_paths([r"D:\homeflix"]) == 2
+
+    async def test_sums_across_multiple_libraries(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/a/one.mkv"))
+        await repo.save(_create_movie(title="B", file_path="/b/two.mkv"))
+        await repo.save(_create_movie(title="C", file_path="/c/three.mkv"))
+
+        assert await repo.count_under_paths(["/a", "/b"]) == 2
+
+    async def test_does_not_match_sibling_directory(self, db_session: AsyncSession) -> None:
+        """``/media/movies`` must not swallow ``/media/movies-extra``."""
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/media/movies/a.mkv"))
+        await repo.save(_create_movie(title="Sibling", file_path="/media/movies-extra/b.mkv"))
+
+        assert await repo.count_under_paths(["/media/movies"]) == 1
+
+    async def test_excludes_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        a = _create_movie(title="A", file_path="/media/a.mkv")
+        b = _create_movie(title="B", file_path="/media/b.mkv")
+        await repo.save(a)
+        await repo.save(b)
+        await repo.delete(_id_of(a))
+
+        assert await repo.count_under_paths(["/media"]) == 1

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -927,3 +927,83 @@ class TestSQLAlchemySeriesRepositoryListPaginatedByGenre:
 
         assert len(page.items) == 1
         assert page.items[0].title.value == "B"
+
+
+def _series_with_episode_paths(
+    title: str,
+    paths: list[str],
+    start_year: int = 2020,
+) -> Series:
+    """Build a series whose single season has one episode per path."""
+    sid = SeriesId.generate()
+    episodes = [
+        _create_episode(sid, season_number=1, episode_number=i + 1, file_path=p)
+        for i, p in enumerate(paths)
+    ]
+    season = Season(
+        id=SeasonId.generate(),
+        series_id=sid,
+        season_number=1,
+        title=Title("Season 1"),
+        episodes=episodes,
+    )
+    return Series(
+        id=sid,
+        title=Title(title),
+        start_year=Year(start_year),
+        seasons=[season],
+    )
+
+
+@pytest.mark.integration
+class TestSeriesCountUnderPaths:
+    """Integration tests for ``SQLAlchemySeriesRepository.count_under_paths``."""
+
+    async def test_returns_zero_for_empty_paths(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_series_with_episode_paths("A", ["/media/tv/a/s01e01.mkv"]))
+
+        assert await repo.count_under_paths([]) == 0
+
+    async def test_counts_series_with_matching_episode(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_series_with_episode_paths("A", ["/media/tv/a/s01e01.mkv"]))
+        await repo.save(_series_with_episode_paths("B", ["/media/tv/b/s01e01.mkv"]))
+        await repo.save(_series_with_episode_paths("Other", ["/elsewhere/x/s01e01.mkv"]))
+
+        assert await repo.count_under_paths(["/media/tv"]) == 2
+
+    async def test_counts_distinct_series_not_episodes(self, db_session: AsyncSession) -> None:
+        """A series with N matching episodes still counts as one."""
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(
+            _series_with_episode_paths(
+                "Multi",
+                [
+                    "/media/tv/multi/s01e01.mkv",
+                    "/media/tv/multi/s01e02.mkv",
+                    "/media/tv/multi/s01e03.mkv",
+                ],
+            )
+        )
+
+        assert await repo.count_under_paths(["/media/tv"]) == 1
+
+    async def test_matches_windows_prefix(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_series_with_episode_paths("W", [r"D:\homeflix\tv\show\s01e01.mkv"]))
+        await repo.save(_series_with_episode_paths("Other", [r"E:\other\s01e01.mkv"]))
+
+        assert await repo.count_under_paths([r"D:\homeflix"]) == 1
+
+    async def test_excludes_soft_deleted_series(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        a = _series_with_episode_paths("A", ["/media/tv/a/s01e01.mkv"])
+        b = _series_with_episode_paths("B", ["/media/tv/b/s01e01.mkv"])
+        await repo.save(a)
+        await repo.save(b)
+        await repo.delete(_id_of(a))
+
+        # The delete cascades to episodes, so A's episode is also
+        # soft-deleted and shouldn't keep the series in the count.
+        assert await repo.count_under_paths(["/media/tv"]) == 1


### PR DESCRIPTION
## Summary

Each Library response now carries `movie_count` and `series_count`, computed from non-deleted movies / series whose `file_path` sits under one of the library's directory prefixes. The association is implicit through path prefix (no new FK on movies/series).

**New**
- `MovieRepository.count_under_paths(paths)` / `SeriesRepository.count_under_paths(paths)` — port + SQLAlchemy impl
- `LibraryOutput.movie_count` / `series_count` in every library response
- `library_to_output` is now async; receives the two media repos via DI

**Path matching**: prefix LIKE with both `\` and `/` separators so Windows-written rows still match when queried from Linux (and vice versa). Trailing separator in the pattern prevents sibling-directory false positives (`/media/movies` must not match `/media/movies-extra`).

**Series semantics**: `COUNT(DISTINCT episodes.series_external_id)` — a series with N matching episodes counts once per library.

**Not included** (intentional, per plan):
- `library_id` FK on movies/series (kept implicit for scope)
- Batched count across libraries (two queries per library is fine for our scale; revisit if needed)
- Plural forms in the UI

## Test plan

- [x] 11 new integration tests (6 movie, 5 series) covering empty input, Posix/Windows prefixes, cross-library, sibling safety, soft-delete exclusion, DISTINCT semantics
- [x] 1513 tests passing (was 1502; +11 new)
- [x] Pre-commit clean (ruff, ruff-format, mypy)
- [ ] Manual end-to-end with frontend — follow-up PR

## Summary by Sourcery

Add per-library movie and series counts to library API responses based on media file path prefixes, wiring media repositories into library use cases to compute these counts asynchronously.

New Features:
- Expose movie_count and series_count fields on LibraryOutput for all library responses.
- Add count_under_paths APIs to movie and series repositories to count media under given directory prefixes using implicit path-based library association.

Enhancements:
- Update library use cases and dependency injection containers to pass media repositories into library_to_output, which is now async and enriches responses with media counts.

Tests:
- Add integration tests for movie and series repository count_under_paths behavior, covering cross-platform paths, multi-library aggregation, sibling directory safety, distinct series counting, and soft-delete handling.
- Adjust library use case unit tests to work with the new media repository dependencies, stubbing count_under_paths results.