### PR TITLE
refactor(library): extract path prefix helper and normalize separators

### DIFF
--- a/src/modules/library/application/use_cases/list_libraries.py
+++ b/src/modules/library/application/use_cases/list_libraries.py
@@ -22,6 +22,15 @@ class ListLibrariesUseCase:
     async def execute(self) -> list[LibraryOutput]:
         """List all libraries.
 
+        The count queries fan out serially on purpose: every repo on
+        this request shares the same ``AsyncSession`` (see
+        ``session_manager.py``), and SQLAlchemy sessions forbid
+        concurrent ``execute`` calls on the same transaction — a
+        ``gather`` here raises ``InvalidRequestError`` the moment two
+        libraries exist. For tens of libraries the serial cost is
+        negligible; batching would require a dedicated short-lived
+        session per library and isn't worth the complexity today.
+
         Returns:
             List of ``LibraryOutput`` ordered by name.
         """

--- a/src/modules/media/infrastructure/persistence/repositories/_path_prefix_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_path_prefix_helpers.py
@@ -13,6 +13,10 @@ rules are identical:
 - Trailing separators on the input (``/media/movies/`` vs
   ``/media/movies``) are normalized away so accidentally passing a
   trailing slash doesn't silently return zero.
+- Root-only inputs (``/``, ``\\``) are a special case: after stripping
+  there's nothing left to anchor the ``LIKE`` on, so we keep the raw
+  separator and use ``{sep}%`` directly — the separator itself is
+  already the prefix we want.
 
 Keeping this in one place means a change to the matching semantics
 (e.g. case-insensitive comparison on Windows volumes) only has to
@@ -23,11 +27,6 @@ from collections.abc import Sequence
 
 from sqlalchemy import ColumnElement
 from sqlalchemy.orm import InstrumentedAttribute
-
-
-def _normalize(path: str) -> str:
-    """Strip trailing path separators so ``LIKE`` patterns stay well-formed."""
-    return path.rstrip("/\\")
 
 
 def build_path_prefix_filters(
@@ -43,8 +42,8 @@ def build_path_prefix_filters(
 
     Args:
         column: The ``file_path``-style column to filter.
-        paths: Library root paths to match under. Empty entries and
-            entries that reduce to empty after trimming are skipped.
+        paths: Library root paths to match under. Empty entries are
+            skipped; root-only entries (``"/"``) are kept as-is.
 
     Returns:
         A list of ``LIKE`` predicates, one per (path, separator) pair.
@@ -52,11 +51,17 @@ def build_path_prefix_filters(
     """
     filters: list[ColumnElement[bool]] = []
     for raw in paths:
-        path = _normalize(raw)
-        if not path:
+        if not raw:
             continue
-        filters.append(column.like(f"{path}/%"))
-        filters.append(column.like(f"{path}\\%"))
+        stripped = raw.rstrip("/\\")
+        if not stripped:
+            # Root-only path: the raw value already ends with the
+            # separator, so ``{raw}%`` is the correct anchor. Emitting
+            # ``/{sep}%`` here would produce ``//%`` and match nothing.
+            filters.append(column.like(f"{raw}%"))
+            continue
+        filters.append(column.like(f"{stripped}/%"))
+        filters.append(column.like(f"{stripped}\\%"))
     return filters
 
 

--- a/src/modules/media/infrastructure/persistence/repositories/_path_prefix_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_path_prefix_helpers.py
@@ -1,0 +1,63 @@
+r"""Shared ``LIKE`` prefix-filter builder for path-scoped count queries.
+
+``MovieRepository.count_under_paths`` and
+``SeriesRepository.count_under_paths`` both need to answer "rows whose
+``file_path`` lives under any of these library paths?". The matching
+rules are identical:
+
+- Both ``/`` and ``\`` are treated as separators so a row written on
+  one OS still matches a filter built on the other.
+- The separator is appended explicitly (``{path}/%`` / ``{path}\\%``)
+  rather than a bare ``{path}%`` so ``/media/movies`` doesn't swallow
+  ``/media/movies-extra``.
+- Trailing separators on the input (``/media/movies/`` vs
+  ``/media/movies``) are normalized away so accidentally passing a
+  trailing slash doesn't silently return zero.
+
+Keeping this in one place means a change to the matching semantics
+(e.g. case-insensitive comparison on Windows volumes) only has to
+happen once.
+"""
+
+from collections.abc import Sequence
+
+from sqlalchemy import ColumnElement
+from sqlalchemy.orm import InstrumentedAttribute
+
+
+def _normalize(path: str) -> str:
+    """Strip trailing path separators so ``LIKE`` patterns stay well-formed."""
+    return path.rstrip("/\\")
+
+
+def build_path_prefix_filters(
+    column: InstrumentedAttribute[str | None],
+    paths: Sequence[str],
+) -> list[ColumnElement[bool]]:
+    """Build ``LIKE`` filters matching ``column`` values under any of ``paths``.
+
+    Safe to pass user-visible library paths directly: values come from
+    the Libraries API which only the owner can write to, and the
+    trailing-separator normalization prevents minor formatting
+    differences from producing empty result sets.
+
+    Args:
+        column: The ``file_path``-style column to filter.
+        paths: Library root paths to match under. Empty entries and
+            entries that reduce to empty after trimming are skipped.
+
+    Returns:
+        A list of ``LIKE`` predicates, one per (path, separator) pair.
+        Combine with ``sqlalchemy.or_`` at the call site.
+    """
+    filters: list[ColumnElement[bool]] = []
+    for raw in paths:
+        path = _normalize(raw)
+        if not path:
+            continue
+        filters.append(column.like(f"{path}/%"))
+        filters.append(column.like(f"{path}\\%"))
+    return filters
+
+
+__all__ = ["build_path_prefix_filters"]

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -22,6 +22,9 @@ from src.modules.media.infrastructure.persistence.repositories._genre_helpers im
     fetch_genre_paginated_page,
     fetch_genre_rows,
 )
+from src.modules.media.infrastructure.persistence.repositories._path_prefix_helpers import (
+    build_path_prefix_filters,
+)
 
 
 class SQLAlchemyMovieRepository(MovieRepository):
@@ -311,19 +314,13 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         Matches both ``\`` and ``/`` separators so the query is
         cross-platform — a library row written on Linux still matches
-        a filter coming from a Windows client and vice versa.
+        a filter coming from a Windows client and vice versa. See
+        ``_path_prefix_helpers.build_path_prefix_filters`` for the
+        normalization rules shared with the series repo.
         """
-        if not paths:
+        prefix_filters = build_path_prefix_filters(MovieModel.file_path, paths)
+        if not prefix_filters:
             return 0
-        prefix_filters = []
-        for path in paths:
-            # LIKE is safe here: library paths come from our own DB and
-            # the user is the only one who can write them via the
-            # Libraries API. We still add explicit separator patterns
-            # rather than "{path}%" to avoid matching sibling dirs
-            # (e.g. ``/media/movies`` matching ``/media/movies-extra``).
-            prefix_filters.append(MovieModel.file_path.like(f"{path}\\%"))
-            prefix_filters.append(MovieModel.file_path.like(f"{path}/%"))
         stmt = (
             select(func.count())
             .select_from(MovieModel)

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -39,6 +39,9 @@ from src.modules.media.infrastructure.persistence.repositories._genre_helpers im
     fetch_genre_paginated_page,
     fetch_genre_rows,
 )
+from src.modules.media.infrastructure.persistence.repositories._path_prefix_helpers import (
+    build_path_prefix_filters,
+)
 
 
 class SQLAlchemySeriesRepository(SeriesRepository):
@@ -391,14 +394,13 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         """Count distinct series with at least one episode under ``paths``.
 
         One SELECT against ``episodes``, DISTINCT by ``series_id`` so a
-        series with ten matching episodes still counts as one.
+        series with ten matching episodes still counts as one. See
+        ``_path_prefix_helpers.build_path_prefix_filters`` for the
+        normalization rules shared with the movie repo.
         """
-        if not paths:
+        prefix_filters = build_path_prefix_filters(EpisodeModel.file_path, paths)
+        if not prefix_filters:
             return 0
-        prefix_filters = []
-        for path in paths:
-            prefix_filters.append(EpisodeModel.file_path.like(f"{path}\\%"))
-            prefix_filters.append(EpisodeModel.file_path.like(f"{path}/%"))
         # DISTINCT on series_external_id (not series_id — episodes
         # reference the series via the public external id, not the
         # internal autoincrement pk).

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -739,7 +739,22 @@ class TestCountUnderPaths:
         assert await repo.count_under_paths(["/media/movies/"]) == 1
 
     async def test_normalizes_trailing_windows_separator(self, db_session: AsyncSession) -> None:
+        """Mirror the POSIX sibling check for the Windows variant."""
         repo = SQLAlchemyMovieRepository(db_session)
         await repo.save(_create_movie(title="W", file_path=r"D:\homeflix\movie1.mkv"))
+        await repo.save(_create_movie(title="Sibling", file_path=r"D:\homeflix-extra\movie2.mkv"))
 
         assert await repo.count_under_paths([r"D:\homeflix" + "\\"]) == 1
+
+    async def test_matches_posix_root_path(self, db_session: AsyncSession) -> None:
+        """A library rooted at ``/`` must match every stored POSIX path.
+
+        Without special handling ``rstrip`` collapses ``/`` to the empty
+        string and the filter is dropped entirely, so this guards against
+        the regression.
+        """
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/media/a.mkv"))
+        await repo.save(_create_movie(title="B", file_path="/other/b.mkv"))
+
+        assert await repo.count_under_paths(["/"]) == 2

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -729,3 +729,17 @@ class TestCountUnderPaths:
         await repo.delete(_id_of(a))
 
         assert await repo.count_under_paths(["/media"]) == 1
+
+    async def test_normalizes_trailing_posix_separator(self, db_session: AsyncSession) -> None:
+        """A trailing ``/`` on the filter path must still match stored rows."""
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/media/movies/a.mkv"))
+        await repo.save(_create_movie(title="Sibling", file_path="/media/movies-extra/b.mkv"))
+
+        assert await repo.count_under_paths(["/media/movies/"]) == 1
+
+    async def test_normalizes_trailing_windows_separator(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="W", file_path=r"D:\homeflix\movie1.mkv"))
+
+        assert await repo.count_under_paths([r"D:\homeflix" + "\\"]) == 1

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -1007,3 +1007,10 @@ class TestSeriesCountUnderPaths:
         # The delete cascades to episodes, so A's episode is also
         # soft-deleted and shouldn't keep the series in the count.
         assert await repo.count_under_paths(["/media/tv"]) == 1
+
+    async def test_normalizes_trailing_separator(self, db_session: AsyncSession) -> None:
+        """A trailing ``/`` on the filter path must still match episode rows."""
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_series_with_episode_paths("A", ["/media/tv/a/s01e01.mkv"]))
+
+        assert await repo.count_under_paths(["/media/tv/"]) == 1


### PR DESCRIPTION
## Summary

- Extract the shared LIKE prefix-filter builder used by ``count_under_paths`` in both ``MovieRepository`` and ``SeriesRepository`` into ``_path_prefix_helpers.build_path_prefix_filters`` so the cross-platform separator handling lives in one place.
- Normalize trailing separators on the input so a library path like ``/media/movies/`` (or ``D:\homeflix\``) still matches stored rows, instead of silently returning zero because the ``LIKE`` pattern grew an extra slash.
- Document why ``ListLibrariesUseCase`` awaits counts serially: every repo on a request shares one ``AsyncSession`` and SQLAlchemy raises ``InvalidRequestError`` the moment two ``execute`` calls run concurrently on it — an earlier ``asyncio.gather`` attempt blew up in dev for that reason.
- Add integration coverage for the trailing-separator case on both repos.

Addresses the Sourcery review from #106.

## Test plan

- [x] ``pytest tests/modules/media/integration/persistence/repositories/test_movie_repository.py::TestCountUnderPaths``
- [x] ``pytest tests/modules/media/integration/persistence/repositories/test_series_repository.py::TestSeriesCountUnderPaths``
- [x] ``pytest tests/modules/library/unit/application/use_cases/test_list_libraries.py``
- [x] ``GET /api/v1/libraries`` returns 200 against a live DB

## Summary by Sourcery

Refactor path-based count queries to share a common prefix filter helper and ensure trailing path separators are handled consistently across repositories.

Enhancements:
- Extract a shared _path_prefix_helpers.build_path_prefix_filters utility for constructing cross-platform LIKE-based path prefix filters used by movie and series repositories.
- Clarify in ListLibrariesUseCase why library count queries are executed serially due to AsyncSession concurrency restrictions.

Tests:
- Add integration tests for movie and series repositories to verify counts behave correctly when filter paths include trailing separators.