### PR TITLE
feat(presentation): add shared response envelope and global exception handlers

### DIFF
--- a/src/building_blocks/presentation/__init__.py
+++ b/src/building_blocks/presentation/__init__.py
@@ -1,0 +1,28 @@
+"""Shared presentation-layer building blocks.
+
+Provides framework-agnostic helpers that every bounded context reuses
+at the HTTP boundary: the API Response Envelope (v3.0 standard),
+global exception-to-HTTP translation, and per-request context middleware.
+
+The building_blocks package stays free of business logic; these helpers
+exist to keep route handlers thin and responses consistent across
+modules.
+"""
+
+from src.building_blocks.presentation.request_context import (
+    RequestContextMiddleware,
+    get_current_request_id,
+)
+from src.building_blocks.presentation.responses import (
+    Pagination,
+    api_list,
+    api_single,
+)
+
+__all__ = [
+    "Pagination",
+    "RequestContextMiddleware",
+    "api_list",
+    "api_single",
+    "get_current_request_id",
+]

--- a/src/building_blocks/presentation/exception_handlers.py
+++ b/src/building_blocks/presentation/exception_handlers.py
@@ -38,6 +38,11 @@ _STATUS_TO_ERROR_TYPE = {
     504: "gateway_timeout_error",
 }
 
+# Keys a caller may supply via ``HTTPException(detail={...})`` — everything
+# else is dropped so an attacker-controlled or typo'd dict can't reshape
+# the envelope (e.g. override the computed ``type``).
+_ALLOWED_DETAIL_KEYS = frozenset({"message", "code", "param", "details"})
+
 
 async def core_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Translate typed domain/application/infra exceptions into HTTP.
@@ -99,14 +104,16 @@ async def http_exception_handler(request: Request, exc: Exception) -> JSONRespon
     error_type = _STATUS_TO_ERROR_TYPE.get(exc.status_code, "api_error")
 
     detail = exc.detail
+    content: dict[str, Any] = {"type": error_type}
     if isinstance(detail, dict):
-        content: dict[str, Any] = {"type": error_type, **detail}
+        for key in _ALLOWED_DETAIL_KEYS:
+            if key in detail:
+                content[key] = detail[key]
+        content.setdefault("message", "")
+        content.setdefault("code", error_type.upper())
     else:
-        content = {
-            "type": error_type,
-            "message": str(detail) if detail is not None else "",
-            "code": error_type.upper(),
-        }
+        content["message"] = str(detail) if detail is not None else ""
+        content["code"] = error_type.upper()
     get_logger().info(
         "HTTP exception handled",
         path=request.url.path,

--- a/src/building_blocks/presentation/exception_handlers.py
+++ b/src/building_blocks/presentation/exception_handlers.py
@@ -1,0 +1,174 @@
+"""Global exception-to-HTTP translation.
+
+Centralises how domain, application, and infrastructure exceptions
+surface to API clients. Routes raise typed exceptions; these handlers
+translate them into the v3.0 error envelope without every controller
+repeating the mapping.
+
+Handlers are intentionally narrow — each knows only how to log and
+serialize a category of errors. The envelope format comes from
+``CoreException.to_dict()`` so the contract stays in one place.
+"""
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.requests import Request
+
+from src.building_blocks.domain.errors import CoreException, Severity
+from src.config.logging import get_logger
+
+_STATUS_TO_ERROR_TYPE = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    405: "invalid_request_error",
+    409: "conflict_error",
+    413: "request_too_large_error",
+    415: "invalid_request_error",
+    422: "validation_error",
+    429: "rate_limit_error",
+    500: "api_error",
+    502: "bad_gateway_error",
+    503: "service_unavailable_error",
+    504: "gateway_timeout_error",
+}
+
+
+async def core_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Translate typed domain/application/infra exceptions into HTTP.
+
+    Logging level is chosen from ``exc.severity`` so a 4xx doesn't look
+    like a 5xx in the logs. The payload uses ``CoreException.to_dict()``
+    — no sensitive ``_internal`` block is ever serialized.
+    """
+    assert isinstance(exc, CoreException)  # narrow type for handler signature
+    logger = get_logger().bind(
+        exception_id=exc.exception_id,
+        code=exc.code,
+        http_status=exc.http_status,
+        path=request.url.path,
+    )
+    _log_with_severity(logger, exc)
+
+    return JSONResponse(status_code=exc.http_status, content=exc.to_dict())
+
+
+async def request_validation_exception_handler(
+    request: Request,
+    exc: Exception,
+) -> JSONResponse:
+    """Format FastAPI/Pydantic request validation errors in v3 shape."""
+    assert isinstance(exc, RequestValidationError)
+    errors = [
+        {
+            "field": ".".join(str(loc) for loc in err.get("loc", ())[1:]),
+            "message": err.get("msg", "Validation error"),
+            "code": err.get("type", "validation_error"),
+        }
+        for err in exc.errors()
+    ]
+    get_logger().info(
+        "Request validation failed",
+        path=request.url.path,
+        error_count=len(errors),
+    )
+    return JSONResponse(
+        status_code=422,
+        content={
+            "type": "validation_error",
+            "message": "Invalid request payload",
+            "code": "REQUEST_VALIDATION_ERROR",
+            "details": errors,
+        },
+    )
+
+
+async def http_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Translate Starlette/FastAPI ``HTTPException`` into the envelope.
+
+    Routes occasionally raise ``HTTPException`` (e.g. 404 from path
+    mismatches or ``Response(404)`` shortcuts). Wrap them so clients
+    see the same shape as typed exceptions.
+    """
+    assert isinstance(exc, StarletteHTTPException)
+    error_type = _STATUS_TO_ERROR_TYPE.get(exc.status_code, "api_error")
+
+    detail = exc.detail
+    if isinstance(detail, dict):
+        content: dict[str, Any] = {"type": error_type, **detail}
+    else:
+        content = {
+            "type": error_type,
+            "message": str(detail) if detail is not None else "",
+            "code": error_type.upper(),
+        }
+    get_logger().info(
+        "HTTP exception handled",
+        path=request.url.path,
+        status=exc.status_code,
+    )
+    return JSONResponse(status_code=exc.status_code, content=content, headers=exc.headers)
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Last-resort handler for unexpected errors.
+
+    Logs with traceback and returns a generic 500 — never leaks the
+    exception message to the client since it may contain stack traces
+    or secrets.
+    """
+    get_logger().error(
+        "Unhandled exception",
+        path=request.url.path,
+        exc_info=exc,
+    )
+    return JSONResponse(
+        status_code=500,
+        content={
+            "type": "api_error",
+            "message": "An unexpected error occurred.",
+            "code": "INTERNAL_ERROR",
+        },
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """Register every global handler on the application instance.
+
+    Call during app creation. Order matters only in that more-specific
+    handlers should shadow more-generic ones; FastAPI dispatches by
+    exception type, so registering both ``CoreException`` and
+    ``Exception`` is safe.
+    """
+    app.add_exception_handler(CoreException, core_exception_handler)
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)
+
+
+def _log_with_severity(logger: Any, exc: CoreException) -> None:
+    """Route to a log level matching the exception severity.
+
+    Keeps domain/use-case validation (often 4xx) out of error dashboards
+    while still surfacing true infrastructure failures.
+    """
+    if exc.severity in (Severity.HIGH, Severity.CRITICAL):
+        logger.error("Handled core exception", exc_info=exc)
+    elif exc.severity is Severity.MEDIUM:
+        logger.warning("Handled core exception", message=exc.message)
+    else:
+        logger.info("Handled core exception", message=exc.message)
+
+
+__all__ = [
+    "core_exception_handler",
+    "http_exception_handler",
+    "register_exception_handlers",
+    "request_validation_exception_handler",
+    "unhandled_exception_handler",
+]

--- a/src/building_blocks/presentation/request_context.py
+++ b/src/building_blocks/presentation/request_context.py
@@ -1,0 +1,72 @@
+"""Per-request context middleware.
+
+Attaches a correlation id to every request:
+
+- Reads ``X-Request-ID`` from the incoming request, or generates one.
+- Exposes it via a ``ContextVar`` so application and infrastructure
+  code (e.g. error handlers, logging) can reach the current request id
+  without threading it through every function.
+- Echoes the id back on the response as ``X-Request-ID`` and emits a
+  coarse ``Server-Timing`` header so operators can see per-request
+  latency without parsing the payload.
+"""
+
+import time
+import uuid
+from contextvars import ContextVar
+
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+_REQUEST_ID_HEADER = "X-Request-ID"
+_current_request_id: ContextVar[str | None] = ContextVar("request_id", default=None)
+
+
+def get_current_request_id() -> str | None:
+    """Return the current request id, if a request is in flight.
+
+    Returns:
+        The id attached to the current request, or ``None`` outside a
+        request (e.g. scheduled jobs).
+    """
+    return _current_request_id.get()
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Set request id, log context, and timing headers for each request.
+
+    The middleware must run before route handlers so error handlers and
+    loggers see the bound request id even when the handler raises.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        """Wrap the request with correlation id and timing."""
+        incoming = request.headers.get(_REQUEST_ID_HEADER)
+        request_id = incoming or f"req_{uuid.uuid4().hex[:16]}"
+
+        token = _current_request_id.set(request_id)
+        structlog.contextvars.bind_contextvars(request_id=request_id)
+
+        started = time.perf_counter()
+        try:
+            response = await call_next(request)
+        finally:
+            _current_request_id.reset(token)
+            structlog.contextvars.unbind_contextvars("request_id")
+
+        duration_ms = (time.perf_counter() - started) * 1000
+        response.headers[_REQUEST_ID_HEADER] = request_id
+        response.headers["Server-Timing"] = f"total;dur={duration_ms:.0f}"
+        return response
+
+
+__all__ = [
+    "RequestContextMiddleware",
+    "get_current_request_id",
+]

--- a/src/building_blocks/presentation/responses.py
+++ b/src/building_blocks/presentation/responses.py
@@ -1,0 +1,118 @@
+"""API Response Envelope helpers (v3.0 standard).
+
+All successful HTTP responses in the project share the same envelope
+so that clients can parse them with one code path. See
+`docs/standards/api-response-standard-rest-v3.md` for the full spec.
+
+Two shapes are supported:
+
+- **Single resource** — ``{"type": "<resource>", "data": {...}}``
+- **Collection** — ``{"type": "list", "data": [...], "metadata": {...}}``
+
+``metadata`` is optional and carries pagination, applied filters, and
+non-breaking extras (e.g. ``total_count``). Pagination is nested inside
+``metadata`` to match the project's existing clients; the standard doc
+describes a top-level placement that can be adopted in a future major.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class Pagination:
+    """Pagination descriptor for list responses.
+
+    Cursor-based pagination is the default; ``total`` is opt-in since
+    ``COUNT(*)`` is costly on large tables.
+
+    Attributes:
+        has_more: Whether the next page exists.
+        next_cursor: Opaque cursor for the next page (if any).
+        prev_cursor: Opaque cursor for the previous page (if any).
+        total: Total item count when explicitly requested.
+    """
+
+    has_more: bool
+    next_cursor: str | None = None
+    prev_cursor: str | None = None
+    total: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize, omitting None-valued fields.
+
+        Returns:
+            Dictionary suitable for JSON serialization.
+        """
+        result: dict[str, Any] = {"has_more": self.has_more}
+        if self.next_cursor is not None:
+            result["next_cursor"] = self.next_cursor
+        if self.prev_cursor is not None:
+            result["prev_cursor"] = self.prev_cursor
+        if self.total is not None:
+            result["total"] = self.total
+        return result
+
+
+def api_single(resource_type: str, data: Any) -> dict[str, Any]:
+    """Wrap a single-resource payload in the standard envelope.
+
+    Args:
+        resource_type: Stable resource identifier exposed to clients
+            (e.g. ``"movie"``, ``"library"``, ``"preferences"``).
+        data: The resource payload (already serialized — typically the
+            output of ``dataclasses.asdict`` on a use-case DTO).
+
+    Returns:
+        Envelope ready to be returned from a FastAPI route.
+
+    Example:
+        >>> api_single("library", {"id": "lib_1", "name": "Movies"})
+        {'type': 'library', 'data': {'id': 'lib_1', 'name': 'Movies'}}
+    """
+    return {"type": resource_type, "data": data}
+
+
+def api_list(
+    data: list[Any],
+    pagination: Pagination | None = None,
+    filters_applied: dict[str, Any] | None = None,
+    metadata_extras: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Wrap a collection payload in the standard envelope.
+
+    ``metadata`` is only emitted when at least one of the optional
+    inputs is present, so minimal list responses stay tidy.
+
+    Args:
+        data: Already-serialized items (list of dicts).
+        pagination: Cursor pagination descriptor, if applicable.
+        filters_applied: Filters reflected in the result set.
+        metadata_extras: Additional stable metadata (e.g. ``total_count``
+            when a caller requests it outside the pagination envelope).
+
+    Returns:
+        Envelope ready to be returned from a FastAPI route.
+
+    Example:
+        >>> api_list([{"id": "mov_1"}], Pagination(has_more=False))
+        {'type': 'list', 'data': [{'id': 'mov_1'}], 'metadata': {'pagination': {'has_more': False}}}
+    """
+    response: dict[str, Any] = {"type": "list", "data": data}
+    metadata: dict[str, Any] = {}
+    if pagination is not None:
+        metadata["pagination"] = pagination.to_dict()
+    if filters_applied:
+        metadata["filters_applied"] = filters_applied
+    if metadata_extras:
+        metadata.update(metadata_extras)
+    if metadata:
+        response["metadata"] = metadata
+    return response
+
+
+__all__ = [
+    "Pagination",
+    "api_list",
+    "api_single",
+]

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,8 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from src.building_blocks.presentation import RequestContextMiddleware
+from src.building_blocks.presentation.exception_handlers import register_exception_handlers
 from src.config.containers import ApplicationContainer
 from src.config.logging import get_logger, setup_logging
 from src.config.settings import get_settings
@@ -157,6 +159,10 @@ def create_app() -> FastAPI:
 
     app.add_middleware(SessionCleanupMiddleware)
 
+    # Request correlation + timing — must run before routes so the
+    # request_id is bound while handlers execute.
+    app.add_middleware(RequestContextMiddleware)
+
     # CORS middleware
     app.add_middleware(
         CORSMiddleware,
@@ -165,6 +171,9 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Translate typed exceptions into the standard v3 error envelope
+    register_exception_handlers(app)
 
     # Register routes
     register_health_routes(app)

--- a/src/modules/collections/presentation/routes/custom_list_routes.py
+++ b/src/modules/collections/presentation/routes/custom_list_routes.py
@@ -6,6 +6,7 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
+from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.collections.application.dtos import (
     AddItemToCustomListInput,
@@ -45,7 +46,7 @@ async def create_custom_list(
 ) -> dict[str, Any]:
     """Create a new custom list."""
     result = await use_case.execute(CreateCustomListInput(name=body.name))
-    return {"type": "custom_list", "data": asdict(result)}
+    return api_single("custom_list", asdict(result))
 
 
 @router.get("")  # type: ignore[misc]
@@ -57,7 +58,7 @@ async def list_custom_lists(
 ) -> dict[str, Any]:
     """List all custom lists."""
     items = await use_case.execute()
-    return {"type": "list", "data": [asdict(item) for item in items]}
+    return api_list([asdict(item) for item in items])
 
 
 @router.patch("/{list_id}")  # type: ignore[misc]
@@ -71,7 +72,7 @@ async def rename_custom_list(
 ) -> dict[str, Any]:
     """Rename a custom list."""
     result = await use_case.execute(RenameCustomListInput(list_id=list_id, name=body.name))
-    return {"type": "custom_list", "data": asdict(result)}
+    return api_single("custom_list", asdict(result))
 
 
 @router.delete("/{list_id}", status_code=204)  # type: ignore[misc]
@@ -100,7 +101,7 @@ async def get_custom_list_items(
 ) -> dict[str, Any]:
     """List all items in a custom list with media metadata."""
     items = await use_case.execute(GetCustomListItemsInput(list_id=list_id, lang=lang))
-    return {"type": "list", "data": [asdict(item) for item in items]}
+    return api_list([asdict(item) for item in items])
 
 
 @router.post("/{list_id}/items", status_code=201)  # type: ignore[misc]
@@ -120,10 +121,10 @@ async def add_item_to_custom_list(
             media_type=body.media_type,
         ),
     )
-    return {
-        "type": "custom_list",
-        "data": {"list_id": list_id, "media_id": body.media_id, "added": True},
-    }
+    return api_single(
+        "custom_list",
+        {"list_id": list_id, "media_id": body.media_id, "added": True},
+    )
 
 
 @router.delete("/{list_id}/items/{media_id}", status_code=204)  # type: ignore[misc]

--- a/src/modules/collections/presentation/routes/watchlist_routes.py
+++ b/src/modules/collections/presentation/routes/watchlist_routes.py
@@ -7,6 +7,7 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
+from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.collections.application.dtos import (
     GetWatchlistInput,
@@ -50,7 +51,7 @@ async def toggle_watchlist(
             media_type=body.media_type,
         ),
     )
-    return {"type": "watchlist", "data": asdict(result)}
+    return api_single("watchlist", asdict(result))
 
 
 @router.get("")  # type: ignore[misc]
@@ -64,10 +65,7 @@ async def get_watchlist(
 ) -> dict[str, Any]:
     """List all items in the user's watchlist."""
     items = await use_case.execute(GetWatchlistInput(limit=limit, lang=lang))
-    return {
-        "type": "list",
-        "data": [asdict(item) for item in items],
-    }
+    return api_list([asdict(item) for item in items])
 
 
 @router.get("/check/{media_id}")  # type: ignore[misc]
@@ -80,7 +78,7 @@ async def check_watchlist(
 ) -> dict[str, Any]:
     """Check if a media item is in the watchlist."""
     in_list = await use_case.execute(media_id)
-    return {"type": "watchlist", "data": {"in_list": in_list}}
+    return api_single("watchlist", {"in_list": in_list})
 
 
 __all__ = ["router"]

--- a/src/modules/library/presentation/routes/library_routes.py
+++ b/src/modules/library/presentation/routes/library_routes.py
@@ -6,6 +6,7 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
+from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.library.application.dtos.library_dtos import (
     CreateLibraryInput,
@@ -46,7 +47,7 @@ async def create_library(
             settings=body.settings.model_dump() if body.settings else None,
         )
     )
-    return {"data": asdict(result)}
+    return api_single("library", asdict(result))
 
 
 @router.get("")  # type: ignore[misc]
@@ -58,10 +59,7 @@ async def list_libraries(
 ) -> dict[str, Any]:
     """List all non-deleted libraries."""
     result = await use_case.execute()
-    return {
-        "type": "list",
-        "data": [asdict(lib) for lib in result],
-    }
+    return api_list([asdict(lib) for lib in result])
 
 
 @router.get("/{library_id}")  # type: ignore[misc]
@@ -74,7 +72,7 @@ async def get_library(
 ) -> dict[str, Any]:
     """Get a library by its external id."""
     result = await use_case.execute(GetLibraryByIdInput(library_id=library_id))
-    return {"data": asdict(result)}
+    return api_single("library", asdict(result))
 
 
 @router.put("/{library_id}")  # type: ignore[misc]
@@ -103,7 +101,7 @@ async def update_library(
             settings=body.settings.model_dump() if body.settings else None,
         )
     )
-    return {"data": asdict(result)}
+    return api_single("library", asdict(result))
 
 
 @router.delete("/{library_id}", status_code=204)  # type: ignore[misc]

--- a/src/modules/media/presentation/routes/catalog_routes.py
+++ b/src/modules/media/presentation/routes/catalog_routes.py
@@ -7,6 +7,7 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
+from src.building_blocks.presentation import Pagination, api_list
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.catalog_dtos import (
     ListByGenreInput,
@@ -58,10 +59,7 @@ async def list_genres(
             other side.
     """
     result = await use_case.execute(ListGenresInput(lang=lang, media_type=type))
-    return {
-        "type": "list",
-        "data": [asdict(g) for g in result.genres],
-    }
+    return api_list([asdict(g) for g in result.genres])
 
 
 @router.get("/by-genre/{genre}")  # type: ignore[misc]
@@ -106,16 +104,10 @@ async def list_by_genre(
             media_type=type,
         )
     )
-    return {
-        "type": "list",
-        "data": [asdict(item) for item in result.items],
-        "metadata": {
-            "pagination": {
-                "next_cursor": result.next_cursor,
-                "has_more": result.has_more,
-            },
-        },
-    }
+    return api_list(
+        [asdict(item) for item in result.items],
+        pagination=Pagination(has_more=result.has_more, next_cursor=result.next_cursor),
+    )
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/routes/enrichment_routes.py
+++ b/src/modules/media/presentation/routes/enrichment_routes.py
@@ -6,6 +6,7 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
+from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.enrichment_dtos import (
     BulkEnrichInput,
@@ -20,19 +21,12 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
 from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
 )
-from src.modules.media.presentation.schemas import (
-    BulkEnrichResponse,
-    EnrichRequest,
-    EnrichResponse,
-)
+from src.modules.media.presentation.schemas import EnrichRequest
 
 router = APIRouter(prefix="/api/v1", tags=["Metadata Enrichment"])
 
 
-@router.post(  # type: ignore[misc]
-    "/movies/{movie_id}/enrich",
-    response_model=EnrichResponse,
-)
+@router.post("/movies/{movie_id}/enrich")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def enrich_movie(
     movie_id: str,
@@ -44,13 +38,10 @@ async def enrich_movie(
     """Enrich a movie with metadata from TMDB."""
     force = body.force if body else False
     output = await use_case.execute(EnrichMediaInput(media_id=movie_id, force=force))
-    return asdict(output)
+    return api_single("enrichment", asdict(output))
 
 
-@router.post(  # type: ignore[misc]
-    "/series/{series_id}/enrich",
-    response_model=EnrichResponse,
-)
+@router.post("/series/{series_id}/enrich")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def enrich_series(
     series_id: str,
@@ -62,13 +53,10 @@ async def enrich_series(
     """Enrich a series with metadata from TMDB."""
     force = body.force if body else False
     output = await use_case.execute(EnrichMediaInput(media_id=series_id, force=force))
-    return asdict(output)
+    return api_single("enrichment", asdict(output))
 
 
-@router.post(  # type: ignore[misc]
-    "/enrich",
-    response_model=BulkEnrichResponse,
-)
+@router.post("/enrich")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def bulk_enrich(
     body: EnrichRequest | None = None,
@@ -79,7 +67,7 @@ async def bulk_enrich(
     """Enrich all movies and series with metadata from TMDB."""
     force = body.force if body else False
     output = await use_case.execute(BulkEnrichInput(force=force))
-    return asdict(output)
+    return api_single("bulk_enrichment", asdict(output))
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/routes/featured_routes.py
+++ b/src/modules/media/presentation/routes/featured_routes.py
@@ -6,6 +6,7 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
+from src.building_blocks.presentation import api_list
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.featured_dtos import GetFeaturedInput
 from src.modules.media.application.use_cases.get_featured_media import GetFeaturedMediaUseCase
@@ -25,10 +26,7 @@ async def get_featured(
 ) -> dict[str, Any]:
     """Get random featured media for the hero banner."""
     items = await use_case.execute(GetFeaturedInput(media_type=type, limit=limit, lang=lang))
-    return {
-        "type": "list",
-        "data": [asdict(item) for item in items],
-    }
+    return api_list([asdict(item) for item in items])
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -6,6 +6,7 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
+from src.building_blocks.presentation import Pagination, api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
@@ -72,19 +73,14 @@ async def list_movies(
             lang=lang,
         )
     )
-    metadata: dict[str, Any] = {
-        "pagination": {
-            "next_cursor": result.next_cursor,
-            "has_more": result.has_more,
-        },
-    }
-    if result.total_count is not None:
-        metadata["total_count"] = result.total_count
-    return {
-        "type": "list",
-        "data": [_dataclass_to_dict(m) for m in result.movies],
-        "metadata": metadata,
-    }
+    extras: dict[str, Any] | None = (
+        {"total_count": result.total_count} if result.total_count is not None else None
+    )
+    return api_list(
+        [_dataclass_to_dict(m) for m in result.movies],
+        pagination=Pagination(has_more=result.has_more, next_cursor=result.next_cursor),
+        metadata_extras=extras,
+    )
 
 
 @router.get("/{movie_id}")  # type: ignore[misc]
@@ -98,10 +94,7 @@ async def get_movie(
 ) -> dict[str, Any]:
     """Get a movie by ID."""
     result = await use_case.execute(GetMovieByIdInput(movie_id=movie_id, lang=lang))
-    return {
-        "type": "movie",
-        "data": _dataclass_to_dict(result),
-    }
+    return api_single("movie", _dataclass_to_dict(result))
 
 
 @router.delete("/{movie_id}", status_code=204)  # type: ignore[misc]
@@ -133,10 +126,7 @@ async def get_file_variants(
 ) -> dict[str, Any]:
     """List all file variants of a movie."""
     result = await use_case.execute(GetFileVariantsInput(media_id=movie_id))
-    return {
-        "type": "list",
-        "data": [_dataclass_to_dict(f) for f in result],
-    }
+    return api_list([_dataclass_to_dict(f) for f in result])
 
 
 @router.post("/{movie_id}/files", status_code=201)  # type: ignore[misc]
@@ -161,10 +151,7 @@ async def add_file_variant(
             is_primary=body.is_primary,
         ),
     )
-    return {
-        "type": "media_file",
-        "data": _dataclass_to_dict(result),
-    }
+    return api_single("media_file", _dataclass_to_dict(result))
 
 
 @router.delete("/{movie_id}/files", status_code=204)  # type: ignore[misc]
@@ -195,10 +182,7 @@ async def set_primary_file(
     result = await use_case.execute(
         SetPrimaryFileInput(media_id=movie_id, file_path=body.file_path),
     )
-    return {
-        "type": "list",
-        "data": [_dataclass_to_dict(f) for f in result],
-    }
+    return api_list([_dataclass_to_dict(f) for f in result])
 
 
 def _dataclass_to_dict(obj: Any) -> dict[str, Any]:

--- a/src/modules/media/presentation/routes/scan_routes.py
+++ b/src/modules/media/presentation/routes/scan_routes.py
@@ -6,19 +6,20 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
+from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
 from src.config.settings import get_settings
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
-from src.modules.media.presentation.schemas import ScanMediaRequest, ScanMediaResponse
+from src.modules.media.presentation.schemas import ScanMediaRequest
 from src.shared_kernel.value_objects.file_path import FilePath
 
 router = APIRouter(prefix="/api/v1/scan", tags=["Scan"])
 
 
-@router.post("", response_model=ScanMediaResponse)  # type: ignore[misc]
+@router.post("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def scan_media(
     body: ScanMediaRequest | None = None,
@@ -35,7 +36,7 @@ async def scan_media(
     directories = [FilePath(d) for d in raw_dirs]
     input_dto = ScanMediaInput(directories=directories)
     output = await use_case.execute(input_dto)
-    return asdict(output)
+    return api_single("scan", asdict(output))
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/routes/search_routes.py
+++ b/src/modules/media/presentation/routes/search_routes.py
@@ -7,6 +7,7 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
 from src.building_blocks.application.pagination import MAX_PAGE_SIZE
+from src.building_blocks.presentation import api_list
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.search_dtos import SearchInput
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
@@ -57,13 +58,10 @@ async def search(
             limit=limit,
         )
     )
-    return {
-        "type": "list",
-        "data": [asdict(item) for item in result.items],
-        "metadata": {
-            "total": result.total,
-        },
-    }
+    return api_list(
+        [asdict(item) for item in result.items],
+        metadata_extras={"total": result.total},
+    )
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -6,6 +6,7 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
+from src.building_blocks.presentation import Pagination, api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
@@ -58,19 +59,14 @@ async def list_series(
             lang=lang,
         )
     )
-    metadata: dict[str, Any] = {
-        "pagination": {
-            "next_cursor": result.next_cursor,
-            "has_more": result.has_more,
-        },
-    }
-    if result.total_count is not None:
-        metadata["total_count"] = result.total_count
-    return {
-        "type": "list",
-        "data": [_dataclass_to_dict(s) for s in result.series],
-        "metadata": metadata,
-    }
+    extras: dict[str, Any] | None = (
+        {"total_count": result.total_count} if result.total_count is not None else None
+    )
+    return api_list(
+        [_dataclass_to_dict(s) for s in result.series],
+        pagination=Pagination(has_more=result.has_more, next_cursor=result.next_cursor),
+        metadata_extras=extras,
+    )
 
 
 @router.get("/{series_id}")  # type: ignore[misc]
@@ -84,10 +80,7 @@ async def get_series(
 ) -> dict[str, Any]:
     """Get a series by ID (includes full season/episode hierarchy)."""
     result = await use_case.execute(GetSeriesByIdInput(series_id=series_id, lang=lang))
-    return {
-        "type": "series",
-        "data": _dataclass_to_dict(result),
-    }
+    return api_single("series", _dataclass_to_dict(result))
 
 
 # ── Episode file variant endpoints ──────────────────────────────────
@@ -103,10 +96,7 @@ async def get_episode_file_variants(
 ) -> dict[str, Any]:
     """List all file variants of an episode."""
     result = await use_case.execute(GetFileVariantsInput(media_id=episode_id))
-    return {
-        "type": "list",
-        "data": [_dataclass_to_dict(f) for f in result],
-    }
+    return api_list([_dataclass_to_dict(f) for f in result])
 
 
 @router.post("/episodes/{episode_id}/files", status_code=201)  # type: ignore[misc]
@@ -131,10 +121,7 @@ async def add_episode_file_variant(
             is_primary=body.is_primary,
         ),
     )
-    return {
-        "type": "media_file",
-        "data": _dataclass_to_dict(result),
-    }
+    return api_single("media_file", _dataclass_to_dict(result))
 
 
 @router.delete("/episodes/{episode_id}/files", status_code=204)  # type: ignore[misc]
@@ -165,10 +152,7 @@ async def set_episode_primary_file(
     result = await use_case.execute(
         SetPrimaryFileInput(media_id=episode_id, file_path=body.file_path),
     )
-    return {
-        "type": "list",
-        "data": [_dataclass_to_dict(f) for f in result],
-    }
+    return api_list([_dataclass_to_dict(f) for f in result])
 
 
 def _dataclass_to_dict(obj: Any) -> dict[str, Any]:

--- a/src/modules/media/presentation/schemas/__init__.py
+++ b/src/modules/media/presentation/schemas/__init__.py
@@ -1,27 +1,17 @@
 """Media API request/response schemas."""
 
-from src.modules.media.presentation.schemas.enrichment_schemas import (
-    BulkEnrichResponse,
-    EnrichRequest,
-    EnrichResponse,
-)
+from src.modules.media.presentation.schemas.enrichment_schemas import EnrichRequest
 from src.modules.media.presentation.schemas.file_variant_schemas import (
     AddFileVariantRequest,
     RemoveFileVariantRequest,
     SetPrimaryFileRequest,
 )
-from src.modules.media.presentation.schemas.scan_schemas import (
-    ScanMediaRequest,
-    ScanMediaResponse,
-)
+from src.modules.media.presentation.schemas.scan_schemas import ScanMediaRequest
 
 __all__ = [
     "AddFileVariantRequest",
-    "BulkEnrichResponse",
     "EnrichRequest",
-    "EnrichResponse",
     "RemoveFileVariantRequest",
     "ScanMediaRequest",
-    "ScanMediaResponse",
     "SetPrimaryFileRequest",
 ]

--- a/src/modules/media/presentation/schemas/enrichment_schemas.py
+++ b/src/modules/media/presentation/schemas/enrichment_schemas.py
@@ -12,22 +12,4 @@ class EnrichRequest(BaseModel):
     )
 
 
-class EnrichResponse(BaseModel):
-    """Response body for single media enrichment."""
-
-    media_id: str
-    enriched: bool
-    provider: str | None = None
-    error: str | None = None
-
-
-class BulkEnrichResponse(BaseModel):
-    """Response body for bulk metadata enrichment."""
-
-    movies_enriched: int
-    series_enriched: int
-    skipped: int
-    errors: list[str] = Field(default_factory=list)
-
-
-__all__ = ["BulkEnrichResponse", "EnrichRequest", "EnrichResponse"]
+__all__ = ["EnrichRequest"]

--- a/src/modules/media/presentation/schemas/scan_schemas.py
+++ b/src/modules/media/presentation/schemas/scan_schemas.py
@@ -12,14 +12,4 @@ class ScanMediaRequest(BaseModel):
     )
 
 
-class ScanMediaResponse(BaseModel):
-    """Response body for a completed media scan."""
-
-    movies_created: int
-    movies_updated: int
-    episodes_created: int
-    episodes_updated: int
-    errors: list[str] = Field(default_factory=list)
-
-
-__all__ = ["ScanMediaRequest", "ScanMediaResponse"]
+__all__ = ["ScanMediaRequest"]

--- a/src/modules/preferences/presentation/routes/preferences_routes.py
+++ b/src/modules/preferences/presentation/routes/preferences_routes.py
@@ -6,6 +6,7 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
+from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
 from src.modules.preferences.application.dtos.preferences_dtos import (
     UpdatePreferencesInput,
@@ -32,7 +33,7 @@ async def get_preferences(
 ) -> dict[str, Any]:
     """Return the current user's playback preferences."""
     result = await use_case.execute()
-    return {"data": asdict(result)}
+    return api_single("preferences", asdict(result))
 
 
 @router.put("")  # type: ignore[misc]
@@ -53,7 +54,7 @@ async def update_preferences(
             speed=body.speed,
         )
     )
-    return {"data": asdict(result)}
+    return api_single("preferences", asdict(result))
 
 
 __all__ = ["router"]

--- a/src/modules/watch_progress/presentation/routes/progress_routes.py
+++ b/src/modules/watch_progress/presentation/routes/progress_routes.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Query
 from fastapi.responses import Response
 from pydantic import BaseModel
 
+from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.watch_progress.application.dtos import (
     GetContinueWatchingInput,
@@ -59,10 +60,7 @@ async def continue_watching(
 ) -> dict[str, Any]:
     """List in-progress items for the Continue Watching section."""
     result = await use_case.execute(GetContinueWatchingInput(limit=limit, lang=lang))
-    return {
-        "type": "list",
-        "data": [asdict(item) for item in result.items],
-    }
+    return api_list([asdict(item) for item in result.items])
 
 
 @router.put("")  # type: ignore[misc]
@@ -84,7 +82,7 @@ async def save_progress(
             subtitle_track=body.subtitle_track,
         ),
     )
-    return {"type": "progress", "data": asdict(result)}
+    return api_single("progress", asdict(result))
 
 
 @router.get("/{media_id}")  # type: ignore[misc]
@@ -98,8 +96,8 @@ async def get_progress(
     """Get watch progress for a media item."""
     result = await use_case.execute(GetProgressInput(media_id=media_id))
     if result is None:
-        return {"type": "progress", "data": None}
-    return {"type": "progress", "data": asdict(result)}
+        return api_single("progress", None)
+    return api_single("progress", asdict(result))
 
 
 @router.delete("/series/{series_id}", status_code=204)  # type: ignore[misc]

--- a/tests/building_blocks/unit/presentation/test_exception_handlers.py
+++ b/tests/building_blocks/unit/presentation/test_exception_handlers.py
@@ -176,6 +176,77 @@ class TestHttpExceptionTranslation:
             "code": "EMAIL_EXISTS",
         }
 
+    def test_should_ignore_caller_supplied_type_override(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise HTTPException(
+                status_code=404,
+                detail={"type": "attacker_injected", "message": "nope"},
+            )
+
+        response = TestClient(app).get("/foo")
+
+        body = response.json()
+        # envelope `type` is always derived from the HTTP status
+        assert body["type"] == "not_found_error"
+
+    def test_should_drop_unknown_keys_from_detail(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise HTTPException(
+                status_code=400,
+                detail={"message": "bad", "secret": "oops", "debug": {"sql": "..."}},
+            )
+
+        response = TestClient(app).get("/foo")
+
+        body = response.json()
+        assert "secret" not in body
+        assert "debug" not in body
+        assert body["message"] == "bad"
+
+    def test_should_preserve_param_and_details_from_detail(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "message": "bad field",
+                    "code": "FIELD_INVALID",
+                    "param": "email",
+                    "details": {"expected": "string"},
+                },
+            )
+
+        response = TestClient(app).get("/foo")
+
+        body = response.json()
+        assert body["param"] == "email"
+        assert body["details"] == {"expected": "string"}
+
+    def test_should_default_message_and_code_when_dict_detail_lacks_them(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise HTTPException(status_code=409, detail={"param": "email"})
+
+        response = TestClient(app).get("/foo")
+
+        body = response.json()
+        assert body == {
+            "type": "conflict_error",
+            "param": "email",
+            "message": "",
+            "code": "CONFLICT_ERROR",
+        }
+
 
 @pytest.mark.unit
 class TestUnhandledException:

--- a/tests/building_blocks/unit/presentation/test_exception_handlers.py
+++ b/tests/building_blocks/unit/presentation/test_exception_handlers.py
@@ -1,0 +1,199 @@
+"""Tests for the global exception handlers.
+
+Wired through a minimal FastAPI app so we verify the actual HTTP
+translation path (status, body, handler selection) rather than calling
+the handlers directly with hand-rolled requests.
+"""
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.building_blocks.domain.errors import (
+    BusinessRuleViolationException,
+    DomainValidationException,
+)
+from src.building_blocks.infrastructure.errors import GatewayTimeoutException
+from src.building_blocks.presentation.exception_handlers import (
+    register_exception_handlers,
+)
+
+
+def _make_app() -> FastAPI:
+    """Build a fresh FastAPI app with just the global handlers registered.
+
+    Each test installs its own route so we can raise the exception of
+    interest without coupling to domain modules.
+    """
+    app = FastAPI()
+    register_exception_handlers(app)
+    return app
+
+
+@pytest.mark.unit
+class TestCoreExceptionTranslation:
+    """Typed exceptions flow through `core_exception_handler`."""
+
+    def test_should_translate_resource_not_found_to_404(self) -> None:
+        app = _make_app()
+
+        @app.get("/movies/{movie_id}")
+        async def _route(movie_id: str) -> dict[str, str]:
+            raise ResourceNotFoundException.for_resource("Movie", movie_id)
+
+        response = TestClient(app).get("/movies/mov_missing")
+
+        assert response.status_code == 404
+        body = response.json()
+        assert body["type"] == "not_found_error"
+        assert body["code"] == "RESOURCE_NOT_FOUND"
+
+    def test_should_translate_use_case_validation_to_400(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise UseCaseValidationException.required_field("movie_id")
+
+        response = TestClient(app).get("/foo")
+
+        assert response.status_code == 400
+        assert response.json()["type"] == "invalid_request_error"
+
+    def test_should_translate_domain_validation_to_422(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise DomainValidationException(
+                message="Bad state",
+                message_code="INVALID_STATE",
+                object_type="Movie",
+            )
+
+        response = TestClient(app).get("/foo")
+
+        assert response.status_code == 422
+        assert response.json()["type"] == "validation_error"
+
+    def test_should_translate_business_rule_to_422(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise BusinessRuleViolationException(
+                message="cannot toggle",
+                rule_code="WATCHLIST_LIMIT_EXCEEDED",
+            )
+
+        response = TestClient(app).get("/foo")
+
+        assert response.status_code == 422
+        assert response.json()["code"] == "BUSINESS_RULE_VIOLATION"
+
+    def test_should_translate_gateway_timeout_to_504(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise GatewayTimeoutException(
+                message="TMDB timed out",
+                gateway_name="TMDB",
+                internal_message="connect timeout after 30s",
+            )
+
+        response = TestClient(app).get("/foo")
+
+        assert response.status_code == 504
+        body = response.json()
+        assert body["type"] == "gateway_timeout_error"
+        assert "internal_message" not in body  # never leaked to client
+
+
+@pytest.mark.unit
+class TestRequestValidation:
+    """FastAPI validation errors surface as 422 in the envelope shape."""
+
+    def test_should_return_structured_details_for_invalid_query(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route(age: int) -> dict[str, int]:
+            return {"age": age}
+
+        response = TestClient(app).get("/foo?age=not-a-number")
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert body["code"] == "REQUEST_VALIDATION_ERROR"
+        assert isinstance(body["details"], list)
+        assert body["details"][0]["field"] == "age"
+
+
+@pytest.mark.unit
+class TestHttpExceptionTranslation:
+    """`HTTPException` raised manually is wrapped in the envelope too."""
+
+    def test_should_wrap_string_detail(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise HTTPException(status_code=404, detail="nope")
+
+        response = TestClient(app).get("/foo")
+
+        assert response.status_code == 404
+        body = response.json()
+        assert body == {
+            "type": "not_found_error",
+            "message": "nope",
+            "code": "NOT_FOUND_ERROR",
+        }
+
+    def test_should_wrap_dict_detail(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise HTTPException(
+                status_code=409,
+                detail={"message": "duplicate", "code": "EMAIL_EXISTS"},
+            )
+
+        response = TestClient(app).get("/foo")
+
+        assert response.status_code == 409
+        body = response.json()
+        assert body == {
+            "type": "conflict_error",
+            "message": "duplicate",
+            "code": "EMAIL_EXISTS",
+        }
+
+
+@pytest.mark.unit
+class TestUnhandledException:
+    """Unexpected errors return a generic 500 without leaking details."""
+
+    def test_should_return_generic_500_payload(self) -> None:
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise RuntimeError("secret stack trace 42")
+
+        response = TestClient(app, raise_server_exceptions=False).get("/foo")
+
+        assert response.status_code == 500
+        body = response.json()
+        assert body == {
+            "type": "api_error",
+            "message": "An unexpected error occurred.",
+            "code": "INTERNAL_ERROR",
+        }

--- a/tests/building_blocks/unit/presentation/test_request_context.py
+++ b/tests/building_blocks/unit/presentation/test_request_context.py
@@ -1,0 +1,53 @@
+"""Tests for the per-request context middleware."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.building_blocks.presentation.request_context import (
+    RequestContextMiddleware,
+    get_current_request_id,
+)
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+
+    @app.get("/probe")
+    async def _probe() -> dict[str, str | None]:
+        return {"request_id": get_current_request_id()}
+
+    return app
+
+
+@pytest.mark.unit
+class TestRequestContextMiddleware:
+    """The middleware sets correlation id + timing headers."""
+
+    def test_should_generate_request_id_when_missing(self) -> None:
+        response = TestClient(_make_app()).get("/probe")
+
+        header_id = response.headers["x-request-id"]
+        body_id = response.json()["request_id"]
+        assert header_id == body_id
+        assert header_id.startswith("req_")
+
+    def test_should_honour_inbound_request_id_header(self) -> None:
+        response = TestClient(_make_app()).get(
+            "/probe", headers={"X-Request-ID": "req_from-client"}
+        )
+
+        assert response.headers["x-request-id"] == "req_from-client"
+        assert response.json()["request_id"] == "req_from-client"
+
+    def test_should_emit_server_timing_header(self) -> None:
+        response = TestClient(_make_app()).get("/probe")
+
+        assert "server-timing" in response.headers
+        assert response.headers["server-timing"].startswith("total;dur=")
+
+    def test_should_clear_context_after_request(self) -> None:
+        TestClient(_make_app()).get("/probe")
+
+        assert get_current_request_id() is None

--- a/tests/building_blocks/unit/presentation/test_responses.py
+++ b/tests/building_blocks/unit/presentation/test_responses.py
@@ -1,0 +1,127 @@
+"""Tests for the API response envelope helpers."""
+
+import pytest
+
+from src.building_blocks.presentation.responses import (
+    Pagination,
+    api_list,
+    api_single,
+)
+
+
+@pytest.mark.unit
+class TestApiSingle:
+    """`api_single` wraps a resource in the v3.0 envelope."""
+
+    def test_should_wrap_payload_with_declared_type(self) -> None:
+        payload = {"id": "lib_1", "name": "Movies"}
+
+        result = api_single("library", payload)
+
+        assert result == {"type": "library", "data": payload}
+
+    def test_should_accept_none_payload(self) -> None:
+        result = api_single("progress", None)
+
+        assert result == {"type": "progress", "data": None}
+
+    def test_should_not_mutate_input_payload(self) -> None:
+        payload: dict[str, object] = {"id": "mov_1"}
+
+        api_single("movie", payload)
+
+        assert payload == {"id": "mov_1"}
+
+
+@pytest.mark.unit
+class TestApiListMinimal:
+    """Without pagination/filters, no metadata block is emitted."""
+
+    def test_should_return_type_and_data_only(self) -> None:
+        result = api_list([{"id": "mov_1"}])
+
+        assert result == {"type": "list", "data": [{"id": "mov_1"}]}
+
+    def test_should_accept_empty_list(self) -> None:
+        result = api_list([])
+
+        assert result == {"type": "list", "data": []}
+
+
+@pytest.mark.unit
+class TestApiListWithPagination:
+    """Pagination nests under `metadata.pagination`."""
+
+    def test_should_include_pagination_in_metadata(self) -> None:
+        page = Pagination(has_more=True, next_cursor="cur_42")
+
+        result = api_list([{"id": "mov_1"}], pagination=page)
+
+        assert result["metadata"]["pagination"] == {
+            "has_more": True,
+            "next_cursor": "cur_42",
+        }
+
+    def test_should_omit_none_pagination_fields(self) -> None:
+        page = Pagination(has_more=False)
+
+        result = api_list([], pagination=page)
+
+        assert result["metadata"]["pagination"] == {"has_more": False}
+
+    def test_should_include_total_when_present(self) -> None:
+        page = Pagination(has_more=False, total=123)
+
+        result = api_list([], pagination=page)
+
+        assert result["metadata"]["pagination"]["total"] == 123
+
+
+@pytest.mark.unit
+class TestApiListWithFilters:
+    """Applied filters surface under `metadata.filters_applied`."""
+
+    def test_should_include_filters_applied(self) -> None:
+        result = api_list([], filters_applied={"genre": "drama"})
+
+        assert result["metadata"]["filters_applied"] == {"genre": "drama"}
+
+    def test_should_ignore_empty_filters(self) -> None:
+        result = api_list([{"id": "mov_1"}], filters_applied={})
+
+        assert "metadata" not in result
+
+
+@pytest.mark.unit
+class TestApiListWithExtras:
+    """Arbitrary stable metadata extras merge into `metadata`."""
+
+    def test_should_merge_extras_into_metadata(self) -> None:
+        result = api_list(
+            [],
+            pagination=Pagination(has_more=False),
+            metadata_extras={"total_count": 9},
+        )
+
+        assert result["metadata"]["total_count"] == 9
+        assert result["metadata"]["pagination"] == {"has_more": False}
+
+
+@pytest.mark.unit
+class TestPaginationSerialization:
+    """Pagination.to_dict omits None to keep the payload minimal."""
+
+    def test_should_include_only_set_fields(self) -> None:
+        page = Pagination(has_more=True, next_cursor="cur_1", prev_cursor="cur_0")
+
+        assert page.to_dict() == {
+            "has_more": True,
+            "next_cursor": "cur_1",
+            "prev_cursor": "cur_0",
+        }
+
+    def test_should_be_frozen(self) -> None:
+        page = Pagination(has_more=False)
+
+        with pytest.raises(AttributeError):
+            page.has_more = True  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Adds `src/building_blocks/presentation/` with framework-agnostic helpers: `api_single` / `api_list` for the v3 response envelope, a `Pagination` descriptor, `RequestContextMiddleware` that attaches `X-Request-ID` + `Server-Timing`, and a set of global exception handlers that translate `CoreException` / `RequestValidationError` / `HTTPException` into the standard error shape (`docs/standards/api-response-standard-rest-v3.md`).
- Wires the handlers and middleware in `src/main.py`.
- Fixes the four routes flagged by the architecture audit as breaking the envelope (`library`, `preferences`, `enrichment`, `scan`) and migrates every other route to the shared helpers so the envelope format lives in one place. Obsolete `EnrichResponse` / `BulkEnrichResponse` / `ScanMediaResponse` Pydantic schemas (which encoded the old un-wrapped shape) are removed.

## Test plan

- [x] `poetry run pytest` — 1585 passing.
- [x] `poetry run ruff check src/` — clean.
- [x] `poetry run ruff format --check src/` — clean.
- [x] `poetry run python -c "from src.main import create_app; create_app()"` — app boots with 58 routes.
- [ ] Manual smoke on a running dev server for one GET (single resource), one list, and a 404 to confirm the envelope / error shape / request-id header.

## Summary by Sourcery

Introduce shared presentation helpers for the API v3 response envelope and global error handling, wire them into the FastAPI app, and migrate existing routes to use the centralized response shape.

New Features:
- Add framework-agnostic response helpers (single and list) with a shared pagination descriptor for the v3 API envelope.
- Introduce per-request context middleware that manages request IDs and exposes basic server timing information.
- Add global exception handlers to translate domain/application/HTTP/validation errors into the standardized error envelope.

Enhancements:
- Refactor media, library, preferences, collections, watch progress, search, featured, and scan routes to use the shared response helpers for consistent envelopes and metadata.
- Remove obsolete Pydantic response schemas for enrichment and scan endpoints now that responses are wrapped by the shared envelope.

Tests:
- Add unit tests covering the response envelope helpers, request context middleware, and global exception handling behavior.