### PR TITLE
feat(media): detect resolution via ffprobe fallback on scan

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -202,6 +202,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         variant_detector=variant_detector,
         movie_repository=movie_repository,
         series_repository=series_repository,
+        probe_service=media_probe_service,
         event_bus=event_bus,
     )
 

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -1,5 +1,6 @@
 """Use case for scanning media directories and registering discovered files."""
 
+import asyncio
 from collections import defaultdict
 
 from src.building_blocks.application.event_bus import EventBus
@@ -17,19 +18,25 @@ from src.modules.media.domain.value_objects import (
     Title,
 )
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
+from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
 
 
 class ScanMediaDirectoriesUseCase:
     """Scan filesystem directories and register discovered media files.
 
     Walks the configured directories, detects movies and series episodes,
-    groups file variants, and persists new or updated entities.
+    groups file variants, and persists new or updated entities. When the
+    filename does not contain a resolution tag, falls back to ffprobe via
+    ``probe_service`` — but only for files that are new or stored as
+    ``Unknown``, so rescans of fully-resolved libraries skip ffprobe.
 
     Args:
         file_scanner: Port for filesystem scanning.
         variant_detector: Service for grouping file variants.
         movie_repository: Repository for movie persistence.
         series_repository: Repository for series persistence.
+        probe_service: Optional ffprobe service for resolution fallback.
+        event_bus: Optional event bus for domain events.
     """
 
     def __init__(
@@ -38,12 +45,14 @@ class ScanMediaDirectoriesUseCase:
         variant_detector: VariantDetector,
         movie_repository: MovieRepository,
         series_repository: SeriesRepository,
+        probe_service: MediaProbeService | None = None,
         event_bus: EventBus | None = None,
     ) -> None:
         self._file_scanner = file_scanner
         self._variant_detector = variant_detector
         self._movie_repository = movie_repository
         self._series_repository = series_repository
+        self._probe_service = probe_service
         self._event_bus = event_bus
 
     async def execute(self, input_dto: ScanMediaInput) -> ScanMediaOutput:
@@ -79,6 +88,61 @@ class ScanMediaDirectoriesUseCase:
             return
         for event in events:
             await self._event_bus.publish(event)
+
+    # =========================================================================
+    # Resolution probing (lazy)
+    # =========================================================================
+
+    async def _probe_resolution(self, file_path: str) -> str | None:
+        """Run ffprobe in a worker thread to detect resolution.
+
+        Returns None if probing is unavailable or yields no result.
+        """
+        if self._probe_service is None:
+            return None
+        return await asyncio.to_thread(self._probe_service.probe_resolution, file_path)
+
+    async def _resolve_new_resolution(self, scanned: ScannedFile) -> str:
+        """Resolution to use when registering a file for the first time."""
+        if scanned.resolution:
+            return scanned.resolution
+        return (await self._probe_resolution(scanned.file_path.value)) or "Unknown"
+
+    async def _maybe_upgrade_resolution(
+        self,
+        current: MediaFile,
+        scanned: ScannedFile,
+    ) -> str | None:
+        """Resolution to use when refreshing an existing file.
+
+        Returns the new resolution name when an upgrade should be applied,
+        or None when the existing value should be kept. Only upgrades when
+        the stored resolution is ``Unknown``; never overwrites a known one.
+        """
+        if current.resolution.name != "Unknown":
+            return None
+        if scanned.resolution:
+            return scanned.resolution
+        return await self._probe_resolution(scanned.file_path.value)
+
+    async def _build_new_media_file(
+        self,
+        scanned: ScannedFile,
+        *,
+        is_primary: bool,
+    ) -> MediaFile:
+        """Build a MediaFile for a path being registered for the first time."""
+        resolution = await self._resolve_new_resolution(scanned)
+        return MediaFile(
+            file_path=scanned.file_path,
+            file_size=scanned.file_size,
+            resolution=Resolution(resolution),
+            is_primary=is_primary,
+        )
+
+    # =========================================================================
+    # Movies
+    # =========================================================================
 
     async def _process_movies(
         self,
@@ -132,13 +196,30 @@ class ScanMediaDirectoriesUseCase:
         paths: list[str],
         by_path: dict[str, ScannedFile],
     ) -> tuple[int, int]:
-        """Add new file variants to an existing movie."""
-        added = False
+        """Add new file variants and refresh existing ones from a fresh scan."""
+        files = list(movie.files)
+        changed = False
+
         for path in paths:
-            if all(f.file_path.value != path for f in movie.files):
-                movie = movie.with_file(_build_media_file(by_path[path], is_primary=False))
-                added = True
-        if added:
+            scanned = by_path[path]
+            existing_idx = next(
+                (i for i, f in enumerate(files) if f.file_path.value == path),
+                None,
+            )
+            if existing_idx is None:
+                files.append(await self._build_new_media_file(scanned, is_primary=False))
+                changed = True
+                continue
+
+            new_res = await self._maybe_upgrade_resolution(files[existing_idx], scanned)
+            if new_res is not None:
+                files[existing_idx] = files[existing_idx].model_copy(
+                    update={"resolution": Resolution(new_res)}
+                )
+                changed = True
+
+        if changed:
+            movie = movie.with_updates(files=files)
             await self._movie_repository.save(movie)
             return 0, 1
         return 0, 0
@@ -150,20 +231,27 @@ class ScanMediaDirectoriesUseCase:
     ) -> tuple[int, int]:
         """Create a new movie from a group of file variants."""
         first = by_path[paths[0]]
+        resolution = await self._resolve_new_resolution(first)
         movie = Movie.create(
             title=first.title,
             year=first.year or _current_year(),
             duration=0,
             file_path=first.file_path.value,
             file_size=first.file_size,
-            resolution=first.resolution or "Unknown",
+            resolution=resolution,
         )
         for path in paths[1:]:
-            movie = movie.with_file(_build_media_file(by_path[path], is_primary=False))
+            movie = movie.with_file(
+                await self._build_new_media_file(by_path[path], is_primary=False)
+            )
         events = movie.pull_events()
         await self._movie_repository.save(movie)
         await self._dispatch_events(events)
         return 1, 0
+
+    # =========================================================================
+    # Episodes
+    # =========================================================================
 
     async def _process_episodes(
         self,
@@ -209,7 +297,9 @@ class ScanMediaDirectoriesUseCase:
                 ep_groups[(f.season_number, f.episode_number)].append(f)
 
         for (season_num, episode_num), ep_files in ep_groups.items():
-            series, c, u = _process_episode_group(series, season_num, episode_num, ep_files)
+            series, c, u = await self._process_episode_group(
+                series, season_num, episode_num, ep_files
+            )
             created += c
             updated += u
 
@@ -218,68 +308,89 @@ class ScanMediaDirectoriesUseCase:
         await self._dispatch_events(events)
         return created, updated
 
+    async def _process_episode_group(
+        self,
+        series: Series,
+        season_num: int,
+        episode_num: int,
+        ep_files: list[ScannedFile],
+    ) -> tuple[Series, int, int]:
+        """Process a group of files for a single episode."""
+        season = series.get_season(season_num)
+        if not season:
+            assert series.id is not None
+            season = Season(series_id=series.id, season_number=SeasonNumber(season_num))
+            series = series.with_season(season)
 
-def _process_episode_group(
-    series: Series,
-    season_num: int,
-    episode_num: int,
-    ep_files: list[ScannedFile],
-) -> tuple[Series, int, int]:
-    """Process a group of files for a single episode."""
-    season = series.get_season(season_num)
-    if not season:
+        episode = season.get_episode(episode_num)
+        if episode:
+            episode, was_updated = await self._refresh_episode(episode, ep_files)
+            created, updated = 0, int(was_updated)
+        else:
+            episode = await self._create_episode(series, season_num, episode_num, ep_files)
+            created, updated = 1, 0
+
+        season = _upsert_episode_in_season(season, episode)
+        series = _upsert_season_in_series(series, season)
+
+        return series, created, updated
+
+    async def _create_episode(
+        self,
+        series: Series,
+        season_num: int,
+        episode_num: int,
+        ep_files: list[ScannedFile],
+    ) -> Episode:
+        """Create a new Episode from scanned files."""
+        first = ep_files[0]
         assert series.id is not None
-        season = Season(series_id=series.id, season_number=SeasonNumber(season_num))
-        series = series.with_season(season)
+        ep_title = first.episode_title or f"Episode {episode_num}"
+        episode = Episode(
+            series_id=series.id,
+            season_number=SeasonNumber(season_num),
+            episode_number=EpisodeNumber(episode_num),
+            title=Title(ep_title),
+            duration=Duration(0),
+            files=[await self._build_new_media_file(first, is_primary=True)],
+        )
+        for f in ep_files[1:]:
+            episode = episode.with_file(await self._build_new_media_file(f, is_primary=False))
+        return episode
 
-    episode = season.get_episode(episode_num)
-    if episode:
-        episode, was_updated = _add_variants_to_episode(episode, ep_files)
-        created, updated = 0, int(was_updated)
-    else:
-        episode = _create_episode(series, season_num, episode_num, ep_files)
-        created, updated = 1, 0
+    async def _refresh_episode(
+        self,
+        episode: Episode,
+        ep_files: list[ScannedFile],
+    ) -> tuple[Episode, bool]:
+        """Add new file variants and refresh existing ones from a fresh scan."""
+        files = list(episode.files)
+        changed = False
 
-    season = _upsert_episode_in_season(season, episode)
-    series = _upsert_season_in_series(series, season)
+        for scanned in ep_files:
+            existing_idx = next(
+                (
+                    i
+                    for i, f in enumerate(files)
+                    if f.file_path.value == scanned.file_path.value
+                ),
+                None,
+            )
+            if existing_idx is None:
+                files.append(await self._build_new_media_file(scanned, is_primary=False))
+                changed = True
+                continue
 
-    return series, created, updated
+            new_res = await self._maybe_upgrade_resolution(files[existing_idx], scanned)
+            if new_res is not None:
+                files[existing_idx] = files[existing_idx].model_copy(
+                    update={"resolution": Resolution(new_res)}
+                )
+                changed = True
 
-
-def _create_episode(
-    series: Series,
-    season_num: int,
-    episode_num: int,
-    ep_files: list[ScannedFile],
-) -> Episode:
-    """Create a new Episode from scanned files."""
-    first = ep_files[0]
-    assert series.id is not None
-    ep_title = first.episode_title or f"Episode {episode_num}"
-    episode = Episode(
-        series_id=series.id,
-        season_number=SeasonNumber(season_num),
-        episode_number=EpisodeNumber(episode_num),
-        title=Title(ep_title),
-        duration=Duration(0),
-        files=[_build_media_file(first, is_primary=True)],
-    )
-    for f in ep_files[1:]:
-        episode = episode.with_file(_build_media_file(f, is_primary=False))
-    return episode
-
-
-def _add_variants_to_episode(
-    episode: Episode,
-    ep_files: list[ScannedFile],
-) -> tuple[Episode, bool]:
-    """Add new file variants to an existing episode."""
-    added = False
-    for f in ep_files:
-        if all(ef.file_path.value != f.file_path.value for ef in episode.files):
-            episode = episode.with_file(_build_media_file(f, is_primary=False))
-            added = True
-    return episode, added
+        if changed:
+            episode = episode.with_updates(files=files)
+        return episode, changed
 
 
 def _upsert_episode_in_season(season: Season, episode: Episode) -> Season:
@@ -304,16 +415,6 @@ def _upsert_season_in_series(series: Series, season: Season) -> Series:
     else:
         seasons.append(season)
     return series.with_updates(seasons=seasons)
-
-
-def _build_media_file(scanned: ScannedFile, *, is_primary: bool) -> MediaFile:
-    """Build a MediaFile value object from a ScannedFile."""
-    return MediaFile(
-        file_path=scanned.file_path,
-        file_size=scanned.file_size,
-        resolution=Resolution(scanned.resolution or "Unknown"),
-        is_primary=is_primary,
-    )
 
 
 def _current_year() -> int:

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -369,11 +369,7 @@ class ScanMediaDirectoriesUseCase:
 
         for scanned in ep_files:
             existing_idx = next(
-                (
-                    i
-                    for i, f in enumerate(files)
-                    if f.file_path.value == scanned.file_path.value
-                ),
+                (i for i, f in enumerate(files) if f.file_path.value == scanned.file_path.value),
                 None,
             )
             if existing_idx is None:

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -22,6 +22,19 @@ _logger = logging.getLogger(__name__)
 
 _FFPROBE_TIMEOUT = 15  # seconds
 
+# Long-edge thresholds for mapping ffprobe dimensions to named resolutions.
+# Tuple of (min_long_edge_pixels, resolution_name), evaluated top-down.
+# Using the longer dimension handles non-standard aspect ratios (e.g. 1920x800
+# cinemascope is still 1080p).
+_RESOLUTION_THRESHOLDS: list[tuple[int, str]] = [
+    (3000, "4K"),
+    (2300, "2K"),
+    (1700, "1080p"),
+    (1200, "720p"),
+    (800, "480p"),
+    (500, "360p"),
+]
+
 # ffprobe codec_name → SubtitleTrack format
 _SUBTITLE_CODEC_MAP: dict[str, str] = {
     "subrip": "srt",
@@ -149,6 +162,75 @@ class MediaProbeService:
             subtitle_tracks=subtitle_tracks,
             external_subtitles=external_subs,
         )
+
+    def probe_resolution(self, file_path: str) -> str | None:
+        """Detect the video resolution of a media file via ffprobe.
+
+        Reads only the first video stream's dimensions and maps the longer
+        edge to a named resolution ("360p", "480p", "720p", "1080p", "2K",
+        "4K"). Returns ``None`` when ffprobe is unavailable, the file does
+        not exist, has no video stream, or its dimensions fall below 360p.
+
+        Args:
+            file_path: Absolute path to the media file.
+
+        Returns:
+            A named resolution string, or ``None`` if it cannot be determined.
+        """
+        source = Path(file_path).resolve()
+        if not source.is_file():
+            _logger.warning("Cannot probe resolution for missing file: %s", file_path)
+            return None
+
+        dimensions = self._run_ffprobe_video_dimensions(str(source))
+        if dimensions is None:
+            return None
+
+        width, height = dimensions
+        return _resolution_from_dimensions(width, height)
+
+    @staticmethod
+    def _run_ffprobe_video_dimensions(file_path: str) -> tuple[int, int] | None:
+        """Run ffprobe to extract width/height of the first video stream."""
+        if not shutil.which("ffprobe"):
+            _logger.warning("ffprobe not found — cannot probe resolution for %s", file_path)
+            return None
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=width,height",
+                    "-of",
+                    "json",
+                    file_path,
+                ],
+                **SUBPROCESS_TEXT_KWARGS,
+                check=False,
+                timeout=_FFPROBE_TIMEOUT,
+            )
+            if result.returncode != 0:
+                _logger.error(
+                    "ffprobe failed for %s: %s", file_path, result.stderr
+                )
+                return None
+            data: dict[str, Any] = json.loads(result.stdout)
+            streams = data.get("streams") or []
+            if not streams:
+                return None
+            stream = streams[0]
+            width = int(stream.get("width") or 0)
+            height = int(stream.get("height") or 0)
+            if width <= 0 or height <= 0:
+                return None
+            return width, height
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError, ValueError) as e:
+            _logger.error("ffprobe error for %s: %s", file_path, e)
+            return None
 
     @staticmethod
     def _run_ffprobe(file_path: str) -> list[dict[str, Any]]:
@@ -344,6 +426,18 @@ class MediaProbeService:
             return _LANG_NAME_MAP.get(name, "un")
 
         return "un"
+
+
+def _resolution_from_dimensions(width: int, height: int) -> str | None:
+    """Map raw video dimensions to a named resolution.
+
+    Uses the longer edge to be tolerant of non-standard aspect ratios.
+    """
+    long_edge = max(width, height)
+    for threshold, name in _RESOLUTION_THRESHOLDS:
+        if long_edge >= threshold:
+            return name
+    return None
 
 
 __all__ = ["MediaProbeResult", "MediaProbeService"]

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -214,9 +214,7 @@ class MediaProbeService:
                 timeout=_FFPROBE_TIMEOUT,
             )
             if result.returncode != 0:
-                _logger.error(
-                    "ffprobe failed for %s: %s", file_path, result.stderr
-                )
+                _logger.error("ffprobe failed for %s: %s", file_path, result.stderr)
                 return None
             data: dict[str, Any] = json.loads(result.stdout)
             streams = data.get("streams") or []

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -9,9 +9,18 @@ from src.modules.media.application.ports import MediaType, ScannedFile
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
-from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.value_objects import (
+    Duration,
+    EpisodeNumber,
+    MediaFile,
+    Resolution,
+    SeasonNumber,
+    Title,
+)
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
+from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
 from src.shared_kernel.value_objects.file_path import FilePath
 
 
@@ -57,6 +66,7 @@ def _make_use_case(
     scanner_results: list[ScannedFile] | None = None,
     movie_repo: AsyncMock | None = None,
     series_repo: AsyncMock | None = None,
+    probe_service: MediaProbeService | MagicMock | None = None,
 ) -> ScanMediaDirectoriesUseCase:
     file_scanner = MagicMock()
     file_scanner.scan_directories.return_value = scanner_results or []
@@ -78,6 +88,7 @@ def _make_use_case(
         variant_detector=variant_detector,
         movie_repository=movie_repo,
         series_repository=series_repo,
+        probe_service=probe_service,
     )
 
 
@@ -211,3 +222,218 @@ class TestScanEpisodes:
 
         assert result.movies_created == 1
         assert result.episodes_created == 1
+
+
+@pytest.mark.unit
+class TestRescanResolutionUpgrade:
+    """Tests for refreshing existing entities when rescanning."""
+
+    @pytest.mark.asyncio
+    async def test_should_upgrade_movie_unknown_resolution(self) -> None:
+        existing = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="Unknown",
+        )
+        saved: list[Movie] = []
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/inception.mkv" else None
+        )
+        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
+        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo)
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_updated == 1
+        assert saved[0].files[0].resolution == Resolution("1080p")
+
+    @pytest.mark.asyncio
+    async def test_should_not_overwrite_known_movie_resolution(self) -> None:
+        existing = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/inception.mkv" else None
+        )
+        movie_repo.save.side_effect = lambda m: m
+
+        # Same path, but scanned now reports a different/Unknown resolution
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
+        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo)
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_updated == 0
+        movie_repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_skip_when_rescan_also_returns_no_resolution(self) -> None:
+        existing = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="Unknown",
+        )
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/inception.mkv" else None
+        )
+        movie_repo.save.side_effect = lambda m: m
+
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
+        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo)
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_updated == 0
+        movie_repo.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_probe_when_creating_movie_without_filename_resolution(
+        self,
+    ) -> None:
+        probe = MagicMock(spec=MediaProbeService)
+        probe.probe_resolution.return_value = "1080p"
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
+        use_case = _make_use_case(scanner_results=files, probe_service=probe)
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_created == 1
+        probe.probe_resolution.assert_called_once_with("/movies/inception.mkv")
+
+    @pytest.mark.asyncio
+    async def test_should_probe_when_existing_resolution_is_unknown(self) -> None:
+        existing = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="Unknown",
+        )
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/inception.mkv" else None
+        )
+        saved: list[Movie] = []
+        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+
+        probe = MagicMock(spec=MediaProbeService)
+        probe.probe_resolution.return_value = "4K"
+
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
+        use_case = _make_use_case(
+            scanner_results=files,
+            movie_repo=movie_repo,
+            probe_service=probe,
+        )
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_updated == 1
+        probe.probe_resolution.assert_called_once_with("/movies/inception.mkv")
+        assert saved[0].files[0].resolution == Resolution("4K")
+
+    @pytest.mark.asyncio
+    async def test_should_not_probe_when_existing_resolution_is_known(self) -> None:
+        existing = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/inception.mkv" else None
+        )
+        movie_repo.save.side_effect = lambda m: m
+
+        probe = MagicMock(spec=MediaProbeService)
+
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
+        use_case = _make_use_case(
+            scanner_results=files,
+            movie_repo=movie_repo,
+            probe_service=probe,
+        )
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_updated == 0
+        probe.probe_resolution.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_not_probe_when_filename_already_has_resolution(self) -> None:
+        probe = MagicMock(spec=MediaProbeService)
+        files = [_movie_file("/movies/inception.1080p.mkv", "Inception", 2010, "1080p")]
+        use_case = _make_use_case(scanner_results=files, probe_service=probe)
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_created == 1
+        probe.probe_resolution.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_upgrade_episode_unknown_resolution(self) -> None:
+        series = Series.create(title="Show", start_year=2024)
+        assert series.id is not None
+        episode = Episode(
+            series_id=series.id,
+            season_number=SeasonNumber(1),
+            episode_number=EpisodeNumber(1),
+            title=Title("Pilot"),
+            duration=Duration(0),
+            files=[
+                MediaFile(
+                    file_path=FilePath("/series/Show/S01/Show.S01E01.mkv"),
+                    file_size=500_000,
+                    resolution=Resolution("Unknown"),
+                    is_primary=True,
+                )
+            ],
+        )
+        season = Season(
+            series_id=series.id,
+            season_number=SeasonNumber(1),
+            episodes=[episode],
+        )
+        series = series.with_updates(seasons=[season])
+
+        saved: list[Series] = []
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.find_by_title.return_value = series
+        series_repo.save.side_effect = lambda s: saved.append(s) or s
+
+        files = [
+            _episode_file(
+                "/series/Show/S01/Show.S01E01.mkv",
+                series_name="Show",
+                season=1,
+                episode=1,
+                resolution="720p",
+            )
+        ]
+        use_case = _make_use_case(scanner_results=files, series_repo=series_repo)
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.episodes_updated == 1
+        saved_episode = saved[0].seasons[0].episodes[0]
+        assert saved_episode.files[0].resolution == Resolution("720p")

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -10,6 +10,7 @@ import pytest
 from src.modules.media.infrastructure.streaming.media_probe_service import (
     MediaProbeResult,
     MediaProbeService,
+    _resolution_from_dimensions,
 )
 
 
@@ -423,3 +424,112 @@ class TestMediaProbeServiceProbe:
         assert result.audio_tracks == []
         assert result.subtitle_tracks == []
         assert result.external_subtitles == []
+
+
+@pytest.mark.unit
+class TestResolutionFromDimensions:
+    """Tests for the dimension-to-named-resolution mapping."""
+
+    @pytest.mark.parametrize(
+        ("width", "height", "expected"),
+        [
+            (3840, 2160, "4K"),
+            (4096, 2160, "4K"),
+            (2560, 1440, "2K"),
+            (1920, 1080, "1080p"),
+            (1920, 800, "1080p"),  # cinemascope still 1080p by long edge
+            (1280, 720, "720p"),
+            (854, 480, "480p"),
+            (640, 360, "360p"),
+        ],
+    )
+    def test_should_map_known_dimensions(
+        self, width: int, height: int, expected: str
+    ) -> None:
+        assert _resolution_from_dimensions(width, height) == expected
+
+    def test_should_return_none_for_below_360p(self) -> None:
+        assert _resolution_from_dimensions(320, 240) is None
+
+    def test_should_return_none_for_zero_dimensions(self) -> None:
+        assert _resolution_from_dimensions(0, 0) is None
+
+
+@pytest.mark.unit
+class TestProbeResolution:
+    """Tests for MediaProbeService.probe_resolution."""
+
+    def test_should_return_none_for_missing_file(self, tmp_path: Path) -> None:
+        service = MediaProbeService()
+        missing = tmp_path / "missing.mkv"
+
+        assert service.probe_resolution(str(missing)) is None
+
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value=None,
+    )
+    def test_should_return_none_when_ffprobe_missing(
+        self, _which: MagicMock, tmp_path: Path
+    ) -> None:
+        video = tmp_path / "movie.mkv"
+        video.touch()
+        service = MediaProbeService()
+
+        assert service.probe_resolution(str(video)) is None
+
+    @patch("src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run")
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value="/usr/bin/ffprobe",
+    )
+    def test_should_return_resolution_from_dimensions(
+        self, _which: MagicMock, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        video = tmp_path / "movie.mkv"
+        video.touch()
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps(
+            {"streams": [{"width": 1920, "height": 1080}]}
+        )
+        mock_run.return_value = mock_result
+        service = MediaProbeService()
+
+        assert service.probe_resolution(str(video)) == "1080p"
+
+    @patch("src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run")
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value="/usr/bin/ffprobe",
+    )
+    def test_should_return_none_when_no_video_stream(
+        self, _which: MagicMock, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        video = tmp_path / "movie.mkv"
+        video.touch()
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"streams": []})
+        mock_run.return_value = mock_result
+        service = MediaProbeService()
+
+        assert service.probe_resolution(str(video)) is None
+
+    @patch("src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run")
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value="/usr/bin/ffprobe",
+    )
+    def test_should_return_none_on_ffprobe_failure(
+        self, _which: MagicMock, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        video = tmp_path / "movie.mkv"
+        video.touch()
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stderr = "error"
+        mock_run.return_value = mock_result
+        service = MediaProbeService()
+
+        assert service.probe_resolution(str(video)) is None

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -443,9 +443,7 @@ class TestResolutionFromDimensions:
             (640, 360, "360p"),
         ],
     )
-    def test_should_map_known_dimensions(
-        self, width: int, height: int, expected: str
-    ) -> None:
+    def test_should_map_known_dimensions(self, width: int, height: int, expected: str) -> None:
         assert _resolution_from_dimensions(width, height) == expected
 
     def test_should_return_none_for_below_360p(self) -> None:
@@ -490,9 +488,7 @@ class TestProbeResolution:
         video.touch()
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = json.dumps(
-            {"streams": [{"width": 1920, "height": 1080}]}
-        )
+        mock_result.stdout = json.dumps({"streams": [{"width": 1920, "height": 1080}]})
         mock_run.return_value = mock_result
         service = MediaProbeService()
 


### PR DESCRIPTION
## Summary
- Add `probe_resolution()` to `MediaProbeService` — runs a lightweight ffprobe call (`-select_streams v:0`) and maps the longer edge to a named resolution (360p–4K).
- Move resolution probing from the scanner into `ScanMediaDirectoriesUseCase`, where it runs lazily: only for files being registered for the first time or stored as `Unknown`. Files already at a known resolution are never re-probed, keeping rescans fast.
- Refresh `Unknown` resolutions on rescan instead of leaving them stale; never overwrite a known resolution.
- Probing runs via `asyncio.to_thread` so the event loop stays responsive during scans.

## Test plan
- [x] Unit tests for `probe_resolution` and `_resolution_from_dimensions` (parametrized over 4K/2K/1080p/720p/480p/360p, plus failure modes: missing file, missing ffprobe, no video stream, ffprobe error).
- [x] Use case tests covering the lazy-probe decision tree: probe on create when filename has no tag; probe on update when stored value is `Unknown`; never probe when filename already has a tag; never probe when stored value is known; never overwrite a known resolution on rescan.
- [x] Existing scan and scanner tests still pass (1540 total).
- [x] `ruff check` clean.

## Summary by Sourcery

Add lazy ffprobe-based resolution detection to media scans and refresh unknown resolutions on rescan without overwriting known values.

New Features:
- Introduce MediaProbeService.probe_resolution to derive named resolutions from ffprobe video dimensions.
- Add lazy resolution fallback in ScanMediaDirectoriesUseCase that probes only when filenames lack tags and stored resolution is Unknown.

Enhancements:
- Update movie and episode scan workflows to refresh existing media files and upgrade Unknown resolutions while preserving known ones.
- Wire MediaProbeService into the media container for use during directory scans.

Tests:
- Extend scan use case tests to cover lazy probing, upgrade rules, and non-overwrite behavior for known resolutions.
- Add unit tests for MediaProbeService resolution mapping and ffprobe resolution probing, including error and edge cases.