### PR TITLE
feat(media): cast carries actor photo and role per member

### DIFF
--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -36,6 +36,26 @@ class DeleteMovieInput:
 
 
 @dataclass(frozen=True)
+class CastMemberOutput:
+    """Cast entry exposed on the API.
+
+    Mirrors the domain ``CastMember`` shape so the detail UI can
+    render an avatar (``profile_path``) + name + role per actor.
+
+    Attributes:
+        name: Actor's display name.
+        profile_path: Full URL to the TMDB profile photo, or ``None``
+            when TMDB has no photo for this person — the UI falls
+            back to an initials avatar.
+        role: Character name played, or ``None`` when not provided.
+    """
+
+    name: str
+    profile_path: str | None
+    role: str | None
+
+
+@dataclass(frozen=True)
 class MovieOutput:
     """Output representation of a Movie.
 
@@ -80,7 +100,7 @@ class MovieOutput:
     logo_path: str | None
     scrub_preview_path: str | None
     genres: list[str]
-    cast: list[str]
+    cast: list[CastMemberOutput]
     directors: list[str]
     writers: list[str]
     content_rating: str | None

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -11,6 +11,7 @@ from src.modules.media.application.ports import MediaMetadata, MetadataProvider
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
+    CastMember,
     ContentRating,
     Duration,
     Genre,
@@ -197,7 +198,9 @@ def _apply_credits(
 ) -> None:
     """Apply cast/director/writer credits from metadata if not already present."""
     if metadata.cast and not movie.cast:
-        updates["cast"] = [p.name for p in metadata.cast]
+        updates["cast"] = [
+            CastMember(name=p.name, profile_path=p.profile_url, role=p.role) for p in metadata.cast
+        ]
     if metadata.directors and not movie.directors:
         updates["directors"] = [p.name for p in metadata.directors]
     if metadata.writers and not movie.writers:

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -1,7 +1,11 @@
 """GetMovieByIdUseCase - Retrieve a single movie by ID."""
 
 from src.building_blocks.application.errors import ResourceNotFoundException
-from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput, MovieOutput
+from src.modules.media.application.dtos.movie_dtos import (
+    CastMemberOutput,
+    GetMovieByIdInput,
+    MovieOutput,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._media_file_helpers import (
     to_media_file_output,
@@ -77,7 +81,10 @@ class GetMovieByIdUseCase:
             logo_path=movie.get_logo_path(lang),
             scrub_preview_path=movie.scrub_preview_path.value if movie.scrub_preview_path else None,
             genres=movie.get_genres(lang),
-            cast=movie.cast,
+            cast=[
+                CastMemberOutput(name=m.name, profile_path=m.profile_path, role=m.role)
+                for m in movie.cast
+            ],
             directors=movie.directors,
             writers=movie.writers,
             content_rating=movie.content_rating.value if movie.content_rating else None,

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -10,6 +10,7 @@ from src.building_blocks.domain import AggregateRoot
 from src.modules.media.domain.entities.file_variant_mixin import FileVariantMixin
 from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.value_objects import (
+    CastMember,
     ContentRating,
     Duration,
     FilePath,
@@ -65,7 +66,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
     files: list[MediaFile] = Field(default_factory=list)
 
     # Credits
-    cast: list[str] = Field(default_factory=list)
+    cast: list[CastMember] = Field(default_factory=list)
     directors: list[str] = Field(default_factory=list)
     writers: list[str] = Field(default_factory=list)
 

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -1,6 +1,7 @@
 """Media domain value objects."""
 
 from src.modules.media.domain.value_objects.air_date import AirDate
+from src.modules.media.domain.value_objects.cast_member import CastMember
 from src.modules.media.domain.value_objects.content_rating import ContentRating
 from src.modules.media.domain.value_objects.duration import Duration
 from src.modules.media.domain.value_objects.episode_number import EpisodeNumber
@@ -29,6 +30,7 @@ from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 __all__ = [
     "AirDate",
     "AudioTrack",
+    "CastMember",
     "ContentRating",
     "Duration",
     "EpisodeId",

--- a/src/modules/media/domain/value_objects/cast_member.py
+++ b/src/modules/media/domain/value_objects/cast_member.py
@@ -1,0 +1,36 @@
+"""CastMember value object — actor entry on a Movie's cast list."""
+
+from src.building_blocks.domain import CompoundValueObject
+
+
+class CastMember(CompoundValueObject):
+    """A cast entry for a Movie.
+
+    Holds the actor's name, the URL of their TMDB profile photo (when
+    available), and the character they played. Replaces the previous
+    plain-string cast list so the detail-page UI can render avatars
+    and roles instead of just names.
+
+    Attributes:
+        name: Actor's display name (always present).
+        profile_path: Full URL to the TMDB profile image. ``None`` when
+            TMDB doesn't have a photo for this person — the UI falls
+            back to an initials avatar.
+        role: Character name played by the actor (e.g. "Cobb",
+            "Detective Mills"). ``None`` when the source didn't
+            provide one.
+
+    Example:
+        >>> CastMember(
+        ...     name="Leonardo DiCaprio",
+        ...     profile_path="https://image.tmdb.org/t/p/original/abc.jpg",
+        ...     role="Cobb",
+        ... )
+    """
+
+    name: str
+    profile_path: str | None = None
+    role: str | None = None
+
+
+__all__ = ["CastMember"]

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -44,18 +44,31 @@ def _deserialize_cast(raw: str | None) -> list[CastMember]:
     so rows enriched before this feature still load — entries without
     photo/role just render as initials avatars on the UI side. The
     next save migrates the row to the new shape implicitly.
+
+    Tolerant of malformed payloads at the storage boundary: a JSON
+    value that is not a list (drift from a future migration, manual
+    DB edit) collapses to an empty cast rather than iterating dict
+    keys as if they were entries; dict entries with no usable
+    ``name`` are skipped so the UI never renders empty cards.
     """
     if not raw:
         return []
     items = json.loads(raw)
+    if not isinstance(items, list):
+        return []
     members: list[CastMember] = []
     for item in items:
         if isinstance(item, str):
-            members.append(CastMember(name=item))
+            name = item.strip()
+            if name:
+                members.append(CastMember(name=name))
         elif isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+            if not name:
+                continue
             members.append(
                 CastMember(
-                    name=str(item.get("name", "")),
+                    name=name,
                     profile_path=item.get("profile_path") or None,
                     role=item.get("role") or None,
                 )

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -4,6 +4,7 @@ import json
 
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
+    CastMember,
     ContentRating,
     Duration,
     FilePath,
@@ -21,6 +22,45 @@ from src.modules.media.infrastructure.persistence.mappers.media_file_mapper impo
     MediaFileMapper,
 )
 from src.modules.media.infrastructure.persistence.models import MediaFileModel, MovieModel
+
+
+def _serialize_cast(cast: list[CastMember]) -> str | None:
+    """Serialize the cast list to the JSON shape stored on disk.
+
+    New shape: ``[{"name": "...", "profile_path": "...", "role": "..."}, ...]``.
+    Always written this way; legacy ``["Name1", "Name2"]`` data is only
+    *read* by ``_deserialize_cast`` and gets converted on the next save.
+    """
+    if not cast:
+        return None
+    payload = [{"name": m.name, "profile_path": m.profile_path, "role": m.role} for m in cast]
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _deserialize_cast(raw: str | None) -> list[CastMember]:
+    """Reconstruct the cast list from the JSON column.
+
+    Accepts both the new dict shape and the legacy ``list[str]`` shape
+    so rows enriched before this feature still load — entries without
+    photo/role just render as initials avatars on the UI side. The
+    next save migrates the row to the new shape implicitly.
+    """
+    if not raw:
+        return []
+    items = json.loads(raw)
+    members: list[CastMember] = []
+    for item in items:
+        if isinstance(item, str):
+            members.append(CastMember(name=item))
+        elif isinstance(item, dict):
+            members.append(
+                CastMember(
+                    name=str(item.get("name", "")),
+                    profile_path=item.get("profile_path") or None,
+                    role=item.get("role") or None,
+                )
+            )
+    return members
 
 
 class MovieMapper:
@@ -68,7 +108,7 @@ class MovieMapper:
             if entity.scrub_preview_path
             else None,
             genres=",".join(g.value for g in entity.genres) if entity.genres else None,
-            cast=json.dumps(entity.cast, ensure_ascii=False) if entity.cast else None,
+            cast=_serialize_cast(entity.cast),
             directors=json.dumps(entity.directors, ensure_ascii=False)
             if entity.directors
             else None,
@@ -144,7 +184,7 @@ class MovieMapper:
             if model.scrub_preview_path
             else None,
             genres=genre_list,
-            cast=json.loads(model.cast) if model.cast else [],
+            cast=_deserialize_cast(model.cast),
             directors=json.loads(model.directors) if model.directors else [],
             writers=json.loads(model.writers) if model.writers else [],
             content_rating=ContentRating(model.content_rating) if model.content_rating else None,
@@ -184,7 +224,7 @@ class MovieMapper:
             entity.scrub_preview_path.value if entity.scrub_preview_path else None
         )
         model.genres = ",".join(g.value for g in entity.genres) if entity.genres else None
-        model.cast = json.dumps(entity.cast, ensure_ascii=False) if entity.cast else None
+        model.cast = _serialize_cast(entity.cast)
         model.directors = (
             json.dumps(entity.directors, ensure_ascii=False) if entity.directors else None
         )

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -264,7 +264,13 @@ class TestApplyMetadataFields:
         metadata = MediaMetadata(
             title="Inception",
             tmdb_id=27205,
-            cast=[CreditPerson(name="Leonardo DiCaprio")],
+            cast=[
+                CreditPerson(
+                    name="Leonardo DiCaprio",
+                    role="Cobb",
+                    profile_url="https://image.tmdb.org/t/p/original/leo.jpg",
+                ),
+            ],
             directors=[CreditPerson(name="Christopher Nolan")],
             writers=[CreditPerson(name="Christopher Nolan")],
             content_rating="PG-13",
@@ -277,7 +283,13 @@ class TestApplyMetadataFields:
         await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         saved = mocks.movies.save.call_args[0][0]
-        assert saved.cast == ["Leonardo DiCaprio"]
+        # Cast carries name + profile_path + role through the enrich
+        # pipeline now — name-only data in tests would mask the
+        # CreditPerson → CastMember plumbing the detail UI relies on.
+        assert len(saved.cast) == 1
+        assert saved.cast[0].name == "Leonardo DiCaprio"
+        assert saved.cast[0].profile_path == "https://image.tmdb.org/t/p/original/leo.jpg"
+        assert saved.cast[0].role == "Cobb"
         assert saved.directors == ["Christopher Nolan"]
         assert saved.writers == ["Christopher Nolan"]
         assert saved.content_rating == ContentRating("PG-13")

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
@@ -113,3 +113,60 @@ class TestMovieMapper:
 
         assert len(entity.files) == 1
         assert entity.files[0].file_path.value == "/movies/test.mkv"
+
+    def test_to_entity_reads_legacy_cast_string_list(self) -> None:
+        """Legacy rows stored ``cast`` as ``["Name1", "Name2"]``.
+
+        After the cast-with-photos change the column holds dicts, but
+        existing data must still load — entries become ``CastMember``
+        with ``profile_path``/``role`` set to ``None``. The next save
+        rewrites the row in the new shape.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            cast='["Leonardo DiCaprio", "Joseph Gordon-Levitt"]',
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model, include_files=False)
+
+        assert len(entity.cast) == 2
+        assert entity.cast[0].name == "Leonardo DiCaprio"
+        assert entity.cast[0].profile_path is None
+        assert entity.cast[0].role is None
+        assert entity.cast[1].name == "Joseph Gordon-Levitt"
+
+    def test_to_entity_reads_new_cast_dict_shape(self) -> None:
+        """New rows store ``cast`` as ``[{"name", "profile_path", "role"}]``.
+
+        Pin both shapes so a future refactor that drops one of the
+        branches in ``_deserialize_cast`` flips a test red.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            cast=(
+                '[{"name": "Leonardo DiCaprio", "profile_path": '
+                '"https://image.tmdb.org/t/p/original/leo.jpg", "role": "Cobb"}]'
+            ),
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model, include_files=False)
+
+        assert len(entity.cast) == 1
+        member = entity.cast[0]
+        assert member.name == "Leonardo DiCaprio"
+        assert member.profile_path == "https://image.tmdb.org/t/p/original/leo.jpg"
+        assert member.role == "Cobb"

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
@@ -170,3 +170,56 @@ class TestMovieMapper:
         assert member.name == "Leonardo DiCaprio"
         assert member.profile_path == "https://image.tmdb.org/t/p/original/leo.jpg"
         assert member.role == "Cobb"
+
+    def test_to_entity_collapses_non_list_cast_payload_to_empty(self) -> None:
+        """Malformed cast JSON (single object instead of list) → empty cast.
+
+        Defends against a future migration or manual DB edit that
+        writes the wrong shape; without the guard, ``for item in items``
+        would iterate dict keys and silently produce ``CastMember``s
+        named ``"name"``, ``"profile_path"`` etc.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            cast='{"name": "Leonardo DiCaprio"}',  # not a list
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model, include_files=False)
+
+        assert entity.cast == []
+
+    def test_to_entity_skips_cast_dicts_without_name(self) -> None:
+        """Cast entries with empty / missing ``name`` are skipped.
+
+        Keeps the UI from rendering placeholder cards (initials ``?``,
+        blank label) when the upstream provider drifts and stops
+        sending names.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            cast=(
+                '[{"name": "Leonardo DiCaprio"}, '
+                '{"name": ""}, '
+                '{"profile_path": "/foo.jpg"}, '
+                '{"name": "   "}]'
+            ),
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model, include_files=False)
+
+        assert len(entity.cast) == 1
+        assert entity.cast[0].name == "Leonardo DiCaprio"


### PR DESCRIPTION
## Summary

Wire the actor photo and role through the cast pipeline so the detail-page UI can render avatars + name + role instead of a comma-joined string of names. The data was already in TMDB's ``CreditPerson`` records; the enrich use case used to drop everything except ``name``.

## Changes

- **Domain**: new ``CastMember`` value object with ``name``, ``profile_path`` (full TMDB URL), and ``role``. ``Movie.cast`` switches from ``list[str]`` to ``list[CastMember]``.
- **Persistence**: ``cast`` column stays JSON ``Text`` on disk; only the inner shape changes from ``["Name", ...]`` to ``[{"name": ..., "profile_path": ..., "role": ...}, ...]``. ``MovieMapper._deserialize_cast`` accepts both shapes — legacy rows still load (entries get ``profile_path=None``, ``role=None``) and migrate to the new shape on next save. No data migration step needed.
- **Application**: new ``CastMemberOutput`` DTO; ``MovieOutput.cast`` switches to ``list[CastMemberOutput]``. ``GetMovieById`` and ``EnrichMovieMetadata`` updated.
- **Tests**: enrich test asserts photo + role are carried through; new mapper tests pin both legacy-string and new-dict read paths.

## Migration of existing rows

None at the schema level. The mapper is shape-tolerant on read; the next save (e.g. via ``EnrichMovieMetadataUseCase`` or ``BulkEnrichMetadataUseCase``) rewrites the row in the new shape with photos populated. Cast on un-enriched movies shows up as initials avatars on the UI side until they're re-enriched.

## Test plan

- [x] ``make lint`` clean
- [x] ``make format`` clean
- [x] Full suite green (1751 tests, +3 new for cast plumbing)
- [ ] Re-enrich a movie via ``POST /api/v1/movies/{id}/enrich`` → verify ``logo_path`` populated; verify response includes ``cast: [{"name": ..., "profile_path": ..., "role": ...}]``
- [ ] Load a movie that hasn't been re-enriched yet → ``cast`` entries return with ``profile_path: null`` and ``role: null`` (no errors, just initials avatars on the UI)

## Frontend dependency

Pair PR ``lucaschf/homeflix-web#cast-with-photos`` consumes the new shape via the ``<CastRow>`` component.

## Summary by Sourcery

Introduce structured cast member support carrying actor photos and roles through the movie domain, persistence, and API layers while remaining compatible with legacy string-based cast data.

New Features:
- Add CastMember domain value object and CastMemberOutput DTO so movies expose cast entries with name, profile photo URL, and role instead of plain strings.

Enhancements:
- Change Movie.cast from a list of strings to a list of CastMember objects and update enrichment logic to build these from TMDB credit metadata.
- Update movie mapping to serialize cast members to a new JSON object shape while transparently deserializing both legacy string lists and the new structured format.
- Adjust GetMovieById output mapping so the API returns structured cast entries including optional profile photos and roles.

Tests:
- Extend enrichment and movie mapper unit tests to cover cast member photo and role propagation and to pin both legacy and new cast storage shapes.