### PR TITLE
refactor(watch_progress): migrate reads and MediaLookupAdapter to UoW

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -80,10 +80,8 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     watch_progress = providers.Container(
         WatchProgressContainer,
-        session=infrastructure.session,
         session_factory=infrastructure.session_factory,
-        movie_repository=media.movie_repository,
-        series_repository=media.series_repository,
+        media_uow_factory=media.media_unit_of_work_factory,
     )
 
     collections = providers.Container(

--- a/src/config/containers/watch_progress.py
+++ b/src/config/containers/watch_progress.py
@@ -12,9 +12,6 @@ from src.modules.watch_progress.application.use_cases.clear_series_progress impo
     ClearSeriesProgressUseCase,
 )
 from src.modules.watch_progress.infrastructure.acl import MediaLookupAdapter
-from src.modules.watch_progress.infrastructure.persistence.repositories import (
-    SQLAlchemyWatchProgressRepository,
-)
 from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyWatchProgressUnitOfWorkFactory,
 )
@@ -23,26 +20,19 @@ from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_wo
 class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Watch Progress bounded context dependencies.
 
-    The ``session``, ``session_factory``, ``movie_repository``, and
-    ``series_repository`` dependencies must be wired from the parent
-    container.
+    The ``session_factory`` and ``media_uow_factory`` dependencies
+    must be wired from the parent container.
     """
 
-    session = providers.Dependency()
     session_factory = providers.Dependency()
-    # Media repositories come in so the ACL adapter can delegate
-    # display lookups. Use cases only ever see ``MediaLookupPort``.
-    movie_repository = providers.Dependency()
-    series_repository = providers.Dependency()
+    # Media UoW factory comes in so the ACL adapter can open its own
+    # short-lived Media transactions. Use cases only see
+    # ``MediaLookupPort``.
+    media_uow_factory = providers.Dependency()
 
     # =========================================================================
-    # Repositories (read-only use cases) and Unit of Work (writes)
+    # Unit of Work
     # =========================================================================
-
-    progress_repository = providers.Factory(
-        SQLAlchemyWatchProgressRepository,
-        session=session,
-    )
 
     watch_progress_unit_of_work_factory = providers.Singleton(
         SqlAlchemyWatchProgressUnitOfWorkFactory,
@@ -55,8 +45,7 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
 
     media_lookup = providers.Factory(
         MediaLookupAdapter,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_uow_factory=media_uow_factory,
     )
 
     # =========================================================================
@@ -70,12 +59,12 @@ class WatchProgressContainer(containers.DeclarativeContainer):  # type: ignore[m
 
     get_progress = providers.Factory(
         GetProgressUseCase,
-        progress_repository=progress_repository,
+        uow_factory=watch_progress_unit_of_work_factory,
     )
 
     get_continue_watching = providers.Factory(
         GetContinueWatchingUseCase,
-        progress_repository=progress_repository,
+        uow_factory=watch_progress_unit_of_work_factory,
         media_lookup=media_lookup,
     )
 

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -25,8 +25,11 @@ if TYPE_CHECKING:
         MediaLookupPort,
         SeriesWithEpisodesInfo,
     )
+    from src.modules.watch_progress.application.unit_of_work import (
+        WatchProgressUnitOfWork,
+        WatchProgressUnitOfWorkFactory,
+    )
     from src.modules.watch_progress.domain.entities import WatchProgress
-    from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 
 _logger = logging.getLogger(__name__)
 
@@ -43,26 +46,26 @@ class GetContinueWatchingUseCase:
     loading data and projecting the selector's output into the DTO.
 
     Example:
-        >>> use_case = GetContinueWatchingUseCase(progress_repo, media_lookup)
+        >>> use_case = GetContinueWatchingUseCase(uow_factory, media_lookup)
         >>> result = await use_case.execute(GetContinueWatchingInput(limit=10))
     """
 
     def __init__(
         self,
-        progress_repository: WatchProgressRepository,
+        uow_factory: WatchProgressUnitOfWorkFactory,
         media_lookup: MediaLookupPort,
         selector: ContinueWatchingSelector | None = None,
     ) -> None:
         """Initialize the use case.
 
         Args:
-            progress_repository: Repository for watch progress.
+            uow_factory: Factory that opens a fresh watch progress UoW.
             media_lookup: Port for resolving media display metadata.
             selector: Domain service that picks the best episode. The
                 default is a fresh instance — callers only pass one in
                 tests that want to stub selection.
         """
-        self._progress_repo = progress_repository
+        self._uow_factory = uow_factory
         self._media_lookup = media_lookup
         self._selector = selector or ContinueWatchingSelector()
 
@@ -75,34 +78,37 @@ class GetContinueWatchingUseCase:
         Returns:
             ContinueWatchingOutput with items including media metadata.
         """
-        progress_list = await self._progress_repo.list_recently_watched(limit=input_dto.limit)
-
         items: list[ContinueWatchingItem] = []
         seen_series: set[str] = set()
 
-        for progress in progress_list:
-            if progress.media_type == WatchableMediaType.MOVIE:
-                if progress.status != WatchStatus.IN_PROGRESS:
-                    continue
-                item = await self._enrich_movie(progress, input_dto.lang)
-                if item:
-                    items.append(item)
-            elif progress.media_type == WatchableMediaType.EPISODE:
-                parsed = EpisodeCompositeId.parse(progress.media_id)
-                if not parsed or parsed.series_id in seen_series:
-                    continue
-                seen_series.add(parsed.series_id)
-                item = await self._resolve_series_episode(
-                    parsed.series_id,
-                    input_dto.lang,
-                )
-                if item:
-                    items.append(item)
+        async with self._uow_factory() as uow:
+            progress_list = await uow.progress.list_recently_watched(limit=input_dto.limit)
+
+            for progress in progress_list:
+                if progress.media_type == WatchableMediaType.MOVIE:
+                    if progress.status != WatchStatus.IN_PROGRESS:
+                        continue
+                    item = await self._enrich_movie(progress, input_dto.lang)
+                    if item:
+                        items.append(item)
+                elif progress.media_type == WatchableMediaType.EPISODE:
+                    parsed = EpisodeCompositeId.parse(progress.media_id)
+                    if not parsed or parsed.series_id in seen_series:
+                        continue
+                    seen_series.add(parsed.series_id)
+                    item = await self._resolve_series_episode(
+                        uow,
+                        parsed.series_id,
+                        input_dto.lang,
+                    )
+                    if item:
+                        items.append(item)
 
         return ContinueWatchingOutput(items=items)
 
     async def _resolve_series_episode(
         self,
+        uow: WatchProgressUnitOfWork,
         series_id: str,
         lang: str,
     ) -> ContinueWatchingItem | None:
@@ -111,7 +117,7 @@ class GetContinueWatchingUseCase:
         if not series:
             return None
 
-        candidates = await self._build_candidates(series_id, series)
+        candidates = await self._build_candidates(uow, series_id, series)
         if not candidates:
             return None
 
@@ -121,8 +127,9 @@ class GetContinueWatchingUseCase:
 
         return self._build_series_item(series, selection.candidate, selection.latest_watched_at)
 
+    @staticmethod
     async def _build_candidates(
-        self,
+        uow: WatchProgressUnitOfWork,
         series_id: str,
         series: SeriesWithEpisodesInfo,
     ) -> list[EpisodeCandidate]:
@@ -144,7 +151,7 @@ class GetContinueWatchingUseCase:
             for ep in series.episodes
         ]
 
-        progress_map = await self._progress_repo.find_by_media_ids(media_ids)
+        progress_map = await uow.progress.find_by_media_ids(media_ids)
 
         return [
             EpisodeCandidate(

--- a/src/modules/watch_progress/application/use_cases/get_progress.py
+++ b/src/modules/watch_progress/application/use_cases/get_progress.py
@@ -1,7 +1,7 @@
 """GetProgressUseCase - Get watch progress for a media item."""
 
 from src.modules.watch_progress.application.dtos import GetProgressInput, ProgressOutput
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.modules.watch_progress.application.unit_of_work import WatchProgressUnitOfWorkFactory
 
 
 class GetProgressUseCase:
@@ -10,17 +10,17 @@ class GetProgressUseCase:
     Returns None if no progress exists (does not raise 404).
 
     Example:
-        >>> use_case = GetProgressUseCase(progress_repository)
+        >>> use_case = GetProgressUseCase(uow_factory)
         >>> result = await use_case.execute(GetProgressInput("mov_abc123def456"))
     """
 
-    def __init__(self, progress_repository: WatchProgressRepository) -> None:
+    def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            progress_repository: Repository for watch progress persistence.
+            uow_factory: Factory that opens a fresh watch progress UoW.
         """
-        self._repo = progress_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: GetProgressInput) -> ProgressOutput | None:
         """Execute the use case.
@@ -31,7 +31,8 @@ class GetProgressUseCase:
         Returns:
             ProgressOutput if found, None otherwise.
         """
-        progress = await self._repo.find_by_media_id(input_dto.media_id)
+        async with self._uow_factory() as uow:
+            progress = await uow.progress.find_by_media_id(input_dto.media_id)
         if progress is None:
             return None
         return ProgressOutput.from_entity(progress)

--- a/src/modules/watch_progress/infrastructure/acl/media_lookup_adapter.py
+++ b/src/modules/watch_progress/infrastructure/acl/media_lookup_adapter.py
@@ -1,11 +1,11 @@
-"""Adapter that implements ``MediaLookupPort`` using Media repositories.
+"""Adapter that implements ``MediaLookupPort`` using the Media UoW.
 
-This is the only file in the Watch Progress BC that imports from
-``src.modules.media.domain``. Above the adapter, the use cases only
-see ``MovieDisplayInfo`` / ``SeriesWithEpisodesInfo``.
+This is the only file in the Watch Progress BC that imports from the
+Media BC. Above the adapter, the use cases only see
+``MovieDisplayInfo`` / ``SeriesWithEpisodesInfo``.
 """
 
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.value_objects import MovieId, SeriesId
 from src.modules.watch_progress.application.ports.media_lookup_port import (
     EpisodeInfo,
@@ -16,19 +16,15 @@ from src.modules.watch_progress.application.ports.media_lookup_port import (
 
 
 class MediaLookupAdapter(MediaLookupPort):
-    """Resolve media metadata via the Media BC's repositories."""
+    """Resolve media metadata via the Media BC's Unit of Work."""
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
 
     async def get_movie(self, media_id: str, lang: str) -> MovieDisplayInfo | None:
         """Map a ``Movie`` entity to a display DTO, or ``None`` when absent."""
-        movie = await self._movie_repo.find_by_id(MovieId(media_id))
+        async with self._media_uow_factory() as uow:
+            movie = await uow.movies.find_by_id(MovieId(media_id))
         if movie is None:
             return None
         return MovieDisplayInfo(
@@ -44,7 +40,8 @@ class MediaLookupAdapter(MediaLookupPort):
         lang: str,
     ) -> SeriesWithEpisodesInfo | None:
         """Flatten a ``Series`` into display + sorted-episode DTOs."""
-        series = await self._series_repo.find_by_id(SeriesId(series_id))
+        async with self._media_uow_factory() as uow:
+            series = await uow.series.find_by_id(SeriesId(series_id))
         if series is None:
             return None
 

--- a/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
+++ b/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
@@ -1,7 +1,7 @@
 """Integration tests for the Watch Progress MediaLookupAdapter."""
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.value_objects import (
@@ -20,6 +20,9 @@ from src.modules.media.domain.value_objects import (
 from src.modules.media.infrastructure.persistence.repositories import (
     SQLAlchemyMovieRepository,
     SQLAlchemySeriesRepository,
+)
+from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyMediaUnitOfWorkFactory,
 )
 from src.modules.watch_progress.infrastructure.acl import MediaLookupAdapter
 
@@ -95,14 +98,16 @@ def _series_with_episodes(
 class TestWatchProgressMediaLookupAdapter:
     """The adapter returns display-ready DTOs for the Watch Progress BC."""
 
-    async def test_get_movie_returns_display_info(self, db_session: AsyncSession) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-
+    async def test_get_movie_returns_display_info(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
         movie_id = MovieId.generate()
-        await movie_repo.save(_movie(movie_id, "Inception"))
+        await SQLAlchemyMovieRepository(db_session).save(_movie(movie_id, "Inception"))
+        await db_session.commit()
 
-        adapter = MediaLookupAdapter(movie_repo, series_repo)
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
         result = await adapter.get_movie(str(movie_id), "en")
 
         assert result is not None
@@ -111,28 +116,29 @@ class TestWatchProgressMediaLookupAdapter:
         assert result.poster_path == "/p/m.jpg"
         assert result.backdrop_path == "/b/m.jpg"
 
-    async def test_get_movie_returns_none_for_missing_id(self, db_session: AsyncSession) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-        adapter = MediaLookupAdapter(movie_repo, series_repo)
+    async def test_get_movie_returns_none_for_missing_id(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
         assert await adapter.get_movie("mov_missing00000", "en") is None
 
     async def test_get_series_with_episodes_returns_sorted_list(
-        self, db_session: AsyncSession
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-
         series_id = SeriesId.generate()
         series = _series_with_episodes(
             series_id,
             "Breaking Bad",
             [(2, 1, "S02E01"), (1, 2, "S01E02"), (1, 1, "S01E01")],
         )
-        await series_repo.save(series)
+        await SQLAlchemySeriesRepository(db_session).save(series)
+        await db_session.commit()
 
-        adapter = MediaLookupAdapter(movie_repo, series_repo)
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
         result = await adapter.get_series_with_episodes(str(series_id), "en")
 
         assert result is not None
@@ -145,9 +151,10 @@ class TestWatchProgressMediaLookupAdapter:
         assert [e.title for e in result.episodes] == ["S01E01", "S01E02", "S02E01"]
         assert all(e.duration_seconds == 1800 for e in result.episodes)
 
-    async def test_get_series_returns_none_for_missing_id(self, db_session: AsyncSession) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-        adapter = MediaLookupAdapter(movie_repo, series_repo)
+    async def test_get_series_returns_none_for_missing_id(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
         assert await adapter.get_series_with_episodes("ser_missing00000", "en") is None

--- a/tests/modules/watch_progress/integration/conftest.py
+++ b/tests/modules/watch_progress/integration/conftest.py
@@ -4,38 +4,49 @@ from collections.abc import AsyncGenerator
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
 
 from src.infrastructure.persistence import Base
 
 
 @pytest.fixture(scope="function")
-async def db_session() -> AsyncGenerator[AsyncSession, None]:
-    """Create an in-memory SQLite database session for testing.
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """Expose an ``async_sessionmaker`` bound to an in-memory SQLite database.
 
-    Creates fresh tables for each test function and tears them down after.
-
-    Yields:
-        AsyncSession: A database session connected to an in-memory SQLite database.
+    ``StaticPool`` pins every connection to the same underlying SQLite
+    instance so sessions created for seeding (via ``db_session``) and
+    sessions opened later by a Unit of Work under test see the same
+    schema and rows.
     """
     engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:",
         echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
     )
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    session_factory = async_sessionmaker(
+    factory = async_sessionmaker(
         bind=engine,
         class_=AsyncSession,
         expire_on_commit=False,
         autoflush=False,
     )
 
-    async with session_factory() as session:
-        yield session
+    yield factory
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
 
     await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+async def db_session(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[AsyncSession, None]:
+    """Seed-time session sharing the ``session_factory`` engine."""
+    async with session_factory() as session:
+        yield session

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -16,8 +16,11 @@ from src.modules.watch_progress.application.ports import (
 )
 from src.modules.watch_progress.application.use_cases import GetContinueWatchingUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from tests.modules.watch_progress.unit.conftest import (
+    WatchProgressUoWMocks,
+    make_watch_progress_uow_mock,
+)
 
 
 def _make_progress(
@@ -72,19 +75,19 @@ def _make_series_info(
 
 
 @pytest.fixture()
-def repos() -> tuple[AsyncMock, AsyncMock]:
-    """Create mock progress repository and media lookup port."""
-    progress_repo = AsyncMock(spec=WatchProgressRepository)
+def repos() -> tuple[WatchProgressUoWMocks, AsyncMock]:
+    """Create mock UoW and media lookup port."""
+    mocks = make_watch_progress_uow_mock()
     media_lookup = AsyncMock(spec=MediaLookupPort)
-    return progress_repo, media_lookup
+    return mocks, media_lookup
 
 
 def _make_use_case(
-    repos: tuple[AsyncMock, AsyncMock],
+    repos: tuple[WatchProgressUoWMocks, AsyncMock],
 ) -> GetContinueWatchingUseCase:
-    progress_repo, media_lookup = repos
+    mocks, media_lookup = repos
     return GetContinueWatchingUseCase(
-        progress_repository=progress_repo,
+        uow_factory=mocks.factory,
         media_lookup=media_lookup,
     )
 
@@ -94,11 +97,11 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_valid_composite_episode(self, repos):
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series = _make_series_info("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_2")
-        progress_repo.list_recently_watched.return_value = [progress]
-        progress_repo.find_by_media_ids.return_value = {
+        mocks.progress.list_recently_watched.return_value = [progress]
+        mocks.progress.find_by_media_ids.return_value = {
             "epi_ser_Hy9VjMfILYZe_3_2": progress,
         }
         media_lookup.get_series_with_episodes.return_value = series
@@ -115,8 +118,8 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_standard_episode_id(self, repos):
-        progress_repo, _ = repos
-        progress_repo.list_recently_watched.return_value = [
+        mocks, _ = repos
+        mocks.progress.list_recently_watched.return_value = [
             _make_progress("epi_03ZzYaQ77FaB"),
         ]
 
@@ -125,8 +128,8 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_series(self, repos):
-        progress_repo, media_lookup = repos
-        progress_repo.list_recently_watched.return_value = [
+        mocks, media_lookup = repos
+        mocks.progress.list_recently_watched.return_value = [
             _make_progress("epi_ser_NotExists123_1_1"),
         ]
         media_lookup.get_series_with_episodes.return_value = None
@@ -136,11 +139,11 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_season(self, repos):
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series = _make_series_info("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_99_1")
-        progress_repo.list_recently_watched.return_value = [progress]
-        progress_repo.find_by_media_ids.return_value = {
+        mocks.progress.list_recently_watched.return_value = [progress]
+        mocks.progress.find_by_media_ids.return_value = {
             "epi_ser_Hy9VjMfILYZe_99_1": progress,
         }
         media_lookup.get_series_with_episodes.return_value = series
@@ -150,11 +153,11 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_episode(self, repos):
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series = _make_series_info("ser_Hy9VjMfILYZe", {3: [2]})
         progress = _make_progress("epi_ser_Hy9VjMfILYZe_3_99")
-        progress_repo.list_recently_watched.return_value = [progress]
-        progress_repo.find_by_media_ids.return_value = {
+        mocks.progress.list_recently_watched.return_value = [progress]
+        mocks.progress.find_by_media_ids.return_value = {
             "epi_ser_Hy9VjMfILYZe_3_99": progress,
         }
         media_lookup.get_series_with_episodes.return_value = series
@@ -164,8 +167,8 @@ class TestEnrichEpisode:
 
     @pytest.mark.asyncio
     async def test_enrich_returns_none_for_malformed_media_id(self, repos):
-        progress_repo, _ = repos
-        progress_repo.list_recently_watched.return_value = [
+        mocks, _ = repos
+        mocks.progress.list_recently_watched.return_value = [
             _make_progress("epi_ser_broken"),
         ]
 
@@ -179,15 +182,15 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_multiple_episodes_same_series_returns_one_item(self, repos):
         """Multiple in-progress episodes from same series → single item."""
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
         media_lookup.get_series_with_episodes.return_value = series
 
         p1 = _make_progress("epi_ser_AAAAAAAAAAAA_1_1")
         p2 = _make_progress("epi_ser_AAAAAAAAAAAA_1_2")
         p3 = _make_progress("epi_ser_AAAAAAAAAAAA_1_3")
-        progress_repo.list_recently_watched.return_value = [p1, p2, p3]
-        progress_repo.find_by_media_ids.return_value = {
+        mocks.progress.list_recently_watched.return_value = [p1, p2, p3]
+        mocks.progress.find_by_media_ids.return_value = {
             "epi_ser_AAAAAAAAAAAA_1_1": p1,
             "epi_ser_AAAAAAAAAAAA_1_2": p2,
             "epi_ser_AAAAAAAAAAAA_1_3": p3,
@@ -200,14 +203,14 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_picks_highest_in_progress_episode(self, repos):
         """Should pick the highest-numbered in-progress episode."""
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3], 2: [1, 2]})
         media_lookup.get_series_with_episodes.return_value = series
 
-        progress_repo.list_recently_watched.return_value = [
+        mocks.progress.list_recently_watched.return_value = [
             _make_progress("epi_ser_AAAAAAAAAAAA_1_2"),
         ]
-        progress_repo.find_by_media_ids.return_value = {
+        mocks.progress.find_by_media_ids.return_value = {
             "epi_ser_AAAAAAAAAAAA_1_2": _make_progress(
                 "epi_ser_AAAAAAAAAAAA_1_2",
                 status="completed",
@@ -231,14 +234,14 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_picks_next_unwatched_when_all_completed(self, repos):
         """Completed episodes + unwatched episodes → next unwatched."""
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
         media_lookup.get_series_with_episodes.return_value = series
 
-        progress_repo.list_recently_watched.return_value = [
+        mocks.progress.list_recently_watched.return_value = [
             _make_progress("epi_ser_AAAAAAAAAAAA_1_1", status="completed"),
         ]
-        progress_repo.find_by_media_ids.return_value = {
+        mocks.progress.find_by_media_ids.return_value = {
             "epi_ser_AAAAAAAAAAAA_1_1": _make_progress(
                 "epi_ser_AAAAAAAAAAAA_1_1",
                 status="completed",
@@ -259,14 +262,14 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_returns_nothing_when_all_episodes_completed(self, repos):
         """All episodes completed, none unwatched → no item."""
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2]})
         media_lookup.get_series_with_episodes.return_value = series
 
-        progress_repo.list_recently_watched.return_value = [
+        mocks.progress.list_recently_watched.return_value = [
             _make_progress("epi_ser_AAAAAAAAAAAA_1_1", status="completed"),
         ]
-        progress_repo.find_by_media_ids.return_value = {
+        mocks.progress.find_by_media_ids.return_value = {
             "epi_ser_AAAAAAAAAAAA_1_1": _make_progress(
                 "epi_ser_AAAAAAAAAAAA_1_1",
                 status="completed",
@@ -283,7 +286,7 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_two_series_return_one_item_each(self, repos):
         """Two different series → two items, one per series."""
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series_a = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2]}, title="Series A")
         series_b = _make_series_info("ser_BBBBBBBBBBBB", {1: [1]}, title="Series B")
 
@@ -298,7 +301,7 @@ class TestSeriesDeduplication:
 
         pa = _make_progress("epi_ser_AAAAAAAAAAAA_1_1")
         pb = _make_progress("epi_ser_BBBBBBBBBBBB_1_1")
-        progress_repo.list_recently_watched.return_value = [pa, pb]
+        mocks.progress.list_recently_watched.return_value = [pa, pb]
 
         def find_by_media_ids_side_effect(ids):
             result = {}
@@ -308,7 +311,7 @@ class TestSeriesDeduplication:
                 result["epi_ser_BBBBBBBBBBBB_1_1"] = pb
             return result
 
-        progress_repo.find_by_media_ids.side_effect = find_by_media_ids_side_effect
+        mocks.progress.find_by_media_ids.side_effect = find_by_media_ids_side_effect
 
         result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
 
@@ -319,14 +322,14 @@ class TestSeriesDeduplication:
     @pytest.mark.asyncio
     async def test_mixed_in_progress_and_completed_across_seasons(self, repos):
         """S1 completed, S2E1 in-progress → picks S2E1."""
-        progress_repo, media_lookup = repos
+        mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2], 2: [1, 2]})
         media_lookup.get_series_with_episodes.return_value = series
 
-        progress_repo.list_recently_watched.return_value = [
+        mocks.progress.list_recently_watched.return_value = [
             _make_progress("epi_ser_AAAAAAAAAAAA_2_1"),
         ]
-        progress_repo.find_by_media_ids.return_value = {
+        mocks.progress.find_by_media_ids.return_value = {
             "epi_ser_AAAAAAAAAAAA_1_1": _make_progress(
                 "epi_ser_AAAAAAAAAAAA_1_1",
                 status="completed",

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_progress.py
@@ -1,14 +1,12 @@
 """Tests for GetProgressUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.modules.watch_progress.application.dtos import GetProgressInput, ProgressOutput
 from src.modules.watch_progress.application.use_cases import GetProgressUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.repositories import WatchProgressRepository
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from tests.modules.watch_progress.unit.conftest import make_watch_progress_uow_mock
 
 
 class TestGetProgressUseCase:
@@ -22,9 +20,9 @@ class TestGetProgressUseCase:
             position_seconds=1800,
             duration_seconds=7200,
         )
-        mock_repo = AsyncMock(spec=WatchProgressRepository)
-        mock_repo.find_by_media_id.return_value = existing
-        use_case = GetProgressUseCase(progress_repository=mock_repo)
+        mocks = make_watch_progress_uow_mock()
+        mocks.progress.find_by_media_id.return_value = existing
+        use_case = GetProgressUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetProgressInput(media_id="mov_abc123def456"))
 
@@ -34,9 +32,9 @@ class TestGetProgressUseCase:
 
     @pytest.mark.asyncio
     async def test_returns_none_when_not_found(self):
-        mock_repo = AsyncMock(spec=WatchProgressRepository)
-        mock_repo.find_by_media_id.return_value = None
-        use_case = GetProgressUseCase(progress_repository=mock_repo)
+        mocks = make_watch_progress_uow_mock()
+        mocks.progress.find_by_media_id.return_value = None
+        use_case = GetProgressUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(GetProgressInput(media_id="mov_abc123def456"))
 


### PR DESCRIPTION
## Summary
- `GetProgressUseCase` and `GetContinueWatchingUseCase` take `WatchProgressUnitOfWorkFactory` instead of `WatchProgressRepository`. Continue-watching helpers receive the active UoW so `list_recently_watched` + `find_by_media_ids` share a single transaction.
- `MediaLookupAdapter` receives `MediaUnitOfWorkFactory`; each call opens a short-lived Media UoW. WatchProgress BC no longer imports Media repositories.
- `WatchProgressContainer` drops `session` / `movie_repository` / `series_repository` dependencies; the main container wires `media.media_unit_of_work_factory` into it.
- Integration fixture uses a `StaticPool`-backed engine so seed-time sessions and UoW-opened sessions share the same in-memory DB.

## Test plan
- [x] `poetry run pytest` — 1693 passed
- [x] `poetry run ruff check src tests` — clean

## Related
- PR 4 of 7; see `docs/uow-full-clean-refactoring-plan.md` for the full plan.

## Summary by Sourcery

Migrate watch progress read use cases and media lookup to use Unit of Work factories instead of direct repositories, and align DI wiring and tests with the new transactional model.

Enhancements:
- Update GetProgressUseCase and GetContinueWatchingUseCase to obtain repositories via WatchProgressUnitOfWorkFactory and operate within explicit UoW contexts.
- Refactor MediaLookupAdapter to depend on MediaUnitOfWorkFactory so each media lookup runs in its own short-lived Media UoW.
- Simplify WatchProgressContainer wiring to drop direct media repository and session dependencies in favor of UoW factories for watch progress and media lookups.
- Adjust integration test fixtures to use a StaticPool-backed in-memory SQLite engine so seed data and UoW sessions share the same database state.

Tests:
- Update watch progress unit and integration tests to work with UoW-based APIs and the new media lookup adapter configuration.