### PR TITLE
feat(catalog): browse movies by cast member

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -30,6 +30,7 @@ from src.modules.media.application.use_cases.get_series_by_id import GetSeriesBy
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
 from src.modules.media.application.use_cases.list_movies import ListMoviesUseCase
+from src.modules.media.application.use_cases.list_movies_by_actor import ListMoviesByActorUseCase
 from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
 from src.modules.media.application.use_cases.scan_media_directories import (
@@ -139,6 +140,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     list_by_genre = providers.Factory(
         ListByGenreUseCase,
+        uow_factory=media_unit_of_work_factory,
+    )
+
+    list_movies_by_actor = providers.Factory(
+        ListMoviesByActorUseCase,
         uow_factory=media_unit_of_work_factory,
     )
 

--- a/src/modules/media/application/use_cases/list_movies_by_actor.py
+++ b/src/modules/media/application/use_cases/list_movies_by_actor.py
@@ -1,0 +1,96 @@
+"""ListMoviesByActorUseCase - paginated listing of movies for one actor."""
+
+from dataclasses import dataclass
+
+from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
+from src.modules.media.application.dtos.movie_dtos import MovieSummaryOutput
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases._movie_summary_helpers import to_movie_summary
+
+
+@dataclass(frozen=True)
+class ListMoviesByActorInput:
+    """Input for ``ListMoviesByActorUseCase``.
+
+    Attributes:
+        actor_name: Exact display name of the cast member. Match is
+            by literal equality against the stored ``cast[].name``
+            values; collisions between two real people who share a
+            name aren't disambiguated (no TMDB person id is persisted
+            yet — see CLAUDE.md roadmap).
+        cursor: Opaque title cursor from the previous page, or
+            ``None`` for the first page.
+        limit: Page size. Routes clamp this to ``[1, MAX_PAGE_SIZE]``
+            before constructing the input.
+        lang: Language code for localized titles / synopses / genres
+            on the returned summaries.
+    """
+
+    actor_name: str
+    cursor: str | None = None
+    limit: int = DEFAULT_PAGE_SIZE
+    lang: str = "en"
+
+
+@dataclass(frozen=True)
+class ListMoviesByActorOutput:
+    """Output for ``ListMoviesByActorUseCase``.
+
+    Attributes:
+        movies: Movies that have ``actor_name`` in their cast,
+            sorted alphabetically by title.
+        next_cursor: Opaque token to pass back as ``cursor`` on the
+            next request, or ``None`` when there are no more pages.
+        has_more: Convenience flag — equivalent to
+            ``next_cursor is not None`` but explicit so clients don't
+            have to infer it.
+    """
+
+    movies: list[MovieSummaryOutput]
+    next_cursor: str | None
+    has_more: bool
+
+
+class ListMoviesByActorUseCase:
+    """List movies whose cast contains the given actor, paginated.
+
+    Single-stream listing — series cast isn't part of the domain yet
+    (deferred to a follow-up that extends ``Series`` with cast), so
+    only the movies repo is queried. When series cast lands, this
+    use case can be promoted to a dual-stream merge mirroring
+    ``ListByGenreUseCase`` without breaking the API contract.
+    """
+
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(self, input_dto: ListMoviesByActorInput) -> ListMoviesByActorOutput:
+        """Execute the use case.
+
+        Args:
+            input_dto: ``actor_name`` (exact display name), ``cursor``,
+                ``limit``, ``lang``.
+
+        Returns:
+            ``ListMoviesByActorOutput`` carrying the page of summaries
+            plus the next cursor.
+        """
+        async with self._uow_factory() as uow:
+            page = await uow.movies.list_paginated_by_cast_member(
+                actor_name=input_dto.actor_name,
+                cursor=input_dto.cursor,
+                limit=input_dto.limit,
+            )
+
+        return ListMoviesByActorOutput(
+            movies=[to_movie_summary(movie, input_dto.lang) for movie in page.items],
+            next_cursor=page.pagination.next_cursor,
+            has_more=page.pagination.has_more,
+        )
+
+
+__all__ = [
+    "ListMoviesByActorInput",
+    "ListMoviesByActorOutput",
+    "ListMoviesByActorUseCase",
+]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -177,6 +177,42 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def list_paginated_by_cast_member(
+        self,
+        actor_name: str,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResult[Movie]:
+        """List movies whose cast includes a member named ``actor_name``.
+
+        Sorted by ``(LOWER(title) ASC, id ASC)`` so the actor-page
+        carousel renders alphabetically. The cursor is a
+        ``(title, id)`` composite (see ``encode_title_cursor``) — same
+        contract as ``list_paginated_by_genre``.
+
+        Match is by exact name. The local catalog has no actor id
+        (TMDB person ids aren't persisted yet, see CLAUDE.md
+        roadmap), so two real people who share the same display name
+        would collide. Acceptable trade-off for a personal-library
+        scale catalog; can be tightened to a tmdb_person_id match
+        without breaking the API surface (the route still receives a
+        name and resolves to id internally).
+
+        Args:
+            actor_name: Exact display name of the cast member.
+            cursor: Opaque title cursor from the previous page, or
+                ``None`` for the first page. Invalid cursors silently
+                fall back to the first page.
+            limit: Page size. Implementations fetch ``limit + 1`` rows
+                to detect ``has_more`` cheaply.
+
+        Returns:
+            ``PaginatedResult`` with the page items and pagination
+            metadata. ``total_count`` is always ``None`` here.
+        """
+        ...
+
+    @abstractmethod
     async def search(
         self,
         query: str,

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -1,8 +1,9 @@
 """SQLAlchemy implementation of MovieRepository."""
 
+import json
 from collections.abc import Sequence
 
-from sqlalchemy import func, or_, select, text
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -10,7 +11,9 @@ from src.building_blocks.application.pagination import (
     PaginatedResult,
     Pagination,
     decode_cursor,
+    decode_title_cursor,
     encode_cursor,
+    encode_title_cursor,
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
@@ -233,6 +236,84 @@ class SQLAlchemyMovieRepository(MovieRepository):
             genre=genre,
             cursor=cursor,
             limit=limit,
+        )
+
+    async def list_paginated_by_cast_member(
+        self,
+        actor_name: str,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResult[Movie]:
+        """List movies whose ``cast`` JSON contains an entry for ``actor_name``.
+
+        Filters with a SQL LIKE against the JSON-serialized ``cast``
+        text column. ``_serialize_cast`` writes entries with ``json.dumps``
+        and default separators, so ``"name": "<name>"`` (with a space
+        after the colon) appears verbatim in storage — the needle
+        builder mirrors that format. Matching by JSON-encoded form
+        rather than by raw substring keeps a name from false-positive
+        matching against a ``role`` or ``profile_path`` field that
+        happened to contain the same text.
+
+        Pagination matches ``list_paginated_by_genre`` (title cursor,
+        ``LOWER(title), id`` order, fetch ``limit + 1`` for ``has_more``)
+        so the actor page can reuse the same cursor-handling
+        conventions as the genre page.
+        """
+        decoded = decode_title_cursor(cursor)
+
+        # JSON-encode the actor name so special characters (``"``, ``\``,
+        # accented letters under ``ensure_ascii=False``) match the form
+        # the row was serialized with. Outer quotes are preserved so
+        # the needle below matches whole-string equality, not a prefix.
+        name_json = json.dumps(actor_name, ensure_ascii=False)
+        needle = f'"name": {name_json}'
+        # Escape SQL LIKE wildcards (``%`` and ``_``) plus the escape
+        # char itself so an actor whose name contains those characters
+        # doesn't widen the match. A trailing-only ``%`` would let
+        # ``"Jane Doe"`` match ``"Jane Doe Jr."`` since both names
+        # share the same prefix; the ``%...%`` wrap below already
+        # prevents that because the needle includes the closing quote
+        # of ``name_json``.
+        needle_escaped = needle.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+        title_lower = func.lower(MovieModel.title)
+
+        stmt = (
+            select(MovieModel)
+            .where(
+                MovieModel.deleted_at.is_(None),
+                MovieModel.cast.is_not(None),
+                MovieModel.cast.like(f"%{needle_escaped}%", escape="\\"),
+            )
+            .options(selectinload(MovieModel.file_variants))
+        )
+
+        if decoded is not None:
+            stmt = stmt.where(
+                or_(
+                    title_lower > decoded.title,
+                    and_(title_lower == decoded.title, MovieModel.id > decoded.id),
+                )
+            )
+
+        stmt = stmt.order_by(title_lower.asc(), MovieModel.id.asc()).limit(limit + 1)
+
+        result = await self._session.execute(stmt)
+        rows = list(result.scalars().all())
+
+        has_more = len(rows) > limit
+        if has_more:
+            rows = rows[:limit]
+
+        next_cursor: str | None = None
+        if has_more and rows:
+            next_cursor = encode_title_cursor(rows[-1].title, rows[-1].id)
+
+        return PaginatedResult(
+            items=[MovieMapper.to_entity(m) for m in rows],
+            pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+            total_count=None,
         )
 
     async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:

--- a/src/modules/media/presentation/routes/catalog_routes.py
+++ b/src/modules/media/presentation/routes/catalog_routes.py
@@ -16,6 +16,10 @@ from src.modules.media.application.dtos.catalog_dtos import (
 )
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
+from src.modules.media.application.use_cases.list_movies_by_actor import (
+    ListMoviesByActorInput,
+    ListMoviesByActorUseCase,
+)
 
 router = APIRouter(prefix="/api/v1/catalog", tags=["Catalog"])
 
@@ -106,6 +110,58 @@ async def list_by_genre(
     )
     return api_list(
         [asdict(item) for item in result.items],
+        pagination=Pagination(has_more=result.has_more, next_cursor=result.next_cursor),
+    )
+
+
+@router.get("/by-actor")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_by_actor(
+    name: str,
+    cursor: str | None = None,
+    limit: int = DEFAULT_PAGE_SIZE,
+    lang: str = "en",
+    use_case: ListMoviesByActorUseCase = Depends(
+        Provide[ApplicationContainer.media.list_movies_by_actor],
+    ),
+) -> dict[str, Any]:
+    """Paginated listing of movies whose cast contains ``name``.
+
+    Match is by exact display name. The local catalog has no actor
+    id (TMDB person ids aren't persisted yet), so the route takes a
+    name in the query string and resolves it server-side. Two real
+    people who share a display name would collide — acceptable for a
+    personal-library scale catalog and reversible without breaking
+    the URL once a TMDB person id is persisted.
+
+    Series cast isn't part of the domain yet, so this route is
+    movies-only. When series cast lands, the use case can be
+    promoted to a dual-stream merge (mirroring ``ListByGenreUseCase``)
+    and the response shape will gain a ``type`` discriminator
+    without changing the URL.
+
+    Query params:
+        name: Exact display name of the cast member (e.g.,
+            ``Sigourney Weaver``). Required.
+        cursor: Opaque token returned by the previous page's
+            ``metadata.pagination.next_cursor``. Omit on the first
+            request. Invalid / tampered cursors silently start over
+            from the beginning.
+        limit: Page size, clamped to ``[1, MAX_PAGE_SIZE]``.
+        lang: Language code for localized titles, synopses, and
+            genre names returned in each item.
+    """
+    clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
+    result = await use_case.execute(
+        ListMoviesByActorInput(
+            actor_name=name,
+            cursor=cursor,
+            limit=clamped_limit,
+            lang=lang,
+        )
+    )
+    return api_list(
+        [asdict(movie) for movie in result.movies],
         pagination=Pagination(has_more=result.has_more, next_cursor=result.next_cursor),
     )
 

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -17,6 +17,7 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.modules.media.domain.value_objects.cast_member import CastMember
 from src.modules.media.infrastructure.persistence.repositories import SQLAlchemyMovieRepository
 
 
@@ -736,6 +737,153 @@ class TestSQLAlchemyMovieRepositoryListPaginatedByGenre:
 
         assert len(page.items) == 1
         assert page.items[0].title.value == "B"
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryListPaginatedByCastMember:
+    """Integration tests for the title-sorted, cast-filtered listing."""
+
+    async def test_should_filter_to_movies_with_the_actor(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        weaver = [CastMember(name="Sigourney Weaver")]
+        other = [CastMember(name="Tom Hanks")]
+        await repo.save(
+            _create_movie(title="Alien", file_path="/m/alien.mkv").with_updates(cast=weaver)
+        )
+        await repo.save(
+            _create_movie(title="Forrest Gump", file_path="/m/fg.mkv").with_updates(cast=other)
+        )
+
+        page = await repo.list_paginated_by_cast_member(
+            actor_name="Sigourney Weaver", cursor=None, limit=10
+        )
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "Alien"
+
+    async def test_should_match_by_exact_name_not_substring(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # "Tom Hanks" must NOT match "Tom Hanks Jr." — the closing
+        # quote of the JSON-encoded needle prevents prefix matches.
+        await repo.save(
+            _create_movie(title="Other", file_path="/m/o.mkv").with_updates(
+                cast=[CastMember(name="Tom Hanks Jr.")]
+            )
+        )
+        await repo.save(
+            _create_movie(title="Forrest Gump", file_path="/m/fg.mkv").with_updates(
+                cast=[CastMember(name="Tom Hanks")]
+            )
+        )
+
+        page = await repo.list_paginated_by_cast_member(
+            actor_name="Tom Hanks", cursor=None, limit=10
+        )
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "Forrest Gump"
+
+    async def test_should_handle_special_characters_in_name(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # Apostrophe + accents must round-trip through JSON encoding
+        # and the LIKE filter correctly.
+        await repo.save(
+            _create_movie(title="Hidden Figures", file_path="/m/hf.mkv").with_updates(
+                cast=[CastMember(name="Taraji P. Henson")]
+            )
+        )
+        await repo.save(
+            _create_movie(title="Cast Away", file_path="/m/ca.mkv").with_updates(
+                cast=[CastMember(name="Wilson O'Brien")]
+            )
+        )
+
+        page = await repo.list_paginated_by_cast_member(
+            actor_name="Wilson O'Brien", cursor=None, limit=10
+        )
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "Cast Away"
+
+    async def test_should_sort_alphabetically_case_insensitive(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        weaver = [CastMember(name="Sigourney Weaver")]
+        for title in ["zebra", "Apple", "mango", "Banana"]:
+            await repo.save(
+                _create_movie(title=title, file_path=f"/m/{title.lower()}.mkv").with_updates(
+                    cast=weaver
+                )
+            )
+
+        page = await repo.list_paginated_by_cast_member(
+            actor_name="Sigourney Weaver", cursor=None, limit=10
+        )
+
+        titles = [m.title.value for m in page.items]
+        assert titles == ["Apple", "Banana", "mango", "zebra"]
+
+    async def test_should_walk_pages_via_cursor(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        weaver = [CastMember(name="Sigourney Weaver")]
+        for title in ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"]:
+            await repo.save(
+                _create_movie(title=title, file_path=f"/m/{title}.mkv").with_updates(cast=weaver)
+            )
+
+        page1 = await repo.list_paginated_by_cast_member(
+            actor_name="Sigourney Weaver", cursor=None, limit=2
+        )
+        page2 = await repo.list_paginated_by_cast_member(
+            actor_name="Sigourney Weaver",
+            cursor=page1.pagination.next_cursor,
+            limit=2,
+        )
+        page3 = await repo.list_paginated_by_cast_member(
+            actor_name="Sigourney Weaver",
+            cursor=page2.pagination.next_cursor,
+            limit=2,
+        )
+
+        all_titles = (
+            [m.title.value for m in page1.items]
+            + [m.title.value for m in page2.items]
+            + [m.title.value for m in page3.items]
+        )
+        assert all_titles == ["Alpha", "Beta", "Delta", "Epsilon", "Gamma"]
+        assert page3.pagination.has_more is False
+
+    async def test_should_exclude_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        weaver = [CastMember(name="Sigourney Weaver")]
+        m1 = _create_movie(title="A", file_path="/m/a.mkv").with_updates(cast=weaver)
+        m2 = _create_movie(title="B", file_path="/m/b.mkv").with_updates(cast=weaver)
+        await repo.save(m1)
+        await repo.save(m2)
+        await repo.delete(_id_of(m1))
+
+        page = await repo.list_paginated_by_cast_member(
+            actor_name="Sigourney Weaver", cursor=None, limit=10
+        )
+
+        assert len(page.items) == 1
+        assert page.items[0].title.value == "B"
+
+    async def test_should_return_empty_when_no_match(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(
+            _create_movie(title="A", file_path="/m/a.mkv").with_updates(
+                cast=[CastMember(name="Someone Else")]
+            )
+        )
+
+        page = await repo.list_paginated_by_cast_member(
+            actor_name="Nobody Famous", cursor=None, limit=10
+        )
+
+        assert page.items == []
+        assert page.pagination.has_more is False
 
 
 @pytest.mark.integration

--- a/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
@@ -1,0 +1,117 @@
+"""Tests for ListMoviesByActorUseCase."""
+
+import pytest
+
+from src.building_blocks.application.pagination import PaginatedResult, Pagination
+from src.modules.media.application.use_cases.list_movies_by_actor import (
+    ListMoviesByActorInput,
+    ListMoviesByActorOutput,
+    ListMoviesByActorUseCase,
+)
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects.cast_member import CastMember
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+
+def _make_movie(
+    title: str = "Test Movie",
+    year: int = 2020,
+    cast: list[CastMember] | None = None,
+) -> Movie:
+    movie = Movie.create(
+        title=title,
+        year=year,
+        duration=7200,
+        file_path=f"/movies/{title.lower().replace(' ', '_')}.mkv",
+        file_size=1_000_000_000,
+        resolution="1080p",
+    )
+    if cast is not None:
+        movie = movie.with_updates(cast=cast)
+    return movie
+
+
+def _page(
+    movies: list[Movie],
+    *,
+    next_cursor: str | None = None,
+    has_more: bool = False,
+) -> PaginatedResult[Movie]:
+    return PaginatedResult(
+        items=movies,
+        pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+        total_count=None,
+    )
+
+
+class TestListMoviesByActorUseCase:
+    """Tests for ListMoviesByActorUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_return_movies_for_actor(self) -> None:
+        mocks = make_media_uow_mock()
+        cast = [CastMember(name="Sigourney Weaver")]
+        mocks.movies.list_paginated_by_cast_member.return_value = _page(
+            [
+                _make_movie("Alien", 1979, cast=cast),
+                _make_movie("Aliens", 1986, cast=cast),
+            ]
+        )
+        use_case = ListMoviesByActorUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(ListMoviesByActorInput(actor_name="Sigourney Weaver"))
+
+        assert isinstance(result, ListMoviesByActorOutput)
+        assert [m.title for m in result.movies] == ["Alien", "Aliens"]
+        mocks.movies.list_paginated_by_cast_member.assert_awaited_once_with(
+            actor_name="Sigourney Weaver",
+            cursor=None,
+            limit=20,
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_pass_cursor_and_limit_to_repository(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_cast_member.return_value = _page([])
+        use_case = ListMoviesByActorUseCase(uow_factory=mocks.factory)
+
+        await use_case.execute(
+            ListMoviesByActorInput(
+                actor_name="Sigourney Weaver",
+                cursor="abc123",
+                limit=15,
+            )
+        )
+
+        mocks.movies.list_paginated_by_cast_member.assert_awaited_once_with(
+            actor_name="Sigourney Weaver",
+            cursor="abc123",
+            limit=15,
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_propagate_pagination_metadata(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_cast_member.return_value = _page(
+            [_make_movie("Alien", cast=[CastMember(name="Sigourney Weaver")])],
+            next_cursor="next-token",
+            has_more=True,
+        )
+        use_case = ListMoviesByActorUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(ListMoviesByActorInput(actor_name="Sigourney Weaver"))
+
+        assert result.next_cursor == "next-token"
+        assert result.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_page_when_no_matches(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_cast_member.return_value = _page([])
+        use_case = ListMoviesByActorUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(ListMoviesByActorInput(actor_name="Nobody Famous"))
+
+        assert result.movies == []
+        assert result.has_more is False
+        assert result.next_cursor is None


### PR DESCRIPTION
## Summary
- New endpoint ``GET /api/v1/catalog/by-actor?name=<name>`` paginates movies whose ``cast`` contains a member with the exact given display name.
- Matches the by-genre conventions: title-based cursor, ``LOWER(title)`` ordering, ``limit + 1`` fetch for ``has_more``. Single-stream (movies-only) since series cast isn't on the domain yet — the use case can be promoted to a dual-stream merge mirroring ``ListByGenreUseCase`` once series cast lands, without breaking the URL.
- ``cast`` is stored as JSON-encoded text. The repository builds the LIKE needle from ``json.dumps`` so the format mirrors what ``_serialize_cast`` writes — special characters (apostrophes, accents, embedded quotes) round-trip; SQL LIKE wildcards (``%``, ``_``) are escaped so they don't widen the match.

## Test plan
- [x] ``tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py`` — 4 tests covering the use case wiring (empty page, cursor passthrough, pagination metadata).
- [x] ``tests/modules/media/integration/persistence/repositories/test_movie_repository.py::TestSQLAlchemyMovieRepositoryListPaginatedByCastMember`` — 7 tests covering the SQL LIKE filter (exact-name match vs prefix, special chars, alphabetical sort, multi-page cursor walk, soft-deleted exclusion, empty result).
- [x] Full media test suite ``pytest tests/modules/media/`` — 972 passed.
- [x] ``ruff check`` + ``ruff format --check`` clean.

## Summary by Sourcery

Add support for browsing the movie catalog by cast member with a new paginated actor-based listing flow.

New Features:
- Expose a new GET /api/v1/catalog/by-actor endpoint that returns a paginated list of movies featuring a given cast member, reusing existing cursor and page-size conventions.
- Introduce the ListMoviesByActor use case and DTOs to orchestrate actor-based movie listings via the media unit of work.
- Extend the movie repository abstraction and SQLAlchemy implementation with a list_paginated_by_cast_member method that filters by exact actor name from JSON-encoded cast data.

Enhancements:
- Wire the new ListMoviesByActorUseCase into the media DI container and catalog routes so actor-based listings participate in existing API response and pagination helpers.

Tests:
- Add unit tests for ListMoviesByActorUseCase covering basic listing, cursor/limit passthrough, pagination metadata propagation, and empty pages.
- Add integration tests for SQLAlchemyMovieRepository list_paginated_by_cast_member validating exact-name filtering, handling of special characters, sorting, pagination, soft-delete exclusion, and empty results.