### PR TITLE
refactor(modules): isolate BCs via read ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ test-cov:
 
 lint:
 	poetry run ruff check src tests
+	poetry run ruff format --check src tests
 
 format:
 	poetry run ruff check --fix src tests

--- a/docs/adr/ADR-009-cross-bc-read-ports.md
+++ b/docs/adr/ADR-009-cross-bc-read-ports.md
@@ -1,0 +1,164 @@
+# ADR-009: Ports de leitura entre Bounded Contexts
+
+**Status:** Aceito
+**Data:** 2026-04-18
+**Deciders:** Lucas Cristovam
+**Technical Story:** Auditoria Clean Architecture + DDD (Fase 1 do plano em `docs/clean-architecture-refactoring-plan.md`).
+
+---
+
+## Contexto
+
+Até aqui, os módulos `library`, `collections` e `watch_progress` importavam diretamente repositórios e entidades do módulo `media` para compor suas respostas (contagens por path, título/poster de itens, árvore de seasons/episodes). O módulo `media` fazia o mesmo na direção oposta, importando `WatchProgressRepository` para anexar progresso no payload de `GET /series/{id}`.
+
+Isso viola a regra do CLAUDE.md:
+
+> Módulos não importam entre si (comunicação futura via integration events)
+
+E quebra o isolamento de Bounded Contexts: qualquer mudança em repositórios ou entidades do `media` arrastava 3 outros BCs; qualquer mudança em `WatchProgress` quebrava o `media`. A linguagem ubíqua também vazava — VOs como `MovieId` / `SeriesId` circulavam em código que nem é do Media BC.
+
+Escrever dados cruzados entre BCs é problema maior (eventual consistency, integration events) e fica fora do escopo deste ADR. **Leitura cruzada**, porém, é necessidade recorrente — a UI exige telas que misturam dados de vários BCs.
+
+## Decisão
+
+Toda leitura que atravessa a fronteira de um Bounded Context é feita através de um **port local** no BC consumidor. O adapter que implementa a port vive na camada de infraestrutura do consumidor e é o **único** ponto que importa do domínio do BC provedor.
+
+Estrutura para cada par (consumidor, provedor):
+
+```
+src/modules/<consumer>/
+├── application/
+│   └── ports/
+│       └── <provider>_lookup_port.py    # Interface + DTOs do contrato
+└── infrastructure/
+    └── acl/
+        └── <provider>_lookup_adapter.py # Implementa a port usando repos do provider
+```
+
+Regras:
+
+1. **DTOs da port pertencem ao consumidor.** Cada BC define o shape que precisa — não se reutiliza o DTO de outro BC nem se promove o shape para `shared_kernel` sem evidência concreta de que são iguais em todos os usos.
+2. **Nomes da port refletem a linguagem do consumidor.** Não é "MovieRepository" — é "MediaLookupPort" do ponto de vista do consumidor.
+3. **Adapter é o único import cross-BC domain.** Use case só conhece a port local.
+4. **ACL vive sempre no consumidor**, nunca no provedor. O provedor não deve saber quem o consome.
+5. **Port por direção.** Se A→B e B→A, são ports separadas, uma em cada BC.
+6. **O wiring fica na composition root** (`src/config/containers/*.py`). O container do consumidor declara o adapter como `providers.Factory(...)`. Quando possível (não houver ciclo de declaração), receber o repo do provider via `providers.Dependency()` vindo do `main.py` é preferível a importar a implementação concreta do provider no container do consumidor.
+
+## Consequências
+
+### Positivas
+
+- BCs viram unidades substituíveis: mexer em `media.domain` não arrasta consumidores desde que a port (e seus DTOs) permaneçam estáveis.
+- Testes de use case ficam mais enxutos: só mockam a port local, não o repositório completo do outro BC com todos os seus métodos.
+- Adiciona um ponto natural para trocar repositório síncrono por fila/RPC/integration events quando a leitura cruzada precisar virar assíncrona.
+- Torna explícito em review o contrato mínimo que um BC precisa do outro — qualquer campo novo passa por discussão.
+
+### Negativas
+
+- Mais arquivos (port + adapter + DTOs) por cada par de BCs acoplados. Custo de boilerplate.
+- DTOs parcialmente redundantes (ex.: "o título da obra" aparece em vários BCs). Aceitamos essa duplicação — é o preço do isolamento.
+- Quando o dataset de leitura cruzada crescer (ex.: `collections` buscando centenas de summaries), o adapter precisa bater em `find_by_ids` (batch) em vez de `find_by_id` (N+1). Regra: a port expõe **o shape batch** desde o começo.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Duplicação de DTO escala mal com o número de pares | Média | Baixo | Revisar periodicamente se 2+ BCs descrevem o mesmo shape — aí sim promover para `shared_kernel` |
+| Ciclo de wiring entre containers (A depende de B e B depende de A) | Média | Médio | Quando `providers.Container(...)` cruzado é inviável, o adapter pode instanciar o repo concreto do provider (infra→infra) via import direto. Aceito como compromisso |
+| Adapter virar "repositório mal disfarçado" com dezenas de métodos | Baixa | Médio | PR review rejeita ports que crescem além do read-only essencial. Se um BC precisa de escrita cruzada, é sinal de domain service / integration event — não de port maior |
+
+## Alternativas Consideradas
+
+### 1. Continuar importando diretamente os repositórios do outro BC
+
+O estado anterior. Funcionava, mas quebrava a regra de isolamento entre módulos e deixava os 4 BCs acoplados em um grafo denso.
+
+**Rejeitado porque:** inviabiliza evolução independente dos BCs; é o problema que motivou este ADR.
+
+### 2. Promover os repositórios compartilhados para `shared_kernel`
+
+Mover `MovieRepository`/`SeriesRepository` para `shared_kernel` e deixar qualquer BC importar.
+
+**Rejeitado porque:** agregados são sempre de um BC específico — `Movie` é do Media Catalog. `shared_kernel` serve para VOs genuinamente universais (ex.: `FilePath`, `LanguageCode`), não para conceitos que pertencem a um BC.
+
+### 3. Domain events / integration events já na Fase 1
+
+Em vez de read ports, fazer cada BC publicar eventos e materializar uma read model local.
+
+**Rejeitado por enquanto:** complexidade alta demais para um `/series/{id}` que hoje é síncrono. Vale voltar a esse modelo quando algum cruzamento ficar grande o suficiente para justificar ou quando houver requisito de consistência eventual. A port **não atrapalha** essa futura migração — ela só substitui o adapter por um `CachedReadModelAdapter` que consulta uma tabela alimentada por eventos.
+
+### 4. Query bus com handlers por BC
+
+Um `QueryBus` central onde `media` publica handlers de suas próprias queries e `watch_progress` os invoca por tipo.
+
+**Rejeitado porque:** reintroduz acoplamento indireto no dispatcher (todos os BCs conhecem o bus), complexidade maior que o benefício para uma app de 5 BCs.
+
+## Referências
+
+- `docs/clean-architecture-refactoring-plan.md` — Fase 1 detalha a ordem de migração e os pares afetados.
+- `docs/adr/ADR-004-dependency-injection.md` — explica por que o container é o composition root.
+- `docs/adr/ADR-008-screaming-architecture.md` — organização por BC que este ADR reforça.
+- Vaughn Vernon, *Implementing Domain-Driven Design* — capítulo sobre Anti-Corruption Layer entre BCs.
+
+---
+
+## Notas de Implementação
+
+Exemplo do padrão, consumidor `watch_progress` → provedor `media`:
+
+```python
+# src/modules/watch_progress/application/ports/media_lookup_port.py
+@dataclass(frozen=True)
+class MovieDisplayInfo:
+    media_id: str
+    title: str              # já localizado
+    poster_path: str | None
+    backdrop_path: str | None
+
+
+class MediaLookupPort(ABC):
+    @abstractmethod
+    async def get_movie(self, media_id: str, lang: str) -> MovieDisplayInfo | None: ...
+```
+
+```python
+# src/modules/watch_progress/infrastructure/acl/media_lookup_adapter.py
+class MediaLookupAdapter(MediaLookupPort):
+    def __init__(self, movie_repository: MovieRepository, ...) -> None: ...
+
+    async def get_movie(self, media_id: str, lang: str) -> MovieDisplayInfo | None:
+        movie = await self._movie_repo.find_by_id(MovieId(media_id))
+        if movie is None:
+            return None
+        return MovieDisplayInfo(
+            media_id=media_id,
+            title=movie.get_title(lang),
+            poster_path=movie.poster_path.value if movie.poster_path else None,
+            backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+        )
+```
+
+```python
+# src/config/containers/watch_progress.py
+class WatchProgressContainer(containers.DeclarativeContainer):
+    movie_repository = providers.Dependency()
+    series_repository = providers.Dependency()
+
+    media_lookup = providers.Factory(
+        MediaLookupAdapter,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
+    )
+
+    get_continue_watching = providers.Factory(
+        GetContinueWatchingUseCase,
+        progress_repository=progress_repository,
+        media_lookup=media_lookup,   # port, não repositório
+    )
+```
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-04-18 | Lucas Cristovam | Criação inicial (Fase 1 da refatoração Clean Architecture) |

--- a/src/config/containers/collections.py
+++ b/src/config/containers/collections.py
@@ -14,6 +14,7 @@ from src.modules.collections.application.use_cases import (
     RenameCustomListUseCase,
     ToggleWatchlistUseCase,
 )
+from src.modules.collections.infrastructure.acl import MediaLookupAdapter
 from src.modules.collections.infrastructure.persistence.repositories import (
     SQLAlchemyCustomListRepository,
     SQLAlchemyWatchlistRepository,
@@ -33,6 +34,8 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     session = providers.Dependency()
     session_factory = providers.Dependency()
+    # Media repositories come in so the ACL adapter can delegate
+    # metadata lookups. Use cases only ever see ``MediaLookupPort``.
     movie_repository = providers.Dependency()
     series_repository = providers.Dependency()
 
@@ -56,6 +59,16 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
     )
 
     # =========================================================================
+    # Anti-corruption layer (cross-BC read ports)
+    # =========================================================================
+
+    media_lookup = providers.Factory(
+        MediaLookupAdapter,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
+    )
+
+    # =========================================================================
     # Watchlist Use Cases
     # =========================================================================
 
@@ -67,8 +80,7 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
     get_watchlist = providers.Factory(
         GetWatchlistUseCase,
         watchlist_repository=watchlist_repository,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_lookup=media_lookup,
     )
 
     check_watchlist = providers.Factory(
@@ -113,6 +125,5 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
     get_custom_list_items = providers.Factory(
         GetCustomListItemsUseCase,
         custom_list_repository=custom_list_repository,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_lookup=media_lookup,
     )

--- a/src/config/containers/library.py
+++ b/src/config/containers/library.py
@@ -12,6 +12,7 @@ from src.modules.library.application.use_cases.get_library_by_id import GetLibra
 from src.modules.library.application.use_cases.list_libraries import ListLibrariesUseCase
 from src.modules.library.application.use_cases.update_library import UpdateLibraryUseCase
 from src.modules.library.domain.services.track_selector import TrackSelector
+from src.modules.library.infrastructure.acl import MediaCountQueryAdapter
 from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
     SqlAlchemyLibraryRepository,
 )
@@ -26,6 +27,7 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     Provides:
     - Repository implementation (SQLAlchemy) for read use cases
     - Unit of Work factory for write use cases
+    - ACL adapter for the Media BC read port
     - CRUD use cases
     - Domain services
     """
@@ -33,9 +35,9 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # Wired from InfrastructureContainer via main container.
     session = providers.Dependency()
     session_factory = providers.Dependency()
-    # Media repositories come from MediaContainer — library responses
-    # include per-library movie/series counts, so the library use
-    # cases need to query those tables too.
+    # Media repositories come in so the ACL adapter can delegate
+    # count queries. The use cases themselves only know the
+    # ``MediaCountQueryPort`` — they never see these concretes.
     movie_repository = providers.Dependency()
     series_repository = providers.Dependency()
 
@@ -54,35 +56,41 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     )
 
     # =========================================================================
+    # Anti-corruption layer (cross-BC read ports)
+    # =========================================================================
+
+    media_count_query = providers.Factory(
+        MediaCountQueryAdapter,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
+    )
+
+    # =========================================================================
     # Use Cases
     # =========================================================================
 
     create_library = providers.Factory(
         CreateLibraryUseCase,
         uow_factory=library_unit_of_work_factory,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_count_query=media_count_query,
     )
 
     list_libraries = providers.Factory(
         ListLibrariesUseCase,
         library_repository=library_repository,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_count_query=media_count_query,
     )
 
     get_library_by_id = providers.Factory(
         GetLibraryByIdUseCase,
         library_repository=library_repository,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_count_query=media_count_query,
     )
 
     update_library = providers.Factory(
         UpdateLibraryUseCase,
         uow_factory=library_unit_of_work_factory,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_count_query=media_count_query,
     )
 
     delete_library = providers.Factory(

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -31,6 +31,7 @@ from src.modules.media.application.use_cases.scan_media_directories import (
 )
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
+from src.modules.media.infrastructure.acl import ProgressLookupAdapter
 from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
 from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
@@ -55,6 +56,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     Provides:
     - Repository implementations (SQLAlchemy)
     - Use cases for movie, series, and file variant operations
+    - ACL adapter for the Watch Progress BC read port
 
     The ``session`` dependency must be wired from the parent container
     once the database provider is added to InfrastructureContainer.
@@ -87,14 +89,26 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         session=session,
     )
 
-    progress_repository = providers.Factory(
+    media_unit_of_work_factory = providers.Singleton(
+        SqlAlchemyMediaUnitOfWorkFactory,
+        session_factory=session_factory,
+    )
+
+    # =========================================================================
+    # Anti-corruption layer (cross-BC read ports)
+    # =========================================================================
+    # Wraps the Watch Progress repository so media use cases see only
+    # the ``ProgressLookupPort`` and never import progress domain types.
+    # Each request builds a fresh adapter bound to the request session.
+
+    _progress_repository = providers.Factory(
         SQLAlchemyWatchProgressRepository,
         session=session,
     )
 
-    media_unit_of_work_factory = providers.Singleton(
-        SqlAlchemyMediaUnitOfWorkFactory,
-        session_factory=session_factory,
+    progress_lookup = providers.Factory(
+        ProgressLookupAdapter,
+        progress_repository=_progress_repository,
     )
 
     # =========================================================================
@@ -125,7 +139,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     get_series_by_id = providers.Factory(
         GetSeriesByIdUseCase,
         series_repository=series_repository,
-        progress_repository=progress_repository,
+        progress_lookup=progress_lookup,
     )
 
     list_series = providers.Factory(

--- a/src/config/containers/watch_progress.py
+++ b/src/config/containers/watch_progress.py
@@ -11,6 +11,7 @@ from src.modules.watch_progress.application.use_cases import (
 from src.modules.watch_progress.application.use_cases.clear_series_progress import (
     ClearSeriesProgressUseCase,
 )
+from src.modules.watch_progress.infrastructure.acl import MediaLookupAdapter
 from src.modules.watch_progress.infrastructure.persistence.repositories import (
     SQLAlchemyWatchProgressRepository,
 )
@@ -29,6 +30,8 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
 
     session = providers.Dependency()
     session_factory = providers.Dependency()
+    # Media repositories come in so the ACL adapter can delegate
+    # display lookups. Use cases only ever see ``MediaLookupPort``.
     movie_repository = providers.Dependency()
     series_repository = providers.Dependency()
 
@@ -44,6 +47,16 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
     watch_progress_unit_of_work_factory = providers.Singleton(
         SqlAlchemyWatchProgressUnitOfWorkFactory,
         session_factory=session_factory,
+    )
+
+    # =========================================================================
+    # Anti-corruption layer (cross-BC read ports)
+    # =========================================================================
+
+    media_lookup = providers.Factory(
+        MediaLookupAdapter,
+        movie_repository=movie_repository,
+        series_repository=series_repository,
     )
 
     # =========================================================================
@@ -63,8 +76,7 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
     get_continue_watching = providers.Factory(
         GetContinueWatchingUseCase,
         progress_repository=progress_repository,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_lookup=media_lookup,
     )
 
     clear_progress = providers.Factory(

--- a/src/modules/collections/application/ports/__init__.py
+++ b/src/modules/collections/application/ports/__init__.py
@@ -1,0 +1,8 @@
+"""Collections application ports (interfaces for external BCs)."""
+
+from src.modules.collections.application.ports.media_lookup_port import (
+    MediaLookupPort,
+    MediaSummary,
+)
+
+__all__ = ["MediaLookupPort", "MediaSummary"]

--- a/src/modules/collections/application/ports/media_lookup_port.py
+++ b/src/modules/collections/application/ports/media_lookup_port.py
@@ -1,0 +1,68 @@
+"""Port for looking up display metadata of media items from the Media BC.
+
+Collections (watchlist, custom lists) embed the title and poster of
+the referenced movies/series in their list responses. This port is
+the only surface through which Collections reaches into the Media
+catalog. The adapter lives in ``collections.infrastructure.acl``.
+
+See ADR-009 for the cross-BC read port pattern.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from src.shared_kernel.value_objects import CollectionMediaType
+
+
+@dataclass(frozen=True)
+class MediaSummary:
+    """Minimal media display data needed by Collections.
+
+    Attributes:
+        media_id: External id (``mov_xxx`` or ``ser_xxx``).
+        media_type: Whether the referenced media is a movie or series.
+        title: Already-localized title (resolved server-side using the
+            ``lang`` argument passed to ``get_many``).
+        poster_path: Absolute or relative poster URL, or ``None`` when
+            the source has no poster.
+    """
+
+    media_id: str
+    media_type: CollectionMediaType
+    title: str
+    poster_path: str | None
+
+
+class MediaLookupPort(ABC):
+    """Batch lookup of media display metadata by id + type.
+
+    The port deliberately takes two parallel id lists instead of a
+    single mixed list so the adapter can issue one query per table.
+    Keeping the argument signature flat (no wrapping object) matches
+    the existing use-case code style.
+    """
+
+    @abstractmethod
+    async def get_many(
+        self,
+        movie_ids: Sequence[str],
+        series_ids: Sequence[str],
+        lang: str,
+    ) -> dict[tuple[CollectionMediaType, str], MediaSummary]:
+        """Resolve metadata for the given movies and series.
+
+        Args:
+            movie_ids: External movie ids (``mov_xxx``).
+            series_ids: External series ids (``ser_xxx``).
+            lang: Language code used to localize titles.
+
+        Returns:
+            Map keyed by ``(media_type, media_id)``. Ids that don't
+            resolve to an entity are simply absent from the map — the
+            use case decides how to handle the gap.
+        """
+        ...
+
+
+__all__ = ["MediaLookupPort", "MediaSummary"]

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -7,9 +7,8 @@ from src.modules.collections.application.dtos import (
     CustomListItemOutput,
     GetCustomListItemsInput,
 )
+from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.domain.repositories import CustomListRepository
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
-from src.modules.media.domain.value_objects import MovieId, SeriesId
 from src.shared_kernel.value_objects import CollectionMediaType
 
 _logger = logging.getLogger(__name__)
@@ -18,13 +17,11 @@ _logger = logging.getLogger(__name__)
 class GetCustomListItemsUseCase:
     """List all items in a custom list with display metadata.
 
-    Joins list items with movie/series data to provide
-    title and poster for the UI. Uses batch lookups to avoid N+1.
+    Joins list items with the Media BC's display data (title, poster)
+    via ``MediaLookupPort``. Uses a single batch lookup to avoid N+1.
 
     Example:
-        >>> use_case = GetCustomListItemsUseCase(
-        ...     custom_list_repo, movie_repo, series_repo,
-        ... )
+        >>> use_case = GetCustomListItemsUseCase(custom_list_repo, media_lookup)
         >>> items = await use_case.execute(
         ...     GetCustomListItemsInput(list_id="lst_abc123", lang="pt-BR"),
         ... )
@@ -33,19 +30,16 @@ class GetCustomListItemsUseCase:
     def __init__(
         self,
         custom_list_repository: CustomListRepository,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        media_lookup: MediaLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
             custom_list_repository: Repository for custom list items.
-            movie_repository: Repository for movie metadata.
-            series_repository: Repository for series metadata.
+            media_lookup: Port for resolving media display metadata.
         """
         self._list_repo = custom_list_repository
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+        self._media_lookup = media_lookup
 
     async def execute(
         self,
@@ -72,43 +66,27 @@ class GetCustomListItemsUseCase:
         if not items:
             return []
 
-        # Batch-load all referenced movies and series
-        movie_ids = [
-            MovieId(i.media_id) for i in items if i.media_type == CollectionMediaType.MOVIE
-        ]
-        series_ids = [
-            SeriesId(i.media_id) for i in items if i.media_type == CollectionMediaType.SERIES
-        ]
+        movie_ids = [i.media_id for i in items if i.media_type == CollectionMediaType.MOVIE]
+        series_ids = [i.media_id for i in items if i.media_type == CollectionMediaType.SERIES]
 
-        movies_map = await self._movie_repo.find_by_ids(movie_ids) if movie_ids else {}
-        series_map = await self._series_repo.find_by_ids(series_ids) if series_ids else {}
+        summaries = await self._media_lookup.get_many(movie_ids, series_ids, input_dto.lang)
 
         result: list[CustomListItemOutput] = []
         for item in items:
-            if item.media_type == CollectionMediaType.MOVIE:
-                movie = movies_map.get(item.media_id)
-                if not movie:
-                    _logger.warning("Could not find movie for custom list item: %s", item.media_id)
-                    continue
-                result.append(
-                    CustomListItemOutput.from_entity(
-                        entity=item,
-                        title=movie.get_title(input_dto.lang),
-                        poster_path=movie.poster_path.value if movie.poster_path else None,
-                    )
+            summary = summaries.get((item.media_type, item.media_id))
+            if summary is None:
+                _logger.warning(
+                    "Could not find media for custom list item: %s",
+                    item.media_id,
                 )
-            elif item.media_type == CollectionMediaType.SERIES:
-                series = series_map.get(item.media_id)
-                if not series:
-                    _logger.warning("Could not find series for custom list item: %s", item.media_id)
-                    continue
-                result.append(
-                    CustomListItemOutput.from_entity(
-                        entity=item,
-                        title=series.get_title(input_dto.lang),
-                        poster_path=series.poster_path.value if series.poster_path else None,
-                    )
+                continue
+            result.append(
+                CustomListItemOutput.from_entity(
+                    entity=item,
+                    title=summary.title,
+                    poster_path=summary.poster_path,
                 )
+            )
 
         return result
 

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -6,9 +6,8 @@ from src.modules.collections.application.dtos import (
     GetWatchlistInput,
     WatchlistItemOutput,
 )
+from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.domain.repositories import WatchlistRepository
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
-from src.modules.media.domain.value_objects import MovieId, SeriesId
 from src.shared_kernel.value_objects import CollectionMediaType
 
 _logger = logging.getLogger(__name__)
@@ -17,31 +16,29 @@ _logger = logging.getLogger(__name__)
 class GetWatchlistUseCase:
     """List all items in the user's watchlist with display metadata.
 
-    Joins watchlist records with movie/series data to provide
-    title and poster for the My List UI section. Uses batch
-    lookups to avoid N+1 queries.
+    Joins watchlist records with the Media BC's display data (title,
+    poster) via ``MediaLookupPort`` so this use case never talks to
+    media repositories directly. Uses a single batch lookup to avoid
+    N+1 queries.
 
     Example:
-        >>> use_case = GetWatchlistUseCase(watchlist_repo, movie_repo, series_repo)
+        >>> use_case = GetWatchlistUseCase(watchlist_repo, media_lookup)
         >>> items = await use_case.execute(GetWatchlistInput(limit=50, lang="pt-BR"))
     """
 
     def __init__(
         self,
         watchlist_repository: WatchlistRepository,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        media_lookup: MediaLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
             watchlist_repository: Repository for watchlist items.
-            movie_repository: Repository for movie metadata.
-            series_repository: Repository for series metadata.
+            media_lookup: Port for resolving media display metadata.
         """
         self._watchlist_repo = watchlist_repository
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+        self._media_lookup = media_lookup
 
     async def execute(self, input_dto: GetWatchlistInput) -> list[WatchlistItemOutput]:
         """Execute the use case.
@@ -58,43 +55,24 @@ class GetWatchlistUseCase:
         if not items:
             return []
 
-        # Batch-load all referenced movies and series
-        movie_ids = [
-            MovieId(i.media_id) for i in items if i.media_type == CollectionMediaType.MOVIE
-        ]
-        series_ids = [
-            SeriesId(i.media_id) for i in items if i.media_type == CollectionMediaType.SERIES
-        ]
+        movie_ids = [i.media_id for i in items if i.media_type == CollectionMediaType.MOVIE]
+        series_ids = [i.media_id for i in items if i.media_type == CollectionMediaType.SERIES]
 
-        movies_map = await self._movie_repo.find_by_ids(movie_ids) if movie_ids else {}
-        series_map = await self._series_repo.find_by_ids(series_ids) if series_ids else {}
+        summaries = await self._media_lookup.get_many(movie_ids, series_ids, input_dto.lang)
 
         result: list[WatchlistItemOutput] = []
         for item in items:
-            if item.media_type == CollectionMediaType.MOVIE:
-                movie = movies_map.get(item.media_id)
-                if not movie:
-                    _logger.warning("Could not find media for watchlist item: %s", item.media_id)
-                    continue
-                result.append(
-                    WatchlistItemOutput.from_entity(
-                        entity=item,
-                        title=movie.get_title(input_dto.lang),
-                        poster_path=movie.poster_path.value if movie.poster_path else None,
-                    )
+            summary = summaries.get((item.media_type, item.media_id))
+            if summary is None:
+                _logger.warning("Could not find media for watchlist item: %s", item.media_id)
+                continue
+            result.append(
+                WatchlistItemOutput.from_entity(
+                    entity=item,
+                    title=summary.title,
+                    poster_path=summary.poster_path,
                 )
-            elif item.media_type == CollectionMediaType.SERIES:
-                series = series_map.get(item.media_id)
-                if not series:
-                    _logger.warning("Could not find media for watchlist item: %s", item.media_id)
-                    continue
-                result.append(
-                    WatchlistItemOutput.from_entity(
-                        entity=item,
-                        title=series.get_title(input_dto.lang),
-                        poster_path=series.poster_path.value if series.poster_path else None,
-                    )
-                )
+            )
 
         return result
 

--- a/src/modules/collections/infrastructure/acl/__init__.py
+++ b/src/modules/collections/infrastructure/acl/__init__.py
@@ -1,0 +1,7 @@
+"""Anti-corruption layer: adapters translating external BCs to local ports."""
+
+from src.modules.collections.infrastructure.acl.media_lookup_adapter import (
+    MediaLookupAdapter,
+)
+
+__all__ = ["MediaLookupAdapter"]

--- a/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
+++ b/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
@@ -1,0 +1,65 @@
+"""Adapter that implements ``MediaLookupPort`` using Media repositories.
+
+This is the only file in the Collections BC that imports from
+``src.modules.media.domain``. Everything above it sees ``MediaSummary``.
+"""
+
+from collections.abc import Sequence
+
+from src.modules.collections.application.ports.media_lookup_port import (
+    MediaLookupPort,
+    MediaSummary,
+)
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.value_objects import MovieId, SeriesId
+from src.shared_kernel.value_objects import CollectionMediaType
+
+
+class MediaLookupAdapter(MediaLookupPort):
+    """Resolve media display data via the Media BC's repositories."""
+
+    def __init__(
+        self,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
+
+    async def get_many(
+        self,
+        movie_ids: Sequence[str],
+        series_ids: Sequence[str],
+        lang: str,
+    ) -> dict[tuple[CollectionMediaType, str], MediaSummary]:
+        """Batch-resolve display metadata via the Media repositories."""
+        result: dict[tuple[CollectionMediaType, str], MediaSummary] = {}
+
+        if movie_ids:
+            movies_map = await self._movie_repo.find_by_ids(
+                [MovieId(mid) for mid in movie_ids],
+            )
+            for media_id, movie in movies_map.items():
+                result[(CollectionMediaType.MOVIE, media_id)] = MediaSummary(
+                    media_id=media_id,
+                    media_type=CollectionMediaType.MOVIE,
+                    title=movie.get_title(lang),
+                    poster_path=movie.poster_path.value if movie.poster_path else None,
+                )
+
+        if series_ids:
+            series_map = await self._series_repo.find_by_ids(
+                [SeriesId(sid) for sid in series_ids],
+            )
+            for media_id, series in series_map.items():
+                result[(CollectionMediaType.SERIES, media_id)] = MediaSummary(
+                    media_id=media_id,
+                    media_type=CollectionMediaType.SERIES,
+                    title=series.get_title(lang),
+                    poster_path=series.poster_path.value if series.poster_path else None,
+                )
+
+        return result
+
+
+__all__ = ["MediaLookupAdapter"]

--- a/src/modules/library/application/ports/__init__.py
+++ b/src/modules/library/application/ports/__init__.py
@@ -1,0 +1,7 @@
+"""Library application ports (interfaces for external BCs)."""
+
+from src.modules.library.application.ports.media_count_query_port import (
+    MediaCountQueryPort,
+)
+
+__all__ = ["MediaCountQueryPort"]

--- a/src/modules/library/application/ports/media_count_query_port.py
+++ b/src/modules/library/application/ports/media_count_query_port.py
@@ -1,0 +1,50 @@
+"""Port for querying media counts from the Media bounded context.
+
+The Library BC exposes per-library movie/series counts in its output
+DTO but does not own the media catalog. This port describes the
+minimal read contract Library requires from Media. The adapter lives
+in ``library.infrastructure.acl`` and translates from Media's
+``MovieRepository`` / ``SeriesRepository``.
+
+See ADR-009 for the cross-BC read port pattern.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+
+class MediaCountQueryPort(ABC):
+    """Read-only query of media counts under a set of directory paths.
+
+    This is the only surface through which the Library BC reaches into
+    the Media catalog. Keep it narrow — anything richer than counts
+    should trigger a conversation about whether the responsibility
+    belongs in Library at all.
+    """
+
+    @abstractmethod
+    async def count_movies_under_paths(self, paths: Sequence[str]) -> int:
+        """Count movies whose primary file sits under any of ``paths``.
+
+        Args:
+            paths: Absolute directory paths. Empty sequence returns ``0``.
+
+        Returns:
+            Non-negative count of distinct movies.
+        """
+        ...
+
+    @abstractmethod
+    async def count_series_under_paths(self, paths: Sequence[str]) -> int:
+        """Count series with at least one episode file under ``paths``.
+
+        Args:
+            paths: Absolute directory paths. Empty sequence returns ``0``.
+
+        Returns:
+            Non-negative count of distinct series.
+        """
+        ...
+
+
+__all__ = ["MediaCountQueryPort"]

--- a/src/modules/library/application/use_cases/_to_output.py
+++ b/src/modules/library/application/use_cases/_to_output.py
@@ -5,25 +5,23 @@ from src.modules.library.application.dtos.library_dtos import (
     LibrarySettingsOutput,
     MetadataProviderOutput,
 )
+from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.domain.entities.library import Library
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 async def library_to_output(
     entity: Library,
-    movie_repository: MovieRepository,
-    series_repository: SeriesRepository,
+    media_count_query: MediaCountQueryPort,
 ) -> LibraryOutput:
     """Convert a Library domain entity to its output DTO.
 
-    The movie/series counts are computed inline from the media repos
-    — two ``COUNT(*)`` style queries per library. This is fine for
-    tens of libraries; batching across libraries would only matter
-    at a scale we don't have today.
+    The movie/series counts are resolved via the ``MediaCountQueryPort``
+    so the Library BC never imports Media repositories directly. See
+    ADR-009 for the cross-BC read port pattern.
     """
     paths = [p.value for p in entity.paths]
-    movie_count = await movie_repository.count_under_paths(paths)
-    series_count = await series_repository.count_under_paths(paths)
+    movie_count = await media_count_query.count_movies_under_paths(paths)
+    series_count = await media_count_query.count_series_under_paths(paths)
     return LibraryOutput(
         id=str(entity.id),
         name=entity.name.value,

--- a/src/modules/library/application/use_cases/create_library.py
+++ b/src/modules/library/application/use_cases/create_library.py
@@ -6,6 +6,7 @@ from src.modules.library.application.dtos.library_dtos import (
     CreateLibraryInput,
     LibraryOutput,
 )
+from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.entities.library import Library
@@ -16,7 +17,6 @@ from src.modules.library.domain.value_objects.metadata_provider import (
     MetadataProviderConfig,
 )
 from src.modules.library.domain.value_objects.subtitle_mode import SubtitleMode
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.shared_kernel.value_objects.language_code import LanguageCode
 
 
@@ -26,12 +26,10 @@ class CreateLibraryUseCase:
     def __init__(
         self,
         uow_factory: LibraryUnitOfWorkFactory,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        media_count_query: MediaCountQueryPort,
     ) -> None:
         self._uow_factory = uow_factory
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+        self._media_count_query = media_count_query
 
     async def execute(self, input_dto: CreateLibraryInput) -> LibraryOutput:
         """Create and persist a new Library.
@@ -66,7 +64,7 @@ class CreateLibraryUseCase:
 
         async with self._uow_factory() as uow:
             saved = await uow.libraries.save(library)
-        return await library_to_output(saved, self._movie_repo, self._series_repo)
+        return await library_to_output(saved, self._media_count_query)
 
 
 def _build_settings(raw: dict[str, Any]) -> LibrarySettings:

--- a/src/modules/library/application/use_cases/get_library_by_id.py
+++ b/src/modules/library/application/use_cases/get_library_by_id.py
@@ -5,10 +5,10 @@ from src.modules.library.application.dtos.library_dtos import (
     GetLibraryByIdInput,
     LibraryOutput,
 )
+from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 class GetLibraryByIdUseCase:
@@ -17,12 +17,10 @@ class GetLibraryByIdUseCase:
     def __init__(
         self,
         library_repository: LibraryRepository,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        media_count_query: MediaCountQueryPort,
     ) -> None:
         self._repo = library_repository
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+        self._media_count_query = media_count_query
 
     async def execute(self, input_dto: GetLibraryByIdInput) -> LibraryOutput:
         """Fetch a library or raise if not found.
@@ -44,7 +42,7 @@ class GetLibraryByIdUseCase:
                 "Library",
                 input_dto.library_id,
             )
-        return await library_to_output(entity, self._movie_repo, self._series_repo)
+        return await library_to_output(entity, self._media_count_query)
 
 
 __all__ = ["GetLibraryByIdUseCase"]

--- a/src/modules/library/application/use_cases/list_libraries.py
+++ b/src/modules/library/application/use_cases/list_libraries.py
@@ -1,9 +1,9 @@
 """ListLibrariesUseCase."""
 
 from src.modules.library.application.dtos.library_dtos import LibraryOutput
+from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 class ListLibrariesUseCase:
@@ -12,12 +12,10 @@ class ListLibrariesUseCase:
     def __init__(
         self,
         library_repository: LibraryRepository,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        media_count_query: MediaCountQueryPort,
     ) -> None:
         self._repo = library_repository
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+        self._media_count_query = media_count_query
 
     async def execute(self) -> list[LibraryOutput]:
         """List all libraries.
@@ -35,7 +33,7 @@ class ListLibrariesUseCase:
             List of ``LibraryOutput`` ordered by name.
         """
         entities = await self._repo.find_all()
-        return [await library_to_output(e, self._movie_repo, self._series_repo) for e in entities]
+        return [await library_to_output(e, self._media_count_query) for e in entities]
 
 
 __all__ = ["ListLibrariesUseCase"]

--- a/src/modules/library/application/use_cases/update_library.py
+++ b/src/modules/library/application/use_cases/update_library.py
@@ -7,6 +7,7 @@ from src.modules.library.application.dtos.library_dtos import (
     LibraryOutput,
     UpdateLibraryInput,
 )
+from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.application.use_cases.create_library import _build_settings
@@ -17,7 +18,6 @@ from src.modules.library.domain.value_objects.metadata_provider import (
     MetadataProvider,
     MetadataProviderConfig,
 )
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
 
@@ -28,12 +28,10 @@ class UpdateLibraryUseCase:
     def __init__(
         self,
         uow_factory: LibraryUnitOfWorkFactory,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        media_count_query: MediaCountQueryPort,
     ) -> None:
         self._uow_factory = uow_factory
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+        self._media_count_query = media_count_query
 
     async def execute(self, input_dto: UpdateLibraryInput) -> LibraryOutput:
         """Apply partial updates to a library.
@@ -85,7 +83,7 @@ class UpdateLibraryUseCase:
 
             updated = entity.with_updates(**updates)
             saved = await uow.libraries.save(updated)
-        return await library_to_output(saved, self._movie_repo, self._series_repo)
+        return await library_to_output(saved, self._media_count_query)
 
 
 __all__ = ["UpdateLibraryUseCase"]

--- a/src/modules/library/infrastructure/acl/__init__.py
+++ b/src/modules/library/infrastructure/acl/__init__.py
@@ -1,0 +1,7 @@
+"""Anti-corruption layer: adapters translating external BCs to local ports."""
+
+from src.modules.library.infrastructure.acl.media_count_query_adapter import (
+    MediaCountQueryAdapter,
+)
+
+__all__ = ["MediaCountQueryAdapter"]

--- a/src/modules/library/infrastructure/acl/media_count_query_adapter.py
+++ b/src/modules/library/infrastructure/acl/media_count_query_adapter.py
@@ -1,0 +1,36 @@
+"""Adapter that implements ``MediaCountQueryPort`` using Media repositories.
+
+This is the only file in the Library BC that imports from
+``src.modules.media.domain``. The port surface isolates the rest of
+Library from the Media catalog.
+"""
+
+from collections.abc import Sequence
+
+from src.modules.library.application.ports.media_count_query_port import (
+    MediaCountQueryPort,
+)
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+
+
+class MediaCountQueryAdapter(MediaCountQueryPort):
+    """Delegate count queries to the Media bounded context's repositories."""
+
+    def __init__(
+        self,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
+
+    async def count_movies_under_paths(self, paths: Sequence[str]) -> int:
+        """Delegate to ``MovieRepository.count_under_paths``."""
+        return await self._movie_repo.count_under_paths(paths)
+
+    async def count_series_under_paths(self, paths: Sequence[str]) -> int:
+        """Delegate to ``SeriesRepository.count_under_paths``."""
+        return await self._series_repo.count_under_paths(paths)
+
+
+__all__ = ["MediaCountQueryAdapter"]

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -1,4 +1,4 @@
-"""Media application ports (interfaces for infrastructure)."""
+"""Media application ports (interfaces for infrastructure and external BCs)."""
 
 from src.modules.media.application.ports.file_scanner_port import (
     FileSystemScanner,
@@ -13,6 +13,10 @@ from src.modules.media.application.ports.metadata_provider_port import (
     MetadataProvider,
     SeasonMetadata,
 )
+from src.modules.media.application.ports.progress_lookup_port import (
+    ProgressLookupPort,
+    ProgressSummary,
+)
 
 __all__ = [
     "CreditPerson",
@@ -22,6 +26,8 @@ __all__ = [
     "MediaMetadata",
     "MediaType",
     "MetadataProvider",
+    "ProgressLookupPort",
+    "ProgressSummary",
     "ScannedFile",
     "SeasonMetadata",
 ]

--- a/src/modules/media/application/ports/progress_lookup_port.py
+++ b/src/modules/media/application/ports/progress_lookup_port.py
@@ -1,0 +1,60 @@
+"""Port for reading watch-progress data alongside series episodes.
+
+The ``GET /api/v1/series/{id}`` endpoint embeds each episode's
+progress (percentage, position, status, last-watched timestamp) into
+the response. Media doesn't own progress data — this port is the
+only surface through which it reaches into the Watch Progress BC.
+The adapter lives in ``media.infrastructure.acl``.
+
+See ADR-009 for the cross-BC read port pattern.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class ProgressSummary:
+    """Snapshot of progress values needed by the Series endpoint.
+
+    ``status`` is a plain string (``"in_progress"``, ``"completed"``,
+    ...) so consumers don't need to import the Watch Progress enum.
+
+    Attributes:
+        media_id: Composite episode media id (``epi_ser_<series>_<s>_<e>``).
+        percentage: Watch percentage in the range ``[0, 100]``.
+        position_seconds: Last known playback position in seconds.
+        status: Watch status label.
+        last_watched_at: Last update timestamp.
+    """
+
+    media_id: str
+    percentage: float
+    position_seconds: int
+    status: str
+    last_watched_at: datetime
+
+
+class ProgressLookupPort(ABC):
+    """Batch lookup of progress records by media id."""
+
+    @abstractmethod
+    async def find_for_media_ids(
+        self,
+        media_ids: Sequence[str],
+    ) -> dict[str, ProgressSummary]:
+        """Return progress summaries for the given media ids.
+
+        Args:
+            media_ids: Composite or standalone media ids to look up.
+
+        Returns:
+            Map keyed by ``media_id``. Ids without a matching progress
+            row are simply absent from the map.
+        """
+        ...
+
+
+__all__ = ["ProgressLookupPort", "ProgressSummary"]

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -7,14 +7,13 @@ from src.modules.media.application.dtos.series_dtos import (
     SeasonOutput,
     SeriesOutput,
 )
+from src.modules.media.application.ports import ProgressLookupPort, ProgressSummary
 from src.modules.media.application.use_cases._media_file_helpers import (
     to_media_file_output,
 )
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import SeriesId
-from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 from src.shared_kernel.episode_composite_id import EpisodeCompositeId
 
 
@@ -22,10 +21,12 @@ class GetSeriesByIdUseCase:
     """Retrieve a series with all seasons and episodes.
 
     This use case fetches a complete series hierarchy from the repository,
-    enriching each episode with watch progress data when available.
+    enriching each episode with watch progress data when available. Progress
+    is resolved via ``ProgressLookupPort`` so the Media BC never imports
+    Watch Progress domain types.
 
     Example:
-        >>> use_case = GetSeriesByIdUseCase(series_repository, progress_repository)
+        >>> use_case = GetSeriesByIdUseCase(series_repository, progress_lookup)
         >>> result = await use_case.execute(GetSeriesByIdInput("ser_abc123"))
         >>> result.title
         'Breaking Bad'
@@ -36,16 +37,16 @@ class GetSeriesByIdUseCase:
     def __init__(
         self,
         series_repository: SeriesRepository,
-        progress_repository: WatchProgressRepository,
+        progress_lookup: ProgressLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
             series_repository: Repository for series persistence.
-            progress_repository: Repository for watch progress.
+            progress_lookup: Port for resolving watch progress snapshots.
         """
         self._series_repository = series_repository
-        self._progress_repo = progress_repository
+        self._progress_lookup = progress_lookup
 
     async def execute(self, input_dto: GetSeriesByIdInput) -> SeriesOutput:
         """Execute the use case.
@@ -73,7 +74,7 @@ class GetSeriesByIdUseCase:
             for s in series.seasons
             for ep in s.episodes
         ]
-        progress_map = await self._progress_repo.find_by_media_ids(composite_ids)
+        progress_map = await self._progress_lookup.find_for_media_ids(composite_ids)
 
         return self._to_output(series, input_dto.lang, progress_map)
 
@@ -81,14 +82,14 @@ class GetSeriesByIdUseCase:
         self,
         series: Series,
         lang: str,
-        progress_map: dict[str, WatchProgress],
+        progress_map: dict[str, ProgressSummary],
     ) -> SeriesOutput:
         """Convert Series entity to output DTO.
 
         Args:
             series: The Series entity to convert.
             lang: Language code for localized fields.
-            progress_map: Map of composite media_id to watch progress.
+            progress_map: Map of composite media_id to progress summary.
 
         Returns:
             SeriesOutput with all fields and nested seasons/episodes.
@@ -120,14 +121,14 @@ class GetSeriesByIdUseCase:
     def _to_season_output(
         season: Season,
         series_id: str,
-        progress_map: dict[str, WatchProgress],
+        progress_map: dict[str, ProgressSummary],
     ) -> SeasonOutput:
         """Convert Season entity to output DTO.
 
         Args:
             season: The Season entity to convert.
             series_id: External series ID for composite key lookup.
-            progress_map: Map of composite media_id to watch progress.
+            progress_map: Map of composite media_id to progress summary.
 
         Returns:
             SeasonOutput with episode list.
@@ -156,7 +157,7 @@ class GetSeriesByIdUseCase:
         episode: Episode,
         series_id: str,
         season_number: int,
-        progress_map: dict[str, WatchProgress],
+        progress_map: dict[str, ProgressSummary],
     ) -> EpisodeOutput:
         """Convert Episode entity to output DTO.
 
@@ -164,7 +165,7 @@ class GetSeriesByIdUseCase:
             episode: The Episode entity to convert.
             series_id: External series ID for composite key lookup.
             season_number: Season number for composite key lookup.
-            progress_map: Map of composite media_id to watch progress.
+            progress_map: Map of composite media_id to progress summary.
 
         Returns:
             EpisodeOutput with all fields including progress.

--- a/src/modules/media/infrastructure/acl/__init__.py
+++ b/src/modules/media/infrastructure/acl/__init__.py
@@ -1,0 +1,7 @@
+"""Anti-corruption layer: adapters translating external BCs to local ports."""
+
+from src.modules.media.infrastructure.acl.progress_lookup_adapter import (
+    ProgressLookupAdapter,
+)
+
+__all__ = ["ProgressLookupAdapter"]

--- a/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
+++ b/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
@@ -1,0 +1,43 @@
+"""Adapter that implements ``ProgressLookupPort`` using the Watch Progress repo.
+
+This is the only file in the Media BC that imports from
+``src.modules.watch_progress.domain``. Above the adapter, the use
+cases only see ``ProgressSummary``.
+"""
+
+from collections.abc import Sequence
+
+from src.modules.media.application.ports.progress_lookup_port import (
+    ProgressLookupPort,
+    ProgressSummary,
+)
+from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+
+
+class ProgressLookupAdapter(ProgressLookupPort):
+    """Resolve progress snapshots via the Watch Progress repository."""
+
+    def __init__(self, progress_repository: WatchProgressRepository) -> None:
+        self._progress_repo = progress_repository
+
+    async def find_for_media_ids(
+        self,
+        media_ids: Sequence[str],
+    ) -> dict[str, ProgressSummary]:
+        """Fetch progress rows and project each into a ``ProgressSummary``."""
+        if not media_ids:
+            return {}
+        progress_map = await self._progress_repo.find_by_media_ids(list(media_ids))
+        return {
+            media_id: ProgressSummary(
+                media_id=media_id,
+                percentage=progress.percentage,
+                position_seconds=progress.position_seconds,
+                status=progress.status,
+                last_watched_at=progress.last_watched_at,
+            )
+            for media_id, progress in progress_map.items()
+        }
+
+
+__all__ = ["ProgressLookupAdapter"]

--- a/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
+++ b/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
@@ -33,7 +33,7 @@ class ProgressLookupAdapter(ProgressLookupPort):
                 media_id=media_id,
                 percentage=progress.percentage,
                 position_seconds=progress.position_seconds,
-                status=progress.status,
+                status=progress.status.value,
                 last_watched_at=progress.last_watched_at,
             )
             for media_id, progress in progress_map.items()

--- a/src/modules/watch_progress/application/ports/__init__.py
+++ b/src/modules/watch_progress/application/ports/__init__.py
@@ -1,0 +1,15 @@
+"""Watch progress application ports (interfaces for external BCs)."""
+
+from src.modules.watch_progress.application.ports.media_lookup_port import (
+    EpisodeInfo,
+    MediaLookupPort,
+    MovieDisplayInfo,
+    SeriesWithEpisodesInfo,
+)
+
+__all__ = [
+    "EpisodeInfo",
+    "MediaLookupPort",
+    "MovieDisplayInfo",
+    "SeriesWithEpisodesInfo",
+]

--- a/src/modules/watch_progress/application/ports/media_lookup_port.py
+++ b/src/modules/watch_progress/application/ports/media_lookup_port.py
@@ -1,0 +1,95 @@
+"""Port for fetching display metadata of media referenced by progress rows.
+
+The Watch Progress BC decorates its "Continue Watching" output with
+the title/poster of the referenced movie or series. This port is the
+only surface through which it reaches into the Media catalog — the
+adapter lives in ``watch_progress.infrastructure.acl``.
+
+See ADR-009 for the cross-BC read port pattern.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MovieDisplayInfo:
+    """Minimal movie data the "continue watching" card needs.
+
+    Attributes:
+        media_id: External id (``mov_xxx``).
+        title: Already-localized title.
+        poster_path: Poster URL or ``None``.
+        backdrop_path: Backdrop URL or ``None``.
+    """
+
+    media_id: str
+    title: str
+    poster_path: str | None
+    backdrop_path: str | None
+
+
+@dataclass(frozen=True)
+class EpisodeInfo:
+    """Minimal episode data needed to pick the next episode to resume.
+
+    Attributes:
+        season_number: One-based season number.
+        episode_number: One-based episode number within the season.
+        title: Episode title (not localized today — no translations
+            exist for episode titles).
+        duration_seconds: Canonical runtime in seconds.
+    """
+
+    season_number: int
+    episode_number: int
+    title: str
+    duration_seconds: int
+
+
+@dataclass(frozen=True)
+class SeriesWithEpisodesInfo:
+    """Series metadata with its episode list.
+
+    The ``episodes`` sequence is already sorted by ``(season_number,
+    episode_number)`` ascending so the selection logic can treat it as
+    chronological progression without re-sorting.
+    """
+
+    series_id: str
+    title: str
+    poster_path: str | None
+    backdrop_path: str | None
+    episodes: Sequence[EpisodeInfo]
+
+
+class MediaLookupPort(ABC):
+    """Fetch movie / series display data on demand.
+
+    One call per item is fine for the "Continue Watching" list — it's
+    capped at a handful of rows. Batching would only pay off if the
+    home-page consumer ever grew past tens of items.
+    """
+
+    @abstractmethod
+    async def get_movie(self, media_id: str, lang: str) -> MovieDisplayInfo | None:
+        """Resolve a single movie. Returns ``None`` when id is unknown."""
+        ...
+
+    @abstractmethod
+    async def get_series_with_episodes(
+        self,
+        series_id: str,
+        lang: str,
+    ) -> SeriesWithEpisodesInfo | None:
+        """Resolve a series including the sorted episode list."""
+        ...
+
+
+__all__ = [
+    "EpisodeInfo",
+    "MediaLookupPort",
+    "MovieDisplayInfo",
+    "SeriesWithEpisodesInfo",
+]

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -17,8 +17,11 @@ from src.shared_kernel.episode_composite_id import EpisodeCompositeId
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from src.modules.media.domain.entities import Series
-    from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+    from src.modules.watch_progress.application.ports import (
+        EpisodeInfo,
+        MediaLookupPort,
+        SeriesWithEpisodesInfo,
+    )
     from src.modules.watch_progress.domain.entities import WatchProgress
     from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 
@@ -33,40 +36,38 @@ class EpisodeCandidate:
     season_number: int
     episode_number: int
     media_id: str
+    episode: EpisodeInfo
     progress: WatchProgress | None
 
 
 class GetContinueWatchingUseCase:
     """List in-progress media items with display metadata.
 
-    Joins progress records with movie/series data to provide title and
-    poster for the "Continue Watching" UI section.
+    Joins progress records with movie/series data (via ``MediaLookupPort``)
+    to provide title and poster for the "Continue Watching" UI section.
 
     For series, returns at most one item per series — the best episode
     to resume. If no episode is in-progress but the series has unwatched
     episodes after completed ones, the next unwatched episode is returned.
 
     Example:
-        >>> use_case = GetContinueWatchingUseCase(progress_repo, movie_repo, series_repo)
+        >>> use_case = GetContinueWatchingUseCase(progress_repo, media_lookup)
         >>> result = await use_case.execute(GetContinueWatchingInput(limit=10))
     """
 
     def __init__(
         self,
         progress_repository: WatchProgressRepository,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        media_lookup: MediaLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
             progress_repository: Repository for watch progress.
-            movie_repository: Repository for movie metadata.
-            series_repository: Repository for series metadata.
+            media_lookup: Port for resolving media display metadata.
         """
         self._progress_repo = progress_repository
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+        self._media_lookup = media_lookup
 
     async def execute(self, input_dto: GetContinueWatchingInput) -> ContinueWatchingOutput:
         """Execute the use case.
@@ -121,9 +122,7 @@ class GetContinueWatchingUseCase:
         Returns:
             ContinueWatchingItem for the best episode, or None.
         """
-        from src.modules.media.domain.value_objects import SeriesId
-
-        series = await self._series_repo.find_by_id(SeriesId(series_id))
+        series = await self._media_lookup.get_series_with_episodes(series_id, lang)
         if not series:
             return None
 
@@ -135,34 +134,34 @@ class GetContinueWatchingUseCase:
         if not best:
             return None
 
-        return self._build_series_item(series, best, lang, latest_watched_at)
+        return self._build_series_item(series, best, latest_watched_at)
 
     async def _build_candidates(
         self,
         series_id: str,
-        series: Series,
+        series: SeriesWithEpisodesInfo,
     ) -> list[EpisodeCandidate]:
         """Build EpisodeCandidate list with progress for all episodes."""
-        candidates: list[EpisodeCandidate] = []
         media_ids: list[str] = []
+        candidates: list[EpisodeCandidate] = []
 
-        for s in sorted(series.seasons, key=lambda s: s.season_number.value):
-            for ep in sorted(s.episodes, key=lambda e: e.episode_number.value):
-                mid = EpisodeCompositeId.build(
-                    series_id,
-                    s.season_number.value,
-                    ep.episode_number.value,
-                ).media_id
-                media_ids.append(mid)
-                candidates.append(
-                    EpisodeCandidate(
-                        series_id=series_id,
-                        season_number=s.season_number.value,
-                        episode_number=ep.episode_number.value,
-                        media_id=mid,
-                        progress=None,
-                    )
+        for episode in series.episodes:
+            mid = EpisodeCompositeId.build(
+                series_id,
+                episode.season_number,
+                episode.episode_number,
+            ).media_id
+            media_ids.append(mid)
+            candidates.append(
+                EpisodeCandidate(
+                    series_id=series_id,
+                    season_number=episode.season_number,
+                    episode_number=episode.episode_number,
+                    media_id=mid,
+                    episode=episode,
+                    progress=None,
                 )
+            )
 
         if not candidates:
             return []
@@ -215,31 +214,22 @@ class GetContinueWatchingUseCase:
 
         return None, latest_watched_at
 
+    @staticmethod
     def _build_series_item(
-        self,
-        series: Series,
+        series: SeriesWithEpisodesInfo,
         candidate: EpisodeCandidate,
-        lang: str,
         fallback_last_watched: datetime | None = None,
-    ) -> ContinueWatchingItem | None:
+    ) -> ContinueWatchingItem:
         """Build a ContinueWatchingItem from a resolved candidate.
 
         Args:
-            series: The series entity.
+            series: The series metadata.
             candidate: The selected episode candidate.
-            lang: Language code.
             fallback_last_watched: Fallback timestamp for unwatched episodes.
 
         Returns:
-            ContinueWatchingItem or None if episode not found in series.
+            ContinueWatchingItem for the candidate.
         """
-        season = series.get_season(candidate.season_number)
-        if not season:
-            return None
-        episode = season.get_episode(candidate.episode_number)
-        if not episode:
-            return None
-
         progress = candidate.progress
         last_watched = (
             progress.last_watched_at.isoformat()
@@ -250,15 +240,17 @@ class GetContinueWatchingUseCase:
         return ContinueWatchingItem(
             media_id=candidate.media_id,
             media_type=WatchableMediaType.EPISODE,
-            title=episode.title.value,
-            poster_path=series.poster_path.value if series.poster_path else None,
-            backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+            title=candidate.episode.title,
+            poster_path=series.poster_path,
+            backdrop_path=series.backdrop_path,
             position_seconds=progress.position_seconds if progress else 0,
-            duration_seconds=progress.duration_seconds if progress else episode.duration.value,
+            duration_seconds=(
+                progress.duration_seconds if progress else candidate.episode.duration_seconds
+            ),
             percentage=progress.percentage if progress else 0.0,
             last_watched_at=last_watched,
-            series_id=str(series.id),
-            series_title=series.get_title(lang),
+            series_id=series.series_id,
+            series_title=series.title,
             season_number=candidate.season_number,
             episode_number=candidate.episode_number,
         )
@@ -269,17 +261,15 @@ class GetContinueWatchingUseCase:
         lang: str,
     ) -> ContinueWatchingItem | None:
         """Enrich a movie progress record with metadata."""
-        from src.modules.media.domain.value_objects import MovieId
-
-        movie = await self._movie_repo.find_by_id(MovieId(progress.media_id))
+        movie = await self._media_lookup.get_movie(progress.media_id, lang)
         if not movie:
             return None
         return ContinueWatchingItem(
             media_id=progress.media_id,
             media_type=progress.media_type,
-            title=movie.get_title(lang),
-            poster_path=movie.poster_path.value if movie.poster_path else None,
-            backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+            title=movie.title,
+            poster_path=movie.poster_path,
+            backdrop_path=movie.backdrop_path,
             position_seconds=progress.position_seconds,
             duration_seconds=progress.duration_seconds,
             percentage=progress.percentage,

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -30,11 +30,14 @@ _logger = logging.getLogger(__name__)
 
 @dataclass
 class EpisodeCandidate:
-    """An episode with its coordinates and optional progress."""
+    """An episode with its series context, composite id and optional progress.
+
+    Season/episode numbers are always read from ``episode`` — keeping
+    them flat on the candidate risks drift if the episode is ever
+    rebuilt with different coordinates.
+    """
 
     series_id: str
-    season_number: int
-    episode_number: int
     media_id: str
     episode: EpisodeInfo
     progress: WatchProgress | None
@@ -155,8 +158,6 @@ class GetContinueWatchingUseCase:
             candidates.append(
                 EpisodeCandidate(
                     series_id=series_id,
-                    season_number=episode.season_number,
-                    episode_number=episode.episode_number,
                     media_id=mid,
                     episode=episode,
                     progress=None,
@@ -195,10 +196,10 @@ class GetContinueWatchingUseCase:
                 latest_watched_at = ep.progress.last_watched_at
 
             if ep.progress.status == WatchStatus.IN_PROGRESS:
-                coords = (ep.season_number, ep.episode_number)
+                coords = (ep.episode.season_number, ep.episode.episode_number)
                 if not best_in_progress or coords > (
-                    best_in_progress.season_number,
-                    best_in_progress.episode_number,
+                    best_in_progress.episode.season_number,
+                    best_in_progress.episode.episode_number,
                 ):
                     best_in_progress = ep
             elif ep.progress.status == WatchStatus.COMPLETED:
@@ -251,8 +252,8 @@ class GetContinueWatchingUseCase:
             last_watched_at=last_watched,
             series_id=series.series_id,
             series_title=series.title,
-            season_number=candidate.season_number,
-            episode_number=candidate.episode_number,
+            season_number=candidate.episode.season_number,
+            episode_number=candidate.episode.episode_number,
         )
 
     async def _enrich_movie(

--- a/src/modules/watch_progress/infrastructure/acl/__init__.py
+++ b/src/modules/watch_progress/infrastructure/acl/__init__.py
@@ -1,0 +1,7 @@
+"""Anti-corruption layer: adapters translating external BCs to local ports."""
+
+from src.modules.watch_progress.infrastructure.acl.media_lookup_adapter import (
+    MediaLookupAdapter,
+)
+
+__all__ = ["MediaLookupAdapter"]

--- a/src/modules/watch_progress/infrastructure/acl/media_lookup_adapter.py
+++ b/src/modules/watch_progress/infrastructure/acl/media_lookup_adapter.py
@@ -1,0 +1,72 @@
+"""Adapter that implements ``MediaLookupPort`` using Media repositories.
+
+This is the only file in the Watch Progress BC that imports from
+``src.modules.media.domain``. Above the adapter, the use cases only
+see ``MovieDisplayInfo`` / ``SeriesWithEpisodesInfo``.
+"""
+
+from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.value_objects import MovieId, SeriesId
+from src.modules.watch_progress.application.ports.media_lookup_port import (
+    EpisodeInfo,
+    MediaLookupPort,
+    MovieDisplayInfo,
+    SeriesWithEpisodesInfo,
+)
+
+
+class MediaLookupAdapter(MediaLookupPort):
+    """Resolve media metadata via the Media BC's repositories."""
+
+    def __init__(
+        self,
+        movie_repository: MovieRepository,
+        series_repository: SeriesRepository,
+    ) -> None:
+        self._movie_repo = movie_repository
+        self._series_repo = series_repository
+
+    async def get_movie(self, media_id: str, lang: str) -> MovieDisplayInfo | None:
+        """Map a ``Movie`` entity to a display DTO, or ``None`` when absent."""
+        movie = await self._movie_repo.find_by_id(MovieId(media_id))
+        if movie is None:
+            return None
+        return MovieDisplayInfo(
+            media_id=media_id,
+            title=movie.get_title(lang),
+            poster_path=movie.poster_path.value if movie.poster_path else None,
+            backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+        )
+
+    async def get_series_with_episodes(
+        self,
+        series_id: str,
+        lang: str,
+    ) -> SeriesWithEpisodesInfo | None:
+        """Flatten a ``Series`` into display + sorted-episode DTOs."""
+        series = await self._series_repo.find_by_id(SeriesId(series_id))
+        if series is None:
+            return None
+
+        episodes: list[EpisodeInfo] = []
+        for season in sorted(series.seasons, key=lambda s: s.season_number.value):
+            for episode in sorted(season.episodes, key=lambda e: e.episode_number.value):
+                episodes.append(
+                    EpisodeInfo(
+                        season_number=season.season_number.value,
+                        episode_number=episode.episode_number.value,
+                        title=episode.title.value,
+                        duration_seconds=episode.duration.value,
+                    )
+                )
+
+        return SeriesWithEpisodesInfo(
+            series_id=series_id,
+            title=series.get_title(lang),
+            poster_path=series.poster_path.value if series.poster_path else None,
+            backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+            episodes=episodes,
+        )
+
+
+__all__ = ["MediaLookupAdapter"]

--- a/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
+++ b/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
@@ -54,9 +54,7 @@ def _series(series_id: SeriesId, title: str, poster: str | None = None) -> Serie
 class TestCollectionsMediaLookupAdapter:
     """The adapter resolves titles + posters for the Collections BC."""
 
-    async def test_get_many_resolves_movies_and_series(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_get_many_resolves_movies_and_series(self, db_session: AsyncSession) -> None:
         movie_repo = SQLAlchemyMovieRepository(db_session)
         series_repo = SQLAlchemySeriesRepository(db_session)
 
@@ -93,9 +91,7 @@ class TestCollectionsMediaLookupAdapter:
 
         assert await adapter.get_many([], [], "en") == {}
 
-    async def test_poster_path_is_none_when_media_has_none(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_poster_path_is_none_when_media_has_none(self, db_session: AsyncSession) -> None:
         movie_repo = SQLAlchemyMovieRepository(db_session)
         series_repo = SQLAlchemySeriesRepository(db_session)
 

--- a/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
+++ b/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
@@ -1,0 +1,109 @@
+"""Integration tests for the Collections MediaLookupAdapter."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.collections.infrastructure.acl import MediaLookupAdapter
+from src.modules.media.domain.entities import Movie, Series
+from src.modules.media.domain.value_objects import (
+    Duration,
+    FilePath,
+    ImageUrl,
+    MediaFile,
+    MovieId,
+    Resolution,
+    SeriesId,
+    Title,
+    Year,
+)
+from src.modules.media.infrastructure.persistence.repositories import (
+    SQLAlchemyMovieRepository,
+    SQLAlchemySeriesRepository,
+)
+from src.shared_kernel.value_objects import CollectionMediaType
+
+
+def _movie(movie_id: MovieId, title: str, poster: str | None = None) -> Movie:
+    return Movie(
+        id=movie_id,
+        title=Title(title),
+        year=Year(2024),
+        duration=Duration(7200),
+        poster_path=ImageUrl(poster) if poster else None,
+        files=[
+            MediaFile(
+                file_path=FilePath(f"/movies/{title}.mkv"),
+                file_size=1_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+        ],
+    )
+
+
+def _series(series_id: SeriesId, title: str, poster: str | None = None) -> Series:
+    return Series(
+        id=series_id,
+        title=Title(title),
+        start_year=Year(2024),
+        poster_path=ImageUrl(poster) if poster else None,
+    )
+
+
+@pytest.mark.integration
+class TestCollectionsMediaLookupAdapter:
+    """The adapter resolves titles + posters for the Collections BC."""
+
+    async def test_get_many_resolves_movies_and_series(
+        self, db_session: AsyncSession
+    ) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+
+        movie_id = MovieId.generate()
+        series_id = SeriesId.generate()
+        await movie_repo.save(_movie(movie_id, "Inception", "/p/inception.jpg"))
+        await series_repo.save(_series(series_id, "Breaking Bad", "/p/bb.jpg"))
+
+        adapter = MediaLookupAdapter(movie_repo, series_repo)
+
+        summaries = await adapter.get_many([str(movie_id)], [str(series_id)], "en")
+
+        movie_summary = summaries[(CollectionMediaType.MOVIE, str(movie_id))]
+        assert movie_summary.title == "Inception"
+        assert movie_summary.poster_path == "/p/inception.jpg"
+
+        series_summary = summaries[(CollectionMediaType.SERIES, str(series_id))]
+        assert series_summary.title == "Breaking Bad"
+        assert series_summary.poster_path == "/p/bb.jpg"
+
+    async def test_get_many_omits_missing_ids(self, db_session: AsyncSession) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+
+        adapter = MediaLookupAdapter(movie_repo, series_repo)
+        summaries = await adapter.get_many(["mov_missing00000"], [], "en")
+
+        assert summaries == {}
+
+    async def test_get_many_handles_empty_input(self, db_session: AsyncSession) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+        adapter = MediaLookupAdapter(movie_repo, series_repo)
+
+        assert await adapter.get_many([], [], "en") == {}
+
+    async def test_poster_path_is_none_when_media_has_none(
+        self, db_session: AsyncSession
+    ) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+
+        movie_id = MovieId.generate()
+        await movie_repo.save(_movie(movie_id, "No Poster"))
+
+        adapter = MediaLookupAdapter(movie_repo, series_repo)
+        summaries = await adapter.get_many([str(movie_id)], [], "en")
+
+        summary = summaries[(CollectionMediaType.MOVIE, str(movie_id))]
+        assert summary.poster_path is None

--- a/tests/modules/collections/unit/application/use_cases/conftest.py
+++ b/tests/modules/collections/unit/application/use_cases/conftest.py
@@ -1,36 +1,56 @@
 """Shared fixtures for collections use case tests."""
 
 from collections.abc import Callable
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
-MediaMockFactory = Callable[..., MagicMock]
+from src.modules.collections.application.ports import MediaLookupPort, MediaSummary
+from src.shared_kernel.value_objects import CollectionMediaType
+
+MediaSummaryFactory = Callable[..., MediaSummary]
 
 
 @pytest.fixture
-def movie_mock() -> MediaMockFactory:
-    """Create a mock movie entity with default values."""
+def movie_summary() -> MediaSummaryFactory:
+    """Create a ``MediaSummary`` representing a movie."""
 
-    def _factory(media_id: str, title: str = "Test Movie") -> MagicMock:
-        movie = MagicMock()
-        movie.id = media_id
-        movie.get_title.return_value = title
-        movie.poster_path = MagicMock(value="https://image.tmdb.org/poster.jpg")
-        return movie
+    def _factory(
+        media_id: str,
+        title: str = "Test Movie",
+        poster_path: str | None = "https://image.tmdb.org/poster.jpg",
+    ) -> MediaSummary:
+        return MediaSummary(
+            media_id=media_id,
+            media_type=CollectionMediaType.MOVIE,
+            title=title,
+            poster_path=poster_path,
+        )
 
     return _factory
 
 
 @pytest.fixture
-def series_mock() -> MediaMockFactory:
-    """Create a mock series entity with default values."""
+def series_summary() -> MediaSummaryFactory:
+    """Create a ``MediaSummary`` representing a series."""
 
-    def _factory(media_id: str, title: str = "Test Series") -> MagicMock:
-        series = MagicMock()
-        series.id = media_id
-        series.get_title.return_value = title
-        series.poster_path = MagicMock(value="https://image.tmdb.org/series.jpg")
-        return series
+    def _factory(
+        media_id: str,
+        title: str = "Test Series",
+        poster_path: str | None = "https://image.tmdb.org/series.jpg",
+    ) -> MediaSummary:
+        return MediaSummary(
+            media_id=media_id,
+            media_type=CollectionMediaType.SERIES,
+            title=title,
+            poster_path=poster_path,
+        )
 
     return _factory
+
+
+def make_media_lookup_mock(*summaries: MediaSummary) -> AsyncMock:
+    """Build an ``AsyncMock`` of ``MediaLookupPort`` returning ``summaries``."""
+    mock = AsyncMock(spec=MediaLookupPort)
+    mock.get_many.return_value = {(s.media_type, s.media_id): s for s in summaries}
+    return mock

--- a/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
@@ -6,10 +6,13 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.application.use_cases.conftest import (
+    make_media_lookup_mock,
+)
 
 if TYPE_CHECKING:
     from tests.modules.collections.unit.application.use_cases.conftest import (
-        MediaMockFactory,
+        MediaSummaryFactory,
     )
 
 from src.building_blocks.application.errors import ResourceNotFoundException
@@ -17,10 +20,10 @@ from src.modules.collections.application.dtos import (
     CustomListItemOutput,
     GetCustomListItemsInput,
 )
+from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetCustomListItemsUseCase
 from src.modules.collections.domain.entities import CustomList, CustomListItem
 from src.modules.collections.domain.repositories import CustomListRepository
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.shared_kernel.value_objects import CollectionMediaType
 
 
@@ -29,7 +32,9 @@ class TestGetCustomListItemsUseCase:
     """Tests for getting custom list items with metadata."""
 
     @pytest.mark.asyncio
-    async def test_should_return_items_with_metadata(self, movie_mock: MediaMockFactory) -> None:
+    async def test_should_return_items_with_metadata(
+        self, movie_summary: MediaSummaryFactory
+    ) -> None:
         custom_list = CustomList.create(name="Test")
         items = [
             CustomListItem.create(
@@ -38,21 +43,18 @@ class TestGetCustomListItemsUseCase:
                 position=0,
             ),
         ]
-        movie = movie_mock("mov_abc123def456", "Inception")
 
         mock_list_repo = AsyncMock(spec=CustomListRepository)
         mock_list_repo.find_by_id.return_value = custom_list
         mock_list_repo.list_items.return_value = items
 
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_movie_repo.find_by_ids.return_value = {"mov_abc123def456": movie}
-
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        media_lookup = make_media_lookup_mock(
+            movie_summary("mov_abc123def456", "Inception"),
+        )
 
         use_case = GetCustomListItemsUseCase(
             custom_list_repository=mock_list_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=media_lookup,
         )
 
         result = await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id)))
@@ -66,12 +68,9 @@ class TestGetCustomListItemsUseCase:
     async def test_should_raise_when_list_not_found(self) -> None:
         mock_list_repo = AsyncMock(spec=CustomListRepository)
         mock_list_repo.find_by_id.return_value = None
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
         use_case = GetCustomListItemsUseCase(
             custom_list_repository=mock_list_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
@@ -85,12 +84,9 @@ class TestGetCustomListItemsUseCase:
         mock_list_repo = AsyncMock(spec=CustomListRepository)
         mock_list_repo.find_by_id.return_value = custom_list
         mock_list_repo.list_items.return_value = []
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
         use_case = GetCustomListItemsUseCase(
             custom_list_repository=mock_list_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
         result = await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id)))
@@ -111,15 +107,9 @@ class TestGetCustomListItemsUseCase:
         mock_list_repo.find_by_id.return_value = custom_list
         mock_list_repo.list_items.return_value = items
 
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_movie_repo.find_by_ids.return_value = {}
-
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
         use_case = GetCustomListItemsUseCase(
             custom_list_repository=mock_list_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=make_media_lookup_mock(),
         )
 
         result = await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id)))
@@ -128,7 +118,9 @@ class TestGetCustomListItemsUseCase:
 
     @pytest.mark.asyncio
     async def test_should_handle_mixed_media_types(
-        self, movie_mock: MediaMockFactory, series_mock: MediaMockFactory
+        self,
+        movie_summary: MediaSummaryFactory,
+        series_summary: MediaSummaryFactory,
     ) -> None:
         custom_list = CustomList.create(name="Mixed")
         items = [
@@ -143,23 +135,19 @@ class TestGetCustomListItemsUseCase:
                 position=1,
             ),
         ]
-        movie = movie_mock("mov_abc123def456", "Inception")
-        series = series_mock("ser_xyz789abc123", "Breaking Bad")
 
         mock_list_repo = AsyncMock(spec=CustomListRepository)
         mock_list_repo.find_by_id.return_value = custom_list
         mock_list_repo.list_items.return_value = items
 
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_movie_repo.find_by_ids.return_value = {"mov_abc123def456": movie}
-
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        mock_series_repo.find_by_ids.return_value = {"ser_xyz789abc123": series}
+        media_lookup = make_media_lookup_mock(
+            movie_summary("mov_abc123def456", "Inception"),
+            series_summary("ser_xyz789abc123", "Breaking Bad"),
+        )
 
         use_case = GetCustomListItemsUseCase(
             custom_list_repository=mock_list_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=media_lookup,
         )
 
         result = await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id)))
@@ -169,7 +157,9 @@ class TestGetCustomListItemsUseCase:
         assert result[1].title == "Breaking Bad"
 
     @pytest.mark.asyncio
-    async def test_should_pass_language_to_get_title(self, movie_mock: MediaMockFactory) -> None:
+    async def test_should_pass_language_to_media_lookup(
+        self, movie_summary: MediaSummaryFactory
+    ) -> None:
         custom_list = CustomList.create(name="Test")
         items = [
             CustomListItem.create(
@@ -178,23 +168,22 @@ class TestGetCustomListItemsUseCase:
                 position=0,
             ),
         ]
-        movie = movie_mock("mov_abc123def456")
 
         mock_list_repo = AsyncMock(spec=CustomListRepository)
         mock_list_repo.find_by_id.return_value = custom_list
         mock_list_repo.list_items.return_value = items
 
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_movie_repo.find_by_ids.return_value = {"mov_abc123def456": movie}
-
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        media_lookup = make_media_lookup_mock(movie_summary("mov_abc123def456"))
 
         use_case = GetCustomListItemsUseCase(
             custom_list_repository=mock_list_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=media_lookup,
         )
 
         await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id), lang="pt-BR"))
 
-        movie.get_title.assert_called_once_with("pt-BR")
+        media_lookup.get_many.assert_awaited_once_with(
+            ["mov_abc123def456"],
+            [],
+            "pt-BR",
+        )

--- a/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
@@ -6,20 +6,23 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.application.use_cases.conftest import (
+    make_media_lookup_mock,
+)
 
 if TYPE_CHECKING:
     from tests.modules.collections.unit.application.use_cases.conftest import (
-        MediaMockFactory,
+        MediaSummaryFactory,
     )
 
 from src.modules.collections.application.dtos import (
     GetWatchlistInput,
     WatchlistItemOutput,
 )
+from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
 from src.modules.collections.domain.repositories import WatchlistRepository
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.shared_kernel.value_objects import CollectionMediaType
 
 
@@ -28,27 +31,26 @@ class TestGetWatchlistUseCase:
     """Tests for getting watchlist items with metadata."""
 
     @pytest.mark.asyncio
-    async def test_should_return_items_with_metadata(self, movie_mock: MediaMockFactory) -> None:
+    async def test_should_return_items_with_metadata(
+        self, movie_summary: MediaSummaryFactory
+    ) -> None:
         items = [
             WatchlistItem.create(
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
             ),
         ]
-        movie = movie_mock("mov_abc123def456", "Inception")
 
         mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
         mock_watchlist_repo.list_all.return_value = items
 
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_movie_repo.find_by_ids.return_value = {"mov_abc123def456": movie}
-
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        media_lookup = make_media_lookup_mock(
+            movie_summary("mov_abc123def456", "Inception"),
+        )
 
         use_case = GetWatchlistUseCase(
             watchlist_repository=mock_watchlist_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=media_lookup,
         )
 
         result = await use_case.execute(GetWatchlistInput())
@@ -61,12 +63,9 @@ class TestGetWatchlistUseCase:
     async def test_should_return_empty_list_when_no_items(self) -> None:
         mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
         mock_watchlist_repo.list_all.return_value = []
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
         use_case = GetWatchlistUseCase(
             watchlist_repository=mock_watchlist_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
         result = await use_case.execute(GetWatchlistInput())
@@ -84,15 +83,9 @@ class TestGetWatchlistUseCase:
         mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
         mock_watchlist_repo.list_all.return_value = items
 
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_movie_repo.find_by_ids.return_value = {}
-
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
         use_case = GetWatchlistUseCase(
             watchlist_repository=mock_watchlist_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=make_media_lookup_mock(),  # no summaries
         )
 
         result = await use_case.execute(GetWatchlistInput())
@@ -101,7 +94,9 @@ class TestGetWatchlistUseCase:
 
     @pytest.mark.asyncio
     async def test_should_handle_mixed_media_types(
-        self, movie_mock: MediaMockFactory, series_mock: MediaMockFactory
+        self,
+        movie_summary: MediaSummaryFactory,
+        series_summary: MediaSummaryFactory,
     ) -> None:
         items = [
             WatchlistItem.create(
@@ -113,22 +108,18 @@ class TestGetWatchlistUseCase:
                 media_type=CollectionMediaType.SERIES,
             ),
         ]
-        movie = movie_mock("mov_abc123def456", "Inception")
-        series = series_mock("ser_xyz789abc123", "Breaking Bad")
 
         mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
         mock_watchlist_repo.list_all.return_value = items
 
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_movie_repo.find_by_ids.return_value = {"mov_abc123def456": movie}
-
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        mock_series_repo.find_by_ids.return_value = {"ser_xyz789abc123": series}
+        media_lookup = make_media_lookup_mock(
+            movie_summary("mov_abc123def456", "Inception"),
+            series_summary("ser_xyz789abc123", "Breaking Bad"),
+        )
 
         use_case = GetWatchlistUseCase(
             watchlist_repository=mock_watchlist_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=media_lookup,
         )
 
         result = await use_case.execute(GetWatchlistInput())
@@ -141,12 +132,9 @@ class TestGetWatchlistUseCase:
     async def test_should_respect_limit(self) -> None:
         mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
         mock_watchlist_repo.list_all.return_value = []
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
         use_case = GetWatchlistUseCase(
             watchlist_repository=mock_watchlist_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
         await use_case.execute(GetWatchlistInput(limit=25))
@@ -154,29 +142,30 @@ class TestGetWatchlistUseCase:
         mock_watchlist_repo.list_all.assert_called_once_with(limit=25)
 
     @pytest.mark.asyncio
-    async def test_should_pass_language_to_get_title(self, movie_mock: MediaMockFactory) -> None:
+    async def test_should_pass_language_to_media_lookup(
+        self, movie_summary: MediaSummaryFactory
+    ) -> None:
         items = [
             WatchlistItem.create(
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
             ),
         ]
-        movie = movie_mock("mov_abc123def456")
 
         mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
         mock_watchlist_repo.list_all.return_value = items
 
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_movie_repo.find_by_ids.return_value = {"mov_abc123def456": movie}
-
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
+        media_lookup = make_media_lookup_mock(movie_summary("mov_abc123def456"))
 
         use_case = GetWatchlistUseCase(
             watchlist_repository=mock_watchlist_repo,
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
+            media_lookup=media_lookup,
         )
 
         await use_case.execute(GetWatchlistInput(lang="pt-BR"))
 
-        movie.get_title.assert_called_once_with("pt-BR")
+        media_lookup.get_many.assert_awaited_once_with(
+            ["mov_abc123def456"],
+            [],
+            "pt-BR",
+        )

--- a/tests/modules/library/integration/acl/test_media_count_query_adapter.py
+++ b/tests/modules/library/integration/acl/test_media_count_query_adapter.py
@@ -1,0 +1,104 @@
+"""Integration tests for MediaCountQueryAdapter."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.library.infrastructure.acl import MediaCountQueryAdapter
+from src.modules.media.domain.entities import Episode, Movie, Season, Series
+from src.modules.media.domain.value_objects import (
+    Duration,
+    EpisodeId,
+    FilePath,
+    MediaFile,
+    MovieId,
+    Resolution,
+    SeasonId,
+    Title,
+    Year,
+)
+from src.modules.media.infrastructure.persistence.repositories import (
+    SQLAlchemyMovieRepository,
+    SQLAlchemySeriesRepository,
+)
+
+
+def _movie(title: str, file_path: str) -> Movie:
+    return Movie(
+        id=MovieId.generate(),
+        title=Title(title),
+        year=Year(2024),
+        duration=Duration(7200),
+        files=[
+            MediaFile(
+                file_path=FilePath(file_path),
+                file_size=1_000_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+        ],
+    )
+
+
+def _series_with_episode(title: str, file_path: str) -> Series:
+    series = Series.create(title=title, start_year=2024)
+    assert series.id is not None
+    season = Season(id=SeasonId.generate(), series_id=series.id, season_number=1)
+    episode = Episode(
+        id=EpisodeId.generate(),
+        series_id=series.id,
+        season_number=1,
+        episode_number=1,
+        title=Title("Pilot"),
+        duration=Duration(3600),
+        files=[
+            MediaFile(
+                file_path=FilePath(file_path),
+                file_size=500_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+        ],
+    )
+    return series.with_season(season.with_episode(episode))
+
+
+@pytest.mark.integration
+class TestMediaCountQueryAdapter:
+    """The adapter delegates counts to Media repositories."""
+
+    async def test_count_movies_under_paths_matches_repository(
+        self, db_session: AsyncSession
+    ) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+        await movie_repo.save(_movie("A", "/movies/a.mkv"))
+        await movie_repo.save(_movie("B", "/movies/b.mkv"))
+        await movie_repo.save(_movie("C", "/other/c.mkv"))
+
+        adapter = MediaCountQueryAdapter(movie_repo, series_repo)
+
+        assert await adapter.count_movies_under_paths(["/movies"]) == 2
+        assert await adapter.count_movies_under_paths(["/other"]) == 1
+        assert await adapter.count_movies_under_paths(["/missing"]) == 0
+
+    async def test_count_series_under_paths_matches_repository(
+        self, db_session: AsyncSession
+    ) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+        await series_repo.save(_series_with_episode("Series A", "/series/a/s01e01.mkv"))
+        await series_repo.save(_series_with_episode("Series B", "/series/b/s01e01.mkv"))
+
+        adapter = MediaCountQueryAdapter(movie_repo, series_repo)
+
+        assert await adapter.count_series_under_paths(["/series"]) == 2
+        assert await adapter.count_series_under_paths(["/series/a"]) == 1
+        assert await adapter.count_series_under_paths(["/missing"]) == 0
+
+    async def test_empty_paths_returns_zero(self, db_session: AsyncSession) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+        adapter = MediaCountQueryAdapter(movie_repo, series_repo)
+
+        assert await adapter.count_movies_under_paths([]) == 0
+        assert await adapter.count_series_under_paths([]) == 0

--- a/tests/modules/library/integration/conftest.py
+++ b/tests/modules/library/integration/conftest.py
@@ -1,0 +1,32 @@
+"""Integration test fixtures for library database operations."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.config.persistence import Base
+
+
+@pytest.fixture(scope="function")
+async def db_session() -> AsyncGenerator[AsyncSession, None]:
+    """Create an in-memory SQLite database session for testing."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+    async with session_factory() as session:
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()

--- a/tests/modules/library/unit/application/use_cases/test_create_library.py
+++ b/tests/modules/library/unit/application/use_cases/test_create_library.py
@@ -6,23 +6,21 @@ import pytest
 from tests.modules.library.unit.conftest import make_library_uow_mock
 
 from src.modules.library.application.dtos.library_dtos import CreateLibraryInput
+from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.use_cases.create_library import CreateLibraryUseCase
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 def _configure_uow_mocks() -> "tuple[CreateLibraryUseCase, object, object]":
     mocks = make_library_uow_mock()
     mocks.libraries.save.side_effect = lambda lib: lib
 
-    movie_repo = AsyncMock(spec=MovieRepository)
-    movie_repo.count_under_paths.return_value = 0
-    series_repo = AsyncMock(spec=SeriesRepository)
-    series_repo.count_under_paths.return_value = 0
+    media_count_query = AsyncMock(spec=MediaCountQueryPort)
+    media_count_query.count_movies_under_paths.return_value = 0
+    media_count_query.count_series_under_paths.return_value = 0
 
     use_case = CreateLibraryUseCase(
         uow_factory=mocks.factory,
-        movie_repository=movie_repo,
-        series_repository=series_repo,
+        media_count_query=media_count_query,
     )
     return use_case, mocks.libraries.save, mocks.factory
 

--- a/tests/modules/library/unit/application/use_cases/test_get_library_by_id.py
+++ b/tests/modules/library/unit/application/use_cases/test_get_library_by_id.py
@@ -6,21 +6,20 @@ import pytest
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.library.application.dtos.library_dtos import GetLibraryByIdInput
+from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.use_cases.get_library_by_id import (
     GetLibraryByIdUseCase,
 )
 from src.modules.library.domain.entities.library import Library
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
-def _make_media_repos() -> tuple[AsyncMock, AsyncMock]:
-    movie_repo = AsyncMock(spec=MovieRepository)
-    movie_repo.count_under_paths.return_value = 0
-    series_repo = AsyncMock(spec=SeriesRepository)
-    series_repo.count_under_paths.return_value = 0
-    return movie_repo, series_repo
+def _make_media_count_query() -> AsyncMock:
+    query = AsyncMock(spec=MediaCountQueryPort)
+    query.count_movies_under_paths.return_value = 0
+    query.count_series_under_paths.return_value = 0
+    return query
 
 
 @pytest.mark.unit
@@ -32,8 +31,7 @@ class TestGetLibraryByIdUseCase:
         lib = Library.create(name="Movies", library_type="movies", paths=["/m"])
         repo = AsyncMock(spec=LibraryRepository)
         repo.find_by_id.return_value = lib
-        movie_repo, series_repo = _make_media_repos()
-        use_case = GetLibraryByIdUseCase(repo, movie_repo, series_repo)
+        use_case = GetLibraryByIdUseCase(repo, _make_media_count_query())
 
         result = await use_case.execute(
             GetLibraryByIdInput(library_id=str(lib.id)),
@@ -45,8 +43,7 @@ class TestGetLibraryByIdUseCase:
     async def test_should_raise_when_not_found(self) -> None:
         repo = AsyncMock(spec=LibraryRepository)
         repo.find_by_id.return_value = None
-        movie_repo, series_repo = _make_media_repos()
-        use_case = GetLibraryByIdUseCase(repo, movie_repo, series_repo)
+        use_case = GetLibraryByIdUseCase(repo, _make_media_count_query())
         lib_id = str(LibraryId.generate())
 
         with pytest.raises(ResourceNotFoundException):

--- a/tests/modules/library/unit/application/use_cases/test_list_libraries.py
+++ b/tests/modules/library/unit/application/use_cases/test_list_libraries.py
@@ -4,18 +4,17 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.use_cases.list_libraries import ListLibrariesUseCase
 from src.modules.library.domain.entities.library import Library
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
-def _make_media_repos() -> tuple[AsyncMock, AsyncMock]:
-    movie_repo = AsyncMock(spec=MovieRepository)
-    movie_repo.count_under_paths.return_value = 0
-    series_repo = AsyncMock(spec=SeriesRepository)
-    series_repo.count_under_paths.return_value = 0
-    return movie_repo, series_repo
+def _make_media_count_query() -> AsyncMock:
+    query = AsyncMock(spec=MediaCountQueryPort)
+    query.count_movies_under_paths.return_value = 0
+    query.count_series_under_paths.return_value = 0
+    return query
 
 
 @pytest.mark.unit
@@ -26,8 +25,7 @@ class TestListLibrariesUseCase:
     async def test_should_return_empty_list_when_no_libraries(self) -> None:
         repo = AsyncMock(spec=LibraryRepository)
         repo.find_all.return_value = []
-        movie_repo, series_repo = _make_media_repos()
-        use_case = ListLibrariesUseCase(repo, movie_repo, series_repo)
+        use_case = ListLibrariesUseCase(repo, _make_media_count_query())
 
         result = await use_case.execute()
 
@@ -40,8 +38,7 @@ class TestListLibrariesUseCase:
             Library.create(name="Movies", library_type="movies", paths=["/m"]),
             Library.create(name="Series", library_type="series", paths=["/s"]),
         ]
-        movie_repo, series_repo = _make_media_repos()
-        use_case = ListLibrariesUseCase(repo, movie_repo, series_repo)
+        use_case = ListLibrariesUseCase(repo, _make_media_count_query())
 
         result = await use_case.execute()
 

--- a/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
+++ b/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
@@ -29,9 +29,7 @@ def _progress(
 class TestProgressLookupAdapter:
     """The adapter exposes ProgressSummary without leaking domain types."""
 
-    async def test_find_for_media_ids_returns_summaries(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_find_for_media_ids_returns_summaries(self, db_session: AsyncSession) -> None:
         progress_repo = SQLAlchemyWatchProgressRepository(db_session)
         await progress_repo.save(_progress("epi_ser_ABC_1_1", position=900))
         await progress_repo.save(_progress("epi_ser_ABC_1_2", position=3300))
@@ -47,9 +45,7 @@ class TestProgressLookupAdapter:
         assert result["epi_ser_ABC_1_1"].percentage == pytest.approx(25.0)
         assert result["epi_ser_ABC_1_2"].status == "completed"
 
-    async def test_find_for_media_ids_with_empty_input(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_find_for_media_ids_with_empty_input(self, db_session: AsyncSession) -> None:
         progress_repo = SQLAlchemyWatchProgressRepository(db_session)
         adapter = ProgressLookupAdapter(progress_repo)
 

--- a/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
+++ b/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
@@ -1,0 +1,69 @@
+"""Integration tests for the Media ProgressLookupAdapter."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.infrastructure.acl import ProgressLookupAdapter
+from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.modules.watch_progress.infrastructure.persistence.repositories import (
+    SQLAlchemyWatchProgressRepository,
+)
+
+
+def _progress(
+    media_id: str,
+    position: int = 1800,
+    duration: int = 3600,
+    media_type: WatchableMediaType = WatchableMediaType.EPISODE,
+) -> WatchProgress:
+    return WatchProgress.create(
+        media_id=media_id,
+        media_type=media_type,
+        position_seconds=position,
+        duration_seconds=duration,
+    )
+
+
+@pytest.mark.integration
+class TestProgressLookupAdapter:
+    """The adapter exposes ProgressSummary without leaking domain types."""
+
+    async def test_find_for_media_ids_returns_summaries(
+        self, db_session: AsyncSession
+    ) -> None:
+        progress_repo = SQLAlchemyWatchProgressRepository(db_session)
+        await progress_repo.save(_progress("epi_ser_ABC_1_1", position=900))
+        await progress_repo.save(_progress("epi_ser_ABC_1_2", position=3300))
+
+        adapter = ProgressLookupAdapter(progress_repo)
+
+        result = await adapter.find_for_media_ids(
+            ["epi_ser_ABC_1_1", "epi_ser_ABC_1_2", "epi_ser_ABC_1_3"],
+        )
+
+        assert set(result.keys()) == {"epi_ser_ABC_1_1", "epi_ser_ABC_1_2"}
+        assert result["epi_ser_ABC_1_1"].position_seconds == 900
+        assert result["epi_ser_ABC_1_1"].percentage == pytest.approx(25.0)
+        assert result["epi_ser_ABC_1_2"].status == "completed"
+
+    async def test_find_for_media_ids_with_empty_input(
+        self, db_session: AsyncSession
+    ) -> None:
+        progress_repo = SQLAlchemyWatchProgressRepository(db_session)
+        adapter = ProgressLookupAdapter(progress_repo)
+
+        assert await adapter.find_for_media_ids([]) == {}
+
+    async def test_progress_summary_includes_last_watched_at(
+        self, db_session: AsyncSession
+    ) -> None:
+        progress_repo = SQLAlchemyWatchProgressRepository(db_session)
+        await progress_repo.save(_progress("epi_ser_ABC_1_1"))
+
+        adapter = ProgressLookupAdapter(progress_repo)
+        result = await adapter.find_for_media_ids(["epi_ser_ABC_1_1"])
+
+        summary = result["epi_ser_ABC_1_1"]
+        assert summary.last_watched_at is not None
+        assert summary.media_id == "epi_ser_ABC_1_1"

--- a/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos import GetSeriesByIdInput, SeriesOutput
+from src.modules.media.application.ports import ProgressLookupPort
 from src.modules.media.application.use_cases import GetSeriesByIdUseCase
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
@@ -18,22 +19,21 @@ from src.modules.media.domain.value_objects import (
     SeasonId,
     Title,
 )
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 
 
 @pytest.fixture()
-def mock_progress_repo() -> AsyncMock:
-    """Create a mock WatchProgressRepository with empty results."""
-    repo = AsyncMock(spec=WatchProgressRepository)
-    repo.find_by_media_ids.return_value = {}
-    return repo
+def mock_progress_lookup() -> AsyncMock:
+    """Create a mock ``ProgressLookupPort`` with empty results."""
+    lookup = AsyncMock(spec=ProgressLookupPort)
+    lookup.find_for_media_ids.return_value = {}
+    return lookup
 
 
 class TestGetSeriesByIdUseCase:
     """Tests for GetSeriesByIdUseCase."""
 
     @pytest.mark.asyncio
-    async def test_should_return_series_when_found(self, mock_progress_repo):
+    async def test_should_return_series_when_found(self, mock_progress_lookup):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Breaking Bad",
@@ -42,7 +42,7 @@ class TestGetSeriesByIdUseCase:
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
             series_repository=mock_repo,
-            progress_repository=mock_progress_repo,
+            progress_lookup=mock_progress_lookup,
         )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
@@ -53,7 +53,7 @@ class TestGetSeriesByIdUseCase:
         assert result.is_ongoing is True
 
     @pytest.mark.asyncio
-    async def test_should_return_series_with_seasons(self, mock_progress_repo):
+    async def test_should_return_series_with_seasons(self, mock_progress_lookup):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Breaking Bad",
@@ -69,7 +69,7 @@ class TestGetSeriesByIdUseCase:
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
             series_repository=mock_repo,
-            progress_repository=mock_progress_repo,
+            progress_lookup=mock_progress_lookup,
         )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
@@ -79,7 +79,7 @@ class TestGetSeriesByIdUseCase:
         assert result.seasons[0].season_number == 1
 
     @pytest.mark.asyncio
-    async def test_should_return_series_with_episodes(self, mock_progress_repo):
+    async def test_should_return_series_with_episodes(self, mock_progress_lookup):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Breaking Bad",
@@ -111,7 +111,7 @@ class TestGetSeriesByIdUseCase:
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
             series_repository=mock_repo,
-            progress_repository=mock_progress_repo,
+            progress_lookup=mock_progress_lookup,
         )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
@@ -124,7 +124,7 @@ class TestGetSeriesByIdUseCase:
         assert episode_output.duration_formatted == "01:00:00"
 
     @pytest.mark.asyncio
-    async def test_should_return_ongoing_status(self, mock_progress_repo):
+    async def test_should_return_ongoing_status(self, mock_progress_lookup):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Ongoing Show",
@@ -133,7 +133,7 @@ class TestGetSeriesByIdUseCase:
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
             series_repository=mock_repo,
-            progress_repository=mock_progress_repo,
+            progress_lookup=mock_progress_lookup,
         )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
@@ -142,7 +142,7 @@ class TestGetSeriesByIdUseCase:
         assert result.end_year is None
 
     @pytest.mark.asyncio
-    async def test_should_return_completed_status(self, mock_progress_repo):
+    async def test_should_return_completed_status(self, mock_progress_lookup):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Completed Show",
@@ -152,7 +152,7 @@ class TestGetSeriesByIdUseCase:
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
             series_repository=mock_repo,
-            progress_repository=mock_progress_repo,
+            progress_lookup=mock_progress_lookup,
         )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
@@ -161,12 +161,12 @@ class TestGetSeriesByIdUseCase:
         assert result.end_year == 2015
 
     @pytest.mark.asyncio
-    async def test_should_raise_not_found_when_series_missing(self, mock_progress_repo):
+    async def test_should_raise_not_found_when_series_missing(self, mock_progress_lookup):
         mock_repo = AsyncMock(spec=SeriesRepository)
         mock_repo.find_by_id.return_value = None
         use_case = GetSeriesByIdUseCase(
             series_repository=mock_repo,
-            progress_repository=mock_progress_repo,
+            progress_lookup=mock_progress_lookup,
         )
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
@@ -176,7 +176,7 @@ class TestGetSeriesByIdUseCase:
         assert exc_info.value.resource_id == "ser_nonexistent1"
 
     @pytest.mark.asyncio
-    async def test_should_handle_series_with_no_seasons(self, mock_progress_repo):
+    async def test_should_handle_series_with_no_seasons(self, mock_progress_lookup):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="New Show",
@@ -185,7 +185,7 @@ class TestGetSeriesByIdUseCase:
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
             series_repository=mock_repo,
-            progress_repository=mock_progress_repo,
+            progress_lookup=mock_progress_lookup,
         )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
@@ -195,7 +195,7 @@ class TestGetSeriesByIdUseCase:
         assert result.seasons == []
 
     @pytest.mark.asyncio
-    async def test_should_return_genres_as_strings(self, mock_progress_repo):
+    async def test_should_return_genres_as_strings(self, mock_progress_lookup):
         mock_repo = AsyncMock(spec=SeriesRepository)
         series = Series.create(
             title="Drama Show",
@@ -205,7 +205,7 @@ class TestGetSeriesByIdUseCase:
         mock_repo.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
             series_repository=mock_repo,
-            progress_repository=mock_progress_repo,
+            progress_lookup=mock_progress_lookup,
         )
 
         result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))

--- a/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
+++ b/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
@@ -1,0 +1,159 @@
+"""Integration tests for the Watch Progress MediaLookupAdapter."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.domain.entities import Episode, Movie, Season, Series
+from src.modules.media.domain.value_objects import (
+    Duration,
+    EpisodeId,
+    FilePath,
+    ImageUrl,
+    MediaFile,
+    MovieId,
+    Resolution,
+    SeasonId,
+    SeriesId,
+    Title,
+    Year,
+)
+from src.modules.media.infrastructure.persistence.repositories import (
+    SQLAlchemyMovieRepository,
+    SQLAlchemySeriesRepository,
+)
+from src.modules.watch_progress.infrastructure.acl import MediaLookupAdapter
+
+
+def _movie(
+    movie_id: MovieId,
+    title: str,
+    poster: str | None = "/p/m.jpg",
+    backdrop: str | None = "/b/m.jpg",
+) -> Movie:
+    return Movie(
+        id=movie_id,
+        title=Title(title),
+        year=Year(2024),
+        duration=Duration(7200),
+        poster_path=ImageUrl(poster) if poster else None,
+        backdrop_path=ImageUrl(backdrop) if backdrop else None,
+        files=[
+            MediaFile(
+                file_path=FilePath(f"/movies/{title}.mkv"),
+                file_size=1_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+        ],
+    )
+
+
+def _series_with_episodes(
+    series_id: SeriesId,
+    title: str,
+    episodes: list[tuple[int, int, str]],
+) -> Series:
+    """Create a series with given (season, episode, title) triples."""
+    series = Series(
+        id=series_id,
+        title=Title(title),
+        start_year=Year(2024),
+        poster_path=ImageUrl("/p/s.jpg"),
+        backdrop_path=ImageUrl("/b/s.jpg"),
+    )
+    by_season: dict[int, list[Episode]] = {}
+    for season_num, ep_num, ep_title in episodes:
+        by_season.setdefault(season_num, []).append(
+            Episode(
+                id=EpisodeId.generate(),
+                series_id=series_id,
+                season_number=season_num,
+                episode_number=ep_num,
+                title=Title(ep_title),
+                duration=Duration(1800),
+                files=[
+                    MediaFile(
+                        file_path=FilePath(
+                            f"/series/{title}/s{season_num:02d}e{ep_num:02d}.mkv"
+                        ),
+                        file_size=500_000,
+                        resolution=Resolution("1080p"),
+                        is_primary=True,
+                    ),
+                ],
+            )
+        )
+
+    for season_num, eps in by_season.items():
+        season = Season(id=SeasonId.generate(), series_id=series_id, season_number=season_num)
+        for ep in eps:
+            season = season.with_episode(ep)
+        series = series.with_season(season)
+
+    return series
+
+
+@pytest.mark.integration
+class TestWatchProgressMediaLookupAdapter:
+    """The adapter returns display-ready DTOs for the Watch Progress BC."""
+
+    async def test_get_movie_returns_display_info(self, db_session: AsyncSession) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+
+        movie_id = MovieId.generate()
+        await movie_repo.save(_movie(movie_id, "Inception"))
+
+        adapter = MediaLookupAdapter(movie_repo, series_repo)
+        result = await adapter.get_movie(str(movie_id), "en")
+
+        assert result is not None
+        assert result.media_id == str(movie_id)
+        assert result.title == "Inception"
+        assert result.poster_path == "/p/m.jpg"
+        assert result.backdrop_path == "/b/m.jpg"
+
+    async def test_get_movie_returns_none_for_missing_id(
+        self, db_session: AsyncSession
+    ) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+        adapter = MediaLookupAdapter(movie_repo, series_repo)
+
+        assert await adapter.get_movie("mov_missing00000", "en") is None
+
+    async def test_get_series_with_episodes_returns_sorted_list(
+        self, db_session: AsyncSession
+    ) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+
+        series_id = SeriesId.generate()
+        series = _series_with_episodes(
+            series_id,
+            "Breaking Bad",
+            [(2, 1, "S02E01"), (1, 2, "S01E02"), (1, 1, "S01E01")],
+        )
+        await series_repo.save(series)
+
+        adapter = MediaLookupAdapter(movie_repo, series_repo)
+        result = await adapter.get_series_with_episodes(str(series_id), "en")
+
+        assert result is not None
+        assert result.title == "Breaking Bad"
+        assert [(e.season_number, e.episode_number) for e in result.episodes] == [
+            (1, 1),
+            (1, 2),
+            (2, 1),
+        ]
+        assert [e.title for e in result.episodes] == ["S01E01", "S01E02", "S02E01"]
+        assert all(e.duration_seconds == 1800 for e in result.episodes)
+
+    async def test_get_series_returns_none_for_missing_id(
+        self, db_session: AsyncSession
+    ) -> None:
+        movie_repo = SQLAlchemyMovieRepository(db_session)
+        series_repo = SQLAlchemySeriesRepository(db_session)
+        adapter = MediaLookupAdapter(movie_repo, series_repo)
+
+        assert await adapter.get_series_with_episodes("ser_missing00000", "en") is None

--- a/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
+++ b/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
@@ -73,9 +73,7 @@ def _series_with_episodes(
                 duration=Duration(1800),
                 files=[
                     MediaFile(
-                        file_path=FilePath(
-                            f"/series/{title}/s{season_num:02d}e{ep_num:02d}.mkv"
-                        ),
+                        file_path=FilePath(f"/series/{title}/s{season_num:02d}e{ep_num:02d}.mkv"),
                         file_size=500_000,
                         resolution=Resolution("1080p"),
                         is_primary=True,
@@ -113,9 +111,7 @@ class TestWatchProgressMediaLookupAdapter:
         assert result.poster_path == "/p/m.jpg"
         assert result.backdrop_path == "/b/m.jpg"
 
-    async def test_get_movie_returns_none_for_missing_id(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_get_movie_returns_none_for_missing_id(self, db_session: AsyncSession) -> None:
         movie_repo = SQLAlchemyMovieRepository(db_session)
         series_repo = SQLAlchemySeriesRepository(db_session)
         adapter = MediaLookupAdapter(movie_repo, series_repo)
@@ -149,9 +145,7 @@ class TestWatchProgressMediaLookupAdapter:
         assert [e.title for e in result.episodes] == ["S01E01", "S01E02", "S02E01"]
         assert all(e.duration_seconds == 1800 for e in result.episodes)
 
-    async def test_get_series_returns_none_for_missing_id(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_get_series_returns_none_for_missing_id(self, db_session: AsyncSession) -> None:
         movie_repo = SQLAlchemyMovieRepository(db_session)
         series_repo = SQLAlchemySeriesRepository(db_session)
         adapter = MediaLookupAdapter(movie_repo, series_repo)

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -5,21 +5,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.modules.media.domain.entities import Episode, Season, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
-from src.modules.media.domain.value_objects import (
-    Duration,
-    EpisodeId,
-    FilePath,
-    MediaFile,
-    Resolution,
-    SeasonId,
-    SeriesId,
-    Title,
-)
 from src.modules.watch_progress.application.dtos import (
     ContinueWatchingItem,
     GetContinueWatchingInput,
+)
+from src.modules.watch_progress.application.ports import (
+    EpisodeInfo,
+    MediaLookupPort,
+    SeriesWithEpisodesInfo,
 )
 from src.modules.watch_progress.application.use_cases import GetContinueWatchingUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
@@ -46,70 +39,53 @@ def _make_progress(
     )
 
 
-def _make_episode(series_id: SeriesId | None, season: int, ep: int, title: str = "") -> Episode:
-    """Create an Episode entity."""
-    return Episode(
-        id=EpisodeId.generate(),
-        series_id=series_id,
-        season_number=season,
-        episode_number=ep,
-        title=Title(title or f"Episode {ep}"),
-        duration=Duration(3600),
-        files=[
-            MediaFile(
-                file_path=FilePath(f"/series/test/s{season:02d}e{ep:02d}.mkv"),
-                file_size=1_000_000,
-                resolution=Resolution("1080p"),
-                is_primary=True,
-            ),
-        ],
-    )
-
-
-def _make_series(
+def _make_series_info(
     series_id: str,
     episodes_per_season: dict[int, list[int]],
     title: str = "Test Series",
-) -> Series:
-    """Create a Series with specified seasons and episodes.
+) -> SeriesWithEpisodesInfo:
+    """Create a ``SeriesWithEpisodesInfo`` with specified seasons/episodes.
 
     Args:
         series_id: External series ID.
         episodes_per_season: Mapping of season_number to list of episode_numbers.
         title: Series title.
     """
-    series = Series.create(title=title, start_year=2024)
-    series = series.with_updates(id=SeriesId(series_id))
-    for season_num, ep_nums in sorted(episodes_per_season.items()):
-        season = Season(
-            id=SeasonId.generate(),
-            series_id=series.id,
-            season_number=season_num,
-        )
-        for ep_num in sorted(ep_nums):
-            episode = _make_episode(series.id, season_num, ep_num)
-            season = season.with_episode(episode)
-        series = series.with_season(season)
-    return series
+    episodes: list[EpisodeInfo] = []
+    for season_num in sorted(episodes_per_season):
+        for ep_num in sorted(episodes_per_season[season_num]):
+            episodes.append(
+                EpisodeInfo(
+                    season_number=season_num,
+                    episode_number=ep_num,
+                    title=f"Episode {ep_num}",
+                    duration_seconds=3600,
+                )
+            )
+    return SeriesWithEpisodesInfo(
+        series_id=series_id,
+        title=title,
+        poster_path=None,
+        backdrop_path=None,
+        episodes=episodes,
+    )
 
 
 @pytest.fixture()
-def repos() -> tuple[AsyncMock, AsyncMock, AsyncMock]:
-    """Create mock repositories."""
+def repos() -> tuple[AsyncMock, AsyncMock]:
+    """Create mock progress repository and media lookup port."""
     progress_repo = AsyncMock(spec=WatchProgressRepository)
-    movie_repo = AsyncMock(spec=MovieRepository)
-    series_repo = AsyncMock(spec=SeriesRepository)
-    return progress_repo, movie_repo, series_repo
+    media_lookup = AsyncMock(spec=MediaLookupPort)
+    return progress_repo, media_lookup
 
 
 def _make_use_case(
-    repos: tuple[AsyncMock, AsyncMock, AsyncMock],
+    repos: tuple[AsyncMock, AsyncMock],
 ) -> GetContinueWatchingUseCase:
-    progress_repo, movie_repo, series_repo = repos
+    progress_repo, media_lookup = repos
     return GetContinueWatchingUseCase(
         progress_repository=progress_repo,
-        movie_repository=movie_repo,
-        series_repository=series_repo,
+        media_lookup=media_lookup,
     )
 
 
@@ -118,14 +94,14 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_valid_composite_episode(self, repos):
-        progress_repo, _, series_repo = repos
-        series = _make_series("ser_Hy9VjMfILYZe", {3: [2]})
+        progress_repo, media_lookup = repos
+        series = _make_series_info("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_2")
         progress_repo.list_recently_watched.return_value = [progress]
         progress_repo.find_by_media_ids.return_value = {
             "epi_ser_Hy9VjMfILYZe_3_2": progress,
         }
-        series_repo.find_by_id.return_value = series
+        media_lookup.get_series_with_episodes.return_value = series
 
         result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
 
@@ -139,7 +115,7 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_standard_episode_id(self, repos):
-        progress_repo, _, _ = repos
+        progress_repo, _ = repos
         progress_repo.list_recently_watched.return_value = [
             _make_progress("epi_03ZzYaQ77FaB"),
         ]
@@ -149,46 +125,46 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_series(self, repos):
-        progress_repo, _, series_repo = repos
+        progress_repo, media_lookup = repos
         progress_repo.list_recently_watched.return_value = [
             _make_progress("epi_ser_NotExists123_1_1"),
         ]
-        series_repo.find_by_id.return_value = None
+        media_lookup.get_series_with_episodes.return_value = None
 
         result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_season(self, repos):
-        progress_repo, _, series_repo = repos
-        series = _make_series("ser_Hy9VjMfILYZe", {3: [2]})
+        progress_repo, media_lookup = repos
+        series = _make_series_info("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_99_1")
         progress_repo.list_recently_watched.return_value = [progress]
         progress_repo.find_by_media_ids.return_value = {
             "epi_ser_Hy9VjMfILYZe_99_1": progress,
         }
-        series_repo.find_by_id.return_value = series
+        media_lookup.get_series_with_episodes.return_value = series
 
         result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_episode(self, repos):
-        progress_repo, _, series_repo = repos
-        series = _make_series("ser_Hy9VjMfILYZe", {3: [2]})
+        progress_repo, media_lookup = repos
+        series = _make_series_info("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_99")
         progress_repo.list_recently_watched.return_value = [progress]
         progress_repo.find_by_media_ids.return_value = {
             "epi_ser_Hy9VjMfILYZe_3_99": progress,
         }
-        series_repo.find_by_id.return_value = series
+        media_lookup.get_series_with_episodes.return_value = series
 
         result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_malformed_media_id(self, repos):
-        progress_repo, _, _ = repos
+        progress_repo, _ = repos
         progress_repo.list_recently_watched.return_value = [
             _make_progress("epi_ser_broken"),
         ]
@@ -203,9 +179,9 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_multiple_episodes_same_series_returns_one_item(self, repos):
         """Multiple in-progress episodes from same series → single item."""
-        progress_repo, _, series_repo = repos
-        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
-        series_repo.find_by_id.return_value = series
+        progress_repo, media_lookup = repos
+        series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
+        media_lookup.get_series_with_episodes.return_value = series
 
         p1 = _make_progress("epi_ser_AAAAAAAAAAAA_1_1")
         p2 = _make_progress("epi_ser_AAAAAAAAAAAA_1_2")
@@ -224,9 +200,9 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_picks_highest_in_progress_episode(self, repos):
         """Should pick the highest-numbered in-progress episode."""
-        progress_repo, _, series_repo = repos
-        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2, 3], 2: [1, 2]})
-        series_repo.find_by_id.return_value = series
+        progress_repo, media_lookup = repos
+        series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3], 2: [1, 2]})
+        media_lookup.get_series_with_episodes.return_value = series
 
         progress_repo.list_recently_watched.return_value = [
             _make_progress("epi_ser_AAAAAAAAAAAA_1_2"),
@@ -255,9 +231,9 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_picks_next_unwatched_when_all_completed(self, repos):
         """Completed episodes + unwatched episodes → next unwatched."""
-        progress_repo, _, series_repo = repos
-        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
-        series_repo.find_by_id.return_value = series
+        progress_repo, media_lookup = repos
+        series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
+        media_lookup.get_series_with_episodes.return_value = series
 
         progress_repo.list_recently_watched.return_value = [
             _make_progress("epi_ser_AAAAAAAAAAAA_1_1", status="completed"),
@@ -283,9 +259,9 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_returns_nothing_when_all_episodes_completed(self, repos):
         """All episodes completed, none unwatched → no item."""
-        progress_repo, _, series_repo = repos
-        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2]})
-        series_repo.find_by_id.return_value = series
+        progress_repo, media_lookup = repos
+        series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2]})
+        media_lookup.get_series_with_episodes.return_value = series
 
         progress_repo.list_recently_watched.return_value = [
             _make_progress("epi_ser_AAAAAAAAAAAA_1_1", status="completed"),
@@ -307,18 +283,18 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_two_series_return_one_item_each(self, repos):
         """Two different series → two items, one per series."""
-        progress_repo, _, series_repo = repos
-        series_a = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2]}, title="Series A")
-        series_b = _make_series("ser_BBBBBBBBBBBB", {1: [1]}, title="Series B")
+        progress_repo, media_lookup = repos
+        series_a = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2]}, title="Series A")
+        series_b = _make_series_info("ser_BBBBBBBBBBBB", {1: [1]}, title="Series B")
 
-        def find_by_id_side_effect(sid):
-            if str(sid) == "ser_AAAAAAAAAAAA":
+        async def get_series_side_effect(sid, lang):
+            if sid == "ser_AAAAAAAAAAAA":
                 return series_a
-            if str(sid) == "ser_BBBBBBBBBBBB":
+            if sid == "ser_BBBBBBBBBBBB":
                 return series_b
             return None
 
-        series_repo.find_by_id.side_effect = find_by_id_side_effect
+        media_lookup.get_series_with_episodes.side_effect = get_series_side_effect
 
         pa = _make_progress("epi_ser_AAAAAAAAAAAA_1_1")
         pb = _make_progress("epi_ser_BBBBBBBBBBBB_1_1")
@@ -328,8 +304,6 @@ class TestSeriesDeduplication:
             result = {}
             if "epi_ser_AAAAAAAAAAAA_1_1" in ids:
                 result["epi_ser_AAAAAAAAAAAA_1_1"] = pa
-            if "epi_ser_AAAAAAAAAAAA_1_2" in ids:
-                pass  # no progress
             if "epi_ser_BBBBBBBBBBBB_1_1" in ids:
                 result["epi_ser_BBBBBBBBBBBB_1_1"] = pb
             return result
@@ -345,9 +319,9 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_mixed_in_progress_and_completed_across_seasons(self, repos):
         """S1 completed, S2E1 in-progress → picks S2E1."""
-        progress_repo, _, series_repo = repos
-        series = _make_series("ser_AAAAAAAAAAAA", {1: [1, 2], 2: [1, 2]})
-        series_repo.find_by_id.return_value = series
+        progress_repo, media_lookup = repos
+        series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2], 2: [1, 2]})
+        media_lookup.get_series_with_episodes.return_value = series
 
         progress_repo.list_recently_watched.return_value = [
             _make_progress("epi_ser_AAAAAAAAAAAA_2_1"),


### PR DESCRIPTION
## Summary

- Replace direct cross-BC domain imports with local application **ports** implemented by **adapters** in each consumer's infrastructure layer (ACL).
- Pairs migrated: `library` → `media` (`MediaCountQueryPort`), `collections` → `media` (`MediaLookupPort`), `watch_progress` → `media` (`MediaLookupPort`), `media` → `watch_progress` (`ProgressLookupPort`).
- New ADR-009 documents the pattern (port + ACL adapter, DTOs owned by the consumer).
- 14 integration tests added for the 4 new adapters; 6 use-case tests rewritten to mock the local port instead of the other BC's repositories.

## Test plan

- [x] `poetry run pytest` — full suite green (1613 passed)
- [x] `poetry run ruff check src/ tests/` — clean
- [x] `grep -r "from src.modules.media.domain" src/modules/{library,collections,watch_progress}/application/` — empty
- [x] `grep -r "from src.modules.watch_progress.domain" src/modules/media/application/` — empty
- [x] Each consumer has `application/ports/*_port.py` and `infrastructure/acl/*_adapter.py`
- [ ] Manual smoke on `/api/v1/libraries`, `/api/v1/watchlist`, `/api/v1/series/{id}`, `/api/v1/continue-watching` after merge to confirm the response envelope matches the pre-refactor shape

## Summary by Sourcery

Introduce bounded-context read ports and ACL adapters between media, library, collections, and watch_progress, refactoring cross-module reads to go through local application ports.

New Features:
- Add MediaLookupPort in watch_progress with adapter to resolve movie and series display data from the Media bounded context.
- Add MediaLookupPort and MediaSummary contract in collections to batch-fetch movie and series summaries from Media.
- Add ProgressLookupPort in media with adapter to expose watch progress snapshots without importing watch_progress domain types.
- Add MediaCountQueryPort in library with adapter to provide per-path movie and series counts from the Media catalog.

Enhancements:
- Refactor GetContinueWatching, GetCustomListItems, GetWatchlist, and GetSeriesById use cases to depend on local ports instead of foreign repositories and entities.
- Adjust DI containers for library, collections, media, and watch_progress to wire new ACL adapters and ports as the cross-BC integration surface.
- Simplify series episode enrichment logic in GetContinueWatching by working directly with flattened episode DTOs from the media lookup port.

Documentation:
- Add ADR-009 documenting the cross-bounded-context read port and ACL adapter pattern.

Tests:
- Add integration tests for the new ACL adapters in watch_progress, collections, library, and media to verify behavior against real repositories.
- Update unit tests for collections, library, media, and watch_progress use cases to mock new ports instead of external repositories.