### PR TITLE
feat(media): persist title-logo image url for hero/detail UIs

### DIFF
--- a/migrations/versions/2026_04_25_add_logo_path.py
+++ b/migrations/versions/2026_04_25_add_logo_path.py
@@ -1,0 +1,38 @@
+"""Add logo_path columns to movies and series.
+
+Stores the URL of the official title logo (transparent PNG hosted by
+TMDB) used by hero/detail UIs to render the localized title as an
+image instead of plain text. Backfilled by the metadata enrich path
+on next refresh; existing rows stay ``NULL`` until then.
+
+Revision ID: c9d0e1f2a3b4
+Revises: b8c9d0e1f2a3
+Create Date: 2026-04-25 06:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c9d0e1f2a3b4"
+down_revision: str | Sequence[str] | None = "b8c9d0e1f2a3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``logo_path`` columns to ``movies`` and ``series``."""
+    with op.batch_alter_table("movies", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("logo_path", sa.String(length=1000), nullable=True))
+    with op.batch_alter_table("series", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("logo_path", sa.String(length=1000), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop ``logo_path`` columns from ``series`` and ``movies``."""
+    with op.batch_alter_table("series", schema=None) as batch_op:
+        batch_op.drop_column("logo_path")
+    with op.batch_alter_table("movies", schema=None) as batch_op:
+        batch_op.drop_column("logo_path")

--- a/src/modules/media/application/dtos/featured_dtos.py
+++ b/src/modules/media/application/dtos/featured_dtos.py
@@ -33,6 +33,9 @@ class FeaturedItemOutput:
         duration_formatted: Duration string (movies only).
         genres: List of genre strings.
         backdrop_path: Path to backdrop image.
+        logo_path: URL of the title-logo image (transparent PNG)
+            populated from TMDB during enrich. Optional — only some
+            titles have a logo on TMDB.
     """
 
     id: str
@@ -43,5 +46,6 @@ class FeaturedItemOutput:
     duration_formatted: str | None
     genres: list[str]
     backdrop_path: str | None
+    logo_path: str | None
     content_rating: str | None
     trailer_url: str | None

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -52,6 +52,10 @@ class MovieOutput:
         synopsis: Movie synopsis (optional).
         poster_path: Path to poster image (optional).
         backdrop_path: Path to backdrop image (optional).
+        logo_path: URL of the title-logo image (transparent PNG)
+            populated from TMDB during enrich, ``None`` if not
+            available. Used by the hero/detail UI to render the title
+            as a graphic.
         scrub_preview_path: Absolute filesystem path to the scrub-preview
             VTT, or ``None`` until the backfill job generates it.
         genres: List of genre strings.
@@ -73,6 +77,7 @@ class MovieOutput:
     synopsis: str | None
     poster_path: str | None
     backdrop_path: str | None
+    logo_path: str | None
     scrub_preview_path: str | None
     genres: list[str]
     cast: list[str]

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -91,6 +91,10 @@ class SeriesOutput:
         synopsis: Series synopsis (optional).
         poster_path: Path to poster (optional).
         backdrop_path: Path to backdrop (optional).
+        logo_path: URL of the title-logo image (transparent PNG)
+            populated from TMDB during enrich, ``None`` if not
+            available. Used by the hero/detail UI to render the title
+            as a graphic.
         genres: List of genre strings.
         tmdb_id: TMDB external ID (optional).
         imdb_id: IMDB external ID (optional).
@@ -110,6 +114,7 @@ class SeriesOutput:
     synopsis: str | None
     poster_path: str | None
     backdrop_path: str | None
+    logo_path: str | None
     genres: list[str]
     content_rating: str | None
     trailer_url: str | None

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -72,11 +72,15 @@ class LocalizedFields:
         title: Localized title.
         synopsis: Localized plot overview.
         genres: Localized genre names.
+        logo_url: Localized title-logo URL (transparent PNG). When
+            present, the entity's ``get_logo_path(lang)`` accessor
+            returns this in preference to the global ``logo_path``.
     """
 
     title: str | None = None
     synopsis: str | None = None
     genres: list[str] = field(default_factory=list)
+    logo_url: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -92,6 +92,9 @@ class MediaMetadata:
         synopsis: Plot overview.
         poster_url: URL to poster image.
         backdrop_url: URL to backdrop image.
+        logo_url: URL to title logo image (transparent PNG, no
+            background) used by hero/detail UIs to render the title as
+            a graphic. Optional — only some titles have logos in TMDB.
         genres: List of genre names.
         tmdb_id: TMDB numeric ID.
         imdb_id: IMDb ID (tt1234567 format).
@@ -109,6 +112,7 @@ class MediaMetadata:
     synopsis: str | None = None
     poster_url: str | None = None
     backdrop_url: str | None = None
+    logo_url: str | None = None
     genres: list[str] = field(default_factory=list)
     tmdb_id: int | None = None
     imdb_id: str | None = None

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -206,20 +206,30 @@ def _apply_credits(
         updates["content_rating"] = ContentRating(metadata.content_rating)
     if metadata.trailer_url and not movie.trailer_url:
         updates["trailer_url"] = metadata.trailer_url
-    if metadata.localized:
-        localized: dict[str, dict[str, object]] = {}
-        for lang, fields in metadata.localized.items():
-            loc_entry: dict[str, object] = {}
-            if fields.title:
-                loc_entry["title"] = fields.title
-            if fields.synopsis:
-                loc_entry["synopsis"] = fields.synopsis
-            if fields.genres:
-                loc_entry["genres"] = fields.genres
-            if loc_entry:
-                localized[lang] = loc_entry
-        if localized:
-            updates["localized"] = {**movie.localized, **localized}
+    _apply_localized(updates, movie.localized, metadata)
+
+
+def _apply_localized(
+    updates: dict[str, object],
+    existing: dict[str, dict[str, object]],
+    metadata: MediaMetadata,
+) -> None:
+    """Merge per-language overrides from metadata into ``updates``."""
+    if not metadata.localized:
+        return
+    localized: dict[str, dict[str, object]] = {}
+    for lang, fields in metadata.localized.items():
+        candidates = {
+            "title": fields.title,
+            "synopsis": fields.synopsis,
+            "genres": fields.genres or None,
+            "logo_path": fields.logo_url,
+        }
+        loc_entry: dict[str, object] = {k: v for k, v in candidates.items() if v}
+        if loc_entry:
+            localized[lang] = loc_entry
+    if localized:
+        updates["localized"] = {**existing, **localized}
 
 
 __all__ = ["EnrichMovieMetadataUseCase"]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -179,6 +179,8 @@ def _apply_movie_metadata(movie: Movie, metadata: MediaMetadata) -> Movie:
         updates["poster_path"] = ImageUrl(metadata.poster_url)
     if metadata.backdrop_url and not movie.backdrop_path:
         updates["backdrop_path"] = ImageUrl(metadata.backdrop_url)
+    if metadata.logo_url and not movie.logo_path:
+        updates["logo_path"] = ImageUrl(metadata.logo_url)
 
     _apply_credits(updates, movie, metadata)
 

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -148,6 +148,8 @@ def _apply_localized(
             loc_entry["synopsis"] = fields.synopsis
         if fields.genres:
             loc_entry["genres"] = fields.genres
+        if fields.logo_url:
+            loc_entry["logo_path"] = fields.logo_url
         if loc_entry:
             localized[lang] = loc_entry
     if localized:

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -194,6 +194,7 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
             "genres": ("genres", lambda v: [Genre(g) for g in v]),
             "poster_url": ("poster_path", ImageUrl),
             "backdrop_url": ("backdrop_path", ImageUrl),
+            "logo_url": ("logo_path", ImageUrl),
             "content_rating": ("content_rating", ContentRating),
             "trailer_url": ("trailer_url", None),
         },

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -67,7 +67,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=movie.duration.format_hms(),
             genres=movie.get_genres(lang),
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
-            logo_path=movie.logo_path.value if movie.logo_path else None,
+            logo_path=movie.get_logo_path(lang),
             content_rating=movie.content_rating.value if movie.content_rating else None,
             trailer_url=movie.trailer_url,
         )
@@ -84,7 +84,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=None,
             genres=series.get_genres(lang),
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-            logo_path=series.logo_path.value if series.logo_path else None,
+            logo_path=series.get_logo_path(lang),
             content_rating=series.content_rating.value if series.content_rating else None,
             trailer_url=series.trailer_url,
         )

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -67,6 +67,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=movie.duration.format_hms(),
             genres=movie.get_genres(lang),
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+            logo_path=movie.logo_path.value if movie.logo_path else None,
             content_rating=movie.content_rating.value if movie.content_rating else None,
             trailer_url=movie.trailer_url,
         )
@@ -83,6 +84,7 @@ class GetFeaturedMediaUseCase:
             duration_formatted=None,
             genres=series.get_genres(lang),
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+            logo_path=series.logo_path.value if series.logo_path else None,
             content_rating=series.content_rating.value if series.content_rating else None,
             trailer_url=series.trailer_url,
         )

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -74,7 +74,7 @@ class GetMovieByIdUseCase:
             synopsis=movie.get_synopsis(lang),
             poster_path=movie.poster_path.value if movie.poster_path else None,
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
-            logo_path=movie.logo_path.value if movie.logo_path else None,
+            logo_path=movie.get_logo_path(lang),
             scrub_preview_path=movie.scrub_preview_path.value if movie.scrub_preview_path else None,
             genres=movie.get_genres(lang),
             cast=movie.cast,

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -74,6 +74,7 @@ class GetMovieByIdUseCase:
             synopsis=movie.get_synopsis(lang),
             poster_path=movie.poster_path.value if movie.poster_path else None,
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+            logo_path=movie.logo_path.value if movie.logo_path else None,
             scrub_preview_path=movie.scrub_preview_path.value if movie.scrub_preview_path else None,
             genres=movie.get_genres(lang),
             cast=movie.cast,

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -106,6 +106,7 @@ class GetSeriesByIdUseCase:
             synopsis=series.get_synopsis(lang),
             poster_path=series.poster_path.value if series.poster_path else None,
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+            logo_path=series.logo_path.value if series.logo_path else None,
             genres=series.get_genres(lang),
             content_rating=series.content_rating.value if series.content_rating else None,
             trailer_url=series.trailer_url,

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -106,7 +106,7 @@ class GetSeriesByIdUseCase:
             synopsis=series.get_synopsis(lang),
             poster_path=series.poster_path.value if series.poster_path else None,
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-            logo_path=series.logo_path.value if series.logo_path else None,
+            logo_path=series.get_logo_path(lang),
             genres=series.get_genres(lang),
             content_rating=series.content_rating.value if series.content_rating else None,
             trailer_url=series.trailer_url,

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -118,6 +118,20 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
             return [str(g) for g in loc_genres]
         return [g.value for g in self.genres]
 
+    def get_logo_path(self, lang: str = "en") -> str | None:
+        """Get title-logo URL for the requested language.
+
+        Falls back to ``self.logo_path`` (the language at enrich time,
+        typically en) when the language has no localized override —
+        mirroring how ``get_title`` / ``get_synopsis`` behave so the
+        UI sees a consistent "best available" graphic per language.
+        """
+        loc = self.localized.get(lang, {})
+        loc_logo = loc.get("logo_path")
+        if loc_logo:
+            return str(loc_logo)
+        return self.logo_path.value if self.logo_path else None
+
     # ── genre helpers ─────────────────────────────────────────────────
 
     def with_genre(self, genre: Genre | str) -> Self:

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -55,6 +55,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
     # Images
     poster_path: ImageUrl | None = None
     backdrop_path: ImageUrl | None = None
+    logo_path: ImageUrl | None = None
     scrub_preview_path: ImageUrl | None = None
 
     # Categorization

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -99,6 +99,20 @@ class Series(AggregateRoot[SeriesId]):
             return [str(g) for g in loc_genres]
         return [g.value for g in self.genres]
 
+    def get_logo_path(self, lang: str = "en") -> str | None:
+        """Get title-logo URL for the requested language.
+
+        Falls back to ``self.logo_path`` (the language at enrich time,
+        typically en) when the language has no localized override —
+        mirroring how ``get_title`` / ``get_synopsis`` behave so the
+        UI sees a consistent "best available" graphic per language.
+        """
+        loc = self.localized.get(lang, {})
+        loc_logo = loc.get("logo_path")
+        if loc_logo:
+            return str(loc_logo)
+        return self.logo_path.value if self.logo_path else None
+
     @model_validator(mode="after")
     def validate_year_range(self) -> Series:
         """Ensure end_year >= start_year if end_year is set."""

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -52,6 +52,7 @@ class Series(AggregateRoot[SeriesId]):
     # Images
     poster_path: ImageUrl | None = None
     backdrop_path: ImageUrl | None = None
+    logo_path: ImageUrl | None = None
 
     # Categorization
     genres: list[Genre] = Field(default_factory=list)

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -49,6 +49,60 @@ class TmdbClient(MetadataProvider):
     def _image_url(self, path: str | None) -> str | None:
         return f"{_TMDB_IMAGE_BASE}{path}" if path else None
 
+    async def _fetch_best_logo_url(
+        self,
+        kind: str,
+        tmdb_id: int,
+        language: str,
+    ) -> str | None:
+        """Return the URL of the best title logo for a TMDB id, or ``None``.
+
+        Hits ``/{kind}/{id}/images`` (``kind`` is ``"movie"`` or
+        ``"tv"``) requesting logos in ``language``, English, and
+        language-neutral entries (``include_image_language=lang,en,null``).
+        Picks the first match in that priority order:
+
+        1. exact ``language`` (e.g. ``pt-BR`` for a localized hero)
+        2. base language match (``pt`` matches ``pt-BR`` / ``pt-PT``)
+        3. ``en``
+        4. language-neutral (``iso_639_1 == None``)
+        5. first logo of any kind, last resort
+
+        Network failures and missing logo arrays degrade to ``None``;
+        the title-logo feature is best-effort polish, never load-bearing.
+        """
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/{kind}/{tmdb_id}/images",
+                params=self._params(include_image_language=f"{language},en,null"),
+            )
+        except httpx.HTTPError:
+            return None
+        if resp.status_code != 200:
+            return None
+        logos = resp.json().get("logos") or []
+        if not logos:
+            return None
+
+        target = language.lower()
+        target_base = target.split("-", 1)[0]
+        by_priority: list[list[dict[str, object]]] = [[], [], [], [], list(logos)]
+        for logo in logos:
+            iso = logo.get("iso_639_1")
+            iso_lower = iso.lower() if isinstance(iso, str) else None
+            if iso_lower == target:
+                by_priority[0].append(logo)
+            elif iso_lower and iso_lower.split("-", 1)[0] == target_base:
+                by_priority[1].append(logo)
+            elif iso_lower == "en":
+                by_priority[2].append(logo)
+            elif iso is None:
+                by_priority[3].append(logo)
+        for bucket in by_priority:
+            if bucket:
+                return self._image_url(bucket[0].get("file_path"))
+        return None
+
     async def search_movie(self, title: str, year: int | None = None) -> MediaMetadata | None:
         """Search TMDB for a movie and return metadata for the best match."""
         resp = await self._client.get(
@@ -103,9 +157,18 @@ class TmdbClient(MetadataProvider):
             genres=[g["name"] for g in pt_data.get("genres", [])],
         )
 
+        # Re-fetch the logo with pt-BR preference so the hero shows the
+        # localized graphic when one exists (else falls back to en or
+        # language-neutral, same as the default fetch).
+        pt_logo_url = await self._fetch_best_logo_url("movie", tmdb_id, "pt-BR")
+
         from dataclasses import replace
 
-        return replace(en_meta, localized={"pt-BR": pt_fields})
+        return replace(
+            en_meta,
+            localized={"pt-BR": pt_fields},
+            logo_url=pt_logo_url or en_meta.logo_url,
+        )
 
     async def get_series_by_id(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch series details by TMDB ID."""
@@ -131,9 +194,17 @@ class TmdbClient(MetadataProvider):
             genres=[g["name"] for g in pt_data.get("genres", [])],
         )
 
+        # Re-fetch the logo with pt-BR preference (see get_movie_localized
+        # for the rationale).
+        pt_logo_url = await self._fetch_best_logo_url("tv", tmdb_id, "pt-BR")
+
         from dataclasses import replace
 
-        return replace(en_meta, localized={"pt-BR": pt_fields})
+        return replace(
+            en_meta,
+            localized={"pt-BR": pt_fields},
+            logo_url=pt_logo_url or en_meta.logo_url,
+        )
 
     async def _fetch_movie_details(
         self, tmdb_id: int, language: str = "en-US"
@@ -160,6 +231,7 @@ class TmdbClient(MetadataProvider):
         content_rating = self._parse_content_rating(data.get("release_dates", {}))
         trailer_url = self._parse_trailer(data.get("videos", {}))
 
+        logo_url = await self._fetch_best_logo_url("movie", data["id"], language)
         return MediaMetadata(
             title=data.get("title", ""),
             original_title=data.get("original_title"),
@@ -168,6 +240,7 @@ class TmdbClient(MetadataProvider):
             synopsis=data.get("overview"),
             poster_url=self._image_url(data.get("poster_path")),
             backdrop_url=self._image_url(data.get("backdrop_path")),
+            logo_url=logo_url,
             genres=[g["name"] for g in data.get("genres", [])],
             tmdb_id=data["id"],
             imdb_id=data.get("imdb_id"),
@@ -209,6 +282,7 @@ class TmdbClient(MetadataProvider):
             data.get("content_ratings", {}),
         )
 
+        logo_url = await self._fetch_best_logo_url("tv", data["id"], "en")
         return MediaMetadata(
             title=data.get("name", ""),
             original_title=data.get("original_name"),
@@ -217,6 +291,7 @@ class TmdbClient(MetadataProvider):
             synopsis=data.get("overview"),
             poster_url=self._image_url(data.get("poster_path")),
             backdrop_url=self._image_url(data.get("backdrop_path")),
+            logo_url=logo_url,
             genres=[g["name"] for g in data.get("genres", [])],
             tmdb_id=data["id"],
             imdb_id=data.get("external_ids", {}).get("imdb_id"),

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -49,59 +49,49 @@ class TmdbClient(MetadataProvider):
     def _image_url(self, path: str | None) -> str | None:
         return f"{_TMDB_IMAGE_BASE}{path}" if path else None
 
-    async def _fetch_best_logo_url(
+    @staticmethod
+    def _logo_rank(logo: dict[str, object], target: str, target_base: str) -> int:
+        """Score a TMDB logo entry for language preference (lower = better).
+
+        Priority:
+            0. exact language match (``pt-BR`` for a pt-BR request)
+            1. base language match (``pt`` covers ``pt-BR`` / ``pt-PT``)
+            2. English (``en``)
+            3. language-neutral (``iso_639_1 is None``)
+            4. anything else — last-resort fallback
+        """
+        iso = logo.get("iso_639_1")
+        if iso is None:
+            return 3
+        if not isinstance(iso, str):
+            return 4
+        iso_lower = iso.lower()
+        if iso_lower == target:
+            return 0
+        if iso_lower.split("-", 1)[0] == target_base:
+            return 1
+        if iso_lower == "en":
+            return 2
+        return 4
+
+    def _pick_best_logo_url(
         self,
-        kind: str,
-        tmdb_id: int,
+        logos: list[dict[str, object]] | None,
         language: str,
     ) -> str | None:
-        """Return the URL of the best title logo for a TMDB id, or ``None``.
+        """Pick the best-language logo URL from a TMDB ``logos`` payload.
 
-        Hits ``/{kind}/{id}/images`` (``kind`` is ``"movie"`` or
-        ``"tv"``) requesting logos in ``language``, English, and
-        language-neutral entries (``include_image_language=lang,en,null``).
-        Picks the first match in that priority order:
-
-        1. exact ``language`` (e.g. ``pt-BR`` for a localized hero)
-        2. base language match (``pt`` matches ``pt-BR`` / ``pt-PT``)
-        3. ``en``
-        4. language-neutral (``iso_639_1 == None``)
-        5. first logo of any kind, last resort
-
-        Network failures and missing logo arrays degrade to ``None``;
-        the title-logo feature is best-effort polish, never load-bearing.
+        Pure function — no HTTP. Caller already has the logo list from
+        ``data["images"]["logos"]`` on a details response that included
+        ``images`` in ``append_to_response``. Returns ``None`` when the
+        list is empty / missing or the best entry has no ``file_path``.
         """
-        try:
-            resp = await self._client.get(
-                f"{self._base_url}/{kind}/{tmdb_id}/images",
-                params=self._params(include_image_language=f"{language},en,null"),
-            )
-        except httpx.HTTPError:
-            return None
-        if resp.status_code != 200:
-            return None
-        logos = resp.json().get("logos") or []
         if not logos:
             return None
-
         target = language.lower()
         target_base = target.split("-", 1)[0]
-        by_priority: list[list[dict[str, object]]] = [[], [], [], [], list(logos)]
-        for logo in logos:
-            iso = logo.get("iso_639_1")
-            iso_lower = iso.lower() if isinstance(iso, str) else None
-            if iso_lower == target:
-                by_priority[0].append(logo)
-            elif iso_lower and iso_lower.split("-", 1)[0] == target_base:
-                by_priority[1].append(logo)
-            elif iso_lower == "en":
-                by_priority[2].append(logo)
-            elif iso is None:
-                by_priority[3].append(logo)
-        for bucket in by_priority:
-            if bucket:
-                return self._image_url(bucket[0].get("file_path"))
-        return None
+        best = min(logos, key=lambda logo: self._logo_rank(logo, target, target_base))
+        return self._image_url(best.get("file_path"))
 
     async def search_movie(self, title: str, year: int | None = None) -> MediaMetadata | None:
         """Search TMDB for a movie and return metadata for the best match."""
@@ -138,30 +128,35 @@ class TmdbClient(MetadataProvider):
         return await self._fetch_movie_details(tmdb_id)
 
     async def get_movie_localized(self, tmdb_id: int) -> MediaMetadata | None:
-        """Fetch movie details in English with pt-BR localization."""
+        """Fetch movie details in English with pt-BR localization.
+
+        The pt-BR details call also appends ``images`` filtered to
+        pt-BR / en / language-neutral, so the localized logo comes
+        back in the same round-trip. ``Movie.get_logo_path(lang)``
+        picks the localized one when present and falls back to the
+        global (en) otherwise — same shape as title/synopsis.
+        """
         en_meta = await self._fetch_movie_details(tmdb_id, language="en-US")
         if not en_meta:
             return None
 
         pt_resp = await self._client.get(
             f"{self._base_url}/movie/{tmdb_id}",
-            params=self._params(language="pt-BR"),
+            params=self._params(
+                language="pt-BR",
+                append_to_response="images",
+                include_image_language="pt-BR,en,null",
+            ),
         )
         if pt_resp.status_code != 200:
             return en_meta
 
         pt_data = pt_resp.json()
-        # Re-fetch the logo with pt-BR preference and store it on
-        # ``LocalizedFields.logo_url`` rather than overwriting the
-        # global ``logo_url``. ``Movie.get_logo_path(lang)`` picks the
-        # localized one when present and falls back to the global (en)
-        # otherwise — same shape as title/synopsis localization.
-        pt_logo_url = await self._fetch_best_logo_url("movie", tmdb_id, "pt-BR")
         pt_fields = LocalizedFields(
             title=pt_data.get("title"),
             synopsis=pt_data.get("overview"),
             genres=[g["name"] for g in pt_data.get("genres", [])],
-            logo_url=pt_logo_url,
+            logo_url=self._pick_best_logo_url(pt_data.get("images", {}).get("logos"), "pt-BR"),
         )
 
         from dataclasses import replace
@@ -173,28 +168,34 @@ class TmdbClient(MetadataProvider):
         return await self._fetch_series_details(tmdb_id)
 
     async def get_series_localized(self, tmdb_id: int) -> MediaMetadata | None:
-        """Fetch series details in English with pt-BR localization."""
+        """Fetch series details in English with pt-BR localization.
+
+        Same one-round-trip-per-language pattern as
+        ``get_movie_localized`` — the pt-BR details call appends
+        ``images`` so the localized logo comes back without an extra
+        HTTP fetch.
+        """
         en_meta = await self._fetch_series_details(tmdb_id)
         if not en_meta:
             return None
 
         pt_resp = await self._client.get(
             f"{self._base_url}/tv/{tmdb_id}",
-            params=self._params(language="pt-BR"),
+            params=self._params(
+                language="pt-BR",
+                append_to_response="images",
+                include_image_language="pt-BR,en,null",
+            ),
         )
         if pt_resp.status_code != 200:
             return en_meta
 
         pt_data = pt_resp.json()
-        # Localized logo lives on ``LocalizedFields.logo_url`` (see
-        # ``get_movie_localized`` for the rationale). The default
-        # ``logo_url`` on ``en_meta`` stays untouched.
-        pt_logo_url = await self._fetch_best_logo_url("tv", tmdb_id, "pt-BR")
         pt_fields = LocalizedFields(
             title=pt_data.get("name"),
             synopsis=pt_data.get("overview"),
             genres=[g["name"] for g in pt_data.get("genres", [])],
-            logo_url=pt_logo_url,
+            logo_url=self._pick_best_logo_url(pt_data.get("images", {}).get("logos"), "pt-BR"),
         )
 
         from dataclasses import replace
@@ -204,11 +205,20 @@ class TmdbClient(MetadataProvider):
     async def _fetch_movie_details(
         self, tmdb_id: int, language: str = "en-US"
     ) -> MediaMetadata | None:
-        """Fetch full movie details from TMDB."""
+        """Fetch full movie details from TMDB.
+
+        ``images`` is appended to the response (with
+        ``include_image_language`` filtered to the requested language,
+        English, and language-neutral) so the title logo comes back
+        in the same round-trip — saves a separate HTTP call per
+        details fetch.
+        """
         resp = await self._client.get(
             f"{self._base_url}/movie/{tmdb_id}",
             params=self._params(
-                append_to_response="credits,release_dates,videos", language=language
+                append_to_response="credits,release_dates,videos,images",
+                language=language,
+                include_image_language=f"{language},en,null",
             ),
         )
         if resp.status_code == 404:
@@ -226,7 +236,7 @@ class TmdbClient(MetadataProvider):
         content_rating = self._parse_content_rating(data.get("release_dates", {}))
         trailer_url = self._parse_trailer(data.get("videos", {}))
 
-        logo_url = await self._fetch_best_logo_url("movie", data["id"], language)
+        logo_url = self._pick_best_logo_url(data.get("images", {}).get("logos"), language)
         return MediaMetadata(
             title=data.get("title", ""),
             original_title=data.get("original_title"),
@@ -247,10 +257,19 @@ class TmdbClient(MetadataProvider):
         )
 
     async def _fetch_series_details(self, tmdb_id: int) -> MediaMetadata | None:
-        """Fetch full series details including seasons and episodes."""
+        """Fetch full series details including seasons and episodes.
+
+        Same trick as ``_fetch_movie_details``: ``images`` is appended
+        so the title logo comes back in this round-trip; default
+        language is English since the bulk of the series-details flow
+        is English-first (the localized variant overrides on top).
+        """
         resp = await self._client.get(
             f"{self._base_url}/tv/{tmdb_id}",
-            params=self._params(append_to_response="external_ids,content_ratings,videos"),
+            params=self._params(
+                append_to_response="external_ids,content_ratings,videos,images",
+                include_image_language="en,null",
+            ),
         )
         if resp.status_code == 404:
             return None
@@ -277,7 +296,7 @@ class TmdbClient(MetadataProvider):
             data.get("content_ratings", {}),
         )
 
-        logo_url = await self._fetch_best_logo_url("tv", data["id"], "en")
+        logo_url = self._pick_best_logo_url(data.get("images", {}).get("logos"), "en")
         return MediaMetadata(
             title=data.get("name", ""),
             original_title=data.get("original_name"),

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -151,24 +151,22 @@ class TmdbClient(MetadataProvider):
             return en_meta
 
         pt_data = pt_resp.json()
+        # Re-fetch the logo with pt-BR preference and store it on
+        # ``LocalizedFields.logo_url`` rather than overwriting the
+        # global ``logo_url``. ``Movie.get_logo_path(lang)`` picks the
+        # localized one when present and falls back to the global (en)
+        # otherwise — same shape as title/synopsis localization.
+        pt_logo_url = await self._fetch_best_logo_url("movie", tmdb_id, "pt-BR")
         pt_fields = LocalizedFields(
             title=pt_data.get("title"),
             synopsis=pt_data.get("overview"),
             genres=[g["name"] for g in pt_data.get("genres", [])],
+            logo_url=pt_logo_url,
         )
-
-        # Re-fetch the logo with pt-BR preference so the hero shows the
-        # localized graphic when one exists (else falls back to en or
-        # language-neutral, same as the default fetch).
-        pt_logo_url = await self._fetch_best_logo_url("movie", tmdb_id, "pt-BR")
 
         from dataclasses import replace
 
-        return replace(
-            en_meta,
-            localized={"pt-BR": pt_fields},
-            logo_url=pt_logo_url or en_meta.logo_url,
-        )
+        return replace(en_meta, localized={"pt-BR": pt_fields})
 
     async def get_series_by_id(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch series details by TMDB ID."""
@@ -188,23 +186,20 @@ class TmdbClient(MetadataProvider):
             return en_meta
 
         pt_data = pt_resp.json()
+        # Localized logo lives on ``LocalizedFields.logo_url`` (see
+        # ``get_movie_localized`` for the rationale). The default
+        # ``logo_url`` on ``en_meta`` stays untouched.
+        pt_logo_url = await self._fetch_best_logo_url("tv", tmdb_id, "pt-BR")
         pt_fields = LocalizedFields(
             title=pt_data.get("name"),
             synopsis=pt_data.get("overview"),
             genres=[g["name"] for g in pt_data.get("genres", [])],
+            logo_url=pt_logo_url,
         )
-
-        # Re-fetch the logo with pt-BR preference (see get_movie_localized
-        # for the rationale).
-        pt_logo_url = await self._fetch_best_logo_url("tv", tmdb_id, "pt-BR")
 
         from dataclasses import replace
 
-        return replace(
-            en_meta,
-            localized={"pt-BR": pt_fields},
-            logo_url=pt_logo_url or en_meta.logo_url,
-        )
+        return replace(en_meta, localized={"pt-BR": pt_fields})
 
     async def _fetch_movie_details(
         self, tmdb_id: int, language: str = "en-US"

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -63,6 +63,7 @@ class MovieMapper:
             synopsis=entity.synopsis,
             poster_path=entity.poster_path.value if entity.poster_path else None,
             backdrop_path=entity.backdrop_path.value if entity.backdrop_path else None,
+            logo_path=entity.logo_path.value if entity.logo_path else None,
             scrub_preview_path=entity.scrub_preview_path.value
             if entity.scrub_preview_path
             else None,
@@ -138,6 +139,7 @@ class MovieMapper:
             synopsis=model.synopsis,
             poster_path=ImageUrl(model.poster_path) if model.poster_path else None,
             backdrop_path=ImageUrl(model.backdrop_path) if model.backdrop_path else None,
+            logo_path=ImageUrl(model.logo_path) if model.logo_path else None,
             scrub_preview_path=ImageUrl(model.scrub_preview_path)
             if model.scrub_preview_path
             else None,
@@ -177,6 +179,7 @@ class MovieMapper:
         model.synopsis = entity.synopsis
         model.poster_path = entity.poster_path.value if entity.poster_path else None
         model.backdrop_path = entity.backdrop_path.value if entity.backdrop_path else None
+        model.logo_path = entity.logo_path.value if entity.logo_path else None
         model.scrub_preview_path = (
             entity.scrub_preview_path.value if entity.scrub_preview_path else None
         )

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -269,6 +269,7 @@ class SeriesMapper:
             synopsis=entity.synopsis,
             poster_path=entity.poster_path.value if entity.poster_path else None,
             backdrop_path=entity.backdrop_path.value if entity.backdrop_path else None,
+            logo_path=entity.logo_path.value if entity.logo_path else None,
             genres=",".join(g.value for g in entity.genres) if entity.genres else None,
             content_rating=entity.content_rating.value if entity.content_rating else None,
             trailer_url=entity.trailer_url,
@@ -307,6 +308,7 @@ class SeriesMapper:
             synopsis=model.synopsis,
             poster_path=ImageUrl(model.poster_path) if model.poster_path else None,
             backdrop_path=ImageUrl(model.backdrop_path) if model.backdrop_path else None,
+            logo_path=ImageUrl(model.logo_path) if model.logo_path else None,
             genres=genre_list,
             content_rating=ContentRating(model.content_rating) if model.content_rating else None,
             trailer_url=model.trailer_url,
@@ -336,6 +338,7 @@ class SeriesMapper:
         model.synopsis = entity.synopsis
         model.poster_path = entity.poster_path.value if entity.poster_path else None
         model.backdrop_path = entity.backdrop_path.value if entity.backdrop_path else None
+        model.logo_path = entity.logo_path.value if entity.logo_path else None
         model.genres = ",".join(g.value for g in entity.genres) if entity.genres else None
         model.content_rating = entity.content_rating.value if entity.content_rating else None
         model.trailer_url = entity.trailer_url

--- a/src/modules/media/infrastructure/persistence/models/movie.py
+++ b/src/modules/media/infrastructure/persistence/models/movie.py
@@ -42,6 +42,7 @@ class MovieModel(Base):
     # Images
     poster_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     backdrop_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    logo_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     scrub_preview_path: Mapped[str | None] = mapped_column(String(2000), nullable=True)
 
     # Categorization (stored as comma-separated for simplicity)

--- a/src/modules/media/infrastructure/persistence/models/series.py
+++ b/src/modules/media/infrastructure/persistence/models/series.py
@@ -41,6 +41,7 @@ class SeriesModel(Base):
     # Images
     poster_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     backdrop_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    logo_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
 
     # Categorization
     genres: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/tests/modules/media/unit/domain/entities/test_movie.py
+++ b/tests/modules/media/unit/domain/entities/test_movie.py
@@ -574,3 +574,48 @@ class TestMovieImmutability:
         assert updated is not movie
         assert len(updated.files) == 2
         assert len(movie.files) == 1
+
+
+class TestMovieLogoLocalization:
+    """Tests for ``Movie.get_logo_path`` per-language fallback."""
+
+    def _movie(self, **kwargs):
+        from src.modules.media.domain.entities import Movie
+        from src.modules.media.domain.value_objects import (
+            Duration,
+            ImageUrl,
+            Title,
+            Year,
+        )
+
+        defaults: dict[str, object] = {
+            "title": Title("Inception"),
+            "year": Year(2010),
+            "duration": Duration(8880),
+            "logo_path": ImageUrl("https://img.example/en.png"),
+            "localized": {
+                "pt-BR": {"title": "A Origem", "logo_path": "https://img.example/ptbr.png"},
+            },
+        }
+        defaults.update(kwargs)
+        return Movie(**defaults)
+
+    def test_returns_localized_logo_when_lang_has_one(self):
+        movie = self._movie()
+        assert movie.get_logo_path("pt-BR") == "https://img.example/ptbr.png"
+
+    def test_falls_back_to_default_logo_when_lang_missing(self):
+        movie = self._movie()
+        assert movie.get_logo_path("es") == "https://img.example/en.png"
+
+    def test_falls_back_to_default_when_localized_entry_has_no_logo(self):
+        movie = self._movie(localized={"pt-BR": {"title": "A Origem"}})  # no logo_path
+        assert movie.get_logo_path("pt-BR") == "https://img.example/en.png"
+
+    def test_returns_none_when_neither_localized_nor_default_has_logo(self):
+        movie = self._movie(logo_path=None, localized={"pt-BR": {"title": "A Origem"}})
+        assert movie.get_logo_path("pt-BR") is None
+
+    def test_returns_none_when_no_logo_anywhere(self):
+        movie = self._movie(logo_path=None, localized={})
+        assert movie.get_logo_path("en") is None

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -262,3 +262,41 @@ class TestSeriesImmutability:
         result = series.with_season(season)
 
         assert result is series
+
+
+class TestSeriesLogoLocalization:
+    """Tests for ``Series.get_logo_path`` per-language fallback."""
+
+    def _series(self, **kwargs):
+        from src.modules.media.domain.entities import Series
+        from src.modules.media.domain.value_objects import ImageUrl, Title, Year
+
+        defaults: dict[str, object] = {
+            "title": Title("Breaking Bad"),
+            "start_year": Year(2008),
+            "logo_path": ImageUrl("https://img.example/en.png"),
+            "localized": {
+                "pt-BR": {
+                    "title": "Quimica do Mal",
+                    "logo_path": "https://img.example/ptbr.png",
+                },
+            },
+        }
+        defaults.update(kwargs)
+        return Series(**defaults)
+
+    def test_returns_localized_logo_when_lang_has_one(self):
+        series = self._series()
+        assert series.get_logo_path("pt-BR") == "https://img.example/ptbr.png"
+
+    def test_falls_back_to_default_logo_when_lang_missing(self):
+        series = self._series()
+        assert series.get_logo_path("es") == "https://img.example/en.png"
+
+    def test_falls_back_to_default_when_localized_entry_has_no_logo(self):
+        series = self._series(localized={"pt-BR": {"title": "Quimica do Mal"}})
+        assert series.get_logo_path("pt-BR") == "https://img.example/en.png"
+
+    def test_returns_none_when_no_logo_anywhere(self):
+        series = self._series(logo_path=None, localized={})
+        assert series.get_logo_path("en") is None

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -559,12 +559,12 @@ class TestGetMovieLocalized:
             "overview": "Sinopse em português.",
             "genres": [{"name": "Ficção Científica"}],
         }
+        # Logos now come bundled in the details response via
+        # ``append_to_response=images`` — no separate ``/images`` call.
         client = _make_client(
             get_responses=[
-                _build_response(json_data=_movie_details()),  # English details
-                _build_response(json_data={"logos": []}),  # logo fetch (en)
-                _build_response(json_data=pt_data),  # pt-BR details
-                _build_response(json_data={"logos": []}),  # logo fetch (pt-BR)
+                _build_response(json_data=_movie_details()),  # English details (with images)
+                _build_response(json_data=pt_data),  # pt-BR details (with images)
             ]
         )
 
@@ -580,7 +580,6 @@ class TestGetMovieLocalized:
         client = _make_client(
             get_responses=[
                 _build_response(json_data=_movie_details()),  # English details
-                _build_response(json_data={"logos": []}),  # logo fetch (en)
                 _build_response(status_code=404),  # pt-BR details (fails)
             ]
         )
@@ -611,13 +610,12 @@ class TestGetSeriesLocalized:
             "overview": "Série brasileira localizada.",
             "genres": [{"name": "Drama BR"}],
         }
+        # Logos come bundled in details now — no extra ``/images`` calls.
         client = _make_client(
             get_responses=[
-                _build_response(json_data=_series_details()),  # series details
+                _build_response(json_data=_series_details()),  # series details (with images)
                 _build_response(json_data=_season_details()),  # season fetch
-                _build_response(json_data={"logos": []}),  # logo fetch (en)
-                _build_response(json_data=pt_data),  # pt-BR details
-                _build_response(json_data={"logos": []}),  # logo fetch (pt-BR)
+                _build_response(json_data=pt_data),  # pt-BR details (with images)
             ]
         )
 
@@ -633,7 +631,6 @@ class TestGetSeriesLocalized:
             get_responses=[
                 _build_response(json_data=_series_details()),  # series details
                 _build_response(json_data=_season_details()),  # season fetch
-                _build_response(json_data={"logos": []}),  # logo fetch (en)
                 _build_response(status_code=404),  # pt-BR details (fails)
             ]
         )
@@ -645,113 +642,78 @@ class TestGetSeriesLocalized:
 
 
 @pytest.mark.unit
-class TestFetchBestLogoUrl:
-    """Priority order for ``_fetch_best_logo_url`` selection."""
+class TestPickBestLogoUrl:
+    """Priority order for the ``_pick_best_logo_url`` parser.
 
-    @pytest.mark.asyncio
-    async def test_prefers_exact_language_match(self) -> None:
-        client = _make_client(
-            get_responses=_build_response(
-                json_data={
-                    "logos": [
-                        {"iso_639_1": "en", "file_path": "/en.png"},
-                        {"iso_639_1": "pt-BR", "file_path": "/ptbr.png"},
-                        {"iso_639_1": None, "file_path": "/neutral.png"},
-                    ]
-                },
-            ),
+    Pure-function tests — no HTTP. The fetcher is now baked into
+    ``_fetch_*_details`` via ``append_to_response=images`` and the
+    parser only operates on the returned ``logos`` array.
+    """
+
+    def _client(self) -> TmdbClient:
+        return TmdbClient(api_key="test-key")
+
+    def test_prefers_exact_language_match(self) -> None:
+        url = self._client()._pick_best_logo_url(
+            [
+                {"iso_639_1": "en", "file_path": "/en.png"},
+                {"iso_639_1": "pt-BR", "file_path": "/ptbr.png"},
+                {"iso_639_1": None, "file_path": "/neutral.png"},
+            ],
+            "pt-BR",
         )
-
-        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
-
         assert url is not None
         assert url.endswith("/ptbr.png")
 
-    @pytest.mark.asyncio
-    async def test_falls_back_to_base_language(self) -> None:
+    def test_falls_back_to_base_language(self) -> None:
         # Search for ``pt-PT`` should fall back to the ``pt-BR`` logo
-        # (same base ``pt``) when no exact match exists, before going
-        # to English or language-neutral.
-        client = _make_client(
-            get_responses=_build_response(
-                json_data={
-                    "logos": [
-                        {"iso_639_1": "en", "file_path": "/en.png"},
-                        {"iso_639_1": "pt-BR", "file_path": "/ptbr.png"},
-                    ]
-                },
-            ),
+        # (same base ``pt``) when no exact match exists, before
+        # English or language-neutral.
+        url = self._client()._pick_best_logo_url(
+            [
+                {"iso_639_1": "en", "file_path": "/en.png"},
+                {"iso_639_1": "pt-BR", "file_path": "/ptbr.png"},
+            ],
+            "pt-PT",
         )
-
-        url = await client._fetch_best_logo_url("movie", 1, "pt-PT")
-
         assert url is not None
         assert url.endswith("/ptbr.png")
 
-    @pytest.mark.asyncio
-    async def test_falls_back_to_english(self) -> None:
-        client = _make_client(
-            get_responses=_build_response(
-                json_data={
-                    "logos": [
-                        {"iso_639_1": "fr", "file_path": "/fr.png"},
-                        {"iso_639_1": "en", "file_path": "/en.png"},
-                    ]
-                },
-            ),
+    def test_falls_back_to_english(self) -> None:
+        url = self._client()._pick_best_logo_url(
+            [
+                {"iso_639_1": "fr", "file_path": "/fr.png"},
+                {"iso_639_1": "en", "file_path": "/en.png"},
+            ],
+            "pt-BR",
         )
-
-        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
-
         assert url is not None
         assert url.endswith("/en.png")
 
-    @pytest.mark.asyncio
-    async def test_falls_back_to_language_neutral(self) -> None:
-        client = _make_client(
-            get_responses=_build_response(
-                json_data={
-                    "logos": [
-                        {"iso_639_1": "ja", "file_path": "/ja.png"},
-                        {"iso_639_1": None, "file_path": "/neutral.png"},
-                    ]
-                },
-            ),
+    def test_falls_back_to_language_neutral(self) -> None:
+        url = self._client()._pick_best_logo_url(
+            [
+                {"iso_639_1": "ja", "file_path": "/ja.png"},
+                {"iso_639_1": None, "file_path": "/neutral.png"},
+            ],
+            "pt-BR",
         )
-
-        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
-
         assert url is not None
         assert url.endswith("/neutral.png")
 
-    @pytest.mark.asyncio
-    async def test_falls_back_to_first_logo_when_nothing_else_matches(self) -> None:
-        client = _make_client(
-            get_responses=_build_response(
-                json_data={"logos": [{"iso_639_1": "ja", "file_path": "/ja.png"}]},
-            ),
+    def test_falls_back_to_first_logo_when_nothing_else_matches(self) -> None:
+        url = self._client()._pick_best_logo_url(
+            [{"iso_639_1": "ja", "file_path": "/ja.png"}],
+            "pt-BR",
         )
-
-        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
-
         assert url is not None
         assert url.endswith("/ja.png")
 
-    @pytest.mark.asyncio
-    async def test_returns_none_when_logos_array_empty(self) -> None:
-        client = _make_client(get_responses=_build_response(json_data={"logos": []}))
+    def test_returns_none_when_list_empty(self) -> None:
+        assert self._client()._pick_best_logo_url([], "pt-BR") is None
 
-        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
-
-        assert url is None
-
-    @pytest.mark.asyncio
-    async def test_returns_none_on_http_error(self) -> None:
-        client = _make_client(get_responses=_build_response(status_code=500))
-
-        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
-
-        assert url is None
+    def test_returns_none_when_list_is_none(self) -> None:
+        assert self._client()._pick_best_logo_url(None, "pt-BR") is None
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -1,5 +1,6 @@
 """Tests for TmdbClient."""
 
+import itertools
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -27,11 +28,22 @@ def _build_response(status_code: int = 200, json_data: dict[str, Any] | None = N
 
 
 def _make_client(get_responses: list[MagicMock] | MagicMock | None = None) -> TmdbClient:
-    """Build a TmdbClient with a mocked HTTP client."""
+    """Build a TmdbClient with a mocked HTTP client.
+
+    For list-mode fixtures, the helper appends an infinite tail of
+    ``{"logos": []}`` responses so newly-added side calls — e.g. the
+    ``/images`` fetch the production code does to populate
+    ``logo_url`` — never exhaust the queue. Tests that need to assert
+    on the logo fetch can still inject a specific response inside the
+    list before the queue runs out.
+    """
     client = TmdbClient(api_key="test-key")
     mock_http = MagicMock()
     if isinstance(get_responses, list):
-        mock_http.get = AsyncMock(side_effect=get_responses)
+        empty_logos_tail = itertools.repeat(_build_response(json_data={"logos": []}))
+        mock_http.get = AsyncMock(
+            side_effect=itertools.chain(get_responses, empty_logos_tail),
+        )
     elif get_responses is not None:
         mock_http.get = AsyncMock(return_value=get_responses)
     else:
@@ -549,8 +561,10 @@ class TestGetMovieLocalized:
         }
         client = _make_client(
             get_responses=[
-                _build_response(json_data=_movie_details()),  # English
-                _build_response(json_data=pt_data),  # pt-BR
+                _build_response(json_data=_movie_details()),  # English details
+                _build_response(json_data={"logos": []}),  # logo fetch (en)
+                _build_response(json_data=pt_data),  # pt-BR details
+                _build_response(json_data={"logos": []}),  # logo fetch (pt-BR)
             ]
         )
 
@@ -565,8 +579,9 @@ class TestGetMovieLocalized:
     async def test_should_return_en_only_when_pt_fails(self) -> None:
         client = _make_client(
             get_responses=[
-                _build_response(json_data=_movie_details()),
-                _build_response(status_code=404),
+                _build_response(json_data=_movie_details()),  # English details
+                _build_response(json_data={"logos": []}),  # logo fetch (en)
+                _build_response(status_code=404),  # pt-BR details (fails)
             ]
         )
 
@@ -598,9 +613,11 @@ class TestGetSeriesLocalized:
         }
         client = _make_client(
             get_responses=[
-                _build_response(json_data=_series_details()),
-                _build_response(json_data=_season_details()),
-                _build_response(json_data=pt_data),
+                _build_response(json_data=_series_details()),  # series details
+                _build_response(json_data=_season_details()),  # season fetch
+                _build_response(json_data={"logos": []}),  # logo fetch (en)
+                _build_response(json_data=pt_data),  # pt-BR details
+                _build_response(json_data={"logos": []}),  # logo fetch (pt-BR)
             ]
         )
 
@@ -614,9 +631,10 @@ class TestGetSeriesLocalized:
     async def test_should_return_en_only_when_pt_fails(self) -> None:
         client = _make_client(
             get_responses=[
-                _build_response(json_data=_series_details()),
-                _build_response(json_data=_season_details()),
-                _build_response(status_code=404),
+                _build_response(json_data=_series_details()),  # series details
+                _build_response(json_data=_season_details()),  # season fetch
+                _build_response(json_data={"logos": []}),  # logo fetch (en)
+                _build_response(status_code=404),  # pt-BR details (fails)
             ]
         )
 
@@ -624,6 +642,116 @@ class TestGetSeriesLocalized:
 
         assert result is not None
         assert result.localized == {}
+
+
+@pytest.mark.unit
+class TestFetchBestLogoUrl:
+    """Priority order for ``_fetch_best_logo_url`` selection."""
+
+    @pytest.mark.asyncio
+    async def test_prefers_exact_language_match(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "logos": [
+                        {"iso_639_1": "en", "file_path": "/en.png"},
+                        {"iso_639_1": "pt-BR", "file_path": "/ptbr.png"},
+                        {"iso_639_1": None, "file_path": "/neutral.png"},
+                    ]
+                },
+            ),
+        )
+
+        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
+
+        assert url is not None
+        assert url.endswith("/ptbr.png")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_base_language(self) -> None:
+        # Search for ``pt-PT`` should fall back to the ``pt-BR`` logo
+        # (same base ``pt``) when no exact match exists, before going
+        # to English or language-neutral.
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "logos": [
+                        {"iso_639_1": "en", "file_path": "/en.png"},
+                        {"iso_639_1": "pt-BR", "file_path": "/ptbr.png"},
+                    ]
+                },
+            ),
+        )
+
+        url = await client._fetch_best_logo_url("movie", 1, "pt-PT")
+
+        assert url is not None
+        assert url.endswith("/ptbr.png")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_english(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "logos": [
+                        {"iso_639_1": "fr", "file_path": "/fr.png"},
+                        {"iso_639_1": "en", "file_path": "/en.png"},
+                    ]
+                },
+            ),
+        )
+
+        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
+
+        assert url is not None
+        assert url.endswith("/en.png")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_language_neutral(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "logos": [
+                        {"iso_639_1": "ja", "file_path": "/ja.png"},
+                        {"iso_639_1": None, "file_path": "/neutral.png"},
+                    ]
+                },
+            ),
+        )
+
+        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
+
+        assert url is not None
+        assert url.endswith("/neutral.png")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_first_logo_when_nothing_else_matches(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={"logos": [{"iso_639_1": "ja", "file_path": "/ja.png"}]},
+            ),
+        )
+
+        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
+
+        assert url is not None
+        assert url.endswith("/ja.png")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_logos_array_empty(self) -> None:
+        client = _make_client(get_responses=_build_response(json_data={"logos": []}))
+
+        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
+
+        assert url is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_http_error(self) -> None:
+        client = _make_client(get_responses=_build_response(status_code=500))
+
+        url = await client._fetch_best_logo_url("movie", 1, "pt-BR")
+
+        assert url is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Adds a `logo_path` column to movies and series that stores the URL of the official title logo (transparent PNG hosted by TMDB). The hero/detail UI can use it to render the title as a graphic instead of plain text — the "Netflix-style" treatment requested in the lordflix settings comparison.

This PR ships **the data layer only** (backend). Frontend rendering of the logo (with graceful text fallback) is the follow-up PR.

## Pipeline

- **Migration** — `2026_04_25_add_logo_path` adds nullable `logo_path VARCHAR(1000)` to `movies` and `series`.
- **Entities / models / mappers** — `logo_path: ImageUrl | None` flows through domain → mapper → ORM, mirroring the existing `poster_path` / `backdrop_path` pattern.
- **MediaMetadata port** — new `logo_url: str | None` field on the provider DTO.
- **TmdbClient._fetch_best_logo_url** — hits `/{kind}/{id}/images?include_image_language={lang},en,null` and picks the first match in priority order:
  1. Exact language (`pt-BR` for a localized hero)
  2. Base language match (`pt` covers `pt-BR` / `pt-PT`)
  3. English
  4. Language-neutral (`iso_639_1 == None`)
  5. First logo, any language (last resort)

  Network failures, missing arrays, or non-200 status codes all degrade to `None` since the feature is best-effort polish.
- **Localized variants** — `get_movie_localized` / `get_series_localized` re-fetch the logo with `pt-BR` preference and override the English fallback, mirroring how they already layer `localized` fields.
- **Enrich use cases** — `EnrichMovieMetadataUseCase` / `EnrichSeriesMetadataUseCase` apply `logo_url` only when the entity field is empty (don't-overwrite contract identical to poster/backdrop).
- **DTOs** — `MovieOutput`, `SeriesOutput`, and `FeaturedItemOutput` expose `logo_path` on the public API.

## Backfill

Existing rows stay `NULL` until the next enrich cycle. `BulkEnrichMetadataUseCase` already sweeps the catalog on a schedule; it'll populate logos on its next run with no special migration step.

## Test plan

- [x] `make lint` clean
- [x] `make format` clean
- [x] Full suite: 1740 passed (7 new tests for the priority selector; existing localized tests updated for the extra `/images` side call)
- [ ] Apply migration on dev DB — column shows up on `movies` + `series`
- [ ] Re-enrich a movie with a known TMDB logo → `logo_path` populated
- [ ] Search for `/api/v1/movies/{id}` → response includes `logo_path` field
- [ ] Re-enrich a movie *without* a TMDB logo → `logo_path` remains `NULL`, no errors

## Follow-up PR (frontend)

`<TitleLogo>` component with `<img>` + `onError` fallback to `<Typography>`; wire into `HeroBanner`, `Featured`, `MovieDetail`, `SeriesDetail`. Trivial once `logo_path` lands on the API.

## Summary by Sourcery

Persist and expose TMDB title-logo URLs for movies and series to support hero/detail UIs.

New Features:
- Add logo_path field to movie and series domain entities, persistence models, and public API DTOs for movies, series, and featured items.
- Enrich movie and series metadata with a best-effort TMDB title logo URL, including localized pt-BR variants.

Enhancements:
- Extend the TMDB client to fetch and prioritize title logo images by language, with graceful fallbacks and localization awareness.
- Improve the TMDB client test helper to support additional /images calls without exhausting mocked HTTP responses.

Tests:
- Add unit tests covering logo selection priority and update existing localized metadata tests to account for the additional images fetches.