### PR TITLE
refactor(library): make library_to_output pure

### DIFF
--- a/src/modules/library/application/use_cases/_counts.py
+++ b/src/modules/library/application/use_cases/_counts.py
@@ -1,0 +1,23 @@
+"""Shared helper for resolving per-library movie/series counts.
+
+Centralizes the "ask the port for the two counts" call so each
+use case reads as ``counts = await resolve_counts(entity, port)``
+instead of inlining the pair of ``await`` calls at every site.
+"""
+
+from src.modules.library.application.ports import MediaCountQueryPort
+from src.modules.library.domain.entities.library import Library
+
+
+async def resolve_counts(
+    entity: Library,
+    media_count_query: MediaCountQueryPort,
+) -> tuple[int, int]:
+    """Return ``(movie_count, series_count)`` for a library's paths."""
+    paths = [p.value for p in entity.paths]
+    movie_count = await media_count_query.count_movies_under_paths(paths)
+    series_count = await media_count_query.count_series_under_paths(paths)
+    return movie_count, series_count
+
+
+__all__ = ["resolve_counts"]

--- a/src/modules/library/application/use_cases/_to_output.py
+++ b/src/modules/library/application/use_cases/_to_output.py
@@ -5,23 +5,24 @@ from src.modules.library.application.dtos.library_dtos import (
     LibrarySettingsOutput,
     MetadataProviderOutput,
 )
-from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.domain.entities.library import Library
 
 
-async def library_to_output(
+def library_to_output(
     entity: Library,
-    media_count_query: MediaCountQueryPort,
+    *,
+    movie_count: int,
+    series_count: int,
 ) -> LibraryOutput:
-    """Convert a Library domain entity to its output DTO.
+    """Project a ``Library`` entity into the transport DTO.
 
-    The movie/series counts are resolved via the ``MediaCountQueryPort``
-    so the Library BC never imports Media repositories directly. See
-    ADR-009 for the cross-BC read port pattern.
+    Pure: no IO, no port dependency. Callers are expected to resolve
+    ``movie_count`` / ``series_count`` via ``MediaCountQueryPort``
+    beforehand and pass them in. Keeping the mapper pure lets every
+    use case decide how to batch (or not) the count queries without
+    leaking that choice into the projection.
     """
     paths = [p.value for p in entity.paths]
-    movie_count = await media_count_query.count_movies_under_paths(paths)
-    series_count = await media_count_query.count_series_under_paths(paths)
     return LibraryOutput(
         id=str(entity.id),
         name=entity.name.value,

--- a/src/modules/library/application/use_cases/create_library.py
+++ b/src/modules/library/application/use_cases/create_library.py
@@ -8,6 +8,7 @@ from src.modules.library.application.dtos.library_dtos import (
 )
 from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
+from src.modules.library.application.use_cases._counts import resolve_counts
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.entities.library import Library
 from src.modules.library.domain.value_objects.library_settings import LibrarySettings
@@ -64,7 +65,8 @@ class CreateLibraryUseCase:
 
         async with self._uow_factory() as uow:
             saved = await uow.libraries.save(library)
-        return await library_to_output(saved, self._media_count_query)
+        movie_count, series_count = await resolve_counts(saved, self._media_count_query)
+        return library_to_output(saved, movie_count=movie_count, series_count=series_count)
 
 
 def _build_settings(raw: dict[str, Any]) -> LibrarySettings:

--- a/src/modules/library/application/use_cases/get_library_by_id.py
+++ b/src/modules/library/application/use_cases/get_library_by_id.py
@@ -6,6 +6,7 @@ from src.modules.library.application.dtos.library_dtos import (
     LibraryOutput,
 )
 from src.modules.library.application.ports import MediaCountQueryPort
+from src.modules.library.application.use_cases._counts import resolve_counts
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
@@ -42,7 +43,8 @@ class GetLibraryByIdUseCase:
                 "Library",
                 input_dto.library_id,
             )
-        return await library_to_output(entity, self._media_count_query)
+        movie_count, series_count = await resolve_counts(entity, self._media_count_query)
+        return library_to_output(entity, movie_count=movie_count, series_count=series_count)
 
 
 __all__ = ["GetLibraryByIdUseCase"]

--- a/src/modules/library/application/use_cases/list_libraries.py
+++ b/src/modules/library/application/use_cases/list_libraries.py
@@ -2,6 +2,7 @@
 
 from src.modules.library.application.dtos.library_dtos import LibraryOutput
 from src.modules.library.application.ports import MediaCountQueryPort
+from src.modules.library.application.use_cases._counts import resolve_counts
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.domain.repositories.library_repository import LibraryRepository
 
@@ -33,7 +34,13 @@ class ListLibrariesUseCase:
             List of ``LibraryOutput`` ordered by name.
         """
         entities = await self._repo.find_all()
-        return [await library_to_output(e, self._media_count_query) for e in entities]
+        outputs: list[LibraryOutput] = []
+        for entity in entities:
+            movie_count, series_count = await resolve_counts(entity, self._media_count_query)
+            outputs.append(
+                library_to_output(entity, movie_count=movie_count, series_count=series_count)
+            )
+        return outputs
 
 
 __all__ = ["ListLibrariesUseCase"]

--- a/src/modules/library/application/use_cases/update_library.py
+++ b/src/modules/library/application/use_cases/update_library.py
@@ -9,6 +9,7 @@ from src.modules.library.application.dtos.library_dtos import (
 )
 from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
+from src.modules.library.application.use_cases._counts import resolve_counts
 from src.modules.library.application.use_cases._to_output import library_to_output
 from src.modules.library.application.use_cases.create_library import _build_settings
 from src.modules.library.domain.value_objects.library_id import LibraryId
@@ -83,7 +84,8 @@ class UpdateLibraryUseCase:
 
             updated = entity.with_updates(**updates)
             saved = await uow.libraries.save(updated)
-        return await library_to_output(saved, self._media_count_query)
+        movie_count, series_count = await resolve_counts(saved, self._media_count_query)
+        return library_to_output(saved, movie_count=movie_count, series_count=series_count)
 
 
 __all__ = ["UpdateLibraryUseCase"]

--- a/tests/modules/library/unit/application/use_cases/test_counts.py
+++ b/tests/modules/library/unit/application/use_cases/test_counts.py
@@ -18,7 +18,7 @@ class TestResolveCounts:
             library_type="mixed",
             paths=["/media/movies", "/media/shows"],
         )
-        query = AsyncMock(spec=MediaCountQueryPort)
+        query = AsyncMock(spec_set=MediaCountQueryPort)
         query.count_movies_under_paths.return_value = 12
         query.count_series_under_paths.return_value = 3
 

--- a/tests/modules/library/unit/application/use_cases/test_counts.py
+++ b/tests/modules/library/unit/application/use_cases/test_counts.py
@@ -1,0 +1,29 @@
+"""Tests for the ``resolve_counts`` helper."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.library.application.ports import MediaCountQueryPort
+from src.modules.library.application.use_cases._counts import resolve_counts
+from src.modules.library.domain.entities.library import Library
+
+
+@pytest.mark.unit
+class TestResolveCounts:
+    @pytest.mark.asyncio
+    async def test_should_issue_both_counts_with_entity_paths(self) -> None:
+        lib = Library.create(
+            name="Mixed",
+            library_type="mixed",
+            paths=["/media/movies", "/media/shows"],
+        )
+        query = AsyncMock(spec=MediaCountQueryPort)
+        query.count_movies_under_paths.return_value = 12
+        query.count_series_under_paths.return_value = 3
+
+        movie_count, series_count = await resolve_counts(lib, query)
+
+        assert (movie_count, series_count) == (12, 3)
+        query.count_movies_under_paths.assert_awaited_once_with(["/media/movies", "/media/shows"])
+        query.count_series_under_paths.assert_awaited_once_with(["/media/movies", "/media/shows"])

--- a/tests/modules/library/unit/application/use_cases/test_to_output.py
+++ b/tests/modules/library/unit/application/use_cases/test_to_output.py
@@ -1,0 +1,37 @@
+"""Tests for the pure ``library_to_output`` mapper."""
+
+import pytest
+
+from src.modules.library.application.use_cases._to_output import library_to_output
+from src.modules.library.domain.entities.library import Library
+
+
+@pytest.mark.unit
+class TestLibraryToOutput:
+    def test_should_project_counts_as_passed(self) -> None:
+        lib = Library.create(name="Movies", library_type="movies", paths=["/m"])
+
+        output = library_to_output(lib, movie_count=42, series_count=7)
+
+        assert output.movie_count == 42
+        assert output.series_count == 7
+
+    def test_should_be_deterministic_for_same_inputs(self) -> None:
+        lib = Library.create(name="Movies", library_type="movies", paths=["/m"])
+
+        first = library_to_output(lib, movie_count=3, series_count=0)
+        second = library_to_output(lib, movie_count=3, series_count=0)
+
+        assert first == second
+
+    def test_should_include_paths_and_name(self) -> None:
+        lib = Library.create(
+            name="Anime",
+            library_type="series",
+            paths=["/media/anime", "/media/anime2"],
+        )
+
+        output = library_to_output(lib, movie_count=0, series_count=10)
+
+        assert output.name == "Anime"
+        assert output.paths == ["/media/anime", "/media/anime2"]


### PR DESCRIPTION
## Summary

- ``library_to_output`` is now a pure, synchronous projection function that takes ``movie_count`` and ``series_count`` as keyword arguments — no port, no ``await``.
- New ``resolve_counts`` helper centralizes the "ask the port for the two counts" step so each use case reads as a single ``resolve → project`` pair.
- ``CreateLibraryUseCase``, ``GetLibraryByIdUseCase``, ``UpdateLibraryUseCase``, ``ListLibrariesUseCase`` each compute the counts before calling the mapper. The ``list_libraries`` fan-out stays serial — the existing comment on ``execute`` explains why (shared session forbids concurrent ``execute`` calls), and a batch ``count_many`` is deferred until the dataset warrants it.
- 4 new unit tests: 3 for the pure mapper, 1 for ``resolve_counts``.

## Test plan

- [x] ``poetry run pytest`` — 1692 passed (1688 + 4 new)
- [x] ``poetry run ruff check src tests`` — clean
- [x] ``poetry run ruff format --check src tests`` — clean
- [x] ``library_to_output`` signature is sync (``def``, not ``async def``) and takes no port
- [ ] Manual smoke on ``GET /api/v1/libraries`` and ``GET /api/v1/libraries/{id}`` after merge — ``movie_count`` / ``series_count`` values must match pre-refactor output.

## Summary by Sourcery

Make the library output mapper a pure, synchronous projection and centralize media count resolution in a shared helper used by library use cases.

Enhancements:
- Refactor `library_to_output` into a pure, synchronous function that receives precomputed movie and series counts instead of depending on a port.
- Introduce a shared `resolve_counts` helper to query movie and series counts for a library and reuse it across library use cases.
- Update library creation, retrieval, update, and listing use cases to resolve media counts before projecting entities to output DTOs.

Tests:
- Add unit tests for the pure `library_to_output` mapper to verify determinism and correct projection of fields and counts.
- Add a unit test for the `resolve_counts` helper to ensure it queries counts correctly using library paths.