### PR TITLE
refactor(persistence): make UoWs own their session lifecycle

### DIFF
--- a/src/modules/collections/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/collections/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -48,6 +48,7 @@ class SqlAlchemyCollectionsUnitOfWork(CollectionsUnitOfWork):
             else:
                 await self._session.rollback()
         finally:
+            await self._session.close()
             self._session = None
 
     async def commit(self) -> None:

--- a/src/modules/library/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/library/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -42,6 +42,7 @@ class SqlAlchemyLibraryUnitOfWork(LibraryUnitOfWork):
             else:
                 await self._session.rollback()
         finally:
+            await self._session.close()
             self._session = None
 
     async def commit(self) -> None:

--- a/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -21,10 +21,11 @@ from src.modules.media.infrastructure.persistence.repositories.series_repository
 class SqlAlchemyMediaUnitOfWork(MediaUnitOfWork):
     """SQLAlchemy-backed Unit of Work for the media bounded context.
 
-    Each ``async with`` block opens a fresh session registered for the
-    request-scoped cleanup middleware, instantiates the movie and
-    series repositories on that session, and commits on success or
-    rolls back on exception.
+    Each ``async with`` block opens a fresh session, instantiates the
+    movie and series repositories on that session, commits on success
+    or rolls back on exception, and always closes the session on exit
+    so the UoW is safe to use outside an HTTP request (scheduler, CLI,
+    workers).
 
     Nesting is not supported — entering an already-open UoW raises
     ``RuntimeError`` rather than silently creating a parallel session.
@@ -55,9 +56,7 @@ class SqlAlchemyMediaUnitOfWork(MediaUnitOfWork):
             else:
                 await self._session.rollback()
         finally:
-            # The request-scoped middleware closes tracked sessions, but
-            # we reset our handle so the UoW instance could be reused in
-            # a new ``async with`` block if the caller holds it.
+            await self._session.close()
             self._session = None
 
     async def commit(self) -> None:

--- a/src/modules/preferences/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/preferences/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -37,12 +37,6 @@ class SqlAlchemyPreferencesUnitOfWork(PreferencesUnitOfWork):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        # Session closure is intentionally NOT done here: the session
-        # was built via ``create_tracked_session`` which registers it
-        # on a ContextVar; ``SessionCleanupMiddleware`` closes every
-        # tracked session when the HTTP request finishes. Closing it
-        # twice would cause the middleware's cleanup loop to log a
-        # benign warning for every UoW exit.
         assert self._session is not None
         try:
             if exc_type is None:
@@ -50,6 +44,7 @@ class SqlAlchemyPreferencesUnitOfWork(PreferencesUnitOfWork):
             else:
                 await self._session.rollback()
         finally:
+            await self._session.close()
             self._session = None
 
     async def commit(self) -> None:

--- a/src/modules/watch_progress/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/watch_progress/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -44,6 +44,7 @@ class SqlAlchemyWatchProgressUnitOfWork(WatchProgressUnitOfWork):
             else:
                 await self._session.rollback()
         finally:
+            await self._session.close()
             self._session = None
 
     async def commit(self) -> None:


### PR DESCRIPTION
## Summary
- Each SQLAlchemy Unit of Work now calls `await session.close()` in the `__aexit__` finally block, releasing the connection regardless of caller context — fixes the connection leak the scheduler (and any non-HTTP caller like a future CLI/worker) had been silently racking up.
- `AsyncSession.close()` is idempotent, so the existing `SessionCleanupMiddleware` keeps working as a safety net for read-side sessions; it will be removed once read use cases move through a UoW in follow-up PRs.

## Test plan
- [x] `poetry run pytest` — 1693 passed
- [x] `poetry run ruff check src tests` — clean