### PR TITLE
refactor(watch_progress): extract continue-watching selector to domain

### DIFF
--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from src.modules.watch_progress.application.dtos import (
@@ -11,14 +10,18 @@ from src.modules.watch_progress.application.dtos import (
     ContinueWatchingOutput,
     GetContinueWatchingInput,
 )
-from src.modules.watch_progress.domain.value_objects import WatchableMediaType, WatchStatus
+from src.modules.watch_progress.domain.services import ContinueWatchingSelector
+from src.modules.watch_progress.domain.value_objects import (
+    EpisodeCandidate,
+    WatchableMediaType,
+    WatchStatus,
+)
 from src.shared_kernel.episode_composite_id import EpisodeCompositeId
 
 if TYPE_CHECKING:
     from datetime import datetime
 
     from src.modules.watch_progress.application.ports import (
-        EpisodeInfo,
         MediaLookupPort,
         SeriesWithEpisodesInfo,
     )
@@ -28,21 +31,6 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
-@dataclass
-class EpisodeCandidate:
-    """An episode with its series context, composite id and optional progress.
-
-    Season/episode numbers are always read from ``episode`` — keeping
-    them flat on the candidate risks drift if the episode is ever
-    rebuilt with different coordinates.
-    """
-
-    series_id: str
-    media_id: str
-    episode: EpisodeInfo
-    progress: WatchProgress | None
-
-
 class GetContinueWatchingUseCase:
     """List in-progress media items with display metadata.
 
@@ -50,8 +38,9 @@ class GetContinueWatchingUseCase:
     to provide title and poster for the "Continue Watching" UI section.
 
     For series, returns at most one item per series — the best episode
-    to resume. If no episode is in-progress but the series has unwatched
-    episodes after completed ones, the next unwatched episode is returned.
+    to resume. The selection rule lives in
+    ``ContinueWatchingSelector``; this use case only orchestrates
+    loading data and projecting the selector's output into the DTO.
 
     Example:
         >>> use_case = GetContinueWatchingUseCase(progress_repo, media_lookup)
@@ -62,15 +51,20 @@ class GetContinueWatchingUseCase:
         self,
         progress_repository: WatchProgressRepository,
         media_lookup: MediaLookupPort,
+        selector: ContinueWatchingSelector | None = None,
     ) -> None:
         """Initialize the use case.
 
         Args:
             progress_repository: Repository for watch progress.
             media_lookup: Port for resolving media display metadata.
+            selector: Domain service that picks the best episode. The
+                default is a fresh instance — callers only pass one in
+                tests that want to stub selection.
         """
         self._progress_repo = progress_repository
         self._media_lookup = media_lookup
+        self._selector = selector or ContinueWatchingSelector()
 
     async def execute(self, input_dto: GetContinueWatchingInput) -> ContinueWatchingOutput:
         """Execute the use case.
@@ -112,19 +106,7 @@ class GetContinueWatchingUseCase:
         series_id: str,
         lang: str,
     ) -> ContinueWatchingItem | None:
-        """Find the best episode to resume for a series.
-
-        Priority:
-        1. Highest-numbered in-progress episode
-        2. Next unwatched episode after the last completed one
-
-        Args:
-            series_id: External series ID.
-            lang: Language code for localized metadata.
-
-        Returns:
-            ContinueWatchingItem for the best episode, or None.
-        """
+        """Fetch series metadata, build candidates, pick one, project to a DTO."""
         series = await self._media_lookup.get_series_with_episodes(series_id, lang)
         if not series:
             return None
@@ -133,20 +115,20 @@ class GetContinueWatchingUseCase:
         if not candidates:
             return None
 
-        best, latest_watched_at = self._pick_series_episode(candidates)
-        if not best:
+        selection = self._selector.pick(candidates)
+        if selection.candidate is None:
             return None
 
-        return self._build_series_item(series, best, latest_watched_at)
+        return self._build_series_item(series, selection.candidate, selection.latest_watched_at)
 
     async def _build_candidates(
         self,
         series_id: str,
         series: SeriesWithEpisodesInfo,
     ) -> list[EpisodeCandidate]:
-        """Build EpisodeCandidate list with progress for all episodes."""
+        """Translate series episodes + their progress into selector inputs."""
         media_ids: list[str] = []
-        candidates: list[EpisodeCandidate] = []
+        episode_tuples: list[tuple[str, int, int, str, int]] = []
 
         for episode in series.episodes:
             mid = EpisodeCompositeId.build(
@@ -155,65 +137,33 @@ class GetContinueWatchingUseCase:
                 episode.episode_number,
             ).media_id
             media_ids.append(mid)
-            candidates.append(
-                EpisodeCandidate(
-                    series_id=series_id,
-                    media_id=mid,
-                    episode=episode,
-                    progress=None,
+            episode_tuples.append(
+                (
+                    mid,
+                    episode.season_number,
+                    episode.episode_number,
+                    episode.title,
+                    episode.duration_seconds,
                 )
             )
 
-        if not candidates:
+        if not episode_tuples:
             return []
 
         progress_map = await self._progress_repo.find_by_media_ids(media_ids)
-        for candidate in candidates:
-            candidate.progress = progress_map.get(candidate.media_id)
 
-        return candidates
-
-    @staticmethod
-    def _pick_series_episode(
-        candidates: list[EpisodeCandidate],
-    ) -> tuple[EpisodeCandidate | None, datetime | None]:
-        """Pick the best episode to resume and the latest watched timestamp.
-
-        Args:
-            candidates: Ordered list of episode candidates with progress.
-
-        Returns:
-            Tuple of (best candidate, latest last_watched_at).
-        """
-        best_in_progress: EpisodeCandidate | None = None
-        last_completed_idx: int | None = None
-        latest_watched_at: datetime | None = None
-
-        for idx, ep in enumerate(candidates):
-            if not ep.progress:
-                continue
-            if not latest_watched_at or ep.progress.last_watched_at > latest_watched_at:
-                latest_watched_at = ep.progress.last_watched_at
-
-            if ep.progress.status == WatchStatus.IN_PROGRESS:
-                coords = (ep.episode.season_number, ep.episode.episode_number)
-                if not best_in_progress or coords > (
-                    best_in_progress.episode.season_number,
-                    best_in_progress.episode.episode_number,
-                ):
-                    best_in_progress = ep
-            elif ep.progress.status == WatchStatus.COMPLETED:
-                last_completed_idx = max(last_completed_idx or -1, idx)
-
-        if best_in_progress:
-            return best_in_progress, latest_watched_at
-
-        if last_completed_idx is not None:
-            for ep in candidates[last_completed_idx + 1 :]:
-                if ep.progress is None:
-                    return ep, latest_watched_at
-
-        return None, latest_watched_at
+        return [
+            EpisodeCandidate(
+                series_id=series_id,
+                media_id=mid,
+                season_number=season,
+                episode_number=episode,
+                episode_title=title,
+                duration_seconds=duration,
+                progress=progress_map.get(mid),
+            )
+            for mid, season, episode, title, duration in episode_tuples
+        ]
 
     @staticmethod
     def _build_series_item(
@@ -221,16 +171,7 @@ class GetContinueWatchingUseCase:
         candidate: EpisodeCandidate,
         fallback_last_watched: datetime | None = None,
     ) -> ContinueWatchingItem:
-        """Build a ContinueWatchingItem from a resolved candidate.
-
-        Args:
-            series: The series metadata.
-            candidate: The selected episode candidate.
-            fallback_last_watched: Fallback timestamp for unwatched episodes.
-
-        Returns:
-            ContinueWatchingItem for the candidate.
-        """
+        """Project a ``(series, selected candidate)`` pair into the transport DTO."""
         progress = candidate.progress
         last_watched = (
             progress.last_watched_at.isoformat()
@@ -241,19 +182,19 @@ class GetContinueWatchingUseCase:
         return ContinueWatchingItem(
             media_id=candidate.media_id,
             media_type=WatchableMediaType.EPISODE,
-            title=candidate.episode.title,
+            title=candidate.episode_title,
             poster_path=series.poster_path,
             backdrop_path=series.backdrop_path,
             position_seconds=progress.position_seconds if progress else 0,
             duration_seconds=(
-                progress.duration_seconds if progress else candidate.episode.duration_seconds
+                progress.duration_seconds if progress else candidate.duration_seconds
             ),
             percentage=progress.percentage if progress else 0.0,
             last_watched_at=last_watched,
             series_id=series.series_id,
             series_title=series.title,
-            season_number=candidate.episode.season_number,
-            episode_number=candidate.episode.episode_number,
+            season_number=candidate.season_number,
+            episode_number=candidate.episode_number,
         )
 
     async def _enrich_movie(

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -126,29 +126,23 @@ class GetContinueWatchingUseCase:
         series_id: str,
         series: SeriesWithEpisodesInfo,
     ) -> list[EpisodeCandidate]:
-        """Translate series episodes + their progress into selector inputs."""
-        media_ids: list[str] = []
-        episode_tuples: list[tuple[str, int, int, str, int]] = []
+        """Translate series episodes + their progress into selector inputs.
 
-        for episode in series.episodes:
-            mid = EpisodeCompositeId.build(
-                series_id,
-                episode.season_number,
-                episode.episode_number,
-            ).media_id
-            media_ids.append(mid)
-            episode_tuples.append(
-                (
-                    mid,
-                    episode.season_number,
-                    episode.episode_number,
-                    episode.title,
-                    episode.duration_seconds,
-                )
-            )
-
-        if not episode_tuples:
+        Candidate fields are kept flat (not composed with
+        ``EpisodeInfo``) so the domain ``EpisodeCandidate`` does not
+        transitively depend on an application-layer port DTO.
+        """
+        if not series.episodes:
             return []
+
+        media_ids = [
+            EpisodeCompositeId.build(
+                series_id,
+                ep.season_number,
+                ep.episode_number,
+            ).media_id
+            for ep in series.episodes
+        ]
 
         progress_map = await self._progress_repo.find_by_media_ids(media_ids)
 
@@ -156,13 +150,13 @@ class GetContinueWatchingUseCase:
             EpisodeCandidate(
                 series_id=series_id,
                 media_id=mid,
-                season_number=season,
-                episode_number=episode,
-                episode_title=title,
-                duration_seconds=duration,
+                season_number=ep.season_number,
+                episode_number=ep.episode_number,
+                episode_title=ep.title,
+                duration_seconds=ep.duration_seconds,
                 progress=progress_map.get(mid),
             )
-            for mid, season, episode, title, duration in episode_tuples
+            for ep, mid in zip(series.episodes, media_ids, strict=True)
         ]
 
     @staticmethod

--- a/src/modules/watch_progress/domain/services/__init__.py
+++ b/src/modules/watch_progress/domain/services/__init__.py
@@ -1,0 +1,8 @@
+"""Watch progress domain services."""
+
+from src.modules.watch_progress.domain.services.continue_watching_selector import (
+    ContinueWatchingSelection,
+    ContinueWatchingSelector,
+)
+
+__all__ = ["ContinueWatchingSelection", "ContinueWatchingSelector"]

--- a/src/modules/watch_progress/domain/services/continue_watching_selector.py
+++ b/src/modules/watch_progress/domain/services/continue_watching_selector.py
@@ -1,0 +1,112 @@
+"""ContinueWatchingSelector — which episode should the user resume?
+
+This domain service encodes the selection rule for the
+"Continue Watching" list:
+
+1. If any episode is ``IN_PROGRESS``, pick the highest-numbered one
+   (treating ``(season, episode)`` as a lexicographic key).
+2. Otherwise, if there are completed episodes, pick the first
+   unwatched episode that follows the last completed one.
+3. Otherwise, skip the series.
+
+Kept pure so the application layer composes it without mocks — the
+inputs are already-materialized ``EpisodeCandidate`` values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from src.modules.watch_progress.domain.value_objects.watch_status import WatchStatus
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime
+
+    from src.modules.watch_progress.domain.value_objects.episode_candidate import (
+        EpisodeCandidate,
+    )
+
+
+@dataclass(frozen=True)
+class ContinueWatchingSelection:
+    """Outcome of running the selector over a series' candidates.
+
+    Attributes:
+        candidate: The episode to resume, or ``None`` when the series
+            should be skipped (no in-progress episode, no unwatched
+            episode after a completed one).
+        latest_watched_at: Most recent ``last_watched_at`` across all
+            candidates that had progress — the use case uses it as a
+            display fallback for the "Continue Watching" card when the
+            chosen candidate itself has no progress yet.
+    """
+
+    candidate: EpisodeCandidate | None
+    latest_watched_at: datetime | None
+
+
+class ContinueWatchingSelector:
+    """Pick the episode to surface on the "Continue Watching" card."""
+
+    def pick(self, candidates: Sequence[EpisodeCandidate]) -> ContinueWatchingSelection:
+        """Apply the in-progress-then-next-unwatched rule.
+
+        Args:
+            candidates: Episodes ordered by ``(season, episode)``.
+
+        Returns:
+            A ``ContinueWatchingSelection`` describing the chosen
+            candidate (if any) and the latest watched timestamp.
+        """
+        best_in_progress: EpisodeCandidate | None = None
+        last_completed_idx: int | None = None
+        latest_watched_at: datetime | None = None
+
+        for idx, ep in enumerate(candidates):
+            if ep.progress is None:
+                continue
+            if latest_watched_at is None or ep.progress.last_watched_at > latest_watched_at:
+                latest_watched_at = ep.progress.last_watched_at
+
+            if ep.progress.status == WatchStatus.IN_PROGRESS:
+                best_in_progress = self._pick_later(best_in_progress, ep)
+            elif ep.progress.status == WatchStatus.COMPLETED:
+                last_completed_idx = max(
+                    last_completed_idx if last_completed_idx is not None else -1, idx
+                )
+
+        if best_in_progress is not None:
+            return ContinueWatchingSelection(
+                candidate=best_in_progress,
+                latest_watched_at=latest_watched_at,
+            )
+
+        if last_completed_idx is not None:
+            for ep in candidates[last_completed_idx + 1 :]:
+                if ep.progress is None:
+                    return ContinueWatchingSelection(
+                        candidate=ep,
+                        latest_watched_at=latest_watched_at,
+                    )
+
+        return ContinueWatchingSelection(
+            candidate=None,
+            latest_watched_at=latest_watched_at,
+        )
+
+    @staticmethod
+    def _pick_later(
+        current_best: EpisodeCandidate | None,
+        contender: EpisodeCandidate,
+    ) -> EpisodeCandidate:
+        """Return whichever candidate has the higher ``(season, episode)`` key."""
+        if current_best is None:
+            return contender
+        contender_coords = (contender.season_number, contender.episode_number)
+        current_coords = (current_best.season_number, current_best.episode_number)
+        return contender if contender_coords > current_coords else current_best
+
+
+__all__ = ["ContinueWatchingSelection", "ContinueWatchingSelector"]

--- a/src/modules/watch_progress/domain/value_objects/__init__.py
+++ b/src/modules/watch_progress/domain/value_objects/__init__.py
@@ -1,9 +1,17 @@
 """Watch Progress value objects."""
 
+from src.modules.watch_progress.domain.value_objects.episode_candidate import (
+    EpisodeCandidate,
+)
 from src.modules.watch_progress.domain.value_objects.progress_id import ProgressId
 from src.modules.watch_progress.domain.value_objects.watch_status import WatchStatus
 from src.modules.watch_progress.domain.value_objects.watchable_media_type import (
     WatchableMediaType,
 )
 
-__all__ = ["ProgressId", "WatchStatus", "WatchableMediaType"]
+__all__ = [
+    "EpisodeCandidate",
+    "ProgressId",
+    "WatchStatus",
+    "WatchableMediaType",
+]

--- a/src/modules/watch_progress/domain/value_objects/episode_candidate.py
+++ b/src/modules/watch_progress/domain/value_objects/episode_candidate.py
@@ -1,0 +1,50 @@
+"""EpisodeCandidate value object — input shape for ``ContinueWatchingSelector``.
+
+Carries the minimum an episode needs to participate in the
+"which episode should the user resume?" decision:
+
+* its series/episode coordinates,
+* the composite media id keyed by the watch progress repo,
+* the optional ``WatchProgress`` for that id.
+
+Lives in the domain so the selector can operate on pure domain
+types with no awareness of the application ports that happened to
+produce them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.modules.watch_progress.domain.entities import WatchProgress
+
+
+@dataclass(frozen=True)
+class EpisodeCandidate:
+    """A single episode weighed by the continue-watching selector.
+
+    Attributes:
+        series_id: External series id (``ser_...``).
+        media_id: Composite episode id keyed by ``WatchProgressRepository``.
+        season_number: One-based season number.
+        episode_number: One-based episode number within the season.
+        episode_title: Display title of the episode (already localized
+            upstream, when translations exist).
+        duration_seconds: Canonical runtime of the episode, used as a
+            fallback when no progress record is present.
+        progress: Existing watch-progress record, or ``None`` if the
+            episode has never been played.
+    """
+
+    series_id: str
+    media_id: str
+    season_number: int
+    episode_number: int
+    episode_title: str
+    duration_seconds: int
+    progress: WatchProgress | None
+
+
+__all__ = ["EpisodeCandidate"]

--- a/tests/modules/watch_progress/unit/domain/services/test_continue_watching_selector.py
+++ b/tests/modules/watch_progress/unit/domain/services/test_continue_watching_selector.py
@@ -1,0 +1,179 @@
+"""Tests for the ContinueWatchingSelector domain service."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.services import (
+    ContinueWatchingSelection,
+    ContinueWatchingSelector,
+)
+from src.modules.watch_progress.domain.value_objects import (
+    EpisodeCandidate,
+    WatchableMediaType,
+    WatchStatus,
+)
+
+
+def _progress(
+    media_id: str,
+    status: WatchStatus = WatchStatus.IN_PROGRESS,
+    last_watched_at: datetime | None = None,
+) -> WatchProgress:
+    """Build a ``WatchProgress`` with the given status and timestamp."""
+    return WatchProgress(
+        media_id=media_id,
+        media_type=WatchableMediaType.EPISODE,
+        position_seconds=900,
+        duration_seconds=3600,
+        status=status,
+        last_watched_at=last_watched_at or datetime(2026, 4, 9, tzinfo=UTC),
+    )
+
+
+def _candidate(
+    season: int,
+    episode: int,
+    *,
+    progress: WatchProgress | None = None,
+    series_id: str = "ser_ABC",
+) -> EpisodeCandidate:
+    """Build an EpisodeCandidate with derived composite id."""
+    media_id = f"epi_{series_id}_{season}_{episode}"
+    return EpisodeCandidate(
+        series_id=series_id,
+        media_id=media_id,
+        season_number=season,
+        episode_number=episode,
+        episode_title=f"Episode {episode}",
+        duration_seconds=3600,
+        progress=progress,
+    )
+
+
+@pytest.mark.unit
+class TestContinueWatchingSelectorEmptyCases:
+    def test_empty_candidates_selects_nothing(self) -> None:
+        selector = ContinueWatchingSelector()
+        result = selector.pick([])
+        assert result == ContinueWatchingSelection(candidate=None, latest_watched_at=None)
+
+    def test_candidates_without_progress_select_nothing(self) -> None:
+        selector = ContinueWatchingSelector()
+        result = selector.pick([_candidate(1, 1), _candidate(1, 2)])
+        assert result.candidate is None
+        assert result.latest_watched_at is None
+
+
+@pytest.mark.unit
+class TestInProgressPriority:
+    def test_single_in_progress_episode_is_selected(self) -> None:
+        cand = _candidate(2, 3, progress=_progress("epi_ser_ABC_2_3"))
+        result = ContinueWatchingSelector().pick([cand])
+        assert result.candidate is cand
+
+    def test_highest_numbered_in_progress_wins_against_earlier_ones(self) -> None:
+        early = _candidate(1, 1, progress=_progress("epi_ser_ABC_1_1"))
+        mid = _candidate(1, 5, progress=_progress("epi_ser_ABC_1_5"))
+        later = _candidate(2, 1, progress=_progress("epi_ser_ABC_2_1"))
+
+        result = ContinueWatchingSelector().pick([early, mid, later])
+
+        assert result.candidate is later
+
+    def test_in_progress_wins_over_completed_even_if_earlier_in_sequence(self) -> None:
+        completed = _candidate(
+            2,
+            5,
+            progress=_progress("epi_ser_ABC_2_5", status=WatchStatus.COMPLETED),
+        )
+        in_progress = _candidate(1, 2, progress=_progress("epi_ser_ABC_1_2"))
+
+        result = ContinueWatchingSelector().pick([in_progress, completed])
+
+        assert result.candidate is in_progress
+
+
+@pytest.mark.unit
+class TestNextUnwatchedFallback:
+    def test_first_unwatched_after_last_completed_is_selected(self) -> None:
+        s01e01 = _candidate(
+            1, 1, progress=_progress("epi_ser_ABC_1_1", status=WatchStatus.COMPLETED)
+        )
+        s01e02 = _candidate(
+            1, 2, progress=_progress("epi_ser_ABC_1_2", status=WatchStatus.COMPLETED)
+        )
+        s01e03 = _candidate(1, 3)
+        s01e04 = _candidate(1, 4)
+
+        result = ContinueWatchingSelector().pick([s01e01, s01e02, s01e03, s01e04])
+
+        assert result.candidate is s01e03
+
+    def test_completed_with_no_unwatched_after_returns_none(self) -> None:
+        s01e01 = _candidate(
+            1, 1, progress=_progress("epi_ser_ABC_1_1", status=WatchStatus.COMPLETED)
+        )
+        s01e02 = _candidate(
+            1, 2, progress=_progress("epi_ser_ABC_1_2", status=WatchStatus.COMPLETED)
+        )
+
+        result = ContinueWatchingSelector().pick([s01e01, s01e02])
+
+        assert result.candidate is None
+
+    def test_unwatched_before_last_completed_is_skipped(self) -> None:
+        """Gaps in the "watched" history don't force the user back to them."""
+        s01e01 = _candidate(1, 1)  # skipped entirely
+        s01e02 = _candidate(
+            1, 2, progress=_progress("epi_ser_ABC_1_2", status=WatchStatus.COMPLETED)
+        )
+        s01e03 = _candidate(1, 3)
+
+        result = ContinueWatchingSelector().pick([s01e01, s01e02, s01e03])
+
+        assert result.candidate is s01e03
+
+
+@pytest.mark.unit
+class TestLatestWatchedAt:
+    def test_returns_max_timestamp_across_progress_records(self) -> None:
+        older = datetime(2026, 1, 1, tzinfo=UTC)
+        newer = older + timedelta(days=5)
+
+        s01e01 = _candidate(
+            1,
+            1,
+            progress=_progress("epi_ser_ABC_1_1", last_watched_at=older),
+        )
+        s01e02 = _candidate(
+            1,
+            2,
+            progress=_progress("epi_ser_ABC_1_2", last_watched_at=newer),
+        )
+
+        result = ContinueWatchingSelector().pick([s01e01, s01e02])
+
+        assert result.latest_watched_at == newer
+
+    def test_returned_even_when_no_candidate_is_selectable(self) -> None:
+        """All-completed series still surfaces the latest timestamp."""
+        older = datetime(2026, 1, 1, tzinfo=UTC)
+        newer = older + timedelta(days=5)
+
+        s01e01 = _candidate(
+            1,
+            1,
+            progress=_progress("epi_ser_ABC_1_1", WatchStatus.COMPLETED, older),
+        )
+        s01e02 = _candidate(
+            1,
+            2,
+            progress=_progress("epi_ser_ABC_1_2", WatchStatus.COMPLETED, newer),
+        )
+
+        result = ContinueWatchingSelector().pick([s01e01, s01e02])
+
+        assert result.candidate is None
+        assert result.latest_watched_at == newer


### PR DESCRIPTION
## Summary

- Moves the in-progress-vs-next-unwatched rule out of ``GetContinueWatchingUseCase`` and into a new ``ContinueWatchingSelector`` domain service backed by a ``ContinueWatchingSelection`` result object.
- Adds ``EpisodeCandidate`` value object in ``watch_progress.domain`` — carries only primitive episode coordinates + optional ``WatchProgress``, so the selector doesn't depend on application-layer port DTOs.
- The use case now orchestrates only: load progress, build candidates from ``SeriesWithEpisodesInfo``, delegate to the selector, project the chosen candidate into the transport DTO.
- 10 new pure unit tests exercise the selector directly (no mocks): in-progress priority, highest ``(season, episode)`` tiebreaker, next-unwatched-after-last-completed fallback, ``latest_watched_at`` aggregation.

## Test plan

- [x] ``poetry run pytest`` — 1688 passed (1678 + 10 new)
- [x] ``poetry run ruff check src tests`` — clean
- [x] ``poetry run ruff format --check src tests`` — clean
- [x] ``grep -r \"_pick_series_episode\" src/`` — empty
- [ ] Manual smoke on ``GET /api/v1/progress/continue-watching`` after merge to confirm the card the UI shows for a half-watched series is identical to the pre-refactor behaviour.

## Summary by Sourcery

Extract the episode selection logic for the continue-watching feature into a dedicated domain service and update the use case to delegate to it.

Enhancements:
- Introduce a pure ContinueWatchingSelector domain service and ContinueWatchingSelection result type to encapsulate episode selection rules for series.
- Add an EpisodeCandidate value object in the domain layer so selection operates on domain primitives instead of application DTOs.
- Update GetContinueWatchingUseCase to build EpisodeCandidate inputs, call the selector, and project its result into the existing ContinueWatchingItem DTO.

Tests:
- Add unit test coverage for ContinueWatchingSelector, covering in-progress prioritisation, next-unwatched fallbacks, and latest watched timestamp aggregation.