### PR TITLE
refactor(preferences): migrate GetPreferencesUseCase to UoW factory

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -74,7 +74,6 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     preferences = providers.Container(
         PreferencesContainer,
-        session=infrastructure.session,
         session_factory=infrastructure.session_factory,
     )
 

--- a/src/config/containers/preferences.py
+++ b/src/config/containers/preferences.py
@@ -8,9 +8,6 @@ from src.modules.preferences.application.use_cases.get_preferences import (
 from src.modules.preferences.application.use_cases.update_preferences import (
     UpdatePreferencesUseCase,
 )
-from src.modules.preferences.infrastructure.persistence.repositories import (
-    SQLAlchemyPreferencesRepository,
-)
 from src.modules.preferences.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyPreferencesUnitOfWorkFactory,
 )
@@ -19,13 +16,7 @@ from src.modules.preferences.infrastructure.persistence.sqlalchemy_unit_of_work 
 class PreferencesContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Preferences bounded context."""
 
-    session = providers.Dependency()
     session_factory = providers.Dependency()
-
-    preferences_repository = providers.Factory(
-        SQLAlchemyPreferencesRepository,
-        session=session,
-    )
 
     preferences_unit_of_work_factory = providers.Singleton(
         SqlAlchemyPreferencesUnitOfWorkFactory,
@@ -34,7 +25,7 @@ class PreferencesContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     get_preferences = providers.Factory(
         GetPreferencesUseCase,
-        preferences_repository=preferences_repository,
+        uow_factory=preferences_unit_of_work_factory,
     )
 
     update_preferences = providers.Factory(

--- a/src/modules/preferences/application/use_cases/get_preferences.py
+++ b/src/modules/preferences/application/use_cases/get_preferences.py
@@ -1,8 +1,8 @@
 """GetPreferencesUseCase."""
 
 from src.modules.preferences.application.dtos.preferences_dtos import PreferencesOutput
+from src.modules.preferences.application.unit_of_work import PreferencesUnitOfWorkFactory
 from src.modules.preferences.domain.entities import DEFAULT_USER_KEY, PlaybackPreferences
-from src.modules.preferences.domain.repositories import PreferencesRepository
 
 
 class GetPreferencesUseCase:
@@ -13,12 +13,13 @@ class GetPreferencesUseCase:
     use case stays thin and keeps no magic constants of its own.
     """
 
-    def __init__(self, preferences_repository: PreferencesRepository) -> None:
-        self._repo = preferences_repository
+    def __init__(self, uow_factory: PreferencesUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
 
     async def execute(self) -> PreferencesOutput:
         """Fetch or default the user's playback preferences."""
-        entity = await self._repo.find_by_user_key(DEFAULT_USER_KEY)
+        async with self._uow_factory() as uow:
+            entity = await uow.preferences.find_by_user_key(DEFAULT_USER_KEY)
         if entity is None:
             entity = PlaybackPreferences.default_for(DEFAULT_USER_KEY)
         return _to_output(entity)

--- a/tests/modules/preferences/unit/application/use_cases/test_get_preferences.py
+++ b/tests/modules/preferences/unit/application/use_cases/test_get_preferences.py
@@ -1,24 +1,22 @@
 """Tests for GetPreferencesUseCase."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.modules.preferences.application.use_cases.get_preferences import (
     GetPreferencesUseCase,
 )
 from src.modules.preferences.domain.entities import DEFAULT_USER_KEY, PlaybackPreferences
-from src.modules.preferences.domain.repositories import PreferencesRepository
 from src.modules.preferences.domain.value_objects import Quality, Speed, SubtitleMode
+from tests.modules.preferences.unit.application.conftest import make_preferences_uow_mock
 
 
 @pytest.mark.unit
 class TestGetPreferencesUseCase:
     @pytest.mark.asyncio
     async def test_should_return_defaults_when_no_row_exists(self) -> None:
-        repo = AsyncMock(spec=PreferencesRepository)
-        repo.find_by_user_key.return_value = None
-        use_case = GetPreferencesUseCase(preferences_repository=repo)
+        mocks = make_preferences_uow_mock()
+        mocks.preferences.find_by_user_key.return_value = None
+        use_case = GetPreferencesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute()
 
@@ -27,17 +25,19 @@ class TestGetPreferencesUseCase:
         assert result.subtitle_mode == "foreignOnly"
         assert result.default_quality == "best"
         assert result.speed == 1.0
-        repo.find_by_user_key.assert_awaited_once_with(DEFAULT_USER_KEY)
+        mocks.preferences.find_by_user_key.assert_awaited_once_with(DEFAULT_USER_KEY)
 
     @pytest.mark.asyncio
     async def test_should_project_persisted_entity(self) -> None:
-        repo = AsyncMock(spec=PreferencesRepository)
-        repo.find_by_user_key.return_value = PlaybackPreferences.default_for().apply_updates(
-            subtitle_mode="always",
-            default_quality="1080p",
-            speed=1.5,
+        mocks = make_preferences_uow_mock()
+        mocks.preferences.find_by_user_key.return_value = (
+            PlaybackPreferences.default_for().apply_updates(
+                subtitle_mode="always",
+                default_quality="1080p",
+                speed=1.5,
+            )
         )
-        use_case = GetPreferencesUseCase(preferences_repository=repo)
+        use_case = GetPreferencesUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute()
 


### PR DESCRIPTION
## Summary
- `GetPreferencesUseCase` takes `PreferencesUnitOfWorkFactory` instead of `PreferencesRepository`; the single read now opens a UoW and releases the session.
- `PreferencesContainer` drops the `session` dependency — both use cases go through the UoW now, so only `session_factory` remains.

## Test plan
- [x] `poetry run pytest` — 1693 passed
- [x] `poetry run ruff check src tests` — clean

## Related
- PR 6 of 7; see `docs/uow-full-clean-refactoring-plan.md` for the full plan.

## Summary by Sourcery

Refactor preferences retrieval to use a unit-of-work factory instead of accessing the repository directly, and update wiring and tests accordingly.

Enhancements:
- Change GetPreferencesUseCase to resolve preferences via PreferencesUnitOfWorkFactory rather than injecting PreferencesRepository directly.
- Simplify PreferencesContainer by removing the direct session and repository providers and wiring use cases through the unit-of-work factory.

Tests:
- Adjust GetPreferencesUseCase unit tests to use a preferences unit-of-work mock instead of a repository mock.