### PR TITLE
refactor(media): drop hierarchy fan-out from FTS search path

### DIFF
--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -90,7 +90,7 @@ class MovieMapper:
         return model
 
     @staticmethod
-    def to_entity(model: MovieModel) -> Movie:
+    def to_entity(model: MovieModel, *, include_files: bool = True) -> Movie:
         """Convert MovieModel to Movie entity.
 
         Uses the file_variants relationship if loaded, otherwise
@@ -98,6 +98,13 @@ class MovieMapper:
 
         Args:
             model: The SQLAlchemy MovieModel.
+            include_files: When ``False``, skip the file_variants
+                relationship entirely and return an entity with
+                ``files=[]``. Used by the search path which only
+                reads root metadata (title, year, poster, ...) and
+                doesn't need the variants — touching ``file_variants``
+                on an unloaded relationship would trigger an async
+                lazy-load outside the session greenlet.
 
         Returns:
             Domain Movie entity with reconstructed value objects.
@@ -107,19 +114,20 @@ class MovieMapper:
             genre_list = [Genre(g.strip()) for g in model.genres.split(",") if g.strip()]
 
         files: list[MediaFile] = []
-        if model.file_variants:
-            files = [
-                MediaFileMapper.to_entity(fv) for fv in model.file_variants if not fv.is_deleted
-            ]
-        elif model.file_path:
-            files = [
-                MediaFile(
-                    file_path=FilePath(model.file_path),
-                    file_size=model.file_size,
-                    resolution=Resolution(model.resolution),
-                    is_primary=True,
-                )
-            ]
+        if include_files:
+            if model.file_variants:
+                files = [
+                    MediaFileMapper.to_entity(fv) for fv in model.file_variants if not fv.is_deleted
+                ]
+            elif model.file_path:
+                files = [
+                    MediaFile(
+                        file_path=FilePath(model.file_path),
+                        file_size=model.file_size,
+                        resolution=Resolution(model.resolution),
+                        is_primary=True,
+                    )
+                ]
 
         return Movie(
             id=MovieId(model.external_id),

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -397,14 +397,16 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         rowid_to_rank = {row[0]: row[1] for row in fts_rows}
 
-        # Step 2: Load full ORM models for the matched rowids
-        stmt = (
-            select(MovieModel)
-            .where(
-                MovieModel.id.in_(rowid_to_rank.keys()),
-                MovieModel.deleted_at.is_(None),
-            )
-            .options(selectinload(MovieModel.file_variants))
+        # Step 2: Load only the root MovieModel rows. ``SearchCatalogUseCase``
+        # builds ``SearchItemOutput`` from root columns + ``localized`` JSON
+        # only — it never touches ``movie.files``. Skipping ``file_variants``
+        # here avoids a fan-out of one extra query plus N rows of file
+        # metadata per hit, which on a 30-result search with rich
+        # multi-resolution variants meant thousands of rows fetched and
+        # immediately discarded.
+        stmt = select(MovieModel).where(
+            MovieModel.id.in_(rowid_to_rank.keys()),
+            MovieModel.deleted_at.is_(None),
         )
         if genre:
             delimited = "," + MovieModel.genres + ","
@@ -417,9 +419,11 @@ class SQLAlchemyMovieRepository(MovieRepository):
         result = await self._session.execute(stmt)
         models = result.scalars().all()
 
-        # Step 3: Map to entities and pair with rank, sorted by rank
+        # Step 3: Map to shallow entities (files=[]) and pair with rank.
         hits = [
-            (MovieMapper.to_entity(m), rowid_to_rank[m.id]) for m in models if m.id in rowid_to_rank
+            (MovieMapper.to_entity(m, include_files=False), rowid_to_rank[m.id])
+            for m in models
+            if m.id in rowid_to_rank
         ]
         hits.sort(key=lambda h: h[1])
         return hits[:limit]

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -657,13 +657,17 @@ class SQLAlchemySeriesRepository(SeriesRepository):
 
         rowid_to_rank = {row[0]: row[1] for row in fts_rows}
 
-        stmt = (
-            select(SeriesModel)
-            .where(
-                SeriesModel.id.in_(rowid_to_rank.keys()),
-                SeriesModel.deleted_at.is_(None),
-            )
-            .options(selectinload(SeriesModel.seasons).selectinload(SeasonModel.episodes))
+        # Load only the root ``SeriesModel`` rows. ``SearchCatalogUseCase``
+        # builds ``SearchItemOutput`` from root columns + ``localized`` JSON
+        # only — it never touches ``series.seasons``. Skipping the
+        # season → episode → file_variants chain avoids fanning out into
+        # potentially thousands of rows per search (e.g. a 10-season,
+        # 22-episode series with multi-resolution variants) just to be
+        # discarded by the use case. Also keeps ``EpisodeMapper`` from
+        # lazy-loading ``file_variants`` outside the session greenlet.
+        stmt = select(SeriesModel).where(
+            SeriesModel.id.in_(rowid_to_rank.keys()),
+            SeriesModel.deleted_at.is_(None),
         )
         if genre:
             delimited = "," + SeriesModel.genres + ","
@@ -677,7 +681,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         models = result.scalars().unique().all()
 
         hits = [
-            (SeriesMapper.to_entity(m), rowid_to_rank[m.id])
+            (SeriesMapper.to_entity(m, include_seasons=False), rowid_to_rank[m.id])
             for m in models
             if m.id in rowid_to_rank
         ]

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
@@ -1,5 +1,7 @@
 """Unit tests for MovieMapper."""
 
+from datetime import UTC, datetime
+
 import pytest
 
 from src.modules.media.domain.entities import Movie
@@ -13,6 +15,7 @@ from src.modules.media.domain.value_objects import (
     Year,
 )
 from src.modules.media.infrastructure.persistence.mappers import MovieMapper
+from src.modules.media.infrastructure.persistence.models import MovieModel
 
 
 def _create_movie(movie_id: MovieId | None = None) -> Movie:
@@ -55,3 +58,58 @@ class TestMovieMapper:
         assert model.title == "Test Movie"
         assert model.year == 2024
         assert model.duration == 7200
+
+    def test_to_entity_shallow_returns_empty_files_even_with_legacy_columns(self) -> None:
+        """``include_files=False`` must skip the file-loading branch entirely.
+
+        Set the legacy flat columns (``file_path`` etc.) so the default
+        path *would* materialize a fallback ``MediaFile``; with the flag
+        off, the result is still empty. This pins the search path's
+        contract: the use case never reads ``movie.files``, so a
+        regression that drops the flag check would re-enable variant
+        loading and could re-introduce the lazy-load bug under search.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            file_path="/movies/test.mkv",
+            file_size=1_000,
+            resolution="1080p",
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model, include_files=False)
+
+        assert entity.id == movie_id
+        assert entity.title.value == "Test Movie"
+        assert entity.files == []
+
+    def test_to_entity_default_loads_files_from_legacy_columns(self) -> None:
+        """Default ``include_files=True`` still falls back to flat columns.
+
+        Pinned alongside the shallow test so the fallback contract
+        doesn't regress silently when someone refactors the flag.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            file_path="/movies/test.mkv",
+            file_size=1_000,
+            resolution="1080p",
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model)
+
+        assert len(entity.files) == 1
+        assert entity.files[0].file_path.value == "/movies/test.mkv"

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
@@ -1,5 +1,7 @@
 """Unit tests for SeriesMapper, SeasonMapper, and EpisodeMapper."""
 
+from datetime import UTC, datetime
+
 import pytest
 
 from src.modules.media.domain.entities import Episode, Season, Series
@@ -19,6 +21,7 @@ from src.modules.media.infrastructure.persistence.mappers import (
     SeasonMapper,
     SeriesMapper,
 )
+from src.modules.media.infrastructure.persistence.models import SeriesModel
 
 
 def _create_episode(
@@ -136,3 +139,29 @@ class TestSeriesMapper:
         assert model.external_id == str(series_id)
         assert model.title == "Test Series"
         assert model.start_year == 2020
+
+    def test_to_entity_shallow_returns_empty_seasons(self) -> None:
+        """``include_seasons=False`` skips the seasons relationship.
+
+        The search path uses this so it never triggers a lazy-load
+        of seasons / episodes / file_variants on the way to building
+        a ``SearchItemOutput`` (which only reads root fields and the
+        ``localized`` JSON). Pinning this contract keeps a future
+        refactor from silently re-enabling the heavy fan-out.
+        """
+        series_id = SeriesId.generate()
+        now = datetime.now(UTC)
+        model = SeriesModel(
+            external_id=str(series_id),
+            title="Shallow Series",
+            start_year=2020,
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = SeriesMapper.to_entity(model, include_seasons=False)
+
+        assert entity.id == series_id
+        assert entity.title.value == "Shallow Series"
+        assert entity.start_year.value == 2020
+        assert entity.seasons == []


### PR DESCRIPTION
## Summary

`SearchCatalogUseCase._to_output` only reads root metadata (title, year, poster, `localized` JSON). It never touches `movie.files` or `series.seasons`. The repositories' `search` methods nonetheless eager-loaded the whole `seasons → episodes → file_variants` chain (and `movie.file_variants`), so on a 30-result hit against a catalog of multi-season series with multi-resolution variants, thousands of rows were fetched and immediately discarded.

This PR drops every `selectinload` from both `search` queries and routes the rows through shallow mapper variants:

- `SeriesMapper.to_entity` already had `include_seasons`; pass `False` from search.
- `MovieMapper.to_entity` gains a symmetric `include_files`; pass `False` from search.

Both shallow paths return entities with empty list relations, which matches what the use case consumes.

## Side benefit

`EpisodeMapper` no longer risks lazy-loading `file_variants` outside the session greenlet — the `MissingGreenlet` failure mode that PR #136 chased disappears entirely on the search path because the chain isn't walked at all.

**This PR supersedes #136.** Once this merges, #136 can be closed unmerged.

## Performance impact (qualitative)

Before: FTS hit (1 query) + seriesroot SELECT (1) + selectin seasons (1) + selectin episodes (1) + selectin file_variants (1) = 5 queries, with the last carrying potentially thousands of rows on rich catalogs.

After: FTS hit (1 query) + series root SELECT (1) = 2 queries. Same for movies (was 2 with file_variants → now 1 single query).

## Test plan

- [x] `make lint` clean
- [x] `make format` clean
- [x] Full suite green (1726 tests, +3 new for the shallow mapper contracts)
- [ ] Manual smoke: search "vingador" / "total recall" / a series title — hits render correctly with title/year/poster
- [ ] Verify with `EXPLAIN QUERY PLAN` (or just SQL log) that the search path no longer issues the seasons/episodes/file_variants follow-ups

## Follow-up

Same as #136/#137: integration test coverage for `search` (FTS5 fixture) is a separate, larger change.

## Summary by Sourcery

Optimize media catalog search to avoid loading hierarchical file and season data that the search output does not use.

Enhancements:
- Introduce a shallow mapping mode for movies via a new include_files flag so search results omit file variants while still supporting legacy flat file columns.
- Use the existing shallow mapping mode for series (include_seasons=False) from the search path to prevent loading seasons, episodes, and file variants.
- Update movie and series search repositories to fetch only root models without selectin-loading related collections, reducing query fan-out and avoiding lazy loads outside the session greenlet.

Tests:
- Add unit tests for MovieMapper and SeriesMapper to pin the shallow mapping contracts and ensure file/season collections remain empty when requested while preserving the legacy file fallback when files are included.