### PR TITLE
fix(watch_progress): restore soft-deleted row on save

### DIFF
--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -40,16 +40,21 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         return None if model is None else WatchProgressMapper.to_entity(model)
 
     async def save(self, progress: WatchProgress) -> WatchProgress:
-        """Create or update a watch progress record."""
+        """Create or update a watch progress record.
+
+        Looks up by ``media_id`` including soft-deleted rows so that
+        resuming a previously dismissed item reuses the original row
+        instead of colliding with the UNIQUE(media_id) index.
+        """
         stmt = select(WatchProgressModel).where(
             WatchProgressModel.media_id == progress.media_id,
-            WatchProgressModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
         existing = result.scalar_one_or_none()
 
         if existing:
             WatchProgressMapper.update_model(existing, progress)
+            existing.restore()
             await self._session.flush()
             await self._session.refresh(existing)
             return WatchProgressMapper.to_entity(existing)

--- a/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
+++ b/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
@@ -54,6 +54,21 @@ class TestSQLAlchemyWatchProgressRepositorySave:
         assert found is not None
         assert found.position_seconds == 3000
 
+    async def test_save_should_restore_and_update_soft_deleted_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        original = _create_progress(position=500)
+        await repo.save(original)
+        await repo.delete(SAMPLE_MOVIE_ID)
+
+        resumed = _create_progress(position=750)
+        await repo.save(resumed)
+
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        assert found is not None
+        assert found.position_seconds == 750
+
     async def test_save_should_auto_complete_at_90_percent(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         progress = WatchProgress.create(


### PR DESCRIPTION
## Summary

- Fix ``UNIQUE constraint failed: watch_progress.media_id`` flood that hits ``PUT /api/v1/progress`` every 10 seconds after a user dismisses an item from Continue Watching and later replays it.
- ``save`` now looks up by ``media_id`` **including** soft-deleted rows, clears ``deleted_at``, and updates in place. New rows still insert. ``find_by_media_id`` keeps filtering soft-deleted rows so business logic is unchanged.
- Adds a regression test: save → delete → save again restores and updates the same row.

## Root cause

The ``watch_progresses`` table has ``UNIQUE(media_id)`` at the DB level, but both ``find_by_media_id`` and ``save`` filtered by ``deleted_at IS NULL``. A dismissed row stays physically in the table holding the ``media_id``, so every subsequent ``INSERT`` from the save path collided with the UNIQUE index.

## Test plan

- [x] ``pytest tests/modules/watch_progress/`` → 79 passed
- [x] ``ruff check`` + ``ruff format --check`` clean on touched files
- [x] Manual smoke test: resume a previously dismissed movie, PUT ``/api/v1/progress`` returns 200, the row's ``deleted_at`` clears, and subsequent auto-saves update the same row.

## Summary by Sourcery

Handle resuming previously dismissed watch progress without violating the unique media_id constraint by reusing soft-deleted rows.

Bug Fixes:
- Restore and update existing soft-deleted watch_progress rows on save instead of attempting a new insert that conflicts with UNIQUE(media_id).

Tests:
- Add an integration test covering save → delete → save flows to ensure soft-deleted watch progress records are restored and updated correctly.