### PR TITLE
refactor(media): add ports for variant detection and probing

### DIFF
--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -35,10 +35,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
     from src.building_blocks.application.event_bus import EventBus
-    from src.modules.media.application.ports import FileSystemScanner
-    from src.modules.media.infrastructure.file_system.variant_detector import (
-        VariantDetector,
-    )
+    from src.modules.media.application.ports import FileSystemScanner, VariantDetectorPort
 
 _logger = get_logger()
 
@@ -64,7 +61,7 @@ class LibraryScanScheduler:
         session_factory: async_sessionmaker[AsyncSession],
         event_bus: EventBus,
         file_scanner: FileSystemScanner,
-        variant_detector: VariantDetector,
+        variant_detector: VariantDetectorPort,
         reconcile_interval_minutes: int,
     ) -> None:
         self._session_factory = session_factory

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -5,6 +5,10 @@ from src.modules.media.application.ports.file_scanner_port import (
     MediaType,
     ScannedFile,
 )
+from src.modules.media.application.ports.media_probe_port import (
+    MediaProbePort,
+    ProbeResult,
+)
 from src.modules.media.application.ports.metadata_provider_port import (
     CreditPerson,
     EpisodeMetadata,
@@ -17,6 +21,9 @@ from src.modules.media.application.ports.progress_lookup_port import (
     ProgressLookupPort,
     ProgressSummary,
 )
+from src.modules.media.application.ports.variant_detector_port import (
+    VariantDetectorPort,
+)
 
 __all__ = [
     "CreditPerson",
@@ -24,10 +31,13 @@ __all__ = [
     "LocalizedFields",
     "FileSystemScanner",
     "MediaMetadata",
+    "MediaProbePort",
     "MediaType",
     "MetadataProvider",
+    "ProbeResult",
     "ProgressLookupPort",
     "ProgressSummary",
     "ScannedFile",
     "SeasonMetadata",
+    "VariantDetectorPort",
 ]

--- a/src/modules/media/application/ports/media_probe_port.py
+++ b/src/modules/media/application/ports/media_probe_port.py
@@ -1,0 +1,62 @@
+"""Port for probing audio/subtitle/resolution metadata from media files.
+
+The scan and streaming use cases need to inspect a media file's
+tracks without depending on the concrete ffprobe-backed service.
+This port owns the ``ProbeResult`` DTO; infrastructure returns it.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Snapshot of tracks + resolution extracted from a media file.
+
+    Attributes:
+        audio_tracks: Embedded audio streams.
+        subtitle_tracks: Embedded subtitle streams.
+        external_subtitles: Sidecar ``.srt`` / ``.ass`` / ``.vtt`` files
+            discovered next to the probed video.
+        resolution: Named resolution (``"1080p"``, ``"4K"``, …) or
+            ``None`` when the video stream is missing or below 360p.
+    """
+
+    audio_tracks: list[AudioTrack] = field(default_factory=list)
+    subtitle_tracks: list[SubtitleTrack] = field(default_factory=list)
+    external_subtitles: list[SubtitleTrack] = field(default_factory=list)
+    resolution: str | None = None
+
+    @property
+    def all_subtitles(self) -> list[SubtitleTrack]:
+        """All subtitle tracks (embedded + external)."""
+        return [*self.subtitle_tracks, *self.external_subtitles]
+
+    @property
+    def text_subtitles(self) -> list[SubtitleTrack]:
+        """Only text-based subtitles convertible to WebVTT."""
+        return [s for s in self.all_subtitles if s.is_text_based]
+
+
+class MediaProbePort(ABC):
+    """Inspect a media file for audio/subtitle/resolution metadata."""
+
+    @abstractmethod
+    def probe(self, file_path: str) -> ProbeResult:
+        """Return the full probe result for the given file.
+
+        Implementations must return a ``ProbeResult`` even on failure
+        (empty tracks, ``resolution=None``); the use case branches on
+        the contents, never on exceptions.
+        """
+        ...
+
+    @abstractmethod
+    def probe_resolution(self, file_path: str) -> str | None:
+        """Return only the named resolution (convenience over ``probe``)."""
+        ...
+
+
+__all__ = ["MediaProbePort", "ProbeResult"]

--- a/src/modules/media/application/ports/media_probe_port.py
+++ b/src/modules/media/application/ports/media_probe_port.py
@@ -53,10 +53,14 @@ class MediaProbePort(ABC):
         """
         ...
 
-    @abstractmethod
     def probe_resolution(self, file_path: str) -> str | None:
-        """Return only the named resolution (convenience over ``probe``)."""
-        ...
+        """Return only the named resolution (convenience over ``probe``).
+
+        Default implementation delegates to ``probe``; override only
+        when the adapter can produce the resolution more cheaply than
+        a full probe.
+        """
+        return self.probe(file_path).resolution
 
 
 __all__ = ["MediaProbePort", "ProbeResult"]

--- a/src/modules/media/application/ports/variant_detector_port.py
+++ b/src/modules/media/application/ports/variant_detector_port.py
@@ -1,0 +1,39 @@
+"""Port for grouping related media files into variants.
+
+The scan use case needs to detect that
+``Inception.2010.1080p.BluRay.mkv`` and ``Inception.2010.4K.HDR.mkv``
+belong to the same movie. The concrete implementation (parsing
+filename tags) lives in ``media.infrastructure.file_system``; the
+use case only depends on this port.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class VariantDetectorPort(ABC):
+    """Group paths that represent the same content at different qualities."""
+
+    @abstractmethod
+    def extract_base_name(self, file_path: str) -> str:
+        """Strip quality-indicator tags and return the base content name."""
+        ...
+
+    @abstractmethod
+    def are_variants(self, file1: str, file2: str) -> bool:
+        """Return ``True`` when two paths share the same base content name."""
+        ...
+
+    @abstractmethod
+    def group_variants(self, files: list[str]) -> dict[str, list[str]]:
+        """Bucket paths by their base content name.
+
+        Args:
+            files: Paths to group.
+
+        Returns:
+            Map from base name to all paths that resolved to it.
+        """
+        ...
+
+
+__all__ = ["VariantDetectorPort"]

--- a/src/modules/media/application/ports/variant_detector_port.py
+++ b/src/modules/media/application/ports/variant_detector_port.py
@@ -8,22 +8,26 @@ use case only depends on this port.
 """
 
 from abc import ABC, abstractmethod
+from collections import defaultdict
 
 
 class VariantDetectorPort(ABC):
-    """Group paths that represent the same content at different qualities."""
+    """Group paths that represent the same content at different qualities.
+
+    Implementations only need to provide ``extract_base_name``; the
+    ``are_variants`` and ``group_variants`` defaults derive from it
+    and rarely need overriding.
+    """
 
     @abstractmethod
     def extract_base_name(self, file_path: str) -> str:
         """Strip quality-indicator tags and return the base content name."""
         ...
 
-    @abstractmethod
     def are_variants(self, file1: str, file2: str) -> bool:
         """Return ``True`` when two paths share the same base content name."""
-        ...
+        return self.extract_base_name(file1) == self.extract_base_name(file2)
 
-    @abstractmethod
     def group_variants(self, files: list[str]) -> dict[str, list[str]]:
         """Bucket paths by their base content name.
 
@@ -33,7 +37,10 @@ class VariantDetectorPort(ABC):
         Returns:
             Map from base name to all paths that resolved to it.
         """
-        ...
+        groups: dict[str, list[str]] = defaultdict(list)
+        for file_path in files:
+            groups[self.extract_base_name(file_path)].append(file_path)
+        return dict(groups)
 
 
 __all__ = ["VariantDetectorPort"]

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -6,7 +6,14 @@ from collections import defaultdict
 from src.building_blocks.application.event_bus import EventBus
 from src.building_blocks.domain.events import DomainEvent
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput, ScanMediaOutput
-from src.modules.media.application.ports import FileSystemScanner, MediaType, ScannedFile
+from src.modules.media.application.ports import (
+    FileSystemScanner,
+    MediaProbePort,
+    MediaType,
+    ProbeResult,
+    ScannedFile,
+    VariantDetectorPort,
+)
 from src.modules.media.application.unit_of_work import (
     MediaUnitOfWork,
     MediaUnitOfWorkFactory,
@@ -22,11 +29,6 @@ from src.modules.media.domain.value_objects import (
     SeasonNumber,
     Title,
     Year,
-)
-from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
-from src.modules.media.infrastructure.streaming.media_probe_service import (
-    MediaProbeResult,
-    MediaProbeService,
 )
 
 
@@ -46,18 +48,18 @@ class ScanMediaDirectoriesUseCase:
 
     Args:
         file_scanner: Port for filesystem scanning.
-        variant_detector: Service for grouping file variants.
+        variant_detector: Port for grouping file variants.
         uow_factory: Factory that opens a fresh media Unit of Work per group.
-        probe_service: Optional ffprobe service for track and resolution detection.
+        probe_service: Optional probe port for track and resolution detection.
         event_bus: Optional event bus for domain events.
     """
 
     def __init__(
         self,
         file_scanner: FileSystemScanner,
-        variant_detector: VariantDetector,
+        variant_detector: VariantDetectorPort,
         uow_factory: MediaUnitOfWorkFactory,
-        probe_service: MediaProbeService | None = None,
+        probe_service: MediaProbePort | None = None,
         event_bus: EventBus | None = None,
     ) -> None:
         self._file_scanner = file_scanner
@@ -104,7 +106,7 @@ class ScanMediaDirectoriesUseCase:
     # ffprobe integration
     # =========================================================================
 
-    async def _probe(self, file_path: str) -> MediaProbeResult | None:
+    async def _probe(self, file_path: str) -> ProbeResult | None:
         """Run full ffprobe in a worker thread.
 
         Returns the complete probe result (tracks + resolution) or ``None``

--- a/src/modules/media/infrastructure/file_system/variant_detector.py
+++ b/src/modules/media/infrastructure/file_system/variant_detector.py
@@ -1,7 +1,6 @@
 """Variant detection for grouping related media files."""
 
 import re
-from collections import defaultdict
 from pathlib import PurePosixPath
 
 from src.modules.media.application.ports.variant_detector_port import VariantDetectorPort
@@ -115,33 +114,6 @@ class VariantDetector(VariantDetectorPort):
         result = re.sub(r"[\.\s_-]+$", "", result)
 
         return result or name
-
-    def are_variants(self, file1: str, file2: str) -> bool:
-        """Check if two files are variants of the same content.
-
-        Args:
-            file1: First file path.
-            file2: Second file path.
-
-        Returns:
-            True if both files share the same base content name.
-        """
-        return self.extract_base_name(file1) == self.extract_base_name(file2)
-
-    def group_variants(self, files: list[str]) -> dict[str, list[str]]:
-        """Group files by their base content name.
-
-        Args:
-            files: List of file paths to group.
-
-        Returns:
-            Dictionary mapping base names to lists of file paths.
-        """
-        groups: dict[str, list[str]] = defaultdict(list)
-        for file_path in files:
-            base = self.extract_base_name(file_path)
-            groups[base].append(file_path)
-        return dict(groups)
 
 
 __all__ = ["VariantDetector"]

--- a/src/modules/media/infrastructure/file_system/variant_detector.py
+++ b/src/modules/media/infrastructure/file_system/variant_detector.py
@@ -4,6 +4,8 @@ import re
 from collections import defaultdict
 from pathlib import PurePosixPath
 
+from src.modules.media.application.ports.variant_detector_port import VariantDetectorPort
+
 # Patterns stripped from filenames to get the base content name.
 # Order matters: more specific patterns before generic ones.
 _STRIP_PATTERNS = [
@@ -74,7 +76,7 @@ _COMBINED_PATTERN = re.compile(
 )
 
 
-class VariantDetector:
+class VariantDetector(VariantDetectorPort):
     """Detect file variants of the same content based on filename patterns.
 
     Strips quality indicators (resolution, codec, source) from filenames

--- a/src/modules/media/infrastructure/streaming/__init__.py
+++ b/src/modules/media/infrastructure/streaming/__init__.py
@@ -5,14 +5,10 @@ from src.modules.media.infrastructure.streaming.hls_service import (
     media_type_for,
     rewrite_m3u8,
 )
-from src.modules.media.infrastructure.streaming.media_probe_service import (
-    MediaProbeResult,
-    MediaProbeService,
-)
+from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
 
 __all__ = [
     "HlsService",
-    "MediaProbeResult",
     "MediaProbeService",
     "media_type_for",
     "rewrite_m3u8",

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -36,11 +36,9 @@ import time
 from pathlib import Path
 from typing import Any
 
+from src.modules.media.application.ports.media_probe_port import ProbeResult
 from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
-from src.modules.media.infrastructure.streaming.media_probe_service import (
-    MediaProbeResult,
-    MediaProbeService,
-)
+from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
 from src.shared_kernel.value_objects.tracks import SubtitleTrack
 
 _logger = logging.getLogger(__name__)
@@ -148,7 +146,7 @@ def media_type_for(filename: str) -> str:
 # -- Module helpers -----------------------------------------------------------
 
 
-def _primary_audio_index(probe: MediaProbeResult) -> int:
+def _primary_audio_index(probe: ProbeResult) -> int:
     """Get the index of the primary audio track (first one, always index 0)."""
     return probe.audio_tracks[0].index if probe.audio_tracks else 0
 
@@ -465,7 +463,7 @@ class HlsService:
         msg = f"Timeout waiting for HLS segments ({_POLL_TIMEOUT}s)"
         raise RuntimeError(msg)
 
-    def probe_tracks(self, file_path: str) -> MediaProbeResult:
+    def probe_tracks(self, file_path: str) -> ProbeResult:
         """Probe a file for tracks, using cache when available."""
         path_hash = self.get_path_hash(file_path)
         cached = self.get_cached_tracks(path_hash)
@@ -684,7 +682,7 @@ class HlsService:
         self,
         file_path: str,
         output_dir: Path,
-        probe: MediaProbeResult,
+        probe: ProbeResult,
         start_seconds: float = 0.0,
     ) -> list[str]:
         """Build FFmpeg command for video + default audio.
@@ -895,7 +893,7 @@ class HlsService:
     # -- Private: master playlist ----------------------------------------------
 
     @staticmethod
-    def _build_master_playlist(output_dir: Path, probe: MediaProbeResult) -> None:
+    def _build_master_playlist(output_dir: Path, probe: ProbeResult) -> None:
         """Generate master.m3u8 with audio renditions and subtitle tracks."""
         lines = ["#EXTM3U", "#EXT-X-VERSION:3"]
 
@@ -947,7 +945,7 @@ class HlsService:
     # -- Private: probe cache --------------------------------------------------
 
     @staticmethod
-    def _save_probe_cache(output_dir: Path, probe: MediaProbeResult) -> None:
+    def _save_probe_cache(output_dir: Path, probe: ProbeResult) -> None:
         """Save probe result as JSON for the tracks API."""
         data = {
             "audio_tracks": [
@@ -982,8 +980,8 @@ class HlsService:
         )
 
     @staticmethod
-    def _deserialize_probe(data: dict[str, Any]) -> MediaProbeResult:
-        """Reconstruct MediaProbeResult from cached JSON."""
+    def _deserialize_probe(data: dict[str, Any]) -> ProbeResult:
+        """Reconstruct ProbeResult from cached JSON."""
         from src.shared_kernel.value_objects.language_code import LanguageCode
         from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
@@ -1026,7 +1024,7 @@ class HlsService:
             for t in data.get("subtitle_tracks", [])
             if t.get("is_external", False)
         ]
-        return MediaProbeResult(audio_tracks=audio, subtitle_tracks=subs, external_subtitles=ext)
+        return ProbeResult(audio_tracks=audio, subtitle_tracks=subs, external_subtitles=ext)
 
     # -- Private: validation ---------------------------------------------------
 

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -948,6 +948,7 @@ class HlsService:
     def _save_probe_cache(output_dir: Path, probe: ProbeResult) -> None:
         """Save probe result as JSON for the tracks API."""
         data = {
+            "resolution": probe.resolution,
             "audio_tracks": [
                 {
                     "index": t.index,
@@ -1024,7 +1025,12 @@ class HlsService:
             for t in data.get("subtitle_tracks", [])
             if t.get("is_external", False)
         ]
-        return ProbeResult(audio_tracks=audio, subtitle_tracks=subs, external_subtitles=ext)
+        return ProbeResult(
+            audio_tracks=audio,
+            subtitle_tracks=subs,
+            external_subtitles=ext,
+            resolution=data.get("resolution"),
+        )
 
     # -- Private: validation ---------------------------------------------------
 

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -10,10 +10,10 @@ import logging
 import re
 import shutil
 import subprocess
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from src.modules.media.application.ports.media_probe_port import MediaProbePort, ProbeResult
 from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
@@ -155,27 +155,7 @@ _ISO639_2_TO_1: dict[str, str] = {
 }
 
 
-@dataclass(frozen=True)
-class MediaProbeResult:
-    """Result of probing a media file for available tracks."""
-
-    audio_tracks: list[AudioTrack] = field(default_factory=list)
-    subtitle_tracks: list[SubtitleTrack] = field(default_factory=list)
-    external_subtitles: list[SubtitleTrack] = field(default_factory=list)
-    resolution: str | None = None
-
-    @property
-    def all_subtitles(self) -> list[SubtitleTrack]:
-        """All subtitle tracks (embedded + external)."""
-        return [*self.subtitle_tracks, *self.external_subtitles]
-
-    @property
-    def text_subtitles(self) -> list[SubtitleTrack]:
-        """Only text-based subtitles that can be converted to WebVTT."""
-        return [s for s in self.all_subtitles if s.is_text_based]
-
-
-class MediaProbeService:
+class MediaProbeService(MediaProbePort):
     """Probe media files for audio and subtitle track information.
 
     Uses ffprobe to inspect embedded streams and scans the file's
@@ -188,19 +168,19 @@ class MediaProbeService:
         2
     """
 
-    def probe(self, file_path: str) -> MediaProbeResult:
+    def probe(self, file_path: str) -> ProbeResult:
         """Probe a media file for all available tracks.
 
         Args:
             file_path: Absolute path to the media file.
 
         Returns:
-            MediaProbeResult with discovered tracks.
+            ProbeResult with discovered tracks.
         """
         source = Path(file_path).resolve()
         if not source.is_file():
             _logger.warning("Cannot probe non-existent file: %s", file_path)
-            return MediaProbeResult()
+            return ProbeResult()
 
         streams = self._run_ffprobe(str(source))
         audio_tracks = self._parse_audio_tracks(streams)
@@ -216,7 +196,7 @@ class MediaProbeService:
             len(external_subs),
         )
 
-        return MediaProbeResult(
+        return ProbeResult(
             audio_tracks=audio_tracks,
             subtitle_tracks=subtitle_tracks,
             external_subtitles=external_subs,
@@ -520,4 +500,4 @@ def _resolution_from_dimensions(width: int, height: int) -> str | None:
     return None
 
 
-__all__ = ["MediaProbeResult", "MediaProbeService"]
+__all__ = ["MediaProbeService"]

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -203,21 +203,6 @@ class MediaProbeService(MediaProbePort):
             resolution=resolution,
         )
 
-    def probe_resolution(self, file_path: str) -> str | None:
-        """Detect the video resolution of a media file via ffprobe.
-
-        Delegates to :meth:`probe` so there is a single ffprobe invocation
-        path.  Returns ``None`` when ffprobe is unavailable, the file does
-        not exist, has no video stream, or its dimensions fall below 360p.
-
-        Args:
-            file_path: Absolute path to the media file.
-
-        Returns:
-            A named resolution string, or ``None`` if it cannot be determined.
-        """
-        return self.probe(file_path).resolution
-
     @staticmethod
     def _run_ffprobe_video_dimensions(file_path: str) -> tuple[int, int] | None:
         """Run ffprobe to extract width/height of the first video stream."""

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -18,6 +18,7 @@ from fastapi.responses import FileResponse, Response, StreamingResponse
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
 from src.modules.media.application.dtos.series_dtos import GetSeriesByIdInput
+from src.modules.media.application.ports import ProbeResult
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
 from src.modules.media.infrastructure.streaming.hls_service import (
@@ -26,7 +27,6 @@ from src.modules.media.infrastructure.streaming.hls_service import (
     media_type_for,
     rewrite_m3u8,
 )
-from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeResult
 
 _logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ def _resolve_file(file_path: str | None) -> Path:
     return path
 
 
-def _serialize_tracks(probe: MediaProbeResult) -> dict[str, list[dict[str, object]]]:
+def _serialize_tracks(probe: ProbeResult) -> dict[str, list[dict[str, object]]]:
     """Serialize probe result into API response format."""
     return {
         "audio_tracks": [

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput, ScanMediaOutput
-from src.modules.media.application.ports import MediaType, ScannedFile
+from src.modules.media.application.ports import (
+    MediaProbePort,
+    MediaType,
+    ProbeResult,
+    ScannedFile,
+)
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
@@ -19,10 +24,6 @@ from src.modules.media.domain.value_objects import (
     Title,
 )
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
-from src.modules.media.infrastructure.streaming.media_probe_service import (
-    MediaProbeResult,
-    MediaProbeService,
-)
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
@@ -89,7 +90,7 @@ def _make_use_case(
     *,
     scanner_results: list[ScannedFile] | None = None,
     mocks: MediaUoWMocks | None = None,
-    probe_service: MediaProbeService | MagicMock | None = None,
+    probe_service: MediaProbePort | MagicMock | None = None,
 ) -> tuple[ScanMediaDirectoriesUseCase, MediaUoWMocks]:
     """Build the scan use case wired to a mock Unit of Work factory."""
     file_scanner = MagicMock()
@@ -327,8 +328,8 @@ class TestRescanResolutionUpgrade:
     async def test_should_probe_when_creating_movie_without_filename_resolution(
         self,
     ) -> None:
-        probe = MagicMock(spec=MediaProbeService)
-        probe.probe.return_value = MediaProbeResult(resolution="1080p")
+        probe = MagicMock(spec=MediaProbePort)
+        probe.probe.return_value = ProbeResult(resolution="1080p")
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
         use_case, _ = _make_use_case(scanner_results=files, probe_service=probe)
 
@@ -354,8 +355,8 @@ class TestRescanResolutionUpgrade:
         saved: list[Movie] = []
         mocks.movies.save.side_effect = lambda m: saved.append(m) or m
 
-        probe = MagicMock(spec=MediaProbeService)
-        probe.probe.return_value = MediaProbeResult(resolution="4K")
+        probe = MagicMock(spec=MediaProbePort)
+        probe.probe.return_value = ProbeResult(resolution="4K")
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
         use_case, _ = _make_use_case(
@@ -397,7 +398,7 @@ class TestRescanResolutionUpgrade:
         )
         mocks.movies.save.side_effect = lambda m: m
 
-        probe = MagicMock(spec=MediaProbeService)
+        probe = MagicMock(spec=MediaProbePort)
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
         use_case, _ = _make_use_case(
@@ -416,8 +417,8 @@ class TestRescanResolutionUpgrade:
         self,
     ) -> None:
         """New files are always probed so audio/subtitle tracks are captured."""
-        probe = MagicMock(spec=MediaProbeService)
-        probe.probe.return_value = MediaProbeResult(
+        probe = MagicMock(spec=MediaProbePort)
+        probe.probe.return_value = ProbeResult(
             audio_tracks=[_audio_track("en"), _audio_track("pt")],
             resolution="1080p",
         )
@@ -484,8 +485,8 @@ class TestTrackDetection:
 
     @pytest.mark.asyncio
     async def test_should_populate_tracks_on_new_movie(self) -> None:
-        probe = MagicMock(spec=MediaProbeService)
-        probe.probe.return_value = MediaProbeResult(
+        probe = MagicMock(spec=MediaProbePort)
+        probe.probe.return_value = ProbeResult(
             audio_tracks=[_audio_track("en"), _audio_track("pt", index=1)],
             subtitle_tracks=[_subtitle_track("en"), _subtitle_track("pt", index=1)],
             resolution="1080p",
@@ -509,8 +510,8 @@ class TestTrackDetection:
 
     @pytest.mark.asyncio
     async def test_should_populate_tracks_on_new_episode(self) -> None:
-        probe = MagicMock(spec=MediaProbeService)
-        probe.probe.return_value = MediaProbeResult(
+        probe = MagicMock(spec=MediaProbePort)
+        probe.probe.return_value = ProbeResult(
             audio_tracks=[_audio_track("ja")],
             subtitle_tracks=[_subtitle_track("en")],
             resolution="1080p",
@@ -549,8 +550,8 @@ class TestTrackDetection:
         )
         mocks.movies.save.side_effect = lambda m: saved.append(m) or m
 
-        probe = MagicMock(spec=MediaProbeService)
-        probe.probe.return_value = MediaProbeResult(
+        probe = MagicMock(spec=MediaProbePort)
+        probe.probe.return_value = ProbeResult(
             audio_tracks=[_audio_track("en")],
             subtitle_tracks=[_subtitle_track("pt")],
         )
@@ -590,7 +591,7 @@ class TestTrackDetection:
         )
         mocks.movies.save.side_effect = lambda m: m
 
-        probe = MagicMock(spec=MediaProbeService)
+        probe = MagicMock(spec=MediaProbePort)
 
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
@@ -609,8 +610,8 @@ class TestTrackDetection:
             is_external=True,
             file_path=FilePath("/movies/inception.pt.srt"),
         )
-        probe = MagicMock(spec=MediaProbeService)
-        probe.probe.return_value = MediaProbeResult(
+        probe = MagicMock(spec=MediaProbePort)
+        probe.probe.return_value = ProbeResult(
             audio_tracks=[_audio_track("en")],
             subtitle_tracks=[_subtitle_track("en")],
             external_subtitles=[ext_sub],

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -9,14 +9,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.modules.media.application.ports import ProbeResult
 from src.modules.media.infrastructure.streaming.hls_service import (
     HlsService,
     _primary_audio_index,
 )
-from src.modules.media.infrastructure.streaming.media_probe_service import (
-    MediaProbeResult,
-    MediaProbeService,
-)
+from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
@@ -58,13 +56,13 @@ class TestPrimaryAudioIndex:
     """Tests for the _primary_audio_index helper."""
 
     def test_should_return_first_track_index(self) -> None:
-        probe = MediaProbeResult(
+        probe = ProbeResult(
             audio_tracks=[_make_audio_track(index=2), _make_audio_track(index=5)],
         )
         assert _primary_audio_index(probe) == 2
 
     def test_should_return_zero_when_no_tracks(self) -> None:
-        probe = MediaProbeResult(audio_tracks=[])
+        probe = ProbeResult(audio_tracks=[])
         assert _primary_audio_index(probe) == 0
 
 
@@ -336,7 +334,7 @@ class TestHlsServiceBuildVideoCmd:
 
     def test_should_copy_video_for_h264(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path / "cache"))
-        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
             cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
@@ -346,7 +344,7 @@ class TestHlsServiceBuildVideoCmd:
 
     def test_should_transcode_non_h264(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path / "cache"))
-        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HlsService, "_probe_video_codec", return_value="hevc"):
             cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
@@ -355,7 +353,7 @@ class TestHlsServiceBuildVideoCmd:
 
     def test_should_map_primary_audio_track(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path / "cache"))
-        probe = MediaProbeResult(
+        probe = ProbeResult(
             audio_tracks=[_make_audio_track(index=3)],
         )
 
@@ -366,7 +364,7 @@ class TestHlsServiceBuildVideoCmd:
 
     def test_should_not_include_ss_when_start_is_zero(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path / "cache"))
-        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
             cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start_seconds=0.0)
@@ -375,7 +373,7 @@ class TestHlsServiceBuildVideoCmd:
 
     def test_should_use_two_pass_seek_when_start_is_set(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path / "cache"))
-        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
             cmd = service._build_video_cmd(
@@ -398,7 +396,7 @@ class TestHlsServiceBuildMasterPlaylist:
     """Tests for _build_master_playlist."""
 
     def test_should_write_master_m3u8(self, tmp_path: Path) -> None:
-        probe = MediaProbeResult(audio_tracks=[_make_audio_track()])
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         HlsService._build_master_playlist(tmp_path, probe)
 
@@ -409,7 +407,7 @@ class TestHlsServiceBuildMasterPlaylist:
         assert "video/playlist.m3u8" in content
 
     def test_should_include_ext_media_for_alt_audio(self, tmp_path: Path) -> None:
-        probe = MediaProbeResult(
+        probe = ProbeResult(
             audio_tracks=[
                 _make_audio_track(index=0, lang="en", is_default=True),
                 _make_audio_track(index=1, lang="pt", is_default=False),
@@ -425,7 +423,7 @@ class TestHlsServiceBuildMasterPlaylist:
         assert 'URI="audio_1/playlist.m3u8"' in content
 
     def test_should_include_ext_media_for_subtitles(self, tmp_path: Path) -> None:
-        probe = MediaProbeResult(
+        probe = ProbeResult(
             audio_tracks=[_make_audio_track()],
             subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="srt")],
         )
@@ -437,7 +435,7 @@ class TestHlsServiceBuildMasterPlaylist:
         assert 'URI="sub_0/playlist.m3u8"' in content
 
     def test_should_skip_image_based_subtitles(self, tmp_path: Path) -> None:
-        probe = MediaProbeResult(
+        probe = ProbeResult(
             audio_tracks=[_make_audio_track()],
             subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="pgs")],
         )
@@ -448,7 +446,7 @@ class TestHlsServiceBuildMasterPlaylist:
         assert 'URI="sub_0/playlist.m3u8"' not in content
 
     def test_should_mark_forced_subtitles(self, tmp_path: Path) -> None:
-        probe = MediaProbeResult(
+        probe = ProbeResult(
             audio_tracks=[_make_audio_track()],
             subtitle_tracks=[
                 _make_subtitle_track(index=0, lang="en", fmt="srt", is_forced=True),
@@ -466,7 +464,7 @@ class TestHlsServiceSaveAndDeserializeProbe:
     """Tests for probe cache serialization round-trip."""
 
     def test_should_save_probe_as_json(self, tmp_path: Path) -> None:
-        probe = MediaProbeResult(
+        probe = ProbeResult(
             audio_tracks=[_make_audio_track(index=0, lang="en", codec="aac")],
             subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="srt")],
         )
@@ -480,7 +478,7 @@ class TestHlsServiceSaveAndDeserializeProbe:
         assert data["audio_tracks"][0]["language"] == "en"
 
     def test_should_round_trip_probe_cache(self, tmp_path: Path) -> None:
-        probe = MediaProbeResult(
+        probe = ProbeResult(
             audio_tracks=[
                 _make_audio_track(index=0, lang="en", codec="aac", title="English"),
                 _make_audio_track(index=1, lang="pt", codec="ac3", channels=6),
@@ -521,7 +519,7 @@ class TestHlsServiceProbeTracks:
 
     def test_should_call_probe_service_when_no_cache(self, tmp_path: Path) -> None:
         probe_mock = MagicMock(spec=MediaProbeService)
-        probe_mock.probe.return_value = MediaProbeResult(audio_tracks=[_make_audio_track()])
+        probe_mock.probe.return_value = ProbeResult(audio_tracks=[_make_audio_track()])
         service = HlsService(cache_dir=str(tmp_path), probe_service=probe_mock)
 
         result = service.probe_tracks("/movies/test.mkv")

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.modules.media.application.ports import ProbeResult
 from src.modules.media.infrastructure.streaming.media_probe_service import (
-    MediaProbeResult,
     MediaProbeService,
     _ffprobe_path,
     _resolution_from_dimensions,
@@ -342,8 +342,8 @@ class TestScanExternalSubtitles:
 
 
 @pytest.mark.unit
-class TestMediaProbeResult:
-    """Tests for MediaProbeResult properties."""
+class TestProbeResult:
+    """Tests for ProbeResult properties."""
 
     def test_all_subtitles_should_combine_embedded_and_external(self) -> None:
         from src.shared_kernel.value_objects.file_path import FilePath
@@ -360,7 +360,7 @@ class TestMediaProbeResult:
             is_external=True,
             file_path=FilePath("/movies/Movie.pt.srt"),
         )
-        result = MediaProbeResult(
+        result = ProbeResult(
             subtitle_tracks=[embedded],
             external_subtitles=[external],
         )
@@ -374,7 +374,7 @@ class TestMediaProbeResult:
         text = SubtitleTrack(index=0, language=LanguageCode("en"), format="srt")
         image = SubtitleTrack(index=1, language=LanguageCode("en"), format="pgs")
 
-        result = MediaProbeResult(subtitle_tracks=[text, image])
+        result = ProbeResult(subtitle_tracks=[text, image])
 
         assert len(result.text_subtitles) == 1
         assert result.text_subtitles[0].format == "srt"


### PR DESCRIPTION
## Summary

- Introduces ``VariantDetectorPort`` and ``MediaProbePort`` in ``src/modules/media/application/ports/``; ``ScanMediaDirectoriesUseCase`` now depends on the ports, not on infrastructure classes.
- Moves the probe DTO from ``media_probe_service.py`` to the port module and renames ``MediaProbeResult`` → ``ProbeResult``. ``VariantDetector`` and ``MediaProbeService`` become the concrete implementations of the new ports (single-line base-class addition each).
- Updates call sites: ``hls_service.py``, ``stream_routes.py``, ``scheduler_service.py``, and the three affected test modules.

## Test plan

- [x] ``poetry run pytest`` — 1613 passed
- [x] ``poetry run ruff check src tests`` — clean
- [x] ``poetry run ruff format --check src tests`` — clean
- [x] ``grep -r \"from src.modules.media.infrastructure\" src/modules/media/application/`` — empty
- [x] ``grep -r \"MediaProbeResult\" src tests`` — empty
- [ ] Manual smoke on scan + HLS streaming endpoints after merge (no API shape changes expected — the rename is internal)

## Summary by Sourcery

Introduce application-level ports for media variant detection and probing so use cases and services depend on abstractions instead of concrete infrastructure implementations.

New Features:
- Add MediaProbePort and ProbeResult DTO to abstract media probing from ffprobe-backed implementation.
- Add VariantDetectorPort to abstract variant grouping logic used by media scanning and scheduling.

Enhancements:
- Update ScanMediaDirectoriesUseCase, HlsService, scheduler, and stream routes to depend on the new ports and shared ProbeResult type instead of infrastructure classes.
- Make VariantDetector and MediaProbeService concrete implementations of their respective ports and adjust exports accordingly.

Tests:
- Update unit tests for media scanning, HLS streaming, and media probing to use the new ports and ProbeResult DTO.