### PR TITLE
fix(media): eager-load episode file_variants in series search

### DIFF
--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -663,7 +663,11 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 SeriesModel.id.in_(rowid_to_rank.keys()),
                 SeriesModel.deleted_at.is_(None),
             )
-            .options(selectinload(SeriesModel.seasons).selectinload(SeasonModel.episodes))
+            .options(
+                selectinload(SeriesModel.seasons)
+                .selectinload(SeasonModel.episodes)
+                .selectinload(EpisodeModel.file_variants),
+            )
         )
         if genre:
             delimited = "," + SeriesModel.genres + ","


### PR DESCRIPTION
## Summary

`SQLAlchemySeriesRepository.search` loaded `seasons → episodes` but stopped short of `episodes → file_variants`. `EpisodeMapper.to_entity` unconditionally reads `model.file_variants`, so any series hit that owned variants triggered a lazy-load after the AsyncSession had already released the greenlet, raising `MissingGreenlet` and 500-ing every search request that matched a series with episode files.

The fix extends the eager-load chain to mirror what `find_by_id` already does (lines 70-72) — both queries hand the same model to the same mapper, so they have to load the same relationships.

## Stack trace excerpt

```
File "src/modules/media/infrastructure/persistence/repositories/series_repository.py", line 680, in search
    (SeriesMapper.to_entity(m), rowid_to_rank[m.id])
File "src/modules/media/infrastructure/persistence/mappers/series_mapper.py", line 98, in to_entity
    if model.file_variants:
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here.
```

## Test plan

- [x] `make lint` clean
- [x] `make format` clean
- [x] Existing media test suite (913 tests) green
- [x] Manual repro confirmed fixed: searching a term that matches a series with episode `file_variants` now returns 200 with hits instead of a 500

## Why no regression test

The integration test fixture for FTS5 is non-trivial (requires the `series_fts` virtual table and triggers from migrations to be present in the test DB), and existing `search` paths have no integration coverage. Adding that scaffolding is worth its own change; this PR is a hot-path fix.

## Summary by Sourcery

Bug Fixes:
- Prevent MissingGreenlet errors in series search by eagerly loading episode file variants along with seasons and episodes.