### PR TITLE
refactor(media): extract stream use cases behind ports

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -10,6 +10,7 @@ from src.modules.media.application.use_cases.add_file_variant import AddFileVari
 from src.modules.media.application.use_cases.bulk_enrich_metadata import (
     BulkEnrichMetadataUseCase,
 )
+from src.modules.media.application.use_cases.clear_hls_cache import ClearHlsCacheUseCase
 from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
 from src.modules.media.application.use_cases.enrich_movie_metadata import (
     EnrichMovieMetadataUseCase,
@@ -17,7 +18,11 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
 from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
 )
+from src.modules.media.application.use_cases.generate_hls_playlist import (
+    GenerateHlsPlaylistUseCase,
+)
 from src.modules.media.application.use_cases.get_featured_media import GetFeaturedMediaUseCase
+from src.modules.media.application.use_cases.get_file_tracks import GetFileTracksUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
@@ -30,7 +35,9 @@ from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
+from src.modules.media.application.use_cases.serve_hls_file import ServeHlsFileUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
+from src.modules.media.application.use_cases.stream_file_range import StreamFileRangeUseCase
 from src.modules.media.infrastructure.acl import ProgressLookupAdapter
 from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
@@ -45,6 +52,7 @@ from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import
     SqlAlchemyMediaUnitOfWorkFactory,
 )
 from src.modules.media.infrastructure.streaming import HlsService, MediaProbeService
+from src.modules.media.infrastructure.streaming.file_streamer import LocalFileStreamer
 from src.modules.watch_progress.infrastructure.persistence.repositories import (
     SQLAlchemyWatchProgressRepository,
 )
@@ -210,6 +218,37 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         probe_service=media_probe_service,
         enable_eviction=True,
         max_cache_size_mb=hls_cache_max_size_mb,
+    )
+
+    file_streamer = providers.Factory(LocalFileStreamer)
+
+    # =========================================================================
+    # Use Cases — Streaming
+    # =========================================================================
+
+    generate_hls_playlist = providers.Factory(
+        GenerateHlsPlaylistUseCase,
+        hls=hls_service,
+    )
+
+    serve_hls_file = providers.Factory(
+        ServeHlsFileUseCase,
+        hls=hls_service,
+    )
+
+    get_file_tracks = providers.Factory(
+        GetFileTracksUseCase,
+        hls=hls_service,
+    )
+
+    clear_hls_cache = providers.Factory(
+        ClearHlsCacheUseCase,
+        hls=hls_service,
+    )
+
+    stream_file_range = providers.Factory(
+        StreamFileRangeUseCase,
+        file_streamer=file_streamer,
     )
 
     # =========================================================================

--- a/src/modules/media/application/dtos/stream_dtos.py
+++ b/src/modules/media/application/dtos/stream_dtos.py
@@ -1,0 +1,112 @@
+"""DTOs for the stream use cases.
+
+Each output encapsulates everything the route needs to build an HTTP
+response so presentation code stays free of streaming concepts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+    from src.modules.media.application.ports.media_probe_port import ProbeResult
+
+
+@dataclass(frozen=True)
+class HlsPlaylistOutput:
+    """Master playlist ready to be served.
+
+    Attributes:
+        path_hash: Cache key for subsequent segment/subtitle requests.
+        rewritten_content: The ``master.m3u8`` with relative references
+            already prefixed with the stream base URL.
+    """
+
+    path_hash: str
+    rewritten_content: str
+
+
+@dataclass(frozen=True)
+class HlsFileOutput:
+    """A cached HLS file resolved by path hash.
+
+    ``kind`` discriminates how the route should build its response:
+
+    - ``"playlist"``: ``content`` is the rewritten m3u8 text.
+    - ``"file"``: ``path`` points to the on-disk file; ``media_type``
+      carries the MIME the route should serve it as.
+    """
+
+    kind: Literal["playlist", "file"]
+    media_type: str
+    content: str | None = None
+    path: Path | None = None
+
+
+@dataclass(frozen=True)
+class TrackListOutput:
+    """Serialized audio + subtitle tracks for the player UI."""
+
+    audio_tracks: list[dict[str, object]]
+    subtitle_tracks: list[dict[str, object]]
+
+
+@dataclass(frozen=True)
+class RangeStreamOutput:
+    """Byte-range streaming response pieces.
+
+    ``body`` is the async generator of chunks to stream; the route
+    wraps it in a FastAPI ``StreamingResponse`` with the provided
+    status code and headers so response construction stays in
+    presentation.
+    """
+
+    status_code: int
+    media_type: str
+    headers: dict[str, str]
+    body: AsyncIterator[bytes]
+
+
+def serialize_tracks(probe: ProbeResult) -> TrackListOutput:
+    """Project a ``ProbeResult`` into the flat track DTO."""
+    return TrackListOutput(
+        audio_tracks=[
+            {
+                "index": t.index,
+                "language": t.language.value,
+                "codec": t.codec,
+                "channels": t.channels,
+                "channel_layout": t.channel_layout,
+                "title": t.title,
+                "is_default": t.is_default,
+            }
+            for t in probe.audio_tracks
+        ],
+        subtitle_tracks=[
+            {
+                "index": t.index,
+                "language": t.language.value,
+                "format": t.format,
+                "title": t.title,
+                "is_default": t.is_default,
+                "is_forced": t.is_forced,
+                "is_external": t.is_external,
+                "is_image_based": t.is_image_based,
+            }
+            for t in probe.all_subtitles
+            if t.is_text_based
+        ],
+    )
+
+
+__all__ = [
+    "HlsFileOutput",
+    "HlsPlaylistOutput",
+    "RangeStreamOutput",
+    "TrackListOutput",
+    "serialize_tracks",
+]

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -5,6 +5,8 @@ from src.modules.media.application.ports.file_scanner_port import (
     MediaType,
     ScannedFile,
 )
+from src.modules.media.application.ports.file_streamer_port import FileStreamerPort
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
 from src.modules.media.application.ports.media_probe_port import (
     MediaProbePort,
     ProbeResult,
@@ -28,8 +30,10 @@ from src.modules.media.application.ports.variant_detector_port import (
 __all__ = [
     "CreditPerson",
     "EpisodeMetadata",
-    "LocalizedFields",
+    "FileStreamerPort",
     "FileSystemScanner",
+    "HlsPlaylistPort",
+    "LocalizedFields",
     "MediaMetadata",
     "MediaProbePort",
     "MediaType",

--- a/src/modules/media/application/ports/file_streamer_port.py
+++ b/src/modules/media/application/ports/file_streamer_port.py
@@ -1,0 +1,26 @@
+"""Port for streaming raw file bytes (direct MP4/WebM playback)."""
+
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
+
+
+class FileStreamerPort(ABC):
+    """Read a file from disk in chunks suitable for HTTP streaming."""
+
+    @abstractmethod
+    def get_file_size(self, file_path: str) -> int:
+        """Return the size of ``file_path`` in bytes."""
+        ...
+
+    @abstractmethod
+    def stream_range(
+        self,
+        file_path: str,
+        start: int,
+        end: int,
+    ) -> AsyncIterator[bytes]:
+        """Yield bytes ``[start, end]`` (inclusive) in streaming chunks."""
+        ...
+
+
+__all__ = ["FileStreamerPort"]

--- a/src/modules/media/application/ports/hls_playlist_port.py
+++ b/src/modules/media/application/ports/hls_playlist_port.py
@@ -1,0 +1,56 @@
+"""Port for HLS playlist generation and cached file serving.
+
+The HLS pipeline (ffmpeg spawning, segment caching, subtitle
+extraction) lives in infrastructure. This port is the contract the
+stream use cases depend on — thin enough that a future
+implementation can swap ffmpeg for another encoder without touching
+the application layer.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from src.modules.media.application.ports.media_probe_port import ProbeResult
+
+
+class HlsPlaylistPort(ABC):
+    """Manage the HLS cache: playlists, segments, subtitles, eviction."""
+
+    @abstractmethod
+    async def ensure_playlist(self, file_path: str, start_seconds: float = 0.0) -> str:
+        """Prepare an HLS cache for ``file_path`` and return its path hash.
+
+        Blocks until at least the master playlist and the first few
+        segments are ready so the caller can serve the playlist
+        immediately. ``start_seconds > 0`` seeks the source before
+        encoding (resume mid-file).
+        """
+        ...
+
+    @abstractmethod
+    def get_master_playlist(self, path_hash: str) -> str | None:
+        """Return the raw master ``m3u8`` for a cached path hash."""
+        ...
+
+    @abstractmethod
+    def get_file_by_hash(self, path_hash: str, relative_path: str) -> Path | None:
+        """Resolve a cached HLS file (segment, sub-playlist, VTT)."""
+        ...
+
+    @abstractmethod
+    def wait_for_subtitle(self, path_hash: str, sub_index: int, timeout: float) -> bool:
+        """Block until the given subtitle finishes extraction or ``timeout`` expires."""
+        ...
+
+    @abstractmethod
+    def probe_tracks(self, file_path: str) -> ProbeResult:
+        """Return track / resolution metadata, using the cached probe when available."""
+        ...
+
+    @abstractmethod
+    def clear_cache(self, file_path: str) -> None:
+        """Discard every cache entry tied to ``file_path`` (all seek offsets)."""
+        ...
+
+
+__all__ = ["HlsPlaylistPort"]

--- a/src/modules/media/application/streaming/__init__.py
+++ b/src/modules/media/application/streaming/__init__.py
@@ -1,0 +1,19 @@
+"""Pure streaming helpers usable by both application and infrastructure."""
+
+from src.modules.media.application.streaming.playlist_rewriter import (
+    SUB_PATH_RE,
+    media_type_for,
+    rewrite_m3u8,
+)
+from src.modules.media.application.streaming.range_parser import (
+    ByteRange,
+    parse_range_header,
+)
+
+__all__ = [
+    "SUB_PATH_RE",
+    "ByteRange",
+    "media_type_for",
+    "parse_range_header",
+    "rewrite_m3u8",
+]

--- a/src/modules/media/application/streaming/playlist_rewriter.py
+++ b/src/modules/media/application/streaming/playlist_rewriter.py
@@ -1,0 +1,46 @@
+"""Pure m3u8 text utilities.
+
+No ffmpeg, no filesystem access — just regex-based rewriting of
+relative references and a suffix → MIME map. Lives in the application
+layer so use cases and tests can exercise it without pulling in the
+infrastructure ``HlsService``.
+"""
+
+import re
+from pathlib import Path
+
+# Matches standalone relative references (non-comment lines).
+_RELATIVE_REF_RE = re.compile(
+    r"^(?!#)(?!https?://)(?!/)(.+)$",
+    re.MULTILINE,
+)
+
+# Matches ``URI="..."`` attributes with relative paths only
+# (skips absolute/protocol URIs).
+_URI_ATTR_RE = re.compile(r'URI="(?!https?://)(?!/)([^"]+)"')
+
+# Identifies cache-relative paths under a ``sub_<index>/`` directory so
+# route handlers / use cases can wait on the right per-subtitle
+# extraction event.
+SUB_PATH_RE = re.compile(r"^sub_(\d+)/")
+
+_MEDIA_TYPES: dict[str, str] = {
+    ".m3u8": "application/vnd.apple.mpegurl",
+    ".ts": "video/mp2t",
+    ".vtt": "text/vtt",
+}
+
+
+def rewrite_m3u8(m3u8_text: str, base_url: str) -> str:
+    """Prefix every relative reference in an m3u8 with ``base_url``."""
+    result = _URI_ATTR_RE.sub(rf'URI="{base_url}/\1"', m3u8_text)
+    return _RELATIVE_REF_RE.sub(rf"{base_url}/\1", result)
+
+
+def media_type_for(filename: str) -> str:
+    """Map a filename suffix to the matching HLS-adjacent MIME type."""
+    suffix = Path(filename).suffix.lower()
+    return _MEDIA_TYPES.get(suffix, "application/octet-stream")
+
+
+__all__ = ["SUB_PATH_RE", "media_type_for", "rewrite_m3u8"]

--- a/src/modules/media/application/streaming/range_parser.py
+++ b/src/modules/media/application/streaming/range_parser.py
@@ -1,0 +1,57 @@
+"""HTTP ``Range`` header parsing.
+
+Pure helper so the use case for byte-range streaming can test the
+parsing logic without spinning up FastAPI. We handle only the single
+``bytes=<start>-<end>`` form the frontend's native video element
+sends — multipart range requests are out of scope.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ByteRange:
+    """An inclusive byte range clamped to a given file size.
+
+    Attributes:
+        start: First byte to send (``0`` when no range).
+        end: Last byte to send, inclusive.
+        is_partial: ``True`` when the source was a real ``Range`` header,
+            ``False`` when the caller sent no ``Range`` (full file).
+    """
+
+    start: int
+    end: int
+    is_partial: bool
+
+    @property
+    def length(self) -> int:
+        """Number of bytes covered by the range, inclusive."""
+        return self.end - self.start + 1
+
+
+def parse_range_header(range_header: str | None, file_size: int) -> ByteRange:
+    """Return the inclusive ``ByteRange`` described by a ``Range`` header.
+
+    Args:
+        range_header: Raw ``Range`` header value (e.g. ``"bytes=0-1024"``)
+            or ``None`` when the client omitted it.
+        file_size: Length of the underlying file in bytes.
+
+    Returns:
+        ``ByteRange`` covering the full file when ``range_header`` is
+        ``None``, otherwise the clamped requested range.
+    """
+    if not range_header:
+        return ByteRange(start=0, end=max(0, file_size - 1), is_partial=False)
+
+    spec = range_header.replace("bytes=", "")
+    parts = spec.split("-")
+    start = int(parts[0]) if parts[0] else 0
+    end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
+    start = max(0, start)
+    end = min(end, file_size - 1)
+    return ByteRange(start=start, end=end, is_partial=True)
+
+
+__all__ = ["ByteRange", "parse_range_header"]

--- a/src/modules/media/application/use_cases/clear_hls_cache.py
+++ b/src/modules/media/application/use_cases/clear_hls_cache.py
@@ -1,0 +1,34 @@
+"""ClearHlsCacheUseCase — drop every cache entry tied to a media file."""
+
+from dataclasses import dataclass
+
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+
+
+@dataclass(frozen=True)
+class ClearHlsCacheInput:
+    """Inputs for the HLS cache-clearing use case.
+
+    Attributes:
+        file_path: Absolute path of the media file whose cache should
+            be discarded. A ``None`` value is tolerated so routes that
+            read the path from a (possibly missing) lookup can skip
+            the call without branching.
+    """
+
+    file_path: str | None
+
+
+class ClearHlsCacheUseCase:
+    """Invalidate every cache bucket for a given source file."""
+
+    def __init__(self, hls: HlsPlaylistPort) -> None:
+        self._hls = hls
+
+    async def execute(self, input_dto: ClearHlsCacheInput) -> None:
+        """Clear the cache; no-op when ``file_path`` is ``None``."""
+        if input_dto.file_path:
+            self._hls.clear_cache(input_dto.file_path)
+
+
+__all__ = ["ClearHlsCacheInput", "ClearHlsCacheUseCase"]

--- a/src/modules/media/application/use_cases/generate_hls_playlist.py
+++ b/src/modules/media/application/use_cases/generate_hls_playlist.py
@@ -14,10 +14,13 @@ class GenerateHlsPlaylistInput:
 
     Attributes:
         file_path: Absolute path to the source video file.
-        base_url: Absolute URL that will prefix all relative references
-            inside the rewritten playlist (e.g.
-            ``/api/v1/stream/hls/<hash>``). The use case does not know
-            its own mount point, so presentation passes it in.
+        base_url_template: ``str.format``-style template the use case
+            resolves against the generated cache hash to produce the
+            absolute URL that prefixes every relative reference inside
+            the rewritten playlist. Must contain ``{path_hash}`` —
+            e.g. ``"/api/v1/stream/hls/{path_hash}"``. The use case
+            does not know its own mount point, so presentation passes
+            it in.
         start_seconds: Optional resume offset (see
             ``HlsPlaylistPort.ensure_playlist``).
     """

--- a/src/modules/media/application/use_cases/generate_hls_playlist.py
+++ b/src/modules/media/application/use_cases/generate_hls_playlist.py
@@ -1,0 +1,63 @@
+"""GenerateHlsPlaylistUseCase — build (or reuse) the HLS master playlist."""
+
+from dataclasses import dataclass
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.stream_dtos import HlsPlaylistOutput
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.streaming.playlist_rewriter import rewrite_m3u8
+
+
+@dataclass(frozen=True)
+class GenerateHlsPlaylistInput:
+    """Inputs required to prepare an HLS master playlist.
+
+    Attributes:
+        file_path: Absolute path to the source video file.
+        base_url: Absolute URL that will prefix all relative references
+            inside the rewritten playlist (e.g.
+            ``/api/v1/stream/hls/<hash>``). The use case does not know
+            its own mount point, so presentation passes it in.
+        start_seconds: Optional resume offset (see
+            ``HlsPlaylistPort.ensure_playlist``).
+    """
+
+    file_path: str
+    base_url_template: str
+    start_seconds: float = 0.0
+
+
+class GenerateHlsPlaylistUseCase:
+    """Ensure the HLS cache is warm and return a ready-to-serve m3u8."""
+
+    def __init__(self, hls: HlsPlaylistPort) -> None:
+        self._hls = hls
+
+    async def execute(self, input_dto: GenerateHlsPlaylistInput) -> HlsPlaylistOutput:
+        """Generate (or reuse) the cache and return the rewritten master playlist.
+
+        Args:
+            input_dto: File path, base URL, and optional seek.
+
+        Returns:
+            Path hash and rewritten master m3u8 content.
+
+        Raises:
+            ResourceNotFoundException: If the playlist content is missing
+                from the cache after ``ensure_playlist`` returns.
+        """
+        start = max(0.0, input_dto.start_seconds)
+        path_hash = await self._hls.ensure_playlist(input_dto.file_path, start)
+
+        content = self._hls.get_master_playlist(path_hash)
+        if content is None:
+            raise ResourceNotFoundException.for_resource("HlsMasterPlaylist", path_hash)
+
+        base_url = input_dto.base_url_template.format(path_hash=path_hash)
+        return HlsPlaylistOutput(
+            path_hash=path_hash,
+            rewritten_content=rewrite_m3u8(content, base_url),
+        )
+
+
+__all__ = ["GenerateHlsPlaylistInput", "GenerateHlsPlaylistUseCase"]

--- a/src/modules/media/application/use_cases/get_file_tracks.py
+++ b/src/modules/media/application/use_cases/get_file_tracks.py
@@ -1,0 +1,35 @@
+"""GetFileTracksUseCase — probe a media file and serialize its tracks."""
+
+from dataclasses import dataclass
+
+from src.modules.media.application.dtos.stream_dtos import (
+    TrackListOutput,
+    serialize_tracks,
+)
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+
+
+@dataclass(frozen=True)
+class GetFileTracksInput:
+    """Inputs required to probe and serialize tracks.
+
+    Attributes:
+        file_path: Absolute path to the source video file.
+    """
+
+    file_path: str
+
+
+class GetFileTracksUseCase:
+    """Return the audio and text subtitle tracks a player can select."""
+
+    def __init__(self, hls: HlsPlaylistPort) -> None:
+        self._hls = hls
+
+    async def execute(self, input_dto: GetFileTracksInput) -> TrackListOutput:
+        """Probe ``file_path`` (using the cache when available) and project."""
+        probe = self._hls.probe_tracks(input_dto.file_path)
+        return serialize_tracks(probe)
+
+
+__all__ = ["GetFileTracksInput", "GetFileTracksUseCase"]

--- a/src/modules/media/application/use_cases/serve_hls_file.py
+++ b/src/modules/media/application/use_cases/serve_hls_file.py
@@ -1,0 +1,111 @@
+"""ServeHlsFileUseCase — resolve a cached HLS file (segment/playlist/VTT)."""
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.stream_dtos import HlsFileOutput
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.streaming.playlist_rewriter import (
+    SUB_PATH_RE,
+    media_type_for,
+    rewrite_m3u8,
+)
+
+# Hard cap on how long the use case will park a request waiting for a
+# background subtitle extraction. Must comfortably exceed the per-track
+# ffmpeg timeout in the HLS adapter so the player gets the .vtt instead
+# of a 404 when it picks a slow track right after playback starts.
+_SUBTITLE_WAIT_TIMEOUT = 60.0
+
+
+@dataclass(frozen=True)
+class ServeHlsFileInput:
+    """Inputs for the HLS file-serving use case.
+
+    Attributes:
+        path_hash: Cache key returned by a previous
+            ``GenerateHlsPlaylistUseCase`` run.
+        relative_path: Path of the requested file inside the cache
+            bundle (e.g. ``video/segment_0001.ts``).
+        base_url_template: Absolute base URL for the cache entry, used
+            to rewrite nested ``.m3u8`` references. Must contain
+            ``{parent}`` — the use case substitutes the directory of
+            the requested file.
+    """
+
+    path_hash: str
+    relative_path: str
+    base_url_template: str
+
+
+class ServeHlsFileUseCase:
+    """Resolve a cached HLS file, rewriting nested playlists inline."""
+
+    def __init__(self, hls: HlsPlaylistPort) -> None:
+        self._hls = hls
+
+    async def execute(self, input_dto: ServeHlsFileInput) -> HlsFileOutput:
+        """Return the requested file (or rewritten playlist).
+
+        Raises:
+            ResourceNotFoundException: When the file is not in the
+                cache, or an ``.m3u8`` cannot be read from disk.
+        """
+        await self._maybe_wait_for_subtitle(input_dto.path_hash, input_dto.relative_path)
+
+        resolved = self._hls.get_file_by_hash(input_dto.path_hash, input_dto.relative_path)
+        if resolved is None:
+            raise ResourceNotFoundException.for_resource(
+                "HlsFile", f"{input_dto.path_hash}/{input_dto.relative_path}"
+            )
+
+        if resolved.suffix == ".m3u8":
+            return self._build_playlist_output(resolved, input_dto)
+
+        return HlsFileOutput(
+            kind="file",
+            media_type=media_type_for(input_dto.relative_path),
+            path=resolved,
+        )
+
+    async def _maybe_wait_for_subtitle(self, path_hash: str, relative_path: str) -> None:
+        """Block on subtitle extraction when the request targets ``sub_<idx>``."""
+        sub_match = SUB_PATH_RE.match(relative_path)
+        if not sub_match:
+            return
+        sub_index = int(sub_match.group(1))
+        # Offload the blocking Event.wait so we don't pin an event loop
+        # thread for tens of seconds while ffmpeg is still demuxing.
+        await asyncio.to_thread(
+            self._hls.wait_for_subtitle,
+            path_hash,
+            sub_index,
+            _SUBTITLE_WAIT_TIMEOUT,
+        )
+
+    @staticmethod
+    def _build_playlist_output(resolved: Path, input_dto: ServeHlsFileInput) -> HlsFileOutput:
+        """Read an ``.m3u8`` off disk and rewrite its relative references."""
+        try:
+            content = resolved.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ResourceNotFoundException.for_resource(
+                "HlsFile", f"{input_dto.path_hash}/{input_dto.relative_path}"
+            ) from exc
+
+        parent_parts = str(Path(input_dto.relative_path).parent)
+        base_url = input_dto.base_url_template.format(
+            path_hash=input_dto.path_hash,
+            parent="" if parent_parts == "." else f"/{parent_parts}",
+        )
+
+        return HlsFileOutput(
+            kind="playlist",
+            media_type=media_type_for(input_dto.relative_path),
+            content=rewrite_m3u8(content, base_url),
+        )
+
+
+__all__ = ["ServeHlsFileInput", "ServeHlsFileUseCase"]

--- a/src/modules/media/application/use_cases/stream_file_range.py
+++ b/src/modules/media/application/use_cases/stream_file_range.py
@@ -1,10 +1,11 @@
 """StreamFileRangeUseCase — byte-range streaming for direct playback."""
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
 from src.modules.media.application.dtos.stream_dtos import RangeStreamOutput
 from src.modules.media.application.ports.file_streamer_port import FileStreamerPort
-from src.modules.media.application.streaming.range_parser import parse_range_header
+from src.modules.media.application.streaming.range_parser import ByteRange, parse_range_header
 
 _DEFAULT_MEDIA_TYPE = "video/mp4"
 
@@ -35,33 +36,34 @@ class StreamFileRangeUseCase:
         """Resolve the requested byte range and return the streaming DTO."""
         file_size = self._streamer.get_file_size(input_dto.file_path)
         byte_range = parse_range_header(input_dto.range_header, file_size)
-
         body = self._streamer.stream_range(
             input_dto.file_path,
             byte_range.start,
             byte_range.end,
         )
+        return self._build_output(input_dto.media_type, file_size, byte_range, body)
 
+    @staticmethod
+    def _build_output(
+        media_type: str,
+        file_size: int,
+        byte_range: ByteRange,
+        body: AsyncIterator[bytes],
+    ) -> RangeStreamOutput:
+        """Assemble status code + headers around ``body`` based on ``byte_range``."""
+        headers = {"Accept-Ranges": "bytes"}
         if byte_range.is_partial:
-            headers = {
-                "Content-Range": f"bytes {byte_range.start}-{byte_range.end}/{file_size}",
-                "Accept-Ranges": "bytes",
-                "Content-Length": str(byte_range.length),
-            }
-            return RangeStreamOutput(
-                status_code=206,
-                media_type=input_dto.media_type,
-                headers=headers,
-                body=body,
-            )
+            headers["Content-Range"] = f"bytes {byte_range.start}-{byte_range.end}/{file_size}"
+            headers["Content-Length"] = str(byte_range.length)
+            status_code = 206
+        else:
+            headers["Content-Length"] = str(file_size)
+            status_code = 200
 
         return RangeStreamOutput(
-            status_code=200,
-            media_type=input_dto.media_type,
-            headers={
-                "Accept-Ranges": "bytes",
-                "Content-Length": str(file_size),
-            },
+            status_code=status_code,
+            media_type=media_type,
+            headers=headers,
             body=body,
         )
 

--- a/src/modules/media/application/use_cases/stream_file_range.py
+++ b/src/modules/media/application/use_cases/stream_file_range.py
@@ -1,0 +1,69 @@
+"""StreamFileRangeUseCase — byte-range streaming for direct playback."""
+
+from dataclasses import dataclass
+
+from src.modules.media.application.dtos.stream_dtos import RangeStreamOutput
+from src.modules.media.application.ports.file_streamer_port import FileStreamerPort
+from src.modules.media.application.streaming.range_parser import parse_range_header
+
+_DEFAULT_MEDIA_TYPE = "video/mp4"
+
+
+@dataclass(frozen=True)
+class StreamFileRangeInput:
+    """Inputs for byte-range streaming.
+
+    Attributes:
+        file_path: Absolute path to the file to stream.
+        range_header: Raw HTTP ``Range`` header value (or ``None``).
+        media_type: MIME type to return; defaults to ``video/mp4`` —
+            routes can override for other containers if needed.
+    """
+
+    file_path: str
+    range_header: str | None
+    media_type: str = _DEFAULT_MEDIA_TYPE
+
+
+class StreamFileRangeUseCase:
+    """Build the byte-range response pieces for a local file."""
+
+    def __init__(self, file_streamer: FileStreamerPort) -> None:
+        self._streamer = file_streamer
+
+    async def execute(self, input_dto: StreamFileRangeInput) -> RangeStreamOutput:
+        """Resolve the requested byte range and return the streaming DTO."""
+        file_size = self._streamer.get_file_size(input_dto.file_path)
+        byte_range = parse_range_header(input_dto.range_header, file_size)
+
+        body = self._streamer.stream_range(
+            input_dto.file_path,
+            byte_range.start,
+            byte_range.end,
+        )
+
+        if byte_range.is_partial:
+            headers = {
+                "Content-Range": f"bytes {byte_range.start}-{byte_range.end}/{file_size}",
+                "Accept-Ranges": "bytes",
+                "Content-Length": str(byte_range.length),
+            }
+            return RangeStreamOutput(
+                status_code=206,
+                media_type=input_dto.media_type,
+                headers=headers,
+                body=body,
+            )
+
+        return RangeStreamOutput(
+            status_code=200,
+            media_type=input_dto.media_type,
+            headers={
+                "Accept-Ranges": "bytes",
+                "Content-Length": str(file_size),
+            },
+            body=body,
+        )
+
+
+__all__ = ["StreamFileRangeInput", "StreamFileRangeUseCase"]

--- a/src/modules/media/infrastructure/streaming/__init__.py
+++ b/src/modules/media/infrastructure/streaming/__init__.py
@@ -1,15 +1,11 @@
 """Video streaming infrastructure."""
 
-from src.modules.media.infrastructure.streaming.hls_service import (
-    HlsService,
-    media_type_for,
-    rewrite_m3u8,
-)
+from src.modules.media.infrastructure.streaming.file_streamer import LocalFileStreamer
+from src.modules.media.infrastructure.streaming.hls_service import HlsService
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
 
 __all__ = [
     "HlsService",
+    "LocalFileStreamer",
     "MediaProbeService",
-    "media_type_for",
-    "rewrite_m3u8",
 ]

--- a/src/modules/media/infrastructure/streaming/file_streamer.py
+++ b/src/modules/media/infrastructure/streaming/file_streamer.py
@@ -1,0 +1,41 @@
+"""Filesystem-backed ``FileStreamerPort`` implementation."""
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+from src.modules.media.application.ports.file_streamer_port import FileStreamerPort
+
+_CHUNK_SIZE = 1024 * 1024  # 1 MB — matches the previous in-route size.
+
+
+class LocalFileStreamer(FileStreamerPort):
+    """Read bytes from local disk in chunks.
+
+    The read loop stays synchronous under the hood — FastAPI runs the
+    generator on a worker thread for streaming responses, so wrapping
+    the `open()` in ``aiofiles`` would only add overhead.
+    """
+
+    def get_file_size(self, file_path: str) -> int:
+        """Return the size of ``file_path`` in bytes."""
+        return Path(file_path).stat().st_size
+
+    async def stream_range(
+        self,
+        file_path: str,
+        start: int,
+        end: int,
+    ) -> AsyncIterator[bytes]:
+        """Yield bytes ``[start, end]`` (inclusive) in ``_CHUNK_SIZE`` chunks."""
+        with Path(file_path).open("rb") as f:
+            f.seek(start)
+            remaining = end - start + 1
+            while remaining > 0:
+                data = f.read(min(_CHUNK_SIZE, remaining))
+                if not data:
+                    break
+                remaining -= len(data)
+                yield data
+
+
+__all__ = ["LocalFileStreamer"]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -28,7 +28,6 @@ import asyncio
 import hashlib
 import json
 import logging
-import re
 import shutil
 import subprocess
 import threading
@@ -36,6 +35,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
 from src.modules.media.application.ports.media_probe_port import ProbeResult
 from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
@@ -111,38 +111,6 @@ def _build_two_pass_seek_args(
 
 _VIDEO_DIR = "video"
 
-# -- Playlist rewriting utilities (used by routes) ----------------------------
-
-# Matches standalone relative references (non-comment lines)
-_RELATIVE_REF_RE = re.compile(
-    r"^(?!#)(?!https?://)(?!/)(.+)$",
-    re.MULTILINE,
-)
-# Matches URI="..." with relative paths only (skip absolute/protocol URIs)
-_URI_ATTR_RE = re.compile(r'URI="(?!https?://)(?!/)([^"]+)"')
-# Identifies cache-relative paths under a sub_<index>/ directory so route
-# handlers can wait on the right per-subtitle extraction event.
-SUB_PATH_RE = re.compile(r"^sub_(\d+)/")
-
-_MEDIA_TYPES: dict[str, str] = {
-    ".m3u8": "application/vnd.apple.mpegurl",
-    ".ts": "video/mp2t",
-    ".vtt": "text/vtt",
-}
-
-
-def rewrite_m3u8(m3u8_text: str, base_url: str) -> str:
-    """Prefix all relative references in an m3u8 with an absolute base URL."""
-    result = _URI_ATTR_RE.sub(rf'URI="{base_url}/\1"', m3u8_text)
-    return _RELATIVE_REF_RE.sub(rf"{base_url}/\1", result)
-
-
-def media_type_for(filename: str) -> str:
-    """Determine media type from file extension."""
-    suffix = Path(filename).suffix.lower()
-    return _MEDIA_TYPES.get(suffix, "application/octet-stream")
-
-
 # -- Module helpers -----------------------------------------------------------
 
 
@@ -151,7 +119,7 @@ def _primary_audio_index(probe: ProbeResult) -> int:
     return probe.audio_tracks[0].index if probe.audio_tracks else 0
 
 
-class HlsService:
+class HlsService(HlsPlaylistPort):
     """Generate and cache HLS segments for video files.
 
     Args:
@@ -1059,4 +1027,4 @@ def _write_subtitle_playlist(sub_dir: Path) -> None:
     )
 
 
-__all__ = ["HlsService", "media_type_for", "rewrite_m3u8"]
+__all__ = ["HlsService"]

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -11,6 +11,7 @@ FastAPI response.
 """
 
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
@@ -53,9 +54,16 @@ _FILE_BASE_URL = "/api/v1/stream/hls/{path_hash}{parent}"
 
 
 def _require_file(file_path: str | None) -> str:
-    """Validate that a file path was resolved and return it."""
+    """Validate that a file was resolved and exists on disk, or 404.
+
+    Mirrors the pre-refactor behaviour: missing DB metadata and a
+    stale/removed file on disk both map to ``404`` here — the
+    streaming use cases downstream can assume the path is reachable.
+    """
     if not file_path:
         raise HTTPException(status_code=404, detail="No video file available")
+    if not Path(file_path).is_file():
+        raise HTTPException(status_code=404, detail="Video file not found on disk")
     return file_path
 
 

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -4,95 +4,59 @@ Uses HLS (HTTP Live Streaming) for all video formats via FFmpeg.
 Supports multi-audio and subtitle tracks via master playlist.
 Segment endpoints use a path-hash scheme so they never touch the
 database — only the initial playlist request needs a DB lookup.
+
+Routes stay thin: look up the movie/episode, hand the file path to
+the streaming use cases, and map the DTO they return into the right
+FastAPI response.
 """
 
-import asyncio
-import logging
-from collections.abc import AsyncGenerator
-from pathlib import Path
+from dataclasses import asdict
+from typing import Any
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import FileResponse, Response, StreamingResponse
 
+from src.building_blocks.application.errors import ResourceNotFoundException
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
 from src.modules.media.application.dtos.series_dtos import GetSeriesByIdInput
-from src.modules.media.application.ports import ProbeResult
+from src.modules.media.application.use_cases.clear_hls_cache import (
+    ClearHlsCacheInput,
+    ClearHlsCacheUseCase,
+)
+from src.modules.media.application.use_cases.generate_hls_playlist import (
+    GenerateHlsPlaylistInput,
+    GenerateHlsPlaylistUseCase,
+)
+from src.modules.media.application.use_cases.get_file_tracks import (
+    GetFileTracksInput,
+    GetFileTracksUseCase,
+)
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
-from src.modules.media.infrastructure.streaming.hls_service import (
-    SUB_PATH_RE,
-    HlsService,
-    media_type_for,
-    rewrite_m3u8,
+from src.modules.media.application.use_cases.serve_hls_file import (
+    ServeHlsFileInput,
+    ServeHlsFileUseCase,
 )
-
-_logger = logging.getLogger(__name__)
-
-# Hard cap on how long the file route will park a request waiting for
-# a background subtitle extraction. Must comfortably exceed the per-track
-# ffmpeg timeout in HlsService so the player gets the .vtt instead of a
-# 404 when it picks a slow track right after playback starts.
-_SUBTITLE_WAIT_TIMEOUT = 60.0
+from src.modules.media.application.use_cases.stream_file_range import (
+    StreamFileRangeInput,
+    StreamFileRangeUseCase,
+)
 
 router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
 
+# Base-URL templates consumed by the stream use cases. The use cases
+# don't know where they're mounted, so the router injects them.
+_MASTER_BASE_URL = "/api/v1/stream/hls/{path_hash}"
+_FILE_BASE_URL = "/api/v1/stream/hls/{path_hash}{parent}"
 
-def _resolve_file(file_path: str | None) -> Path:
-    """Validate file path exists and return Path object."""
+
+def _require_file(file_path: str | None) -> str:
+    """Validate that a file path was resolved and return it."""
     if not file_path:
         raise HTTPException(status_code=404, detail="No video file available")
-    path = Path(file_path)
-    if not path.is_file():
-        raise HTTPException(status_code=404, detail="Video file not found on disk")
-    return path
-
-
-def _serialize_tracks(probe: ProbeResult) -> dict[str, list[dict[str, object]]]:
-    """Serialize probe result into API response format."""
-    return {
-        "audio_tracks": [
-            {
-                "index": t.index,
-                "language": t.language.value,
-                "codec": t.codec,
-                "channels": t.channels,
-                "channel_layout": t.channel_layout,
-                "title": t.title,
-                "is_default": t.is_default,
-            }
-            for t in probe.audio_tracks
-        ],
-        "subtitle_tracks": [
-            {
-                "index": t.index,
-                "language": t.language.value,
-                "format": t.format,
-                "title": t.title,
-                "is_default": t.is_default,
-                "is_forced": t.is_forced,
-                "is_external": t.is_external,
-                "is_image_based": t.is_image_based,
-            }
-            for t in probe.all_subtitles
-            if t.is_text_based
-        ],
-    }
-
-
-def _serve_master_playlist(hls: HlsService, path_hash: str) -> Response:
-    """Read master playlist and rewrite all relative URLs."""
-    content = hls.get_master_playlist(path_hash)
-    if not content:
-        raise HTTPException(status_code=404, detail="Playlist not found")
-
-    base_url = f"/api/v1/stream/hls/{path_hash}"
-    return Response(
-        content=rewrite_m3u8(content, base_url),
-        media_type="application/vnd.apple.mpegurl",
-        headers={"Cache-Control": "no-cache"},
-    )
+    return file_path
 
 
 # -- HLS file serving (no DB access) ------------------------------------------
@@ -103,52 +67,30 @@ def _serve_master_playlist(hls: HlsService, path_hash: str) -> Response:
 async def hls_file(
     path_hash: str,
     file_path: str,
-    hls: HlsService = Depends(
-        Provide[ApplicationContainer.media.hls_service],
+    use_case: ServeHlsFileUseCase = Depends(
+        Provide[ApplicationContainer.media.serve_hls_file],
     ),
 ) -> Response:
-    """Serve any HLS file (segment, sub-playlist, VTT) by cache hash.
+    """Serve any HLS file (segment, sub-playlist, VTT) by cache hash."""
+    try:
+        output = await use_case.execute(
+            ServeHlsFileInput(
+                path_hash=path_hash,
+                relative_path=file_path,
+                base_url_template=_FILE_BASE_URL,
+            )
+        )
+    except ResourceNotFoundException as exc:
+        raise HTTPException(status_code=404, detail="File not found") from exc
 
-    For .m3u8 files, rewrites relative references to absolute URLs.
-    Subtitle requests block on the matching readiness event so the
-    player gets the .vtt as soon as ffmpeg finishes extracting it,
-    instead of getting an early 404 and giving up. No database access
-    needed.
-    """
-    sub_match = SUB_PATH_RE.match(file_path)
-    if sub_match:
-        sub_index = int(sub_match.group(1))
-        # Offload the blocking Event.wait so we don't pin an event
-        # loop thread for tens of seconds while ffmpeg is still
-        # demuxing the source container.
-        await asyncio.to_thread(hls.wait_for_subtitle, path_hash, sub_index, _SUBTITLE_WAIT_TIMEOUT)
-
-    resolved = hls.get_file_by_hash(path_hash, file_path)
-    if not resolved:
-        raise HTTPException(status_code=404, detail="File not found")
-
-    if resolved.suffix == ".m3u8":
-        try:
-            content = resolved.read_text(encoding="utf-8")
-        except OSError as e:
-            raise HTTPException(status_code=404, detail="Playlist not readable") from e
-
-        parent_parts = str(Path(file_path).parent)
-        if parent_parts == ".":
-            base_url = f"/api/v1/stream/hls/{path_hash}"
-        else:
-            base_url = f"/api/v1/stream/hls/{path_hash}/{parent_parts}"
-
+    if output.kind == "playlist":
         return Response(
-            content=rewrite_m3u8(content, base_url),
-            media_type="application/vnd.apple.mpegurl",
+            content=output.content,
+            media_type=output.media_type,
             headers={"Cache-Control": "no-cache"},
         )
-
-    return FileResponse(
-        str(resolved),
-        media_type=media_type_for(file_path),
-    )
+    assert output.path is not None
+    return FileResponse(str(output.path), media_type=output.media_type)
 
 
 # -- HLS playlist endpoints (need DB to resolve file path) ---------------------
@@ -159,37 +101,17 @@ async def hls_file(
 async def movie_hls_playlist(
     movie_id: str,
     start: float = 0.0,
-    use_case: GetMovieByIdUseCase = Depends(
+    movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
-    hls: HlsService = Depends(
-        Provide[ApplicationContainer.media.hls_service],
+    hls_uc: GenerateHlsPlaylistUseCase = Depends(
+        Provide[ApplicationContainer.media.generate_hls_playlist],
     ),
 ) -> Response:
-    """Generate and serve HLS master playlist for a movie.
-
-    The ``start`` query parameter (default 0) is an optional seek offset
-    in seconds. FFmpeg trims the source so the HLS output starts at
-    (original time = start), which lets the client resume mid-file
-    without waiting for segments to be produced from position 0.
-    """
-    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
-    file_path = _resolve_file(movie.file_path)
-    start_seconds = max(0.0, start)
-
-    try:
-        path_hash = await hls.ensure_playlist(str(file_path), start_seconds)
-    except Exception as e:
-        _logger.exception(
-            "HLS generation failed for movie %s (file=%s, start=%ss)",
-            movie_id,
-            file_path,
-            start_seconds,
-        )
-        detail = str(e) or f"{type(e).__name__}: check server logs"
-        raise HTTPException(status_code=500, detail=detail) from e
-
-    return _serve_master_playlist(hls, path_hash)
+    """Generate and serve HLS master playlist for a movie."""
+    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    file_path = _require_file(movie.file_path)
+    return await _serve_master(hls_uc, file_path, start)
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/playlist.m3u8")  # type: ignore[misc]
@@ -199,37 +121,17 @@ async def episode_hls_playlist(
     season_number: int,
     episode_number: int,
     start: float = 0.0,
-    use_case: GetSeriesByIdUseCase = Depends(
+    series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
-    hls: HlsService = Depends(
-        Provide[ApplicationContainer.media.hls_service],
+    hls_uc: GenerateHlsPlaylistUseCase = Depends(
+        Provide[ApplicationContainer.media.generate_hls_playlist],
     ),
 ) -> Response:
-    """Generate and serve HLS master playlist for an episode.
-
-    The ``start`` query parameter (default 0) is an optional seek offset
-    in seconds — same semantics as the movie endpoint.
-    """
-    file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
-    path = _resolve_file(file_path)
-    start_seconds = max(0.0, start)
-
-    try:
-        path_hash = await hls.ensure_playlist(str(path), start_seconds)
-    except Exception as e:
-        _logger.exception(
-            "HLS generation failed for episode %s/S%sE%s (file=%s, start=%ss)",
-            series_id,
-            season_number,
-            episode_number,
-            path,
-            start_seconds,
-        )
-        detail = str(e) or f"{type(e).__name__}: check server logs"
-        raise HTTPException(status_code=500, detail=detail) from e
-
-    return _serve_master_playlist(hls, path_hash)
+    """Generate and serve HLS master playlist for an episode."""
+    file_path = await _find_episode_file(series_uc, series_id, season_number, episode_number)
+    file_path = _require_file(file_path)
+    return await _serve_master(hls_uc, file_path, start)
 
 
 # -- Track info ----------------------------------------------------------------
@@ -239,18 +141,18 @@ async def episode_hls_playlist(
 @inject  # type: ignore[misc]
 async def movie_tracks(
     movie_id: str,
-    use_case: GetMovieByIdUseCase = Depends(
+    movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
-    hls: HlsService = Depends(
-        Provide[ApplicationContainer.media.hls_service],
+    tracks_uc: GetFileTracksUseCase = Depends(
+        Provide[ApplicationContainer.media.get_file_tracks],
     ),
-) -> dict[str, list[dict[str, object]]]:
+) -> dict[str, Any]:
     """Get available audio and subtitle tracks for a movie."""
-    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
-    file_path = _resolve_file(movie.file_path)
-    probe = hls.probe_tracks(str(file_path))
-    return _serialize_tracks(probe)
+    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    file_path = _require_file(movie.file_path)
+    tracks = await tracks_uc.execute(GetFileTracksInput(file_path=file_path))
+    return asdict(tracks)
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}/tracks")  # type: ignore[misc]
@@ -259,18 +161,18 @@ async def episode_tracks(
     series_id: str,
     season_number: int,
     episode_number: int,
-    use_case: GetSeriesByIdUseCase = Depends(
+    series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
-    hls: HlsService = Depends(
-        Provide[ApplicationContainer.media.hls_service],
+    tracks_uc: GetFileTracksUseCase = Depends(
+        Provide[ApplicationContainer.media.get_file_tracks],
     ),
-) -> dict[str, list[dict[str, object]]]:
+) -> dict[str, Any]:
     """Get available audio and subtitle tracks for an episode."""
-    file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
-    path = _resolve_file(file_path)
-    probe = hls.probe_tracks(str(path))
-    return _serialize_tracks(probe)
+    file_path = await _find_episode_file(series_uc, series_id, season_number, episode_number)
+    file_path = _require_file(file_path)
+    tracks = await tracks_uc.execute(GetFileTracksInput(file_path=file_path))
+    return asdict(tracks)
 
 
 # -- Cache management ----------------------------------------------------------
@@ -280,17 +182,16 @@ async def episode_tracks(
 @inject  # type: ignore[misc]
 async def clear_movie_hls_cache(
     movie_id: str,
-    use_case: GetMovieByIdUseCase = Depends(
+    movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
-    hls: HlsService = Depends(
-        Provide[ApplicationContainer.media.hls_service],
+    clear_uc: ClearHlsCacheUseCase = Depends(
+        Provide[ApplicationContainer.media.clear_hls_cache],
     ),
 ) -> Response:
     """Clear cached HLS segments for a movie, forcing regeneration."""
-    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
-    if movie.file_path:
-        hls.clear_cache(movie.file_path)
+    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    await clear_uc.execute(ClearHlsCacheInput(file_path=movie.file_path))
     return Response(status_code=204)
 
 
@@ -302,15 +203,17 @@ async def clear_movie_hls_cache(
 async def stream_movie(
     movie_id: str,
     request: Request,
-    use_case: GetMovieByIdUseCase = Depends(
+    movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
+    ),
+    stream_uc: StreamFileRangeUseCase = Depends(
+        Provide[ApplicationContainer.media.stream_file_range],
     ),
 ) -> StreamingResponse:
     """Direct stream a movie file with Range support (MP4/WebM only)."""
-    movie = await use_case.execute(GetMovieByIdInput(movie_id=movie_id))
-    path = _resolve_file(movie.file_path)
-
-    return _build_range_response(str(path), path.stat().st_size, request.headers.get("range"))
+    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    file_path = _require_file(movie.file_path)
+    return await _stream_range(stream_uc, file_path, request.headers.get("range"))
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}")  # type: ignore[misc]
@@ -320,18 +223,57 @@ async def stream_episode(
     season_number: int,
     episode_number: int,
     request: Request,
-    use_case: GetSeriesByIdUseCase = Depends(
+    series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
+    ),
+    stream_uc: StreamFileRangeUseCase = Depends(
+        Provide[ApplicationContainer.media.stream_file_range],
     ),
 ) -> StreamingResponse:
     """Direct stream an episode file with Range support."""
-    file_path = await _find_episode_file(use_case, series_id, season_number, episode_number)
-    path = _resolve_file(file_path)
-
-    return _build_range_response(str(path), path.stat().st_size, request.headers.get("range"))
+    file_path = await _find_episode_file(series_uc, series_id, season_number, episode_number)
+    file_path = _require_file(file_path)
+    return await _stream_range(stream_uc, file_path, request.headers.get("range"))
 
 
 # -- Helpers -------------------------------------------------------------------
+
+
+async def _serve_master(
+    use_case: GenerateHlsPlaylistUseCase,
+    file_path: str,
+    start_seconds: float,
+) -> Response:
+    """Run the generate-playlist use case and wrap its DTO in a Response."""
+    output = await use_case.execute(
+        GenerateHlsPlaylistInput(
+            file_path=file_path,
+            base_url_template=_MASTER_BASE_URL,
+            start_seconds=start_seconds,
+        )
+    )
+    return Response(
+        content=output.rewritten_content,
+        media_type="application/vnd.apple.mpegurl",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
+async def _stream_range(
+    use_case: StreamFileRangeUseCase,
+    file_path: str,
+    range_header: str | None,
+) -> StreamingResponse:
+    """Run the range-streaming use case and build a StreamingResponse."""
+    output = await use_case.execute(
+        StreamFileRangeInput(file_path=file_path, range_header=range_header),
+    )
+    return StreamingResponse(
+        output.body,
+        status_code=output.status_code,
+        media_type=output.media_type,
+        headers=output.headers,
+    )
 
 
 async def _find_episode_file(
@@ -349,59 +291,6 @@ async def _find_episode_file(
                     return episode.file_path
             break
     return None
-
-
-async def _stream_range(
-    file_path: str,
-    start: int,
-    end: int,
-) -> AsyncGenerator[bytes, None]:
-    """Stream file bytes in 1MB chunks."""
-    chunk_size = 1024 * 1024
-    with Path(file_path).open("rb") as f:
-        f.seek(start)
-        remaining = end - start + 1
-        while remaining > 0:
-            data = f.read(min(chunk_size, remaining))
-            if not data:
-                break
-            remaining -= len(data)
-            yield data
-
-
-def _build_range_response(
-    file_path: str,
-    file_size: int,
-    range_header: str | None,
-) -> StreamingResponse:
-    """Build Range-based streaming response."""
-    if range_header:
-        range_spec = range_header.replace("bytes=", "")
-        parts = range_spec.split("-")
-        start = int(parts[0]) if parts[0] else 0
-        end = int(parts[1]) if parts[1] else file_size - 1
-        start = max(0, start)
-        end = min(end, file_size - 1)
-
-        return StreamingResponse(
-            _stream_range(file_path, start, end),
-            status_code=206,
-            media_type="video/mp4",
-            headers={
-                "Content-Range": f"bytes {start}-{end}/{file_size}",
-                "Accept-Ranges": "bytes",
-                "Content-Length": str(end - start + 1),
-            },
-        )
-
-    return StreamingResponse(
-        _stream_range(file_path, 0, file_size - 1),
-        media_type="video/mp4",
-        headers={
-            "Accept-Ranges": "bytes",
-            "Content-Length": str(file_size),
-        },
-    )
 
 
 __all__ = ["router"]

--- a/tests/modules/media/unit/application/streaming/test_range_parser.py
+++ b/tests/modules/media/unit/application/streaming/test_range_parser.py
@@ -1,0 +1,41 @@
+"""Tests for the HTTP Range header parser."""
+
+import pytest
+
+from src.modules.media.application.streaming.range_parser import (
+    ByteRange,
+    parse_range_header,
+)
+
+
+@pytest.mark.unit
+class TestParseRangeHeader:
+    def test_missing_header_returns_full_file_non_partial(self) -> None:
+        result = parse_range_header(None, 1000)
+        assert result == ByteRange(start=0, end=999, is_partial=False)
+        assert result.length == 1000
+
+    def test_empty_header_is_treated_as_missing(self) -> None:
+        assert parse_range_header("", 1000).is_partial is False
+
+    def test_bounded_range_is_parsed(self) -> None:
+        result = parse_range_header("bytes=100-199", 1000)
+        assert result == ByteRange(start=100, end=199, is_partial=True)
+        assert result.length == 100
+
+    def test_open_ended_range_defaults_end_to_last_byte(self) -> None:
+        result = parse_range_header("bytes=500-", 1000)
+        assert result == ByteRange(start=500, end=999, is_partial=True)
+
+    def test_range_is_clamped_to_file_size(self) -> None:
+        result = parse_range_header("bytes=800-5000", 1000)
+        assert result == ByteRange(start=800, end=999, is_partial=True)
+
+    def test_negative_start_is_clamped_to_zero(self) -> None:
+        # Malformed but defensively handled, mirroring the legacy behaviour.
+        result = parse_range_header("bytes=0-10", 1000)
+        assert result.start == 0
+
+    def test_bytes_prefix_is_optional_for_resilience(self) -> None:
+        result = parse_range_header("100-199", 1000)
+        assert result == ByteRange(start=100, end=199, is_partial=True)

--- a/tests/modules/media/unit/application/use_cases/test_clear_hls_cache.py
+++ b/tests/modules/media/unit/application/use_cases/test_clear_hls_cache.py
@@ -1,0 +1,32 @@
+"""Tests for ClearHlsCacheUseCase."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.use_cases.clear_hls_cache import (
+    ClearHlsCacheInput,
+    ClearHlsCacheUseCase,
+)
+
+
+@pytest.mark.unit
+class TestClearHlsCacheUseCase:
+    @pytest.mark.asyncio
+    async def test_should_delegate_to_port_when_path_present(self) -> None:
+        hls = MagicMock(spec=HlsPlaylistPort)
+        use_case = ClearHlsCacheUseCase(hls=hls)
+
+        await use_case.execute(ClearHlsCacheInput(file_path="/movies/a.mkv"))
+
+        hls.clear_cache.assert_called_once_with("/movies/a.mkv")
+
+    @pytest.mark.asyncio
+    async def test_should_be_noop_when_path_is_none(self) -> None:
+        hls = MagicMock(spec=HlsPlaylistPort)
+        use_case = ClearHlsCacheUseCase(hls=hls)
+
+        await use_case.execute(ClearHlsCacheInput(file_path=None))
+
+        hls.clear_cache.assert_not_called()

--- a/tests/modules/media/unit/application/use_cases/test_generate_hls_playlist.py
+++ b/tests/modules/media/unit/application/use_cases/test_generate_hls_playlist.py
@@ -1,0 +1,72 @@
+"""Tests for GenerateHlsPlaylistUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.use_cases.generate_hls_playlist import (
+    GenerateHlsPlaylistInput,
+    GenerateHlsPlaylistUseCase,
+)
+
+
+def _make_hls_mock(
+    path_hash: str = "abc123",
+    master_content: str | None = "#EXTM3U\nvideo/playlist.m3u8\n",
+) -> MagicMock:
+    hls = MagicMock(spec=HlsPlaylistPort)
+    hls.ensure_playlist = AsyncMock(return_value=path_hash)
+    hls.get_master_playlist = MagicMock(return_value=master_content)
+    return hls
+
+
+@pytest.mark.unit
+class TestGenerateHlsPlaylistUseCase:
+    @pytest.mark.asyncio
+    async def test_should_rewrite_relative_references(self) -> None:
+        hls = _make_hls_mock(
+            path_hash="abc",
+            master_content="#EXTM3U\nvideo/playlist.m3u8\n",
+        )
+        use_case = GenerateHlsPlaylistUseCase(hls=hls)
+
+        output = await use_case.execute(
+            GenerateHlsPlaylistInput(
+                file_path="/movies/file.mkv",
+                base_url_template="/api/v1/stream/hls/{path_hash}",
+            )
+        )
+
+        assert output.path_hash == "abc"
+        assert "/api/v1/stream/hls/abc/video/playlist.m3u8" in output.rewritten_content
+        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv", 0.0)
+
+    @pytest.mark.asyncio
+    async def test_should_clamp_negative_start_to_zero(self) -> None:
+        hls = _make_hls_mock()
+        use_case = GenerateHlsPlaylistUseCase(hls=hls)
+
+        await use_case.execute(
+            GenerateHlsPlaylistInput(
+                file_path="/a.mkv",
+                base_url_template="/base/{path_hash}",
+                start_seconds=-5.0,
+            )
+        )
+        hls.ensure_playlist.assert_awaited_once_with("/a.mkv", 0.0)
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_master_playlist_missing(self) -> None:
+        hls = _make_hls_mock(master_content=None)
+        use_case = GenerateHlsPlaylistUseCase(hls=hls)
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                GenerateHlsPlaylistInput(
+                    file_path="/a.mkv",
+                    base_url_template="/base/{path_hash}",
+                )
+            )
+        assert exc_info.value.resource_type == "HlsMasterPlaylist"

--- a/tests/modules/media/unit/application/use_cases/test_get_file_tracks.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_file_tracks.py
@@ -1,0 +1,76 @@
+"""Tests for GetFileTracksUseCase."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.modules.media.application.ports import ProbeResult
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.use_cases.get_file_tracks import (
+    GetFileTracksInput,
+    GetFileTracksUseCase,
+)
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+
+def _audio(index: int = 0, lang: str = "en") -> AudioTrack:
+    return AudioTrack(
+        index=index,
+        language=LanguageCode(lang),
+        codec="aac",
+        channels=2,
+        is_default=index == 0,
+    )
+
+
+def _text_subtitle(index: int = 0, lang: str = "en") -> SubtitleTrack:
+    return SubtitleTrack(
+        index=index,
+        language=LanguageCode(lang),
+        format="srt",
+        is_external=False,
+    )
+
+
+def _image_subtitle(index: int = 1, lang: str = "en") -> SubtitleTrack:
+    return SubtitleTrack(
+        index=index,
+        language=LanguageCode(lang),
+        format="pgs",
+        is_external=False,
+    )
+
+
+@pytest.mark.unit
+class TestGetFileTracksUseCase:
+    @pytest.mark.asyncio
+    async def test_should_serialize_audio_and_text_subtitles(self) -> None:
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[_audio(0, "en"), _audio(1, "pt")],
+            subtitle_tracks=[_text_subtitle(0, "en")],
+        )
+        use_case = GetFileTracksUseCase(hls=hls)
+
+        output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
+
+        assert len(output.audio_tracks) == 2
+        assert {t["language"] for t in output.audio_tracks} == {"en", "pt"}
+        assert len(output.subtitle_tracks) == 1
+        assert output.subtitle_tracks[0]["format"] == "srt"
+        hls.probe_tracks.assert_called_once_with("/m.mkv")
+
+    @pytest.mark.asyncio
+    async def test_should_drop_image_based_subtitles(self) -> None:
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[_audio()],
+            subtitle_tracks=[_text_subtitle(0, "en"), _image_subtitle(1, "ja")],
+        )
+        use_case = GetFileTracksUseCase(hls=hls)
+
+        output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
+
+        assert len(output.subtitle_tracks) == 1
+        assert output.subtitle_tracks[0]["language"] == "en"

--- a/tests/modules/media/unit/application/use_cases/test_serve_hls_file.py
+++ b/tests/modules/media/unit/application/use_cases/test_serve_hls_file.py
@@ -1,0 +1,123 @@
+"""Tests for ServeHlsFileUseCase."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.use_cases.serve_hls_file import (
+    ServeHlsFileInput,
+    ServeHlsFileUseCase,
+)
+
+_BASE_URL = "/api/v1/stream/hls/{path_hash}{parent}"
+
+
+def _make_hls_mock() -> MagicMock:
+    return MagicMock(spec=HlsPlaylistPort)
+
+
+@pytest.mark.unit
+class TestServeHlsFileUseCase:
+    @pytest.mark.asyncio
+    async def test_should_return_file_output_for_non_playlist(self, tmp_path: Path) -> None:
+        segment = tmp_path / "segment_0001.ts"
+        segment.write_bytes(b"segment-bytes")
+
+        hls = _make_hls_mock()
+        hls.get_file_by_hash.return_value = segment
+        use_case = ServeHlsFileUseCase(hls=hls)
+
+        output = await use_case.execute(
+            ServeHlsFileInput(
+                path_hash="abc",
+                relative_path="video/segment_0001.ts",
+                base_url_template=_BASE_URL,
+            )
+        )
+
+        assert output.kind == "file"
+        assert output.path == segment
+        assert output.media_type == "video/mp2t"
+
+    @pytest.mark.asyncio
+    async def test_should_rewrite_playlist_content(self, tmp_path: Path) -> None:
+        sub_dir = tmp_path / "video"
+        sub_dir.mkdir()
+        playlist = sub_dir / "playlist.m3u8"
+        playlist.write_text("#EXTM3U\nsegment_0001.ts\n", encoding="utf-8")
+
+        hls = _make_hls_mock()
+        hls.get_file_by_hash.return_value = playlist
+        use_case = ServeHlsFileUseCase(hls=hls)
+
+        output = await use_case.execute(
+            ServeHlsFileInput(
+                path_hash="abc",
+                relative_path="video/playlist.m3u8",
+                base_url_template=_BASE_URL,
+            )
+        )
+
+        assert output.kind == "playlist"
+        assert output.content is not None
+        assert "/api/v1/stream/hls/abc/video/segment_0001.ts" in output.content
+
+    @pytest.mark.asyncio
+    async def test_should_wait_for_subtitle_before_resolving(self, tmp_path: Path) -> None:
+        vtt = tmp_path / "sub.vtt"
+        vtt.write_text("WEBVTT\n", encoding="utf-8")
+
+        hls = _make_hls_mock()
+        hls.get_file_by_hash.return_value = vtt
+        hls.wait_for_subtitle.return_value = True
+        use_case = ServeHlsFileUseCase(hls=hls)
+
+        await use_case.execute(
+            ServeHlsFileInput(
+                path_hash="abc",
+                relative_path="sub_2/sub.vtt",
+                base_url_template=_BASE_URL,
+            )
+        )
+
+        hls.wait_for_subtitle.assert_called_once()
+        args = hls.wait_for_subtitle.call_args.args
+        assert args[0] == "abc"
+        assert args[1] == 2
+
+    @pytest.mark.asyncio
+    async def test_should_skip_subtitle_wait_for_other_paths(self, tmp_path: Path) -> None:
+        segment = tmp_path / "segment.ts"
+        segment.write_bytes(b"x")
+
+        hls = _make_hls_mock()
+        hls.get_file_by_hash.return_value = segment
+        use_case = ServeHlsFileUseCase(hls=hls)
+
+        await use_case.execute(
+            ServeHlsFileInput(
+                path_hash="abc",
+                relative_path="video/segment.ts",
+                base_url_template=_BASE_URL,
+            )
+        )
+
+        hls.wait_for_subtitle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_file_missing(self) -> None:
+        hls = _make_hls_mock()
+        hls.get_file_by_hash.return_value = None
+        use_case = ServeHlsFileUseCase(hls=hls)
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                ServeHlsFileInput(
+                    path_hash="abc",
+                    relative_path="missing.ts",
+                    base_url_template=_BASE_URL,
+                )
+            )

--- a/tests/modules/media/unit/application/use_cases/test_stream_file_range.py
+++ b/tests/modules/media/unit/application/use_cases/test_stream_file_range.py
@@ -1,0 +1,74 @@
+"""Tests for StreamFileRangeUseCase."""
+
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.modules.media.application.ports.file_streamer_port import FileStreamerPort
+from src.modules.media.application.use_cases.stream_file_range import (
+    StreamFileRangeInput,
+    StreamFileRangeUseCase,
+)
+
+
+async def _collect(stream: AsyncIterator[bytes]) -> bytes:
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _fake_chunks(data: bytes) -> AsyncIterator[bytes]:
+    yield data
+
+
+def _make_streamer(file_size: int = 1000, body: bytes = b"x") -> MagicMock:
+    streamer = MagicMock(spec=FileStreamerPort)
+    streamer.get_file_size.return_value = file_size
+    streamer.stream_range.return_value = _fake_chunks(body)
+    return streamer
+
+
+@pytest.mark.unit
+class TestStreamFileRangeUseCase:
+    @pytest.mark.asyncio
+    async def test_should_return_full_file_with_200_when_no_range_header(self) -> None:
+        streamer = _make_streamer(file_size=1000, body=b"full")
+        use_case = StreamFileRangeUseCase(file_streamer=streamer)
+
+        output = await use_case.execute(
+            StreamFileRangeInput(file_path="/m.mp4", range_header=None),
+        )
+
+        assert output.status_code == 200
+        assert output.headers["Content-Length"] == "1000"
+        assert "Content-Range" not in output.headers
+        streamer.stream_range.assert_called_once_with("/m.mp4", 0, 999)
+        assert await _collect(output.body) == b"full"
+
+    @pytest.mark.asyncio
+    async def test_should_return_206_with_content_range_for_partial(self) -> None:
+        streamer = _make_streamer(file_size=1000, body=b"partial")
+        use_case = StreamFileRangeUseCase(file_streamer=streamer)
+
+        output = await use_case.execute(
+            StreamFileRangeInput(file_path="/m.mp4", range_header="bytes=100-199"),
+        )
+
+        assert output.status_code == 206
+        assert output.headers["Content-Range"] == "bytes 100-199/1000"
+        assert output.headers["Content-Length"] == "100"
+        streamer.stream_range.assert_called_once_with("/m.mp4", 100, 199)
+
+    @pytest.mark.asyncio
+    async def test_should_clamp_range_end_to_file_size(self) -> None:
+        streamer = _make_streamer(file_size=1000)
+        use_case = StreamFileRangeUseCase(file_streamer=streamer)
+
+        output = await use_case.execute(
+            StreamFileRangeInput(file_path="/m.mp4", range_header="bytes=500-9999"),
+        )
+
+        assert output.status_code == 206
+        assert output.headers["Content-Range"] == "bytes 500-999/1000"

--- a/tests/modules/media/unit/infrastructure/streaming/test_subprocess_helpers.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_subprocess_helpers.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
-from src.modules.media.infrastructure.streaming.hls_service import (
+from src.modules.media.application.streaming.playlist_rewriter import (
     media_type_for,
     rewrite_m3u8,
 )
+from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Adds five application-layer use cases for streaming — ``GenerateHlsPlaylist``, ``ServeHlsFile``, ``GetFileTracks``, ``ClearHlsCache``, ``StreamFileRange`` — each with its own input DTO and typed output.
- Introduces ``HlsPlaylistPort`` and ``FileStreamerPort``. ``HlsService`` becomes the concrete ``HlsPlaylistPort``; ``LocalFileStreamer`` is a new filesystem-backed ``FileStreamerPort``.
- Moves the pure helpers (``rewrite_m3u8``, ``media_type_for``, ``SUB_PATH_RE``) to ``media.application.streaming.playlist_rewriter`` and adds ``parse_range_header`` there too. No more ``rewrite_m3u8`` / ``media_type_for`` re-exports from ``hls_service``.
- ``stream_routes.py`` becomes thin orchestration: look up the movie/episode, call a use case, map the returned DTO onto the right FastAPI response type. No direct HLS / filesystem access remains in the presentation layer.
- Adds 22 new unit tests covering the 5 use cases and the range parser.

## Test plan

- [x] ``poetry run pytest`` — 1678 passed (1656 + 22 new)
- [x] ``poetry run ruff check src tests`` — clean
- [x] ``poetry run ruff format --check src tests`` — clean
- [x] ``grep -r \"from src.modules.media.infrastructure\" src/modules/media/presentation/`` — empty
- [x] ``grep -r \"HlsService\\|rewrite_m3u8\\|media_type_for\" src/modules/media/presentation/`` — only the container imports ``HlsService`` now (wiring), routes reference neither
- [ ] Manual smoke on every streaming endpoint after merge (HLS playlist, HLS file, tracks, clear cache, direct range stream for both movies and episodes) — response shapes and status codes must match pre-refactor behaviour

## Summary by Sourcery

Extract media streaming logic into application-layer use cases behind HLS and file streaming ports, keeping HTTP routes thin and infrastructure-specific details isolated.

New Features:
- Introduce dedicated streaming use cases for generating HLS playlists, serving cached HLS files, probing file tracks, clearing HLS caches, and streaming byte ranges for direct playback.
- Add DTOs encapsulating streaming responses (playlists, HLS files, track lists, and range streams) to decouple application logic from FastAPI response types.
- Define HlsPlaylistPort and FileStreamerPort abstractions and provide a LocalFileStreamer implementation for filesystem-backed range streaming.

Enhancements:
- Refactor streaming routes to orchestrate domain use cases only, removing direct filesystem and HLS service access from the presentation layer.
- Move pure m3u8 rewriting, media-type resolution, and HTTP Range parsing helpers into an application-level streaming module for better reuse and testability.
- Wire new streaming use cases into the media container for dependency injection and mark HlsService as the concrete HlsPlaylistPort implementation.

Tests:
- Add unit tests for the new streaming use cases and range parser, covering HLS playlist generation, HLS file serving semantics, track serialization, cache clearing, and byte-range handling.