### PR TITLE
refactor(media): one HLS cache bucket per file, native seek

### DIFF
--- a/src/modules/media/application/ports/hls_playlist_port.py
+++ b/src/modules/media/application/ports/hls_playlist_port.py
@@ -17,13 +17,15 @@ class HlsPlaylistPort(ABC):
     """Manage the HLS cache: playlists, segments, subtitles, eviction."""
 
     @abstractmethod
-    async def ensure_playlist(self, file_path: str, start_seconds: float = 0.0) -> str:
+    async def ensure_playlist(self, file_path: str) -> str:
         """Prepare an HLS cache for ``file_path`` and return its path hash.
 
-        Blocks until at least the master playlist and the first few
-        segments are ready so the caller can serve the playlist
-        immediately. ``start_seconds > 0`` seeks the source before
-        encoding (resume mid-file).
+        Blocks until at least the master playlist and the first segment
+        are ready so the caller can serve the playlist immediately. The
+        transcode always starts at the beginning of the source —
+        resume positions are a player-side concern applied via
+        ``HTMLMediaElement.currentTime`` once the manifest loads, which
+        keeps a single cache bucket per file reusable across sessions.
         """
         ...
 
@@ -49,7 +51,7 @@ class HlsPlaylistPort(ABC):
 
     @abstractmethod
     def clear_cache(self, file_path: str) -> None:
-        """Discard every cache entry tied to ``file_path`` (all seek offsets)."""
+        """Discard the cache entry for ``file_path``."""
         ...
 
 

--- a/src/modules/media/application/use_cases/generate_hls_playlist.py
+++ b/src/modules/media/application/use_cases/generate_hls_playlist.py
@@ -21,13 +21,10 @@ class GenerateHlsPlaylistInput:
             e.g. ``"/api/v1/stream/hls/{path_hash}"``. The use case
             does not know its own mount point, so presentation passes
             it in.
-        start_seconds: Optional resume offset (see
-            ``HlsPlaylistPort.ensure_playlist``).
     """
 
     file_path: str
     base_url_template: str
-    start_seconds: float = 0.0
 
 
 class GenerateHlsPlaylistUseCase:
@@ -40,7 +37,7 @@ class GenerateHlsPlaylistUseCase:
         """Generate (or reuse) the cache and return the rewritten master playlist.
 
         Args:
-            input_dto: File path, base URL, and optional seek.
+            input_dto: File path and base URL template.
 
         Returns:
             Path hash and rewritten master m3u8 content.
@@ -49,8 +46,7 @@ class GenerateHlsPlaylistUseCase:
             ResourceNotFoundException: If the playlist content is missing
                 from the cache after ``ensure_playlist`` returns.
         """
-        start = max(0.0, input_dto.start_seconds)
-        path_hash = await self._hls.ensure_playlist(input_dto.file_path, start)
+        path_hash = await self._hls.ensure_playlist(input_dto.file_path)
 
         content = self._hls.get_master_playlist(path_hash)
         if content is None:

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -61,20 +61,9 @@ _POLL_TIMEOUT = 120  # max seconds to wait for first segment
 _BROWSER_SAFE_CODECS = {"h264"}
 
 # Number of segments ffmpeg must produce before ensure_playlist returns.
-# When start_seconds > 0 we wait for more segments to give ffmpeg a head
-# start over the player, since the player begins consuming from the same
-# source position the encoder is writing to (no natural buffer build-up).
+# The transcode always starts at t=0, so one segment is enough to give
+# hls.js something to render; the rest stream in as they're written.
 _MIN_SEGMENTS_FRESH = 1
-_MIN_SEGMENTS_WITH_SEEK = 3
-
-# Seconds of decoded runway before the target position when using
-# the two-pass seek strategy (-ss before -i + -ss after -i). The
-# outer seek jumps cheaply to `start - runway`; the inner seek
-# decodes `runway` seconds so the audio codec is fully primed.
-# 5 seconds is enough for AAC initialization and safely within the
-# typical GOP size. Clamped to start_seconds at the call site so
-# we never seek to a negative position.
-_SEEK_RUNWAY = 5.0
 
 # Idle eviction defaults: kill ffmpeg after this many seconds with no
 # segment requests. Trade-off: short timeout frees CPU faster after the
@@ -82,53 +71,6 @@ _SEEK_RUNWAY = 5.0
 # next segment fail and the player rebuffer when they resume.
 _DEFAULT_IDLE_TIMEOUT = 30.0
 _EVICTION_INTERVAL = 10.0
-
-
-def _build_two_pass_seek_args(
-    start_seconds: float,
-    file_path: str,
-) -> list[str]:
-    """Return FFmpeg args for the two-pass seek strategy.
-
-    When ``start_seconds > 0``:
-      * outer ``-ss`` (before ``-i``): fast demuxer seek to a keyframe
-        a few seconds before the target.
-      * inner ``-ss`` (after ``-i``): accurate decoder seek over the
-        short runway so the AAC encoder has a full codec context.
-      * ``-avoid_negative_ts make_zero``: rebase PTS so both streams
-        start at exactly 0.
-
-    Do NOT add ``-copyts -start_at_zero`` here: those flags preserve
-    the pre-runway timestamps the inner ``-ss`` was supposed to drop,
-    which pushes audio ~``_SEEK_RUNWAY`` seconds ahead of video.
-    The audio-priming gap that the original two-pass seek was meant
-    to hide (video at local t=0, audio at t~0.5-1.0s from AAC warm-up)
-    is smoothed out in the encoder-level audio filter
-    (``aresample=async=1000``), which pads silence at the front of
-    the audio stream so both tracks start at t=0 without disturbing
-    the inner-seek trim.
-
-    When ``start_seconds <= 0`` (fresh play from the beginning),
-    returns just ``["-i", file_path]`` with no seek flags.
-
-    Shared by both ``_build_video_cmd`` and ``_build_audio_cmd`` so
-    the seek behaviour stays consistent and changes only need to
-    happen in one place.
-    """
-    if start_seconds <= 0:
-        return ["-i", file_path]
-
-    runway = min(start_seconds, _SEEK_RUNWAY)
-    return [
-        "-ss",
-        str(start_seconds - runway),
-        "-i",
-        file_path,
-        "-ss",
-        str(runway),
-        "-avoid_negative_ts",
-        "make_zero",
-    ]
 
 
 _VIDEO_DIR = "video"
@@ -297,20 +239,20 @@ class HlsService(HlsPlaylistPort):
 
     # -- Public API ------------------------------------------------------------
 
-    def get_path_hash(self, file_path: str, start_seconds: float = 0.0) -> str:
-        """Get the hash key for a (file path, start offset) pair.
+    def get_path_hash(self, file_path: str) -> str:
+        """Get the hash key for a source file.
 
         Args:
             file_path: Absolute path to the source video file.
-            start_seconds: Start offset in seconds for partial transcodes.
 
         Returns:
-            Hex MD5 digest uniquely identifying the cache bucket. Different
-            start offsets produce different hashes so partial transcodes do
-            not collide with full transcodes on disk.
+            Hex MD5 digest uniquely identifying the cache bucket for
+            this file. One bucket per file regardless of resume offset —
+            playback positions are handled client-side via the native
+            ``HTMLMediaElement.currentTime`` seek once the manifest
+            loads.
         """
-        key = f"{file_path}:{start_seconds}" if start_seconds else file_path
-        return hashlib.md5(key.encode()).hexdigest()
+        return hashlib.md5(file_path.encode()).hexdigest()
 
     def get_file_by_hash(self, path_hash: str, relative_path: str) -> Path | None:
         """Get any file from cache by hash + relative path.
@@ -403,23 +345,23 @@ class HlsService(HlsPlaylistPort):
         except (OSError, json.JSONDecodeError):
             return None
 
-    async def ensure_playlist(self, file_path: str, start_seconds: float = 0.0) -> str:
+    async def ensure_playlist(self, file_path: str) -> str:
         """Start generation and wait until the first segments are ready.
 
         Args:
             file_path: Absolute path to the source video file.
-            start_seconds: Start offset in seconds. FFmpeg seeks to this
-                position before transcoding, so the first produced segment
-                corresponds to (original time = start_seconds).
 
         Returns:
-            The path hash for this (file, start) pair.
+            The path hash for this file. Always the same hash for a
+            given path — resume positions are applied client-side after
+            the full manifest loads, so a single cache bucket per file
+            is reused across every session.
 
         Raises:
             RuntimeError: If FFmpeg is not available, fails, or times out.
             FileNotFoundError: If the source file does not exist.
         """
-        path_hash = self.get_path_hash(file_path, start_seconds)
+        path_hash = self.get_path_hash(file_path)
         # Touch immediately so the eviction loop never kills a process
         # that the user just asked for, even if no segments have been
         # served yet (e.g. while waiting for ffmpeg to start).
@@ -437,10 +379,9 @@ class HlsService(HlsPlaylistPort):
             msg = f"Source file not found: {file_path}"
             raise FileNotFoundError(msg)
 
-        await asyncio.to_thread(self._start_generation, file_path, start_seconds)
+        await asyncio.to_thread(self._start_generation, file_path)
 
         video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
-        min_segments = _MIN_SEGMENTS_WITH_SEEK if start_seconds > 0 else _MIN_SEGMENTS_FRESH
         attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
         for _ in range(attempts):
             if video_playlist.is_file():
@@ -450,7 +391,7 @@ class HlsService(HlsPlaylistPort):
                     # ffmpeg AFTER a segment is fully written and renamed,
                     # so anything counted here is safe to serve.
                     extinf_count = content.count("#EXTINF:")
-                    if extinf_count >= min_segments:
+                    if extinf_count >= _MIN_SEGMENTS_FRESH:
                         return path_hash
                 except OSError:
                     pass
@@ -472,20 +413,14 @@ class HlsService(HlsPlaylistPort):
             return self._deserialize_probe(cached)
         return self._probe.probe(file_path)
 
-    def clear_cache(
-        self,
-        file_path: str | None = None,
-        start_seconds: float = 0.0,
-    ) -> None:
+    def clear_cache(self, file_path: str | None = None) -> None:
         """Clear cached HLS segments.
 
         Args:
-            file_path: Clear cache for specific file, or all if None.
-            start_seconds: When ``file_path`` is given, targets the specific
-                (file, start) bucket. Ignored when clearing the full cache.
+            file_path: Clear cache for specific file, or all if ``None``.
         """
         if file_path:
-            path_hash = self.get_path_hash(file_path, start_seconds)
+            path_hash = self.get_path_hash(file_path)
             self._kill_processes(path_hash)
             shutil.rmtree(self._cache_dir / path_hash, ignore_errors=True)
         else:
@@ -533,17 +468,21 @@ class HlsService(HlsPlaylistPort):
 
     # -- Private: generation ---------------------------------------------------
 
-    def _start_generation(self, file_path: str, start_seconds: float = 0.0) -> str:
+    def _start_generation(self, file_path: str) -> str:
         """Start all FFmpeg processes for multi-track HLS generation.
+
+        Always transcodes from t=0 into a single per-file bucket. Resume
+        positions are applied client-side via ``video.currentTime`` once
+        the event-style playlist starts populating — this keeps the
+        cache reusable across sessions and lets the browser seek freely
+        in either direction.
 
         Args:
             file_path: Absolute path to the source video file.
-            start_seconds: Seek to this position before transcoding so the
-                output starts at (original time = start_seconds).
         """
         source = self._validate_source(file_path)
         safe_path = str(source)
-        path_hash = self.get_path_hash(file_path, start_seconds)
+        path_hash = self.get_path_hash(file_path)
 
         if self.is_complete(path_hash):
             return path_hash
@@ -585,8 +524,8 @@ class HlsService(HlsPlaylistPort):
             # 1. Main: video + default audio (always first in list)
             video_dir = output_dir / _VIDEO_DIR
             video_dir.mkdir()
-            cmd = self._build_video_cmd(safe_path, video_dir, probe_result, start_seconds)
-            _logger.info("Starting video HLS for %s (start=%ss)", safe_path, start_seconds)
+            cmd = self._build_video_cmd(safe_path, video_dir, probe_result)
+            _logger.info("Starting video HLS for %s", safe_path)
             procs.append(self._spawn_ffmpeg(cmd))
 
             # 2. Additional audio tracks (audio-only HLS)
@@ -596,13 +535,12 @@ class HlsService(HlsPlaylistPort):
                     continue
                 audio_dir = output_dir / f"audio_{track.index}"
                 audio_dir.mkdir()
-                cmd = self._build_audio_cmd(safe_path, audio_dir, track.index, start_seconds)
+                cmd = self._build_audio_cmd(safe_path, audio_dir, track.index)
                 _logger.info(
-                    "Starting audio HLS for track %d (%s) of %s (start=%ss)",
+                    "Starting audio HLS for track %d (%s) of %s",
                     track.index,
                     track.language.value,
                     safe_path,
-                    start_seconds,
                 )
                 procs.append(self._spawn_ffmpeg(cmd))
 
@@ -631,7 +569,7 @@ class HlsService(HlsPlaylistPort):
         for sub in text_subs:
             threading.Thread(
                 target=self._extract_one_subtitle,
-                args=(safe_path, output_dir, sub, start_seconds, path_hash),
+                args=(safe_path, output_dir, sub, path_hash),
                 daemon=True,
                 name=f"hls-sub-{path_hash[:8]}-{sub.index}",
             ).start()
@@ -642,7 +580,7 @@ class HlsService(HlsPlaylistPort):
         # sessions that started before the sprite was ready.
         threading.Thread(
             target=self._extract_thumbnails,
-            args=(safe_path, output_dir, start_seconds),
+            args=(safe_path, output_dir),
             daemon=True,
             name=f"hls-thumbs-{path_hash[:8]}",
         ).start()
@@ -695,13 +633,13 @@ class HlsService(HlsPlaylistPort):
         file_path: str,
         output_dir: Path,
         probe: ProbeResult,
-        start_seconds: float = 0.0,
     ) -> list[str]:
         """Build FFmpeg command for video + default audio.
 
-        When ``start_seconds > 0``, ``-ss`` is placed before ``-i`` so FFmpeg
-        does a fast demuxer-level seek to the nearest keyframe before the
-        requested position.
+        Always transcodes (or remuxes, for already-H.264 sources) from
+        the beginning of the file. Resume positions are a client-side
+        concern — the player calls ``video.currentTime`` once the
+        event-style playlist starts populating.
         """
         codec = self._probe_video_codec(file_path)
         needs_transcode = codec not in _BROWSER_SAFE_CODECS
@@ -716,102 +654,77 @@ class HlsService(HlsPlaylistPort):
         primary_idx = _primary_audio_index(probe)
         audio_map = f"0:a:{primary_idx}"
 
-        cmd = ["ffmpeg"]
-        cmd.extend(_build_two_pass_seek_args(start_seconds, file_path))
-        cmd.extend(
-            [
-                "-map",
-                "0:v:0",
-                "-map",
-                audio_map,
-                "-sn",
-                *video_args,
-                "-c:a",
-                "aac",
-                # aresample=async=1000 pads silence (or drops up to 1000
-                # samples per second) at the audio stream start so the
-                # first AAC frame aligns with the first video frame even
-                # after the two-pass seek. Without it the AAC encoder's
-                # priming period leaves a ~0.5-1s gap at the front of
-                # the audio stream; hls.js reads the gap as a buffer
-                # hole and the player either stalls or the user hears
-                # the dialogue start a beat after the picture.
-                "-af",
-                "aresample=async=1000",
-                "-ac",
-                "2",
-                "-ar",
-                "48000",
-                "-hls_time",
-                str(_SEGMENT_DURATION),
-                "-hls_list_size",
-                "0",
-                "-hls_playlist_type",
-                "event",
-                # temp_file: write each segment to .ts.tmp and rename to .ts
-                # only after it's fully written. Prevents the player from
-                # racing the encoder and grabbing partial bytes.
-                "-hls_flags",
-                "temp_file",
-                "-hls_segment_filename",
-                str(output_dir / "segment_%04d.ts"),
-                "-loglevel",
-                "error",
-                "-y",
-                str(output_dir / "playlist.m3u8"),
-            ]
-        )
-        return cmd
+        return [
+            "ffmpeg",
+            "-i",
+            file_path,
+            "-map",
+            "0:v:0",
+            "-map",
+            audio_map,
+            "-sn",
+            *video_args,
+            "-c:a",
+            "aac",
+            "-ac",
+            "2",
+            "-ar",
+            "48000",
+            "-hls_time",
+            str(_SEGMENT_DURATION),
+            "-hls_list_size",
+            "0",
+            "-hls_playlist_type",
+            "event",
+            # temp_file: write each segment to .ts.tmp and rename to .ts
+            # only after it's fully written. Prevents the player from
+            # racing the encoder and grabbing partial bytes.
+            "-hls_flags",
+            "temp_file",
+            "-hls_segment_filename",
+            str(output_dir / "segment_%04d.ts"),
+            "-loglevel",
+            "error",
+            "-y",
+            str(output_dir / "playlist.m3u8"),
+        ]
 
     @staticmethod
     def _build_audio_cmd(
         file_path: str,
         output_dir: Path,
         audio_index: int,
-        start_seconds: float = 0.0,
     ) -> list[str]:
-        """Build FFmpeg command for audio-only HLS track.
-
-        When ``start_seconds > 0``, uses the same two-pass seek
-        strategy as ``_build_video_cmd`` so the audio track starts
-        with a full codec context and stays aligned with the video.
-        """
-        cmd = ["ffmpeg"]
-        cmd.extend(_build_two_pass_seek_args(start_seconds, file_path))
-        cmd.extend(
-            [
-                "-map",
-                f"0:a:{audio_index}",
-                "-vn",
-                "-sn",
-                "-c:a",
-                "aac",
-                # Pad/drop at the stream start so audio_N segments stay
-                # aligned with the video track across seek boundaries.
-                # See the matching comment in ``_build_video_cmd``.
-                "-af",
-                "aresample=async=1000",
-                "-ac",
-                "2",
-                "-ar",
-                "48000",
-                "-hls_time",
-                str(_SEGMENT_DURATION),
-                "-hls_list_size",
-                "0",
-                "-hls_playlist_type",
-                "event",
-                "-hls_flags",
-                "temp_file",
-                "-hls_segment_filename",
-                str(output_dir / "segment_%04d.ts"),
-                "-loglevel",
-                "error",
-                "-y",
-                str(output_dir / "playlist.m3u8"),
-            ]
-        )
-        return cmd
+        """Build FFmpeg command for audio-only HLS track."""
+        return [
+            "ffmpeg",
+            "-i",
+            file_path,
+            "-map",
+            f"0:a:{audio_index}",
+            "-vn",
+            "-sn",
+            "-c:a",
+            "aac",
+            "-ac",
+            "2",
+            "-ar",
+            "48000",
+            "-hls_time",
+            str(_SEGMENT_DURATION),
+            "-hls_list_size",
+            "0",
+            "-hls_playlist_type",
+            "event",
+            "-hls_flags",
+            "temp_file",
+            "-hls_segment_filename",
+            str(output_dir / "segment_%04d.ts"),
+            "-loglevel",
+            "error",
+            "-y",
+            str(output_dir / "playlist.m3u8"),
+        ]
 
     # -- Private: subtitle extraction ------------------------------------------
 
@@ -820,39 +733,24 @@ class HlsService(HlsPlaylistPort):
         file_path: str,
         output_dir: Path,
         track: SubtitleTrack,
-        start_seconds: float,
         path_hash: str,
     ) -> None:
         """Extract a single text-based subtitle to WebVTT.
 
-        Runs ffmpeg synchronously and signals the readiness Event for this
-        track in ``self._subtitle_events`` from a ``finally`` block, so any
-        route handler waiting on it always unblocks (even on ffmpeg failure
-        or timeout) and gets a chance to respond — typically with a 404 if
-        extraction never produced a file.
+        Runs ffmpeg synchronously and signals the readiness Event for
+        this track in ``self._subtitle_events`` from a ``finally``
+        block, so any route handler waiting on it always unblocks (even
+        on ffmpeg failure or timeout) and gets a chance to respond —
+        typically with a 404 if extraction never produced a file.
 
-        When ``start_seconds > 0``, ``-ss`` is placed **after** ``-i``
-        (accurate decoder-level seek) so subtitle timestamps are
-        frame-accurate with the video. Unlike video/audio, subtitle
-        extraction is a one-shot background operation with negligible
-        data to decode, so accurate seek has no measurable cost.
-
-        The old code placed ``-ss`` before ``-i`` (fast demuxer seek)
-        which landed on the nearest keyframe — typically 1-5 seconds
-        off — causing subtitles to be out of sync with the video.
-
-        Note: ffmpeg is invoked with two separate inline literal-list
-        calls (embedded vs external) instead of building one ``cmd``
-        variable so the static-analysis rule against passing a
-        non-literal command to ``subprocess.run`` stays happy.
+        The source is read from the beginning; subtitle timestamps are
+        in source time, which matches the HLS stream (also from t=0)
+        and the player's ``video.currentTime``.
         """
         try:
             sub_dir = output_dir / f"sub_{track.index}"
             sub_dir.mkdir(exist_ok=True)
             vtt_path = sub_dir / "sub.vtt"
-            # Accurate seek: -ss AFTER -i so the decoder processes
-            # from the start and trims precisely at the target second.
-            ss_args = ["-ss", str(start_seconds)] if start_seconds > 0 else []
 
             if track.is_external:
                 if track.file_path is None:
@@ -865,7 +763,6 @@ class HlsService(HlsPlaylistPort):
                             "ffmpeg",
                             "-i",
                             input_arg,
-                            *ss_args,
                             "-c:s",
                             "webvtt",
                             "-loglevel",
@@ -888,7 +785,6 @@ class HlsService(HlsPlaylistPort):
                             "ffmpeg",
                             "-i",
                             file_path,
-                            *ss_args,
                             "-map",
                             f"0:s:{track.index}",
                             "-c:s",
@@ -923,33 +819,30 @@ class HlsService(HlsPlaylistPort):
         self,
         file_path: str,
         output_dir: Path,
-        start_seconds: float,
     ) -> None:
         """Produce sprite.jpg + sprite.vtt for scrub preview.
 
         Synchronous (runs inside its own thread from ``_start_generation``).
         Every failure mode — missing ffprobe, zero duration, ffmpeg
         non-zero exit, timeout — degrades to "no thumbnails this session"
-        rather than bubbling up, because the player works fine without them.
-
-        ``start_seconds`` shifts the source so the sprite covers from that
-        offset forward, matching the bucket's HLS timeline (which also
-        starts at zero local time when resuming mid-file).
+        rather than bubbling up, because the player works fine without
+        them. The sprite always covers the full source timeline so the
+        player's hover-over-seek-bar ``currentTime`` maps directly into
+        a cue regardless of where the viewer resumed playback.
         """
         duration = self._probe_duration(file_path)
         if duration <= 0:
             _logger.debug("Thumbs skipped for %s: unknown duration", file_path)
             return
-        effective_duration = max(0.0, duration - start_seconds)
-        if effective_duration < _THUMB_INTERVAL:
+        if duration < _THUMB_INTERVAL:
             _logger.debug(
-                "Thumbs skipped for %s: effective duration %.1fs below interval",
+                "Thumbs skipped for %s: duration %.1fs below interval",
                 file_path,
-                effective_duration,
+                duration,
             )
             return
 
-        layout = _compute_thumbnail_layout(effective_duration)
+        layout = _compute_thumbnail_layout(duration)
         thumbs_dir = output_dir / _THUMBNAILS_DIR
         thumbs_dir.mkdir(exist_ok=True)
         sprite_path = thumbs_dir / _THUMBNAIL_SPRITE_NAME
@@ -962,61 +855,29 @@ class HlsService(HlsPlaylistPort):
             f"tile={layout.columns}x{layout.rows}"
         )
 
-        # ffmpeg is invoked with two separate inline literal-list calls
-        # (with vs without ``-ss``) instead of building one ``cmd``
-        # variable so the static-analysis rule against passing a
-        # non-literal command to ``subprocess.run`` stays happy, and
-        # every argument on screen is either a constant or a validated
-        # path so a quick audit confirms nothing is user-controllable.
         try:
-            if start_seconds > 0:
-                result = subprocess.run(
-                    [
-                        "ffmpeg",
-                        "-ss",
-                        str(start_seconds),
-                        "-i",
-                        file_path,
-                        "-vf",
-                        filter_expr,
-                        "-frames:v",
-                        "1",
-                        "-q:v",
-                        str(_THUMBNAIL_JPEG_QUALITY),
-                        "-an",
-                        "-sn",
-                        "-loglevel",
-                        "error",
-                        "-y",
-                        str(sprite_path),
-                    ],
-                    **SUBPROCESS_TEXT_KWARGS,
-                    check=False,
-                    timeout=_THUMBNAIL_TIMEOUT,
-                )
-            else:
-                result = subprocess.run(
-                    [
-                        "ffmpeg",
-                        "-i",
-                        file_path,
-                        "-vf",
-                        filter_expr,
-                        "-frames:v",
-                        "1",
-                        "-q:v",
-                        str(_THUMBNAIL_JPEG_QUALITY),
-                        "-an",
-                        "-sn",
-                        "-loglevel",
-                        "error",
-                        "-y",
-                        str(sprite_path),
-                    ],
-                    **SUBPROCESS_TEXT_KWARGS,
-                    check=False,
-                    timeout=_THUMBNAIL_TIMEOUT,
-                )
+            result = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-i",
+                    file_path,
+                    "-vf",
+                    filter_expr,
+                    "-frames:v",
+                    "1",
+                    "-q:v",
+                    str(_THUMBNAIL_JPEG_QUALITY),
+                    "-an",
+                    "-sn",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    str(sprite_path),
+                ],
+                **SUBPROCESS_TEXT_KWARGS,
+                check=False,
+                timeout=_THUMBNAIL_TIMEOUT,
+            )
         except subprocess.TimeoutExpired:
             _logger.warning("Thumbnail generation timed out for %s", file_path)
             return

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -108,7 +108,6 @@ async def hls_file(
 @inject  # type: ignore[misc]
 async def movie_hls_playlist(
     movie_id: str,
-    start: float = 0.0,
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
@@ -119,7 +118,7 @@ async def movie_hls_playlist(
     """Generate and serve HLS master playlist for a movie."""
     movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
     file_path = _require_file(movie.file_path)
-    return await _serve_master(hls_uc, file_path, start)
+    return await _serve_master(hls_uc, file_path)
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/playlist.m3u8")  # type: ignore[misc]
@@ -128,7 +127,6 @@ async def episode_hls_playlist(
     series_id: str,
     season_number: int,
     episode_number: int,
-    start: float = 0.0,
     series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
@@ -139,7 +137,7 @@ async def episode_hls_playlist(
     """Generate and serve HLS master playlist for an episode."""
     file_path = await _find_episode_file(series_uc, series_id, season_number, episode_number)
     file_path = _require_file(file_path)
-    return await _serve_master(hls_uc, file_path, start)
+    return await _serve_master(hls_uc, file_path)
 
 
 # -- Track info ----------------------------------------------------------------
@@ -250,14 +248,12 @@ async def stream_episode(
 async def _serve_master(
     use_case: GenerateHlsPlaylistUseCase,
     file_path: str,
-    start_seconds: float,
 ) -> Response:
     """Run the generate-playlist use case and wrap its DTO in a Response."""
     output = await use_case.execute(
         GenerateHlsPlaylistInput(
             file_path=file_path,
             base_url_template=_MASTER_BASE_URL,
-            start_seconds=start_seconds,
         )
     )
     return Response(

--- a/tests/modules/media/unit/application/use_cases/test_generate_hls_playlist.py
+++ b/tests/modules/media/unit/application/use_cases/test_generate_hls_playlist.py
@@ -41,21 +41,7 @@ class TestGenerateHlsPlaylistUseCase:
 
         assert output.path_hash == "abc"
         assert "/api/v1/stream/hls/abc/video/playlist.m3u8" in output.rewritten_content
-        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv", 0.0)
-
-    @pytest.mark.asyncio
-    async def test_should_clamp_negative_start_to_zero(self) -> None:
-        hls = _make_hls_mock()
-        use_case = GenerateHlsPlaylistUseCase(hls=hls)
-
-        await use_case.execute(
-            GenerateHlsPlaylistInput(
-                file_path="/a.mkv",
-                base_url_template="/base/{path_hash}",
-                start_seconds=-5.0,
-            )
-        )
-        hls.ensure_playlist.assert_awaited_once_with("/a.mkv", 0.0)
+        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv")
 
     @pytest.mark.asyncio
     async def test_should_raise_when_master_playlist_missing(self) -> None:

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -103,25 +103,14 @@ class TestHlsServiceGetPathHash:
         service = HlsService(cache_dir=str(tmp_path / "hls"))
         assert service.get_path_hash("/a.mkv") != service.get_path_hash("/b.mkv")
 
-    def test_should_match_default_hash_when_start_seconds_is_zero(self, tmp_path: Path) -> None:
+    def test_should_depend_only_on_file_path(self, tmp_path: Path) -> None:
+        # The cache bucket is keyed by the source file alone: resume
+        # positions apply client-side via ``video.currentTime`` so every
+        # session for the same file reuses the same transcode output.
         service = HlsService(cache_dir=str(tmp_path / "hls"))
         path = "/movies/test.mkv"
-        assert service.get_path_hash(path) == service.get_path_hash(path, 0.0)
-
-    def test_should_differ_for_different_start_seconds(self, tmp_path: Path) -> None:
-        service = HlsService(cache_dir=str(tmp_path / "hls"))
-        path = "/movies/test.mkv"
-        hash_zero = service.get_path_hash(path, 0.0)
-        hash_middle = service.get_path_hash(path, 1800.0)
-        hash_end = service.get_path_hash(path, 5400.0)
-        assert hash_zero != hash_middle
-        assert hash_middle != hash_end
-        assert hash_zero != hash_end
-
-    def test_should_be_deterministic_with_start_seconds(self, tmp_path: Path) -> None:
-        service = HlsService(cache_dir=str(tmp_path / "hls"))
-        path = "/movies/test.mkv"
-        assert service.get_path_hash(path, 1234.5) == service.get_path_hash(path, 1234.5)
+        expected = hashlib.md5(path.encode()).hexdigest()
+        assert service.get_path_hash(path) == expected
 
 
 @pytest.mark.unit
@@ -292,60 +281,14 @@ class TestHlsServiceBuildAudioCmd:
 
         assert "aac" in cmd
 
-    def test_should_resample_audio_async_to_align_start_with_video(self, tmp_path: Path) -> None:
-        # ``aresample=async=1000`` pads or drops samples at the stream
-        # start so the first AAC frame aligns with the first video
-        # frame. Without it the AAC encoder's priming gap shows up as
-        # a buffer hole and hls.js stalls on resume.
-        cmd = HlsService._build_audio_cmd(
-            "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=30.0
-        )
-
-        af_idx = cmd.index("-af")
-        assert cmd[af_idx + 1] == "aresample=async=1000"
-
-    def test_should_not_include_ss_when_start_is_zero(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd(
-            "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=0.0
-        )
+    def test_should_never_emit_a_seek_flag(self, tmp_path: Path) -> None:
+        # The transcode always starts at t=0 — resume positions are
+        # applied client-side via ``video.currentTime``. A ``-ss`` in
+        # the ffmpeg argv would re-introduce the per-offset bucket
+        # problem the per-file cache was designed to avoid.
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
 
         assert "-ss" not in cmd
-
-    def test_should_use_two_pass_seek_when_start_is_set(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd(
-            "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=1800.0
-        )
-
-        ss_positions = [i for i, v in enumerate(cmd) if v == "-ss"]
-        assert len(ss_positions) == 2, "Expected two -ss flags (fast + accurate)"
-        i_idx = cmd.index("-i")
-        assert ss_positions[0] < i_idx, "First -ss must come before -i"
-        assert ss_positions[1] > i_idx, "Second -ss must come after -i"
-        assert cmd[ss_positions[0] + 1] == "1795.0"  # 1800 - 5 runway
-        assert cmd[ss_positions[1] + 1] == "5.0"  # runway
-        # ``-avoid_negative_ts make_zero`` keeps the rebase-to-zero.
-        # Explicitly asserting the ABSENCE of ``-copyts`` / ``-start_at_zero``
-        # so a well-meaning future edit can't reintroduce them: combined
-        # with two-pass seek those flags preserve the pre-runway samples
-        # the inner ``-ss`` is supposed to drop and push audio ~5s ahead
-        # of video.
-        assert "-avoid_negative_ts" in cmd
-        assert cmd[cmd.index("-avoid_negative_ts") + 1] == "make_zero"
-        assert "-copyts" not in cmd
-        assert "-start_at_zero" not in cmd
-
-    def test_should_clamp_runway_when_start_is_less_than_runway(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd(
-            "/movies/test.mkv", tmp_path, audio_index=0, start_seconds=2.0
-        )
-
-        ss_positions = [i for i, v in enumerate(cmd) if v == "-ss"]
-        assert len(ss_positions) == 2
-        # Outer seek is clamped to 0 so we never seek to a negative position
-        assert cmd[ss_positions[0] + 1] == "0.0"
-        # Inner seek equals the full start_seconds (runway == start)
-        assert cmd[ss_positions[1] + 1] == "2.0"
-        assert "-avoid_negative_ts" in cmd
 
 
 @pytest.mark.unit
@@ -371,19 +314,6 @@ class TestHlsServiceBuildVideoCmd:
 
         assert "libx264" in cmd
 
-    def test_should_resample_audio_async_to_align_start_with_video(self, tmp_path: Path) -> None:
-        # Same fix as in the audio-only path: the video pipeline's
-        # muxed AAC track needs the initial resample-pad so it doesn't
-        # lag behind the video at the start of each bucket.
-        service = HlsService(cache_dir=str(tmp_path / "cache"))
-        probe = ProbeResult(audio_tracks=[_make_audio_track()])
-
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start_seconds=30.0)
-
-        af_idx = cmd.index("-af")
-        assert cmd[af_idx + 1] == "aresample=async=1000"
-
     def test_should_map_primary_audio_track(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path / "cache"))
         probe = ProbeResult(
@@ -395,38 +325,16 @@ class TestHlsServiceBuildVideoCmd:
 
         assert "0:a:3" in cmd
 
-    def test_should_not_include_ss_when_start_is_zero(self, tmp_path: Path) -> None:
+    def test_should_never_emit_a_seek_flag(self, tmp_path: Path) -> None:
+        # Symmetric with the audio-only pipeline: the video transcode
+        # starts at t=0 and the player seeks natively.
         service = HlsService(cache_dir=str(tmp_path / "cache"))
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start_seconds=0.0)
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "-ss" not in cmd
-
-    def test_should_use_two_pass_seek_when_start_is_set(self, tmp_path: Path) -> None:
-        service = HlsService(cache_dir=str(tmp_path / "cache"))
-        probe = ProbeResult(audio_tracks=[_make_audio_track()])
-
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd(
-                "/movies/test.mkv", tmp_path, probe, start_seconds=5400.0
-            )
-
-        ss_positions = [i for i, v in enumerate(cmd) if v == "-ss"]
-        assert len(ss_positions) == 2, "Expected two -ss flags (fast + accurate)"
-        i_idx = cmd.index("-i")
-        assert ss_positions[0] < i_idx, "First -ss must come before -i"
-        assert ss_positions[1] > i_idx, "Second -ss must come after -i"
-        assert cmd[ss_positions[0] + 1] == "5395.0"  # 5400 - 5 runway
-        assert cmd[ss_positions[1] + 1] == "5.0"  # runway
-        # Two-pass seek keeps just ``-avoid_negative_ts make_zero`` — see
-        # the matching comment in the audio-cmd test for why we keep
-        # ``-copyts`` / ``-start_at_zero`` OUT of this pipeline.
-        assert "-avoid_negative_ts" in cmd
-        assert cmd[cmd.index("-avoid_negative_ts") + 1] == "make_zero"
-        assert "-copyts" not in cmd
-        assert "-start_at_zero" not in cmd
 
 
 @pytest.mark.unit
@@ -792,7 +700,6 @@ class TestHlsServiceExtractOneSubtitle:
                 file_path="/movies/test.mkv",
                 output_dir=output_dir,
                 track=track,
-                start_seconds=0.0,
                 path_hash="abc",
             )
 
@@ -817,7 +724,6 @@ class TestHlsServiceExtractOneSubtitle:
                 file_path="/movies/test.mkv",
                 output_dir=output_dir,
                 track=track,
-                start_seconds=0.0,
                 path_hash="abc",
             )
 
@@ -842,13 +748,14 @@ class TestHlsServiceExtractOneSubtitle:
                 file_path="/movies/test.mkv",
                 output_dir=output_dir,
                 track=track,
-                start_seconds=0.0,
                 path_hash="abc",
             )
 
         assert event.is_set()
 
-    def test_should_pass_ss_args_when_start_seconds_is_positive(self, tmp_path: Path) -> None:
+    def test_should_not_emit_a_seek_flag(self, tmp_path: Path) -> None:
+        # Subtitle timestamps are absolute source times, which is also
+        # what the player's ``currentTime`` reports — no seek needed.
         import threading
 
         service, output_dir = self._make_service(tmp_path)
@@ -867,18 +774,10 @@ class TestHlsServiceExtractOneSubtitle:
                 file_path="/movies/test.mkv",
                 output_dir=output_dir,
                 track=track,
-                start_seconds=42.0,
                 path_hash="abc",
             )
 
-        cmd = captured["cmd"]
-        assert "-ss" in cmd
-        ss_index = cmd.index("-ss")
-        assert cmd[ss_index + 1] == "42.0"
-        # -ss must come AFTER -i for accurate decoder-level seek
-        # (subtitles are text — accurate seek has negligible cost
-        # and keeps subs in sync with the two-pass video seek)
-        assert cmd.index("-ss") > cmd.index("-i")
+        assert "-ss" not in captured["cmd"]
 
     def test_kill_processes_should_release_subtitle_waiters(self, tmp_path: Path) -> None:
         import threading
@@ -1027,7 +926,7 @@ class TestHlsServiceExtractThumbnails:
                 side_effect=self._patch_ffmpeg_success(sprite_path),
             ),
         ):
-            service._extract_thumbnails("/fake/movie.mkv", output_dir, start_seconds=0.0)
+            service._extract_thumbnails("/fake/movie.mkv", output_dir)
 
         vtt_path = output_dir / "thumbnails" / "sprite.vtt"
         assert sprite_path.is_file()
@@ -1056,13 +955,13 @@ class TestHlsServiceExtractThumbnails:
                 side_effect=run,
             ) as mock_run,
         ):
-            service._extract_thumbnails("/fake/movie.mkv", output_dir, start_seconds=0.0)
+            service._extract_thumbnails("/fake/movie.mkv", output_dir)
 
         # Only ffprobe should have been called — no ffmpeg attempt, no outputs.
         assert mock_run.call_count == 1
         assert not (output_dir / "thumbnails").exists()
 
-    def test_should_skip_when_effective_duration_below_interval(self, tmp_path: Path) -> None:
+    def test_should_skip_when_duration_below_interval(self, tmp_path: Path) -> None:
         service = self._service(tmp_path)
         output_dir = tmp_path / "bucket"
         output_dir.mkdir()
@@ -1080,7 +979,7 @@ class TestHlsServiceExtractThumbnails:
                 side_effect=run,
             ) as mock_run,
         ):
-            service._extract_thumbnails("/fake/movie.mkv", output_dir, start_seconds=0.0)
+            service._extract_thumbnails("/fake/movie.mkv", output_dir)
 
         # Duration too short — no ffmpeg, no thumbnails directory.
         assert mock_run.call_count == 1
@@ -1106,7 +1005,7 @@ class TestHlsServiceExtractThumbnails:
                 side_effect=run,
             ),
         ):
-            service._extract_thumbnails("/fake/movie.mkv", output_dir, start_seconds=0.0)
+            service._extract_thumbnails("/fake/movie.mkv", output_dir)
 
         # thumbs dir was created before ffmpeg ran — but neither the
         # sprite nor the VTT should exist after the failure.
@@ -1133,14 +1032,15 @@ class TestHlsServiceExtractThumbnails:
                 side_effect=run,
             ),
         ):
-            service._extract_thumbnails("/fake/movie.mkv", output_dir, start_seconds=0.0)
+            service._extract_thumbnails("/fake/movie.mkv", output_dir)
 
         assert not (output_dir / "thumbnails" / "sprite.jpg").exists()
         assert not (output_dir / "thumbnails" / "sprite.vtt").exists()
 
-    def test_should_shift_sprite_coverage_by_start_seconds(self, tmp_path: Path) -> None:
-        # Resume at 90s out of 120s leaves 30s of effective duration,
-        # which should still produce at least one tile.
+    def test_should_cover_full_source_duration_without_seeking(self, tmp_path: Path) -> None:
+        # The sprite covers source time 0..duration for every session:
+        # resume positions are a player-side concern and the VTT's cue
+        # times match ``video.currentTime`` directly.
         service = self._service(tmp_path)
         output_dir = tmp_path / "bucket"
         output_dir.mkdir()
@@ -1156,17 +1056,14 @@ class TestHlsServiceExtractThumbnails:
                 side_effect=self._patch_ffmpeg_success(sprite_path),
             ) as mock_run,
         ):
-            service._extract_thumbnails("/fake/movie.mkv", output_dir, start_seconds=90.0)
+            service._extract_thumbnails("/fake/movie.mkv", output_dir)
 
-        # ffmpeg invocation should have carried a -ss 90.0 before -i.
+        # No ``-ss`` anywhere — the ffmpeg call reads the whole file.
         ffmpeg_call = next(call for call in mock_run.call_args_list if call.args[0][0] == "ffmpeg")
         cmd = ffmpeg_call.args[0]
-        assert "-ss" in cmd
-        assert cmd[cmd.index("-ss") + 1] == "90.0"
-        # And the VTT covers only the remaining 30 seconds from t=0 locally —
-        # three cues of 10s each, last one ending exactly at 30s.
+        assert "-ss" not in cmd
+
+        # 120s / 10s interval → 12 cues, last one ending at 02:00.
         vtt_text = (output_dir / "thumbnails" / "sprite.vtt").read_text(encoding="utf-8")
-        assert "00:00:00.000 --> 00:00:10.000" in vtt_text
-        assert "00:00:20.000 --> 00:00:30.000" in vtt_text
-        assert "00:00:30.000 --> 00:00:40.000" not in vtt_text
-        assert vtt_text.count("-->") == 3
+        assert vtt_text.count("-->") == 12
+        assert "00:01:50.000 --> 00:02:00.000" in vtt_text


### PR DESCRIPTION
## Summary
Drop per-offset HLS bucketing. ffmpeg always starts at t=0, serves an event-style playlist, and resume positions apply client-side via `HTMLMediaElement.currentTime`. One cache bucket per source file.

**Why:**
- **Seek backwards works.** Previously the bucket was keyed on `(file, start_seconds)`, so seeking to a point before the resume offset silently clamped to 0-of-bucket (= resume position), not 0-of-source.
- **Thumbnails and subtitles generate once.** Each resume used to spin up a new bucket that regenerated both; now they're reused for every session on the same file.
- **No more audio/video desync.** The two-pass seek math (`-ss` before + `-ss` after `-i`) could not always rebase audio and video PTS to the same local zero. Removing the seek removes the class of bug.

**Tradeoff:** resume to minute N in a long movie waits for ffmpeg to produce segments up to N. For `-c:v copy` (H.264, most of the library) that's disk-read speed — tens of seconds for typical movies. For non-H.264 sources the wait scales with transcode speed. Acceptable for a personal lab; on-demand segment spawning is the follow-up if it proves painful.

**API changes:**
- `HlsPlaylistPort.ensure_playlist(file_path)` — removed `start_seconds`.
- `HlsService.get_path_hash(file_path)` — removed `start_seconds`.
- `HlsService.clear_cache(file_path)` — removed `start_seconds`.
- `_build_video_cmd`, `_build_audio_cmd`, `_extract_one_subtitle`, `_extract_thumbnails` — all drop `start_seconds`.
- `GenerateHlsPlaylistInput.start_seconds` — removed (ignored if an old client passes `?start=`).
- `?start=` query param removed from `/movie/{id}/hls/playlist.m3u8` and the episode variant.
- `_build_two_pass_seek_args`, `_SEEK_RUNWAY`, `_MIN_SEGMENTS_WITH_SEEK` — deleted.

## Test plan
- [x] `poetry run pytest` — 1705 passed
- [x] `poetry run ruff check src tests && ruff format --check src tests` — clean
- [x] **Manual smoke:** played a fresh movie (start=0), paused mid-playback, closed player, reopened via Continue Watching → player seeked to saved position on its own, seek-backward worked. Verified by the user before this PR was opened.

## Frontend companion
The frontend also drops `?start=` and `startOffset` math in favor of native seek. Tracked separately in `homeflix-web`.

## Summary by Sourcery

Refactor HLS streaming to use a single per-file cache bucket and always transcode from t=0 while delegating resume/seek behavior to the browser’s native media seeking.

Enhancements:
- Simplify HLS cache keying to depend only on the source file path, removing start-offset–based buckets.
- Change the HLS generation pipeline (video, audio, subtitles, thumbnails) to always process from the beginning of the source without ffmpeg seek flags.
- Update HLS playlist application ports, use case DTOs, and streaming routes to drop start_seconds/start query parameters in favor of client-side seeking.
- Adjust thumbnail and subtitle generation so outputs cover the full source timeline and align directly with player currentTime semantics.

Tests:
- Update and add unit tests for HlsService, playlist generation, subtitles, and thumbnails to reflect per-file caching and the removal of server-side seek behavior.