### PR TITLE
refactor(library): migrate reads and MediaCountQueryAdapter to UoW

### DIFF
--- a/src/config/containers/library.py
+++ b/src/config/containers/library.py
@@ -13,9 +13,6 @@ from src.modules.library.application.use_cases.list_libraries import ListLibrari
 from src.modules.library.application.use_cases.update_library import UpdateLibraryUseCase
 from src.modules.library.domain.services.track_selector import TrackSelector
 from src.modules.library.infrastructure.acl import MediaCountQueryAdapter
-from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
-    SqlAlchemyLibraryRepository,
-)
 from src.modules.library.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyLibraryUnitOfWorkFactory,
 )
@@ -25,30 +22,22 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Library bounded context dependencies.
 
     Provides:
-    - Repository implementation (SQLAlchemy) for read use cases
-    - Unit of Work factory for write use cases
+    - Unit of Work factory (reads and writes both go through it)
     - ACL adapter for the Media BC read port
     - CRUD use cases
     - Domain services
     """
 
     # Wired from InfrastructureContainer via main container.
-    session = providers.Dependency()
     session_factory = providers.Dependency()
-    # Media repositories come in so the ACL adapter can delegate
-    # count queries. The use cases themselves only know the
-    # ``MediaCountQueryPort`` — they never see these concretes.
-    movie_repository = providers.Dependency()
-    series_repository = providers.Dependency()
+    # Media UoW factory comes in so the ACL adapter can open short-lived
+    # transactions against the Media catalog for count queries. Use
+    # cases themselves only know ``MediaCountQueryPort``.
+    media_uow_factory = providers.Dependency()
 
     # =========================================================================
-    # Repositories (read-only) and Unit of Work (writes)
+    # Unit of Work
     # =========================================================================
-
-    library_repository = providers.Factory(
-        SqlAlchemyLibraryRepository,
-        session=session,
-    )
 
     library_unit_of_work_factory = providers.Singleton(
         SqlAlchemyLibraryUnitOfWorkFactory,
@@ -61,8 +50,7 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     media_count_query = providers.Factory(
         MediaCountQueryAdapter,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_uow_factory=media_uow_factory,
     )
 
     # =========================================================================
@@ -77,13 +65,13 @@ class LibraryContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     list_libraries = providers.Factory(
         ListLibrariesUseCase,
-        library_repository=library_repository,
+        uow_factory=library_unit_of_work_factory,
         media_count_query=media_count_query,
     )
 
     get_library_by_id = providers.Factory(
         GetLibraryByIdUseCase,
-        library_repository=library_repository,
+        uow_factory=library_unit_of_work_factory,
         media_count_query=media_count_query,
     )
 

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -68,10 +68,8 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     library = providers.Container(
         LibraryContainer,
-        session=infrastructure.session,
         session_factory=infrastructure.session_factory,
-        movie_repository=media.movie_repository,
-        series_repository=media.series_repository,
+        media_uow_factory=media.media_unit_of_work_factory,
     )
 
     preferences = providers.Container(

--- a/src/modules/library/application/use_cases/get_library_by_id.py
+++ b/src/modules/library/application/use_cases/get_library_by_id.py
@@ -6,9 +6,9 @@ from src.modules.library.application.dtos.library_dtos import (
     LibraryOutput,
 )
 from src.modules.library.application.ports import MediaCountQueryPort
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.library.application.use_cases._counts import resolve_counts
 from src.modules.library.application.use_cases._to_output import library_to_output
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
 
 
@@ -17,10 +17,10 @@ class GetLibraryByIdUseCase:
 
     def __init__(
         self,
-        library_repository: LibraryRepository,
+        uow_factory: LibraryUnitOfWorkFactory,
         media_count_query: MediaCountQueryPort,
     ) -> None:
-        self._repo = library_repository
+        self._uow_factory = uow_factory
         self._media_count_query = media_count_query
 
     async def execute(self, input_dto: GetLibraryByIdInput) -> LibraryOutput:
@@ -37,7 +37,8 @@ class GetLibraryByIdUseCase:
                 non-deleted library.
         """
         library_id = LibraryId(input_dto.library_id)
-        entity = await self._repo.find_by_id(library_id)
+        async with self._uow_factory() as uow:
+            entity = await uow.libraries.find_by_id(library_id)
         if entity is None:
             raise ResourceNotFoundException.for_resource(
                 "Library",

--- a/src/modules/library/application/use_cases/list_libraries.py
+++ b/src/modules/library/application/use_cases/list_libraries.py
@@ -2,9 +2,9 @@
 
 from src.modules.library.application.dtos.library_dtos import LibraryOutput
 from src.modules.library.application.ports import MediaCountQueryPort
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.library.application.use_cases._counts import resolve_counts
 from src.modules.library.application.use_cases._to_output import library_to_output
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
 
 
 class ListLibrariesUseCase:
@@ -12,28 +12,27 @@ class ListLibrariesUseCase:
 
     def __init__(
         self,
-        library_repository: LibraryRepository,
+        uow_factory: LibraryUnitOfWorkFactory,
         media_count_query: MediaCountQueryPort,
     ) -> None:
-        self._repo = library_repository
+        self._uow_factory = uow_factory
         self._media_count_query = media_count_query
 
     async def execute(self) -> list[LibraryOutput]:
         """List all libraries.
 
-        The count queries fan out serially on purpose: every repo on
-        this request shares the same ``AsyncSession`` (see
-        ``session_manager.py``), and SQLAlchemy sessions forbid
-        concurrent ``execute`` calls on the same transaction — a
-        ``gather`` here raises ``InvalidRequestError`` the moment two
-        libraries exist. For tens of libraries the serial cost is
-        negligible; batching would require a dedicated short-lived
-        session per library and isn't worth the complexity today.
+        The count queries fan out serially: each
+        ``MediaCountQueryPort`` call opens its own short-lived
+        ``AsyncSession`` internally, so a ``gather`` would only buy
+        concurrency at the cost of spawning 2N connections for N
+        libraries. For tens of libraries the serial cost is
+        negligible.
 
         Returns:
             List of ``LibraryOutput`` ordered by name.
         """
-        entities = await self._repo.find_all()
+        async with self._uow_factory() as uow:
+            entities = await uow.libraries.find_all()
         outputs: list[LibraryOutput] = []
         for entity in entities:
             movie_count, series_count = await resolve_counts(entity, self._media_count_query)

--- a/src/modules/library/infrastructure/acl/media_count_query_adapter.py
+++ b/src/modules/library/infrastructure/acl/media_count_query_adapter.py
@@ -1,8 +1,8 @@
-"""Adapter that implements ``MediaCountQueryPort`` using Media repositories.
+"""Adapter that implements ``MediaCountQueryPort`` using the Media UoW.
 
-This is the only file in the Library BC that imports from
-``src.modules.media.domain``. The port surface isolates the rest of
-Library from the Media catalog.
+This is the only file in the Library BC that imports from the Media
+BC. The port surface isolates the rest of Library from the Media
+catalog — use cases depend only on ``MediaCountQueryPort``.
 """
 
 from collections.abc import Sequence
@@ -10,27 +10,24 @@ from collections.abc import Sequence
 from src.modules.library.application.ports.media_count_query_port import (
     MediaCountQueryPort,
 )
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 
 
 class MediaCountQueryAdapter(MediaCountQueryPort):
-    """Delegate count queries to the Media bounded context's repositories."""
+    """Delegate count queries to the Media bounded context's Unit of Work."""
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
 
     async def count_movies_under_paths(self, paths: Sequence[str]) -> int:
         """Delegate to ``MovieRepository.count_under_paths``."""
-        return await self._movie_repo.count_under_paths(paths)
+        async with self._media_uow_factory() as uow:
+            return await uow.movies.count_under_paths(paths)
 
     async def count_series_under_paths(self, paths: Sequence[str]) -> int:
         """Delegate to ``SeriesRepository.count_under_paths``."""
-        return await self._series_repo.count_under_paths(paths)
+        async with self._media_uow_factory() as uow:
+            return await uow.series.count_under_paths(paths)
 
 
 __all__ = ["MediaCountQueryAdapter"]

--- a/tests/modules/library/integration/acl/test_media_count_query_adapter.py
+++ b/tests/modules/library/integration/acl/test_media_count_query_adapter.py
@@ -1,7 +1,7 @@
 """Integration tests for MediaCountQueryAdapter."""
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.modules.library.infrastructure.acl import MediaCountQueryAdapter
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
@@ -19,6 +19,9 @@ from src.modules.media.domain.value_objects import (
 from src.modules.media.infrastructure.persistence.repositories import (
     SQLAlchemyMovieRepository,
     SQLAlchemySeriesRepository,
+)
+from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyMediaUnitOfWorkFactory,
 )
 
 
@@ -64,41 +67,46 @@ def _series_with_episode(title: str, file_path: str) -> Series:
 
 @pytest.mark.integration
 class TestMediaCountQueryAdapter:
-    """The adapter delegates counts to Media repositories."""
+    """The adapter delegates counts to the Media Unit of Work."""
 
     async def test_count_movies_under_paths_matches_repository(
-        self, db_session: AsyncSession
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
         await movie_repo.save(_movie("A", "/movies/a.mkv"))
         await movie_repo.save(_movie("B", "/movies/b.mkv"))
         await movie_repo.save(_movie("C", "/other/c.mkv"))
+        await db_session.commit()
 
-        adapter = MediaCountQueryAdapter(movie_repo, series_repo)
+        adapter = MediaCountQueryAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
         assert await adapter.count_movies_under_paths(["/movies"]) == 2
         assert await adapter.count_movies_under_paths(["/other"]) == 1
         assert await adapter.count_movies_under_paths(["/missing"]) == 0
 
     async def test_count_series_under_paths_matches_repository(
-        self, db_session: AsyncSession
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
         series_repo = SQLAlchemySeriesRepository(db_session)
         await series_repo.save(_series_with_episode("Series A", "/series/a/s01e01.mkv"))
         await series_repo.save(_series_with_episode("Series B", "/series/b/s01e01.mkv"))
+        await db_session.commit()
 
-        adapter = MediaCountQueryAdapter(movie_repo, series_repo)
+        adapter = MediaCountQueryAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
         assert await adapter.count_series_under_paths(["/series"]) == 2
         assert await adapter.count_series_under_paths(["/series/a"]) == 1
         assert await adapter.count_series_under_paths(["/missing"]) == 0
 
-    async def test_empty_paths_returns_zero(self, db_session: AsyncSession) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-        adapter = MediaCountQueryAdapter(movie_repo, series_repo)
+    async def test_empty_paths_returns_zero(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        adapter = MediaCountQueryAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
         assert await adapter.count_movies_under_paths([]) == 0
         assert await adapter.count_series_under_paths([]) == 0

--- a/tests/modules/library/integration/conftest.py
+++ b/tests/modules/library/integration/conftest.py
@@ -4,29 +4,49 @@ from collections.abc import AsyncGenerator
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
 
 from src.infrastructure.persistence import Base
 
 
 @pytest.fixture(scope="function")
-async def db_session() -> AsyncGenerator[AsyncSession, None]:
-    """Create an in-memory SQLite database session for testing."""
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """Expose an ``async_sessionmaker`` bound to an in-memory SQLite database.
+
+    ``StaticPool`` pins every connection to the same underlying SQLite
+    instance so sessions created for seeding (via ``db_session``) and
+    sessions opened later by a Unit of Work under test see the same
+    schema and rows.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    session_factory = async_sessionmaker(
+    factory = async_sessionmaker(
         bind=engine,
         class_=AsyncSession,
         expire_on_commit=False,
         autoflush=False,
     )
 
-    async with session_factory() as session:
-        yield session
+    yield factory
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
 
     await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+async def db_session(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[AsyncSession, None]:
+    """Seed-time session sharing the ``session_factory`` engine."""
+    async with session_factory() as session:
+        yield session

--- a/tests/modules/library/unit/application/use_cases/test_get_library_by_id.py
+++ b/tests/modules/library/unit/application/use_cases/test_get_library_by_id.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.library.unit.conftest import make_library_uow_mock
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.library.application.dtos.library_dtos import GetLibraryByIdInput
@@ -11,7 +12,6 @@ from src.modules.library.application.use_cases.get_library_by_id import (
     GetLibraryByIdUseCase,
 )
 from src.modules.library.domain.entities.library import Library
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
 from src.modules.library.domain.value_objects.library_id import LibraryId
 
 
@@ -29,9 +29,9 @@ class TestGetLibraryByIdUseCase:
     @pytest.mark.asyncio
     async def test_should_return_library_when_found(self) -> None:
         lib = Library.create(name="Movies", library_type="movies", paths=["/m"])
-        repo = AsyncMock(spec=LibraryRepository)
-        repo.find_by_id.return_value = lib
-        use_case = GetLibraryByIdUseCase(repo, _make_media_count_query())
+        mocks = make_library_uow_mock()
+        mocks.libraries.find_by_id.return_value = lib
+        use_case = GetLibraryByIdUseCase(mocks.factory, _make_media_count_query())
 
         result = await use_case.execute(
             GetLibraryByIdInput(library_id=str(lib.id)),
@@ -41,9 +41,9 @@ class TestGetLibraryByIdUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_not_found(self) -> None:
-        repo = AsyncMock(spec=LibraryRepository)
-        repo.find_by_id.return_value = None
-        use_case = GetLibraryByIdUseCase(repo, _make_media_count_query())
+        mocks = make_library_uow_mock()
+        mocks.libraries.find_by_id.return_value = None
+        use_case = GetLibraryByIdUseCase(mocks.factory, _make_media_count_query())
         lib_id = str(LibraryId.generate())
 
         with pytest.raises(ResourceNotFoundException):

--- a/tests/modules/library/unit/application/use_cases/test_list_libraries.py
+++ b/tests/modules/library/unit/application/use_cases/test_list_libraries.py
@@ -3,11 +3,11 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.library.unit.conftest import make_library_uow_mock
 
 from src.modules.library.application.ports import MediaCountQueryPort
 from src.modules.library.application.use_cases.list_libraries import ListLibrariesUseCase
 from src.modules.library.domain.entities.library import Library
-from src.modules.library.domain.repositories.library_repository import LibraryRepository
 
 
 def _make_media_count_query() -> AsyncMock:
@@ -23,9 +23,9 @@ class TestListLibrariesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_no_libraries(self) -> None:
-        repo = AsyncMock(spec=LibraryRepository)
-        repo.find_all.return_value = []
-        use_case = ListLibrariesUseCase(repo, _make_media_count_query())
+        mocks = make_library_uow_mock()
+        mocks.libraries.find_all.return_value = []
+        use_case = ListLibrariesUseCase(mocks.factory, _make_media_count_query())
 
         result = await use_case.execute()
 
@@ -33,12 +33,12 @@ class TestListLibrariesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_all_libraries(self) -> None:
-        repo = AsyncMock(spec=LibraryRepository)
-        repo.find_all.return_value = [
+        mocks = make_library_uow_mock()
+        mocks.libraries.find_all.return_value = [
             Library.create(name="Movies", library_type="movies", paths=["/m"]),
             Library.create(name="Series", library_type="series", paths=["/s"]),
         ]
-        use_case = ListLibrariesUseCase(repo, _make_media_count_query())
+        use_case = ListLibrariesUseCase(mocks.factory, _make_media_count_query())
 
         result = await use_case.execute()
 


### PR DESCRIPTION
## Summary
- `ListLibrariesUseCase` and `GetLibraryByIdUseCase` take `LibraryUnitOfWorkFactory` instead of `LibraryRepository`, opening a UoW per read.
- `MediaCountQueryAdapter` now receives `MediaUnitOfWorkFactory`; each count call opens its own short-lived Media UoW so the Library BC no longer depends on Media repositories directly.
- `LibraryContainer` drops its `movie_repository` / `series_repository` dependencies; the main container wires `media.media_unit_of_work_factory` into Library.
- Library integration fixture uses a `StaticPool`-backed in-memory engine so seed-time and UoW-opened sessions share the same DB rows.

## Test plan
- [x] `poetry run pytest` — 1693 passed
- [x] `poetry run ruff check src tests` — clean

## Related
- PR 3 of 7; see `docs/uow-full-clean-refactoring-plan.md` for the full plan.

## Summary by Sourcery

Refactor the library bounded context to use Unit of Work factories for read operations and media count queries, and align tests and containers with the new composition.

Enhancements:
- Route library read use cases through LibraryUnitOfWorkFactory instead of directly using LibraryRepository.
- Update MediaCountQueryAdapter to depend on MediaUnitOfWorkFactory so each count query runs in its own short-lived Media Unit of Work.
- Rewire the LibraryContainer and main application container to inject media and library Unit of Work factories instead of repositories.
- Adjust the list/get library use cases and their unit tests to operate against Unit of Work abstractions rather than repositories.
- Improve the library integration test fixture to share an in-memory SQLite engine via StaticPool between seed and Unit of Work sessions.