### PR TITLE
refactor: introduce Unit of Work pattern across modules

### DIFF
--- a/src/building_blocks/application/unit_of_work.py
+++ b/src/building_blocks/application/unit_of_work.py
@@ -1,0 +1,73 @@
+"""Unit of Work — transactional boundary around repository operations.
+
+The Unit of Work (UoW) owns a single transaction and the repositories
+that participate in it. Application code declares its transactional
+intent by wrapping writes in ``async with uow: ...``; on clean exit the
+UoW commits, on any exception it rolls back. Repositories stay free of
+commit/rollback logic so the transaction boundary lives where the
+business operation lives — the use case.
+
+Each bounded context exposes its own UoW interface in its application
+layer (subclassing this base) that advertises the repositories it can
+compose. Infrastructure provides the concrete implementation.
+
+See docs/adr/ for the motivation and the alternatives considered.
+"""
+
+from abc import ABC, abstractmethod
+from types import TracebackType
+from typing import Self
+
+
+class UnitOfWork(ABC):
+    """Abstract transactional boundary.
+
+    Subclasses in each bounded context expose the concrete repository
+    set they manage (e.g. ``MediaUnitOfWork.movies``). The base contract
+    only spans the transaction lifecycle so every module enforces the
+    same semantics: commit on clean exit, rollback on error, idempotent
+    teardown.
+
+    Typical use::
+
+        async with self._uow as uow:
+            movie = await uow.movies.find_by_id(movie_id)
+            movie = movie.mark_unavailable()
+            await uow.movies.save(movie)
+        # commit happens here on success; rollback on exception
+    """
+
+    @abstractmethod
+    async def __aenter__(self) -> Self:
+        """Start the transaction and make repositories available."""
+
+    @abstractmethod
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Commit on clean exit, rollback on any exception."""
+
+    @abstractmethod
+    async def commit(self) -> None:
+        """Persist all staged changes in this unit.
+
+        Callable from inside the context for multi-commit scenarios
+        (rare). The context manager will also commit automatically on
+        clean exit — calling ``commit`` manually means the final exit
+        has nothing left to do.
+        """
+
+    @abstractmethod
+    async def rollback(self) -> None:
+        """Discard all staged changes in this unit.
+
+        Automatically invoked on exception inside the context manager.
+        Available for explicit rollback on domain-driven conditions
+        (e.g. a business rule violation detected mid-operation).
+        """
+
+
+__all__ = ["UnitOfWork"]

--- a/src/config/containers/collections.py
+++ b/src/config/containers/collections.py
@@ -18,21 +18,26 @@ from src.modules.collections.infrastructure.persistence.repositories import (
     SQLAlchemyCustomListRepository,
     SQLAlchemyWatchlistRepository,
 )
+from src.modules.collections.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyCollectionsUnitOfWorkFactory,
+)
 
 
 class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Collections bounded context dependencies.
 
-    The ``session``, ``movie_repository``, and ``series_repository``
-    dependencies must be wired from the parent container.
+    The ``session``, ``session_factory``, ``movie_repository``, and
+    ``series_repository`` dependencies must be wired from the parent
+    container.
     """
 
     session = providers.Dependency()
+    session_factory = providers.Dependency()
     movie_repository = providers.Dependency()
     series_repository = providers.Dependency()
 
     # =========================================================================
-    # Repositories
+    # Repositories (read-only use cases) and Unit of Work (writes)
     # =========================================================================
 
     watchlist_repository = providers.Factory(
@@ -45,13 +50,18 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
         session=session,
     )
 
+    collections_unit_of_work_factory = providers.Singleton(
+        SqlAlchemyCollectionsUnitOfWorkFactory,
+        session_factory=session_factory,
+    )
+
     # =========================================================================
     # Watchlist Use Cases
     # =========================================================================
 
     toggle_watchlist = providers.Factory(
         ToggleWatchlistUseCase,
-        watchlist_repository=watchlist_repository,
+        uow_factory=collections_unit_of_work_factory,
     )
 
     get_watchlist = providers.Factory(
@@ -72,7 +82,7 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     create_custom_list = providers.Factory(
         CreateCustomListUseCase,
-        custom_list_repository=custom_list_repository,
+        uow_factory=collections_unit_of_work_factory,
     )
 
     list_custom_lists = providers.Factory(
@@ -82,22 +92,22 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     rename_custom_list = providers.Factory(
         RenameCustomListUseCase,
-        custom_list_repository=custom_list_repository,
+        uow_factory=collections_unit_of_work_factory,
     )
 
     delete_custom_list = providers.Factory(
         DeleteCustomListUseCase,
-        custom_list_repository=custom_list_repository,
+        uow_factory=collections_unit_of_work_factory,
     )
 
     add_item_to_custom_list = providers.Factory(
         AddItemToCustomListUseCase,
-        custom_list_repository=custom_list_repository,
+        uow_factory=collections_unit_of_work_factory,
     )
 
     remove_item_from_custom_list = providers.Factory(
         RemoveItemFromCustomListUseCase,
-        custom_list_repository=custom_list_repository,
+        uow_factory=collections_unit_of_work_factory,
     )
 
     get_custom_list_items = providers.Factory(

--- a/src/config/containers/library.py
+++ b/src/config/containers/library.py
@@ -15,19 +15,24 @@ from src.modules.library.domain.services.track_selector import TrackSelector
 from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
     SqlAlchemyLibraryRepository,
 )
+from src.modules.library.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyLibraryUnitOfWorkFactory,
+)
 
 
 class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Library bounded context dependencies.
 
     Provides:
-    - Repository implementation (SQLAlchemy)
+    - Repository implementation (SQLAlchemy) for read use cases
+    - Unit of Work factory for write use cases
     - CRUD use cases
     - Domain services
     """
 
     # Wired from InfrastructureContainer via main container.
     session = providers.Dependency()
+    session_factory = providers.Dependency()
     # Media repositories come from MediaContainer — library responses
     # include per-library movie/series counts, so the library use
     # cases need to query those tables too.
@@ -35,12 +40,17 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     series_repository = providers.Dependency()
 
     # =========================================================================
-    # Repositories
+    # Repositories (read-only) and Unit of Work (writes)
     # =========================================================================
 
     library_repository = providers.Factory(
         SqlAlchemyLibraryRepository,
         session=session,
+    )
+
+    library_unit_of_work_factory = providers.Singleton(
+        SqlAlchemyLibraryUnitOfWorkFactory,
+        session_factory=session_factory,
     )
 
     # =========================================================================
@@ -49,7 +59,7 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     create_library = providers.Factory(
         CreateLibraryUseCase,
-        library_repository=library_repository,
+        uow_factory=library_unit_of_work_factory,
         movie_repository=movie_repository,
         series_repository=series_repository,
     )
@@ -70,14 +80,14 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     update_library = providers.Factory(
         UpdateLibraryUseCase,
-        library_repository=library_repository,
+        uow_factory=library_unit_of_work_factory,
         movie_repository=movie_repository,
         series_repository=series_repository,
     )
 
     delete_library = providers.Factory(
         DeleteLibraryUseCase,
-        library_repository=library_repository,
+        uow_factory=library_unit_of_work_factory,
     )
 
     # =========================================================================

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -58,6 +58,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     media = providers.Container(
         MediaContainer,
         session=infrastructure.session,
+        session_factory=infrastructure.session_factory,
         event_bus=infrastructure.event_bus,
         tmdb_api_key=config.provided.tmdb_api_key,
         hls_cache_directory=config.provided.hls_cache_directory,

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -68,6 +68,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     library = providers.Container(
         LibraryContainer,
         session=infrastructure.session,
+        session_factory=infrastructure.session_factory,
         movie_repository=media.movie_repository,
         series_repository=media.series_repository,
     )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -88,6 +88,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     collections = providers.Container(
         CollectionsContainer,
         session=infrastructure.session,
+        session_factory=infrastructure.session_factory,
         movie_repository=media.movie_repository,
         series_repository=media.series_repository,
     )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -81,6 +81,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     watch_progress = providers.Container(
         WatchProgressContainer,
         session=infrastructure.session,
+        session_factory=infrastructure.session_factory,
         movie_repository=media.movie_repository,
         series_repository=media.series_repository,
     )

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -40,6 +40,9 @@ from src.modules.media.infrastructure.persistence.repositories.movie_repository 
 from src.modules.media.infrastructure.persistence.repositories.series_repository import (
     SQLAlchemySeriesRepository,
 )
+from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyMediaUnitOfWorkFactory,
+)
 from src.modules.media.infrastructure.streaming import HlsService, MediaProbeService
 from src.modules.watch_progress.infrastructure.persistence.repositories import (
     SQLAlchemyWatchProgressRepository,
@@ -63,6 +66,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     # Must be wired from InfrastructureContainer
     session = providers.Dependency()
+    session_factory = providers.Dependency()
     event_bus = providers.Dependency()
 
     # Must be wired from parent container (Settings.hls_cache_directory / hls_cache_max_size_mb)
@@ -70,7 +74,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     hls_cache_max_size_mb = providers.Dependency(default=5120)
 
     # =========================================================================
-    # Repositories
+    # Repositories (read-only use cases) and Unit of Work (writes)
     # =========================================================================
 
     movie_repository = providers.Factory(
@@ -86,6 +90,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     progress_repository = providers.Factory(
         SQLAlchemyWatchProgressRepository,
         session=session,
+    )
+
+    media_unit_of_work_factory = providers.Singleton(
+        SqlAlchemyMediaUnitOfWorkFactory,
+        session_factory=session_factory,
     )
 
     # =========================================================================
@@ -110,7 +119,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     delete_movie = providers.Factory(
         DeleteMovieUseCase,
-        movie_repository=movie_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     get_series_by_id = providers.Factory(
@@ -158,20 +167,17 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     add_file_variant = providers.Factory(
         AddFileVariantUseCase,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     remove_file_variant = providers.Factory(
         RemoveFileVariantUseCase,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     set_primary_file = providers.Factory(
         SetPrimaryFileUseCase,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     # =========================================================================
@@ -200,8 +206,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         ScanMediaDirectoriesUseCase,
         file_scanner=file_scanner,
         variant_detector=variant_detector,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
         probe_service=media_probe_service,
         event_bus=event_bus,
     )
@@ -221,13 +226,13 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     enrich_movie_metadata = providers.Factory(
         EnrichMovieMetadataUseCase,
-        movie_repository=movie_repository,
+        uow_factory=media_unit_of_work_factory,
         primary_provider=tmdb_client,
     )
 
     enrich_series_metadata = providers.Factory(
         EnrichSeriesMetadataUseCase,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
         primary_provider=tmdb_client,
     )
 

--- a/src/config/containers/watch_progress.py
+++ b/src/config/containers/watch_progress.py
@@ -14,26 +14,36 @@ from src.modules.watch_progress.application.use_cases.clear_series_progress impo
 from src.modules.watch_progress.infrastructure.persistence.repositories import (
     SQLAlchemyWatchProgressRepository,
 )
+from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyWatchProgressUnitOfWorkFactory,
+)
 
 
 class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Watch Progress bounded context dependencies.
 
-    The ``session`` and ``movie_repository`` dependencies must be
-    wired from the parent container.
+    The ``session``, ``session_factory``, ``movie_repository``, and
+    ``series_repository`` dependencies must be wired from the parent
+    container.
     """
 
     session = providers.Dependency()
+    session_factory = providers.Dependency()
     movie_repository = providers.Dependency()
     series_repository = providers.Dependency()
 
     # =========================================================================
-    # Repositories
+    # Repositories (read-only use cases) and Unit of Work (writes)
     # =========================================================================
 
     progress_repository = providers.Factory(
         SQLAlchemyWatchProgressRepository,
         session=session,
+    )
+
+    watch_progress_unit_of_work_factory = providers.Singleton(
+        SqlAlchemyWatchProgressUnitOfWorkFactory,
+        session_factory=session_factory,
     )
 
     # =========================================================================
@@ -42,7 +52,7 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
 
     save_progress = providers.Factory(
         SaveProgressUseCase,
-        progress_repository=progress_repository,
+        uow_factory=watch_progress_unit_of_work_factory,
     )
 
     get_progress = providers.Factory(
@@ -59,10 +69,10 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
 
     clear_progress = providers.Factory(
         ClearProgressUseCase,
-        progress_repository=progress_repository,
+        uow_factory=watch_progress_unit_of_work_factory,
     )
 
     clear_series_progress = providers.Factory(
         ClearSeriesProgressUseCase,
-        progress_repository=progress_repository,
+        uow_factory=watch_progress_unit_of_work_factory,
     )

--- a/src/modules/collections/application/unit_of_work.py
+++ b/src/modules/collections/application/unit_of_work.py
@@ -1,0 +1,27 @@
+"""Collections bounded-context Unit of Work interface."""
+
+from abc import ABC, abstractmethod
+
+from src.building_blocks.application.unit_of_work import UnitOfWork
+from src.modules.collections.domain.repositories import (
+    CustomListRepository,
+    WatchlistRepository,
+)
+
+
+class CollectionsUnitOfWork(UnitOfWork):
+    """Transactional boundary for Watchlist and Custom List writes."""
+
+    watchlist: WatchlistRepository
+    custom_lists: CustomListRepository
+
+
+class CollectionsUnitOfWorkFactory(ABC):
+    """Builds fresh ``CollectionsUnitOfWork`` instances on demand."""
+
+    @abstractmethod
+    def __call__(self) -> CollectionsUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+
+
+__all__ = ["CollectionsUnitOfWork", "CollectionsUnitOfWorkFactory"]

--- a/src/modules/collections/application/use_cases/add_item_to_custom_list.py
+++ b/src/modules/collections/application/use_cases/add_item_to_custom_list.py
@@ -3,31 +3,23 @@
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.building_blocks.domain import BusinessRuleViolationException
 from src.modules.collections.application.dtos import AddItemToCustomListInput
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.modules.collections.domain.entities import CustomListItem
-from src.modules.collections.domain.repositories import CustomListRepository
 
 
 class AddItemToCustomListUseCase:
     """Add a movie or series to a custom list.
 
     Enforces item limit per list and prevents duplicates.
-
-    Example:
-        >>> use_case = AddItemToCustomListUseCase(custom_list_repository)
-        >>> await use_case.execute(AddItemToCustomListInput(
-        ...     list_id="lst_abc123",
-        ...     media_id="mov_xyz789",
-        ...     media_type="movie",
-        ... ))
     """
 
-    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            custom_list_repository: Repository for custom list persistence.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
         """
-        self._repo = custom_list_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: AddItemToCustomListInput) -> None:
         """Execute the use case.
@@ -39,31 +31,34 @@ class AddItemToCustomListUseCase:
             ResourceNotFoundException: If the list does not exist.
             BusinessRuleViolationException: If item already in list or list is full.
         """
-        custom_list = await self._repo.find_by_id(input_dto.list_id)
-        if not custom_list:
-            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+        async with self._uow_factory() as uow:
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id)
+            if not custom_list:
+                raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-        existing_item = await self._repo.find_item(input_dto.list_id, input_dto.media_id)
-        if existing_item:
-            raise BusinessRuleViolationException(
-                message="Item already exists in this list",
-                message_code="CUSTOM_LIST_ITEM_DUPLICATE",
-                rule_code="CUSTOM_LIST_ITEM_DUPLICATE",
+            existing_item = await uow.custom_lists.find_item(
+                input_dto.list_id, input_dto.media_id
+            )
+            if existing_item:
+                raise BusinessRuleViolationException(
+                    message="Item already exists in this list",
+                    message_code="CUSTOM_LIST_ITEM_DUPLICATE",
+                    rule_code="CUSTOM_LIST_ITEM_DUPLICATE",
+                )
+
+            # Validate item limit via domain entity
+            updated_list = custom_list.increment_item_count()
+
+            next_position = await uow.custom_lists.get_next_position(input_dto.list_id)
+
+            item = CustomListItem.create(
+                media_id=input_dto.media_id,
+                media_type=input_dto.media_type,
+                position=next_position,
             )
 
-        # Validate item limit via domain entity
-        updated_list = custom_list.increment_item_count()
-
-        next_position = await self._repo.get_next_position(input_dto.list_id)
-
-        item = CustomListItem.create(
-            media_id=input_dto.media_id,
-            media_type=input_dto.media_type,
-            position=next_position,
-        )
-
-        await self._repo.add_item(input_dto.list_id, item)
-        await self._repo.update(updated_list)
+            await uow.custom_lists.add_item(input_dto.list_id, item)
+            await uow.custom_lists.update(updated_list)
 
 
 __all__ = ["AddItemToCustomListUseCase"]

--- a/src/modules/collections/application/use_cases/add_item_to_custom_list.py
+++ b/src/modules/collections/application/use_cases/add_item_to_custom_list.py
@@ -36,9 +36,7 @@ class AddItemToCustomListUseCase:
             if not custom_list:
                 raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-            existing_item = await uow.custom_lists.find_item(
-                input_dto.list_id, input_dto.media_id
-            )
+            existing_item = await uow.custom_lists.find_item(input_dto.list_id, input_dto.media_id)
             if existing_item:
                 raise BusinessRuleViolationException(
                     message="Item already exists in this list",

--- a/src/modules/collections/application/use_cases/create_custom_list.py
+++ b/src/modules/collections/application/use_cases/create_custom_list.py
@@ -5,8 +5,8 @@ from src.modules.collections.application.dtos import (
     CreateCustomListInput,
     CustomListOutput,
 )
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.modules.collections.domain.entities import MAX_LISTS, CustomList
-from src.modules.collections.domain.repositories import CustomListRepository
 
 
 class CreateCustomListUseCase:
@@ -15,17 +15,17 @@ class CreateCustomListUseCase:
     Enforces the maximum list limit and unique name constraint.
 
     Example:
-        >>> use_case = CreateCustomListUseCase(custom_list_repository)
+        >>> use_case = CreateCustomListUseCase(uow_factory)
         >>> result = await use_case.execute(CreateCustomListInput(name="Action Movies"))
     """
 
-    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            custom_list_repository: Repository for custom list persistence.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
         """
-        self._repo = custom_list_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: CreateCustomListInput) -> CustomListOutput:
         """Execute the use case.
@@ -39,24 +39,25 @@ class CreateCustomListUseCase:
         Raises:
             BusinessRuleViolationException: If list limit reached or name already exists.
         """
-        current_count = await self._repo.count()
-        if current_count >= MAX_LISTS:
-            raise BusinessRuleViolationException(
-                message=f"Cannot create more than {MAX_LISTS} custom lists",
-                message_code="CUSTOM_LIST_LIMIT_EXCEEDED",
-                rule_code="CUSTOM_LIST_LIMIT_EXCEEDED",
-            )
+        async with self._uow_factory() as uow:
+            current_count = await uow.custom_lists.count()
+            if current_count >= MAX_LISTS:
+                raise BusinessRuleViolationException(
+                    message=f"Cannot create more than {MAX_LISTS} custom lists",
+                    message_code="CUSTOM_LIST_LIMIT_EXCEEDED",
+                    rule_code="CUSTOM_LIST_LIMIT_EXCEEDED",
+                )
 
-        existing = await self._repo.find_by_name(input_dto.name.strip())
-        if existing:
-            raise BusinessRuleViolationException(
-                message=f"A list named '{input_dto.name.strip()}' already exists",
-                message_code="CUSTOM_LIST_NAME_DUPLICATE",
-                rule_code="CUSTOM_LIST_NAME_DUPLICATE",
-            )
+            existing = await uow.custom_lists.find_by_name(input_dto.name.strip())
+            if existing:
+                raise BusinessRuleViolationException(
+                    message=f"A list named '{input_dto.name.strip()}' already exists",
+                    message_code="CUSTOM_LIST_NAME_DUPLICATE",
+                    rule_code="CUSTOM_LIST_NAME_DUPLICATE",
+                )
 
-        custom_list = CustomList.create(name=input_dto.name)
-        saved = await self._repo.add(custom_list)
+            custom_list = CustomList.create(name=input_dto.name)
+            saved = await uow.custom_lists.add(custom_list)
         return CustomListOutput.from_entity(saved)
 
 

--- a/src/modules/collections/application/use_cases/delete_custom_list.py
+++ b/src/modules/collections/application/use_cases/delete_custom_list.py
@@ -1,24 +1,19 @@
 """DeleteCustomListUseCase - Delete a custom list."""
 
 from src.building_blocks.application.errors import ResourceNotFoundException
-from src.modules.collections.domain.repositories import CustomListRepository
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 
 
 class DeleteCustomListUseCase:
-    """Delete a custom list and all its items.
+    """Delete a custom list and all its items."""
 
-    Example:
-        >>> use_case = DeleteCustomListUseCase(custom_list_repository)
-        >>> await use_case.execute("lst_abc123def456")
-    """
-
-    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            custom_list_repository: Repository for custom list persistence.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
         """
-        self._repo = custom_list_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, list_id: str) -> None:
         """Execute the use case.
@@ -29,7 +24,8 @@ class DeleteCustomListUseCase:
         Raises:
             ResourceNotFoundException: If the list does not exist.
         """
-        removed = await self._repo.remove(list_id)
+        async with self._uow_factory() as uow:
+            removed = await uow.custom_lists.remove(list_id)
         if not removed:
             raise ResourceNotFoundException.for_resource("CustomList", list_id)
 

--- a/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
+++ b/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
@@ -2,27 +2,19 @@
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.collections.application.dtos import RemoveItemFromCustomListInput
-from src.modules.collections.domain.repositories import CustomListRepository
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 
 
 class RemoveItemFromCustomListUseCase:
-    """Remove a movie or series from a custom list.
+    """Remove a movie or series from a custom list."""
 
-    Example:
-        >>> use_case = RemoveItemFromCustomListUseCase(custom_list_repository)
-        >>> await use_case.execute(RemoveItemFromCustomListInput(
-        ...     list_id="lst_abc123",
-        ...     media_id="mov_xyz789",
-        ... ))
-    """
-
-    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            custom_list_repository: Repository for custom list persistence.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
         """
-        self._repo = custom_list_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: RemoveItemFromCustomListInput) -> None:
         """Execute the use case.
@@ -33,16 +25,21 @@ class RemoveItemFromCustomListUseCase:
         Raises:
             ResourceNotFoundException: If the list or item does not exist.
         """
-        custom_list = await self._repo.find_by_id(input_dto.list_id)
-        if not custom_list:
-            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+        async with self._uow_factory() as uow:
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id)
+            if not custom_list:
+                raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-        removed = await self._repo.remove_item(input_dto.list_id, input_dto.media_id)
-        if not removed:
-            raise ResourceNotFoundException.for_resource("CustomListItem", input_dto.media_id)
+            removed = await uow.custom_lists.remove_item(
+                input_dto.list_id, input_dto.media_id
+            )
+            if not removed:
+                raise ResourceNotFoundException.for_resource(
+                    "CustomListItem", input_dto.media_id
+                )
 
-        updated_list = custom_list.decrement_item_count()
-        await self._repo.update(updated_list)
+            updated_list = custom_list.decrement_item_count()
+            await uow.custom_lists.update(updated_list)
 
 
 __all__ = ["RemoveItemFromCustomListUseCase"]

--- a/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
+++ b/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
@@ -30,13 +30,9 @@ class RemoveItemFromCustomListUseCase:
             if not custom_list:
                 raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-            removed = await uow.custom_lists.remove_item(
-                input_dto.list_id, input_dto.media_id
-            )
+            removed = await uow.custom_lists.remove_item(input_dto.list_id, input_dto.media_id)
             if not removed:
-                raise ResourceNotFoundException.for_resource(
-                    "CustomListItem", input_dto.media_id
-                )
+                raise ResourceNotFoundException.for_resource("CustomListItem", input_dto.media_id)
 
             updated_list = custom_list.decrement_item_count()
             await uow.custom_lists.update(updated_list)

--- a/src/modules/collections/application/use_cases/rename_custom_list.py
+++ b/src/modules/collections/application/use_cases/rename_custom_list.py
@@ -6,28 +6,19 @@ from src.modules.collections.application.dtos import (
     CustomListOutput,
     RenameCustomListInput,
 )
-from src.modules.collections.domain.repositories import CustomListRepository
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 
 
 class RenameCustomListUseCase:
-    """Rename an existing custom list.
+    """Rename an existing custom list."""
 
-    Enforces unique name constraint.
-
-    Example:
-        >>> use_case = RenameCustomListUseCase(custom_list_repository)
-        >>> result = await use_case.execute(
-        ...     RenameCustomListInput(list_id="lst_abc123", name="New Name"),
-        ... )
-    """
-
-    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            custom_list_repository: Repository for custom list persistence.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
         """
-        self._repo = custom_list_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: RenameCustomListInput) -> CustomListOutput:
         """Execute the use case.
@@ -42,21 +33,22 @@ class RenameCustomListUseCase:
             ResourceNotFoundException: If the list does not exist.
             BusinessRuleViolationException: If the name is already taken.
         """
-        custom_list = await self._repo.find_by_id(input_dto.list_id)
-        if not custom_list:
-            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+        async with self._uow_factory() as uow:
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id)
+            if not custom_list:
+                raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-        new_name = input_dto.name.strip()
-        existing = await self._repo.find_by_name(new_name)
-        if existing and str(existing.id) != input_dto.list_id:
-            raise BusinessRuleViolationException(
-                message=f"A list named '{new_name}' already exists",
-                message_code="CUSTOM_LIST_NAME_DUPLICATE",
-                rule_code="CUSTOM_LIST_NAME_DUPLICATE",
-            )
+            new_name = input_dto.name.strip()
+            existing = await uow.custom_lists.find_by_name(new_name)
+            if existing and str(existing.id) != input_dto.list_id:
+                raise BusinessRuleViolationException(
+                    message=f"A list named '{new_name}' already exists",
+                    message_code="CUSTOM_LIST_NAME_DUPLICATE",
+                    rule_code="CUSTOM_LIST_NAME_DUPLICATE",
+                )
 
-        updated = custom_list.rename(new_name)
-        saved = await self._repo.update(updated)
+            updated = custom_list.rename(new_name)
+            saved = await uow.custom_lists.update(updated)
         return CustomListOutput.from_entity(saved)
 
 

--- a/src/modules/collections/application/use_cases/toggle_watchlist.py
+++ b/src/modules/collections/application/use_cases/toggle_watchlist.py
@@ -4,8 +4,8 @@ from src.modules.collections.application.dtos import (
     ToggleWatchlistInput,
     ToggleWatchlistOutput,
 )
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.modules.collections.domain.entities import WatchlistItem
-from src.modules.collections.domain.repositories import WatchlistRepository
 
 
 class ToggleWatchlistUseCase:
@@ -15,7 +15,7 @@ class ToggleWatchlistUseCase:
     If it is not in the watchlist, it is added.
 
     Example:
-        >>> use_case = ToggleWatchlistUseCase(watchlist_repository)
+        >>> use_case = ToggleWatchlistUseCase(uow_factory)
         >>> result = await use_case.execute(ToggleWatchlistInput(
         ...     media_id="mov_abc123def456",
         ...     media_type="movie",
@@ -24,13 +24,13 @@ class ToggleWatchlistUseCase:
         True
     """
 
-    def __init__(self, watchlist_repository: WatchlistRepository) -> None:
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            watchlist_repository: Repository for watchlist persistence.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
         """
-        self._repo = watchlist_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ToggleWatchlistInput) -> ToggleWatchlistOutput:
         """Execute the use case.
@@ -41,18 +41,19 @@ class ToggleWatchlistUseCase:
         Returns:
             ToggleWatchlistOutput with added=True if added, False if removed.
         """
-        exists = await self._repo.exists(input_dto.media_id)
+        async with self._uow_factory() as uow:
+            exists = await uow.watchlist.exists(input_dto.media_id)
 
-        if exists:
-            await self._repo.remove(input_dto.media_id)
-            return ToggleWatchlistOutput(media_id=input_dto.media_id, added=False)
+            if exists:
+                await uow.watchlist.remove(input_dto.media_id)
+                return ToggleWatchlistOutput(media_id=input_dto.media_id, added=False)
 
-        item = WatchlistItem.create(
-            media_id=input_dto.media_id,
-            media_type=input_dto.media_type,
-        )
-        await self._repo.add(item)
-        return ToggleWatchlistOutput(media_id=input_dto.media_id, added=True)
+            item = WatchlistItem.create(
+                media_id=input_dto.media_id,
+                media_type=input_dto.media_type,
+            )
+            await uow.watchlist.add(item)
+            return ToggleWatchlistOutput(media_id=input_dto.media_id, added=True)
 
 
 __all__ = ["ToggleWatchlistUseCase"]

--- a/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
@@ -57,7 +57,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         """Persist a new custom list."""
         model = CustomListMapper.to_model(custom_list)
         self._session.add(model)
-        await self._session.commit()
+        await self._session.flush()
         await self._session.refresh(model)
         return CustomListMapper.to_entity(model)
 
@@ -75,7 +75,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
             raise ValueError(msg)
 
         CustomListMapper.update_model(model, custom_list)
-        await self._session.commit()
+        await self._session.flush()
         await self._session.refresh(model)
         return CustomListMapper.to_entity(model)
 
@@ -101,7 +101,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
             item_model.soft_delete()
 
         model.soft_delete()
-        await self._session.commit()
+        await self._session.flush()
         return True
 
     async def list_all(self) -> list[CustomList]:
@@ -177,13 +177,13 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
             existing.restore()
             existing.position = item.position
             existing.added_at = item.added_at
-            await self._session.commit()
+            await self._session.flush()
             await self._session.refresh(existing)
             return CustomListItemMapper.to_entity(existing)
 
         model = CustomListItemMapper.to_model(item, list_internal_id=internal_id)
         self._session.add(model)
-        await self._session.commit()
+        await self._session.flush()
         await self._session.refresh(model)
         return CustomListItemMapper.to_entity(model)
 
@@ -205,7 +205,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
             return False
 
         model.soft_delete()
-        await self._session.commit()
+        await self._session.flush()
         return True
 
     async def list_items(self, list_id: str) -> list[CustomListItem]:

--- a/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
@@ -56,13 +56,13 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         if existing:
             existing.restore()
             WatchlistItemMapper.update_model(existing, item)
-            await self._session.commit()
+            await self._session.flush()
             await self._session.refresh(existing)
             return WatchlistItemMapper.to_entity(existing)
 
         model = WatchlistItemMapper.to_model(item)
         self._session.add(model)
-        await self._session.commit()
+        await self._session.flush()
         await self._session.refresh(model)
         return WatchlistItemMapper.to_entity(model)
 
@@ -79,7 +79,7 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
             return False
 
         model.soft_delete()
-        await self._session.commit()
+        await self._session.flush()
         return True
 
     async def list_all(self, limit: int = 100) -> list[WatchlistItem]:

--- a/src/modules/collections/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/collections/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -1,0 +1,78 @@
+"""SQLAlchemy implementation of CollectionsUnitOfWork."""
+
+from types import TracebackType
+from typing import Self
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.config.persistence.session_manager import create_tracked_session
+from src.modules.collections.application.unit_of_work import (
+    CollectionsUnitOfWork,
+    CollectionsUnitOfWorkFactory,
+)
+from src.modules.collections.infrastructure.persistence.repositories.custom_list_repository import (
+    SQLAlchemyCustomListRepository,
+)
+from src.modules.collections.infrastructure.persistence.repositories.watchlist_repository import (
+    SQLAlchemyWatchlistRepository,
+)
+
+
+class SqlAlchemyCollectionsUnitOfWork(CollectionsUnitOfWork):
+    """SQLAlchemy-backed Unit of Work for the collections bounded context."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+        self._session: AsyncSession | None = None
+
+    async def __aenter__(self) -> Self:
+        if self._session is not None:
+            raise RuntimeError(
+                "CollectionsUnitOfWork is already active; nested use is not supported."
+            )
+        self._session = create_tracked_session(self._session_factory)
+        self.watchlist = SQLAlchemyWatchlistRepository(self._session)
+        self.custom_lists = SQLAlchemyCustomListRepository(self._session)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        assert self._session is not None
+        try:
+            if exc_type is None:
+                await self._session.commit()
+            else:
+                await self._session.rollback()
+        finally:
+            self._session = None
+
+    async def commit(self) -> None:
+        """Commit the active transaction."""
+        assert self._session is not None, "UnitOfWork not started; use `async with`."
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the active transaction."""
+        assert self._session is not None, "UnitOfWork not started; use `async with`."
+        await self._session.rollback()
+
+
+class SqlAlchemyCollectionsUnitOfWorkFactory(CollectionsUnitOfWorkFactory):
+    """Produce fresh :class:`SqlAlchemyCollectionsUnitOfWork` instances."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    def __call__(self) -> CollectionsUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+        return SqlAlchemyCollectionsUnitOfWork(self._session_factory)
+
+
+__all__ = [
+    "SqlAlchemyCollectionsUnitOfWork",
+    "SqlAlchemyCollectionsUnitOfWorkFactory",
+]

--- a/src/modules/library/application/unit_of_work.py
+++ b/src/modules/library/application/unit_of_work.py
@@ -1,0 +1,27 @@
+"""Library bounded-context Unit of Work interface."""
+
+from abc import ABC, abstractmethod
+
+from src.building_blocks.application.unit_of_work import UnitOfWork
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+
+
+class LibraryUnitOfWork(UnitOfWork):
+    """Transactional boundary for Library aggregate operations.
+
+    Subclasses populate ``libraries`` on ``__aenter__`` so writes within
+    the same ``async with`` block share a transaction.
+    """
+
+    libraries: LibraryRepository
+
+
+class LibraryUnitOfWorkFactory(ABC):
+    """Builds fresh ``LibraryUnitOfWork`` instances on demand."""
+
+    @abstractmethod
+    def __call__(self) -> LibraryUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+
+
+__all__ = ["LibraryUnitOfWork", "LibraryUnitOfWorkFactory"]

--- a/src/modules/library/application/use_cases/create_library.py
+++ b/src/modules/library/application/use_cases/create_library.py
@@ -6,9 +6,9 @@ from src.modules.library.application.dtos.library_dtos import (
     CreateLibraryInput,
     LibraryOutput,
 )
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.entities.library import Library
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_settings import LibrarySettings
 from src.modules.library.domain.value_objects.library_type import LibraryType
 from src.modules.library.domain.value_objects.metadata_provider import (
@@ -25,11 +25,11 @@ class CreateLibraryUseCase:
 
     def __init__(
         self,
-        library_repository: LibraryRepository,
+        uow_factory: LibraryUnitOfWorkFactory,
         movie_repository: MovieRepository,
         series_repository: SeriesRepository,
     ) -> None:
-        self._repo = library_repository
+        self._uow_factory = uow_factory
         self._movie_repo = movie_repository
         self._series_repo = series_repository
 
@@ -64,7 +64,8 @@ class CreateLibraryUseCase:
         if input_dto.scan_schedule:
             library = library.with_updates(scan_schedule=input_dto.scan_schedule)
 
-        saved = await self._repo.save(library)
+        async with self._uow_factory() as uow:
+            saved = await uow.libraries.save(library)
         return await library_to_output(saved, self._movie_repo, self._series_repo)
 
 

--- a/src/modules/library/application/use_cases/delete_library.py
+++ b/src/modules/library/application/use_cases/delete_library.py
@@ -2,15 +2,15 @@
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.library.application.dtos.library_dtos import DeleteLibraryInput
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.library.domain.value_objects.library_id import LibraryId
 
 
 class DeleteLibraryUseCase:
     """Soft-delete a library."""
 
-    def __init__(self, library_repository: LibraryRepository) -> None:
-        self._repo = library_repository
+    def __init__(self, uow_factory: LibraryUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: DeleteLibraryInput) -> None:
         """Soft-delete a library by id.
@@ -23,7 +23,9 @@ class DeleteLibraryUseCase:
                 matches the id.
         """
         library_id = LibraryId(input_dto.library_id)
-        deleted = await self._repo.delete(library_id)
+        async with self._uow_factory() as uow:
+            deleted = await uow.libraries.delete(library_id)
+
         if not deleted:
             raise ResourceNotFoundException.for_resource(
                 "Library",

--- a/src/modules/library/application/use_cases/update_library.py
+++ b/src/modules/library/application/use_cases/update_library.py
@@ -7,9 +7,9 @@ from src.modules.library.application.dtos.library_dtos import (
     LibraryOutput,
     UpdateLibraryInput,
 )
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.application.use_cases.create_library import _build_settings
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
 from src.modules.library.domain.value_objects.library_name import LibraryName
 from src.modules.library.domain.value_objects.library_type import LibraryType
@@ -27,11 +27,11 @@ class UpdateLibraryUseCase:
 
     def __init__(
         self,
-        library_repository: LibraryRepository,
+        uow_factory: LibraryUnitOfWorkFactory,
         movie_repository: MovieRepository,
         series_repository: SeriesRepository,
     ) -> None:
-        self._repo = library_repository
+        self._uow_factory = uow_factory
         self._movie_repo = movie_repository
         self._series_repo = series_repository
 
@@ -51,38 +51,40 @@ class UpdateLibraryUseCase:
             ResourceNotFoundException: If the library doesn't exist.
         """
         library_id = LibraryId(input_dto.library_id)
-        entity = await self._repo.find_by_id(library_id)
-        if entity is None:
-            raise ResourceNotFoundException.for_resource(
-                "Library",
-                input_dto.library_id,
-            )
 
-        updates: dict[str, Any] = {}
-        if input_dto.name is not None:
-            updates["name"] = LibraryName(input_dto.name)
-        if input_dto.library_type is not None:
-            updates["library_type"] = LibraryType(input_dto.library_type)
-        if input_dto.paths is not None:
-            updates["paths"] = [FilePath(p) for p in input_dto.paths]
-        if input_dto.language is not None:
-            updates["language"] = LanguageCode(input_dto.language)
-        if input_dto.metadata_providers is not None:
-            updates["metadata_providers"] = [
-                MetadataProviderConfig(
-                    provider=MetadataProvider(p["provider"]),
-                    priority=p.get("priority", 1),
-                    enabled=p.get("enabled", True),
+        async with self._uow_factory() as uow:
+            entity = await uow.libraries.find_by_id(library_id)
+            if entity is None:
+                raise ResourceNotFoundException.for_resource(
+                    "Library",
+                    input_dto.library_id,
                 )
-                for p in input_dto.metadata_providers
-            ]
-        if input_dto.scan_schedule is not None:
-            updates["scan_schedule"] = input_dto.scan_schedule
-        if input_dto.settings is not None:
-            updates["settings"] = _build_settings(input_dto.settings)
 
-        updated = entity.with_updates(**updates)
-        saved = await self._repo.save(updated)
+            updates: dict[str, Any] = {}
+            if input_dto.name is not None:
+                updates["name"] = LibraryName(input_dto.name)
+            if input_dto.library_type is not None:
+                updates["library_type"] = LibraryType(input_dto.library_type)
+            if input_dto.paths is not None:
+                updates["paths"] = [FilePath(p) for p in input_dto.paths]
+            if input_dto.language is not None:
+                updates["language"] = LanguageCode(input_dto.language)
+            if input_dto.metadata_providers is not None:
+                updates["metadata_providers"] = [
+                    MetadataProviderConfig(
+                        provider=MetadataProvider(p["provider"]),
+                        priority=p.get("priority", 1),
+                        enabled=p.get("enabled", True),
+                    )
+                    for p in input_dto.metadata_providers
+                ]
+            if input_dto.scan_schedule is not None:
+                updates["scan_schedule"] = input_dto.scan_schedule
+            if input_dto.settings is not None:
+                updates["settings"] = _build_settings(input_dto.settings)
+
+            updated = entity.with_updates(**updates)
+            saved = await uow.libraries.save(updated)
         return await library_to_output(saved, self._movie_repo, self._series_repo)
 
 

--- a/src/modules/library/infrastructure/persistence/repositories/sqlalchemy_library_repository.py
+++ b/src/modules/library/infrastructure/persistence/repositories/sqlalchemy_library_repository.py
@@ -57,8 +57,7 @@ class SqlAlchemyLibraryRepository(LibraryRepository):
             self._session.add(model)
             await self._session.flush()
 
-        await self._session.commit()
-
+        # Transaction commit is the Unit of Work's responsibility.
         assert library.id is not None
         saved = await self.find_by_id(library.id)
         assert saved is not None
@@ -116,7 +115,6 @@ class SqlAlchemyLibraryRepository(LibraryRepository):
             return False
         model.soft_delete()
         await self._session.flush()
-        await self._session.commit()
         return True
 
     async def exists(self, library_id: LibraryId) -> bool:

--- a/src/modules/library/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/library/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -1,0 +1,72 @@
+"""SQLAlchemy implementation of LibraryUnitOfWork."""
+
+from types import TracebackType
+from typing import Self
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.config.persistence.session_manager import create_tracked_session
+from src.modules.library.application.unit_of_work import (
+    LibraryUnitOfWork,
+    LibraryUnitOfWorkFactory,
+)
+from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
+    SqlAlchemyLibraryRepository,
+)
+
+
+class SqlAlchemyLibraryUnitOfWork(LibraryUnitOfWork):
+    """SQLAlchemy-backed Unit of Work for the library bounded context."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+        self._session: AsyncSession | None = None
+
+    async def __aenter__(self) -> Self:
+        if self._session is not None:
+            raise RuntimeError("LibraryUnitOfWork is already active; nested use is not supported.")
+        self._session = create_tracked_session(self._session_factory)
+        self.libraries = SqlAlchemyLibraryRepository(self._session)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        assert self._session is not None
+        try:
+            if exc_type is None:
+                await self._session.commit()
+            else:
+                await self._session.rollback()
+        finally:
+            self._session = None
+
+    async def commit(self) -> None:
+        """Commit the active transaction."""
+        assert self._session is not None, "UnitOfWork not started; use `async with`."
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the active transaction."""
+        assert self._session is not None, "UnitOfWork not started; use `async with`."
+        await self._session.rollback()
+
+
+class SqlAlchemyLibraryUnitOfWorkFactory(LibraryUnitOfWorkFactory):
+    """Produce fresh :class:`SqlAlchemyLibraryUnitOfWork` instances."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    def __call__(self) -> LibraryUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+        return SqlAlchemyLibraryUnitOfWork(self._session_factory)
+
+
+__all__ = [
+    "SqlAlchemyLibraryUnitOfWork",
+    "SqlAlchemyLibraryUnitOfWorkFactory",
+]

--- a/src/modules/media/application/unit_of_work.py
+++ b/src/modules/media/application/unit_of_work.py
@@ -1,0 +1,44 @@
+"""Media bounded-context Unit of Work interface.
+
+Exposes the repositories that participate in a single media transaction.
+Concrete implementations live in the infrastructure layer; use cases
+depend only on this abstraction so they stay framework-agnostic.
+"""
+
+from abc import ABC, abstractmethod
+
+from src.building_blocks.application.unit_of_work import UnitOfWork
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+class MediaUnitOfWork(UnitOfWork):
+    """Transactional boundary for operations on movies and series.
+
+    Subclasses populate ``movies`` and ``series`` on ``__aenter__`` so
+    writes within the same ``async with`` block share a transaction.
+    Outside the context manager the attributes are not guaranteed to
+    exist — accessing them raises ``AttributeError``, which surfaces
+    misuse at the call site instead of silently operating against
+    a stale or foreign session.
+    """
+
+    movies: MovieRepository
+    series: SeriesRepository
+
+
+class MediaUnitOfWorkFactory(ABC):
+    """Builds fresh ``MediaUnitOfWork`` instances on demand.
+
+    Use cases depend on this factory rather than a single UoW so they
+    can open a new transaction per business operation. A scan that
+    processes thousands of files, for example, opens one UoW per file
+    group — a failure on one file rolls back only that group, not the
+    whole scan.
+    """
+
+    @abstractmethod
+    def __call__(self) -> MediaUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+
+
+__all__ = ["MediaUnitOfWork", "MediaUnitOfWorkFactory"]

--- a/src/modules/media/application/use_cases/add_file_variant.py
+++ b/src/modules/media/application/use_cases/add_file_variant.py
@@ -5,10 +5,13 @@ from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
     MediaFileOutput,
 )
+from src.modules.media.application.unit_of_work import (
+    MediaUnitOfWork,
+    MediaUnitOfWorkFactory,
+)
 from src.modules.media.application.use_cases._media_file_helpers import (
     to_media_file_output,
 )
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import (
     EpisodeId,
     HdrFormat,
@@ -27,7 +30,7 @@ class AddFileVariantUseCase:
     the new file variant to its file list.
 
     Example:
-        >>> use_case = AddFileVariantUseCase(movie_repo, series_repo)
+        >>> use_case = AddFileVariantUseCase(uow_factory)
         >>> result = await use_case.execute(AddFileVariantInput(
         ...     media_id="mov_abc123",
         ...     file_path="/movies/inception_4k.mkv",
@@ -36,19 +39,13 @@ class AddFileVariantUseCase:
         ... ))
     """
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Repository for movie persistence.
-            series_repository: Repository for series persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: AddFileVariantInput) -> MediaFileOutput:
         """Execute the use case.
@@ -74,24 +71,35 @@ class AddFileVariantUseCase:
 
         prefix = input_dto.media_id.split("_")[0] if "_" in input_dto.media_id else ""
 
-        if prefix == "mov":
-            return await self._add_to_movie(input_dto.media_id, media_file)
-        if prefix == "epi":
-            return await self._add_to_episode(input_dto.media_id, media_file)
+        async with self._uow_factory() as uow:
+            if prefix == "mov":
+                return await self._add_to_movie(uow, input_dto.media_id, media_file)
+            if prefix == "epi":
+                return await self._add_to_episode(uow, input_dto.media_id, media_file)
 
         raise ResourceNotFoundException.for_resource("Media", input_dto.media_id)
 
-    async def _add_to_movie(self, movie_id: str, media_file: MediaFile) -> MediaFileOutput:
-        movie = await self._movie_repository.find_by_id(MovieId(movie_id))
+    @staticmethod
+    async def _add_to_movie(
+        uow: MediaUnitOfWork,
+        movie_id: str,
+        media_file: MediaFile,
+    ) -> MediaFileOutput:
+        movie = await uow.movies.find_by_id(MovieId(movie_id))
         if movie is None:
             raise ResourceNotFoundException.for_resource("Movie", movie_id)
 
         movie = movie.with_file(media_file)
-        await self._movie_repository.save(movie)
+        await uow.movies.save(movie)
         return to_media_file_output(media_file)
 
-    async def _add_to_episode(self, episode_id: str, media_file: MediaFile) -> MediaFileOutput:
-        series = await self._series_repository.find_by_episode_id(EpisodeId(episode_id))
+    @staticmethod
+    async def _add_to_episode(
+        uow: MediaUnitOfWork,
+        episode_id: str,
+        media_file: MediaFile,
+    ) -> MediaFileOutput:
+        series = await uow.series.find_by_episode_id(EpisodeId(episode_id))
         if series is None:
             raise ResourceNotFoundException.for_resource("Episode", episode_id)
 
@@ -105,7 +113,7 @@ class AddFileVariantUseCase:
             updated_seasons.append(season.with_updates(episodes=updated_episodes))
 
         updated_series = series.with_updates(seasons=updated_seasons)
-        await self._series_repository.save(updated_series)
+        await uow.series.save(updated_series)
         return to_media_file_output(media_file)
 
 

--- a/src/modules/media/application/use_cases/delete_movie.py
+++ b/src/modules/media/application/use_cases/delete_movie.py
@@ -2,7 +2,7 @@
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.movie_dtos import DeleteMovieInput
-from src.modules.media.domain.repositories import MovieRepository
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.value_objects import MovieId
 
 
@@ -13,17 +13,17 @@ class DeleteMovieUseCase:
     physically removed, allowing for future recovery if needed.
 
     Example:
-        >>> use_case = DeleteMovieUseCase(movie_repository)
+        >>> use_case = DeleteMovieUseCase(uow_factory)
         >>> await use_case.execute(DeleteMovieInput("mov_abc123"))
     """
 
-    def __init__(self, movie_repository: MovieRepository) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Repository for movie persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repository = movie_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: DeleteMovieInput) -> None:
         """Execute the use case.
@@ -35,7 +35,8 @@ class DeleteMovieUseCase:
             ResourceNotFoundException: If movie with given ID doesn't exist.
         """
         movie_id = MovieId(input_dto.movie_id)
-        deleted = await self._movie_repository.delete(movie_id)
+        async with self._uow_factory() as uow:
+            deleted = await uow.movies.delete(movie_id)
 
         if not deleted:
             raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -8,8 +8,8 @@ from src.modules.media.application.dtos.enrichment_dtos import (
     EnrichMediaOutput,
 )
 from src.modules.media.application.ports import MediaMetadata, MetadataProvider
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.repositories import MovieRepository
 from src.modules.media.domain.value_objects import (
     ContentRating,
     Duration,
@@ -32,18 +32,18 @@ class EnrichMovieMetadataUseCase:
     if the primary returns no results.
 
     Args:
-        movie_repository: Repository for movie persistence.
+        uow_factory: Factory that opens a fresh media Unit of Work.
         primary_provider: Primary metadata provider (e.g., TMDB).
         fallback_provider: Optional fallback provider (e.g., OMDb).
     """
 
     def __init__(
         self,
-        movie_repository: MovieRepository,
+        uow_factory: MediaUnitOfWorkFactory,
         primary_provider: MetadataProvider,
         fallback_provider: MetadataProvider | None = None,
     ) -> None:
-        self._movie_repository = movie_repository
+        self._uow_factory = uow_factory
         self._primary = primary_provider
         self._fallback = fallback_provider
 
@@ -56,30 +56,33 @@ class EnrichMovieMetadataUseCase:
         Returns:
             Enrichment result with success/failure status.
         """
-        movie = await self._movie_repository.find_by_id(MovieId(input_dto.media_id))
-        if not movie:
-            raise ResourceNotFoundException.for_resource("Movie", input_dto.media_id)
+        async with self._uow_factory() as uow:
+            movie = await uow.movies.find_by_id(MovieId(input_dto.media_id))
+            if not movie:
+                raise ResourceNotFoundException.for_resource("Movie", input_dto.media_id)
 
-        if movie.tmdb_id and not input_dto.force:
-            return EnrichMediaOutput(media_id=input_dto.media_id, enriched=False, provider=None)
+            if movie.tmdb_id and not input_dto.force:
+                return EnrichMediaOutput(
+                    media_id=input_dto.media_id, enriched=False, provider=None
+                )
 
-        metadata, provider_name = await self._fetch_metadata(movie)
-        if not metadata:
-            return EnrichMediaOutput(
-                media_id=input_dto.media_id,
-                enriched=False,
-                error="No metadata found from any provider",
-            )
+            metadata, provider_name = await self._fetch_metadata(movie)
+            if not metadata:
+                return EnrichMediaOutput(
+                    media_id=input_dto.media_id,
+                    enriched=False,
+                    error="No metadata found from any provider",
+                )
 
-        # Re-fetch with localization if TMDB provider supports it
-        if metadata.tmdb_id and hasattr(self._primary, "get_movie_localized"):
-            get_localized = self._primary.get_movie_localized
-            localized_meta: MediaMetadata | None = await get_localized(metadata.tmdb_id)
-            if localized_meta is not None:
-                metadata = localized_meta
+            # Re-fetch with localization if TMDB provider supports it
+            if metadata.tmdb_id and hasattr(self._primary, "get_movie_localized"):
+                get_localized = self._primary.get_movie_localized
+                localized_meta: MediaMetadata | None = await get_localized(metadata.tmdb_id)
+                if localized_meta is not None:
+                    metadata = localized_meta
 
-        movie = _apply_movie_metadata(movie, metadata)
-        await self._movie_repository.save(movie)
+            movie = _apply_movie_metadata(movie, metadata)
+            await uow.movies.save(movie)
 
         return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)
 

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -62,9 +62,7 @@ class EnrichMovieMetadataUseCase:
                 raise ResourceNotFoundException.for_resource("Movie", input_dto.media_id)
 
             if movie.tmdb_id and not input_dto.force:
-                return EnrichMediaOutput(
-                    media_id=input_dto.media_id, enriched=False, provider=None
-                )
+                return EnrichMediaOutput(media_id=input_dto.media_id, enriched=False, provider=None)
 
             metadata, provider_name = await self._fetch_metadata(movie)
             if not metadata:

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -69,9 +69,7 @@ class EnrichSeriesMetadataUseCase:
                 raise ResourceNotFoundException.for_resource("Series", input_dto.media_id)
 
             if series.tmdb_id and not input_dto.force:
-                return EnrichMediaOutput(
-                    media_id=input_dto.media_id, enriched=False, provider=None
-                )
+                return EnrichMediaOutput(media_id=input_dto.media_id, enriched=False, provider=None)
 
             metadata, provider_name = await self._fetch_metadata(series)
             if not metadata:

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -16,8 +16,8 @@ from src.modules.media.application.ports import (
     MetadataProvider,
     SeasonMetadata,
 )
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Episode, Season, Series
-from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import (
     AirDate,
     ContentRating,
@@ -39,18 +39,18 @@ class EnrichSeriesMetadataUseCase:
     Enriches series-level, season-level, and episode-level metadata.
 
     Args:
-        series_repository: Repository for series persistence.
+        uow_factory: Factory that opens a fresh media Unit of Work.
         primary_provider: Primary metadata provider (e.g., TMDB).
         fallback_provider: Optional fallback provider (e.g., OMDb).
     """
 
     def __init__(
         self,
-        series_repository: SeriesRepository,
+        uow_factory: MediaUnitOfWorkFactory,
         primary_provider: MetadataProvider,
         fallback_provider: MetadataProvider | None = None,
     ) -> None:
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
         self._primary = primary_provider
         self._fallback = fallback_provider
 
@@ -63,30 +63,33 @@ class EnrichSeriesMetadataUseCase:
         Returns:
             Enrichment result with success/failure status.
         """
-        series = await self._series_repository.find_by_id(SeriesId(input_dto.media_id))
-        if not series:
-            raise ResourceNotFoundException.for_resource("Series", input_dto.media_id)
+        async with self._uow_factory() as uow:
+            series = await uow.series.find_by_id(SeriesId(input_dto.media_id))
+            if not series:
+                raise ResourceNotFoundException.for_resource("Series", input_dto.media_id)
 
-        if series.tmdb_id and not input_dto.force:
-            return EnrichMediaOutput(media_id=input_dto.media_id, enriched=False, provider=None)
+            if series.tmdb_id and not input_dto.force:
+                return EnrichMediaOutput(
+                    media_id=input_dto.media_id, enriched=False, provider=None
+                )
 
-        metadata, provider_name = await self._fetch_metadata(series)
-        if not metadata:
-            return EnrichMediaOutput(
-                media_id=input_dto.media_id,
-                enriched=False,
-                error="No metadata found from any provider",
-            )
+            metadata, provider_name = await self._fetch_metadata(series)
+            if not metadata:
+                return EnrichMediaOutput(
+                    media_id=input_dto.media_id,
+                    enriched=False,
+                    error="No metadata found from any provider",
+                )
 
-        # Re-fetch with localization if provider supports it
-        if metadata.tmdb_id and hasattr(self._primary, "get_series_localized"):
-            get_localized = self._primary.get_series_localized
-            localized_meta: MediaMetadata | None = await get_localized(metadata.tmdb_id)
-            if localized_meta is not None:
-                metadata = localized_meta
+            # Re-fetch with localization if provider supports it
+            if metadata.tmdb_id and hasattr(self._primary, "get_series_localized"):
+                get_localized = self._primary.get_series_localized
+                localized_meta: MediaMetadata | None = await get_localized(metadata.tmdb_id)
+                if localized_meta is not None:
+                    metadata = localized_meta
 
-        series = _apply_series_metadata(series, metadata)
-        await self._series_repository.save(series)
+            series = _apply_series_metadata(series, metadata)
+            await uow.series.save(series)
 
         return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)
 

--- a/src/modules/media/application/use_cases/remove_file_variant.py
+++ b/src/modules/media/application/use_cases/remove_file_variant.py
@@ -5,8 +5,11 @@ from src.building_blocks.application.errors import (
     UseCaseValidationException,
 )
 from src.modules.media.application.dtos.media_file_dtos import RemoveFileVariantInput
+from src.modules.media.application.unit_of_work import (
+    MediaUnitOfWork,
+    MediaUnitOfWorkFactory,
+)
 from src.modules.media.domain.entities.file_variant_mixin import FileVariantMixin
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import EpisodeId, MediaFile, MovieId
 from src.shared_kernel.value_objects.file_path import FilePath
 
@@ -18,26 +21,20 @@ class RemoveFileVariantUseCase:
     is promoted to primary.
 
     Example:
-        >>> use_case = RemoveFileVariantUseCase(movie_repo, series_repo)
+        >>> use_case = RemoveFileVariantUseCase(uow_factory)
         >>> await use_case.execute(RemoveFileVariantInput(
         ...     media_id="mov_abc123",
         ...     file_path="/movies/inception_720p.mkv",
         ... ))
     """
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Repository for movie persistence.
-            series_repository: Repository for series persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: RemoveFileVariantInput) -> None:
         """Execute the use case.
@@ -51,26 +48,35 @@ class RemoveFileVariantUseCase:
         """
         prefix = input_dto.media_id.split("_")[0] if "_" in input_dto.media_id else ""
 
-        if prefix == "mov":
-            await self._remove_from_movie(input_dto)
-        elif prefix == "epi":
-            await self._remove_from_episode(input_dto)
-        else:
-            raise ResourceNotFoundException.for_resource("Media", input_dto.media_id)
+        async with self._uow_factory() as uow:
+            if prefix == "mov":
+                await self._remove_from_movie(uow, input_dto)
+                return
+            if prefix == "epi":
+                await self._remove_from_episode(uow, input_dto)
+                return
 
-    async def _remove_from_movie(self, input_dto: RemoveFileVariantInput) -> None:
-        movie = await self._movie_repository.find_by_id(MovieId(input_dto.media_id))
+        raise ResourceNotFoundException.for_resource("Media", input_dto.media_id)
+
+    @staticmethod
+    async def _remove_from_movie(
+        uow: MediaUnitOfWork,
+        input_dto: RemoveFileVariantInput,
+    ) -> None:
+        movie = await uow.movies.find_by_id(MovieId(input_dto.media_id))
         if movie is None:
             raise ResourceNotFoundException.for_resource("Movie", input_dto.media_id)
 
         new_files = _remove_file_and_promote(movie, input_dto.file_path)
         movie = movie.with_updates(files=new_files)
-        await self._movie_repository.save(movie)
+        await uow.movies.save(movie)
 
-    async def _remove_from_episode(self, input_dto: RemoveFileVariantInput) -> None:
-        series = await self._series_repository.find_by_episode_id(
-            EpisodeId(input_dto.media_id),
-        )
+    @staticmethod
+    async def _remove_from_episode(
+        uow: MediaUnitOfWork,
+        input_dto: RemoveFileVariantInput,
+    ) -> None:
+        series = await uow.series.find_by_episode_id(EpisodeId(input_dto.media_id))
         if series is None:
             raise ResourceNotFoundException.for_resource("Episode", input_dto.media_id)
 
@@ -86,7 +92,7 @@ class RemoveFileVariantUseCase:
             updated_seasons.append(season.with_updates(episodes=updated_episodes))
 
         updated_series = series.with_updates(seasons=updated_seasons)
-        await self._series_repository.save(updated_series)
+        await uow.series.save(updated_series)
 
 
 def _remove_file_and_promote(

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -7,9 +7,12 @@ from src.building_blocks.application.event_bus import EventBus
 from src.building_blocks.domain.events import DomainEvent
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput, ScanMediaOutput
 from src.modules.media.application.ports import FileSystemScanner, MediaType, ScannedFile
+from src.modules.media.application.unit_of_work import (
+    MediaUnitOfWork,
+    MediaUnitOfWorkFactory,
+)
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.events import MediaCreatedEvent
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeNumber,
@@ -37,11 +40,14 @@ class ScanMediaDirectoriesUseCase:
     when their stored resolution is ``Unknown`` or their track lists are
     still empty, so rescans of fully-populated libraries skip ffprobe.
 
+    Each movie group and each series is persisted in its own Unit of
+    Work so a failure on one group rolls back only that transaction —
+    other groups discovered in the same scan commit independently.
+
     Args:
         file_scanner: Port for filesystem scanning.
         variant_detector: Service for grouping file variants.
-        movie_repository: Repository for movie persistence.
-        series_repository: Repository for series persistence.
+        uow_factory: Factory that opens a fresh media Unit of Work per group.
         probe_service: Optional ffprobe service for track and resolution detection.
         event_bus: Optional event bus for domain events.
     """
@@ -50,15 +56,13 @@ class ScanMediaDirectoriesUseCase:
         self,
         file_scanner: FileSystemScanner,
         variant_detector: VariantDetector,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        uow_factory: MediaUnitOfWorkFactory,
         probe_service: MediaProbeService | None = None,
         event_bus: EventBus | None = None,
     ) -> None:
         self._file_scanner = file_scanner
         self._variant_detector = variant_detector
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
         self._probe_service = probe_service
         self._event_bus = event_bus
 
@@ -202,26 +206,29 @@ class ScanMediaDirectoriesUseCase:
         paths: list[str],
         by_path: dict[str, ScannedFile],
     ) -> tuple[int, int]:
-        """Process a single group of movie file variants."""
-        existing = await self._find_existing_movie(paths, by_path)
-        if existing:
-            return await self._update_movie(existing, paths, by_path)
-        return await self._create_movie(paths, by_path)
+        """Process a single group of movie file variants in its own UoW."""
+        async with self._uow_factory() as uow:
+            existing = await self._find_existing_movie(uow, paths, by_path)
+            if existing:
+                return await self._update_movie(uow, existing, paths, by_path)
+            return await self._create_movie(uow, paths, by_path)
 
+    @staticmethod
     async def _find_existing_movie(
-        self,
+        uow: MediaUnitOfWork,
         paths: list[str],
         by_path: dict[str, ScannedFile],
     ) -> Movie | None:
         """Find an existing movie matching any of the given file paths."""
         for path in paths:
-            movie = await self._movie_repository.find_by_file_path(by_path[path].file_path)
+            movie = await uow.movies.find_by_file_path(by_path[path].file_path)
             if movie:
                 return movie
         return None
 
     async def _update_movie(
         self,
+        uow: MediaUnitOfWork,
         movie: Movie,
         paths: list[str],
         by_path: dict[str, ScannedFile],
@@ -248,12 +255,13 @@ class ScanMediaDirectoriesUseCase:
 
         if changed:
             movie = movie.with_updates(files=files)
-            await self._movie_repository.save(movie)
+            await uow.movies.save(movie)
             return 0, 1
         return 0, 0
 
     async def _create_movie(
         self,
+        uow: MediaUnitOfWork,
         paths: list[str],
         by_path: dict[str, ScannedFile],
     ) -> tuple[int, int]:
@@ -274,7 +282,7 @@ class ScanMediaDirectoriesUseCase:
                 await self._build_new_media_file(by_path[path], is_primary=False)
             )
         events = movie.pull_events()
-        await self._movie_repository.save(movie)
+        await uow.movies.save(movie)
         await self._dispatch_events(events)
         return 1, 0
 
@@ -311,29 +319,30 @@ class ScanMediaDirectoriesUseCase:
         series_name: str,
         files: list[ScannedFile],
     ) -> tuple[int, int]:
-        """Process all episodes of a single series."""
+        """Process all episodes of a single series in its own UoW."""
         created = 0
         updated = 0
 
-        series = await self._series_repository.find_by_title(Title(series_name))
-        if not series:
-            year = min((f.year for f in files if f.year), default=_current_year())
-            series = Series.create(title=series_name, start_year=year)
+        async with self._uow_factory() as uow:
+            series = await uow.series.find_by_title(Title(series_name))
+            if not series:
+                year = min((f.year for f in files if f.year), default=_current_year())
+                series = Series.create(title=series_name, start_year=year)
 
-        ep_groups: dict[tuple[int, int], list[ScannedFile]] = defaultdict(list)
-        for f in files:
-            if f.season_number is not None and f.episode_number is not None:
-                ep_groups[(f.season_number, f.episode_number)].append(f)
+            ep_groups: dict[tuple[int, int], list[ScannedFile]] = defaultdict(list)
+            for f in files:
+                if f.season_number is not None and f.episode_number is not None:
+                    ep_groups[(f.season_number, f.episode_number)].append(f)
 
-        for (season_num, episode_num), ep_files in ep_groups.items():
-            series, c, u = await self._process_episode_group(
-                series, season_num, episode_num, ep_files
-            )
-            created += c
-            updated += u
+            for (season_num, episode_num), ep_files in ep_groups.items():
+                series, c, u = await self._process_episode_group(
+                    series, season_num, episode_num, ep_files
+                )
+                created += c
+                updated += u
 
-        events = series.pull_events()
-        await self._series_repository.save(series)
+            events = series.pull_events()
+            await uow.series.save(series)
         await self._dispatch_events(events)
         return created, updated
 

--- a/src/modules/media/application/use_cases/set_primary_file.py
+++ b/src/modules/media/application/use_cases/set_primary_file.py
@@ -5,11 +5,14 @@ from src.modules.media.application.dtos.media_file_dtos import (
     MediaFileOutput,
     SetPrimaryFileInput,
 )
+from src.modules.media.application.unit_of_work import (
+    MediaUnitOfWork,
+    MediaUnitOfWorkFactory,
+)
 from src.modules.media.application.use_cases._media_file_helpers import (
     to_media_file_output,
 )
 from src.modules.media.domain.entities.file_variant_mixin import FileVariantMixin
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import EpisodeId, MediaFile, MovieId
 from src.shared_kernel.value_objects.file_path import FilePath
 
@@ -21,26 +24,20 @@ class SetPrimaryFileUseCase:
     specified file_path.
 
     Example:
-        >>> use_case = SetPrimaryFileUseCase(movie_repo, series_repo)
+        >>> use_case = SetPrimaryFileUseCase(uow_factory)
         >>> result = await use_case.execute(SetPrimaryFileInput(
         ...     media_id="mov_abc123",
         ...     file_path="/movies/inception_4k.mkv",
         ... ))
     """
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Repository for movie persistence.
-            series_repository: Repository for series persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: SetPrimaryFileInput) -> list[MediaFileOutput]:
         """Execute the use case.
@@ -56,27 +53,34 @@ class SetPrimaryFileUseCase:
         """
         prefix = input_dto.media_id.split("_")[0] if "_" in input_dto.media_id else ""
 
-        if prefix == "mov":
-            return await self._set_for_movie(input_dto)
-        if prefix == "epi":
-            return await self._set_for_episode(input_dto)
+        async with self._uow_factory() as uow:
+            if prefix == "mov":
+                return await self._set_for_movie(uow, input_dto)
+            if prefix == "epi":
+                return await self._set_for_episode(uow, input_dto)
 
         raise ResourceNotFoundException.for_resource("Media", input_dto.media_id)
 
-    async def _set_for_movie(self, input_dto: SetPrimaryFileInput) -> list[MediaFileOutput]:
-        movie = await self._movie_repository.find_by_id(MovieId(input_dto.media_id))
+    @staticmethod
+    async def _set_for_movie(
+        uow: MediaUnitOfWork,
+        input_dto: SetPrimaryFileInput,
+    ) -> list[MediaFileOutput]:
+        movie = await uow.movies.find_by_id(MovieId(input_dto.media_id))
         if movie is None:
             raise ResourceNotFoundException.for_resource("Movie", input_dto.media_id)
 
         new_files = _switch_primary(movie, input_dto.file_path)
         movie = movie.with_updates(files=new_files)
-        saved = await self._movie_repository.save(movie)
+        saved = await uow.movies.save(movie)
         return [to_media_file_output(f) for f in saved.files]
 
-    async def _set_for_episode(self, input_dto: SetPrimaryFileInput) -> list[MediaFileOutput]:
-        series = await self._series_repository.find_by_episode_id(
-            EpisodeId(input_dto.media_id),
-        )
+    @staticmethod
+    async def _set_for_episode(
+        uow: MediaUnitOfWork,
+        input_dto: SetPrimaryFileInput,
+    ) -> list[MediaFileOutput]:
+        series = await uow.series.find_by_episode_id(EpisodeId(input_dto.media_id))
         if series is None:
             raise ResourceNotFoundException.for_resource("Episode", input_dto.media_id)
 
@@ -95,7 +99,7 @@ class SetPrimaryFileUseCase:
             updated_seasons.append(season.with_updates(episodes=updated_episodes))
 
         updated_series = series.with_updates(seasons=updated_seasons)
-        await self._series_repository.save(updated_series)
+        await uow.series.save(updated_series)
         return result_files
 
 

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -101,9 +101,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
             self._session.add(model)
             await self._session.flush()
 
-        await self._session.commit()
-
-        # Reload with relationships to return a complete entity
+        # Reload with relationships to return a complete entity.
+        # Transaction commit is the Unit of Work's responsibility.
         assert movie.id is not None
         result_entity = await self.find_by_id(movie.id)
         assert result_entity is not None
@@ -130,7 +129,6 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         model.soft_delete()
         await self._session.flush()
-        await self._session.commit()
         return True
 
     async def list_all(self) -> Sequence[Movie]:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -163,7 +163,6 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 episode.soft_delete()
 
         await self._session.flush()
-        await self._session.commit()
         return True
 
     async def list_all(self) -> Sequence[Series]:
@@ -467,9 +466,9 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 self._session.add(episode_model)
 
         await self._session.flush()
-        await self._session.commit()
 
-        # Reload and return (series.id is guaranteed to exist after _ensure_ids)
+        # Reload and return (series.id is guaranteed to exist after _ensure_ids).
+        # Transaction commit is the Unit of Work's responsibility.
         assert series.id is not None
         result = await self.find_by_id(series.id)
         assert result is not None
@@ -521,9 +520,9 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 ep_model.soft_delete()
 
         await self._session.flush()
-        await self._session.commit()
 
-        # Reload and return (series.id is guaranteed to exist)
+        # Reload and return (series.id is guaranteed to exist).
+        # Transaction commit is the Unit of Work's responsibility.
         assert series.id is not None
         result = await self.find_by_id(series.id)
         assert result is not None

--- a/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -1,0 +1,89 @@
+"""SQLAlchemy implementation of MediaUnitOfWork."""
+
+from types import TracebackType
+from typing import Self
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.config.persistence.session_manager import create_tracked_session
+from src.modules.media.application.unit_of_work import (
+    MediaUnitOfWork,
+    MediaUnitOfWorkFactory,
+)
+from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
+    SQLAlchemyMovieRepository,
+)
+from src.modules.media.infrastructure.persistence.repositories.series_repository import (
+    SQLAlchemySeriesRepository,
+)
+
+
+class SqlAlchemyMediaUnitOfWork(MediaUnitOfWork):
+    """SQLAlchemy-backed Unit of Work for the media bounded context.
+
+    Each ``async with`` block opens a fresh session registered for the
+    request-scoped cleanup middleware, instantiates the movie and
+    series repositories on that session, and commits on success or
+    rolls back on exception.
+
+    Nesting is not supported — entering an already-open UoW raises
+    ``RuntimeError`` rather than silently creating a parallel session.
+    """
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+        self._session: AsyncSession | None = None
+
+    async def __aenter__(self) -> Self:
+        if self._session is not None:
+            raise RuntimeError("MediaUnitOfWork is already active; nested use is not supported.")
+        self._session = create_tracked_session(self._session_factory)
+        self.movies = SQLAlchemyMovieRepository(self._session)
+        self.series = SQLAlchemySeriesRepository(self._session)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        assert self._session is not None
+        try:
+            if exc_type is None:
+                await self._session.commit()
+            else:
+                await self._session.rollback()
+        finally:
+            # The request-scoped middleware closes tracked sessions, but
+            # we reset our handle so the UoW instance could be reused in
+            # a new ``async with`` block if the caller holds it.
+            self._session = None
+
+    async def commit(self) -> None:
+        assert self._session is not None, "UnitOfWork not started; use `async with`."
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        assert self._session is not None, "UnitOfWork not started; use `async with`."
+        await self._session.rollback()
+
+
+class SqlAlchemyMediaUnitOfWorkFactory(MediaUnitOfWorkFactory):
+    """Produce fresh :class:`SqlAlchemyMediaUnitOfWork` instances.
+
+    Holds the app-scoped session factory and hands out one new UoW
+    per call, so each transactional block starts with its own session.
+    """
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    def __call__(self) -> MediaUnitOfWork:
+        return SqlAlchemyMediaUnitOfWork(self._session_factory)
+
+
+__all__ = [
+    "SqlAlchemyMediaUnitOfWork",
+    "SqlAlchemyMediaUnitOfWorkFactory",
+]

--- a/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -61,10 +61,12 @@ class SqlAlchemyMediaUnitOfWork(MediaUnitOfWork):
             self._session = None
 
     async def commit(self) -> None:
+        """Commit the active transaction."""
         assert self._session is not None, "UnitOfWork not started; use `async with`."
         await self._session.commit()
 
     async def rollback(self) -> None:
+        """Roll back the active transaction."""
         assert self._session is not None, "UnitOfWork not started; use `async with`."
         await self._session.rollback()
 
@@ -80,6 +82,7 @@ class SqlAlchemyMediaUnitOfWorkFactory(MediaUnitOfWorkFactory):
         self._session_factory = session_factory
 
     def __call__(self) -> MediaUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
         return SqlAlchemyMediaUnitOfWork(self._session_factory)
 
 

--- a/src/modules/watch_progress/application/unit_of_work.py
+++ b/src/modules/watch_progress/application/unit_of_work.py
@@ -1,0 +1,23 @@
+"""Watch Progress bounded-context Unit of Work interface."""
+
+from abc import ABC, abstractmethod
+
+from src.building_blocks.application.unit_of_work import UnitOfWork
+from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+
+
+class WatchProgressUnitOfWork(UnitOfWork):
+    """Transactional boundary for WatchProgress writes."""
+
+    progress: WatchProgressRepository
+
+
+class WatchProgressUnitOfWorkFactory(ABC):
+    """Builds fresh ``WatchProgressUnitOfWork`` instances on demand."""
+
+    @abstractmethod
+    def __call__(self) -> WatchProgressUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+
+
+__all__ = ["WatchProgressUnitOfWork", "WatchProgressUnitOfWorkFactory"]

--- a/src/modules/watch_progress/application/use_cases/clear_progress.py
+++ b/src/modules/watch_progress/application/use_cases/clear_progress.py
@@ -2,7 +2,9 @@
 
 from dataclasses import dataclass
 
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.modules.watch_progress.application.unit_of_work import (
+    WatchProgressUnitOfWorkFactory,
+)
 
 
 @dataclass(frozen=True)
@@ -17,20 +19,15 @@ class ClearProgressInput:
 
 
 class ClearProgressUseCase:
-    """Clear (soft-delete) watch progress for a media item.
+    """Clear (soft-delete) watch progress for a media item."""
 
-    Example:
-        >>> use_case = ClearProgressUseCase(progress_repository)
-        >>> await use_case.execute(ClearProgressInput("mov_abc123def456"))
-    """
-
-    def __init__(self, progress_repository: WatchProgressRepository) -> None:
+    def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            progress_repository: Repository for watch progress persistence.
+            uow_factory: Factory that opens a fresh watch progress UoW.
         """
-        self._repo = progress_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ClearProgressInput) -> bool:
         """Execute the use case.
@@ -41,7 +38,8 @@ class ClearProgressUseCase:
         Returns:
             True if progress was found and deleted, False otherwise.
         """
-        return await self._repo.delete(input_dto.media_id)
+        async with self._uow_factory() as uow:
+            return await uow.progress.delete(input_dto.media_id)
 
 
 __all__ = ["ClearProgressUseCase"]

--- a/src/modules/watch_progress/application/use_cases/clear_series_progress.py
+++ b/src/modules/watch_progress/application/use_cases/clear_series_progress.py
@@ -2,7 +2,9 @@
 
 from dataclasses import dataclass
 
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.modules.watch_progress.application.unit_of_work import (
+    WatchProgressUnitOfWorkFactory,
+)
 
 
 @dataclass(frozen=True)
@@ -25,8 +27,8 @@ class ClearSeriesProgressUseCase:
     next in-progress episode and the series reappears.
     """
 
-    def __init__(self, progress_repository: WatchProgressRepository) -> None:
-        self._repo = progress_repository
+    def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ClearSeriesProgressInput) -> int:
         """Execute the use case.
@@ -37,7 +39,8 @@ class ClearSeriesProgressUseCase:
         Returns:
             Number of episode progress records soft-deleted.
         """
-        return await self._repo.delete_by_series(input_dto.series_id)
+        async with self._uow_factory() as uow:
+            return await uow.progress.delete_by_series(input_dto.series_id)
 
 
 __all__ = ["ClearSeriesProgressUseCase"]

--- a/src/modules/watch_progress/application/use_cases/save_progress.py
+++ b/src/modules/watch_progress/application/use_cases/save_progress.py
@@ -1,8 +1,10 @@
 """SaveProgressUseCase - Save or update watch progress."""
 
 from src.modules.watch_progress.application.dtos import ProgressOutput, SaveProgressInput
+from src.modules.watch_progress.application.unit_of_work import (
+    WatchProgressUnitOfWorkFactory,
+)
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
 
 
@@ -11,24 +13,15 @@ class SaveProgressUseCase:
 
     Creates a new progress record if none exists, or updates the
     existing one. Automatically marks as completed at ≥90%.
-
-    Example:
-        >>> use_case = SaveProgressUseCase(progress_repository)
-        >>> result = await use_case.execute(SaveProgressInput(
-        ...     media_id="mov_abc123def456",
-        ...     media_type="movie",
-        ...     position_seconds=3600,
-        ...     duration_seconds=7200,
-        ... ))
     """
 
-    def __init__(self, progress_repository: WatchProgressRepository) -> None:
+    def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            progress_repository: Repository for watch progress persistence.
+            uow_factory: Factory that opens a fresh watch progress UoW.
         """
-        self._repo = progress_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: SaveProgressInput) -> ProgressOutput:
         """Execute the use case.
@@ -39,26 +32,27 @@ class SaveProgressUseCase:
         Returns:
             The saved progress output.
         """
-        existing = await self._repo.find_by_media_id(input_dto.media_id)
+        async with self._uow_factory() as uow:
+            existing = await uow.progress.find_by_media_id(input_dto.media_id)
 
-        if existing:
-            progress = existing.update_position(
-                position_seconds=input_dto.position_seconds,
-                duration_seconds=input_dto.duration_seconds,
-                audio_track=input_dto.audio_track,
-                subtitle_track=input_dto.subtitle_track,
-            )
-        else:
-            progress = WatchProgress.create(
-                media_id=input_dto.media_id,
-                media_type=WatchableMediaType(input_dto.media_type),
-                position_seconds=input_dto.position_seconds,
-                duration_seconds=input_dto.duration_seconds,
-                audio_track=input_dto.audio_track,
-                subtitle_track=input_dto.subtitle_track,
-            )
+            if existing:
+                progress = existing.update_position(
+                    position_seconds=input_dto.position_seconds,
+                    duration_seconds=input_dto.duration_seconds,
+                    audio_track=input_dto.audio_track,
+                    subtitle_track=input_dto.subtitle_track,
+                )
+            else:
+                progress = WatchProgress.create(
+                    media_id=input_dto.media_id,
+                    media_type=WatchableMediaType(input_dto.media_type),
+                    position_seconds=input_dto.position_seconds,
+                    duration_seconds=input_dto.duration_seconds,
+                    audio_track=input_dto.audio_track,
+                    subtitle_track=input_dto.subtitle_track,
+                )
 
-        saved = await self._repo.save(progress)
+            saved = await uow.progress.save(progress)
         return ProgressOutput.from_entity(saved)
 
 

--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -50,13 +50,13 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
 
         if existing:
             WatchProgressMapper.update_model(existing, progress)
-            await self._session.commit()
+            await self._session.flush()
             await self._session.refresh(existing)
             return WatchProgressMapper.to_entity(existing)
 
         model = WatchProgressMapper.to_model(progress)
         self._session.add(model)
-        await self._session.commit()
+        await self._session.flush()
         await self._session.refresh(model)
         return WatchProgressMapper.to_entity(model)
 
@@ -112,7 +112,7 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
             return False
 
         model.soft_delete()
-        await self._session.commit()
+        await self._session.flush()
         return True
 
     async def delete_by_series(self, series_id: str) -> int:
@@ -127,7 +127,7 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         for model in models:
             model.soft_delete()
         if models:
-            await self._session.commit()
+            await self._session.flush()
         return len(models)
 
 

--- a/src/modules/watch_progress/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/watch_progress/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -1,0 +1,74 @@
+"""SQLAlchemy implementation of WatchProgressUnitOfWork."""
+
+from types import TracebackType
+from typing import Self
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.config.persistence.session_manager import create_tracked_session
+from src.modules.watch_progress.application.unit_of_work import (
+    WatchProgressUnitOfWork,
+    WatchProgressUnitOfWorkFactory,
+)
+from src.modules.watch_progress.infrastructure.persistence.repositories.watch_progress_repository import (
+    SQLAlchemyWatchProgressRepository,
+)
+
+
+class SqlAlchemyWatchProgressUnitOfWork(WatchProgressUnitOfWork):
+    """SQLAlchemy-backed Unit of Work for the watch_progress context."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+        self._session: AsyncSession | None = None
+
+    async def __aenter__(self) -> Self:
+        if self._session is not None:
+            raise RuntimeError(
+                "WatchProgressUnitOfWork is already active; nested use is not supported."
+            )
+        self._session = create_tracked_session(self._session_factory)
+        self.progress = SQLAlchemyWatchProgressRepository(self._session)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        assert self._session is not None
+        try:
+            if exc_type is None:
+                await self._session.commit()
+            else:
+                await self._session.rollback()
+        finally:
+            self._session = None
+
+    async def commit(self) -> None:
+        """Commit the active transaction."""
+        assert self._session is not None, "UnitOfWork not started; use `async with`."
+        await self._session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the active transaction."""
+        assert self._session is not None, "UnitOfWork not started; use `async with`."
+        await self._session.rollback()
+
+
+class SqlAlchemyWatchProgressUnitOfWorkFactory(WatchProgressUnitOfWorkFactory):
+    """Produce fresh :class:`SqlAlchemyWatchProgressUnitOfWork` instances."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    def __call__(self) -> WatchProgressUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+        return SqlAlchemyWatchProgressUnitOfWork(self._session_factory)
+
+
+__all__ = [
+    "SqlAlchemyWatchProgressUnitOfWork",
+    "SqlAlchemyWatchProgressUnitOfWorkFactory",
+]

--- a/tests/building_blocks/unit/application/test_unit_of_work.py
+++ b/tests/building_blocks/unit/application/test_unit_of_work.py
@@ -1,0 +1,86 @@
+"""Contract tests for the abstract UnitOfWork base."""
+
+from types import TracebackType
+from typing import Self
+
+import pytest
+
+from src.building_blocks.application.unit_of_work import UnitOfWork
+
+
+class _RecordingUnitOfWork(UnitOfWork):
+    """Minimal concrete implementation used to verify the contract.
+
+    Tracks the lifecycle calls so tests can assert enter/exit/commit/
+    rollback ordering without touching a real database.
+    """
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    async def __aenter__(self) -> Self:
+        self.events.append("enter")
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if exc_type is None:
+            await self.commit()
+        else:
+            await self.rollback()
+        self.events.append("exit")
+
+    async def commit(self) -> None:
+        self.commits += 1
+        self.events.append("commit")
+
+    async def rollback(self) -> None:
+        self.rollbacks += 1
+        self.events.append("rollback")
+
+
+@pytest.mark.unit
+class TestUnitOfWorkContract:
+    """Every UoW must commit on success and rollback on failure."""
+
+    @pytest.mark.asyncio
+    async def test_should_commit_on_clean_exit(self) -> None:
+        uow = _RecordingUnitOfWork()
+
+        async with uow:
+            pass
+
+        assert uow.events == ["enter", "commit", "exit"]
+        assert uow.commits == 1
+        assert uow.rollbacks == 0
+
+    @pytest.mark.asyncio
+    async def test_should_rollback_on_exception_and_propagate(self) -> None:
+        uow = _RecordingUnitOfWork()
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with uow:
+                raise RuntimeError("boom")
+
+        assert uow.events == ["enter", "rollback", "exit"]
+        assert uow.commits == 0
+        assert uow.rollbacks == 1
+
+    @pytest.mark.asyncio
+    async def test_should_allow_explicit_commit_inside_context(self) -> None:
+        uow = _RecordingUnitOfWork()
+
+        async with uow:
+            await uow.commit()
+
+        assert uow.commits == 2  # explicit + auto on exit
+
+    def test_should_refuse_instantiation_without_implementing_abstract_methods(self) -> None:
+        with pytest.raises(TypeError):
+            UnitOfWork()  # type: ignore[abstract]

--- a/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
@@ -1,8 +1,8 @@
 """Tests for AddItemToCustomListUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.building_blocks.domain import BusinessRuleViolationException
@@ -14,7 +14,6 @@ from src.modules.collections.domain.entities import (
     CustomListItem,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
-from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 def _create_list(name: str = "Test List", item_count: int = 0) -> CustomList:

--- a/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
@@ -13,8 +13,8 @@ from src.modules.collections.domain.entities import (
     CustomList,
     CustomListItem,
 )
-from src.modules.collections.domain.repositories import CustomListRepository
 from src.shared_kernel.value_objects import CollectionMediaType
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 def _create_list(name: str = "Test List", item_count: int = 0) -> CustomList:
@@ -28,7 +28,8 @@ class TestAddItemToCustomListUseCase:
     @pytest.mark.asyncio
     async def test_should_add_item_successfully(self) -> None:
         custom_list = _create_list()
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.find_item.return_value = None
         mock_repo.get_next_position.return_value = 0
@@ -38,7 +39,7 @@ class TestAddItemToCustomListUseCase:
             position=0,
         )
         mock_repo.update.return_value = custom_list.increment_item_count()
-        use_case = AddItemToCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = AddItemToCustomListUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             AddItemToCustomListInput(
@@ -53,9 +54,10 @@ class TestAddItemToCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = None
-        use_case = AddItemToCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = AddItemToCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
@@ -75,10 +77,11 @@ class TestAddItemToCustomListUseCase:
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.find_item.return_value = existing_item
-        use_case = AddItemToCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = AddItemToCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(BusinessRuleViolationException) as exc_info:
             await use_case.execute(
@@ -94,10 +97,11 @@ class TestAddItemToCustomListUseCase:
     @pytest.mark.asyncio
     async def test_should_raise_when_list_is_full(self) -> None:
         custom_list = _create_list(item_count=MAX_ITEMS_PER_LIST)
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.find_item.return_value = None
-        use_case = AddItemToCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = AddItemToCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(BusinessRuleViolationException) as exc_info:
             await use_case.execute(
@@ -113,7 +117,8 @@ class TestAddItemToCustomListUseCase:
     @pytest.mark.asyncio
     async def test_should_use_next_position(self) -> None:
         custom_list = _create_list(item_count=3)
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.find_item.return_value = None
         mock_repo.get_next_position.return_value = 3
@@ -123,7 +128,7 @@ class TestAddItemToCustomListUseCase:
             position=3,
         )
         mock_repo.update.return_value = custom_list.increment_item_count()
-        use_case = AddItemToCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = AddItemToCustomListUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             AddItemToCustomListInput(

--- a/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
@@ -11,7 +11,7 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.use_cases import CreateCustomListUseCase
 from src.modules.collections.domain.entities import MAX_LISTS, CustomList
-from src.modules.collections.domain.repositories import CustomListRepository
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit
@@ -20,12 +20,13 @@ class TestCreateCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_create_list_successfully(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 0
         mock_repo.find_by_name.return_value = None
         saved_list = CustomList.create(name="Action Movies")
         mock_repo.add.return_value = saved_list
-        use_case = CreateCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(CreateCustomListInput(name="Action Movies"))
 
@@ -36,9 +37,10 @@ class TestCreateCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_list_limit_reached(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.count.return_value = MAX_LISTS
-        use_case = CreateCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(BusinessRuleViolationException) as exc_info:
             await use_case.execute(CreateCustomListInput(name="New List"))
@@ -48,10 +50,11 @@ class TestCreateCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_name_already_exists(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 1
         mock_repo.find_by_name.return_value = CustomList.create(name="Action Movies")
-        use_case = CreateCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(BusinessRuleViolationException) as exc_info:
             await use_case.execute(CreateCustomListInput(name="Action Movies"))
@@ -61,12 +64,13 @@ class TestCreateCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_strip_name_before_duplicate_check(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 0
         mock_repo.find_by_name.return_value = None
         saved_list = CustomList.create(name="Action Movies")
         mock_repo.add.return_value = saved_list
-        use_case = CreateCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(CreateCustomListInput(name="  Action Movies  "))
 

--- a/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
@@ -1,8 +1,8 @@
 """Tests for CreateCustomListUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.building_blocks.domain import BusinessRuleViolationException
 from src.modules.collections.application.dtos import (
@@ -11,7 +11,6 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.use_cases import CreateCustomListUseCase
 from src.modules.collections.domain.entities import MAX_LISTS, CustomList
-from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit

--- a/tests/modules/collections/unit/application/use_cases/test_delete_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_delete_custom_list.py
@@ -7,7 +7,7 @@ import pytest
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.collections.application.use_cases import DeleteCustomListUseCase
 from src.modules.collections.domain.entities import CustomList
-from src.modules.collections.domain.repositories import CustomListRepository
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit
@@ -17,9 +17,10 @@ class TestDeleteCustomListUseCase:
     @pytest.mark.asyncio
     async def test_should_delete_successfully(self) -> None:
         custom_list = CustomList.create(name="To Delete")
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.remove.return_value = True
-        use_case = DeleteCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = DeleteCustomListUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(str(custom_list.id))
 
@@ -27,9 +28,10 @@ class TestDeleteCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.remove.return_value = False
-        use_case = DeleteCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = DeleteCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute("lst_nonexistent00")

--- a/tests/modules/collections/unit/application/use_cases/test_delete_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_delete_custom_list.py
@@ -1,13 +1,12 @@
 """Tests for DeleteCustomListUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.collections.application.use_cases import DeleteCustomListUseCase
 from src.modules.collections.domain.entities import CustomList
-from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit

--- a/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
@@ -10,7 +10,7 @@ from src.modules.collections.application.use_cases import (
     RemoveItemFromCustomListUseCase,
 )
 from src.modules.collections.domain.entities import CustomList
-from src.modules.collections.domain.repositories import CustomListRepository
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit
@@ -20,11 +20,12 @@ class TestRemoveItemFromCustomListUseCase:
     @pytest.mark.asyncio
     async def test_should_remove_item_successfully(self) -> None:
         custom_list = CustomList.create(name="Test").with_updates(item_count=3)
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.remove_item.return_value = True
         mock_repo.update.return_value = custom_list.decrement_item_count()
-        use_case = RemoveItemFromCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = RemoveItemFromCustomListUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             RemoveItemFromCustomListInput(
@@ -38,9 +39,10 @@ class TestRemoveItemFromCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = None
-        use_case = RemoveItemFromCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = RemoveItemFromCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
@@ -55,10 +57,11 @@ class TestRemoveItemFromCustomListUseCase:
     @pytest.mark.asyncio
     async def test_should_raise_when_item_not_in_list(self) -> None:
         custom_list = CustomList.create(name="Test")
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.remove_item.return_value = False
-        use_case = RemoveItemFromCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = RemoveItemFromCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
@@ -73,11 +76,12 @@ class TestRemoveItemFromCustomListUseCase:
     @pytest.mark.asyncio
     async def test_should_decrement_item_count_after_removal(self) -> None:
         custom_list = CustomList.create(name="Test").with_updates(item_count=5)
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.remove_item.return_value = True
         mock_repo.update.return_value = custom_list.decrement_item_count()
-        use_case = RemoveItemFromCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = RemoveItemFromCustomListUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             RemoveItemFromCustomListInput(

--- a/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
@@ -1,8 +1,8 @@
 """Tests for RemoveItemFromCustomListUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.collections.application.dtos import RemoveItemFromCustomListInput
@@ -10,7 +10,6 @@ from src.modules.collections.application.use_cases import (
     RemoveItemFromCustomListUseCase,
 )
 from src.modules.collections.domain.entities import CustomList
-from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit

--- a/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
@@ -12,7 +12,7 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.use_cases import RenameCustomListUseCase
 from src.modules.collections.domain.entities import CustomList
-from src.modules.collections.domain.repositories import CustomListRepository
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit
@@ -23,11 +23,12 @@ class TestRenameCustomListUseCase:
     async def test_should_rename_successfully(self) -> None:
         custom_list = CustomList.create(name="Old Name")
         renamed = custom_list.rename("New Name")
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.find_by_name.return_value = None
         mock_repo.update.return_value = renamed
-        use_case = RenameCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = RenameCustomListUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             RenameCustomListInput(list_id=str(custom_list.id), name="New Name")
@@ -39,9 +40,10 @@ class TestRenameCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = None
-        use_case = RenameCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = RenameCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
@@ -54,10 +56,11 @@ class TestRenameCustomListUseCase:
     async def test_should_raise_when_name_taken_by_other_list(self) -> None:
         custom_list = CustomList.create(name="My List")
         other_list = CustomList.create(name="Taken Name")
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.find_by_name.return_value = other_list
-        use_case = RenameCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = RenameCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(BusinessRuleViolationException) as exc_info:
             await use_case.execute(
@@ -69,11 +72,12 @@ class TestRenameCustomListUseCase:
     @pytest.mark.asyncio
     async def test_should_allow_renaming_to_same_name(self) -> None:
         custom_list = CustomList.create(name="Same Name")
-        mock_repo = AsyncMock(spec=CustomListRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
         mock_repo.find_by_name.return_value = custom_list
         mock_repo.update.return_value = custom_list
-        use_case = RenameCustomListUseCase(custom_list_repository=mock_repo)
+        use_case = RenameCustomListUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             RenameCustomListInput(list_id=str(custom_list.id), name="Same Name")

--- a/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
@@ -1,8 +1,8 @@
 """Tests for RenameCustomListUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.building_blocks.domain import BusinessRuleViolationException
@@ -12,7 +12,6 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.use_cases import RenameCustomListUseCase
 from src.modules.collections.domain.entities import CustomList
-from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit

--- a/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
@@ -10,8 +10,8 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.use_cases import ToggleWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
-from src.modules.collections.domain.repositories import WatchlistRepository
 from src.shared_kernel.value_objects import CollectionMediaType
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit
@@ -20,13 +20,14 @@ class TestToggleWatchlistUseCase:
 
     @pytest.mark.asyncio
     async def test_should_add_when_not_in_watchlist(self) -> None:
-        mock_repo = AsyncMock(spec=WatchlistRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.watchlist
         mock_repo.exists.return_value = False
         mock_repo.add.return_value = WatchlistItem.create(
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
-        use_case = ToggleWatchlistUseCase(watchlist_repository=mock_repo)
+        use_case = ToggleWatchlistUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             ToggleWatchlistInput(
@@ -42,10 +43,11 @@ class TestToggleWatchlistUseCase:
 
     @pytest.mark.asyncio
     async def test_should_remove_when_already_in_watchlist(self) -> None:
-        mock_repo = AsyncMock(spec=WatchlistRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.watchlist
         mock_repo.exists.return_value = True
         mock_repo.remove.return_value = True
-        use_case = ToggleWatchlistUseCase(watchlist_repository=mock_repo)
+        use_case = ToggleWatchlistUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             ToggleWatchlistInput(
@@ -60,13 +62,14 @@ class TestToggleWatchlistUseCase:
 
     @pytest.mark.asyncio
     async def test_should_toggle_series(self) -> None:
-        mock_repo = AsyncMock(spec=WatchlistRepository)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.watchlist
         mock_repo.exists.return_value = False
         mock_repo.add.return_value = WatchlistItem.create(
             media_id="ser_abc123def456",
             media_type=CollectionMediaType.SERIES,
         )
-        use_case = ToggleWatchlistUseCase(watchlist_repository=mock_repo)
+        use_case = ToggleWatchlistUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             ToggleWatchlistInput(

--- a/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
@@ -1,8 +1,8 @@
 """Tests for ToggleWatchlistUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.modules.collections.application.dtos import (
     ToggleWatchlistInput,
@@ -11,7 +11,6 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.use_cases import ToggleWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
 from src.shared_kernel.value_objects import CollectionMediaType
-from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 
 @pytest.mark.unit

--- a/tests/modules/collections/unit/conftest.py
+++ b/tests/modules/collections/unit/conftest.py
@@ -1,0 +1,40 @@
+"""Unit test fixtures and helpers for the collections bounded context."""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+from src.modules.collections.application.unit_of_work import (
+    CollectionsUnitOfWork,
+    CollectionsUnitOfWorkFactory,
+)
+from src.modules.collections.domain.repositories import (
+    CustomListRepository,
+    WatchlistRepository,
+)
+
+
+@dataclass
+class CollectionsUoWMocks:
+    """Bundle of mocks produced by ``make_collections_uow_mock``."""
+
+    factory: CollectionsUnitOfWorkFactory
+    uow: CollectionsUnitOfWork
+    watchlist: AsyncMock
+    custom_lists: AsyncMock
+
+
+def make_collections_uow_mock() -> CollectionsUoWMocks:
+    """Build a mock :class:`CollectionsUnitOfWork` factory."""
+    watchlist = AsyncMock(spec=WatchlistRepository)
+    custom_lists = AsyncMock(spec=CustomListRepository)
+
+    uow: CollectionsUnitOfWork = AsyncMock()
+    uow.__aenter__.return_value = uow  # type: ignore[attr-defined]
+    uow.__aexit__.return_value = None  # type: ignore[attr-defined]
+    uow.watchlist = watchlist
+    uow.custom_lists = custom_lists
+
+    factory = MagicMock(return_value=uow)
+    return CollectionsUoWMocks(
+        factory=factory, uow=uow, watchlist=watchlist, custom_lists=custom_lists
+    )

--- a/tests/modules/library/unit/application/use_cases/test_create_library.py
+++ b/tests/modules/library/unit/application/use_cases/test_create_library.py
@@ -3,11 +3,11 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.library.unit.conftest import make_library_uow_mock
 
 from src.modules.library.application.dtos.library_dtos import CreateLibraryInput
 from src.modules.library.application.use_cases.create_library import CreateLibraryUseCase
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
-from tests.modules.library.unit.conftest import make_library_uow_mock
 
 
 def _configure_uow_mocks() -> "tuple[CreateLibraryUseCase, object, object]":

--- a/tests/modules/library/unit/application/use_cases/test_create_library.py
+++ b/tests/modules/library/unit/application/use_cases/test_create_library.py
@@ -6,23 +6,25 @@ import pytest
 
 from src.modules.library.application.dtos.library_dtos import CreateLibraryInput
 from src.modules.library.application.use_cases.create_library import CreateLibraryUseCase
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from tests.modules.library.unit.conftest import make_library_uow_mock
 
 
-def _make_repo() -> AsyncMock:
-    repo = AsyncMock(spec=LibraryRepository)
-    # save echoes back whatever it receives
-    repo.save.side_effect = lambda lib: lib
-    return repo
+def _configure_uow_mocks() -> "tuple[CreateLibraryUseCase, object, object]":
+    mocks = make_library_uow_mock()
+    mocks.libraries.save.side_effect = lambda lib: lib
 
-
-def _make_media_repos() -> tuple[AsyncMock, AsyncMock]:
     movie_repo = AsyncMock(spec=MovieRepository)
     movie_repo.count_under_paths.return_value = 0
     series_repo = AsyncMock(spec=SeriesRepository)
     series_repo.count_under_paths.return_value = 0
-    return movie_repo, series_repo
+
+    use_case = CreateLibraryUseCase(
+        uow_factory=mocks.factory,
+        movie_repository=movie_repo,
+        series_repository=series_repo,
+    )
+    return use_case, mocks.libraries.save, mocks.factory
 
 
 @pytest.mark.unit
@@ -31,9 +33,7 @@ class TestCreateLibraryUseCase:
 
     @pytest.mark.asyncio
     async def test_should_create_library_with_generated_id(self) -> None:
-        repo = _make_repo()
-        movie_repo, series_repo = _make_media_repos()
-        use_case = CreateLibraryUseCase(repo, movie_repo, series_repo)
+        use_case, save, factory = _configure_uow_mocks()
 
         result = await use_case.execute(
             CreateLibraryInput(
@@ -47,13 +47,12 @@ class TestCreateLibraryUseCase:
         assert result.library_type == "movies"
         assert result.paths == ["/media/movies"]
         assert result.id.startswith("lib_")
-        repo.save.assert_awaited_once()
+        save.assert_awaited_once()
+        factory.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_should_pass_settings_through(self) -> None:
-        repo = _make_repo()
-        movie_repo, series_repo = _make_media_repos()
-        use_case = CreateLibraryUseCase(repo, movie_repo, series_repo)
+        use_case, _, _ = _configure_uow_mocks()
 
         result = await use_case.execute(
             CreateLibraryInput(
@@ -75,9 +74,7 @@ class TestCreateLibraryUseCase:
 
     @pytest.mark.asyncio
     async def test_should_pass_metadata_providers(self) -> None:
-        repo = _make_repo()
-        movie_repo, series_repo = _make_media_repos()
-        use_case = CreateLibraryUseCase(repo, movie_repo, series_repo)
+        use_case, _, _ = _configure_uow_mocks()
 
         result = await use_case.execute(
             CreateLibraryInput(

--- a/tests/modules/library/unit/application/use_cases/test_delete_library.py
+++ b/tests/modules/library/unit/application/use_cases/test_delete_library.py
@@ -1,12 +1,12 @@
 """Tests for DeleteLibraryUseCase."""
 
 import pytest
+from tests.modules.library.unit.conftest import make_library_uow_mock
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.library.application.dtos.library_dtos import DeleteLibraryInput
 from src.modules.library.application.use_cases.delete_library import DeleteLibraryUseCase
 from src.modules.library.domain.value_objects.library_id import LibraryId
-from tests.modules.library.unit.conftest import make_library_uow_mock
 
 
 @pytest.mark.unit

--- a/tests/modules/library/unit/application/use_cases/test_delete_library.py
+++ b/tests/modules/library/unit/application/use_cases/test_delete_library.py
@@ -1,14 +1,12 @@
 """Tests for DeleteLibraryUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.library.application.dtos.library_dtos import DeleteLibraryInput
 from src.modules.library.application.use_cases.delete_library import DeleteLibraryUseCase
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
+from tests.modules.library.unit.conftest import make_library_uow_mock
 
 
 @pytest.mark.unit
@@ -17,20 +15,21 @@ class TestDeleteLibraryUseCase:
 
     @pytest.mark.asyncio
     async def test_should_delete_when_found(self) -> None:
-        repo = AsyncMock(spec=LibraryRepository)
-        repo.delete.return_value = True
-        use_case = DeleteLibraryUseCase(repo)
+        mocks = make_library_uow_mock()
+        mocks.libraries.delete.return_value = True
+        use_case = DeleteLibraryUseCase(uow_factory=mocks.factory)
         lib_id = str(LibraryId.generate())
 
         await use_case.execute(DeleteLibraryInput(library_id=lib_id))
 
-        repo.delete.assert_awaited_once()
+        mocks.libraries.delete.assert_awaited_once()
+        mocks.factory.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_should_raise_when_not_found(self) -> None:
-        repo = AsyncMock(spec=LibraryRepository)
-        repo.delete.return_value = False
-        use_case = DeleteLibraryUseCase(repo)
+        mocks = make_library_uow_mock()
+        mocks.libraries.delete.return_value = False
+        use_case = DeleteLibraryUseCase(uow_factory=mocks.factory)
         lib_id = str(LibraryId.generate())
 
         with pytest.raises(ResourceNotFoundException):

--- a/tests/modules/library/unit/conftest.py
+++ b/tests/modules/library/unit/conftest.py
@@ -1,0 +1,36 @@
+"""Unit test fixtures and helpers for the library bounded context."""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+from src.modules.library.application.unit_of_work import (
+    LibraryUnitOfWork,
+    LibraryUnitOfWorkFactory,
+)
+from src.modules.library.domain.repositories.library_repository import LibraryRepository
+
+
+@dataclass
+class LibraryUoWMocks:
+    """Bundle of mocks produced by ``make_library_uow_mock``.
+
+    Attributes:
+        factory: Callable matching ``LibraryUnitOfWorkFactory``; returns ``uow``.
+        uow: The mock ``LibraryUnitOfWork`` — an async context manager returning itself.
+        libraries: Mock ``LibraryRepository`` exposed as ``uow.libraries``.
+    """
+
+    factory: LibraryUnitOfWorkFactory
+    uow: LibraryUnitOfWork
+    libraries: AsyncMock
+
+
+def make_library_uow_mock() -> LibraryUoWMocks:
+    """Build a mock :class:`LibraryUnitOfWork` factory."""
+    libraries = AsyncMock(spec=LibraryRepository)
+    uow: LibraryUnitOfWork = AsyncMock()
+    uow.__aenter__.return_value = uow  # type: ignore[attr-defined]
+    uow.__aexit__.return_value = None  # type: ignore[attr-defined]
+    uow.libraries = libraries
+    factory = MagicMock(return_value=uow)
+    return LibraryUoWMocks(factory=factory, uow=uow, libraries=libraries)

--- a/tests/modules/media/integration/persistence/test_sqlalchemy_unit_of_work.py
+++ b/tests/modules/media/integration/persistence/test_sqlalchemy_unit_of_work.py
@@ -1,0 +1,164 @@
+"""Integration tests for SqlAlchemyMediaUnitOfWork.
+
+Exercises the real commit/rollback behaviour against an in-memory
+SQLite database so the contract under production SQLAlchemy semantics
+is covered.
+"""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.config.persistence import Base
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects import (
+    Duration,
+    FilePath,
+    MediaFile,
+    MovieId,
+    Resolution,
+    Title,
+    Year,
+)
+from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyMediaUnitOfWork,
+    SqlAlchemyMediaUnitOfWorkFactory,
+)
+
+
+@pytest.fixture
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """Build a dedicated in-memory engine and session factory per test."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+    yield factory
+
+    await engine.dispose()
+
+
+def _movie(title: str = "Inception") -> Movie:
+    return Movie(
+        id=MovieId.generate(),
+        title=Title(title),
+        year=Year(2010),
+        duration=Duration(8880),
+        files=[
+            MediaFile(
+                file_path=FilePath(f"/movies/{title.lower()}.mkv"),
+                file_size=1_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            )
+        ],
+    )
+
+
+@pytest.mark.integration
+class TestSqlAlchemyMediaUnitOfWork:
+    """Commit/rollback semantics under SQLAlchemy."""
+
+    async def test_should_commit_on_clean_exit(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        uow = SqlAlchemyMediaUnitOfWork(session_factory)
+        movie = _movie("Arrival")
+
+        async with uow as active:
+            await active.movies.save(movie)
+
+        # A fresh UoW should see the committed row.
+        async with SqlAlchemyMediaUnitOfWork(session_factory) as reader:
+            assert movie.id is not None
+            found = await reader.movies.find_by_id(movie.id)
+            assert found is not None
+            assert found.title.value == "Arrival"
+
+    async def test_should_rollback_on_exception(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        uow = SqlAlchemyMediaUnitOfWork(session_factory)
+        movie = _movie("Tenet")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with uow as active:
+                await active.movies.save(movie)
+                raise RuntimeError("boom")
+
+        async with SqlAlchemyMediaUnitOfWork(session_factory) as reader:
+            assert movie.id is not None
+            found = await reader.movies.find_by_id(movie.id)
+            assert found is None
+
+    async def test_should_reject_nested_enter(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        uow = SqlAlchemyMediaUnitOfWork(session_factory)
+
+        async with uow:
+            with pytest.raises(RuntimeError, match="already active"):
+                await uow.__aenter__()
+
+    async def test_should_allow_reuse_across_transactions(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        uow = SqlAlchemyMediaUnitOfWork(session_factory)
+
+        first = _movie("First")
+        second = _movie("Second")
+
+        async with uow as active:
+            await active.movies.save(first)
+        async with uow as active:
+            await active.movies.save(second)
+
+        async with SqlAlchemyMediaUnitOfWork(session_factory) as reader:
+            assert first.id is not None and second.id is not None
+            assert await reader.movies.find_by_id(first.id) is not None
+            assert await reader.movies.find_by_id(second.id) is not None
+
+    async def test_factory_should_produce_fresh_instances(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        factory = SqlAlchemyMediaUnitOfWorkFactory(session_factory)
+
+        uow1 = factory()
+        uow2 = factory()
+
+        assert uow1 is not uow2
+
+    async def test_factory_uows_should_isolate_failures(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """A failure inside one UoW must not roll back a sibling UoW's commit."""
+        factory = SqlAlchemyMediaUnitOfWorkFactory(session_factory)
+        ok_movie = _movie("Ok")
+        bad_movie = _movie("Bad")
+
+        async with factory() as uow:
+            await uow.movies.save(ok_movie)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            async with factory() as uow:
+                await uow.movies.save(bad_movie)
+                raise RuntimeError("boom")
+
+        async with factory() as reader:
+            assert ok_movie.id is not None and bad_movie.id is not None
+            assert await reader.movies.find_by_id(ok_movie.id) is not None
+            assert await reader.movies.find_by_id(bad_movie.id) is None

--- a/tests/modules/media/unit/application/use_cases/test_add_file_variant.py
+++ b/tests/modules/media/unit/application/use_cases/test_add_file_variant.py
@@ -1,14 +1,12 @@
 """Tests for AddFileVariantUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos import AddFileVariantInput, MediaFileOutput
 from src.modules.media.application.use_cases import AddFileVariantUseCase
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 @pytest.mark.unit
@@ -16,9 +14,8 @@ class TestAddFileVariantUseCase:
     """Tests for AddFileVariantUseCase."""
 
     @pytest.mark.asyncio
-    async def test_should_add_variant_to_movie(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
+    async def test_should_add_variant_to_movie(self) -> None:
+        mocks = make_media_uow_mock()
 
         movie = Movie.create(
             title="Inception",
@@ -28,13 +25,10 @@ class TestAddFileVariantUseCase:
             file_size=4_000_000_000,
             resolution="1080p",
         )
-        mock_movie_repo.find_by_id.return_value = movie
-        mock_movie_repo.save.return_value = movie
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.return_value = movie
 
-        use_case = AddFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = AddFileVariantUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             AddFileVariantInput(
@@ -48,18 +42,14 @@ class TestAddFileVariantUseCase:
         assert isinstance(result, MediaFileOutput)
         assert result.file_path == "/movies/inception_4k.mkv"
         assert result.resolution == "4K"
-        mock_movie_repo.save.assert_called_once()
+        mocks.movies.save.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_should_raise_not_found_for_missing_movie(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        mock_movie_repo.find_by_id.return_value = None
+    async def test_should_raise_not_found_for_missing_movie(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
 
-        use_case = AddFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = AddFileVariantUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(
@@ -72,14 +62,10 @@ class TestAddFileVariantUseCase:
             )
 
     @pytest.mark.asyncio
-    async def test_should_raise_not_found_for_invalid_prefix(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
+    async def test_should_raise_not_found_for_invalid_prefix(self) -> None:
+        mocks = make_media_uow_mock()
 
-        use_case = AddFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = AddFileVariantUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(

--- a/tests/modules/media/unit/application/use_cases/test_delete_movie.py
+++ b/tests/modules/media/unit/application/use_cases/test_delete_movie.py
@@ -1,33 +1,32 @@
 """Tests for DeleteMovieUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos import DeleteMovieInput
 from src.modules.media.application.use_cases import DeleteMovieUseCase
-from src.modules.media.domain.repositories import MovieRepository
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 class TestDeleteMovieUseCase:
     """Tests for DeleteMovieUseCase."""
 
     @pytest.mark.asyncio
-    async def test_should_delete_movie_when_found(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.delete.return_value = True
-        use_case = DeleteMovieUseCase(movie_repository=mock_repo)
+    async def test_should_delete_movie_when_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.delete.return_value = True
+        use_case = DeleteMovieUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(DeleteMovieInput(movie_id="mov_abc123def456"))
 
-        mock_repo.delete.assert_called_once()
+        mocks.movies.delete.assert_called_once()
+        mocks.factory.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_should_raise_not_found_when_movie_missing(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.delete.return_value = False
-        use_case = DeleteMovieUseCase(movie_repository=mock_repo)
+    async def test_should_raise_not_found_when_movie_missing(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.delete.return_value = False
+        use_case = DeleteMovieUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(DeleteMovieInput(movie_id="mov_nonexistent1"))
@@ -36,12 +35,12 @@ class TestDeleteMovieUseCase:
         assert exc_info.value.resource_id == "mov_nonexistent1"
 
     @pytest.mark.asyncio
-    async def test_should_call_repository_with_correct_movie_id(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.delete.return_value = True
-        use_case = DeleteMovieUseCase(movie_repository=mock_repo)
+    async def test_should_call_repository_with_correct_movie_id(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.delete.return_value = True
+        use_case = DeleteMovieUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(DeleteMovieInput(movie_id="mov_abc123def456"))
 
-        call_arg = mock_repo.delete.call_args[0][0]
+        call_arg = mocks.movies.delete.call_args[0][0]
         assert str(call_arg) == "mov_abc123def456"

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -17,8 +17,8 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
     _clean_title,
 )
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.repositories import MovieRepository
 from src.modules.media.domain.value_objects import ContentRating, TmdbId
+from tests.modules.media.unit.conftest import MediaUoWMocks, make_media_uow_mock
 
 
 def _make_movie() -> Movie:
@@ -45,6 +45,16 @@ def _make_metadata() -> MediaMetadata:
     )
 
 
+def _set_up_enrichment(
+    movie: Movie, provider: MetadataProvider
+) -> tuple[EnrichMovieMetadataUseCase, MediaUoWMocks]:
+    mocks = make_media_uow_mock()
+    mocks.movies.find_by_id.return_value = movie
+    mocks.movies.save.side_effect = lambda m: m
+    use_case = EnrichMovieMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+    return use_case, mocks
+
+
 @pytest.mark.unit
 class TestEnrichMovieMetadata:
     """Tests for EnrichMovieMetadataUseCase."""
@@ -52,31 +62,22 @@ class TestEnrichMovieMetadata:
     @pytest.mark.asyncio
     async def test_should_enrich_movie_with_metadata(self) -> None:
         movie = _make_movie()
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
-
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_movie.return_value = _make_metadata()
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case, mocks = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is True
         assert result.provider == "tmdb"
-        repo.save.assert_called_once()
+        mocks.movies.save.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_should_skip_already_enriched_movie(self) -> None:
-        movie = _make_movie()
-        movie = movie.with_updates(tmdb_id=TmdbId(27205))
-
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-
+        movie = _make_movie().with_updates(tmdb_id=TmdbId(27205))
         provider = AsyncMock(spec=MetadataProvider)
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
 
+        use_case, _ = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is False
@@ -84,18 +85,11 @@ class TestEnrichMovieMetadata:
 
     @pytest.mark.asyncio
     async def test_should_force_re_enrich(self) -> None:
-        movie = _make_movie()
-        movie = movie.with_updates(tmdb_id=TmdbId(27205))
-
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
-
+        movie = _make_movie().with_updates(tmdb_id=TmdbId(27205))
         provider = AsyncMock(spec=MetadataProvider)
         provider.get_movie_by_id.return_value = _make_metadata()
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
-
+        use_case, _ = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id), force=True))
 
         assert result.enriched is True
@@ -103,10 +97,9 @@ class TestEnrichMovieMetadata:
     @pytest.mark.asyncio
     async def test_should_use_fallback_when_primary_fails(self) -> None:
         movie = _make_movie()
-
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
 
         primary = AsyncMock(spec=MetadataProvider)
         primary.search_movie.return_value = None
@@ -115,7 +108,7 @@ class TestEnrichMovieMetadata:
         fallback.search_movie.return_value = _make_metadata()
 
         use_case = EnrichMovieMetadataUseCase(
-            movie_repository=repo,
+            uow_factory=mocks.factory,
             primary_provider=primary,
             fallback_provider=fallback,
         )
@@ -128,15 +121,10 @@ class TestEnrichMovieMetadata:
     @pytest.mark.asyncio
     async def test_should_return_error_when_no_metadata_found(self) -> None:
         movie = _make_movie()
-
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_movie.return_value = None
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
-
+        use_case, _ = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is False
@@ -144,11 +132,11 @@ class TestEnrichMovieMetadata:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_movie_not_found(self) -> None:
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = None
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
 
         provider = AsyncMock(spec=MetadataProvider)
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case = EnrichMovieMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
 
         from src.modules.media.domain.value_objects import MovieId
 
@@ -159,11 +147,10 @@ class TestEnrichMovieMetadata:
     @pytest.mark.asyncio
     async def test_should_use_localized_metadata_when_available(self) -> None:
         movie = _make_movie()
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
 
-        # Provider with get_movie_localized method
         provider = MagicMock(spec=["search_movie", "get_movie_by_id", "get_movie_localized"])
         provider.search_movie = AsyncMock(return_value=_make_metadata())
         localized_meta = MediaMetadata(
@@ -175,12 +162,12 @@ class TestEnrichMovieMetadata:
         )
         provider.get_movie_localized = AsyncMock(return_value=localized_meta)
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case = EnrichMovieMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is True
         provider.get_movie_localized.assert_awaited_once_with(27205)
-        saved = repo.save.call_args[0][0]
+        saved = mocks.movies.save.call_args[0][0]
         assert "pt-BR" in saved.localized
 
     @pytest.mark.asyncio
@@ -193,34 +180,22 @@ class TestEnrichMovieMetadata:
             file_size=4_000_000_000,
             resolution="1080p",
         )
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
-
         provider = AsyncMock(spec=MetadataProvider)
-
-        # First call (with year): None. Second call (cleaned title): success
         provider.search_movie.side_effect = [None, _make_metadata()]
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case, _ = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is True
-        # Two attempts: with year, then cleaned
         assert provider.search_movie.await_count == 2
 
     @pytest.mark.asyncio
     async def test_should_retry_with_title_only_when_year_search_fails(self) -> None:
         movie = _make_movie()
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
-
         provider = AsyncMock(spec=MetadataProvider)
-        # All searches return None except the title-only one
         provider.search_movie.side_effect = [None, _make_metadata()]
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case, _ = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is True
@@ -262,31 +237,25 @@ class TestApplyMetadataFields:
     @pytest.mark.asyncio
     async def test_should_apply_synopsis_when_missing(self) -> None:
         movie = _make_movie()
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_movie.return_value = _make_metadata()
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case, mocks = _set_up_enrichment(movie, provider)
         await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.movies.save.call_args[0][0]
         assert saved.synopsis == "A mind-bending thriller."
 
     @pytest.mark.asyncio
     async def test_should_apply_genres_when_missing(self) -> None:
         movie = _make_movie()
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_movie.return_value = _make_metadata()
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case, mocks = _set_up_enrichment(movie, provider)
         await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.movies.save.call_args[0][0]
         assert {g.value for g in saved.genres} == {"Sci-Fi", "Action"}
 
     @pytest.mark.asyncio
@@ -301,16 +270,13 @@ class TestApplyMetadataFields:
             content_rating="PG-13",
             trailer_url="https://youtube.com/abc",
         )
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_movie.return_value = metadata
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case, mocks = _set_up_enrichment(movie, provider)
         await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.movies.save.call_args[0][0]
         assert saved.cast == ["Leonardo DiCaprio"]
         assert saved.directors == ["Christopher Nolan"]
         assert saved.writers == ["Christopher Nolan"]
@@ -331,16 +297,13 @@ class TestApplyMetadataFields:
                 ),
             },
         )
-        repo = AsyncMock(spec=MovieRepository)
-        repo.find_by_id.return_value = movie
-        repo.save.side_effect = lambda m: m
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_movie.return_value = metadata
 
-        use_case = EnrichMovieMetadataUseCase(movie_repository=repo, primary_provider=provider)
+        use_case, mocks = _set_up_enrichment(movie, provider)
         await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.movies.save.call_args[0][0]
         assert saved.localized["pt-BR"]["title"] == "A Origem"
         assert saved.localized["pt-BR"]["synopsis"] == "Sonho dentro do sonho."
         assert saved.localized["pt-BR"]["genres"] == ["Ficção Científica"]

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -20,7 +20,6 @@ from src.modules.media.application.use_cases.enrich_series_metadata import (
     _parse_date,
 )
 from src.modules.media.domain.entities import Episode, Season, Series
-from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import (
     ContentRating,
     Duration,
@@ -30,6 +29,7 @@ from src.modules.media.domain.value_objects import (
     Title,
     TmdbId,
 )
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _make_series(**kwargs: object) -> Series:
@@ -93,37 +93,37 @@ class TestEnrichSeriesMetadata:
     @pytest.mark.asyncio
     async def test_should_enrich_series_with_metadata(self) -> None:
         series = _make_series()
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_series.return_value = _make_metadata()
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
         assert result.enriched is True
         assert result.provider == "tmdb"
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.series.save.call_args[0][0]
         assert saved.tmdb_id == TmdbId(1396)
         assert saved.synopsis is not None
 
     @pytest.mark.asyncio
     async def test_should_enrich_episode_title(self) -> None:
         series = _make_series()
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_series.return_value = _make_metadata()
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.series.save.call_args[0][0]
         episode = saved.seasons[0].episodes[0]
         assert episode.title.value == "Pilot"
 
@@ -132,11 +132,11 @@ class TestEnrichSeriesMetadata:
         series = _make_series()
         series = series.with_updates(tmdb_id=TmdbId(1396))
 
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
 
         provider = AsyncMock(spec=MetadataProvider)
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
 
         result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
@@ -144,11 +144,11 @@ class TestEnrichSeriesMetadata:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_series_not_found(self) -> None:
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = None
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = None
 
         provider = AsyncMock(spec=MetadataProvider)
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
 
         from src.modules.media.domain.value_objects import SeriesId
 
@@ -207,17 +207,17 @@ class TestEnrichSeriesMetadata:
             ],
         )
 
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_series.return_value = metadata
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.series.save.call_args[0][0]
         ep = saved.seasons[0].episodes[0]
         assert ep.title.value == "Downtown as Fruits / Eugene's Bike"
         assert ep.duration.value == 1320  # 660 + 660
@@ -275,17 +275,17 @@ class TestEnrichSeriesMetadata:
             ],
         )
 
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_series.return_value = metadata
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.series.save.call_args[0][0]
         ep = saved.seasons[0].episodes[0]
         # Title already has " / " so should NOT be overwritten
         assert ep.title.value == "Downtown as Fruits / Eugene's Bike"
@@ -362,14 +362,14 @@ class TestEnrichSeriesByTmdbId:
     @pytest.mark.asyncio
     async def test_should_fetch_by_tmdb_id_when_force(self) -> None:
         series = _make_series().with_updates(tmdb_id=TmdbId(1396))
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         provider = AsyncMock(spec=MetadataProvider)
         provider.get_series_by_id.return_value = _make_metadata()
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(series.id), force=True))
 
         assert result.enriched is True
@@ -378,15 +378,15 @@ class TestEnrichSeriesByTmdbId:
     @pytest.mark.asyncio
     async def test_should_retry_with_cleaned_title(self) -> None:
         series = Series.create(title="Breaking Bad 1080p BluRay", start_year=2008)
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         provider = AsyncMock(spec=MetadataProvider)
         # First call (with year): None. Second call (cleaned): success
         provider.search_series.side_effect = [None, _make_metadata()]
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
         assert result.enriched is True
@@ -395,9 +395,9 @@ class TestEnrichSeriesByTmdbId:
     @pytest.mark.asyncio
     async def test_should_use_fallback_when_primary_fails(self) -> None:
         series = _make_series()
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         primary = AsyncMock(spec=MetadataProvider)
         primary.search_series.return_value = None
@@ -406,7 +406,7 @@ class TestEnrichSeriesByTmdbId:
         fallback.search_series.return_value = _make_metadata()
 
         use_case = EnrichSeriesMetadataUseCase(
-            series_repository=repo,
+            uow_factory=mocks.factory,
             primary_provider=primary,
             fallback_provider=fallback,
         )
@@ -418,13 +418,13 @@ class TestEnrichSeriesByTmdbId:
     @pytest.mark.asyncio
     async def test_should_return_error_when_no_metadata_found(self) -> None:
         series = _make_series()
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
 
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_series.return_value = None
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
         assert result.enriched is False
@@ -433,9 +433,9 @@ class TestEnrichSeriesByTmdbId:
     @pytest.mark.asyncio
     async def test_should_use_localized_metadata_when_available(self) -> None:
         series = _make_series()
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         provider = MagicMock(spec=["search_series", "get_series_by_id", "get_series_localized"])
         provider.search_series = AsyncMock(return_value=_make_metadata())
@@ -448,12 +448,12 @@ class TestEnrichSeriesByTmdbId:
         )
         provider.get_series_localized = AsyncMock(return_value=localized_meta)
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
         assert result.enriched is True
         provider.get_series_localized.assert_awaited_once_with(1396)
-        saved = repo.save.call_args[0][0]
+        saved = mocks.series.save.call_args[0][0]
         assert "pt-BR" in saved.localized
 
 
@@ -479,17 +479,17 @@ class TestApplySeriesFields:
             trailer_url="https://youtube.com/abc",
         )
 
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
 
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_series.return_value = metadata
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.series.save.call_args[0][0]
         assert saved.tmdb_id == TmdbId(1396)
         assert saved.end_year is not None
         assert saved.synopsis == "Crime drama."
@@ -513,15 +513,15 @@ class TestApplySeriesFields:
             },
         )
 
-        repo = AsyncMock(spec=SeriesRepository)
-        repo.find_by_id.return_value = series
-        repo.save.side_effect = lambda s: s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_series.return_value = metadata
 
-        use_case = EnrichSeriesMetadataUseCase(series_repository=repo, primary_provider=provider)
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
         await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
-        saved = repo.save.call_args[0][0]
+        saved = mocks.series.save.call_args[0][0]
         assert "pt-BR" in saved.localized
         assert saved.localized["pt-BR"]["synopsis"] == "Drama de crime."

--- a/tests/modules/media/unit/application/use_cases/test_remove_file_variant.py
+++ b/tests/modules/media/unit/application/use_cases/test_remove_file_variant.py
@@ -1,7 +1,5 @@
 """Tests for RemoveFileVariantUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.building_blocks.application.errors import (
@@ -11,7 +9,6 @@ from src.building_blocks.application.errors import (
 from src.modules.media.application.dtos import RemoveFileVariantInput
 from src.modules.media.application.use_cases import RemoveFileVariantUseCase
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
@@ -20,6 +17,7 @@ from src.modules.media.domain.value_objects import (
     Title,
 )
 from src.shared_kernel.value_objects.file_path import FilePath
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _create_movie_with_variants() -> Movie:
@@ -46,18 +44,13 @@ class TestRemoveFileVariantUseCase:
     """Tests for RemoveFileVariantUseCase."""
 
     @pytest.mark.asyncio
-    async def test_should_remove_non_primary_variant(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+    async def test_should_remove_non_primary_variant(self) -> None:
+        mocks = make_media_uow_mock()
         movie = _create_movie_with_variants()
-        mock_movie_repo.find_by_id.return_value = movie
-        mock_movie_repo.save.return_value = movie
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.return_value = movie
 
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             RemoveFileVariantInput(
@@ -66,23 +59,18 @@ class TestRemoveFileVariantUseCase:
             ),
         )
 
-        mock_movie_repo.save.assert_called_once()
-        saved_movie = mock_movie_repo.save.call_args[0][0]
+        mocks.movies.save.assert_called_once()
+        saved_movie = mocks.movies.save.call_args[0][0]
         assert len(saved_movie.files) == 1
 
     @pytest.mark.asyncio
-    async def test_should_promote_best_when_removing_primary(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+    async def test_should_promote_best_when_removing_primary(self) -> None:
+        mocks = make_media_uow_mock()
         movie = _create_movie_with_variants()
-        mock_movie_repo.find_by_id.return_value = movie
-        mock_movie_repo.save.return_value = movie
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.return_value = movie
 
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             RemoveFileVariantInput(
@@ -91,16 +79,14 @@ class TestRemoveFileVariantUseCase:
             ),
         )
 
-        saved_movie = mock_movie_repo.save.call_args[0][0]
+        saved_movie = mocks.movies.save.call_args[0][0]
         assert len(saved_movie.files) == 1
         assert saved_movie.files[0].is_primary is True
         assert saved_movie.files[0].file_path == FilePath("/movies/inception_4k.mkv")
 
     @pytest.mark.asyncio
-    async def test_should_raise_when_removing_last_file(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+    async def test_should_raise_when_removing_last_file(self) -> None:
+        mocks = make_media_uow_mock()
         movie = Movie.create(
             title="Inception",
             year=2010,
@@ -109,12 +95,9 @@ class TestRemoveFileVariantUseCase:
             file_size=4_000_000_000,
             resolution="1080p",
         )
-        mock_movie_repo.find_by_id.return_value = movie
+        mocks.movies.find_by_id.return_value = movie
 
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(UseCaseValidationException, match="last file variant"):
             await use_case.execute(
@@ -125,17 +108,12 @@ class TestRemoveFileVariantUseCase:
             )
 
     @pytest.mark.asyncio
-    async def test_should_raise_when_file_path_not_found(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+    async def test_should_raise_when_file_path_not_found(self) -> None:
+        mocks = make_media_uow_mock()
         movie = _create_movie_with_variants()
-        mock_movie_repo.find_by_id.return_value = movie
+        mocks.movies.find_by_id.return_value = movie
 
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(
@@ -146,15 +124,11 @@ class TestRemoveFileVariantUseCase:
             )
 
     @pytest.mark.asyncio
-    async def test_should_raise_when_movie_not_found(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        mock_movie_repo.find_by_id.return_value = None
+    async def test_should_raise_when_movie_not_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
 
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
@@ -167,14 +141,9 @@ class TestRemoveFileVariantUseCase:
         assert exc_info.value.resource_type == "Movie"
 
     @pytest.mark.asyncio
-    async def test_should_raise_for_invalid_media_id_prefix(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+    async def test_should_raise_for_invalid_media_id_prefix(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
@@ -187,14 +156,9 @@ class TestRemoveFileVariantUseCase:
         assert exc_info.value.resource_type == "Media"
 
     @pytest.mark.asyncio
-    async def test_should_raise_when_media_id_has_no_underscore(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+    async def test_should_raise_when_media_id_has_no_underscore(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(
@@ -242,18 +206,13 @@ class TestRemoveFileVariantFromEpisode:
 
     @pytest.mark.asyncio
     async def test_should_remove_variant_from_episode(self) -> None:
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+        mocks = make_media_uow_mock()
         series = _create_series_with_episode_variants()
         episode = series.seasons[0].episodes[0]
-        mock_series_repo.find_by_episode_id.return_value = series
-        mock_series_repo.save.return_value = series
+        mocks.series.find_by_episode_id.return_value = series
+        mocks.series.save.return_value = series
 
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             RemoveFileVariantInput(
@@ -262,25 +221,20 @@ class TestRemoveFileVariantFromEpisode:
             ),
         )
 
-        saved_series = mock_series_repo.save.call_args[0][0]
+        saved_series = mocks.series.save.call_args[0][0]
         saved_episode = saved_series.seasons[0].episodes[0]
         assert len(saved_episode.files) == 1
         assert saved_episode.files[0].file_path == FilePath("/series/bb/s01e01_1080p.mkv")
 
     @pytest.mark.asyncio
     async def test_should_promote_best_when_removing_primary_from_episode(self) -> None:
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+        mocks = make_media_uow_mock()
         series = _create_series_with_episode_variants()
         episode = series.seasons[0].episodes[0]
-        mock_series_repo.find_by_episode_id.return_value = series
-        mock_series_repo.save.return_value = series
+        mocks.series.find_by_episode_id.return_value = series
+        mocks.series.save.return_value = series
 
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             RemoveFileVariantInput(
@@ -289,7 +243,7 @@ class TestRemoveFileVariantFromEpisode:
             ),
         )
 
-        saved_series = mock_series_repo.save.call_args[0][0]
+        saved_series = mocks.series.save.call_args[0][0]
         saved_episode = saved_series.seasons[0].episodes[0]
         assert len(saved_episode.files) == 1
         assert saved_episode.files[0].is_primary is True
@@ -297,14 +251,10 @@ class TestRemoveFileVariantFromEpisode:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_episode_not_found(self) -> None:
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        mock_series_repo.find_by_episode_id.return_value = None
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_episode_id.return_value = None
 
-        use_case = RemoveFileVariantUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = RemoveFileVariantUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -1,6 +1,6 @@
 """Tests for ScanMediaDirectoriesUseCase."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -10,7 +10,6 @@ from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeNumber,
@@ -27,6 +26,7 @@ from src.modules.media.infrastructure.streaming.media_probe_service import (
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+from tests.modules.media.unit.conftest import MediaUoWMocks, make_media_uow_mock
 
 
 def _audio_track(lang: str, *, index: int = 0) -> AudioTrack:
@@ -88,32 +88,29 @@ def _episode_file(
 def _make_use_case(
     *,
     scanner_results: list[ScannedFile] | None = None,
-    movie_repo: AsyncMock | None = None,
-    series_repo: AsyncMock | None = None,
+    mocks: MediaUoWMocks | None = None,
     probe_service: MediaProbeService | MagicMock | None = None,
-) -> ScanMediaDirectoriesUseCase:
+) -> tuple[ScanMediaDirectoriesUseCase, MediaUoWMocks]:
+    """Build the scan use case wired to a mock Unit of Work factory."""
     file_scanner = MagicMock()
     file_scanner.scan_directories.return_value = scanner_results or []
 
     variant_detector = VariantDetector()
 
-    if movie_repo is None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.return_value = None
-        movie_repo.save.side_effect = lambda m: m
+    if mocks is None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.movies.save.side_effect = lambda m: m
+        mocks.series.find_by_title.return_value = None
+        mocks.series.save.side_effect = lambda s: s
 
-    if series_repo is None:
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_by_title.return_value = None
-        series_repo.save.side_effect = lambda s: s
-
-    return ScanMediaDirectoriesUseCase(
+    use_case = ScanMediaDirectoriesUseCase(
         file_scanner=file_scanner,
         variant_detector=variant_detector,
-        movie_repository=movie_repo,
-        series_repository=series_repo,
+        uow_factory=mocks.factory,
         probe_service=probe_service,
     )
+    return use_case, mocks
 
 
 @pytest.mark.unit
@@ -123,7 +120,7 @@ class TestScanMovies:
     @pytest.mark.asyncio
     async def test_should_create_movie_from_scanned_file(self) -> None:
         files = [_movie_file("/movies/Inception.2010.1080p.mkv", "Inception", 2010)]
-        use_case = _make_use_case(scanner_results=files)
+        use_case, _ = _make_use_case(scanner_results=files)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -137,7 +134,7 @@ class TestScanMovies:
             _movie_file("/movies/Inception.2010.1080p.mkv", "Inception", 2010, "1080p"),
             _movie_file("/movies/Inception.2010.4K.mkv", "Inception", 2010, "4K"),
         ]
-        use_case = _make_use_case(scanner_results=files)
+        use_case, _ = _make_use_case(scanner_results=files)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -150,7 +147,7 @@ class TestScanMovies:
             _movie_file("/movies/Inception.2010.1080p.mkv", "Inception", 2010),
             _movie_file("/movies/Interstellar.2014.1080p.mkv", "Interstellar", 2014),
         ]
-        use_case = _make_use_case(scanner_results=files)
+        use_case, _ = _make_use_case(scanner_results=files)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -167,17 +164,17 @@ class TestScanMovies:
             resolution="1080p",
         )
 
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.side_effect = lambda fp: (
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/Inception.2010.1080p.mkv" else None
         )
-        movie_repo.save.side_effect = lambda m: m
+        mocks.movies.save.side_effect = lambda m: m
 
         files = [
             _movie_file("/movies/Inception.2010.1080p.mkv", "Inception", 2010, "1080p"),
             _movie_file("/movies/Inception.2010.4K.mkv", "Inception", 2010, "4K"),
         ]
-        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -186,7 +183,7 @@ class TestScanMovies:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_when_no_files(self) -> None:
-        use_case = _make_use_case(scanner_results=[])
+        use_case, _ = _make_use_case(scanner_results=[])
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -203,7 +200,7 @@ class TestScanEpisodes:
         files = [
             _episode_file("/series/Show/S01/Show.S01E01.mkv"),
         ]
-        use_case = _make_use_case(scanner_results=files)
+        use_case, _ = _make_use_case(scanner_results=files)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -216,7 +213,7 @@ class TestScanEpisodes:
             _episode_file("/series/Show/S01/Show.S01E02.mkv", episode=2),
             _episode_file("/series/Show/S01/Show.S01E03.mkv", episode=3),
         ]
-        use_case = _make_use_case(scanner_results=files)
+        use_case, _ = _make_use_case(scanner_results=files)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -228,7 +225,7 @@ class TestScanEpisodes:
             _episode_file("/series/Show/S01/Show.S01E01.mkv", season=1, episode=1),
             _episode_file("/series/Show/S02/Show.S02E01.mkv", season=2, episode=1),
         ]
-        use_case = _make_use_case(scanner_results=files)
+        use_case, _ = _make_use_case(scanner_results=files)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -240,7 +237,7 @@ class TestScanEpisodes:
             _movie_file("/movies/Movie.2024.mkv"),
             _episode_file("/series/Show/S01/Show.S01E01.mkv"),
         ]
-        use_case = _make_use_case(scanner_results=files)
+        use_case, _ = _make_use_case(scanner_results=files)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -263,14 +260,14 @@ class TestRescanResolutionUpgrade:
             resolution="Unknown",
         )
         saved: list[Movie] = []
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.side_effect = lambda fp: (
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/inception.mkv" else None
         )
-        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -287,20 +284,20 @@ class TestRescanResolutionUpgrade:
             file_size=4_000_000_000,
             resolution="1080p",
         )
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.side_effect = lambda fp: (
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/inception.mkv" else None
         )
-        movie_repo.save.side_effect = lambda m: m
+        mocks.movies.save.side_effect = lambda m: m
 
         # Same path, but scanned now reports a different/Unknown resolution
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
-        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
         result = await use_case.execute(ScanMediaInput())
 
         assert result.movies_updated == 0
-        movie_repo.save.assert_not_called()
+        mocks.movies.save.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_should_skip_when_rescan_also_returns_no_resolution(self) -> None:
@@ -312,19 +309,19 @@ class TestRescanResolutionUpgrade:
             file_size=4_000_000_000,
             resolution="Unknown",
         )
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.side_effect = lambda fp: (
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/inception.mkv" else None
         )
-        movie_repo.save.side_effect = lambda m: m
+        mocks.movies.save.side_effect = lambda m: m
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
-        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
         result = await use_case.execute(ScanMediaInput())
 
         assert result.movies_updated == 0
-        movie_repo.save.assert_not_called()
+        mocks.movies.save.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_should_probe_when_creating_movie_without_filename_resolution(
@@ -333,7 +330,7 @@ class TestRescanResolutionUpgrade:
         probe = MagicMock(spec=MediaProbeService)
         probe.probe.return_value = MediaProbeResult(resolution="1080p")
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
-        use_case = _make_use_case(scanner_results=files, probe_service=probe)
+        use_case, _ = _make_use_case(scanner_results=files, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -350,20 +347,20 @@ class TestRescanResolutionUpgrade:
             file_size=4_000_000_000,
             resolution="Unknown",
         )
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.side_effect = lambda fp: (
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/inception.mkv" else None
         )
         saved: list[Movie] = []
-        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
 
         probe = MagicMock(spec=MediaProbeService)
         probe.probe.return_value = MediaProbeResult(resolution="4K")
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
-        use_case = _make_use_case(
+        use_case, _ = _make_use_case(
             scanner_results=files,
-            movie_repo=movie_repo,
+            mocks=mocks,
             probe_service=probe,
         )
 
@@ -394,18 +391,18 @@ class TestRescanResolutionUpgrade:
         )
         existing = existing.with_updates(files=[populated_file])
 
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.side_effect = lambda fp: (
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/inception.mkv" else None
         )
-        movie_repo.save.side_effect = lambda m: m
+        mocks.movies.save.side_effect = lambda m: m
 
         probe = MagicMock(spec=MediaProbeService)
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(
+        use_case, _ = _make_use_case(
             scanner_results=files,
-            movie_repo=movie_repo,
+            mocks=mocks,
             probe_service=probe,
         )
 
@@ -425,7 +422,7 @@ class TestRescanResolutionUpgrade:
             resolution="1080p",
         )
         files = [_movie_file("/movies/inception.1080p.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(scanner_results=files, probe_service=probe)
+        use_case, _ = _make_use_case(scanner_results=files, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -459,9 +456,9 @@ class TestRescanResolutionUpgrade:
         series = series.with_updates(seasons=[season])
 
         saved: list[Series] = []
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_by_title.return_value = series
-        series_repo.save.side_effect = lambda s: saved.append(s) or s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_title.return_value = series
+        mocks.series.save.side_effect = lambda s: saved.append(s) or s
 
         files = [
             _episode_file(
@@ -472,7 +469,7 @@ class TestRescanResolutionUpgrade:
                 resolution="720p",
             )
         ]
-        use_case = _make_use_case(scanner_results=files, series_repo=series_repo)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -494,12 +491,12 @@ class TestTrackDetection:
             resolution="1080p",
         )
         saved: list[Movie] = []
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.return_value = None
-        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
 
         files = [_movie_file("/movies/Inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo, probe_service=probe)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -519,14 +516,12 @@ class TestTrackDetection:
             resolution="1080p",
         )
         saved: list[Series] = []
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_by_title.return_value = None
-        series_repo.save.side_effect = lambda s: saved.append(s) or s
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_title.return_value = None
+        mocks.series.save.side_effect = lambda s: saved.append(s) or s
 
         files = [_episode_file("/series/Anime/S01/Anime.S01E01.mkv")]
-        use_case = _make_use_case(
-            scanner_results=files, series_repo=series_repo, probe_service=probe
-        )
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -548,11 +543,11 @@ class TestTrackDetection:
             resolution="1080p",
         )
         saved: list[Movie] = []
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.side_effect = lambda fp: (
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/inception.mkv" else None
         )
-        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
 
         probe = MagicMock(spec=MediaProbeService)
         probe.probe.return_value = MediaProbeResult(
@@ -561,7 +556,7 @@ class TestTrackDetection:
         )
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo, probe_service=probe)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -589,16 +584,16 @@ class TestTrackDetection:
         )
         existing = existing.with_updates(files=[populated_file])
 
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.side_effect = lambda fp: (
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
             existing if fp.value == "/movies/inception.mkv" else None
         )
-        movie_repo.save.side_effect = lambda m: m
+        mocks.movies.save.side_effect = lambda m: m
 
         probe = MagicMock(spec=MediaProbeService)
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo, probe_service=probe)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 
@@ -622,12 +617,12 @@ class TestTrackDetection:
             resolution="1080p",
         )
         saved: list[Movie] = []
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_by_file_path.return_value = None
-        movie_repo.save.side_effect = lambda m: saved.append(m) or m
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
-        use_case = _make_use_case(scanner_results=files, movie_repo=movie_repo, probe_service=probe)
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
         result = await use_case.execute(ScanMediaInput())
 

--- a/tests/modules/media/unit/application/use_cases/test_set_primary_file.py
+++ b/tests/modules/media/unit/application/use_cases/test_set_primary_file.py
@@ -1,14 +1,11 @@
 """Tests for SetPrimaryFileUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos import SetPrimaryFileInput
 from src.modules.media.application.use_cases import SetPrimaryFileUseCase
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
@@ -17,6 +14,7 @@ from src.modules.media.domain.value_objects import (
     Title,
 )
 from src.shared_kernel.value_objects.file_path import FilePath
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _create_movie_with_variants() -> Movie:
@@ -75,18 +73,13 @@ class TestSetPrimaryFileUseCase:
     """Tests for SetPrimaryFileUseCase."""
 
     @pytest.mark.asyncio
-    async def test_should_switch_primary(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+    async def test_should_switch_primary(self) -> None:
+        mocks = make_media_uow_mock()
         movie = _create_movie_with_variants()
-        mock_movie_repo.find_by_id.return_value = movie
-        mock_movie_repo.save.return_value = movie
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.return_value = movie
 
-        use_case = SetPrimaryFileUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = SetPrimaryFileUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             SetPrimaryFileInput(
@@ -95,26 +88,18 @@ class TestSetPrimaryFileUseCase:
             ),
         )
 
-        # Verify the save was called with updated primary
-        saved_movie = mock_movie_repo.save.call_args[0][0]
+        saved_movie = mocks.movies.save.call_args[0][0]
         primary = next(f for f in saved_movie.files if f.is_primary)
         assert primary.file_path == FilePath("/movies/inception_4k.mkv")
-
-        # Verify return value
         assert len(result) == 2
 
     @pytest.mark.asyncio
-    async def test_should_raise_for_missing_file_path(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+    async def test_should_raise_for_missing_file_path(self) -> None:
+        mocks = make_media_uow_mock()
         movie = _create_movie_with_variants()
-        mock_movie_repo.find_by_id.return_value = movie
+        mocks.movies.find_by_id.return_value = movie
 
-        use_case = SetPrimaryFileUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = SetPrimaryFileUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(
@@ -125,15 +110,11 @@ class TestSetPrimaryFileUseCase:
             )
 
     @pytest.mark.asyncio
-    async def test_should_raise_for_missing_movie(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        mock_movie_repo.find_by_id.return_value = None
+    async def test_should_raise_for_missing_movie(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
 
-        use_case = SetPrimaryFileUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = SetPrimaryFileUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(
@@ -144,13 +125,9 @@ class TestSetPrimaryFileUseCase:
             )
 
     @pytest.mark.asyncio
-    async def test_should_raise_for_invalid_media_id_prefix(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        use_case = SetPrimaryFileUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+    async def test_should_raise_for_invalid_media_id_prefix(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = SetPrimaryFileUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
@@ -163,13 +140,9 @@ class TestSetPrimaryFileUseCase:
         assert exc_info.value.resource_type == "Media"
 
     @pytest.mark.asyncio
-    async def test_should_raise_when_media_id_has_no_underscore(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        use_case = SetPrimaryFileUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+    async def test_should_raise_when_media_id_has_no_underscore(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = SetPrimaryFileUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(
@@ -186,18 +159,13 @@ class TestSetPrimaryFileForEpisode:
 
     @pytest.mark.asyncio
     async def test_should_switch_primary_for_episode(self) -> None:
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+        mocks = make_media_uow_mock()
         series = _create_series_with_episode_variants()
         episode = series.seasons[0].episodes[0]
-        mock_series_repo.find_by_episode_id.return_value = series
-        mock_series_repo.save.return_value = series
+        mocks.series.find_by_episode_id.return_value = series
+        mocks.series.save.return_value = series
 
-        use_case = SetPrimaryFileUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = SetPrimaryFileUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             SetPrimaryFileInput(
@@ -206,25 +174,18 @@ class TestSetPrimaryFileForEpisode:
             ),
         )
 
-        # Verify save was called with the updated series
-        saved_series = mock_series_repo.save.call_args[0][0]
+        saved_series = mocks.series.save.call_args[0][0]
         saved_episode = saved_series.seasons[0].episodes[0]
         primary = next(f for f in saved_episode.files if f.is_primary)
         assert primary.file_path == FilePath("/series/bb/s01e01_4k.mkv")
-
-        # Verify return value contains the updated files
         assert len(result) == 2
 
     @pytest.mark.asyncio
     async def test_should_raise_when_episode_not_found(self) -> None:
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        mock_series_repo.find_by_episode_id.return_value = None
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_episode_id.return_value = None
 
-        use_case = SetPrimaryFileUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = SetPrimaryFileUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
@@ -238,17 +199,12 @@ class TestSetPrimaryFileForEpisode:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_episode_file_path_missing(self) -> None:
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+        mocks = make_media_uow_mock()
         series = _create_series_with_episode_variants()
         episode = series.seasons[0].episodes[0]
-        mock_series_repo.find_by_episode_id.return_value = series
+        mocks.series.find_by_episode_id.return_value = series
 
-        use_case = SetPrimaryFileUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        use_case = SetPrimaryFileUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(

--- a/tests/modules/media/unit/conftest.py
+++ b/tests/modules/media/unit/conftest.py
@@ -1,8 +1,54 @@
-"""Unit test fixtures.
+"""Unit test fixtures and helpers for the media bounded context.
 
-Fixtures for unit tests - no I/O, no external dependencies.
-
-Note:
-    Domain-specific fixtures (MovieId, SeriesId, etc.) will be added
-    as each bounded context is implemented.
+Provides the small amount of shared scaffolding that more than one
+unit test reaches for — chiefly a factory that builds a mock
+``MediaUnitOfWork`` suitable for use as an async context manager.
 """
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+from src.modules.media.application.unit_of_work import (
+    MediaUnitOfWork,
+    MediaUnitOfWorkFactory,
+)
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+@dataclass
+class MediaUoWMocks:
+    """Bundle of mocks produced by ``make_media_uow_mock``.
+
+    Attributes:
+        factory: Callable matching ``MediaUnitOfWorkFactory``; returns ``uow``.
+        uow: The mock ``MediaUnitOfWork`` — already configured as an async
+            context manager returning itself on ``__aenter__``.
+        movies: Mock ``MovieRepository`` exposed as ``uow.movies``.
+        series: Mock ``SeriesRepository`` exposed as ``uow.series``.
+    """
+
+    factory: MediaUnitOfWorkFactory
+    uow: MediaUnitOfWork
+    movies: AsyncMock
+    series: AsyncMock
+
+
+def make_media_uow_mock() -> MediaUoWMocks:
+    """Build a mock :class:`MediaUnitOfWork` factory.
+
+    The returned ``factory`` is callable and yields the same ``uow``
+    every invocation — sufficient for tests that drive a single use
+    case, and explicit enough that tests which care about multiple
+    transactions can assert on ``factory.call_count``.
+    """
+    movies = AsyncMock(spec=MovieRepository)
+    series = AsyncMock(spec=SeriesRepository)
+
+    uow: MediaUnitOfWork = AsyncMock()
+    uow.__aenter__.return_value = uow  # type: ignore[attr-defined]
+    uow.__aexit__.return_value = None  # type: ignore[attr-defined]
+    uow.movies = movies
+    uow.series = series
+
+    factory = MagicMock(return_value=uow)
+    return MediaUoWMocks(factory=factory, uow=uow, movies=movies, series=series)

--- a/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
@@ -1,14 +1,13 @@
 """Tests for SaveProgressUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
 
 from src.modules.watch_progress.application.dtos import ProgressOutput, SaveProgressInput
 from src.modules.watch_progress.application.use_cases import SaveProgressUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from tests.modules.watch_progress.unit.conftest import make_watch_progress_uow_mock
 
 
 class TestSaveProgressUseCase:
@@ -16,10 +15,11 @@ class TestSaveProgressUseCase:
 
     @pytest.mark.asyncio
     async def test_creates_new_progress_when_none_exists(self):
-        mock_repo = AsyncMock(spec=WatchProgressRepository)
+        mocks = make_watch_progress_uow_mock()
+        mock_repo = mocks.progress
         mock_repo.find_by_media_id.return_value = None
         mock_repo.save.side_effect = lambda p: p
-        use_case = SaveProgressUseCase(progress_repository=mock_repo)
+        use_case = SaveProgressUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             SaveProgressInput(
@@ -44,10 +44,11 @@ class TestSaveProgressUseCase:
             position_seconds=1000,
             duration_seconds=7200,
         )
-        mock_repo = AsyncMock(spec=WatchProgressRepository)
+        mocks = make_watch_progress_uow_mock()
+        mock_repo = mocks.progress
         mock_repo.find_by_media_id.return_value = existing
         mock_repo.save.side_effect = lambda p: p
-        use_case = SaveProgressUseCase(progress_repository=mock_repo)
+        use_case = SaveProgressUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             SaveProgressInput(
@@ -63,10 +64,11 @@ class TestSaveProgressUseCase:
 
     @pytest.mark.asyncio
     async def test_auto_completes_at_90_percent(self):
-        mock_repo = AsyncMock(spec=WatchProgressRepository)
+        mocks = make_watch_progress_uow_mock()
+        mock_repo = mocks.progress
         mock_repo.find_by_media_id.return_value = None
         mock_repo.save.side_effect = lambda p: p
-        use_case = SaveProgressUseCase(progress_repository=mock_repo)
+        use_case = SaveProgressUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             SaveProgressInput(
@@ -81,10 +83,11 @@ class TestSaveProgressUseCase:
 
     @pytest.mark.asyncio
     async def test_saves_audio_and_subtitle_track(self):
-        mock_repo = AsyncMock(spec=WatchProgressRepository)
+        mocks = make_watch_progress_uow_mock()
+        mock_repo = mocks.progress
         mock_repo.find_by_media_id.return_value = None
         mock_repo.save.side_effect = lambda p: p
-        use_case = SaveProgressUseCase(progress_repository=mock_repo)
+        use_case = SaveProgressUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             SaveProgressInput(

--- a/tests/modules/watch_progress/unit/conftest.py
+++ b/tests/modules/watch_progress/unit/conftest.py
@@ -1,0 +1,30 @@
+"""Unit test fixtures and helpers for the watch_progress bounded context."""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+from src.modules.watch_progress.application.unit_of_work import (
+    WatchProgressUnitOfWork,
+    WatchProgressUnitOfWorkFactory,
+)
+from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+
+
+@dataclass
+class WatchProgressUoWMocks:
+    """Bundle of mocks produced by ``make_watch_progress_uow_mock``."""
+
+    factory: WatchProgressUnitOfWorkFactory
+    uow: WatchProgressUnitOfWork
+    progress: AsyncMock
+
+
+def make_watch_progress_uow_mock() -> WatchProgressUoWMocks:
+    """Build a mock :class:`WatchProgressUnitOfWork` factory."""
+    progress = AsyncMock(spec=WatchProgressRepository)
+    uow: WatchProgressUnitOfWork = AsyncMock()
+    uow.__aenter__.return_value = uow  # type: ignore[attr-defined]
+    uow.__aexit__.return_value = None  # type: ignore[attr-defined]
+    uow.progress = progress
+    factory = MagicMock(return_value=uow)
+    return WatchProgressUoWMocks(factory=factory, uow=uow, progress=progress)


### PR DESCRIPTION
## Summary

- Add abstract `UnitOfWork` base in `building_blocks` to standardize transactional boundaries across bounded contexts
- Introduce module-level Unit of Work for `media`, `library`, `collections`, and `watch_progress`, each with a SQLAlchemy implementation and a factory
- Route every write use case (create/update/delete/save/clear) through a fresh UoW; commits are no longer issued from repositories
- Repositories now `flush` instead of `commit`, keeping the in-session identity map consistent for follow-up reads while leaving transaction control to the UoW
- Reads (list/get) continue to use the session-scoped repositories already wired in the containers

## Test plan

- [x] All unit and integration tests pass (1599 total)
- [x] New per-module conftests provide UoW factories for use case tests
- [x] `tests/modules/media/integration/persistence/test_sqlalchemy_unit_of_work.py` exercises commit/rollback semantics end-to-end
- [ ] Manual: scan a library — verify failures in one media group no longer poison subsequent groups
- [ ] Manual: trigger save/clear progress and library CRUD endpoints — verify writes are persisted and rolled back on errors

## Summary by Sourcery

Introduce a shared Unit of Work abstraction and wire media, library, collections, and watch_progress write paths through per-module UoW factories instead of committing directly in repositories.

New Features:
- Add a generic asynchronous UnitOfWork base and per-bounded-context UoW interfaces and SQLAlchemy implementations for media, library, collections, and watch_progress.
- Allow media scan operations to process each movie group and series within its own transactional Unit of Work so failures are isolated to that group.

Enhancements:
- Refactor write-oriented use cases across media, collections, library, and watch_progress to depend on UoW factories rather than concrete repositories, decoupling application logic from persistence details.
- Change SQLAlchemy repositories to flush instead of commit so transaction control is centralized in the Unit of Work layer.
- Update dependency injection containers to provide session factories and expose UoW factories alongside existing read-only repositories.
- Simplify unit tests by introducing per-module UoW mock helpers and adjusting use case tests to assert against UoW-backed repositories.

Tests:
- Add a unit test suite for the abstract UnitOfWork contract to validate commit/rollback semantics.
- Add an integration test for SqlAlchemyMediaUnitOfWork to exercise commit, rollback, reuse, and factory isolation behaviour against an in-memory database.