### PR TITLE
refactor(scheduling): wire LibraryScanScheduler via UoW factories

### DIFF
--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -13,7 +13,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from src.building_blocks.infrastructure.in_process_event_bus import InProcessEventBus
 from src.config.persistence.session_manager import create_tracked_session
 from src.config.settings import Settings
-from src.infrastructure.scheduling import LibraryScanScheduler
 from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
 
@@ -79,12 +78,3 @@ class InfrastructureContainer(containers.DeclarativeContainer):  # type: ignore[
     # Stateless services reused across requests and background jobs.
     file_scanner = providers.Singleton(LocalFileSystemScanner)
     variant_detector = providers.Singleton(VariantDetector)
-
-    library_scan_scheduler = providers.Singleton(
-        LibraryScanScheduler,
-        session_factory=session_factory,
-        event_bus=event_bus,
-        file_scanner=file_scanner,
-        variant_detector=variant_detector,
-        reconcile_interval_minutes=config.provided.scheduler_reconcile_interval_minutes,
-    )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -15,6 +15,7 @@ from src.config.containers.media import MediaContainer
 from src.config.containers.preferences import PreferencesContainer
 from src.config.containers.watch_progress import WatchProgressContainer
 from src.config.settings import Settings
+from src.infrastructure.scheduling import LibraryScanScheduler
 
 
 class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[misc]
@@ -93,6 +94,23 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         session_factory=infrastructure.session_factory,
         movie_repository=media.movie_repository,
         series_repository=media.series_repository,
+    )
+
+    # =========================================================================
+    # Cross-BC Services
+    # =========================================================================
+    # Wired at the composition root because it needs UoW factories from
+    # two sibling containers (``library`` and ``media``).
+
+    library_scan_scheduler = providers.Singleton(
+        LibraryScanScheduler,
+        library_uow_factory=library.library_unit_of_work_factory,
+        media_uow_factory=media.media_unit_of_work_factory,
+        file_scanner=infrastructure.file_scanner,
+        variant_detector=infrastructure.variant_detector,
+        event_bus=infrastructure.event_bus,
+        reconcile_interval_minutes=config.provided.scheduler_reconcile_interval_minutes,
+        probe_service=media.media_probe_service,
     )
 
 

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -4,8 +4,8 @@ Wraps APScheduler with a domain-aware reconciliation loop.  The
 ``Library`` entity stores its own cron expression; this service reads
 those rows periodically and mirrors them into the APScheduler job
 registry — adding new jobs, removing deleted ones, and replacing jobs
-whose cron changed.  Each scan opens a fresh DB session so background
-work never shares a request-scoped one.
+whose cron changed.  Each scan opens its own Unit of Work so
+background work never shares a request-scoped session.
 """
 
 from __future__ import annotations
@@ -17,25 +17,21 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from src.config.logging import get_logger
-from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
-    SqlAlchemyLibraryRepository,
-)
+from src.modules.library.domain.value_objects.library_id import LibraryId
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
-from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
-    SQLAlchemyMovieRepository,
-)
-from src.modules.media.infrastructure.persistence.repositories.series_repository import (
-    SQLAlchemySeriesRepository,
-)
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-
     from src.building_blocks.application.event_bus import EventBus
-    from src.modules.media.application.ports import FileSystemScanner, VariantDetectorPort
+    from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
+    from src.modules.media.application.ports import (
+        FileSystemScanner,
+        MediaProbePort,
+        VariantDetectorPort,
+    )
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 
 _logger = get_logger()
 
@@ -58,17 +54,21 @@ class LibraryScanScheduler:
 
     def __init__(
         self,
-        session_factory: async_sessionmaker[AsyncSession],
-        event_bus: EventBus,
+        library_uow_factory: LibraryUnitOfWorkFactory,
+        media_uow_factory: MediaUnitOfWorkFactory,
         file_scanner: FileSystemScanner,
         variant_detector: VariantDetectorPort,
+        event_bus: EventBus,
         reconcile_interval_minutes: int,
+        probe_service: MediaProbePort | None = None,
     ) -> None:
-        self._session_factory = session_factory
-        self._event_bus = event_bus
+        self._library_uow_factory = library_uow_factory
+        self._media_uow_factory = media_uow_factory
         self._file_scanner = file_scanner
         self._variant_detector = variant_detector
+        self._event_bus = event_bus
         self._reconcile_interval_minutes = reconcile_interval_minutes
+        self._probe_service = probe_service
         self._scheduler = AsyncIOScheduler(timezone="UTC")
 
     async def start(self) -> None:
@@ -104,9 +104,8 @@ class LibraryScanScheduler:
         Invalid crons are logged and skipped — we never crash startup
         or reconciliation over a bad expression.
         """
-        async with self._session_factory() as session:
-            repo = SqlAlchemyLibraryRepository(session)
-            libraries = await repo.find_all()
+        async with self._library_uow_factory() as uow:
+            libraries = await uow.libraries.find_all()
 
         desired: dict[str, tuple[str, str]] = {}  # job_id -> (library_id, cron)
         for library in libraries:
@@ -157,49 +156,37 @@ class LibraryScanScheduler:
     async def _run_scan(self, library_id: str) -> None:
         """Run a single library scan and record completion.
 
-        Opens a fresh session, loads the library, runs the scan use
-        case for its configured paths, and persists an updated
-        ``last_scan_at`` on success. Errors are logged — failure
-        tracking beyond logs is out of scope for v1.
+        Loads the library in a short-lived UoW, releases it before the
+        long-running scan, then opens a fresh UoW to persist
+        ``last_scan_at`` on success. The scan use case drives its own
+        media UoW per file group so failures on one group roll back
+        only that transaction.
         """
         _logger.info("[scheduler] Running scan", library_id=library_id)
 
-        async with self._session_factory() as session:
-            library_repo = SqlAlchemyLibraryRepository(session)
-            from src.modules.library.domain.value_objects.library_id import LibraryId
+        paths = await self._load_library_paths(library_id)
+        if paths is None:
+            return
 
-            library = await library_repo.find_by_id(LibraryId(library_id))
-            if library is None:
-                _logger.warning(
-                    "[scheduler] Library vanished before scan; skipping",
-                    library_id=library_id,
-                )
-                return
-
-            scan_input = ScanMediaInput(directories=list(library.paths))
-            use_case = ScanMediaDirectoriesUseCase(
-                file_scanner=self._file_scanner,
-                variant_detector=self._variant_detector,
-                movie_repository=SQLAlchemyMovieRepository(session),
-                series_repository=SQLAlchemySeriesRepository(session),
-                event_bus=self._event_bus,
+        use_case = ScanMediaDirectoriesUseCase(
+            file_scanner=self._file_scanner,
+            variant_detector=self._variant_detector,
+            uow_factory=self._media_uow_factory,
+            probe_service=self._probe_service,
+            event_bus=self._event_bus,
+        )
+        try:
+            result = await use_case.execute(ScanMediaInput(directories=paths))
+        except Exception as exc:
+            _logger.error(
+                "[scheduler] Scan failed",
+                library_id=library_id,
+                error=str(exc),
+                exc_info=True,
             )
+            return
 
-            try:
-                result = await use_case.execute(scan_input)
-            except Exception as exc:
-                _logger.error(
-                    "[scheduler] Scan failed",
-                    library_id=library_id,
-                    error=str(exc),
-                    exc_info=True,
-                )
-                await session.rollback()
-                return
-
-            updated = library.with_scan_completed(datetime.now(UTC))
-            await library_repo.save(updated)
-            await session.commit()
+        await self._mark_library_scanned(library_id)
 
         _logger.info(
             "[scheduler] Scan done",
@@ -210,6 +197,27 @@ class LibraryScanScheduler:
             episodes_updated=result.episodes_updated,
             errors=len(result.errors),
         )
+
+    async def _load_library_paths(self, library_id: str) -> list[str] | None:
+        """Return the library's configured paths, or ``None`` if it vanished."""
+        async with self._library_uow_factory() as uow:
+            library = await uow.libraries.find_by_id(LibraryId(library_id))
+            if library is None:
+                _logger.warning(
+                    "[scheduler] Library vanished before scan; skipping",
+                    library_id=library_id,
+                )
+                return None
+            return [p.value for p in library.paths]
+
+    async def _mark_library_scanned(self, library_id: str) -> None:
+        """Persist the completed-scan timestamp in its own UoW."""
+        async with self._library_uow_factory() as uow:
+            library = await uow.libraries.find_by_id(LibraryId(library_id))
+            if library is None:
+                return
+            updated = library.with_scan_completed(datetime.now(UTC))
+            await uow.libraries.save(updated)
 
 
 __all__ = ["LibraryScanScheduler"]

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -215,6 +215,13 @@ class LibraryScanScheduler:
         async with self._library_uow_factory() as uow:
             library = await uow.libraries.find_by_id(LibraryId(library_id))
             if library is None:
+                # Matches the warning emitted at load-time so ops can
+                # correlate "scan started" with "scan finished but row
+                # vanished" in the logs.
+                _logger.warning(
+                    "[scheduler] Library vanished before persisting last_scan_at",
+                    library_id=library_id,
+                )
                 return
             updated = library.with_scan_completed(datetime.now(UTC))
             await uow.libraries.save(updated)

--- a/src/main.py
+++ b/src/main.py
@@ -99,7 +99,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # app.state so the shutdown handler can do a single truthy check.
     app.state.scheduler = None
     if settings.scheduler_enabled:
-        scheduler = await container.infrastructure.library_scan_scheduler()
+        scheduler = await container.library_scan_scheduler()
         await scheduler.start()
         app.state.scheduler = scheduler
 

--- a/tests/infrastructure/scheduling/test_scheduler_service.py
+++ b/tests/infrastructure/scheduling/test_scheduler_service.py
@@ -3,11 +3,14 @@
 These tests exercise the reconciliation logic and job execution path
 without starting a real APScheduler — we swap the ``_scheduler``
 attribute for a lightweight fake that records add/remove calls.
+
+Unit-of-Work factories are stubbed with a small helper that yields
+an ``AsyncMock`` UoW so the scheduler can read and persist
+libraries without touching a real database.
 """
 
 from __future__ import annotations
 
-from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -61,23 +64,30 @@ def _make_library(name: str = "Test", schedule: str | None = "0 * * * *") -> Lib
     )
 
 
-def _session_factory(session: object) -> object:
-    """Build a callable that yields ``session`` from an ``async with``."""
-
-    @asynccontextmanager
-    async def _factory():
-        yield session
-
-    return _factory
+def _build_uow(library_repo: AsyncMock) -> AsyncMock:
+    """Build an async-context-manager UoW whose ``libraries`` is ``library_repo``."""
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.libraries = library_repo
+    return uow
 
 
 @pytest.fixture
-def scheduler() -> LibraryScanScheduler:
+def library_repo() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def scheduler(library_repo: AsyncMock) -> LibraryScanScheduler:
+    uow = _build_uow(library_repo)
+    library_uow_factory = MagicMock(return_value=uow)
     instance = LibraryScanScheduler(
-        session_factory=MagicMock(),
-        event_bus=MagicMock(),
+        library_uow_factory=library_uow_factory,
+        media_uow_factory=MagicMock(),
         file_scanner=MagicMock(),
         variant_detector=MagicMock(),
+        event_bus=MagicMock(),
         reconcile_interval_minutes=5,
     )
     instance._scheduler = _FakeScheduler()
@@ -87,21 +97,14 @@ def scheduler() -> LibraryScanScheduler:
 class TestReconcile:
     @pytest.mark.asyncio
     async def test_adds_job_for_each_library_with_schedule(
-        self, scheduler: LibraryScanScheduler
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
     ) -> None:
         lib_a = _make_library("A", "0 3 * * *")
         lib_b = _make_library("B", "30 4 * * *")
         lib_no_sched = _make_library("C", schedule=None)
+        library_repo.find_all.return_value = [lib_a, lib_b, lib_no_sched]
 
-        repo = AsyncMock()
-        repo.find_all.return_value = [lib_a, lib_b, lib_no_sched]
-        scheduler._session_factory = _session_factory(MagicMock())  # type: ignore[assignment]
-
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
-            return_value=repo,
-        ):
-            await scheduler._reconcile()
+        await scheduler._reconcile()
 
         fake: _FakeScheduler = scheduler._scheduler
         assert _job_id_for(str(lib_a.id)) in fake.jobs
@@ -110,7 +113,7 @@ class TestReconcile:
 
     @pytest.mark.asyncio
     async def test_removes_job_when_library_loses_schedule(
-        self, scheduler: LibraryScanScheduler
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
     ) -> None:
         lib = _make_library("A", "0 3 * * *")
         job_id = _job_id_for(str(lib.id))
@@ -118,37 +121,25 @@ class TestReconcile:
         fake.jobs[job_id] = {"cron": "0 3 * * *"}
 
         lib_cleared = lib.with_updates(scan_schedule=None)
+        library_repo.find_all.return_value = [lib_cleared]
 
-        repo = AsyncMock()
-        repo.find_all.return_value = [lib_cleared]
-        scheduler._session_factory = _session_factory(MagicMock())  # type: ignore[assignment]
-
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
-            return_value=repo,
-        ):
-            await scheduler._reconcile()
+        await scheduler._reconcile()
 
         assert job_id not in fake.jobs
 
     @pytest.mark.asyncio
-    async def test_replaces_job_when_cron_changes(self, scheduler: LibraryScanScheduler) -> None:
+    async def test_replaces_job_when_cron_changes(
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
+    ) -> None:
         lib = _make_library("A", "0 3 * * *")
         job_id = _job_id_for(str(lib.id))
         fake: _FakeScheduler = scheduler._scheduler
         fake.jobs[job_id] = {"existing": True}
 
         lib_updated = lib.with_updates(scan_schedule="30 5 * * *")
+        library_repo.find_all.return_value = [lib_updated]
 
-        repo = AsyncMock()
-        repo.find_all.return_value = [lib_updated]
-        scheduler._session_factory = _session_factory(MagicMock())  # type: ignore[assignment]
-
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
-            return_value=repo,
-        ):
-            await scheduler._reconcile()
+        await scheduler._reconcile()
 
         assert job_id in fake.jobs
         # The job got replaced — our fake's `existing` marker is gone.
@@ -156,20 +147,13 @@ class TestReconcile:
 
     @pytest.mark.asyncio
     async def test_skips_invalid_cron_without_crashing(
-        self, scheduler: LibraryScanScheduler
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
     ) -> None:
         # Passes the entity-level regex but fails real cron parsing.
         lib = _make_library("A", "99 99 * * *")
+        library_repo.find_all.return_value = [lib]
 
-        repo = AsyncMock()
-        repo.find_all.return_value = [lib]
-        scheduler._session_factory = _session_factory(MagicMock())  # type: ignore[assignment]
-
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
-            return_value=repo,
-        ):
-            await scheduler._reconcile()  # must not raise
+        await scheduler._reconcile()  # must not raise
 
         fake: _FakeScheduler = scheduler._scheduler
         assert _job_id_for(str(lib.id)) not in fake.jobs
@@ -177,16 +161,12 @@ class TestReconcile:
 
 class TestRunScan:
     @pytest.mark.asyncio
-    async def test_updates_last_scan_at_on_success(self, scheduler: LibraryScanScheduler) -> None:
+    async def test_updates_last_scan_at_on_success(
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
+    ) -> None:
         lib = _make_library("A", "0 * * * *")
-        lib_id = str(lib.id)
-
-        library_repo = AsyncMock()
         library_repo.find_by_id.return_value = lib
         library_repo.save = AsyncMock()
-
-        session = AsyncMock()
-        scheduler._session_factory = _session_factory(session)  # type: ignore[assignment]
 
         fake_use_case = AsyncMock()
         fake_use_case.execute.return_value = MagicMock(
@@ -197,69 +177,78 @@ class TestRunScan:
             errors=[],
         )
 
-        with (
-            patch(
-                "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
-                return_value=library_repo,
-            ),
-            patch(
-                "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
-                return_value=fake_use_case,
-            ),
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
+            return_value=fake_use_case,
         ):
-            await scheduler._run_scan(lib_id)
+            await scheduler._run_scan(str(lib.id))
 
         library_repo.save.assert_awaited_once()
-        await_args = library_repo.save.await_args
-        assert await_args is not None
-        saved = await_args.args[0]
+        saved = library_repo.save.await_args.args[0]
         assert saved.last_scan_at is not None
         assert saved.last_scan_at.tzinfo == UTC
         assert saved.last_scan_at <= datetime.now(UTC)
 
     @pytest.mark.asyncio
     async def test_skips_when_library_deleted_mid_run(
-        self, scheduler: LibraryScanScheduler
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
     ) -> None:
-        library_repo = AsyncMock()
         library_repo.find_by_id.return_value = None
         library_repo.save = AsyncMock()
 
-        session = AsyncMock()
-        scheduler._session_factory = _session_factory(session)  # type: ignore[assignment]
-
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
-            return_value=library_repo,
-        ):
-            await scheduler._run_scan(str(LibraryId.generate()))
+        await scheduler._run_scan(str(LibraryId.generate()))
 
         library_repo.save.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_rolls_back_on_scan_failure(self, scheduler: LibraryScanScheduler) -> None:
+    async def test_does_not_mark_scan_completed_on_failure(
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
+    ) -> None:
         lib = _make_library("A", "0 * * * *")
-        library_repo = AsyncMock()
         library_repo.find_by_id.return_value = lib
         library_repo.save = AsyncMock()
-
-        session = AsyncMock()
-        scheduler._session_factory = _session_factory(session)  # type: ignore[assignment]
 
         fake_use_case = AsyncMock()
         fake_use_case.execute.side_effect = RuntimeError("scan blew up")
 
-        with (
-            patch(
-                "src.infrastructure.scheduling.scheduler_service.SqlAlchemyLibraryRepository",
-                return_value=library_repo,
-            ),
-            patch(
-                "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
-                return_value=fake_use_case,
-            ),
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
+            return_value=fake_use_case,
         ):
             await scheduler._run_scan(str(lib.id))
 
-        session.rollback.assert_awaited_once()
         library_repo.save.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_builds_scan_use_case_with_injected_dependencies(
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
+    ) -> None:
+        """Guard the fix for the pre-UoW scheduler bug: the use case is built
+        from the injected ``media_uow_factory`` + ports, never from per-session
+        concrete repositories."""
+        lib = _make_library("A", "0 * * * *")
+        library_repo.find_by_id.return_value = lib
+        library_repo.save = AsyncMock()
+
+        fake_use_case = AsyncMock()
+        fake_use_case.execute.return_value = MagicMock(
+            movies_created=0,
+            movies_updated=0,
+            episodes_created=0,
+            episodes_updated=0,
+            errors=[],
+        )
+
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
+            return_value=fake_use_case,
+        ) as use_case_cls:
+            await scheduler._run_scan(str(lib.id))
+
+        use_case_cls.assert_called_once()
+        kwargs = use_case_cls.call_args.kwargs
+        assert kwargs["uow_factory"] is scheduler._media_uow_factory
+        assert kwargs["file_scanner"] is scheduler._file_scanner
+        assert kwargs["variant_detector"] is scheduler._variant_detector
+        assert kwargs["event_bus"] is scheduler._event_bus
+        assert kwargs["probe_service"] is scheduler._probe_service


### PR DESCRIPTION
## Summary

- ``LibraryScanScheduler`` no longer imports concrete repositories. The constructor receives abstract ``LibraryUnitOfWorkFactory`` and ``MediaUnitOfWorkFactory`` plus the ports it already used (``FileSystemScanner``, ``VariantDetectorPort``, ``EventBus``, new optional ``MediaProbePort``). All concrete imports move to ``TYPE_CHECKING``.
- Scheduler provider moves from ``InfrastructureContainer`` to ``ApplicationContainer`` so it can draw UoW factories from the sibling ``library`` and ``media`` containers. ``main.py`` resolves it via ``container.library_scan_scheduler()``.
- **Bug fix (latent since the Phase 1 UoW refactor):** ``_run_scan`` used to instantiate ``ScanMediaDirectoriesUseCase`` with ``movie_repository`` / ``series_repository`` kwargs that the use case stopped accepting. Only the scheduler tests hid it (they patched the use case class whole). The scan now builds from ``uow_factory`` + ports, and gains the ``probe_service`` that was silently omitted.
- V9 (inline imports in ``get_continue_watching``) was already resolved by Phase 1 — verified no work needed.

## Test plan

- [x] ``poetry run pytest`` — 1693 passed (1692 + 1 regression guard)
- [x] ``poetry run ruff check src tests`` — clean
- [x] ``poetry run ruff format --check src tests`` — clean
- [x] ``grep -r \"SqlAlchemyLibraryRepository\\|SQLAlchemyMovieRepository\\|SQLAlchemySeriesRepository\" src/infrastructure/`` — empty
- [x] New test asserts ``ScanMediaDirectoriesUseCase`` receives ``uow_factory`` / ``probe_service`` / ports / event bus via DI (guards against the bug recurring)
- [ ] Manual smoke with ``scheduler_enabled=true`` on a library with a cron schedule after merge — job fires, scan completes, ``last_scan_at`` updates.

## Summary by Sourcery

Refactor the library scan scheduler to depend on unit-of-work factories and be wired from the application container, while tightening its scan flow and error handling.

Bug Fixes:
- Ensure the scheduled library scan builds the media scan use case with the correct dependencies and no longer relies on outdated repository-based kwargs.
- Prevent failed library scans from marking a library as successfully scanned.

Enhancements:
- Decouple LibraryScanScheduler from concrete repositories by injecting library and media unit-of-work factories and optional media probe service.
- Split scan execution into separate steps for loading library paths and persisting completion timestamps using short-lived unit-of-work scopes.
- Move LibraryScanScheduler wiring from the infrastructure container to the application container to compose it from sibling library and media containers.

Tests:
- Update scheduler tests to use unit-of-work-style repository mocks instead of patching concrete SQLAlchemy repositories.
- Add a regression test asserting ScanMediaDirectoriesUseCase is constructed using injected unit-of-work factory and ports.