### PR TITLE
feat(media): TMDB-backed "you might also like" for movies

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -25,6 +25,7 @@ from src.modules.media.application.use_cases.get_featured_media import GetFeatur
 from src.modules.media.application.use_cases.get_file_tracks import GetFileTracksUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
+from src.modules.media.application.use_cases.get_related_movies import GetRelatedMoviesUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
@@ -259,6 +260,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         EnrichMovieMetadataUseCase,
         uow_factory=media_unit_of_work_factory,
         primary_provider=tmdb_client,
+    )
+
+    get_related_movies = providers.Factory(
+        GetRelatedMoviesUseCase,
+        uow_factory=media_unit_of_work_factory,
+        metadata_provider=tmdb_client,
     )
 
     enrich_series_metadata = providers.Factory(

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -182,6 +182,22 @@ class MetadataProvider(ABC):
         """
         ...
 
+    @abstractmethod
+    async def get_movie_recommendations(self, tmdb_id: int) -> list[int]:
+        """Return TMDB ids of movies recommended for ``tmdb_id``.
+
+        Order matters: the first item is the most relevant recommendation
+        according to the provider; callers preserve this order so the UI
+        renders by descending relevance. Returns an empty list when the
+        provider has no recommendations or the call fails — recommendation
+        rendering is best-effort polish, never load-bearing.
+
+        The returned ids are the *external provider* ids (TMDB person /
+        movie ids); callers cross-reference them with their own catalog
+        to filter to titles that actually exist locally.
+        """
+        ...
+
 
 __all__ = [
     "CreditPerson",

--- a/src/modules/media/application/use_cases/_movie_summary_helpers.py
+++ b/src/modules/media/application/use_cases/_movie_summary_helpers.py
@@ -1,0 +1,32 @@
+"""Shared converters for ``MovieSummaryOutput``.
+
+Several use cases (``ListMoviesUseCase``, ``GetRelatedMoviesUseCase``,
+future genre / search variants) build the same lightweight movie
+summary the catalog UI consumes. Keeping the converter in one place
+avoids the inevitable drift where one site adds a new field and
+others render an older shape.
+"""
+
+from src.modules.media.application.dtos.movie_dtos import MovieSummaryOutput
+from src.modules.media.domain.entities.movie import Movie
+
+
+def to_movie_summary(movie: Movie, lang: str = "en") -> MovieSummaryOutput:
+    """Convert a ``Movie`` entity to its catalog-card DTO."""
+    best = movie.best_file
+    return MovieSummaryOutput(
+        id=str(movie.id),
+        title=movie.get_title(lang),
+        year=movie.year.value,
+        duration_formatted=movie.duration.format_hms(),
+        synopsis=movie.get_synopsis(lang),
+        poster_path=movie.poster_path.value if movie.poster_path else None,
+        backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
+        resolution=best.resolution.value if best else None,
+        variant_count=len(movie.files),
+        available_resolutions=[r.value for r in movie.available_resolutions],
+        genres=movie.get_genres(lang),
+    )
+
+
+__all__ = ["to_movie_summary"]

--- a/src/modules/media/application/use_cases/get_related_movies.py
+++ b/src/modules/media/application/use_cases/get_related_movies.py
@@ -1,0 +1,86 @@
+"""GetRelatedMoviesUseCase — TMDB recommendations filtered by library."""
+
+from dataclasses import dataclass
+
+from src.modules.media.application.dtos.movie_dtos import MovieSummaryOutput
+from src.modules.media.application.ports import MetadataProvider
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases._movie_summary_helpers import to_movie_summary
+from src.modules.media.domain.value_objects import MovieId
+
+
+@dataclass(frozen=True)
+class GetRelatedMoviesInput:
+    """Input for ``GetRelatedMoviesUseCase``.
+
+    Attributes:
+        movie_id: External id of the movie to look up recommendations for.
+        lang: Language for localized fields on the response.
+        limit: Maximum number of related movies to return.
+    """
+
+    movie_id: str
+    lang: str = "en"
+    limit: int = 12
+
+
+class GetRelatedMoviesUseCase:
+    """Return movies in the library that TMDB recommends for the input.
+
+    Pulls TMDB's recommendation list for the input movie (falling back
+    to TMDB's "similar" endpoint when recommendations is empty), then
+    intersects with the local catalog by ``tmdb_id``. The TMDB ordering
+    (by relevance) is preserved on the way out.
+
+    The feature is best-effort polish: any failure (movie not found,
+    movie not enriched with TMDB id, provider unavailable, no overlap
+    with local catalog) yields an empty list rather than raising — the
+    UI simply doesn't render the carousel.
+
+    Example:
+        >>> use_case = GetRelatedMoviesUseCase(uow_factory, tmdb_client)
+        >>> result = await use_case.execute(GetRelatedMoviesInput("mov_abc"))
+        >>> [m.title for m in result]
+        ['Interstellar', 'The Prestige', ...]
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        metadata_provider: MetadataProvider,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._metadata = metadata_provider
+
+    async def execute(self, input_dto: GetRelatedMoviesInput) -> list[MovieSummaryOutput]:
+        """Run the lookup."""
+        async with self._uow_factory() as uow:
+            source = await uow.movies.find_by_id(MovieId(input_dto.movie_id))
+            if source is None or source.tmdb_id is None:
+                return []
+
+            tmdb_ids = await self._metadata.get_movie_recommendations(source.tmdb_id.value)
+            if not tmdb_ids:
+                return []
+
+            # Trim before hitting the DB so a TMDB result of 50 doesn't
+            # cost us 50 rows when the carousel only shows ``limit``.
+            # Slight over-fetch (2x) so a few catalog gaps don't leave
+            # the carousel sparse.
+            candidate_ids = tmdb_ids[: input_dto.limit * 2]
+            local = await uow.movies.find_by_tmdb_ids(candidate_ids)
+
+        # Preserve TMDB's relevance ordering by iterating the request
+        # list rather than the dict's insertion order.
+        ordered: list[MovieSummaryOutput] = []
+        for tid in candidate_ids:
+            movie = local.get(tid)
+            if movie is None:
+                continue
+            ordered.append(to_movie_summary(movie, input_dto.lang))
+            if len(ordered) >= input_dto.limit:
+                break
+        return ordered
+
+
+__all__ = ["GetRelatedMoviesInput", "GetRelatedMoviesUseCase"]

--- a/src/modules/media/application/use_cases/list_movies.py
+++ b/src/modules/media/application/use_cases/list_movies.py
@@ -6,6 +6,7 @@ from src.modules.media.application.dtos.movie_dtos import (
     MovieSummaryOutput,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases._movie_summary_helpers import to_movie_summary
 from src.modules.media.domain.entities import Movie
 
 
@@ -62,29 +63,8 @@ class ListMoviesUseCase:
 
     @staticmethod
     def _to_summary(movie: Movie, lang: str = "en") -> MovieSummaryOutput:
-        """Convert Movie entity to summary output.
-
-        Args:
-            movie: The Movie entity to convert.
-            lang: Language code for localized fields.
-
-        Returns:
-            MovieSummaryOutput with essential fields.
-        """
-        best = movie.best_file
-        return MovieSummaryOutput(
-            id=str(movie.id),
-            title=movie.get_title(lang),
-            year=movie.year.value,
-            duration_formatted=movie.duration.format_hms(),
-            synopsis=movie.get_synopsis(lang),
-            poster_path=movie.poster_path.value if movie.poster_path else None,
-            backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
-            resolution=best.resolution.value if best else None,
-            variant_count=len(movie.files),
-            available_resolutions=[r.value for r in movie.available_resolutions],
-            genres=movie.get_genres(lang),
-        )
+        """Convert Movie entity to summary output."""
+        return to_movie_summary(movie, lang)
 
 
 __all__ = ["ListMoviesUseCase"]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -232,6 +232,27 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_by_tmdb_ids(self, tmdb_ids: Sequence[int]) -> dict[int, Movie]:
+        """Find movies whose ``tmdb_id`` is in ``tmdb_ids``.
+
+        Used by the "you might also like" path: ``GetRelatedMovies``
+        asks TMDB for related ids, then this method maps the subset
+        present in the local catalog. Returning a dict keyed by
+        ``tmdb_id`` lets the caller preserve the original TMDB
+        ordering (which is by relevance) without paying for an extra
+        traversal — the caller iterates ``tmdb_ids`` and looks each
+        up in the dict.
+
+        Soft-deleted rows are excluded.
+
+        Returns:
+            Dict mapping ``tmdb_id`` int to ``Movie`` entity. Keys
+            present in ``tmdb_ids`` but absent in the catalog simply
+            don't appear in the result — no ``KeyError`` semantics.
+        """
+        ...
+
+    @abstractmethod
     async def find_by_file_path(self, file_path: FilePath) -> Movie | None:
         """Find a movie by its file path.
 

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -167,6 +167,55 @@ class TmdbClient(MetadataProvider):
         """Fetch series details by TMDB ID."""
         return await self._fetch_series_details(tmdb_id)
 
+    async def get_movie_recommendations(self, tmdb_id: int) -> list[int]:
+        """Return TMDB ids of movies recommended for ``tmdb_id``.
+
+        TMDB exposes two related-content endpoints for movies:
+
+        - ``/movie/{id}/recommendations`` — ML-based, often empty for
+          obscure titles.
+        - ``/movie/{id}/similar`` — heuristic (genre / keyword
+          overlap), almost always populated.
+
+        We try ``recommendations`` first; if it returns nothing
+        useful, fall back to ``similar`` so the "you might also like"
+        section never goes blank just because TMDB hasn't built up
+        signal for that title yet.
+
+        Network failures and unexpected payload shapes degrade to an
+        empty list — recommendation rendering is best-effort polish,
+        never load-bearing.
+        """
+        ids = await self._fetch_related_movie_ids(tmdb_id, "recommendations")
+        if not ids:
+            ids = await self._fetch_related_movie_ids(tmdb_id, "similar")
+        return ids
+
+    async def _fetch_related_movie_ids(self, tmdb_id: int, endpoint: str) -> list[int]:
+        """Hit a single ``/movie/{id}/<endpoint>`` and extract numeric ids.
+
+        ``endpoint`` is ``"recommendations"`` or ``"similar"``; both
+        paginate but page 1 already carries enough candidates for the
+        UI's ~10-item carousel and a second request would just burn
+        latency on results we'd discard.
+        """
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/movie/{tmdb_id}/{endpoint}",
+                params=self._params(),
+            )
+        except httpx.HTTPError:
+            return []
+        if resp.status_code != 200:
+            return []
+        results = resp.json().get("results") or []
+        ids: list[int] = []
+        for item in results:
+            raw = item.get("id") if isinstance(item, dict) else None
+            if isinstance(raw, int):
+                ids.append(raw)
+        return ids
+
     async def get_series_localized(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch series details in English with pt-BR localization.
 

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -168,27 +168,88 @@ class TmdbClient(MetadataProvider):
         return await self._fetch_series_details(tmdb_id)
 
     async def get_movie_recommendations(self, tmdb_id: int) -> list[int]:
-        """Return TMDB ids of movies recommended for ``tmdb_id``.
+        """Return TMDB ids of movies related to ``tmdb_id``.
 
-        TMDB exposes two related-content endpoints for movies:
+        Three sources are merged, in descending relevance:
 
-        - ``/movie/{id}/recommendations`` — ML-based, often empty for
-          obscure titles.
-        - ``/movie/{id}/similar`` — heuristic (genre / keyword
-          overlap), almost always populated.
+        1. **Collection siblings** — when the movie belongs to a TMDB
+           collection (franchises, e.g. "Creepshow Collection"), every
+           other entry in the collection. Sequels / prequels are the
+           most obvious "related" signal but TMDB's ML doesn't always
+           expose them, especially for older or less popular titles.
+        2. **``/recommendations``** — ML-based.
+        3. **``/similar``** — heuristic fallback (genre / keyword
+           overlap), only used when recommendations is empty.
 
-        We try ``recommendations`` first; if it returns nothing
-        useful, fall back to ``similar`` so the "you might also like"
-        section never goes blank just because TMDB hasn't built up
-        signal for that title yet.
+        Sources 1 + 2 (or 1 + 3) are merged in order, with the input
+        movie itself skipped and duplicates removed so the same id
+        never appears twice.
 
         Network failures and unexpected payload shapes degrade to an
         empty list — recommendation rendering is best-effort polish,
         never load-bearing.
         """
-        ids = await self._fetch_related_movie_ids(tmdb_id, "recommendations")
-        if not ids:
-            ids = await self._fetch_related_movie_ids(tmdb_id, "similar")
+        collection_ids = await self._fetch_collection_movie_ids(tmdb_id)
+        other_ids = await self._fetch_related_movie_ids(tmdb_id, "recommendations")
+        if not other_ids:
+            other_ids = await self._fetch_related_movie_ids(tmdb_id, "similar")
+
+        seen: set[int] = {tmdb_id}
+        ordered: list[int] = []
+        for tid in [*collection_ids, *other_ids]:
+            if tid in seen:
+                continue
+            seen.add(tid)
+            ordered.append(tid)
+        return ordered
+
+    async def _fetch_collection_movie_ids(self, tmdb_id: int) -> list[int]:  # noqa: PLR0911
+        """Return ids of every movie in the input movie's TMDB collection.
+
+        Two-call shape: first ``/movie/{id}`` (minimal, just to read
+        ``belongs_to_collection``), then ``/collection/{coll_id}`` for
+        the ``parts`` list. Both are cheap on the TMDB side and only
+        run for the recommendations endpoint, so the extra round-trip
+        is fine.
+
+        Returns an empty list when the movie has no collection or any
+        step fails — collection lookup is best-effort polish.
+        """
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/movie/{tmdb_id}",
+                params=self._params(),
+            )
+        except httpx.HTTPError:
+            return []
+        if resp.status_code != 200:
+            return []
+
+        coll = resp.json().get("belongs_to_collection")
+        if not isinstance(coll, dict):
+            return []
+        coll_id = coll.get("id")
+        if not isinstance(coll_id, int):
+            return []
+
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/collection/{coll_id}",
+                params=self._params(),
+            )
+        except httpx.HTTPError:
+            return []
+        if resp.status_code != 200:
+            return []
+
+        parts = resp.json().get("parts") or []
+        ids: list[int] = []
+        for part in parts:
+            if not isinstance(part, dict):
+                continue
+            pid = part.get("id")
+            if isinstance(pid, int):
+                ids.append(pid)
         return ids
 
     async def _fetch_related_movie_ids(self, tmdb_id: int, endpoint: str) -> list[int]:

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -270,6 +270,31 @@ class SQLAlchemyMovieRepository(MovieRepository):
         result = await self._session.execute(stmt)
         return {model.external_id: MovieMapper.to_entity(model) for model in result.scalars().all()}
 
+    async def find_by_tmdb_ids(self, tmdb_ids: Sequence[int]) -> dict[int, Movie]:
+        """Find movies whose ``tmdb_id`` matches any of ``tmdb_ids``.
+
+        Used by ``GetRelatedMovies`` to resolve the subset of TMDB's
+        recommendation list that exists locally. Returning a dict
+        keyed by ``tmdb_id`` lets the caller preserve TMDB's
+        relevance ordering by iterating the request list.
+        """
+        if not tmdb_ids:
+            return {}
+        stmt = (
+            select(MovieModel)
+            .where(
+                MovieModel.tmdb_id.in_(tmdb_ids),
+                MovieModel.deleted_at.is_(None),
+            )
+            .options(selectinload(MovieModel.file_variants))
+        )
+        result = await self._session.execute(stmt)
+        return {
+            model.tmdb_id: MovieMapper.to_entity(model)
+            for model in result.scalars().all()
+            if model.tmdb_id is not None
+        }
+
     async def find_by_file_path(self, file_path: FilePath) -> Movie | None:
         """Find a movie by any of its file variant paths.
 

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -23,6 +23,10 @@ from src.modules.media.application.use_cases.add_file_variant import AddFileVari
 from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
+from src.modules.media.application.use_cases.get_related_movies import (
+    GetRelatedMoviesInput,
+    GetRelatedMoviesUseCase,
+)
 from src.modules.media.application.use_cases.list_movies import ListMoviesUseCase
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
@@ -95,6 +99,29 @@ async def get_movie(
     """Get a movie by ID."""
     result = await use_case.execute(GetMovieByIdInput(movie_id=movie_id, lang=lang))
     return api_single("movie", _dataclass_to_dict(result))
+
+
+@router.get("/{movie_id}/related")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_related_movies(
+    movie_id: str,
+    lang: str = "en",
+    limit: int = 12,
+    use_case: GetRelatedMoviesUseCase = Depends(
+        Provide[ApplicationContainer.media.get_related_movies],
+    ),
+) -> dict[str, Any]:
+    """Return movies in the local catalog that TMDB recommends for ``movie_id``.
+
+    Best-effort polish for the "you might also like" carousel: the
+    response is an empty list whenever the movie has no TMDB id, the
+    provider returns nothing, or no recommendation overlaps with the
+    local catalog. The route never raises.
+    """
+    items = await use_case.execute(
+        GetRelatedMoviesInput(movie_id=movie_id, lang=lang, limit=max(1, min(limit, 30))),
+    )
+    return api_list([_dataclass_to_dict(item) for item in items])
 
 
 @router.delete("/{movie_id}", status_code=204)  # type: ignore[misc]

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -353,6 +353,66 @@ class TestSQLAlchemyMovieRepositoryFindByIds:
 
 
 @pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryFindByTmdbIds:
+    """Tests for ``find_by_tmdb_ids`` — used by ``GetRelatedMovies``."""
+
+    async def test_returns_empty_dict_for_empty_input(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        assert await repo.find_by_tmdb_ids([]) == {}
+
+    async def test_returns_mapping_by_tmdb_id(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        a = _create_movie(title="A", file_path="/movies/a.mkv", tmdb_id=TmdbId(100))
+        b = _create_movie(title="B", file_path="/movies/b.mkv", tmdb_id=TmdbId(200))
+        await repo.save(a)
+        await repo.save(b)
+
+        result = await repo.find_by_tmdb_ids([100, 200])
+
+        assert set(result.keys()) == {100, 200}
+        assert result[100].title.value == "A"
+        assert result[200].title.value == "B"
+
+    async def test_skips_ids_not_in_catalog(self, db_session: AsyncSession) -> None:
+        # Mirrors how the real flow works: TMDB recommendations include
+        # titles the user doesn't have; the use case relies on missing
+        # ids simply not appearing in the result.
+        repo = SQLAlchemyMovieRepository(db_session)
+        present = _create_movie(
+            title="Present",
+            file_path="/movies/p.mkv",
+            tmdb_id=TmdbId(42),
+        )
+        await repo.save(present)
+
+        result = await repo.find_by_tmdb_ids([42, 9999])
+
+        assert set(result.keys()) == {42}
+
+    async def test_excludes_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _create_movie(
+            title="Trashed",
+            file_path="/movies/trashed.mkv",
+            tmdb_id=TmdbId(7),
+        )
+        await repo.save(movie)
+        await repo.delete(_id_of(movie))
+
+        assert await repo.find_by_tmdb_ids([7]) == {}
+
+    async def test_skips_movies_with_null_tmdb_id(self, db_session: AsyncSession) -> None:
+        # Defensive: the SQL filter is ``tmdb_id IN (...)`` but movies
+        # without a ``tmdb_id`` shouldn't appear under any key, even
+        # if a ``None`` somehow leaks through.
+        repo = SQLAlchemyMovieRepository(db_session)
+        no_tmdb = _create_movie(title="Manual", file_path="/movies/manual.mkv")
+        await repo.save(no_tmdb)
+
+        assert await repo.find_by_tmdb_ids([1, 2, 3]) == {}
+
+
+@pytest.mark.integration
 class TestSQLAlchemyMovieRepositorySaveRestore:
     """Tests for save restoring soft-deleted records."""
 

--- a/tests/modules/media/unit/application/use_cases/test_get_related_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_related_movies.py
@@ -1,0 +1,118 @@
+"""Tests for ``GetRelatedMoviesUseCase``."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.application.ports import MetadataProvider
+from src.modules.media.application.use_cases.get_related_movies import (
+    GetRelatedMoviesInput,
+    GetRelatedMoviesUseCase,
+)
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects import MovieId, TmdbId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+
+def _movie(*, title: str, tmdb_id: int | None) -> Movie:
+    movie = Movie.create(
+        title=title,
+        year=2010,
+        duration=8880,
+        file_path=f"/movies/{title.lower()}.mkv",
+        file_size=1_000_000_000,
+        resolution="1080p",
+    )
+    return movie.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id else movie
+
+
+class TestGetRelatedMoviesUseCase:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_source_movie_missing(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
+        provider = AsyncMock(spec=MetadataProvider)
+
+        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedMoviesInput(movie_id=str(MovieId.generate())),
+        )
+
+        assert result == []
+        provider.get_movie_recommendations.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_source_has_no_tmdb_id(self) -> None:
+        # Movie was added manually (no enrich) — no way to look up
+        # recommendations. Bail before hitting the provider.
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = _movie(title="Manual", tmdb_id=None)
+        provider = AsyncMock(spec=MetadataProvider)
+
+        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedMoviesInput(movie_id=str(MovieId.generate())),
+        )
+
+        assert result == []
+        provider.get_movie_recommendations.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_filters_to_local_catalog_preserving_tmdb_order(self) -> None:
+        # TMDB returns 4 ids in relevance order. Only ids 1422 and 27205
+        # exist locally; the response must be ordered [1422, 27205] —
+        # TMDB's relevance ranking, NOT the dict's insertion order.
+        mocks = make_media_uow_mock()
+        source = _movie(title="The Dark Knight", tmdb_id=155)
+        mocks.movies.find_by_id.return_value = source
+        mocks.movies.find_by_tmdb_ids.return_value = {
+            27205: _movie(title="Inception", tmdb_id=27205),
+            1422: _movie(title="The Departed", tmdb_id=1422),
+        }
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_movie_recommendations.return_value = [
+            1422,
+            999999,
+            27205,
+            888888,
+        ]
+
+        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedMoviesInput(movie_id=str(MovieId.generate()), limit=10),
+        )
+
+        assert [m.title for m in result] == ["The Departed", "Inception"]
+
+    @pytest.mark.asyncio
+    async def test_truncates_to_limit(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = _movie(title="Source", tmdb_id=1)
+        mocks.movies.find_by_tmdb_ids.return_value = {
+            i: _movie(title=f"M{i}", tmdb_id=i) for i in (10, 11, 12, 13, 14)
+        }
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_movie_recommendations.return_value = [10, 11, 12, 13, 14]
+
+        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedMoviesInput(movie_id=str(MovieId.generate()), limit=3),
+        )
+
+        assert len(result) == 3
+        assert [m.title for m in result] == ["M10", "M11", "M12"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_local_overlap(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = _movie(title="Source", tmdb_id=1)
+        mocks.movies.find_by_tmdb_ids.return_value = {}
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_movie_recommendations.return_value = [99, 100, 101]
+
+        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedMoviesInput(movie_id=str(MovieId.generate())),
+        )
+
+        assert result == []

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -642,6 +642,85 @@ class TestGetSeriesLocalized:
 
 
 @pytest.mark.unit
+class TestGetMovieRecommendations:
+    """``get_movie_recommendations`` — TMDB-backed, with ``/similar`` fallback."""
+
+    @pytest.mark.asyncio
+    async def test_returns_recommended_ids_in_order(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={"results": [{"id": 27205}, {"id": 1422}, {"id": 524434}]},
+            ),
+        )
+
+        ids = await client.get_movie_recommendations(155)
+
+        assert ids == [27205, 1422, 524434]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_similar_when_recommendations_empty(self) -> None:
+        # Recommendations is sparse for less popular movies; ``/similar``
+        # is heuristic and almost always populated. The fallback keeps
+        # the carousel from going blank when ML signal is missing.
+        client = _make_client(
+            get_responses=[
+                _build_response(json_data={"results": []}),  # /recommendations
+                _build_response(json_data={"results": [{"id": 99}, {"id": 100}]}),  # /similar
+            ],
+        )
+
+        ids = await client.get_movie_recommendations(42)
+
+        assert ids == [99, 100]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_both_endpoints_empty(self) -> None:
+        client = _make_client(
+            get_responses=[
+                _build_response(json_data={"results": []}),  # /recommendations
+                _build_response(json_data={"results": []}),  # /similar
+            ],
+        )
+
+        ids = await client.get_movie_recommendations(42)
+
+        assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_http_error(self) -> None:
+        client = _make_client(
+            get_responses=[
+                _build_response(status_code=500),  # /recommendations errors
+                _build_response(status_code=500),  # /similar also errors
+            ],
+        )
+
+        ids = await client.get_movie_recommendations(42)
+
+        assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_skips_non_int_ids_in_payload(self) -> None:
+        # Defensive: a malformed TMDB row shouldn't crash the parser.
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "results": [
+                        {"id": 1},
+                        {"id": "not-an-int"},
+                        {"name": "no id here"},
+                        {"id": 2},
+                    ]
+                },
+            ),
+        )
+
+        ids = await client.get_movie_recommendations(155)
+
+        assert ids == [1, 2]
+
+
+@pytest.mark.unit
 class TestPickBestLogoUrl:
     """Priority order for the ``_pick_best_logo_url`` parser.
 

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -643,14 +643,28 @@ class TestGetSeriesLocalized:
 
 @pytest.mark.unit
 class TestGetMovieRecommendations:
-    """``get_movie_recommendations`` — TMDB-backed, with ``/similar`` fallback."""
+    """``get_movie_recommendations`` — collection + ML / heuristic merge.
+
+    Call sequence in production is:
+
+    1. ``/movie/{id}`` to read ``belongs_to_collection`` (always).
+    2. ``/collection/{id}`` for the franchise siblings (only when
+       ``belongs_to_collection`` is set).
+    3. ``/movie/{id}/recommendations`` for ML-based recs.
+    4. ``/movie/{id}/similar`` only when recommendations is empty.
+
+    Tests provide a mock per call in that order.
+    """
 
     @pytest.mark.asyncio
     async def test_returns_recommended_ids_in_order(self) -> None:
         client = _make_client(
-            get_responses=_build_response(
-                json_data={"results": [{"id": 27205}, {"id": 1422}, {"id": 524434}]},
-            ),
+            get_responses=[
+                _build_response(json_data={}),  # /movie/{id} — no collection
+                _build_response(  # /recommendations
+                    json_data={"results": [{"id": 27205}, {"id": 1422}, {"id": 524434}]},
+                ),
+            ],
         )
 
         ids = await client.get_movie_recommendations(155)
@@ -659,13 +673,15 @@ class TestGetMovieRecommendations:
 
     @pytest.mark.asyncio
     async def test_falls_back_to_similar_when_recommendations_empty(self) -> None:
-        # Recommendations is sparse for less popular movies; ``/similar``
-        # is heuristic and almost always populated. The fallback keeps
-        # the carousel from going blank when ML signal is missing.
+        # ``/recommendations`` is sparse for less popular movies;
+        # ``/similar`` is heuristic and almost always populated.
         client = _make_client(
             get_responses=[
+                _build_response(json_data={}),  # /movie/{id} — no collection
                 _build_response(json_data={"results": []}),  # /recommendations
-                _build_response(json_data={"results": [{"id": 99}, {"id": 100}]}),  # /similar
+                _build_response(  # /similar
+                    json_data={"results": [{"id": 99}, {"id": 100}]},
+                ),
             ],
         )
 
@@ -674,9 +690,10 @@ class TestGetMovieRecommendations:
         assert ids == [99, 100]
 
     @pytest.mark.asyncio
-    async def test_returns_empty_when_both_endpoints_empty(self) -> None:
+    async def test_returns_empty_when_all_sources_empty(self) -> None:
         client = _make_client(
             get_responses=[
+                _build_response(json_data={}),  # /movie/{id}
                 _build_response(json_data={"results": []}),  # /recommendations
                 _build_response(json_data={"results": []}),  # /similar
             ],
@@ -690,8 +707,9 @@ class TestGetMovieRecommendations:
     async def test_returns_empty_on_http_error(self) -> None:
         client = _make_client(
             get_responses=[
-                _build_response(status_code=500),  # /recommendations errors
-                _build_response(status_code=500),  # /similar also errors
+                _build_response(status_code=500),  # /movie/{id}
+                _build_response(status_code=500),  # /recommendations
+                _build_response(status_code=500),  # /similar
             ],
         )
 
@@ -703,21 +721,101 @@ class TestGetMovieRecommendations:
     async def test_skips_non_int_ids_in_payload(self) -> None:
         # Defensive: a malformed TMDB row shouldn't crash the parser.
         client = _make_client(
-            get_responses=_build_response(
-                json_data={
-                    "results": [
-                        {"id": 1},
-                        {"id": "not-an-int"},
-                        {"name": "no id here"},
-                        {"id": 2},
-                    ]
-                },
-            ),
+            get_responses=[
+                _build_response(json_data={}),  # /movie/{id}
+                _build_response(  # /recommendations
+                    json_data={
+                        "results": [
+                            {"id": 1},
+                            {"id": "not-an-int"},
+                            {"name": "no id here"},
+                            {"id": 2},
+                        ]
+                    },
+                ),
+            ],
         )
 
         ids = await client.get_movie_recommendations(155)
 
         assert ids == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_includes_collection_siblings_first(self) -> None:
+        # Creepshow-style: TMDB's ML rarely surfaces sequels for
+        # older titles, but the franchise's collection always lists
+        # them. Collection ids come first in the merged result and
+        # the input movie itself is skipped.
+        client = _make_client(
+            get_responses=[
+                _build_response(  # /movie/12552
+                    json_data={
+                        "belongs_to_collection": {
+                            "id": 91349,
+                            "name": "Creepshow Collection",
+                        },
+                    },
+                ),
+                _build_response(  # /collection/91349
+                    json_data={
+                        "parts": [
+                            {"id": 12552},  # input movie itself, skipped
+                            {"id": 12551},  # Creepshow 2
+                            {"id": 50122},  # Creepshow 3
+                        ],
+                    },
+                ),
+                _build_response(  # /recommendations
+                    json_data={"results": [{"id": 999}]},
+                ),
+            ],
+        )
+
+        ids = await client.get_movie_recommendations(12552)
+
+        assert ids == [12551, 50122, 999]
+
+    @pytest.mark.asyncio
+    async def test_dedupes_overlap_between_collection_and_recommendations(self) -> None:
+        # Same id appearing in both sources renders once at the
+        # collection's position (highest relevance).
+        client = _make_client(
+            get_responses=[
+                _build_response(  # /movie/{id}
+                    json_data={"belongs_to_collection": {"id": 1}},
+                ),
+                _build_response(  # /collection/1
+                    json_data={"parts": [{"id": 100}, {"id": 200}]},
+                ),
+                _build_response(  # /recommendations
+                    json_data={"results": [{"id": 200}, {"id": 300}]},
+                ),
+            ],
+        )
+
+        ids = await client.get_movie_recommendations(50)
+
+        assert ids == [100, 200, 300]
+
+    @pytest.mark.asyncio
+    async def test_collection_lookup_failure_falls_through_to_recommendations(self) -> None:
+        # The collection endpoint flaking shouldn't sink the rest
+        # of the lookup — recommendations still come back.
+        client = _make_client(
+            get_responses=[
+                _build_response(  # /movie/{id}
+                    json_data={"belongs_to_collection": {"id": 1}},
+                ),
+                _build_response(status_code=500),  # /collection/1 fails
+                _build_response(  # /recommendations still works
+                    json_data={"results": [{"id": 999}]},
+                ),
+            ],
+        )
+
+        ids = await client.get_movie_recommendations(50)
+
+        assert ids == [999]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

New ``GET /api/v1/movies/{id}/related`` returns the subset of TMDB's recommendations for a movie that exists in the local catalog, preserving TMDB's relevance ordering. Powers the "Você também pode gostar" / "You might also like" carousel on the movie detail page (separate frontend PR).

## Changes

### Domain port
- ``MetadataProvider.get_movie_recommendations(tmdb_id) -> list[int]``.

### TmdbClient
- Implementation hits ``/movie/{id}/recommendations`` first.
- Falls back to ``/movie/{id}/similar`` when recommendations is empty (less popular titles often lack ML signal but always have heuristic similarity).
- Network failures and malformed payloads degrade to ``[]`` — best-effort polish.

### Repository
- ``MovieRepository.find_by_tmdb_ids(ids) -> dict[int, Movie]`` — returns a dict keyed by ``tmdb_id`` so the use case can preserve TMDB's relevance order by iterating the request list.

### Use case
- ``GetRelatedMoviesUseCase``: load source → ask provider → intersect with local catalog → emit ``MovieSummaryOutput`` items in TMDB's relevance order, capped at ``limit``.
- Refactored ``ListMoviesUseCase._to_summary`` into a shared ``_movie_summary_helpers.to_movie_summary`` so both list and related queries emit identical DTO shapes.

### Route
- ``GET /movies/{id}/related?lang=&limit=`` — limit clamped to ``[1, 30]``.

### Tests
- TmdbClient: priority order, ``/similar`` fallback, HTTP error handling, malformed payload.
- Repository: empty input, mapping by ``tmdb_id``, missing ids skipped, soft-deleted excluded, movies without ``tmdb_id`` invisible.
- Use case: source missing / no ``tmdb_id`` / no overlap → empty; relevance order preserved when local catalog is sparse; ``limit`` truncates correctly.

## Out of scope

Series-side equivalent (``/tv/{id}/recommendations``) ships in a separate PR.

## Frontend dependency

Pair PR consumes the new endpoint via ``useRelatedMovies`` and renders ``<MediaCarousel>`` below the cast row.

## Test plan

- [x] ``make lint`` clean
- [x] ``make format`` clean
- [x] Full suite green (1768 tests, +14 new)
- [ ] Re-enrich a popular movie (``Inception``, ``Interstellar``) → ``GET /movies/{id}/related`` returns at least a few items if catalog has overlap
- [ ] Movie without ``tmdb_id`` (manually added) → endpoint returns empty list, no error
- [ ] ``limit=1`` query → response has at most 1 item

## Summary by Sourcery

Add TMDB-backed related-movies support and wire it into the media API and use cases.

New Features:
- Expose a TMDB-based movie recommendations endpoint via GET /movies/{id}/related for powering the "you might also like" UI carousel.
- Introduce GetRelatedMoviesUseCase that fetches TMDB recommendations, filters them to the local catalog, and returns ordered movie summaries.
- Add a metadata provider method and TMDB client support for fetching movie recommendation IDs with a fallback to similar titles.
- Extend the movie repository with a tmdb_id-based lookup used to resolve recommended titles in the local library.

Enhancements:
- Extract shared Movie-to-MovieSummaryOutput mapping into a reusable helper to keep summary DTOs consistent across use cases.

Tests:
- Add unit tests for TMDB client movie recommendations behavior including fallbacks and malformed payload handling.
- Add integration tests for the new tmdb_id-based movie repository lookup, covering empty input, soft deletes, and null IDs.
- Add unit tests for GetRelatedMoviesUseCase covering missing sources, tmdb-less sources, catalog overlap, ordering, and limit handling.