### PR TITLE
refactor(media): cache ffprobe path lookup to silence log spam

### DIFF
--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -207,12 +207,13 @@ class MediaProbeService:
     @staticmethod
     def _run_ffprobe_video_dimensions(file_path: str) -> tuple[int, int] | None:
         """Run ffprobe to extract width/height of the first video stream."""
-        if _ffprobe_path() is None:
+        ffprobe = _ffprobe_path()
+        if ffprobe is None:
             return None
         try:
             result = subprocess.run(
                 [
-                    "ffprobe",
+                    ffprobe,
                     "-v",
                     "error",
                     "-select_streams",
@@ -247,12 +248,13 @@ class MediaProbeService:
     @staticmethod
     def _run_ffprobe(file_path: str) -> list[dict[str, Any]]:
         """Run ffprobe and return stream data as JSON."""
-        if _ffprobe_path() is None:
+        ffprobe = _ffprobe_path()
+        if ffprobe is None:
             return []
         try:
             result = subprocess.run(
                 [
-                    "ffprobe",
+                    ffprobe,
                     "-v",
                     "error",
                     "-show_streams",

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -4,6 +4,7 @@ Discovers audio tracks, subtitle tracks (embedded and external)
 from a media file, returning structured domain value objects.
 """
 
+import functools
 import json
 import logging
 import re
@@ -21,6 +22,20 @@ from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 _logger = logging.getLogger(__name__)
 
 _FFPROBE_TIMEOUT = 15  # seconds
+
+
+@functools.lru_cache(maxsize=1)
+def _ffprobe_path() -> str | None:
+    """Return the resolved path to ffprobe, or None if not on PATH.
+
+    Cached so that the PATH lookup runs once per process and the missing-binary
+    warning is logged at most once even across thousands of probe calls.
+    """
+    path = shutil.which("ffprobe")
+    if path is None:
+        _logger.warning("ffprobe not found — probing disabled")
+    return path
+
 
 # Long-edge thresholds for mapping ffprobe dimensions to named resolutions.
 # Tuple of (min_long_edge_pixels, resolution_name), evaluated top-down.
@@ -192,8 +207,7 @@ class MediaProbeService:
     @staticmethod
     def _run_ffprobe_video_dimensions(file_path: str) -> tuple[int, int] | None:
         """Run ffprobe to extract width/height of the first video stream."""
-        if not shutil.which("ffprobe"):
-            _logger.warning("ffprobe not found — cannot probe resolution for %s", file_path)
+        if _ffprobe_path() is None:
             return None
         try:
             result = subprocess.run(
@@ -233,8 +247,7 @@ class MediaProbeService:
     @staticmethod
     def _run_ffprobe(file_path: str) -> list[dict[str, Any]]:
         """Run ffprobe and return stream data as JSON."""
-        if not shutil.which("ffprobe"):
-            _logger.warning("ffprobe not found — cannot probe %s", file_path)
+        if _ffprobe_path() is None:
             return []
         try:
             result = subprocess.run(

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -10,8 +10,15 @@ import pytest
 from src.modules.media.infrastructure.streaming.media_probe_service import (
     MediaProbeResult,
     MediaProbeService,
+    _ffprobe_path,
     _resolution_from_dimensions,
 )
+
+
+@pytest.fixture(autouse=True)  # type: ignore[misc]
+def _clear_ffprobe_path_cache() -> None:
+    """Reset the cached ffprobe lookup so each test sees its own ``shutil.which`` patch."""
+    _ffprobe_path.cache_clear()
 
 
 def _ffprobe_stream(
@@ -529,3 +536,36 @@ class TestProbeResolution:
         service = MediaProbeService()
 
         assert service.probe_resolution(str(video)) is None
+
+
+@pytest.mark.unit
+class TestFfprobePathCache:
+    """Tests for the cached ffprobe lookup helper."""
+
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value=None,
+    )
+    def test_should_log_missing_warning_only_once(
+        self,
+        mock_which: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level("WARNING"):
+            for _ in range(5):
+                MediaProbeService._run_ffprobe("/path/to/movie.mkv")
+                MediaProbeService._run_ffprobe_video_dimensions("/path/to/movie.mkv")
+
+        warnings = [r for r in caplog.records if "ffprobe not found" in r.message]
+        assert len(warnings) == 1
+        assert mock_which.call_count == 1
+
+    @patch(
+        "src.modules.media.infrastructure.streaming.media_probe_service.shutil.which",
+        return_value="/usr/bin/ffprobe",
+    )
+    def test_should_cache_resolved_path(self, mock_which: MagicMock) -> None:
+        for _ in range(5):
+            assert _ffprobe_path() == "/usr/bin/ffprobe"
+
+        assert mock_which.call_count == 1


### PR DESCRIPTION
## Summary
- Extract `_ffprobe_path()` — an `lru_cache(maxsize=1)`-backed helper that runs `shutil.which(\"ffprobe\")` once per process and logs the missing-binary warning at most once.
- Replace the duplicated `shutil.which` checks in `_run_ffprobe` and `_run_ffprobe_video_dimensions` with a single `if _ffprobe_path() is None` gate.

Before: a 1000-file scan with ffprobe missing produced 1000 identical WARNING lines. Now it emits one.

Closes #109

## Test plan
- [x] New \`TestFfprobePathCache\` tests assert the warning is logged exactly once across 10 calls and that \`shutil.which\` is invoked only once.
- [x] Autouse fixture clears the cache between tests so existing \`shutil.which\` patches keep working.
- [x] Full suite (1542 tests), \`ruff check\`, and \`ruff format --check\` all green.

## Summary by Sourcery

Cache ffprobe path resolution to avoid repeated PATH lookups and duplicated missing-binary warnings during media probing.

Enhancements:
- Introduce an lru_cached helper for resolving the ffprobe binary path once per process and centralizing the missing-binary warning.
- Refactor media probing methods to reuse the cached ffprobe path instead of performing repeated shutil.which checks.

Tests:
- Add unit tests to verify the ffprobe path lookup is cached, shutil.which is called only once, and the missing-binary warning is emitted at most once across multiple calls.
- Introduce an autouse test fixture to clear the ffprobe path cache between tests to keep existing shutil.which patches isolated.