### PR TITLE
fix(media): dispatch scan events after UoW commits

### DIFF
--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -210,9 +210,7 @@ class ScanMediaDirectoriesUseCase:
         async with self._uow_factory() as uow:
             existing = await self._find_existing_movie(uow, paths, by_path)
             if existing:
-                created, updated, events = await self._update_movie(
-                    uow, existing, paths, by_path
-                )
+                created, updated, events = await self._update_movie(uow, existing, paths, by_path)
             else:
                 created, updated, events = await self._create_movie(uow, paths, by_path)
         await self._dispatch_events(events)

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -210,8 +210,13 @@ class ScanMediaDirectoriesUseCase:
         async with self._uow_factory() as uow:
             existing = await self._find_existing_movie(uow, paths, by_path)
             if existing:
-                return await self._update_movie(uow, existing, paths, by_path)
-            return await self._create_movie(uow, paths, by_path)
+                created, updated, events = await self._update_movie(
+                    uow, existing, paths, by_path
+                )
+            else:
+                created, updated, events = await self._create_movie(uow, paths, by_path)
+        await self._dispatch_events(events)
+        return created, updated
 
     @staticmethod
     async def _find_existing_movie(
@@ -232,7 +237,7 @@ class ScanMediaDirectoriesUseCase:
         movie: Movie,
         paths: list[str],
         by_path: dict[str, ScannedFile],
-    ) -> tuple[int, int]:
+    ) -> tuple[int, int, list[DomainEvent]]:
         """Add new file variants and refresh existing ones from a fresh scan."""
         files = list(movie.files)
         changed = False
@@ -255,16 +260,17 @@ class ScanMediaDirectoriesUseCase:
 
         if changed:
             movie = movie.with_updates(files=files)
+            events = movie.pull_events()
             await uow.movies.save(movie)
-            return 0, 1
-        return 0, 0
+            return 0, 1, events
+        return 0, 0, []
 
     async def _create_movie(
         self,
         uow: MediaUnitOfWork,
         paths: list[str],
         by_path: dict[str, ScannedFile],
-    ) -> tuple[int, int]:
+    ) -> tuple[int, int, list[DomainEvent]]:
         """Create a new movie from a group of file variants."""
         first = by_path[paths[0]]
         primary_file = await self._build_new_media_file(first, is_primary=True)
@@ -283,8 +289,7 @@ class ScanMediaDirectoriesUseCase:
             )
         events = movie.pull_events()
         await uow.movies.save(movie)
-        await self._dispatch_events(events)
-        return 1, 0
+        return 1, 0, events
 
     # =========================================================================
     # Episodes


### PR DESCRIPTION
## Summary

- `ScanMediaDirectoriesUseCase._create_movie` published `MediaCreatedEvent` while still inside the UoW `async with` block, so `OnMediaCreatedHandler` opened a fresh session and raised `ResourceNotFoundException` because the movie row had not been committed yet (same symptom reproduced in dev logs for every newly scanned movie).
- `_create_movie` and `_update_movie` now return their events; `_process_movie_group` dispatches them after the UoW exits, matching the pattern already used by `_process_series`.

## Test plan

- [x] `pytest tests/modules/media/unit/application/use_cases/test_scan_media_directories.py`
- [ ] Run a full library scan in dev and confirm no `Handler OnMediaCreatedHandler failed` entries appear

## Summary by Sourcery

Defer dispatching movie scan domain events until after the media unit of work commits to avoid handlers running before database changes are persisted.

Bug Fixes:
- Prevent media created handlers from failing with missing movie records by dispatching movie-related domain events only after the unit of work has completed.

Enhancements:
- Unify movie processing with the existing series processing pattern by having create and update helpers return domain events for later dispatch.