### PR TITLE
refactor(media): migrate read use cases to UoW factory

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -125,18 +125,17 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     get_featured_media = providers.Factory(
         GetFeaturedMediaUseCase,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     get_movie_by_id = providers.Factory(
         GetMovieByIdUseCase,
-        movie_repository=movie_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     list_movies = providers.Factory(
         ListMoviesUseCase,
-        movie_repository=movie_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     delete_movie = providers.Factory(
@@ -146,13 +145,13 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     get_series_by_id = providers.Factory(
         GetSeriesByIdUseCase,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
         progress_lookup=progress_lookup,
     )
 
     list_series = providers.Factory(
         ListSeriesUseCase,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     # =========================================================================
@@ -161,20 +160,17 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     list_genres = providers.Factory(
         ListGenresUseCase,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     list_by_genre = providers.Factory(
         ListByGenreUseCase,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     search_catalog = providers.Factory(
         SearchCatalogUseCase,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     # =========================================================================
@@ -183,8 +179,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     get_file_variants = providers.Factory(
         GetFileVariantsUseCase,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     add_file_variant = providers.Factory(
@@ -293,8 +288,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         BulkEnrichMetadataUseCase,
         enrich_movie=enrich_movie_metadata,
         enrich_series=enrich_series_metadata,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        uow_factory=media_unit_of_work_factory,
     )
 
     # =========================================================================

--- a/src/modules/media/application/use_cases/bulk_enrich_metadata.py
+++ b/src/modules/media/application/use_cases/bulk_enrich_metadata.py
@@ -8,13 +8,13 @@ from src.modules.media.application.dtos.enrichment_dtos import (
     EnrichMediaInput,
     EnrichMediaOutput,
 )
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases.enrich_movie_metadata import (
     EnrichMovieMetadataUseCase,
 )
 from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
 )
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 class BulkEnrichMetadataUseCase:
@@ -26,21 +26,20 @@ class BulkEnrichMetadataUseCase:
     Args:
         enrich_movie: Use case for single movie enrichment.
         enrich_series: Use case for single series enrichment.
-        movie_repository: Repository for listing movies.
-        series_repository: Repository for listing series.
+        uow_factory: Factory that opens a fresh media Unit of Work used
+            to list the catalog before dispatching to the per-item use
+            cases (which each open their own write-scoped UoW).
     """
 
     def __init__(
         self,
         enrich_movie: EnrichMovieMetadataUseCase,
         enrich_series: EnrichSeriesMetadataUseCase,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
+        uow_factory: MediaUnitOfWorkFactory,
     ) -> None:
         self._enrich_movie = enrich_movie
         self._enrich_series = enrich_series
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: BulkEnrichInput) -> BulkEnrichOutput:
         """Execute bulk metadata enrichment.
@@ -53,7 +52,10 @@ class BulkEnrichMetadataUseCase:
         """
         errors: list[str] = []
 
-        movies = await self._movie_repository.list_all()
+        async with self._uow_factory() as uow:
+            movies = await uow.movies.list_all()
+            all_series = await uow.series.list_all()
+
         m_enriched, m_skipped = await self._enrich_all(
             items=[(str(m.id), m.title.value) for m in movies if m.id],
             enrich_fn=self._enrich_movie.execute,
@@ -62,7 +64,6 @@ class BulkEnrichMetadataUseCase:
             errors=errors,
         )
 
-        all_series = await self._series_repository.list_all()
         s_enriched, s_skipped = await self._enrich_all(
             items=[(str(s.id), s.title.value) for s in all_series if s.id],
             enrich_fn=self._enrich_series.execute,

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -6,8 +6,8 @@ from src.modules.media.application.dtos.featured_dtos import (
     FeaturedItemOutput,
     GetFeaturedInput,
 )
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 class GetFeaturedMediaUseCase:
@@ -17,23 +17,17 @@ class GetFeaturedMediaUseCase:
     random ordering, then maps to a flat output list.
 
     Example:
-        >>> use_case = GetFeaturedMediaUseCase(movie_repo, series_repo)
+        >>> use_case = GetFeaturedMediaUseCase(uow_factory)
         >>> items = await use_case.execute(GetFeaturedInput(media_type="all", limit=6))
     """
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Repository for movie persistence.
-            series_repository: Repository for series persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: GetFeaturedInput) -> list[FeaturedItemOutput]:
         """Execute the use case.
@@ -47,15 +41,14 @@ class GetFeaturedMediaUseCase:
         results: list[FeaturedItemOutput] = []
         lang = input_dto.lang
 
-        if input_dto.media_type in ("all", "movie"):
-            limit = input_dto.limit if input_dto.media_type == "movie" else input_dto.limit
-            movies = await self._movie_repo.find_random(limit, with_backdrop=True)
-            results.extend(self._movie_to_output(m, lang) for m in movies)
+        async with self._uow_factory() as uow:
+            if input_dto.media_type in ("all", "movie"):
+                movies = await uow.movies.find_random(input_dto.limit, with_backdrop=True)
+                results.extend(self._movie_to_output(m, lang) for m in movies)
 
-        if input_dto.media_type in ("all", "series"):
-            limit = input_dto.limit if input_dto.media_type == "series" else input_dto.limit
-            series_list = await self._series_repo.find_random(limit, with_backdrop=True)
-            results.extend(self._series_to_output(s, lang) for s in series_list)
+            if input_dto.media_type in ("all", "series"):
+                series_list = await uow.series.find_random(input_dto.limit, with_backdrop=True)
+                results.extend(self._series_to_output(s, lang) for s in series_list)
 
         if input_dto.media_type == "all":
             random.shuffle(results)

--- a/src/modules/media/application/use_cases/get_file_variants.py
+++ b/src/modules/media/application/use_cases/get_file_variants.py
@@ -5,10 +5,10 @@ from src.modules.media.application.dtos.media_file_dtos import (
     GetFileVariantsInput,
     MediaFileOutput,
 )
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._media_file_helpers import (
     to_media_file_output,
 )
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import EpisodeId, MovieId
 
 
@@ -16,7 +16,7 @@ class GetFileVariantsUseCase:
     """List all file variants of a movie or episode.
 
     Example:
-        >>> use_case = GetFileVariantsUseCase(movie_repo, series_repo)
+        >>> use_case = GetFileVariantsUseCase(uow_factory)
         >>> variants = await use_case.execute(
         ...     GetFileVariantsInput(media_id="mov_abc123"),
         ... )
@@ -24,19 +24,13 @@ class GetFileVariantsUseCase:
         3
     """
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Repository for movie persistence.
-            series_repository: Repository for series persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: GetFileVariantsInput) -> list[MediaFileOutput]:
         """Execute the use case.
@@ -52,23 +46,24 @@ class GetFileVariantsUseCase:
         """
         prefix = input_dto.media_id.split("_")[0] if "_" in input_dto.media_id else ""
 
-        if prefix == "mov":
-            movie = await self._movie_repository.find_by_id(MovieId(input_dto.media_id))
-            if movie is None:
-                raise ResourceNotFoundException.for_resource("Movie", input_dto.media_id)
-            return [to_media_file_output(f) for f in movie.files]
+        async with self._uow_factory() as uow:
+            if prefix == "mov":
+                movie = await uow.movies.find_by_id(MovieId(input_dto.media_id))
+                if movie is None:
+                    raise ResourceNotFoundException.for_resource("Movie", input_dto.media_id)
+                return [to_media_file_output(f) for f in movie.files]
 
-        if prefix == "epi":
-            series = await self._series_repository.find_by_episode_id(
-                EpisodeId(input_dto.media_id),
-            )
-            if series is None:
-                raise ResourceNotFoundException.for_resource("Episode", input_dto.media_id)
+            if prefix == "epi":
+                series = await uow.series.find_by_episode_id(
+                    EpisodeId(input_dto.media_id),
+                )
+                if series is None:
+                    raise ResourceNotFoundException.for_resource("Episode", input_dto.media_id)
 
-            for season in series.seasons:
-                for episode in season.episodes:
-                    if str(episode.id) == input_dto.media_id:
-                        return [to_media_file_output(f) for f in episode.files]
+                for season in series.seasons:
+                    for episode in season.episodes:
+                        if str(episode.id) == input_dto.media_id:
+                            return [to_media_file_output(f) for f in episode.files]
 
         raise ResourceNotFoundException.for_resource("Media", input_dto.media_id)
 

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -2,11 +2,11 @@
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput, MovieOutput
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._media_file_helpers import (
     to_media_file_output,
 )
 from src.modules.media.domain.entities.movie import Movie
-from src.modules.media.domain.repositories import MovieRepository
 from src.modules.media.domain.value_objects import MovieId
 
 
@@ -17,19 +17,19 @@ class GetMovieByIdUseCase:
     it in a format suitable for API consumption.
 
     Example:
-        >>> use_case = GetMovieByIdUseCase(movie_repository)
+        >>> use_case = GetMovieByIdUseCase(uow_factory)
         >>> result = await use_case.execute(GetMovieByIdInput("mov_abc123"))
         >>> result.title
         'Inception'
     """
 
-    def __init__(self, movie_repository: MovieRepository) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Repository for movie persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repository = movie_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: GetMovieByIdInput) -> MovieOutput:
         """Execute the use case.
@@ -44,7 +44,8 @@ class GetMovieByIdUseCase:
             ResourceNotFoundException: If movie with given ID doesn't exist.
         """
         movie_id = MovieId(input_dto.movie_id)
-        movie = await self._movie_repository.find_by_id(movie_id)
+        async with self._uow_factory() as uow:
+            movie = await uow.movies.find_by_id(movie_id)
 
         if movie is None:
             raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -8,11 +8,11 @@ from src.modules.media.application.dtos.series_dtos import (
     SeriesOutput,
 )
 from src.modules.media.application.ports import ProgressLookupPort, ProgressSummary
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._media_file_helpers import (
     to_media_file_output,
 )
 from src.modules.media.domain.entities import Episode, Season, Series
-from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import SeriesId
 from src.shared_kernel.episode_composite_id import EpisodeCompositeId
 
@@ -26,7 +26,7 @@ class GetSeriesByIdUseCase:
     Watch Progress domain types.
 
     Example:
-        >>> use_case = GetSeriesByIdUseCase(series_repository, progress_lookup)
+        >>> use_case = GetSeriesByIdUseCase(uow_factory, progress_lookup)
         >>> result = await use_case.execute(GetSeriesByIdInput("ser_abc123"))
         >>> result.title
         'Breaking Bad'
@@ -36,16 +36,16 @@ class GetSeriesByIdUseCase:
 
     def __init__(
         self,
-        series_repository: SeriesRepository,
+        uow_factory: MediaUnitOfWorkFactory,
         progress_lookup: ProgressLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
-            series_repository: Repository for series persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
             progress_lookup: Port for resolving watch progress snapshots.
         """
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
         self._progress_lookup = progress_lookup
 
     async def execute(self, input_dto: GetSeriesByIdInput) -> SeriesOutput:
@@ -61,7 +61,8 @@ class GetSeriesByIdUseCase:
             ResourceNotFoundException: If series doesn't exist.
         """
         series_id = SeriesId(input_dto.series_id)
-        series = await self._series_repository.find_by_id(series_id)
+        async with self._uow_factory() as uow:
+            series = await uow.series.find_by_id(series_id)
 
         if series is None:
             raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)

--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -16,8 +16,8 @@ from src.modules.media.application.dtos.catalog_dtos import (
     ListByGenreInput,
     ListByGenreOutput,
 )
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import Genre
 
 _T = TypeVar("_T")
@@ -85,13 +85,8 @@ class ListByGenreUseCase:
     free.
     """
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ListByGenreInput) -> ListByGenreOutput:
         """Execute the use case.
@@ -107,13 +102,6 @@ class ListByGenreUseCase:
         decoded = decode_dual_cursor(input_dto.cursor)
         genre = Genre(input_dto.genre)
 
-        # Both repository calls are independent I/O — issue them
-        # concurrently via `asyncio.gather` so the by-genre endpoint
-        # only waits for the slower of the two queries instead of
-        # serializing them. The DI container hands each repository
-        # its own AsyncSession (Factory provider), so there's no
-        # session contention to worry about.
-        #
         # When ``media_type`` restricts the stream to one side, the
         # excluded repo is skipped entirely and a synthetic empty
         # page stands in for it so the merge / cursor logic below
@@ -187,40 +175,64 @@ class ListByGenreUseCase:
     ) -> tuple[PaginatedResult[Movie], PaginatedResult[Series]]:
         """Fetch the movie and series pages, honoring the media-type filter.
 
-        Both repos are awaited concurrently via ``asyncio.gather``
-        when no filter is active. When ``media_type`` excludes a
-        stream, only the surviving repo is called and an empty
-        ``PaginatedResult`` stands in for the other — preserving the
-        caller's ``(movies, series)`` tuple shape and the "previous
-        cursor stays put if nothing is consumed" semantics of the
-        merge sort.
+        Both repos are awaited concurrently via ``asyncio.gather`` when
+        no filter is active; each branch opens its own ``MediaUnitOfWork``
+        so the two queries run on independent sessions (SQLAlchemy's
+        AsyncSession forbids concurrent execution on the same session).
+        When ``media_type`` excludes a stream, only the surviving repo
+        is called and an empty ``PaginatedResult`` stands in for the
+        other — preserving the caller's ``(movies, series)`` tuple
+        shape and the "previous cursor stays put if nothing is consumed"
+        semantics of the merge sort.
         """
         if media_type == "movie":
-            movies_page = await self._movie_repository.list_paginated_by_genre(
-                genre=genre,
-                cursor=decoded.movies,
-                limit=limit,
-            )
+            async with self._uow_factory() as uow:
+                movies_page = await uow.movies.list_paginated_by_genre(
+                    genre=genre,
+                    cursor=decoded.movies,
+                    limit=limit,
+                )
             return movies_page, _empty_page(Series)
         if media_type == "series":
-            series_page = await self._series_repository.list_paginated_by_genre(
-                genre=genre,
-                cursor=decoded.series,
-                limit=limit,
-            )
+            async with self._uow_factory() as uow:
+                series_page = await uow.series.list_paginated_by_genre(
+                    genre=genre,
+                    cursor=decoded.series,
+                    limit=limit,
+                )
             return _empty_page(Movie), series_page
         return await asyncio.gather(
-            self._movie_repository.list_paginated_by_genre(
-                genre=genre,
-                cursor=decoded.movies,
-                limit=limit,
-            ),
-            self._series_repository.list_paginated_by_genre(
-                genre=genre,
-                cursor=decoded.series,
-                limit=limit,
-            ),
+            self._fetch_movies_page(genre=genre, cursor=decoded.movies, limit=limit),
+            self._fetch_series_page(genre=genre, cursor=decoded.series, limit=limit),
         )
+
+    async def _fetch_movies_page(
+        self,
+        *,
+        genre: Genre,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResult[Movie]:
+        async with self._uow_factory() as uow:
+            return await uow.movies.list_paginated_by_genre(
+                genre=genre,
+                cursor=cursor,
+                limit=limit,
+            )
+
+    async def _fetch_series_page(
+        self,
+        *,
+        genre: Genre,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResult[Series]:
+        async with self._uow_factory() as uow:
+            return await uow.series.list_paginated_by_genre(
+                genre=genre,
+                cursor=cursor,
+                limit=limit,
+            )
 
     @staticmethod
     def _compute_next_cursor(

--- a/src/modules/media/application/use_cases/list_genres.py
+++ b/src/modules/media/application/use_cases/list_genres.py
@@ -5,7 +5,7 @@ from src.modules.media.application.dtos.catalog_dtos import (
     ListGenresInput,
     ListGenresOutput,
 )
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.repositories.movie_repository import GenreRow
 
 
@@ -29,25 +29,19 @@ class ListGenresUseCase:
     Home page where they're most useful.
 
     Example:
-        >>> use_case = ListGenresUseCase(movie_repo, series_repo)
+        >>> use_case = ListGenresUseCase(uow_factory)
         >>> result = await use_case.execute(ListGenresInput(lang="pt-BR"))
         >>> result.genres[0]
         GenreOutput(id="Action", name="Ação", count=42)
     """
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Movie repo, used for ``list_genre_rows``.
-            series_repository: Series repo, used for ``list_genre_rows``.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ListGenresInput) -> ListGenresOutput:
         """Execute the use case.
@@ -66,16 +60,17 @@ class ListGenresUseCase:
         # use this to get counts scoped to just their half of the
         # catalog, so e.g. a genre that only tags series shouldn't
         # appear on the Movies tab.
-        movie_rows = (
-            await self._movie_repository.list_genre_rows(input_dto.lang)
-            if input_dto.media_type != "series"
-            else []
-        )
-        series_rows = (
-            await self._series_repository.list_genre_rows(input_dto.lang)
-            if input_dto.media_type != "movie"
-            else []
-        )
+        async with self._uow_factory() as uow:
+            movie_rows = (
+                await uow.movies.list_genre_rows(input_dto.lang)
+                if input_dto.media_type != "series"
+                else []
+            )
+            series_rows = (
+                await uow.series.list_genre_rows(input_dto.lang)
+                if input_dto.media_type != "movie"
+                else []
+            )
 
         counts: dict[str, int] = {}
         localized_label: dict[str, str] = {}

--- a/src/modules/media/application/use_cases/list_movies.py
+++ b/src/modules/media/application/use_cases/list_movies.py
@@ -5,8 +5,8 @@ from src.modules.media.application.dtos.movie_dtos import (
     ListMoviesOutput,
     MovieSummaryOutput,
 )
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.repositories import MovieRepository
 
 
 class ListMoviesUseCase:
@@ -18,7 +18,7 @@ class ListMoviesUseCase:
     decodes or encodes it, the repository owns that contract.
 
     Example:
-        >>> use_case = ListMoviesUseCase(movie_repository)
+        >>> use_case = ListMoviesUseCase(uow_factory)
         >>> result = await use_case.execute(ListMoviesInput(limit=20))
         >>> len(result.movies)
         20
@@ -26,13 +26,13 @@ class ListMoviesUseCase:
         True
     """
 
-    def __init__(self, movie_repository: MovieRepository) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            movie_repository: Repository for movie persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._movie_repository = movie_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ListMoviesInput) -> ListMoviesOutput:
         """Execute the use case.
@@ -46,11 +46,12 @@ class ListMoviesUseCase:
             ``has_more``, and an optional ``total_count`` (only when
             ``include_total=True``).
         """
-        page = await self._movie_repository.list_paginated(
-            cursor=input_dto.cursor,
-            limit=input_dto.limit,
-            include_total=input_dto.include_total,
-        )
+        async with self._uow_factory() as uow:
+            page = await uow.movies.list_paginated(
+                cursor=input_dto.cursor,
+                limit=input_dto.limit,
+                include_total=input_dto.include_total,
+            )
 
         return ListMoviesOutput(
             movies=[self._to_summary(movie, input_dto.lang) for movie in page.items],

--- a/src/modules/media/application/use_cases/list_series.py
+++ b/src/modules/media/application/use_cases/list_series.py
@@ -5,8 +5,8 @@ from src.modules.media.application.dtos.series_dtos import (
     ListSeriesOutput,
     SeriesSummaryOutput,
 )
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Series
-from src.modules.media.domain.repositories import SeriesRepository
 
 
 class ListSeriesUseCase:
@@ -18,7 +18,7 @@ class ListSeriesUseCase:
     opaquely.
 
     Example:
-        >>> use_case = ListSeriesUseCase(series_repository)
+        >>> use_case = ListSeriesUseCase(uow_factory)
         >>> result = await use_case.execute(ListSeriesInput())
         >>> len(result.series)
         20
@@ -26,13 +26,13 @@ class ListSeriesUseCase:
         True
     """
 
-    def __init__(self, series_repository: SeriesRepository) -> None:
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            series_repository: Repository for series persistence.
+            uow_factory: Factory that opens a fresh media Unit of Work.
         """
-        self._series_repository = series_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ListSeriesInput) -> ListSeriesOutput:
         """Execute the use case.
@@ -46,11 +46,12 @@ class ListSeriesUseCase:
             ``has_more``, and an optional ``total_count`` (only when
             ``include_total=True``).
         """
-        page = await self._series_repository.list_paginated(
-            cursor=input_dto.cursor,
-            limit=input_dto.limit,
-            include_total=input_dto.include_total,
-        )
+        async with self._uow_factory() as uow:
+            page = await uow.series.list_paginated(
+                cursor=input_dto.cursor,
+                limit=input_dto.limit,
+                include_total=input_dto.include_total,
+            )
 
         return ListSeriesOutput(
             series=[self._to_summary(s, input_dto.lang) for s in page.items],

--- a/src/modules/media/application/use_cases/search_catalog.py
+++ b/src/modules/media/application/use_cases/search_catalog.py
@@ -7,8 +7,8 @@ from src.modules.media.application.dtos.search_dtos import (
     SearchItemOutput,
     SearchOutput,
 )
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 
 
 class SearchCatalogUseCase:
@@ -27,13 +27,8 @@ class SearchCatalogUseCase:
     tables produces comparable scores for practical purposes.
     """
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
-        self._movie_repository = movie_repository
-        self._series_repository = series_repository
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: SearchInput) -> SearchOutput:
         """Execute the search.
@@ -46,42 +41,20 @@ class SearchCatalogUseCase:
             total count.
         """
         # Fetch from both repos in parallel, skipping the excluded
-        # type when a filter is active.
+        # type when a filter is active. Each branch opens its own
+        # UoW so parallel queries run on independent sessions
+        # (AsyncSession forbids concurrent execution on the same one).
         movie_hits: list[tuple[Movie, float]] = []
         series_hits: list[tuple[Series, float]] = []
 
         if input_dto.media_type == "movie":
-            movie_hits = await self._movie_repository.search(
-                input_dto.query,
-                genre=input_dto.genre,
-                year_min=input_dto.year_min,
-                year_max=input_dto.year_max,
-                limit=input_dto.limit,
-            )
+            movie_hits = await self._search_movies(input_dto)
         elif input_dto.media_type == "series":
-            series_hits = await self._series_repository.search(
-                input_dto.query,
-                genre=input_dto.genre,
-                year_min=input_dto.year_min,
-                year_max=input_dto.year_max,
-                limit=input_dto.limit,
-            )
+            series_hits = await self._search_series(input_dto)
         else:
             movie_hits, series_hits = await asyncio.gather(
-                self._movie_repository.search(
-                    input_dto.query,
-                    genre=input_dto.genre,
-                    year_min=input_dto.year_min,
-                    year_max=input_dto.year_max,
-                    limit=input_dto.limit,
-                ),
-                self._series_repository.search(
-                    input_dto.query,
-                    genre=input_dto.genre,
-                    year_min=input_dto.year_min,
-                    year_max=input_dto.year_max,
-                    limit=input_dto.limit,
-                ),
+                self._search_movies(input_dto),
+                self._search_series(input_dto),
             )
 
         # Pool and sort by rank (ascending = most relevant first)
@@ -95,6 +68,26 @@ class SearchCatalogUseCase:
         items = [self._to_output(kind, entity, input_dto.lang) for entity, _, kind in page]
 
         return SearchOutput(items=items, total=len(combined))
+
+    async def _search_movies(self, input_dto: SearchInput) -> list[tuple[Movie, float]]:
+        async with self._uow_factory() as uow:
+            return await uow.movies.search(
+                input_dto.query,
+                genre=input_dto.genre,
+                year_min=input_dto.year_min,
+                year_max=input_dto.year_max,
+                limit=input_dto.limit,
+            )
+
+    async def _search_series(self, input_dto: SearchInput) -> list[tuple[Series, float]]:
+        async with self._uow_factory() as uow:
+            return await uow.series.search(
+                input_dto.query,
+                genre=input_dto.genre,
+                year_min=input_dto.year_min,
+                year_max=input_dto.year_max,
+                limit=input_dto.limit,
+            )
 
     @staticmethod
     def _to_output(kind: str, entity: Movie | Series, lang: str) -> SearchItemOutput:

--- a/tests/modules/media/unit/application/use_cases/test_get_featured_media.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_featured_media.py
@@ -1,7 +1,5 @@
 """Tests for GetFeaturedMediaUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.modules.media.application.dtos.featured_dtos import (
@@ -12,8 +10,8 @@ from src.modules.media.application.use_cases.get_featured_media import (
     GetFeaturedMediaUseCase,
 )
 from src.modules.media.domain.entities import Movie, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import ImageUrl
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _make_movie(title: str = "Inception") -> Movie:
@@ -43,13 +41,9 @@ class TestGetFeaturedMediaUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_movies_only(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_random.return_value = [_make_movie("Inception")]
-        series_repo = AsyncMock(spec=SeriesRepository)
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_random.return_value = [_make_movie("Inception")]
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=10))
 
@@ -57,35 +51,27 @@ class TestGetFeaturedMediaUseCase:
         assert isinstance(result[0], FeaturedItemOutput)
         assert result[0].type == "movie"
         assert result[0].title == "Inception"
-        series_repo.find_random.assert_not_called()
+        mocks.series.find_random.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_should_return_series_only(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_random.return_value = [_make_series("Breaking Bad")]
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.series.find_random.return_value = [_make_series("Breaking Bad")]
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetFeaturedInput(media_type="series", limit=10))
 
         assert len(result) == 1
         assert result[0].type == "series"
         assert result[0].title == "Breaking Bad"
-        movie_repo.find_random.assert_not_called()
+        mocks.movies.find_random.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_should_return_both_movies_and_series_when_all(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_random.return_value = [_make_movie("Inception")]
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_random.return_value = [_make_series("Breaking Bad")]
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_random.return_value = [_make_movie("Inception")]
+        mocks.series.find_random.return_value = [_make_series("Breaking Bad")]
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetFeaturedInput(media_type="all", limit=10))
 
@@ -95,14 +81,10 @@ class TestGetFeaturedMediaUseCase:
 
     @pytest.mark.asyncio
     async def test_should_truncate_to_limit(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_random.return_value = [_make_movie(f"Movie{i}") for i in range(5)]
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_random.return_value = [_make_series(f"Series{i}") for i in range(5)]
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_random.return_value = [_make_movie(f"Movie{i}") for i in range(5)]
+        mocks.series.find_random.return_value = [_make_series(f"Series{i}") for i in range(5)]
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetFeaturedInput(media_type="all", limit=4))
 
@@ -110,14 +92,10 @@ class TestGetFeaturedMediaUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_when_no_results(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_random.return_value = []
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_random.return_value = []
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_random.return_value = []
+        mocks.series.find_random.return_value = []
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetFeaturedInput(media_type="all", limit=10))
 
@@ -125,18 +103,13 @@ class TestGetFeaturedMediaUseCase:
 
     @pytest.mark.asyncio
     async def test_should_filter_with_backdrop(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_random.return_value = []
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_random.return_value = []
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_random.return_value = []
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(GetFeaturedInput(media_type="movie", limit=5))
 
-        movie_repo.find_random.assert_called_once_with(5, with_backdrop=True)
+        mocks.movies.find_random.assert_called_once_with(5, with_backdrop=True)
 
     @pytest.mark.asyncio
     async def test_should_pass_language_to_movie_outputs(self) -> None:
@@ -144,13 +117,9 @@ class TestGetFeaturedMediaUseCase:
         movie = movie.with_updates(
             localized={"pt-BR": {"title": "A Origem"}},
         )
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_random.return_value = [movie]
-        series_repo = AsyncMock(spec=SeriesRepository)
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_random.return_value = [movie]
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=1, lang="pt-BR"))
 
@@ -159,13 +128,9 @@ class TestGetFeaturedMediaUseCase:
     @pytest.mark.asyncio
     async def test_movie_output_should_include_backdrop_and_genres(self) -> None:
         movie = _make_movie("Inception")
-        movie_repo = AsyncMock(spec=MovieRepository)
-        movie_repo.find_random.return_value = [movie]
-        series_repo = AsyncMock(spec=SeriesRepository)
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_random.return_value = [movie]
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=1))
 
@@ -176,13 +141,9 @@ class TestGetFeaturedMediaUseCase:
     @pytest.mark.asyncio
     async def test_series_output_should_have_no_duration(self) -> None:
         series = _make_series("Breaking Bad")
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.find_random.return_value = [series]
-        use_case = GetFeaturedMediaUseCase(
-            movie_repository=movie_repo,
-            series_repository=series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.series.find_random.return_value = [series]
+        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetFeaturedInput(media_type="series", limit=1))
 

--- a/tests/modules/media/unit/application/use_cases/test_get_file_variants.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_file_variants.py
@@ -1,16 +1,14 @@
 """Tests for GetFileVariantsUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos import GetFileVariantsInput, MediaFileOutput
 from src.modules.media.application.use_cases import GetFileVariantsUseCase
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.value_objects import MediaFile, Resolution
 from src.shared_kernel.value_objects.file_path import FilePath
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 @pytest.mark.unit
@@ -19,9 +17,7 @@ class TestGetFileVariantsUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_all_variants(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
+        mocks = make_media_uow_mock()
         movie = Movie.create(
             title="Inception",
             year=2010,
@@ -37,12 +33,8 @@ class TestGetFileVariantsUseCase:
                 resolution=Resolution("4K"),
             ),
         )
-        mock_movie_repo.find_by_id.return_value = movie
-
-        use_case = GetFileVariantsUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        mocks.movies.find_by_id.return_value = movie
+        use_case = GetFileVariantsUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
             GetFileVariantsInput(media_id=str(movie.id)),
@@ -53,14 +45,9 @@ class TestGetFileVariantsUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_not_found_for_missing_movie(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-        mock_movie_repo.find_by_id.return_value = None
-
-        use_case = GetFileVariantsUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
+        use_case = GetFileVariantsUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(
@@ -69,13 +56,8 @@ class TestGetFileVariantsUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_not_found_for_invalid_prefix(self):
-        mock_movie_repo = AsyncMock(spec=MovieRepository)
-        mock_series_repo = AsyncMock(spec=SeriesRepository)
-
-        use_case = GetFileVariantsUseCase(
-            movie_repository=mock_movie_repo,
-            series_repository=mock_series_repo,
-        )
+        mocks = make_media_uow_mock()
+        use_case = GetFileVariantsUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException):
             await use_case.execute(

--- a/tests/modules/media/unit/application/use_cases/test_get_movie_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_movie_by_id.py
@@ -1,6 +1,5 @@
 """Tests for GetMovieByIdUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -8,7 +7,7 @@ from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos import GetMovieByIdInput, MovieOutput
 from src.modules.media.application.use_cases import GetMovieByIdUseCase
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.repositories import MovieRepository
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 class TestGetMovieByIdUseCase:
@@ -16,7 +15,7 @@ class TestGetMovieByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_movie_when_found(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
+        mocks = make_media_uow_mock()
         movie = Movie.create(
             title="Inception",
             year=2010,
@@ -25,8 +24,8 @@ class TestGetMovieByIdUseCase:
             file_size=4_000_000_000,
             resolution="1080p",
         )
-        mock_repo.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(movie_repository=mock_repo)
+        mocks.movies.find_by_id.return_value = movie
+        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
 
@@ -38,7 +37,7 @@ class TestGetMovieByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_formatted_duration(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
+        mocks = make_media_uow_mock()
         movie = Movie.create(
             title="Test Movie",
             year=2020,
@@ -47,8 +46,8 @@ class TestGetMovieByIdUseCase:
             file_size=1_000_000_000,
             resolution="1080p",
         )
-        mock_repo.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(movie_repository=mock_repo)
+        mocks.movies.find_by_id.return_value = movie
+        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
 
@@ -56,7 +55,7 @@ class TestGetMovieByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_genres_as_strings(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
+        mocks = make_media_uow_mock()
         movie = Movie.create(
             title="Test Movie",
             year=2020,
@@ -67,8 +66,8 @@ class TestGetMovieByIdUseCase:
         )
         movie = movie.with_genre("Action")
         movie = movie.with_genre("Sci-Fi")
-        mock_repo.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(movie_repository=mock_repo)
+        mocks.movies.find_by_id.return_value = movie
+        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
 
@@ -76,7 +75,7 @@ class TestGetMovieByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_handle_optional_fields_as_none(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
+        mocks = make_media_uow_mock()
         movie = Movie.create(
             title="Test Movie",
             year=2020,
@@ -85,8 +84,8 @@ class TestGetMovieByIdUseCase:
             file_size=1_000_000_000,
             resolution="1080p",
         )
-        mock_repo.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(movie_repository=mock_repo)
+        mocks.movies.find_by_id.return_value = movie
+        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
 
@@ -99,9 +98,9 @@ class TestGetMovieByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_not_found_when_movie_missing(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.find_by_id.return_value = None
-        use_case = GetMovieByIdUseCase(movie_repository=mock_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
+        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(GetMovieByIdInput(movie_id="mov_nonexistent1"))
@@ -111,7 +110,7 @@ class TestGetMovieByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_call_repository_with_movie_id(self):
-        mock_repo = AsyncMock(spec=MovieRepository)
+        mocks = make_media_uow_mock()
         movie = Movie.create(
             title="Test Movie",
             year=2020,
@@ -120,11 +119,11 @@ class TestGetMovieByIdUseCase:
             file_size=1_000_000_000,
             resolution="1080p",
         )
-        mock_repo.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(movie_repository=mock_repo)
+        mocks.movies.find_by_id.return_value = movie
+        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
 
-        mock_repo.find_by_id.assert_called_once()
-        call_arg = mock_repo.find_by_id.call_args[0][0]
+        mocks.movies.find_by_id.assert_called_once()
+        call_arg = mocks.movies.find_by_id.call_args[0][0]
         assert str(call_arg) == str(movie.id)

--- a/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
@@ -9,7 +9,6 @@ from src.modules.media.application.dtos import GetSeriesByIdInput, SeriesOutput
 from src.modules.media.application.ports import ProgressLookupPort
 from src.modules.media.application.use_cases import GetSeriesByIdUseCase
 from src.modules.media.domain.entities import Episode, Season, Series
-from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
@@ -19,6 +18,7 @@ from src.modules.media.domain.value_objects import (
     SeasonId,
     Title,
 )
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 @pytest.fixture()
@@ -34,14 +34,14 @@ class TestGetSeriesByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_series_when_found(self, mock_progress_lookup):
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(
             title="Breaking Bad",
             start_year=2008,
         )
-        mock_repo.find_by_id.return_value = series
+        mocks.series.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
-            series_repository=mock_repo,
+            uow_factory=mocks.factory,
             progress_lookup=mock_progress_lookup,
         )
 
@@ -54,7 +54,7 @@ class TestGetSeriesByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_series_with_seasons(self, mock_progress_lookup):
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(
             title="Breaking Bad",
             start_year=2008,
@@ -66,9 +66,9 @@ class TestGetSeriesByIdUseCase:
             season_number=1,
         )
         series = series.with_season(season)
-        mock_repo.find_by_id.return_value = series
+        mocks.series.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
-            series_repository=mock_repo,
+            uow_factory=mocks.factory,
             progress_lookup=mock_progress_lookup,
         )
 
@@ -80,7 +80,7 @@ class TestGetSeriesByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_series_with_episodes(self, mock_progress_lookup):
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(
             title="Breaking Bad",
             start_year=2008,
@@ -108,9 +108,9 @@ class TestGetSeriesByIdUseCase:
         )
         season = season.with_episode(episode)
         series = series.with_season(season)
-        mock_repo.find_by_id.return_value = series
+        mocks.series.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
-            series_repository=mock_repo,
+            uow_factory=mocks.factory,
             progress_lookup=mock_progress_lookup,
         )
 
@@ -125,14 +125,14 @@ class TestGetSeriesByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_ongoing_status(self, mock_progress_lookup):
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(
             title="Ongoing Show",
             start_year=2020,
         )
-        mock_repo.find_by_id.return_value = series
+        mocks.series.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
-            series_repository=mock_repo,
+            uow_factory=mocks.factory,
             progress_lookup=mock_progress_lookup,
         )
 
@@ -143,15 +143,15 @@ class TestGetSeriesByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_completed_status(self, mock_progress_lookup):
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(
             title="Completed Show",
             start_year=2010,
             end_year=2015,
         )
-        mock_repo.find_by_id.return_value = series
+        mocks.series.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
-            series_repository=mock_repo,
+            uow_factory=mocks.factory,
             progress_lookup=mock_progress_lookup,
         )
 
@@ -162,10 +162,10 @@ class TestGetSeriesByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_not_found_when_series_missing(self, mock_progress_lookup):
-        mock_repo = AsyncMock(spec=SeriesRepository)
-        mock_repo.find_by_id.return_value = None
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = None
         use_case = GetSeriesByIdUseCase(
-            series_repository=mock_repo,
+            uow_factory=mocks.factory,
             progress_lookup=mock_progress_lookup,
         )
 
@@ -177,14 +177,14 @@ class TestGetSeriesByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_handle_series_with_no_seasons(self, mock_progress_lookup):
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(
             title="New Show",
             start_year=2024,
         )
-        mock_repo.find_by_id.return_value = series
+        mocks.series.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
-            series_repository=mock_repo,
+            uow_factory=mocks.factory,
             progress_lookup=mock_progress_lookup,
         )
 
@@ -196,15 +196,15 @@ class TestGetSeriesByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_genres_as_strings(self, mock_progress_lookup):
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(
             title="Drama Show",
             start_year=2020,
             genres=["Drama", "Thriller"],
         )
-        mock_repo.find_by_id.return_value = series
+        mocks.series.find_by_id.return_value = series
         use_case = GetSeriesByIdUseCase(
-            series_repository=mock_repo,
+            uow_factory=mocks.factory,
             progress_lookup=mock_progress_lookup,
         )
 

--- a/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
@@ -1,6 +1,5 @@
 """Tests for ListByGenreUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -16,7 +15,7 @@ from src.modules.media.application.dtos.catalog_dtos import (
 )
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.domain.entities import Movie, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _movie(title: str) -> Movie:
@@ -68,13 +67,12 @@ class TestListByGenreUseCase:
 
     @pytest.mark.asyncio
     async def test_should_merge_movies_and_series_alphabetically(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
             [_movie("Avatar"), _movie("Cyrano")]
         )
-        series_repo.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        mocks.series.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListByGenreInput(genre="Action"))
 
@@ -85,11 +83,10 @@ class TestListByGenreUseCase:
 
     @pytest.mark.asyncio
     async def test_should_tag_each_item_with_its_type(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page([_movie("Avatar")])
-        series_repo.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page([_movie("Avatar")])
+        mocks.series.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListByGenreInput(genre="Action"))
 
@@ -98,11 +95,10 @@ class TestListByGenreUseCase:
 
     @pytest.mark.asyncio
     async def test_should_pass_decoded_cursors_to_each_repo(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page([])
-        series_repo.list_paginated_by_genre.return_value = _series_page([])
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page([])
+        mocks.series.list_paginated_by_genre.return_value = _series_page([])
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         # Build a real dual cursor so the use case decodes it
         from src.building_blocks.application.pagination import encode_dual_cursor
@@ -110,8 +106,8 @@ class TestListByGenreUseCase:
         cursor = encode_dual_cursor("movies-token", "series-token")
         await use_case.execute(ListByGenreInput(genre="Action", cursor=cursor))
 
-        movie_call_kwargs = movie_repo.list_paginated_by_genre.await_args.kwargs
-        series_call_kwargs = series_repo.list_paginated_by_genre.await_args.kwargs
+        movie_call_kwargs = mocks.movies.list_paginated_by_genre.await_args.kwargs
+        series_call_kwargs = mocks.series.list_paginated_by_genre.await_args.kwargs
         assert movie_call_kwargs["cursor"] == "movies-token"
         assert series_call_kwargs["cursor"] == "series-token"
 
@@ -121,19 +117,18 @@ class TestListByGenreUseCase:
         # alphabetically before any series). The series cursor must
         # stay at its previous value so the next page re-considers
         # the same starting series.
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
             [_movie("Apple"), _movie("Banana")],
             has_more=True,
         )
         # Series with title "Zebra" — sorts AFTER both movies, so it
         # won't fit in a 2-item page.
-        series_repo.list_paginated_by_genre.return_value = _series_page(
+        mocks.series.list_paginated_by_genre.return_value = _series_page(
             [_series("Zebra")],
             has_more=False,
         )
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         from src.building_blocks.application.pagination import encode_dual_cursor
 
@@ -155,20 +150,19 @@ class TestListByGenreUseCase:
     async def test_should_truncate_to_requested_limit_and_set_has_more(
         self,
     ) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         # Each repo returns 3 items, total 6 — limit 2 means 4 are
         # left over and `has_more` must be true even if neither
         # individual repo says so.
-        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
             [_movie("Apple"), _movie("Cherry"), _movie("Eggplant")],
             has_more=False,
         )
-        series_repo.list_paginated_by_genre.return_value = _series_page(
+        mocks.series.list_paginated_by_genre.return_value = _series_page(
             [_series("Banana"), _series("Date"), _series("Fig")],
             has_more=False,
         )
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListByGenreInput(genre="Action", limit=2))
 
@@ -178,15 +172,14 @@ class TestListByGenreUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_no_cursor_when_both_streams_exhausted(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
             [_movie("Avatar")], has_more=False
         )
-        series_repo.list_paginated_by_genre.return_value = _series_page(
+        mocks.series.list_paginated_by_genre.return_value = _series_page(
             [_series("Breaking Bad")], has_more=False
         )
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListByGenreInput(genre="Action", limit=10))
 
@@ -196,11 +189,10 @@ class TestListByGenreUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_when_no_items_match(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page([])
-        series_repo.list_paginated_by_genre.return_value = _series_page([])
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page([])
+        mocks.series.list_paginated_by_genre.return_value = _series_page([])
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListByGenreInput(genre="NoSuchGenre"))
 
@@ -213,33 +205,31 @@ class TestListByGenreUseCase:
         # media_type="movie" restricts the merge to the movie stream
         # — series repo stays silent so the output is a pure movies
         # listing for the Movies tab.
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
             [_movie("Avatar"), _movie("Cyrano")]
         )
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListByGenreInput(genre="Action", media_type="movie"))
 
-        movie_repo.list_paginated_by_genre.assert_awaited_once()
-        series_repo.list_paginated_by_genre.assert_not_awaited()
+        mocks.movies.list_paginated_by_genre.assert_awaited_once()
+        mocks.series.list_paginated_by_genre.assert_not_awaited()
         assert [item.type for item in result.items] == ["movie", "movie"]
         assert [item.title for item in result.items] == ["Avatar", "Cyrano"]
 
     @pytest.mark.asyncio
     async def test_should_skip_movie_repo_when_filtered_to_series(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.list_paginated_by_genre.return_value = _series_page(
+        mocks = make_media_uow_mock()
+        mocks.series.list_paginated_by_genre.return_value = _series_page(
             [_series("Breaking Bad"), _series("Dark")]
         )
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListByGenreInput(genre="Action", media_type="series"))
 
-        series_repo.list_paginated_by_genre.assert_awaited_once()
-        movie_repo.list_paginated_by_genre.assert_not_awaited()
+        mocks.series.list_paginated_by_genre.assert_awaited_once()
+        mocks.movies.list_paginated_by_genre.assert_not_awaited()
         assert [item.type for item in result.items] == ["series", "series"]
         assert [item.title for item in result.items] == ["Breaking Bad", "Dark"]
 
@@ -251,13 +241,12 @@ class TestListByGenreUseCase:
         # cursor should advance — the skipped stream's slot in the
         # dual cursor must round-trip unchanged so a later unfiltered
         # request doesn't have to start from scratch.
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page(
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
             [_movie("Apple"), _movie("Banana")],
             has_more=True,
         )
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         from src.building_blocks.application.pagination import encode_dual_cursor
 
@@ -278,11 +267,10 @@ class TestListByGenreUseCase:
 
     @pytest.mark.asyncio
     async def test_catalog_item_output_carries_required_fields(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_paginated_by_genre.return_value = _movies_page([_movie("Test")])
-        series_repo.list_paginated_by_genre.return_value = _series_page([])
-        use_case = ListByGenreUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page([_movie("Test")])
+        mocks.series.list_paginated_by_genre.return_value = _series_page([])
+        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListByGenreInput(genre="Action"))
 

--- a/tests/modules/media/unit/application/use_cases/test_list_genres.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_genres.py
@@ -1,6 +1,5 @@
 """Tests for ListGenresUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -10,8 +9,8 @@ from src.modules.media.application.dtos.catalog_dtos import (
     ListGenresOutput,
 )
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
 from src.modules.media.domain.repositories.movie_repository import GenreRow
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _row(canonical: list[str], localized: list[str] | None = None) -> GenreRow:
@@ -24,17 +23,16 @@ class TestListGenresUseCase:
 
     @pytest.mark.asyncio
     async def test_should_count_unique_genres_across_movies_and_series(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_genre_rows.return_value = [
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = [
             _row(["Action", "Comedy"]),
             _row(["Action"]),
         ]
-        series_repo.list_genre_rows.return_value = [
+        mocks.series.list_genre_rows.return_value = [
             _row(["Comedy"]),
             _row(["Drama"]),
         ]
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListGenresInput())
 
@@ -44,9 +42,8 @@ class TestListGenresUseCase:
 
     @pytest.mark.asyncio
     async def test_should_sort_by_count_desc_then_alphabetical(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_genre_rows.return_value = [
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = [
             _row(["Drama"]),
             _row(["Drama"]),
             _row(["Drama"]),
@@ -55,8 +52,8 @@ class TestListGenresUseCase:
             _row(["Action"]),
             _row(["Action"]),
         ]
-        series_repo.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        mocks.series.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListGenresInput())
 
@@ -65,14 +62,13 @@ class TestListGenresUseCase:
 
     @pytest.mark.asyncio
     async def test_should_use_first_seen_localized_label(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_genre_rows.return_value = [
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = [
             _row(["Action"], ["Ação"]),
             _row(["Action"], ["A Wrong Translation"]),  # ignored — first wins
         ]
-        series_repo.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        mocks.series.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListGenresInput(lang="pt-BR"))
 
@@ -80,12 +76,11 @@ class TestListGenresUseCase:
 
     @pytest.mark.asyncio
     async def test_should_fall_back_to_canonical_when_no_localized_label(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         # No localized genres available — repo returns empty list for that field
-        movie_repo.list_genre_rows.return_value = [_row(["Action"])]
-        series_repo.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        mocks.movies.list_genre_rows.return_value = [_row(["Action"])]
+        mocks.series.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListGenresInput(lang="pt-BR"))
 
@@ -96,14 +91,13 @@ class TestListGenresUseCase:
     async def test_should_skip_empty_localized_label(self) -> None:
         # An empty string in the localized list shouldn't beat a later
         # non-empty translation. The "first non-empty" rule.
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_genre_rows.return_value = [
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = [
             _row(["Action"], [""]),
             _row(["Action"], ["Ação"]),
         ]
-        series_repo.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        mocks.series.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListGenresInput(lang="pt-BR"))
 
@@ -111,11 +105,10 @@ class TestListGenresUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_no_rows(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_genre_rows.return_value = []
-        series_repo.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = []
+        mocks.series.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListGenresInput())
 
@@ -123,16 +116,15 @@ class TestListGenresUseCase:
 
     @pytest.mark.asyncio
     async def test_should_pass_lang_through_to_repos(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_genre_rows.return_value = []
-        series_repo.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = []
+        mocks.series.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(ListGenresInput(lang="pt-BR"))
 
-        movie_repo.list_genre_rows.assert_awaited_once_with("pt-BR")
-        series_repo.list_genre_rows.assert_awaited_once_with("pt-BR")
+        mocks.movies.list_genre_rows.assert_awaited_once_with("pt-BR")
+        mocks.series.list_genre_rows.assert_awaited_once_with("pt-BR")
 
     @pytest.mark.asyncio
     async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
@@ -140,30 +132,28 @@ class TestListGenresUseCase:
         # repo — the series repo must not be called at all so the
         # counts reflect movies only (and the Movies tab on the
         # frontend doesn't surface series-only genres).
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_genre_rows.return_value = [_row(["Action"]), _row(["Comedy"])]
-        series_repo.list_genre_rows.return_value = [_row(["Drama"])]
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = [_row(["Action"]), _row(["Comedy"])]
+        mocks.series.list_genre_rows.return_value = [_row(["Drama"])]
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListGenresInput(media_type="movie"))
 
-        movie_repo.list_genre_rows.assert_awaited_once()
-        series_repo.list_genre_rows.assert_not_awaited()
+        mocks.movies.list_genre_rows.assert_awaited_once()
+        mocks.series.list_genre_rows.assert_not_awaited()
         assert {g.id for g in result.genres} == {"Action", "Comedy"}
 
     @pytest.mark.asyncio
     async def test_should_skip_movie_repo_when_filtered_to_series(self) -> None:
         # Mirror of the previous test — Series tab should only hit
         # the series repo.
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.list_genre_rows.return_value = [_row(["Action"])]
-        series_repo.list_genre_rows.return_value = [_row(["Drama"]), _row(["Thriller"])]
-        use_case = ListGenresUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = [_row(["Action"])]
+        mocks.series.list_genre_rows.return_value = [_row(["Drama"]), _row(["Thriller"])]
+        use_case = ListGenresUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListGenresInput(media_type="series"))
 
-        series_repo.list_genre_rows.assert_awaited_once()
-        movie_repo.list_genre_rows.assert_not_awaited()
+        mocks.series.list_genre_rows.assert_awaited_once()
+        mocks.movies.list_genre_rows.assert_not_awaited()
         assert {g.id for g in result.genres} == {"Drama", "Thriller"}

--- a/tests/modules/media/unit/application/use_cases/test_list_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies.py
@@ -1,14 +1,12 @@
 """Tests for ListMoviesUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.building_blocks.application.pagination import PaginatedResult, Pagination
 from src.modules.media.application.dtos import ListMoviesInput, ListMoviesOutput, MovieSummaryOutput
 from src.modules.media.application.use_cases import ListMoviesUseCase
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.repositories import MovieRepository
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _make_movie(title: str = "Test Movie", year: int = 2020) -> Movie:
@@ -41,12 +39,12 @@ class TestListMoviesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_first_page(self) -> None:
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.list_paginated.return_value = _page(
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated.return_value = _page(
             [_make_movie("Movie 1"), _make_movie("Movie 2")],
             has_more=False,
         )
-        use_case = ListMoviesUseCase(movie_repository=mock_repo)
+        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListMoviesInput())
 
@@ -56,7 +54,7 @@ class TestListMoviesUseCase:
         assert result.next_cursor is None
         # include_total defaults to False → repo gets include_total=False → total_count is None
         assert result.total_count is None
-        mock_repo.list_paginated.assert_awaited_once_with(
+        mocks.movies.list_paginated.assert_awaited_once_with(
             cursor=None,
             limit=20,
             include_total=False,
@@ -64,10 +62,10 @@ class TestListMoviesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_convert_movies_to_summaries(self) -> None:
-        mock_repo = AsyncMock(spec=MovieRepository)
+        mocks = make_media_uow_mock()
         movie = _make_movie("Test Movie", 2020).with_genre("Action")
-        mock_repo.list_paginated.return_value = _page([movie])
-        use_case = ListMoviesUseCase(movie_repository=mock_repo)
+        mocks.movies.list_paginated.return_value = _page([movie])
+        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListMoviesInput())
 
@@ -81,13 +79,13 @@ class TestListMoviesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_pass_cursor_and_limit_to_repository(self) -> None:
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.list_paginated.return_value = _page([])
-        use_case = ListMoviesUseCase(movie_repository=mock_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated.return_value = _page([])
+        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(ListMoviesInput(cursor="abc123", limit=15))
 
-        mock_repo.list_paginated.assert_awaited_once_with(
+        mocks.movies.list_paginated.assert_awaited_once_with(
             cursor="abc123",
             limit=15,
             include_total=False,
@@ -95,13 +93,13 @@ class TestListMoviesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_propagate_next_cursor_and_has_more(self) -> None:
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.list_paginated.return_value = _page(
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated.return_value = _page(
             [_make_movie("Movie 1")],
             next_cursor="next-token",
             has_more=True,
         )
-        use_case = ListMoviesUseCase(movie_repository=mock_repo)
+        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListMoviesInput())
 
@@ -110,9 +108,9 @@ class TestListMoviesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_page_when_no_movies(self) -> None:
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.list_paginated.return_value = _page([])
-        use_case = ListMoviesUseCase(movie_repository=mock_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated.return_value = _page([])
+        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListMoviesInput())
 
@@ -122,17 +120,17 @@ class TestListMoviesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_request_total_when_include_total_is_true(self) -> None:
-        mock_repo = AsyncMock(spec=MovieRepository)
-        mock_repo.list_paginated.return_value = _page(
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated.return_value = _page(
             [_make_movie("Movie 1")],
             total_count=42,
         )
-        use_case = ListMoviesUseCase(movie_repository=mock_repo)
+        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListMoviesInput(include_total=True))
 
         assert result.total_count == 42
-        mock_repo.list_paginated.assert_awaited_once_with(
+        mocks.movies.list_paginated.assert_awaited_once_with(
             cursor=None,
             limit=20,
             include_total=True,

--- a/tests/modules/media/unit/application/use_cases/test_list_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series.py
@@ -1,6 +1,5 @@
 """Tests for ListSeriesUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -12,7 +11,7 @@ from src.modules.media.application.dtos import (
 )
 from src.modules.media.application.use_cases import ListSeriesUseCase
 from src.modules.media.domain.entities import Series
-from src.modules.media.domain.repositories import SeriesRepository
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _page(
@@ -34,14 +33,14 @@ class TestListSeriesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_first_page(self) -> None:
-        mock_repo = AsyncMock(spec=SeriesRepository)
-        mock_repo.list_paginated.return_value = _page(
+        mocks = make_media_uow_mock()
+        mocks.series.list_paginated.return_value = _page(
             [
                 Series.create(title="Show 1", start_year=2020),
                 Series.create(title="Show 2", start_year=2021),
             ]
         )
-        use_case = ListSeriesUseCase(series_repository=mock_repo)
+        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListSeriesInput())
 
@@ -50,7 +49,7 @@ class TestListSeriesUseCase:
         assert result.has_more is False
         assert result.next_cursor is None
         assert result.total_count is None
-        mock_repo.list_paginated.assert_awaited_once_with(
+        mocks.series.list_paginated.assert_awaited_once_with(
             cursor=None,
             limit=20,
             include_total=False,
@@ -58,15 +57,15 @@ class TestListSeriesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_convert_series_to_summaries(self) -> None:
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(
             title="Breaking Bad",
             start_year=2008,
             end_year=2013,
             genres=["Drama", "Crime"],
         )
-        mock_repo.list_paginated.return_value = _page([series])
-        use_case = ListSeriesUseCase(series_repository=mock_repo)
+        mocks.series.list_paginated.return_value = _page([series])
+        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListSeriesInput())
 
@@ -80,13 +79,13 @@ class TestListSeriesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_pass_cursor_and_limit_to_repository(self) -> None:
-        mock_repo = AsyncMock(spec=SeriesRepository)
-        mock_repo.list_paginated.return_value = _page([])
-        use_case = ListSeriesUseCase(series_repository=mock_repo)
+        mocks = make_media_uow_mock()
+        mocks.series.list_paginated.return_value = _page([])
+        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(ListSeriesInput(cursor="abc123", limit=15))
 
-        mock_repo.list_paginated.assert_awaited_once_with(
+        mocks.series.list_paginated.assert_awaited_once_with(
             cursor="abc123",
             limit=15,
             include_total=False,
@@ -94,13 +93,13 @@ class TestListSeriesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_propagate_next_cursor_and_has_more(self) -> None:
-        mock_repo = AsyncMock(spec=SeriesRepository)
-        mock_repo.list_paginated.return_value = _page(
+        mocks = make_media_uow_mock()
+        mocks.series.list_paginated.return_value = _page(
             [Series.create(title="Show 1", start_year=2020)],
             next_cursor="next-token",
             has_more=True,
         )
-        use_case = ListSeriesUseCase(series_repository=mock_repo)
+        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListSeriesInput())
 
@@ -109,9 +108,9 @@ class TestListSeriesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_page_when_no_series(self) -> None:
-        mock_repo = AsyncMock(spec=SeriesRepository)
-        mock_repo.list_paginated.return_value = _page([])
-        use_case = ListSeriesUseCase(series_repository=mock_repo)
+        mocks = make_media_uow_mock()
+        mocks.series.list_paginated.return_value = _page([])
+        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListSeriesInput())
 
@@ -121,10 +120,10 @@ class TestListSeriesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_indicate_ongoing_series(self) -> None:
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(title="Ongoing Show", start_year=2020)
-        mock_repo.list_paginated.return_value = _page([series])
-        use_case = ListSeriesUseCase(series_repository=mock_repo)
+        mocks.series.list_paginated.return_value = _page([series])
+        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListSeriesInput())
 
@@ -133,10 +132,10 @@ class TestListSeriesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_include_season_and_episode_counts(self) -> None:
-        mock_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         series = Series.create(title="Test Show", start_year=2020)
-        mock_repo.list_paginated.return_value = _page([series])
-        use_case = ListSeriesUseCase(series_repository=mock_repo)
+        mocks.series.list_paginated.return_value = _page([series])
+        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListSeriesInput())
 
@@ -145,17 +144,17 @@ class TestListSeriesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_request_total_when_include_total_is_true(self) -> None:
-        mock_repo = AsyncMock(spec=SeriesRepository)
-        mock_repo.list_paginated.return_value = _page(
+        mocks = make_media_uow_mock()
+        mocks.series.list_paginated.return_value = _page(
             [Series.create(title="Show 1", start_year=2020)],
             total_count=10,
         )
-        use_case = ListSeriesUseCase(series_repository=mock_repo)
+        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(ListSeriesInput(include_total=True))
 
         assert result.total_count == 10
-        mock_repo.list_paginated.assert_awaited_once_with(
+        mocks.series.list_paginated.assert_awaited_once_with(
             cursor=None,
             limit=20,
             include_total=True,

--- a/tests/modules/media/unit/application/use_cases/test_search_catalog.py
+++ b/tests/modules/media/unit/application/use_cases/test_search_catalog.py
@@ -1,6 +1,5 @@
 """Tests for SearchCatalogUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
 
@@ -11,7 +10,7 @@ from src.modules.media.application.dtos.search_dtos import (
 )
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
 from src.modules.media.domain.entities import Movie, Series
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _movie(title: str) -> Movie:
@@ -35,12 +34,11 @@ class TestSearchCatalogUseCase:
 
     @pytest.mark.asyncio
     async def test_should_merge_results_from_both_repos_by_rank(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
+        mocks = make_media_uow_mock()
         # Movie rank -5 (better) + series rank -2 (worse)
-        movie_repo.search.return_value = [(_movie("Inception"), -5.0)]
-        series_repo.search.return_value = [(_series("Breaking Bad"), -2.0)]
-        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+        mocks.movies.search.return_value = [(_movie("Inception"), -5.0)]
+        mocks.series.search.return_value = [(_series("Breaking Bad"), -2.0)]
+        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(SearchInput(query="test"))
 
@@ -51,46 +49,43 @@ class TestSearchCatalogUseCase:
 
     @pytest.mark.asyncio
     async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.search.return_value = [(_movie("Avatar"), -3.0)]
-        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.search.return_value = [(_movie("Avatar"), -3.0)]
+        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(SearchInput(query="avatar", media_type="movie"))
 
-        movie_repo.search.assert_awaited_once()
-        series_repo.search.assert_not_awaited()
+        mocks.movies.search.assert_awaited_once()
+        mocks.series.search.assert_not_awaited()
         assert len(result.items) == 1
         assert result.items[0].type == "movie"
 
     @pytest.mark.asyncio
     async def test_should_skip_movie_repo_when_filtered_to_series(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        series_repo.search.return_value = [(_series("Dark"), -4.0)]
-        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.series.search.return_value = [(_series("Dark"), -4.0)]
+        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(SearchInput(query="dark", media_type="series"))
 
-        series_repo.search.assert_awaited_once()
-        movie_repo.search.assert_not_awaited()
+        mocks.series.search.assert_awaited_once()
+        mocks.movies.search.assert_not_awaited()
         assert len(result.items) == 1
         assert result.items[0].type == "series"
 
     @pytest.mark.asyncio
     async def test_should_trim_combined_results_to_limit(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.search.return_value = [
+        mocks = make_media_uow_mock()
+        mocks.movies.search.return_value = [
             (_movie("A"), -5.0),
             (_movie("B"), -4.0),
             (_movie("C"), -3.0),
         ]
-        series_repo.search.return_value = [
+        mocks.series.search.return_value = [
             (_series("D"), -2.0),
             (_series("E"), -1.0),
         ]
-        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(SearchInput(query="test", limit=3))
 
@@ -99,11 +94,10 @@ class TestSearchCatalogUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_when_no_matches(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.search.return_value = []
-        series_repo.search.return_value = []
-        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.search.return_value = []
+        mocks.series.search.return_value = []
+        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(SearchInput(query="nonexistent"))
 
@@ -112,11 +106,10 @@ class TestSearchCatalogUseCase:
 
     @pytest.mark.asyncio
     async def test_should_forward_filters_to_repos(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.search.return_value = []
-        series_repo.search.return_value = []
-        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.search.return_value = []
+        mocks.series.search.return_value = []
+        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
 
         await use_case.execute(
             SearchInput(
@@ -128,7 +121,7 @@ class TestSearchCatalogUseCase:
             )
         )
 
-        call_kwargs = movie_repo.search.await_args
+        call_kwargs = mocks.movies.search.await_args
         assert call_kwargs.kwargs["genre"] == "Action"
         assert call_kwargs.kwargs["year_min"] == 2000
         assert call_kwargs.kwargs["year_max"] == 2020
@@ -136,11 +129,10 @@ class TestSearchCatalogUseCase:
 
     @pytest.mark.asyncio
     async def test_search_item_output_carries_required_fields(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.search.return_value = [(_movie("Test Movie"), -5.0)]
-        series_repo.search.return_value = [(_series("Test Series"), -3.0)]
-        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.search.return_value = [(_movie("Test Movie"), -5.0)]
+        mocks.series.search.return_value = [(_series("Test Series"), -3.0)]
+        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(SearchInput(query="test"))
 
@@ -153,11 +145,10 @@ class TestSearchCatalogUseCase:
 
     @pytest.mark.asyncio
     async def test_should_tag_items_with_correct_type(self) -> None:
-        movie_repo = AsyncMock(spec=MovieRepository)
-        series_repo = AsyncMock(spec=SeriesRepository)
-        movie_repo.search.return_value = [(_movie("Avatar"), -5.0)]
-        series_repo.search.return_value = [(_series("Dark"), -3.0)]
-        use_case = SearchCatalogUseCase(movie_repo, series_repo)
+        mocks = make_media_uow_mock()
+        mocks.movies.search.return_value = [(_movie("Avatar"), -5.0)]
+        mocks.series.search.return_value = [(_series("Dark"), -3.0)]
+        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(SearchInput(query="test"))
 


### PR DESCRIPTION
## Summary
- Ten Media read use cases now take `MediaUnitOfWorkFactory` instead of `MovieRepository`/`SeriesRepository` directly (`GetMovieById`, `ListMovies`, `GetSeriesById`, `ListSeries`, `GetFeaturedMedia`, `ListGenres`, `ListByGenre`, `SearchCatalog`, `GetFileVariants`, `BulkEnrichMetadata`). Each one opens a UoW, reads, and releases the session on exit.
- `ListByGenre` and `SearchCatalog` keep their concurrent fetches: each branch of `asyncio.gather` opens its own UoW so two parallel queries never hit the same `AsyncSession` (which forbids it).
- Tests migrate to the existing `make_media_uow_mock` helper.
- `MediaContainer` keeps the `movie_repository` / `series_repository` providers — they remain wired into cross-BC ACL adapters and get removed once those migrate (PRs 3–5) and the session plumbing is deleted in PR 7.

## Test plan
- [x] `poetry run pytest` — 1693 passed
- [x] `poetry run ruff check src tests` — clean

## Related
- PR 2 of 7; see `docs/uow-full-clean-refactoring-plan.md` for the full plan.

## Summary by Sourcery

Refactor media read-side use cases to depend on a media Unit-of-Work factory instead of repositories and ensure concurrent operations use separate sessions.

Enhancements:
- Switch media read use cases (listing, lookup, search, featured, genres, and bulk metadata enrichment) to use MediaUnitOfWorkFactory for data access, opening scoped units of work per operation and concurrent branch.
- Update the media DI container wiring so these use cases receive a Unit-of-Work factory rather than concrete movie/series repositories.
- Adjust UoW usage in search and by-genre flows so parallel queries run on independent sessions while preserving existing pagination and merging semantics.

Tests:
- Update media use case unit tests to rely on the shared make_media_uow_mock helper instead of mocking repositories directly, aligning tests with the new Unit-of-Work-based design.