### PR TITLE
chore: replace asserts in production code with explicit raises

### DIFF
--- a/src/building_blocks/infrastructure/sqlalchemy_unit_of_work.py
+++ b/src/building_blocks/infrastructure/sqlalchemy_unit_of_work.py
@@ -49,25 +49,38 @@ class SqlAlchemyUnitOfWork(UnitOfWork):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        assert self._session is not None
+        session = self._require_session()
         try:
             if exc_type is None:
-                await self._session.commit()
+                await session.commit()
             else:
-                await self._session.rollback()
+                await session.rollback()
         finally:
-            await self._session.close()
+            await session.close()
             self._session = None
 
     async def commit(self) -> None:
         """Commit the active transaction."""
-        assert self._session is not None, "UnitOfWork not started; use `async with`."
-        await self._session.commit()
+        await self._require_session().commit()
 
     async def rollback(self) -> None:
         """Roll back the active transaction."""
-        assert self._session is not None, "UnitOfWork not started; use `async with`."
-        await self._session.rollback()
+        await self._require_session().rollback()
+
+    def _require_session(self) -> AsyncSession:
+        """Return the active session or raise ``RuntimeError`` if not started.
+
+        Replaces the previous ``assert`` guards: ``assert`` would be
+        stripped under ``python -O``, leaving an ``AttributeError`` on
+        the next call instead of a clear "you forgot ``async with``"
+        message. ``RuntimeError`` is unconditional and explicit.
+        """
+        if self._session is None:
+            raise RuntimeError(
+                f"{type(self).__name__} not started; use `async with` before "
+                "calling commit/rollback or accessing repositories."
+            )
+        return self._session
 
     def _build_repositories(self, session: AsyncSession) -> None:
         """Attach bounded-context repositories to ``self`` for this transaction.

--- a/src/building_blocks/presentation/exception_handlers.py
+++ b/src/building_blocks/presentation/exception_handlers.py
@@ -10,7 +10,7 @@ serialize a category of errors. The envelope format comes from
 ``CoreException.to_dict()`` so the contract stays in one place.
 """
 
-from typing import Any
+from typing import Any, cast
 
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
@@ -50,8 +50,13 @@ async def core_exception_handler(request: Request, exc: Exception) -> JSONRespon
     Logging level is chosen from ``exc.severity`` so a 4xx doesn't look
     like a 5xx in the logs. The payload uses ``CoreException.to_dict()``
     — no sensitive ``_internal`` block is ever serialized.
+
+    The ``Exception`` parameter type matches FastAPI's handler protocol;
+    registration in ``register_exception_handlers`` guarantees this
+    handler only receives ``CoreException`` instances, so we narrow via
+    ``cast`` instead of a runtime check.
     """
-    assert isinstance(exc, CoreException)  # narrow type for handler signature
+    exc = cast(CoreException, exc)
     logger = get_logger().bind(
         exception_id=exc.exception_id,
         code=exc.code,
@@ -68,7 +73,7 @@ async def request_validation_exception_handler(
     exc: Exception,
 ) -> JSONResponse:
     """Format FastAPI/Pydantic request validation errors in v3 shape."""
-    assert isinstance(exc, RequestValidationError)
+    exc = cast(RequestValidationError, exc)
     errors = [
         {
             "field": ".".join(str(loc) for loc in err.get("loc", ())[1:]),
@@ -100,7 +105,7 @@ async def http_exception_handler(request: Request, exc: Exception) -> JSONRespon
     mismatches or ``Response(404)`` shortcuts). Wrap them so clients
     see the same shape as typed exceptions.
     """
-    assert isinstance(exc, StarletteHTTPException)
+    exc = cast(StarletteHTTPException, exc)
     error_type = _STATUS_TO_ERROR_TYPE.get(exc.status_code, "api_error")
 
     detail = exc.detail

--- a/src/infrastructure/scheduling/thumbnail_backfill_job.py
+++ b/src/infrastructure/scheduling/thumbnail_backfill_job.py
@@ -221,7 +221,8 @@ class ThumbnailBackfillJob:
             await uow.movies.save(movie.with_updates(scrub_preview_path=path_value))
 
     async def _persist_episode(self, episode: Episode, result: ThumbnailResult) -> None:
-        assert episode.id is not None
+        if episode.id is None:
+            raise RuntimeError("Episode loaded from repository has no id")
         async with self._media_uow_factory() as uow:
             await uow.series.update_episode_scrub_preview_path(
                 episode.id,

--- a/src/modules/library/infrastructure/persistence/repositories/sqlalchemy_library_repository.py
+++ b/src/modules/library/infrastructure/persistence/repositories/sqlalchemy_library_repository.py
@@ -58,9 +58,11 @@ class SqlAlchemyLibraryRepository(LibraryRepository):
             await self._session.flush()
 
         # Transaction commit is the Unit of Work's responsibility.
-        assert library.id is not None
+        if library.id is None:
+            raise RuntimeError("Library id was not assigned before save")
         saved = await self.find_by_id(library.id)
-        assert saved is not None
+        if saved is None:
+            raise RuntimeError(f"Library {library.id} disappeared between flush and reload")
         return saved
 
     async def find_by_id(self, library_id: LibraryId) -> Library | None:

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -361,7 +361,8 @@ class ScanMediaDirectoriesUseCase:
         """Process a group of files for a single episode."""
         season = series.get_season(season_num)
         if not season:
-            assert series.id is not None
+            if series.id is None:
+                raise RuntimeError("Series id must be assigned before creating seasons")
             season = Season(series_id=series.id, season_number=SeasonNumber(season_num))
             series = series.with_season(season)
 
@@ -387,7 +388,8 @@ class ScanMediaDirectoriesUseCase:
     ) -> Episode:
         """Create a new Episode from scanned files."""
         first = ep_files[0]
-        assert series.id is not None
+        if series.id is None:
+            raise RuntimeError("Series id must be assigned before creating episodes")
         ep_title = first.episode_title or f"Episode {episode_num}"
         episode = Episode(
             series_id=series.id,

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -103,9 +103,11 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         # Reload with relationships to return a complete entity.
         # Transaction commit is the Unit of Work's responsibility.
-        assert movie.id is not None
+        if movie.id is None:
+            raise RuntimeError("Movie id must be assigned before reload")
         result_entity = await self.find_by_id(movie.id)
-        assert result_entity is not None
+        if result_entity is None:
+            raise RuntimeError(f"Movie {movie.id} disappeared between flush and reload")
         return result_entity
 
     async def delete(self, movie_id: MovieId) -> bool:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -527,9 +527,11 @@ class SQLAlchemySeriesRepository(SeriesRepository):
 
         # Reload and return (series.id is guaranteed to exist after _ensure_ids).
         # Transaction commit is the Unit of Work's responsibility.
-        assert series.id is not None
+        if series.id is None:
+            raise RuntimeError("Series id must be assigned before reload")
         result = await self.find_by_id(series.id)
-        assert result is not None
+        if result is None:
+            raise RuntimeError(f"Series {series.id} disappeared between flush and reload")
         return result
 
     async def _update_series(
@@ -581,9 +583,11 @@ class SQLAlchemySeriesRepository(SeriesRepository):
 
         # Reload and return (series.id is guaranteed to exist).
         # Transaction commit is the Unit of Work's responsibility.
-        assert series.id is not None
+        if series.id is None:
+            raise RuntimeError("Series id must be assigned before reload")
         result = await self.find_by_id(series.id)
-        assert result is not None
+        if result is None:
+            raise RuntimeError(f"Series {series.id} disappeared between flush and reload")
         return result
 
     async def _update_season_episodes(

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -117,7 +117,10 @@ async def hls_file(
             media_type=output.media_type,
             headers={"Cache-Control": "no-cache"},
         )
-    assert output.path is not None
+    if output.path is None:
+        raise RuntimeError(
+            f"ServeHlsFile returned non-playlist output without a path (kind={output.kind!r})"
+        )
     return FileResponse(str(output.path), media_type=output.media_type)
 
 


### PR DESCRIPTION
## Summary

`assert` statements are stripped when Python runs with `-O`, silently converting every invariant guard in production code into a no-op. This PR replaces all 18 occurrences in `src/` with the right runtime mechanism so the checks survive optimization mode.

| Where | Replacement |
|---|---|
| `SqlAlchemyUnitOfWork` (3 asserts on `self._session`) | New `_require_session()` helper that raises `RuntimeError` with a clear "use `async with`" message; `__aexit__`, `commit`, and `rollback` go through it |
| Repository post-save / post-load invariants (movie / series / library) and the scan use case (6 asserts) | Explicit `if x is None: raise RuntimeError(...)` so a flush/reload mismatch fails loudly instead of writing `None` downstream |
| `stream_routes` `output.path` (1) and `thumbnail_backfill_job` `episode.id` (1) | Same explicit-raise pattern |
| Global exception handlers (3 asserts) | `typing.cast` — these were pure type narrowing dictated by FastAPI's `Exception` handler protocol; registration already guarantees the concrete type and a runtime check on every error path adds no value |

No behavior change for any path that wasn't already a logic bug.

## Test plan

- [x] `make lint` clean
- [x] `make format` clean
- [x] Full test suite: 1723 passed
- [ ] Smoke-test the app under `python -O` (optional) — the asserts that used to be stripped now actually run, so any path that triggered an invariant violation previously would have silently continued; we want to confirm nothing legitimate trips them.

## Summary by Sourcery

Replace Python assert statements in production code with explicit runtime checks and type casts so invariants are enforced even under optimized execution.

Bug Fixes:
- Ensure SqlAlchemyUnitOfWork methods fail with a clear RuntimeError when used without an active session instead of relying on stripped asserts.
- Raise explicit RuntimeError exceptions when expected entity IDs or reload results are missing in movie, series, and library repository operations.
- Guard media scan, streaming routes, and thumbnail backfill paths with explicit RuntimeError when required attributes like IDs or output paths are absent.

Enhancements:
- Use typing.cast for FastAPI exception handlers to narrow exception types without runtime isinstance assertions that are removed under optimization.