### PR TITLE
refactor(collections): migrate reads and MediaLookupAdapter to UoW

### DIFF
--- a/src/config/containers/collections.py
+++ b/src/config/containers/collections.py
@@ -15,10 +15,6 @@ from src.modules.collections.application.use_cases import (
     ToggleWatchlistUseCase,
 )
 from src.modules.collections.infrastructure.acl import MediaLookupAdapter
-from src.modules.collections.infrastructure.persistence.repositories import (
-    SQLAlchemyCustomListRepository,
-    SQLAlchemyWatchlistRepository,
-)
 from src.modules.collections.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyCollectionsUnitOfWorkFactory,
 )
@@ -27,31 +23,19 @@ from src.modules.collections.infrastructure.persistence.sqlalchemy_unit_of_work 
 class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Collections bounded context dependencies.
 
-    The ``session``, ``session_factory``, ``movie_repository``, and
-    ``series_repository`` dependencies must be wired from the parent
-    container.
+    The ``session_factory`` and ``media_uow_factory`` dependencies must
+    be wired from the parent container.
     """
 
-    session = providers.Dependency()
     session_factory = providers.Dependency()
-    # Media repositories come in so the ACL adapter can delegate
-    # metadata lookups. Use cases only ever see ``MediaLookupPort``.
-    movie_repository = providers.Dependency()
-    series_repository = providers.Dependency()
+    # Media UoW factory comes in so the ACL adapter can open its own
+    # short-lived Media transactions. Use cases only see
+    # ``MediaLookupPort``.
+    media_uow_factory = providers.Dependency()
 
     # =========================================================================
-    # Repositories (read-only use cases) and Unit of Work (writes)
+    # Unit of Work
     # =========================================================================
-
-    watchlist_repository = providers.Factory(
-        SQLAlchemyWatchlistRepository,
-        session=session,
-    )
-
-    custom_list_repository = providers.Factory(
-        SQLAlchemyCustomListRepository,
-        session=session,
-    )
 
     collections_unit_of_work_factory = providers.Singleton(
         SqlAlchemyCollectionsUnitOfWorkFactory,
@@ -64,8 +48,7 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     media_lookup = providers.Factory(
         MediaLookupAdapter,
-        movie_repository=movie_repository,
-        series_repository=series_repository,
+        media_uow_factory=media_uow_factory,
     )
 
     # =========================================================================
@@ -79,13 +62,13 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     get_watchlist = providers.Factory(
         GetWatchlistUseCase,
-        watchlist_repository=watchlist_repository,
+        uow_factory=collections_unit_of_work_factory,
         media_lookup=media_lookup,
     )
 
     check_watchlist = providers.Factory(
         CheckWatchlistUseCase,
-        watchlist_repository=watchlist_repository,
+        uow_factory=collections_unit_of_work_factory,
     )
 
     # =========================================================================
@@ -99,7 +82,7 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     list_custom_lists = providers.Factory(
         ListCustomListsUseCase,
-        custom_list_repository=custom_list_repository,
+        uow_factory=collections_unit_of_work_factory,
     )
 
     rename_custom_list = providers.Factory(
@@ -124,6 +107,6 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     get_custom_list_items = providers.Factory(
         GetCustomListItemsUseCase,
-        custom_list_repository=custom_list_repository,
+        uow_factory=collections_unit_of_work_factory,
         media_lookup=media_lookup,
     )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -86,10 +86,8 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     collections = providers.Container(
         CollectionsContainer,
-        session=infrastructure.session,
         session_factory=infrastructure.session_factory,
-        movie_repository=media.movie_repository,
-        series_repository=media.series_repository,
+        media_uow_factory=media.media_unit_of_work_factory,
     )
 
     # =========================================================================

--- a/src/modules/collections/application/use_cases/check_watchlist.py
+++ b/src/modules/collections/application/use_cases/check_watchlist.py
@@ -1,25 +1,25 @@
 """CheckWatchlistUseCase - Check if a media item is in the watchlist."""
 
-from src.modules.collections.domain.repositories import WatchlistRepository
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 
 
 class CheckWatchlistUseCase:
     """Check whether a media item exists in the user's watchlist.
 
     Example:
-        >>> use_case = CheckWatchlistUseCase(watchlist_repository)
+        >>> use_case = CheckWatchlistUseCase(uow_factory)
         >>> in_list = await use_case.execute("mov_abc123def456")
         >>> in_list
         True
     """
 
-    def __init__(self, watchlist_repository: WatchlistRepository) -> None:
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            watchlist_repository: Repository for watchlist persistence.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
         """
-        self._repo = watchlist_repository
+        self._uow_factory = uow_factory
 
     async def execute(self, media_id: str) -> bool:
         """Execute the use case.
@@ -30,7 +30,8 @@ class CheckWatchlistUseCase:
         Returns:
             True if the item is in the watchlist, False otherwise.
         """
-        return await self._repo.exists(media_id)
+        async with self._uow_factory() as uow:
+            return await uow.watchlist.exists(media_id)
 
 
 __all__ = ["CheckWatchlistUseCase"]

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -8,7 +8,7 @@ from src.modules.collections.application.dtos import (
     GetCustomListItemsInput,
 )
 from src.modules.collections.application.ports import MediaLookupPort
-from src.modules.collections.domain.repositories import CustomListRepository
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.shared_kernel.value_objects import CollectionMediaType
 
 _logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ class GetCustomListItemsUseCase:
     via ``MediaLookupPort``. Uses a single batch lookup to avoid N+1.
 
     Example:
-        >>> use_case = GetCustomListItemsUseCase(custom_list_repo, media_lookup)
+        >>> use_case = GetCustomListItemsUseCase(uow_factory, media_lookup)
         >>> items = await use_case.execute(
         ...     GetCustomListItemsInput(list_id="lst_abc123", lang="pt-BR"),
         ... )
@@ -29,16 +29,16 @@ class GetCustomListItemsUseCase:
 
     def __init__(
         self,
-        custom_list_repository: CustomListRepository,
+        uow_factory: CollectionsUnitOfWorkFactory,
         media_lookup: MediaLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
-            custom_list_repository: Repository for custom list items.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
             media_lookup: Port for resolving media display metadata.
         """
-        self._list_repo = custom_list_repository
+        self._uow_factory = uow_factory
         self._media_lookup = media_lookup
 
     async def execute(
@@ -56,11 +56,12 @@ class GetCustomListItemsUseCase:
         Raises:
             ResourceNotFoundException: If the list does not exist.
         """
-        custom_list = await self._list_repo.find_by_id(input_dto.list_id)
-        if not custom_list:
-            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+        async with self._uow_factory() as uow:
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id)
+            if not custom_list:
+                raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-        items = await self._list_repo.list_items(input_dto.list_id)
+            items = await uow.custom_lists.list_items(input_dto.list_id)
         _logger.info("Found %d items in custom list %s", len(items), input_dto.list_id)
 
         if not items:

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -7,7 +7,7 @@ from src.modules.collections.application.dtos import (
     WatchlistItemOutput,
 )
 from src.modules.collections.application.ports import MediaLookupPort
-from src.modules.collections.domain.repositories import WatchlistRepository
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.shared_kernel.value_objects import CollectionMediaType
 
 _logger = logging.getLogger(__name__)
@@ -22,22 +22,22 @@ class GetWatchlistUseCase:
     N+1 queries.
 
     Example:
-        >>> use_case = GetWatchlistUseCase(watchlist_repo, media_lookup)
+        >>> use_case = GetWatchlistUseCase(uow_factory, media_lookup)
         >>> items = await use_case.execute(GetWatchlistInput(limit=50, lang="pt-BR"))
     """
 
     def __init__(
         self,
-        watchlist_repository: WatchlistRepository,
+        uow_factory: CollectionsUnitOfWorkFactory,
         media_lookup: MediaLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
-            watchlist_repository: Repository for watchlist items.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
             media_lookup: Port for resolving media display metadata.
         """
-        self._watchlist_repo = watchlist_repository
+        self._uow_factory = uow_factory
         self._media_lookup = media_lookup
 
     async def execute(self, input_dto: GetWatchlistInput) -> list[WatchlistItemOutput]:
@@ -49,7 +49,8 @@ class GetWatchlistUseCase:
         Returns:
             List of WatchlistItemOutput with media metadata.
         """
-        items = await self._watchlist_repo.list_all(limit=input_dto.limit)
+        async with self._uow_factory() as uow:
+            items = await uow.watchlist.list_all(limit=input_dto.limit)
         _logger.info("Found %d watchlist items", len(items))
 
         if not items:

--- a/src/modules/collections/application/use_cases/list_custom_lists.py
+++ b/src/modules/collections/application/use_cases/list_custom_lists.py
@@ -1,24 +1,24 @@
 """ListCustomListsUseCase - List all custom lists."""
 
 from src.modules.collections.application.dtos import CustomListOutput
-from src.modules.collections.domain.repositories import CustomListRepository
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 
 
 class ListCustomListsUseCase:
     """List all user-created custom lists.
 
     Example:
-        >>> use_case = ListCustomListsUseCase(custom_list_repository)
+        >>> use_case = ListCustomListsUseCase(uow_factory)
         >>> lists = await use_case.execute()
     """
 
-    def __init__(self, custom_list_repository: CustomListRepository) -> None:
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
         """Initialize the use case.
 
         Args:
-            custom_list_repository: Repository for custom list persistence.
+            uow_factory: Factory that opens a fresh collections Unit of Work.
         """
-        self._repo = custom_list_repository
+        self._uow_factory = uow_factory
 
     async def execute(self) -> list[CustomListOutput]:
         """Execute the use case.
@@ -26,7 +26,8 @@ class ListCustomListsUseCase:
         Returns:
             List of CustomListOutput DTOs.
         """
-        lists = await self._repo.list_all()
+        async with self._uow_factory() as uow:
+            lists = await uow.custom_lists.list_all()
         return [CustomListOutput.from_entity(cl) for cl in lists]
 
 

--- a/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
+++ b/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
@@ -1,7 +1,7 @@
-"""Adapter that implements ``MediaLookupPort`` using Media repositories.
+"""Adapter that implements ``MediaLookupPort`` using the Media UoW.
 
-This is the only file in the Collections BC that imports from
-``src.modules.media.domain``. Everything above it sees ``MediaSummary``.
+This is the only file in the Collections BC that imports from the
+Media BC. Everything above it sees ``MediaSummary``.
 """
 
 from collections.abc import Sequence
@@ -10,21 +10,16 @@ from src.modules.collections.application.ports.media_lookup_port import (
     MediaLookupPort,
     MediaSummary,
 )
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.value_objects import MovieId, SeriesId
 from src.shared_kernel.value_objects import CollectionMediaType
 
 
 class MediaLookupAdapter(MediaLookupPort):
-    """Resolve media display data via the Media BC's repositories."""
+    """Resolve media display data via the Media BC's Unit of Work."""
 
-    def __init__(
-        self,
-        movie_repository: MovieRepository,
-        series_repository: SeriesRepository,
-    ) -> None:
-        self._movie_repo = movie_repository
-        self._series_repo = series_repository
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
 
     async def get_many(
         self,
@@ -32,32 +27,36 @@ class MediaLookupAdapter(MediaLookupPort):
         series_ids: Sequence[str],
         lang: str,
     ) -> dict[tuple[CollectionMediaType, str], MediaSummary]:
-        """Batch-resolve display metadata via the Media repositories."""
+        """Batch-resolve display metadata via a single Media UoW."""
         result: dict[tuple[CollectionMediaType, str], MediaSummary] = {}
 
-        if movie_ids:
-            movies_map = await self._movie_repo.find_by_ids(
-                [MovieId(mid) for mid in movie_ids],
-            )
-            for media_id, movie in movies_map.items():
-                result[(CollectionMediaType.MOVIE, media_id)] = MediaSummary(
-                    media_id=media_id,
-                    media_type=CollectionMediaType.MOVIE,
-                    title=movie.get_title(lang),
-                    poster_path=movie.poster_path.value if movie.poster_path else None,
-                )
+        if not movie_ids and not series_ids:
+            return result
 
-        if series_ids:
-            series_map = await self._series_repo.find_by_ids(
-                [SeriesId(sid) for sid in series_ids],
-            )
-            for media_id, series in series_map.items():
-                result[(CollectionMediaType.SERIES, media_id)] = MediaSummary(
-                    media_id=media_id,
-                    media_type=CollectionMediaType.SERIES,
-                    title=series.get_title(lang),
-                    poster_path=series.poster_path.value if series.poster_path else None,
+        async with self._media_uow_factory() as uow:
+            if movie_ids:
+                movies_map = await uow.movies.find_by_ids(
+                    [MovieId(mid) for mid in movie_ids],
                 )
+                for media_id, movie in movies_map.items():
+                    result[(CollectionMediaType.MOVIE, media_id)] = MediaSummary(
+                        media_id=media_id,
+                        media_type=CollectionMediaType.MOVIE,
+                        title=movie.get_title(lang),
+                        poster_path=movie.poster_path.value if movie.poster_path else None,
+                    )
+
+            if series_ids:
+                series_map = await uow.series.find_by_ids(
+                    [SeriesId(sid) for sid in series_ids],
+                )
+                for media_id, series in series_map.items():
+                    result[(CollectionMediaType.SERIES, media_id)] = MediaSummary(
+                        media_id=media_id,
+                        media_type=CollectionMediaType.SERIES,
+                        title=series.get_title(lang),
+                        poster_path=series.poster_path.value if series.poster_path else None,
+                    )
 
         return result
 

--- a/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
+++ b/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
@@ -1,7 +1,7 @@
 """Integration tests for the Collections MediaLookupAdapter."""
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.modules.collections.infrastructure.acl import MediaLookupAdapter
 from src.modules.media.domain.entities import Movie, Series
@@ -19,6 +19,9 @@ from src.modules.media.domain.value_objects import (
 from src.modules.media.infrastructure.persistence.repositories import (
     SQLAlchemyMovieRepository,
     SQLAlchemySeriesRepository,
+)
+from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyMediaUnitOfWorkFactory,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
 
@@ -54,16 +57,22 @@ def _series(series_id: SeriesId, title: str, poster: str | None = None) -> Serie
 class TestCollectionsMediaLookupAdapter:
     """The adapter resolves titles + posters for the Collections BC."""
 
-    async def test_get_many_resolves_movies_and_series(self, db_session: AsyncSession) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-
+    async def test_get_many_resolves_movies_and_series(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
         movie_id = MovieId.generate()
         series_id = SeriesId.generate()
-        await movie_repo.save(_movie(movie_id, "Inception", "/p/inception.jpg"))
-        await series_repo.save(_series(series_id, "Breaking Bad", "/p/bb.jpg"))
+        await SQLAlchemyMovieRepository(db_session).save(
+            _movie(movie_id, "Inception", "/p/inception.jpg"),
+        )
+        await SQLAlchemySeriesRepository(db_session).save(
+            _series(series_id, "Breaking Bad", "/p/bb.jpg"),
+        )
+        await db_session.commit()
 
-        adapter = MediaLookupAdapter(movie_repo, series_repo)
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
         summaries = await adapter.get_many([str(movie_id)], [str(series_id)], "en")
 
@@ -75,30 +84,33 @@ class TestCollectionsMediaLookupAdapter:
         assert series_summary.title == "Breaking Bad"
         assert series_summary.poster_path == "/p/bb.jpg"
 
-    async def test_get_many_omits_missing_ids(self, db_session: AsyncSession) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-
-        adapter = MediaLookupAdapter(movie_repo, series_repo)
+    async def test_get_many_omits_missing_ids(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
         summaries = await adapter.get_many(["mov_missing00000"], [], "en")
 
         assert summaries == {}
 
-    async def test_get_many_handles_empty_input(self, db_session: AsyncSession) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-        adapter = MediaLookupAdapter(movie_repo, series_repo)
+    async def test_get_many_handles_empty_input(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
         assert await adapter.get_many([], [], "en") == {}
 
-    async def test_poster_path_is_none_when_media_has_none(self, db_session: AsyncSession) -> None:
-        movie_repo = SQLAlchemyMovieRepository(db_session)
-        series_repo = SQLAlchemySeriesRepository(db_session)
-
+    async def test_poster_path_is_none_when_media_has_none(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
         movie_id = MovieId.generate()
-        await movie_repo.save(_movie(movie_id, "No Poster"))
+        await SQLAlchemyMovieRepository(db_session).save(_movie(movie_id, "No Poster"))
+        await db_session.commit()
 
-        adapter = MediaLookupAdapter(movie_repo, series_repo)
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
         summaries = await adapter.get_many([str(movie_id)], [], "en")
 
         summary = summaries[(CollectionMediaType.MOVIE, str(movie_id))]

--- a/tests/modules/collections/integration/conftest.py
+++ b/tests/modules/collections/integration/conftest.py
@@ -4,38 +4,48 @@ from collections.abc import AsyncGenerator
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
 
 from src.infrastructure.persistence import Base
 
 
 @pytest.fixture(scope="function")
-async def db_session() -> AsyncGenerator[AsyncSession, None]:
-    """Create an in-memory SQLite database session for testing.
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """Expose an ``async_sessionmaker`` bound to an in-memory SQLite database.
 
-    Creates fresh tables for each test function and tears them down after.
-
-    Yields:
-        AsyncSession: A database session connected to an in-memory SQLite database.
+    ``StaticPool`` pins every connection to the same underlying SQLite
+    instance so seed-time sessions and UoW-opened sessions see the
+    same schema and rows.
     """
     engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:",
         echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
     )
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-    session_factory = async_sessionmaker(
+    factory = async_sessionmaker(
         bind=engine,
         class_=AsyncSession,
         expire_on_commit=False,
         autoflush=False,
     )
 
-    async with session_factory() as session:
-        yield session
+    yield factory
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
 
     await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+async def db_session(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[AsyncSession, None]:
+    """Seed-time session sharing the ``session_factory`` engine."""
+    async with session_factory() as session:
+        yield session

--- a/tests/modules/collections/unit/application/use_cases/test_check_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_check_watchlist.py
@@ -1,11 +1,10 @@
 """Tests for CheckWatchlistUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.modules.collections.application.use_cases import CheckWatchlistUseCase
-from src.modules.collections.domain.repositories import WatchlistRepository
 
 
 @pytest.mark.unit
@@ -14,20 +13,20 @@ class TestCheckWatchlistUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_true_when_in_watchlist(self) -> None:
-        mock_repo = AsyncMock(spec=WatchlistRepository)
-        mock_repo.exists.return_value = True
-        use_case = CheckWatchlistUseCase(watchlist_repository=mock_repo)
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.exists.return_value = True
+        use_case = CheckWatchlistUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute("mov_abc123def456")
 
         assert result is True
-        mock_repo.exists.assert_called_once_with("mov_abc123def456")
+        mocks.watchlist.exists.assert_called_once_with("mov_abc123def456")
 
     @pytest.mark.asyncio
     async def test_should_return_false_when_not_in_watchlist(self) -> None:
-        mock_repo = AsyncMock(spec=WatchlistRepository)
-        mock_repo.exists.return_value = False
-        use_case = CheckWatchlistUseCase(watchlist_repository=mock_repo)
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.exists.return_value = False
+        use_case = CheckWatchlistUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute("mov_abc123def456")
 

--- a/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
@@ -9,11 +9,7 @@ import pytest
 from tests.modules.collections.unit.application.use_cases.conftest import (
     make_media_lookup_mock,
 )
-
-if TYPE_CHECKING:
-    from tests.modules.collections.unit.application.use_cases.conftest import (
-        MediaSummaryFactory,
-    )
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.collections.application.dtos import (
@@ -23,8 +19,12 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetCustomListItemsUseCase
 from src.modules.collections.domain.entities import CustomList, CustomListItem
-from src.modules.collections.domain.repositories import CustomListRepository
 from src.shared_kernel.value_objects import CollectionMediaType
+
+if TYPE_CHECKING:
+    from tests.modules.collections.unit.application.use_cases.conftest import (
+        MediaSummaryFactory,
+    )
 
 
 @pytest.mark.unit
@@ -43,17 +43,16 @@ class TestGetCustomListItemsUseCase:
                 position=0,
             ),
         ]
-
-        mock_list_repo = AsyncMock(spec=CustomListRepository)
-        mock_list_repo.find_by_id.return_value = custom_list
-        mock_list_repo.list_items.return_value = items
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.find_by_id.return_value = custom_list
+        mocks.custom_lists.list_items.return_value = items
 
         media_lookup = make_media_lookup_mock(
             movie_summary("mov_abc123def456", "Inception"),
         )
 
         use_case = GetCustomListItemsUseCase(
-            custom_list_repository=mock_list_repo,
+            uow_factory=mocks.factory,
             media_lookup=media_lookup,
         )
 
@@ -66,10 +65,10 @@ class TestGetCustomListItemsUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:
-        mock_list_repo = AsyncMock(spec=CustomListRepository)
-        mock_list_repo.find_by_id.return_value = None
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.find_by_id.return_value = None
         use_case = GetCustomListItemsUseCase(
-            custom_list_repository=mock_list_repo,
+            uow_factory=mocks.factory,
             media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
@@ -81,11 +80,11 @@ class TestGetCustomListItemsUseCase:
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_no_items(self) -> None:
         custom_list = CustomList.create(name="Empty List")
-        mock_list_repo = AsyncMock(spec=CustomListRepository)
-        mock_list_repo.find_by_id.return_value = custom_list
-        mock_list_repo.list_items.return_value = []
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.find_by_id.return_value = custom_list
+        mocks.custom_lists.list_items.return_value = []
         use_case = GetCustomListItemsUseCase(
-            custom_list_repository=mock_list_repo,
+            uow_factory=mocks.factory,
             media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
@@ -103,12 +102,12 @@ class TestGetCustomListItemsUseCase:
                 position=0,
             ),
         ]
-        mock_list_repo = AsyncMock(spec=CustomListRepository)
-        mock_list_repo.find_by_id.return_value = custom_list
-        mock_list_repo.list_items.return_value = items
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.find_by_id.return_value = custom_list
+        mocks.custom_lists.list_items.return_value = items
 
         use_case = GetCustomListItemsUseCase(
-            custom_list_repository=mock_list_repo,
+            uow_factory=mocks.factory,
             media_lookup=make_media_lookup_mock(),
         )
 
@@ -135,10 +134,9 @@ class TestGetCustomListItemsUseCase:
                 position=1,
             ),
         ]
-
-        mock_list_repo = AsyncMock(spec=CustomListRepository)
-        mock_list_repo.find_by_id.return_value = custom_list
-        mock_list_repo.list_items.return_value = items
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.find_by_id.return_value = custom_list
+        mocks.custom_lists.list_items.return_value = items
 
         media_lookup = make_media_lookup_mock(
             movie_summary("mov_abc123def456", "Inception"),
@@ -146,7 +144,7 @@ class TestGetCustomListItemsUseCase:
         )
 
         use_case = GetCustomListItemsUseCase(
-            custom_list_repository=mock_list_repo,
+            uow_factory=mocks.factory,
             media_lookup=media_lookup,
         )
 
@@ -168,15 +166,14 @@ class TestGetCustomListItemsUseCase:
                 position=0,
             ),
         ]
-
-        mock_list_repo = AsyncMock(spec=CustomListRepository)
-        mock_list_repo.find_by_id.return_value = custom_list
-        mock_list_repo.list_items.return_value = items
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.find_by_id.return_value = custom_list
+        mocks.custom_lists.list_items.return_value = items
 
         media_lookup = make_media_lookup_mock(movie_summary("mov_abc123def456"))
 
         use_case = GetCustomListItemsUseCase(
-            custom_list_repository=mock_list_repo,
+            uow_factory=mocks.factory,
             media_lookup=media_lookup,
         )
 

--- a/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
@@ -9,11 +9,7 @@ import pytest
 from tests.modules.collections.unit.application.use_cases.conftest import (
     make_media_lookup_mock,
 )
-
-if TYPE_CHECKING:
-    from tests.modules.collections.unit.application.use_cases.conftest import (
-        MediaSummaryFactory,
-    )
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.modules.collections.application.dtos import (
     GetWatchlistInput,
@@ -22,8 +18,12 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
-from src.modules.collections.domain.repositories import WatchlistRepository
 from src.shared_kernel.value_objects import CollectionMediaType
+
+if TYPE_CHECKING:
+    from tests.modules.collections.unit.application.use_cases.conftest import (
+        MediaSummaryFactory,
+    )
 
 
 @pytest.mark.unit
@@ -40,16 +40,15 @@ class TestGetWatchlistUseCase:
                 media_type=CollectionMediaType.MOVIE,
             ),
         ]
-
-        mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
-        mock_watchlist_repo.list_all.return_value = items
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.list_all.return_value = items
 
         media_lookup = make_media_lookup_mock(
             movie_summary("mov_abc123def456", "Inception"),
         )
 
         use_case = GetWatchlistUseCase(
-            watchlist_repository=mock_watchlist_repo,
+            uow_factory=mocks.factory,
             media_lookup=media_lookup,
         )
 
@@ -61,10 +60,10 @@ class TestGetWatchlistUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_no_items(self) -> None:
-        mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
-        mock_watchlist_repo.list_all.return_value = []
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.list_all.return_value = []
         use_case = GetWatchlistUseCase(
-            watchlist_repository=mock_watchlist_repo,
+            uow_factory=mocks.factory,
             media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
@@ -80,11 +79,11 @@ class TestGetWatchlistUseCase:
                 media_type=CollectionMediaType.MOVIE,
             ),
         ]
-        mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
-        mock_watchlist_repo.list_all.return_value = items
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.list_all.return_value = items
 
         use_case = GetWatchlistUseCase(
-            watchlist_repository=mock_watchlist_repo,
+            uow_factory=mocks.factory,
             media_lookup=make_media_lookup_mock(),  # no summaries
         )
 
@@ -108,9 +107,8 @@ class TestGetWatchlistUseCase:
                 media_type=CollectionMediaType.SERIES,
             ),
         ]
-
-        mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
-        mock_watchlist_repo.list_all.return_value = items
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.list_all.return_value = items
 
         media_lookup = make_media_lookup_mock(
             movie_summary("mov_abc123def456", "Inception"),
@@ -118,7 +116,7 @@ class TestGetWatchlistUseCase:
         )
 
         use_case = GetWatchlistUseCase(
-            watchlist_repository=mock_watchlist_repo,
+            uow_factory=mocks.factory,
             media_lookup=media_lookup,
         )
 
@@ -130,16 +128,16 @@ class TestGetWatchlistUseCase:
 
     @pytest.mark.asyncio
     async def test_should_respect_limit(self) -> None:
-        mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
-        mock_watchlist_repo.list_all.return_value = []
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.list_all.return_value = []
         use_case = GetWatchlistUseCase(
-            watchlist_repository=mock_watchlist_repo,
+            uow_factory=mocks.factory,
             media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
         await use_case.execute(GetWatchlistInput(limit=25))
 
-        mock_watchlist_repo.list_all.assert_called_once_with(limit=25)
+        mocks.watchlist.list_all.assert_called_once_with(limit=25)
 
     @pytest.mark.asyncio
     async def test_should_pass_language_to_media_lookup(
@@ -151,14 +149,13 @@ class TestGetWatchlistUseCase:
                 media_type=CollectionMediaType.MOVIE,
             ),
         ]
-
-        mock_watchlist_repo = AsyncMock(spec=WatchlistRepository)
-        mock_watchlist_repo.list_all.return_value = items
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.list_all.return_value = items
 
         media_lookup = make_media_lookup_mock(movie_summary("mov_abc123def456"))
 
         use_case = GetWatchlistUseCase(
-            watchlist_repository=mock_watchlist_repo,
+            uow_factory=mocks.factory,
             media_lookup=media_lookup,
         )
 

--- a/tests/modules/collections/unit/application/use_cases/test_list_custom_lists.py
+++ b/tests/modules/collections/unit/application/use_cases/test_list_custom_lists.py
@@ -1,13 +1,12 @@
 """Tests for ListCustomListsUseCase."""
 
-from unittest.mock import AsyncMock
 
 import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.modules.collections.application.dtos import CustomListOutput
 from src.modules.collections.application.use_cases import ListCustomListsUseCase
 from src.modules.collections.domain.entities import CustomList
-from src.modules.collections.domain.repositories import CustomListRepository
 
 
 @pytest.mark.unit
@@ -20,9 +19,9 @@ class TestListCustomListsUseCase:
             CustomList.create(name="Action"),
             CustomList.create(name="Comedy"),
         ]
-        mock_repo = AsyncMock(spec=CustomListRepository)
-        mock_repo.list_all.return_value = lists
-        use_case = ListCustomListsUseCase(custom_list_repository=mock_repo)
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.list_all.return_value = lists
+        use_case = ListCustomListsUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute()
 
@@ -33,9 +32,9 @@ class TestListCustomListsUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_none_exist(self) -> None:
-        mock_repo = AsyncMock(spec=CustomListRepository)
-        mock_repo.list_all.return_value = []
-        use_case = ListCustomListsUseCase(custom_list_repository=mock_repo)
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.list_all.return_value = []
+        use_case = ListCustomListsUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute()
 


### PR DESCRIPTION
## Summary
- `ListCustomListsUseCase`, `CheckWatchlistUseCase`, `GetWatchlistUseCase`, and `GetCustomListItemsUseCase` take `CollectionsUnitOfWorkFactory` instead of `WatchlistRepository` / `CustomListRepository`. Each opens a UoW for reads and releases the session before the media lookup runs.
- `MediaLookupAdapter` receives `MediaUnitOfWorkFactory`; `get_many` batches `find_by_ids` inside a single short-lived Media UoW.
- `CollectionsContainer` drops `session` / `movie_repository` / `series_repository` dependencies; main container wires `media.media_unit_of_work_factory` into it.
- Integration fixture uses a `StaticPool`-backed engine so seed-time sessions and UoW-opened sessions share the same in-memory DB.

## Test plan
- [x] `poetry run pytest` — 1693 passed
- [x] `poetry run ruff check src tests` — clean

## Related
- PR 5 of 7; see `docs/uow-full-clean-refactoring-plan.md` for the full plan.

## Summary by Sourcery

Migrate collections read-side use cases and media lookup to use unit-of-work factories and align dependency wiring and tests with the new UoW-based design.

Bug Fixes:
- Ensure in-memory SQLite integration tests share a single database instance between seed-time sessions and unit-of-work sessions using a StaticPool-backed session factory.

Enhancements:
- Refactor collections read use cases (watchlist and custom lists) to operate through CollectionsUnitOfWorkFactory instead of direct repositories.
- Update MediaLookupAdapter to resolve movie and series summaries within a single short-lived Media unit of work instead of using direct repositories.
- Simplify CollectionsContainer wiring by removing direct session and media repository dependencies in favor of collections and media unit-of-work factories.

Tests:
- Adjust unit tests for collections use cases to work with mocked collections unit-of-work factories instead of repository mocks.
- Update collections/media integration tests to construct MediaLookupAdapter with a Media unit-of-work factory and use the shared session factory fixture.
- Refactor collections integration test fixtures to expose a reusable async_sessionmaker and derive db_session from it so UoW and seeding share the same engine.