### PR TITLE
feat(media): detect audio/subtitle track languages on scan

### DIFF
--- a/src/modules/media/application/dtos/media_file_dtos.py
+++ b/src/modules/media/application/dtos/media_file_dtos.py
@@ -1,6 +1,52 @@
 """MediaFile DTOs for file variant operations."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class AudioTrackOutput:
+    """Output representation of an audio track.
+
+    Attributes:
+        index: Track index in the container.
+        language: ISO 639-1 language code.
+        codec: Audio codec name.
+        channels: Number of audio channels.
+        channel_layout: Human-readable layout (e.g., "5.1", "Stereo").
+        title: Descriptive title from file metadata.
+        is_default: Whether marked as default in the container.
+    """
+
+    index: int
+    language: str
+    codec: str
+    channels: int
+    channel_layout: str
+    title: str | None
+    is_default: bool
+
+
+@dataclass(frozen=True)
+class SubtitleTrackOutput:
+    """Output representation of a subtitle track.
+
+    Attributes:
+        index: Track index.
+        language: ISO 639-1 language code.
+        format: Subtitle format (srt, ass, pgs, etc.).
+        title: Descriptive title.
+        is_default: Whether marked as default.
+        is_forced: Whether this is a forced (signs-only) track.
+        is_external: True if from a separate file.
+    """
+
+    index: int
+    language: str
+    format: str
+    title: str | None
+    is_default: bool
+    is_forced: bool
+    is_external: bool
 
 
 @dataclass(frozen=True)
@@ -16,6 +62,8 @@ class MediaFileOutput:
         hdr_format: HDR format if applicable.
         is_primary: Whether this is the primary file variant.
         added_at: ISO timestamp of when the file was registered.
+        audio_tracks: Detected audio tracks with language info.
+        subtitle_tracks: Detected subtitle tracks with language info.
     """
 
     file_path: str
@@ -26,6 +74,8 @@ class MediaFileOutput:
     hdr_format: str | None
     is_primary: bool
     added_at: str
+    audio_tracks: list[AudioTrackOutput] = field(default_factory=list)
+    subtitle_tracks: list[SubtitleTrackOutput] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -92,8 +142,10 @@ class GetFileVariantsInput:
 
 __all__ = [
     "AddFileVariantInput",
+    "AudioTrackOutput",
     "GetFileVariantsInput",
     "MediaFileOutput",
     "RemoveFileVariantInput",
     "SetPrimaryFileInput",
+    "SubtitleTrackOutput",
 ]

--- a/src/modules/media/application/use_cases/_media_file_helpers.py
+++ b/src/modules/media/application/use_cases/_media_file_helpers.py
@@ -1,7 +1,36 @@
 """Shared helpers for media file variant use cases."""
 
-from src.modules.media.application.dtos.media_file_dtos import MediaFileOutput
+from src.modules.media.application.dtos.media_file_dtos import (
+    AudioTrackOutput,
+    MediaFileOutput,
+    SubtitleTrackOutput,
+)
 from src.modules.media.domain.value_objects import MediaFile
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+
+def _to_audio_track_output(track: AudioTrack) -> AudioTrackOutput:
+    return AudioTrackOutput(
+        index=track.index,
+        language=track.language.value,
+        codec=track.codec,
+        channels=track.channels,
+        channel_layout=track.channel_layout,
+        title=track.title,
+        is_default=track.is_default,
+    )
+
+
+def _to_subtitle_track_output(track: SubtitleTrack) -> SubtitleTrackOutput:
+    return SubtitleTrackOutput(
+        index=track.index,
+        language=track.language.value,
+        format=track.format,
+        title=track.title,
+        is_default=track.is_default,
+        is_forced=track.is_forced,
+        is_external=track.is_external,
+    )
 
 
 def to_media_file_output(file: MediaFile) -> MediaFileOutput:
@@ -22,4 +51,6 @@ def to_media_file_output(file: MediaFile) -> MediaFileOutput:
         hdr_format=file.hdr_format.value if file.hdr_format else None,
         is_primary=file.is_primary,
         added_at=file.added_at.isoformat(),
+        audio_tracks=[_to_audio_track_output(t) for t in file.audio_tracks],
+        subtitle_tracks=[_to_subtitle_track_output(t) for t in file.subtitle_tracks],
     )

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -122,9 +122,7 @@ class ScanMediaDirectoriesUseCase:
         languages — are persisted on first registration.
         """
         probed = await self._probe(scanned.file_path.value)
-        resolution = (
-            scanned.resolution or (probed.resolution if probed else None) or "Unknown"
-        )
+        resolution = scanned.resolution or (probed.resolution if probed else None) or "Unknown"
         return MediaFile(
             file_path=scanned.file_path,
             file_size=scanned.file_size,

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -8,14 +8,17 @@ from src.building_blocks.domain.events import DomainEvent
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput, ScanMediaOutput
 from src.modules.media.application.ports import FileSystemScanner, MediaType, ScannedFile
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
+from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeNumber,
     MediaFile,
+    MovieId,
     Resolution,
     SeasonNumber,
     Title,
+    Year,
 )
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
 from src.modules.media.infrastructure.streaming.media_probe_service import (
@@ -138,13 +141,15 @@ class ScanMediaDirectoriesUseCase:
     ) -> MediaFile | None:
         """Return a refreshed MediaFile when stored metadata can be enriched.
 
-        Upgrades ``Unknown`` resolutions and backfills empty track lists. Never
-        overwrites a known resolution or non-empty track lists. Returns
-        ``None`` when no change is needed.
+        Upgrades ``Unknown`` resolutions and backfills empty audio or
+        subtitle track lists independently. Never overwrites a known
+        resolution or non-empty track lists. Returns ``None`` when no
+        change is needed.
         """
         needs_resolution = current.resolution.name == "Unknown"
-        needs_tracks = not current.audio_tracks and not current.subtitle_tracks
-        if not needs_resolution and not needs_tracks:
+        needs_audio = not current.audio_tracks
+        needs_subtitles = not current.subtitle_tracks
+        if not needs_resolution and not needs_audio and not needs_subtitles:
             return None
 
         updates: dict[str, object] = {}
@@ -153,14 +158,14 @@ class ScanMediaDirectoriesUseCase:
             updates["resolution"] = Resolution(scanned.resolution)
             needs_resolution = False
 
-        if needs_resolution or needs_tracks:
+        if needs_resolution or needs_audio or needs_subtitles:
             probed = await self._probe(scanned.file_path.value)
             if probed is not None:
                 if needs_resolution and probed.resolution:
                     updates["resolution"] = Resolution(probed.resolution)
-                if not current.audio_tracks and probed.audio_tracks:
+                if needs_audio and probed.audio_tracks:
                     updates["audio_tracks"] = list(probed.audio_tracks)
-                if not current.subtitle_tracks and probed.all_subtitles:
+                if needs_subtitles and probed.all_subtitles:
                     updates["subtitle_tracks"] = list(probed.all_subtitles)
 
         if not updates:
@@ -257,17 +262,15 @@ class ScanMediaDirectoriesUseCase:
         """Create a new movie from a group of file variants."""
         first = by_path[paths[0]]
         primary_file = await self._build_new_media_file(first, is_primary=True)
-        movie = Movie.create(
-            title=first.title,
-            year=first.year or _current_year(),
-            duration=0,
-            file_path=primary_file.file_path.value,
-            file_size=primary_file.file_size,
-            resolution=primary_file.resolution.name,
+        movie_id = MovieId.generate()
+        movie = Movie(
+            id=movie_id,
+            title=Title(first.title),
+            year=Year(first.year or _current_year()),
+            duration=Duration(0),
+            files=[primary_file],
         )
-        # Movie.create builds its own primary MediaFile; replace it with the
-        # probed one so audio/subtitle tracks are carried over.
-        movie = movie.with_updates(files=[primary_file])
+        movie.add_event(MediaCreatedEvent(media_id=str(movie_id), media_type="movie"))
         for path in paths[1:]:
             movie = movie.with_file(
                 await self._build_new_media_file(by_path[path], is_primary=False)

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -18,24 +18,28 @@ from src.modules.media.domain.value_objects import (
     Title,
 )
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
-from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
+from src.modules.media.infrastructure.streaming.media_probe_service import (
+    MediaProbeResult,
+    MediaProbeService,
+)
 
 
 class ScanMediaDirectoriesUseCase:
     """Scan filesystem directories and register discovered media files.
 
     Walks the configured directories, detects movies and series episodes,
-    groups file variants, and persists new or updated entities. When the
-    filename does not contain a resolution tag, falls back to ffprobe via
-    ``probe_service`` — but only for files that are new or stored as
-    ``Unknown``, so rescans of fully-resolved libraries skip ffprobe.
+    groups file variants, and persists new or updated entities. New files
+    are always probed via ``probe_service`` to detect audio and subtitle
+    tracks (including their languages). Existing files are re-probed only
+    when their stored resolution is ``Unknown`` or their track lists are
+    still empty, so rescans of fully-populated libraries skip ffprobe.
 
     Args:
         file_scanner: Port for filesystem scanning.
         variant_detector: Service for grouping file variants.
         movie_repository: Repository for movie persistence.
         series_repository: Repository for series persistence.
-        probe_service: Optional ffprobe service for resolution fallback.
+        probe_service: Optional ffprobe service for track and resolution detection.
         event_bus: Optional event bus for domain events.
     """
 
@@ -90,40 +94,18 @@ class ScanMediaDirectoriesUseCase:
             await self._event_bus.publish(event)
 
     # =========================================================================
-    # Resolution probing (lazy)
+    # ffprobe integration
     # =========================================================================
 
-    async def _probe_resolution(self, file_path: str) -> str | None:
-        """Run ffprobe in a worker thread to detect resolution.
+    async def _probe(self, file_path: str) -> MediaProbeResult | None:
+        """Run full ffprobe in a worker thread.
 
-        Returns None if probing is unavailable or yields no result.
+        Returns the complete probe result (tracks + resolution) or ``None``
+        when probing is unavailable.
         """
         if self._probe_service is None:
             return None
-        return await asyncio.to_thread(self._probe_service.probe_resolution, file_path)
-
-    async def _resolve_new_resolution(self, scanned: ScannedFile) -> str:
-        """Resolution to use when registering a file for the first time."""
-        if scanned.resolution:
-            return scanned.resolution
-        return (await self._probe_resolution(scanned.file_path.value)) or "Unknown"
-
-    async def _maybe_upgrade_resolution(
-        self,
-        current: MediaFile,
-        scanned: ScannedFile,
-    ) -> str | None:
-        """Resolution to use when refreshing an existing file.
-
-        Returns the new resolution name when an upgrade should be applied,
-        or None when the existing value should be kept. Only upgrades when
-        the stored resolution is ``Unknown``; never overwrites a known one.
-        """
-        if current.resolution.name != "Unknown":
-            return None
-        if scanned.resolution:
-            return scanned.resolution
-        return await self._probe_resolution(scanned.file_path.value)
+        return await asyncio.to_thread(self._probe_service.probe, file_path)
 
     async def _build_new_media_file(
         self,
@@ -131,14 +113,59 @@ class ScanMediaDirectoriesUseCase:
         *,
         is_primary: bool,
     ) -> MediaFile:
-        """Build a MediaFile for a path being registered for the first time."""
-        resolution = await self._resolve_new_resolution(scanned)
+        """Build a MediaFile for a path being registered for the first time.
+
+        Always probes the file so audio and subtitle tracks — including their
+        languages — are persisted on first registration.
+        """
+        probed = await self._probe(scanned.file_path.value)
+        resolution = (
+            scanned.resolution or (probed.resolution if probed else None) or "Unknown"
+        )
         return MediaFile(
             file_path=scanned.file_path,
             file_size=scanned.file_size,
             resolution=Resolution(resolution),
+            audio_tracks=list(probed.audio_tracks) if probed else [],
+            subtitle_tracks=list(probed.all_subtitles) if probed else [],
             is_primary=is_primary,
         )
+
+    async def _maybe_refresh_media_file(
+        self,
+        current: MediaFile,
+        scanned: ScannedFile,
+    ) -> MediaFile | None:
+        """Return a refreshed MediaFile when stored metadata can be enriched.
+
+        Upgrades ``Unknown`` resolutions and backfills empty track lists. Never
+        overwrites a known resolution or non-empty track lists. Returns
+        ``None`` when no change is needed.
+        """
+        needs_resolution = current.resolution.name == "Unknown"
+        needs_tracks = not current.audio_tracks and not current.subtitle_tracks
+        if not needs_resolution and not needs_tracks:
+            return None
+
+        updates: dict[str, object] = {}
+
+        if needs_resolution and scanned.resolution:
+            updates["resolution"] = Resolution(scanned.resolution)
+            needs_resolution = False
+
+        if needs_resolution or needs_tracks:
+            probed = await self._probe(scanned.file_path.value)
+            if probed is not None:
+                if needs_resolution and probed.resolution:
+                    updates["resolution"] = Resolution(probed.resolution)
+                if not current.audio_tracks and probed.audio_tracks:
+                    updates["audio_tracks"] = list(probed.audio_tracks)
+                if not current.subtitle_tracks and probed.all_subtitles:
+                    updates["subtitle_tracks"] = list(probed.all_subtitles)
+
+        if not updates:
+            return None
+        return current.model_copy(update=updates)
 
     # =========================================================================
     # Movies
@@ -211,11 +238,9 @@ class ScanMediaDirectoriesUseCase:
                 changed = True
                 continue
 
-            new_res = await self._maybe_upgrade_resolution(files[existing_idx], scanned)
-            if new_res is not None:
-                files[existing_idx] = files[existing_idx].model_copy(
-                    update={"resolution": Resolution(new_res)}
-                )
+            refreshed = await self._maybe_refresh_media_file(files[existing_idx], scanned)
+            if refreshed is not None:
+                files[existing_idx] = refreshed
                 changed = True
 
         if changed:
@@ -231,15 +256,18 @@ class ScanMediaDirectoriesUseCase:
     ) -> tuple[int, int]:
         """Create a new movie from a group of file variants."""
         first = by_path[paths[0]]
-        resolution = await self._resolve_new_resolution(first)
+        primary_file = await self._build_new_media_file(first, is_primary=True)
         movie = Movie.create(
             title=first.title,
             year=first.year or _current_year(),
             duration=0,
-            file_path=first.file_path.value,
-            file_size=first.file_size,
-            resolution=resolution,
+            file_path=primary_file.file_path.value,
+            file_size=primary_file.file_size,
+            resolution=primary_file.resolution.name,
         )
+        # Movie.create builds its own primary MediaFile; replace it with the
+        # probed one so audio/subtitle tracks are carried over.
+        movie = movie.with_updates(files=[primary_file])
         for path in paths[1:]:
             movie = movie.with_file(
                 await self._build_new_media_file(by_path[path], is_primary=False)
@@ -377,11 +405,9 @@ class ScanMediaDirectoriesUseCase:
                 changed = True
                 continue
 
-            new_res = await self._maybe_upgrade_resolution(files[existing_idx], scanned)
-            if new_res is not None:
-                files[existing_idx] = files[existing_idx].model_copy(
-                    update={"resolution": Resolution(new_res)}
-                )
+            refreshed = await self._maybe_refresh_media_file(files[existing_idx], scanned)
+            if refreshed is not None:
+                files[existing_idx] = refreshed
                 changed = True
 
         if changed:

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -120,6 +120,7 @@ class MediaProbeResult:
     audio_tracks: list[AudioTrack] = field(default_factory=list)
     subtitle_tracks: list[SubtitleTrack] = field(default_factory=list)
     external_subtitles: list[SubtitleTrack] = field(default_factory=list)
+    resolution: str | None = None
 
     @property
     def all_subtitles(self) -> list[SubtitleTrack]:
@@ -163,6 +164,7 @@ class MediaProbeService:
         audio_tracks = self._parse_audio_tracks(streams)
         subtitle_tracks = self._parse_subtitle_tracks(streams)
         external_subs = self._scan_external_subtitles(source, len(subtitle_tracks))
+        resolution = self._parse_resolution(streams)
 
         _logger.info(
             "Probed %s: %d audio, %d embedded subs, %d external subs",
@@ -176,6 +178,7 @@ class MediaProbeService:
             audio_tracks=audio_tracks,
             subtitle_tracks=subtitle_tracks,
             external_subtitles=external_subs,
+            resolution=resolution,
         )
 
     def probe_resolution(self, file_path: str) -> str | None:
@@ -274,6 +277,27 @@ class MediaProbeService:
         except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError) as e:
             _logger.error("ffprobe error for %s: %s", file_path, e)
             return []
+
+    @staticmethod
+    def _parse_resolution(streams: list[dict[str, Any]]) -> str | None:
+        """Extract the named resolution from the first video stream.
+
+        Reuses the streams already loaded by ``probe`` to avoid a second
+        ffprobe invocation. Returns ``None`` when no video stream is
+        present or its dimensions fall below 360p.
+        """
+        for stream in streams:
+            if stream.get("codec_type") != "video":
+                continue
+            try:
+                width = int(stream.get("width") or 0)
+                height = int(stream.get("height") or 0)
+            except (TypeError, ValueError):
+                return None
+            if width <= 0 or height <= 0:
+                return None
+            return _resolution_from_dimensions(width, height)
+        return None
 
     @staticmethod
     def _extract_language(stream: dict[str, Any]) -> str:

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -112,6 +112,48 @@ _LANG_FULLNAME_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# ISO 639-2 (3-letter) → ISO 639-1 (2-letter) mapping for codes commonly
+# found in MKV/MP4 containers via ffprobe.
+_ISO639_2_TO_1: dict[str, str] = {
+    "eng": "en",
+    "por": "pt",
+    "spa": "es",
+    "fra": "fr",
+    "fre": "fr",
+    "deu": "de",
+    "ger": "de",
+    "ita": "it",
+    "jpn": "ja",
+    "kor": "ko",
+    "zho": "zh",
+    "chi": "zh",
+    "rus": "ru",
+    "ara": "ar",
+    "nld": "nl",
+    "dut": "nl",
+    "pol": "pl",
+    "swe": "sv",
+    "nor": "no",
+    "dan": "da",
+    "fin": "fi",
+    "tur": "tr",
+    "ell": "el",
+    "gre": "el",
+    "ces": "cs",
+    "cze": "cs",
+    "hun": "hu",
+    "ron": "ro",
+    "rum": "ro",
+    "ukr": "uk",
+    "tha": "th",
+    "vie": "vi",
+    "ind": "id",
+    "msa": "ms",
+    "may": "ms",
+    "heb": "he",
+    "hin": "hi",
+}
+
 
 @dataclass(frozen=True)
 class MediaProbeResult:
@@ -301,16 +343,19 @@ class MediaProbeService:
 
     @staticmethod
     def _extract_language(stream: dict[str, Any]) -> str:
-        """Extract ISO 639-1 language code from stream tags."""
+        """Extract ISO 639-1 language code from stream tags.
+
+        Handles ISO 639-2/B and 639-2/T three-letter codes (e.g. ``por``,
+        ``fre``, ``ger``) by mapping them to the standard two-letter code
+        via ``_ISO639_2_TO_1``.
+        """
         tags: dict[str, Any] = dict(stream.get("tags", {}))
         lang = str(tags.get("language", tags.get("LANGUAGE", "und")))
         lang = lang.lower().strip()
 
-        # Handle 3-letter codes by taking first 2
         if len(lang) == 3 and lang != "und":
-            lang = lang[:2]
+            lang = _ISO639_2_TO_1.get(lang, lang[:2])
 
-        # Validate: must be 2 lowercase letters
         if re.match(r"^[a-z]{2}$", lang):
             return lang
         return "un"

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -226,9 +226,8 @@ class MediaProbeService:
     def probe_resolution(self, file_path: str) -> str | None:
         """Detect the video resolution of a media file via ffprobe.
 
-        Reads only the first video stream's dimensions and maps the longer
-        edge to a named resolution ("360p", "480p", "720p", "1080p", "2K",
-        "4K"). Returns ``None`` when ffprobe is unavailable, the file does
+        Delegates to :meth:`probe` so there is a single ffprobe invocation
+        path.  Returns ``None`` when ffprobe is unavailable, the file does
         not exist, has no video stream, or its dimensions fall below 360p.
 
         Args:
@@ -237,17 +236,7 @@ class MediaProbeService:
         Returns:
             A named resolution string, or ``None`` if it cannot be determined.
         """
-        source = Path(file_path).resolve()
-        if not source.is_file():
-            _logger.warning("Cannot probe resolution for missing file: %s", file_path)
-            return None
-
-        dimensions = self._run_ffprobe_video_dimensions(str(source))
-        if dimensions is None:
-            return None
-
-        width, height = dimensions
-        return _resolution_from_dimensions(width, height)
+        return self.probe(file_path).resolution
 
     @staticmethod
     def _run_ffprobe_video_dimensions(file_path: str) -> tuple[int, int] | None:
@@ -322,11 +311,15 @@ class MediaProbeService:
 
     @staticmethod
     def _parse_resolution(streams: list[dict[str, Any]]) -> str | None:
-        """Extract the named resolution from the first video stream.
+        """Extract the named resolution from the first valid video stream.
 
         Reuses the streams already loaded by ``probe`` to avoid a second
-        ffprobe invocation. Returns ``None`` when no video stream is
-        present or its dimensions fall below 360p.
+        ffprobe invocation. Skips video streams with missing or invalid
+        dimensions (e.g. embedded cover art) so that a valid stream
+        later in the list can still be matched.
+
+        Returns ``None`` when no video stream has usable dimensions or
+        all fall below 360p.
         """
         for stream in streams:
             if stream.get("codec_type") != "video":
@@ -335,10 +328,12 @@ class MediaProbeService:
                 width = int(stream.get("width") or 0)
                 height = int(stream.get("height") or 0)
             except (TypeError, ValueError):
-                return None
+                continue
             if width <= 0 or height <= 0:
-                return None
-            return _resolution_from_dimensions(width, height)
+                continue
+            resolved = _resolution_from_dimensions(width, height)
+            if resolved is not None:
+                return resolved
         return None
 
     @staticmethod
@@ -354,7 +349,10 @@ class MediaProbeService:
         lang = lang.lower().strip()
 
         if len(lang) == 3 and lang != "und":
-            lang = _ISO639_2_TO_1.get(lang, lang[:2])
+            mapped = _ISO639_2_TO_1.get(lang)
+            if mapped is None:
+                return "un"
+            lang = mapped
 
         if re.match(r"^[a-z]{2}$", lang):
             return lang

--- a/tests/modules/media/unit/application/use_cases/test_media_file_helpers.py
+++ b/tests/modules/media/unit/application/use_cases/test_media_file_helpers.py
@@ -1,0 +1,127 @@
+"""Tests for to_media_file_output track mapping."""
+
+import pytest
+
+from src.modules.media.application.use_cases._media_file_helpers import to_media_file_output
+from src.modules.media.domain.value_objects import MediaFile, Resolution
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+
+def _media_file_with_tracks() -> MediaFile:
+    return MediaFile(
+        file_path=FilePath("/movies/movie.mkv"),
+        file_size=4_000_000_000,
+        resolution=Resolution("1080p"),
+        is_primary=True,
+        audio_tracks=[
+            AudioTrack(
+                index=0,
+                language=LanguageCode("en"),
+                codec="dts",
+                channels=6,
+                title="English DTS 5.1",
+                is_default=True,
+            ),
+            AudioTrack(
+                index=1,
+                language=LanguageCode("ja"),
+                codec="aac",
+                channels=2,
+                is_default=False,
+            ),
+        ],
+        subtitle_tracks=[
+            SubtitleTrack(
+                index=0,
+                language=LanguageCode("en"),
+                format="srt",
+                is_default=True,
+                is_forced=False,
+                is_external=False,
+            ),
+            SubtitleTrack(
+                index=1,
+                language=LanguageCode("pt"),
+                format="srt",
+                title="External (SRT)",
+                is_default=False,
+                is_forced=False,
+                is_external=True,
+                file_path=FilePath("/movies/movie.pt.srt"),
+            ),
+        ],
+    )
+
+
+@pytest.mark.unit
+class TestToMediaFileOutputTracks:
+    """Tests for audio/subtitle track mapping in to_media_file_output."""
+
+    def test_should_preserve_audio_track_count(self) -> None:
+        output = to_media_file_output(_media_file_with_tracks())
+        assert len(output.audio_tracks) == 2
+
+    def test_should_preserve_subtitle_track_count(self) -> None:
+        output = to_media_file_output(_media_file_with_tracks())
+        assert len(output.subtitle_tracks) == 2
+
+    def test_should_map_audio_track_fields(self) -> None:
+        output = to_media_file_output(_media_file_with_tracks())
+        a0 = output.audio_tracks[0]
+
+        assert a0.index == 0
+        assert a0.language == "en"
+        assert a0.codec == "dts"
+        assert a0.channels == 6
+        assert a0.channel_layout == "5.1"
+        assert a0.title == "English DTS 5.1"
+        assert a0.is_default is True
+
+    def test_should_map_secondary_audio_track(self) -> None:
+        output = to_media_file_output(_media_file_with_tracks())
+        a1 = output.audio_tracks[1]
+
+        assert a1.index == 1
+        assert a1.language == "ja"
+        assert a1.codec == "aac"
+        assert a1.channels == 2
+        assert a1.channel_layout == "Stereo"
+        assert a1.title is None
+        assert a1.is_default is False
+
+    def test_should_map_embedded_subtitle_fields(self) -> None:
+        output = to_media_file_output(_media_file_with_tracks())
+        s0 = output.subtitle_tracks[0]
+
+        assert s0.index == 0
+        assert s0.language == "en"
+        assert s0.format == "srt"
+        assert s0.is_default is True
+        assert s0.is_forced is False
+        assert s0.is_external is False
+
+    def test_should_map_external_subtitle_fields(self) -> None:
+        output = to_media_file_output(_media_file_with_tracks())
+        s1 = output.subtitle_tracks[1]
+
+        assert s1.index == 1
+        assert s1.language == "pt"
+        assert s1.format == "srt"
+        assert s1.title == "External (SRT)"
+        assert s1.is_default is False
+        assert s1.is_forced is False
+        assert s1.is_external is True
+
+    def test_should_return_empty_tracks_when_none_present(self) -> None:
+        media_file = MediaFile(
+            file_path=FilePath("/movies/movie.mkv"),
+            file_size=1_000,
+            resolution=Resolution("720p"),
+            is_primary=True,
+        )
+        output = to_media_file_output(media_file)
+
+        assert output.audio_tracks == []
+        assert output.subtitle_tracks == []

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -20,8 +20,32 @@ from src.modules.media.domain.value_objects import (
     Title,
 )
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
-from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
+from src.modules.media.infrastructure.streaming.media_probe_service import (
+    MediaProbeResult,
+    MediaProbeService,
+)
 from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+
+def _audio_track(lang: str, *, index: int = 0) -> AudioTrack:
+    return AudioTrack(
+        index=index,
+        language=LanguageCode(lang),
+        codec="aac",
+        channels=2,
+        is_default=index == 0,
+    )
+
+
+def _subtitle_track(lang: str, *, index: int = 0) -> SubtitleTrack:
+    return SubtitleTrack(
+        index=index,
+        language=LanguageCode(lang),
+        format="srt",
+        is_external=False,
+    )
 
 
 def _movie_file(
@@ -307,14 +331,14 @@ class TestRescanResolutionUpgrade:
         self,
     ) -> None:
         probe = MagicMock(spec=MediaProbeService)
-        probe.probe_resolution.return_value = "1080p"
+        probe.probe.return_value = MediaProbeResult(resolution="1080p")
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
         use_case = _make_use_case(scanner_results=files, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
         assert result.movies_created == 1
-        probe.probe_resolution.assert_called_once_with("/movies/inception.mkv")
+        probe.probe.assert_called_once_with("/movies/inception.mkv")
 
     @pytest.mark.asyncio
     async def test_should_probe_when_existing_resolution_is_unknown(self) -> None:
@@ -334,7 +358,7 @@ class TestRescanResolutionUpgrade:
         movie_repo.save.side_effect = lambda m: saved.append(m) or m
 
         probe = MagicMock(spec=MediaProbeService)
-        probe.probe_resolution.return_value = "4K"
+        probe.probe.return_value = MediaProbeResult(resolution="4K")
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
         use_case = _make_use_case(
@@ -346,11 +370,13 @@ class TestRescanResolutionUpgrade:
         result = await use_case.execute(ScanMediaInput())
 
         assert result.movies_updated == 1
-        probe.probe_resolution.assert_called_once_with("/movies/inception.mkv")
+        probe.probe.assert_called_once_with("/movies/inception.mkv")
         assert saved[0].files[0].resolution == Resolution("4K")
 
     @pytest.mark.asyncio
-    async def test_should_not_probe_when_existing_resolution_is_known(self) -> None:
+    async def test_should_not_probe_on_rescan_when_resolution_known_and_tracks_populated(
+        self,
+    ) -> None:
         existing = Movie.create(
             title="Inception",
             year=2010,
@@ -359,6 +385,12 @@ class TestRescanResolutionUpgrade:
             file_size=4_000_000_000,
             resolution="1080p",
         )
+        # Populate tracks so the refresh path has nothing to backfill.
+        populated_file = existing.files[0].model_copy(
+            update={"audio_tracks": [_audio_track("en")]}
+        )
+        existing = existing.with_updates(files=[populated_file])
+
         movie_repo = AsyncMock(spec=MovieRepository)
         movie_repo.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/inception.mkv" else None
@@ -367,7 +399,7 @@ class TestRescanResolutionUpgrade:
 
         probe = MagicMock(spec=MediaProbeService)
 
-        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
         use_case = _make_use_case(
             scanner_results=files,
             movie_repo=movie_repo,
@@ -377,18 +409,25 @@ class TestRescanResolutionUpgrade:
         result = await use_case.execute(ScanMediaInput())
 
         assert result.movies_updated == 0
-        probe.probe_resolution.assert_not_called()
+        probe.probe.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_should_not_probe_when_filename_already_has_resolution(self) -> None:
+    async def test_should_probe_new_file_even_when_filename_has_resolution(
+        self,
+    ) -> None:
+        """New files are always probed so audio/subtitle tracks are captured."""
         probe = MagicMock(spec=MediaProbeService)
+        probe.probe.return_value = MediaProbeResult(
+            audio_tracks=[_audio_track("en"), _audio_track("pt")],
+            resolution="1080p",
+        )
         files = [_movie_file("/movies/inception.1080p.mkv", "Inception", 2010, "1080p")]
         use_case = _make_use_case(scanner_results=files, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
         assert result.movies_created == 1
-        probe.probe_resolution.assert_not_called()
+        probe.probe.assert_called_once_with("/movies/inception.1080p.mkv")
 
     @pytest.mark.asyncio
     async def test_should_upgrade_episode_unknown_resolution(self) -> None:
@@ -437,3 +476,165 @@ class TestRescanResolutionUpgrade:
         assert result.episodes_updated == 1
         saved_episode = saved[0].seasons[0].episodes[0]
         assert saved_episode.files[0].resolution == Resolution("720p")
+
+
+@pytest.mark.unit
+class TestTrackDetection:
+    """Tests for audio/subtitle track detection during scan."""
+
+    @pytest.mark.asyncio
+    async def test_should_populate_tracks_on_new_movie(self) -> None:
+        probe = MagicMock(spec=MediaProbeService)
+        probe.probe.return_value = MediaProbeResult(
+            audio_tracks=[_audio_track("en"), _audio_track("pt", index=1)],
+            subtitle_tracks=[_subtitle_track("en"), _subtitle_track("pt", index=1)],
+            resolution="1080p",
+        )
+        saved: list[Movie] = []
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.return_value = None
+        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+
+        files = [_movie_file("/movies/Inception.mkv", "Inception", 2010, "1080p")]
+        use_case = _make_use_case(
+            scanner_results=files, movie_repo=movie_repo, probe_service=probe
+        )
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_created == 1
+        media_file = saved[0].files[0]
+        assert len(media_file.audio_tracks) == 2
+        assert media_file.audio_tracks[0].language == LanguageCode("en")
+        assert media_file.audio_tracks[1].language == LanguageCode("pt")
+        assert len(media_file.subtitle_tracks) == 2
+
+    @pytest.mark.asyncio
+    async def test_should_populate_tracks_on_new_episode(self) -> None:
+        probe = MagicMock(spec=MediaProbeService)
+        probe.probe.return_value = MediaProbeResult(
+            audio_tracks=[_audio_track("ja")],
+            subtitle_tracks=[_subtitle_track("en")],
+            resolution="1080p",
+        )
+        saved: list[Series] = []
+        series_repo = AsyncMock(spec=SeriesRepository)
+        series_repo.find_by_title.return_value = None
+        series_repo.save.side_effect = lambda s: saved.append(s) or s
+
+        files = [_episode_file("/series/Anime/S01/Anime.S01E01.mkv")]
+        use_case = _make_use_case(
+            scanner_results=files, series_repo=series_repo, probe_service=probe
+        )
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.episodes_created == 1
+        ep_file = saved[0].seasons[0].episodes[0].files[0]
+        assert len(ep_file.audio_tracks) == 1
+        assert ep_file.audio_tracks[0].language == LanguageCode("ja")
+        assert len(ep_file.subtitle_tracks) == 1
+        assert ep_file.subtitle_tracks[0].language == LanguageCode("en")
+
+    @pytest.mark.asyncio
+    async def test_should_backfill_empty_tracks_on_rescan(self) -> None:
+        existing = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        saved: list[Movie] = []
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/inception.mkv" else None
+        )
+        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+
+        probe = MagicMock(spec=MediaProbeService)
+        probe.probe.return_value = MediaProbeResult(
+            audio_tracks=[_audio_track("en")],
+            subtitle_tracks=[_subtitle_track("pt")],
+        )
+
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
+        use_case = _make_use_case(
+            scanner_results=files, movie_repo=movie_repo, probe_service=probe
+        )
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_updated == 1
+        media_file = saved[0].files[0]
+        assert len(media_file.audio_tracks) == 1
+        assert media_file.audio_tracks[0].language == LanguageCode("en")
+        assert len(media_file.subtitle_tracks) == 1
+
+    @pytest.mark.asyncio
+    async def test_should_not_overwrite_existing_tracks_on_rescan(self) -> None:
+        existing = Movie.create(
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        original_track = _audio_track("fr")
+        populated_file = existing.files[0].model_copy(
+            update={"audio_tracks": [original_track]}
+        )
+        existing = existing.with_updates(files=[populated_file])
+
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/inception.mkv" else None
+        )
+        movie_repo.save.side_effect = lambda m: m
+
+        probe = MagicMock(spec=MediaProbeService)
+
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
+        use_case = _make_use_case(
+            scanner_results=files, movie_repo=movie_repo, probe_service=probe
+        )
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_updated == 0
+        probe.probe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_include_external_subtitles_in_tracks(self) -> None:
+        ext_sub = SubtitleTrack(
+            index=1,
+            language=LanguageCode("pt"),
+            format="srt",
+            is_external=True,
+            file_path=FilePath("/movies/inception.pt.srt"),
+        )
+        probe = MagicMock(spec=MediaProbeService)
+        probe.probe.return_value = MediaProbeResult(
+            audio_tracks=[_audio_track("en")],
+            subtitle_tracks=[_subtitle_track("en")],
+            external_subtitles=[ext_sub],
+            resolution="1080p",
+        )
+        saved: list[Movie] = []
+        movie_repo = AsyncMock(spec=MovieRepository)
+        movie_repo.find_by_file_path.return_value = None
+        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
+        use_case = _make_use_case(
+            scanner_results=files, movie_repo=movie_repo, probe_service=probe
+        )
+
+        result = await use_case.execute(ScanMediaInput())
+
+        assert result.movies_created == 1
+        media_file = saved[0].files[0]
+        assert len(media_file.subtitle_tracks) == 2
+        assert any(t.is_external for t in media_file.subtitle_tracks)

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -499,9 +499,7 @@ class TestTrackDetection:
         movie_repo.save.side_effect = lambda m: saved.append(m) or m
 
         files = [_movie_file("/movies/Inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(
-            scanner_results=files, movie_repo=movie_repo, probe_service=probe
-        )
+        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -563,9 +561,7 @@ class TestTrackDetection:
         )
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(
-            scanner_results=files, movie_repo=movie_repo, probe_service=probe
-        )
+        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -602,9 +598,7 @@ class TestTrackDetection:
         probe = MagicMock(spec=MediaProbeService)
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(
-            scanner_results=files, movie_repo=movie_repo, probe_service=probe
-        )
+        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -633,9 +627,7 @@ class TestTrackDetection:
         movie_repo.save.side_effect = lambda m: saved.append(m) or m
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(
-            scanner_results=files, movie_repo=movie_repo, probe_service=probe
-        )
+        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -385,9 +385,12 @@ class TestRescanResolutionUpgrade:
             file_size=4_000_000_000,
             resolution="1080p",
         )
-        # Populate tracks so the refresh path has nothing to backfill.
+        # Populate both track lists so the refresh path has nothing to backfill.
         populated_file = existing.files[0].model_copy(
-            update={"audio_tracks": [_audio_track("en")]}
+            update={
+                "audio_tracks": [_audio_track("en")],
+                "subtitle_tracks": [_subtitle_track("en")],
+            }
         )
         existing = existing.with_updates(files=[populated_file])
 
@@ -582,9 +585,11 @@ class TestTrackDetection:
             file_size=4_000_000_000,
             resolution="1080p",
         )
-        original_track = _audio_track("fr")
         populated_file = existing.files[0].model_copy(
-            update={"audio_tracks": [original_track]}
+            update={
+                "audio_tracks": [_audio_track("fr")],
+                "subtitle_tracks": [_subtitle_track("fr")],
+            }
         )
         existing = existing.with_updates(files=[populated_file])
 
@@ -637,4 +642,13 @@ class TestTrackDetection:
         assert result.movies_created == 1
         media_file = saved[0].files[0]
         assert len(media_file.subtitle_tracks) == 2
-        assert any(t.is_external for t in media_file.subtitle_tracks)
+
+        embedded = [t for t in media_file.subtitle_tracks if not t.is_external]
+        external = [t for t in media_file.subtitle_tracks if t.is_external]
+        assert len(embedded) == 1
+        assert embedded[0].language == LanguageCode("en")
+
+        assert len(external) == 1
+        assert external[0].language == LanguageCode("pt")
+        assert external[0].index == 1
+        assert external[0].file_path == FilePath("/movies/inception.pt.srt")

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -515,7 +515,9 @@ class TestProbeResolution:
         video.touch()
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = json.dumps({"streams": [{"width": 1920, "height": 1080}]})
+        mock_result.stdout = json.dumps(
+            {"streams": [{"codec_type": "video", "width": 1920, "height": 1080}]}
+        )
         mock_run.return_value = mock_result
         service = MediaProbeService()
 

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -55,9 +55,29 @@ class TestExtractLanguage:
         stream = {"tags": {"language": "en"}}
         assert MediaProbeService._extract_language(stream) == "en"
 
-    def test_should_truncate_3_letter_code(self) -> None:
+    def test_should_map_3_letter_eng_to_en(self) -> None:
         stream = {"tags": {"language": "eng"}}
         assert MediaProbeService._extract_language(stream) == "en"
+
+    def test_should_map_3_letter_por_to_pt(self) -> None:
+        stream = {"tags": {"language": "por"}}
+        assert MediaProbeService._extract_language(stream) == "pt"
+
+    def test_should_map_3_letter_spa_to_es(self) -> None:
+        stream = {"tags": {"language": "spa"}}
+        assert MediaProbeService._extract_language(stream) == "es"
+
+    def test_should_map_3_letter_fre_to_fr(self) -> None:
+        stream = {"tags": {"language": "fre"}}
+        assert MediaProbeService._extract_language(stream) == "fr"
+
+    def test_should_map_3_letter_ger_to_de(self) -> None:
+        stream = {"tags": {"language": "ger"}}
+        assert MediaProbeService._extract_language(stream) == "de"
+
+    def test_should_map_3_letter_jpn_to_ja(self) -> None:
+        stream = {"tags": {"language": "jpn"}}
+        assert MediaProbeService._extract_language(stream) == "ja"
 
     def test_should_handle_uppercase(self) -> None:
         stream = {"tags": {"LANGUAGE": "EN"}}


### PR DESCRIPTION
## Summary

- Probe every new media file via ffprobe during library scan to extract audio tracks, subtitle tracks (embedded + external), and their language codes
- Existing files with empty track lists are backfilled on rescan without overwriting previously populated tracks
- Add `AudioTrackOutput` and `SubtitleTrackOutput` DTOs to the API so track metadata is returned in all media file responses
- Fix ISO 639-2 → 639-1 language code mapping (`por` → `pt`, `spa` → `es`, etc.) replacing the naive 2-char truncation

## Test plan

- [x] 1547 existing tests pass (zero regressions)
- [x] 5 new tests for track population during scan (new movie, new episode, backfill, no-overwrite, external subs)
- [x] 6 new tests for ISO 639-2 → 639-1 mapping (`por`, `spa`, `fre`, `ger`, `jpn`, `eng`)
- [x] Existing resolution upgrade tests updated to use full `probe()` mock
- [ ] Manual: scan a library with multilingual MKVs, verify audio/subtitle languages appear in API response
- [ ] Manual: rescan an existing library — verify tracks are backfilled for files previously scanned without track detection

## Summary by Sourcery

Probe media files during library scans to capture audio/subtitle track metadata and expose it via the media file API while improving language code handling and re-scan behavior.

New Features:
- Always probe new media files to detect audio and subtitle tracks, including external subtitle files, and persist them on first registration.
- Expose audio and subtitle track metadata on media file API responses via dedicated output DTOs.

Bug Fixes:
- Correct ISO 639-2 to ISO 639-1 language code mapping when extracting track languages from ffprobe streams, replacing the previous naive truncation.

Enhancements:
- Reuse a unified media probe result for both resolution and track extraction to avoid redundant ffprobe calls and enrich existing media files only when resolution or track data is missing.
- Refine rescan logic so existing files are re-probed only when resolution is unknown or track lists are empty, preventing unnecessary work and avoiding overwriting populated metadata.

Tests:
- Extend unit tests for directory scanning and media probing to cover track population on new and existing media, external subtitle handling, and the updated language mapping logic.