### PR TITLE
feat(media): persist tmdb_id on cast and expose person bio endpoint

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -25,6 +25,7 @@ from src.modules.media.application.use_cases.get_featured_media import GetFeatur
 from src.modules.media.application.use_cases.get_file_tracks import GetFileTracksUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
+from src.modules.media.application.use_cases.get_person_bio import GetPersonBioUseCase
 from src.modules.media.application.use_cases.get_related_movies import GetRelatedMoviesUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
@@ -271,6 +272,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     get_related_movies = providers.Factory(
         GetRelatedMoviesUseCase,
         uow_factory=media_unit_of_work_factory,
+        metadata_provider=tmdb_client,
+    )
+
+    get_person_bio = providers.Factory(
+        GetPersonBioUseCase,
         metadata_provider=tmdb_client,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from src.modules.media.presentation.routes import (
     enrichment_router,
     featured_router,
     movie_router,
+    people_router,
     scan_router,
     search_router,
     series_router,
@@ -75,6 +76,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "src.modules.media.presentation.routes.enrichment_routes",
             "src.modules.media.presentation.routes.featured_routes",
             "src.modules.media.presentation.routes.movie_routes",
+            "src.modules.media.presentation.routes.people_routes",
             "src.modules.media.presentation.routes.scan_routes",
             "src.modules.media.presentation.routes.series_routes",
             "src.modules.media.presentation.routes.stream_routes",
@@ -184,6 +186,7 @@ def create_app() -> FastAPI:
     app.include_router(enrichment_router)
     app.include_router(featured_router)
     app.include_router(movie_router)
+    app.include_router(people_router)
     app.include_router(scan_router)
     app.include_router(series_router)
     app.include_router(stream_router)

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -40,7 +40,8 @@ class CastMemberOutput:
     """Cast entry exposed on the API.
 
     Mirrors the domain ``CastMember`` shape so the detail UI can
-    render an avatar (``profile_path``) + name + role per actor.
+    render an avatar (``profile_path``) + name + role per actor and
+    deep-link to the actor's bio page via ``tmdb_id``.
 
     Attributes:
         name: Actor's display name.
@@ -48,11 +49,16 @@ class CastMemberOutput:
             when TMDB has no photo for this person — the UI falls
             back to an initials avatar.
         role: Character name played, or ``None`` when not provided.
+        tmdb_id: TMDB person id, or ``None`` for rows enriched before
+            the id was captured. The actor page uses this to fetch
+            biography and birth date from ``/people/{id}``; absence
+            degrades to a name-only header.
     """
 
     name: str
     profile_path: str | None
     role: str | None
+    tmdb_id: int | None
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -17,6 +17,7 @@ from src.modules.media.application.ports.metadata_provider_port import (
     LocalizedFields,
     MediaMetadata,
     MetadataProvider,
+    PersonMetadata,
     SeasonMetadata,
 )
 from src.modules.media.application.ports.progress_lookup_port import (
@@ -38,6 +39,7 @@ __all__ = [
     "MediaProbePort",
     "MediaType",
     "MetadataProvider",
+    "PersonMetadata",
     "ProbeResult",
     "ProgressLookupPort",
     "ProgressSummary",

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -218,7 +218,11 @@ class MetadataProvider(ABC):
         ...
 
     @abstractmethod
-    async def get_person(self, tmdb_id: int) -> PersonMetadata | None:
+    async def get_person(
+        self,
+        tmdb_id: int,
+        language: str = "en-US",
+    ) -> PersonMetadata | None:
         """Fetch biographical metadata for a person by id.
 
         Used by the actor page to render bio + birth date + known
@@ -229,6 +233,12 @@ class MetadataProvider(ABC):
 
         Args:
             tmdb_id: TMDB person id captured during movie enrichment.
+            language: BCP-47 tag (e.g. ``"pt-BR"``, ``"en-US"``) for
+                the localized bio. TMDB's coverage of non-English
+                bios is uneven — implementations should fall back to
+                English when the requested language returns an empty
+                biography so the actor page never shows a blank
+                section just because the translation is missing.
 
         Returns:
             ``PersonMetadata`` for the person, or ``None`` when the

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -65,6 +65,41 @@ class CreditPerson:
 
 
 @dataclass(frozen=True)
+class PersonMetadata:
+    """Biographical metadata for a single person fetched by id.
+
+    Returned by ``MetadataProvider.get_person`` and surfaced by the
+    actor page. Fields are deliberately a strict subset of TMDB's
+    ``/person/{id}`` payload — only the ones the UI renders today —
+    so adding fields later is additive at every layer.
+
+    Attributes:
+        tmdb_id: TMDB person ID.
+        name: Display name.
+        biography: Long-form biography text. Empty string when TMDB
+            has no bio for this person; the UI hides the section then.
+        birthday: ISO date (``YYYY-MM-DD``) or ``None`` when unknown /
+            withheld.
+        deathday: ISO date or ``None`` when alive / unknown.
+        place_of_birth: Free-form string (e.g. ``"Los Angeles, California, USA"``)
+            or ``None``.
+        known_for_department: Primary department on TMDB
+            (``"Acting"``, ``"Directing"``, etc.). ``None`` when not
+            categorized.
+        profile_path: Full URL to the profile image, or ``None``.
+    """
+
+    tmdb_id: int
+    name: str
+    biography: str = ""
+    birthday: str | None = None
+    deathday: str | None = None
+    place_of_birth: str | None = None
+    known_for_department: str | None = None
+    profile_path: str | None = None
+
+
+@dataclass(frozen=True)
 class LocalizedFields:
     """Localized metadata fields for a specific language.
 
@@ -183,6 +218,25 @@ class MetadataProvider(ABC):
         ...
 
     @abstractmethod
+    async def get_person(self, tmdb_id: int) -> PersonMetadata | None:
+        """Fetch biographical metadata for a person by id.
+
+        Used by the actor page to render bio + birth date + known
+        department alongside the catalog filmography. Returns ``None``
+        when the provider has nothing for ``tmdb_id`` (deleted person,
+        404, network error) — the actor page degrades gracefully and
+        falls back to a name-only header.
+
+        Args:
+            tmdb_id: TMDB person id captured during movie enrichment.
+
+        Returns:
+            ``PersonMetadata`` for the person, or ``None`` when the
+            provider has no record / the call failed.
+        """
+        ...
+
+    @abstractmethod
     async def get_movie_recommendations(self, tmdb_id: int) -> list[int]:
         """Return TMDB ids of movies recommended for ``tmdb_id``.
 
@@ -202,6 +256,7 @@ class MetadataProvider(ABC):
 __all__ = [
     "CreditPerson",
     "EpisodeMetadata",
+    "PersonMetadata",
     "MediaMetadata",
     "MetadataProvider",
     "SeasonMetadata",

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -199,7 +199,13 @@ def _apply_credits(
     """Apply cast/director/writer credits from metadata if not already present."""
     if metadata.cast and not movie.cast:
         updates["cast"] = [
-            CastMember(name=p.name, profile_path=p.profile_url, role=p.role) for p in metadata.cast
+            CastMember(
+                name=p.name,
+                profile_path=p.profile_url,
+                role=p.role,
+                tmdb_id=p.tmdb_id,
+            )
+            for p in metadata.cast
         ]
     if metadata.directors and not movie.directors:
         updates["directors"] = [p.name for p in metadata.directors]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -80,7 +80,7 @@ class EnrichMovieMetadataUseCase:
                 if localized_meta is not None:
                     metadata = localized_meta
 
-            movie = _apply_movie_metadata(movie, metadata)
+            movie = _apply_movie_metadata(movie, metadata, force=input_dto.force)
             await uow.movies.save(movie)
 
         return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)
@@ -156,13 +156,26 @@ def _clean_title(title: str) -> str:
     return result
 
 
-def _apply_movie_metadata(movie: Movie, metadata: MediaMetadata) -> Movie:
-    """Apply metadata fields to a movie entity."""
+def _apply_movie_metadata(
+    movie: Movie,
+    metadata: MediaMetadata,
+    *,
+    force: bool = False,
+) -> Movie:
+    """Apply metadata fields to a movie entity.
+
+    Each field has a "fill if empty" guard by default so re-enrichment
+    doesn't clobber user customizations (a synopsis the user edited,
+    a poster they picked manually, etc.). When ``force=True`` every
+    guard is bypassed and TMDB's payload wins — used by the bulk
+    enrich's "force update" toggle to backfill new fields (like the
+    cast member ``tmdb_id``) on rows that were already enriched.
+    """
     updates: dict[str, object] = {}
 
     if metadata.title:
         updates["title"] = Title(metadata.title)
-    if metadata.synopsis and not movie.synopsis:
+    if metadata.synopsis and (force or not movie.synopsis):
         updates["synopsis"] = metadata.synopsis
     if metadata.tmdb_id:
         updates["tmdb_id"] = TmdbId(metadata.tmdb_id)
@@ -170,20 +183,20 @@ def _apply_movie_metadata(movie: Movie, metadata: MediaMetadata) -> Movie:
         updates["imdb_id"] = ImdbId(metadata.imdb_id)
     if metadata.original_title:
         updates["original_title"] = Title(metadata.original_title)
-    if metadata.duration_seconds and movie.duration.value == 0:
+    if metadata.duration_seconds and (force or movie.duration.value == 0):
         updates["duration"] = Duration(metadata.duration_seconds)
     if metadata.year:
         updates["year"] = Year(metadata.year)
-    if metadata.genres and not movie.genres:
+    if metadata.genres and (force or not movie.genres):
         updates["genres"] = [Genre(g) for g in metadata.genres]
-    if metadata.poster_url and not movie.poster_path:
+    if metadata.poster_url and (force or not movie.poster_path):
         updates["poster_path"] = ImageUrl(metadata.poster_url)
-    if metadata.backdrop_url and not movie.backdrop_path:
+    if metadata.backdrop_url and (force or not movie.backdrop_path):
         updates["backdrop_path"] = ImageUrl(metadata.backdrop_url)
-    if metadata.logo_url and not movie.logo_path:
+    if metadata.logo_url and (force or not movie.logo_path):
         updates["logo_path"] = ImageUrl(metadata.logo_url)
 
-    _apply_credits(updates, movie, metadata)
+    _apply_credits(updates, movie, metadata, force=force)
 
     if updates:
         movie = movie.with_updates(**updates)
@@ -195,9 +208,17 @@ def _apply_credits(
     updates: dict[str, object],
     movie: Movie,
     metadata: MediaMetadata,
+    *,
+    force: bool = False,
 ) -> None:
-    """Apply cast/director/writer credits from metadata if not already present."""
-    if metadata.cast and not movie.cast:
+    """Apply cast/director/writer credits.
+
+    Each field defaults to a "fill if empty" guard; ``force=True``
+    bypasses the guard so a refresh repopulates credits from TMDB.
+    The motivating use case is backfilling ``tmdb_id`` on cast
+    members that were already saved before the id was captured.
+    """
+    if metadata.cast and (force or not movie.cast):
         updates["cast"] = [
             CastMember(
                 name=p.name,
@@ -207,13 +228,13 @@ def _apply_credits(
             )
             for p in metadata.cast
         ]
-    if metadata.directors and not movie.directors:
+    if metadata.directors and (force or not movie.directors):
         updates["directors"] = [p.name for p in metadata.directors]
-    if metadata.writers and not movie.writers:
+    if metadata.writers and (force or not movie.writers):
         updates["writers"] = [p.name for p in metadata.writers]
-    if metadata.content_rating and not movie.content_rating:
+    if metadata.content_rating and (force or not movie.content_rating):
         updates["content_rating"] = ContentRating(metadata.content_rating)
-    if metadata.trailer_url and not movie.trailer_url:
+    if metadata.trailer_url and (force or not movie.trailer_url):
         updates["trailer_url"] = metadata.trailer_url
     _apply_localized(updates, movie.localized, metadata)
 

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -82,7 +82,12 @@ class GetMovieByIdUseCase:
             scrub_preview_path=movie.scrub_preview_path.value if movie.scrub_preview_path else None,
             genres=movie.get_genres(lang),
             cast=[
-                CastMemberOutput(name=m.name, profile_path=m.profile_path, role=m.role)
+                CastMemberOutput(
+                    name=m.name,
+                    profile_path=m.profile_path,
+                    role=m.role,
+                    tmdb_id=m.tmdb_id,
+                )
                 for m in movie.cast
             ],
             directors=movie.directors,

--- a/src/modules/media/application/use_cases/get_person_bio.py
+++ b/src/modules/media/application/use_cases/get_person_bio.py
@@ -13,9 +13,15 @@ class GetPersonBioInput:
         tmdb_id: TMDB person id captured during movie enrichment.
             Provided by the frontend from ``CastMember.tmdb_id``;
             invalid / unknown ids return ``None`` from the use case.
+        lang: BCP-47 language tag (e.g. ``"pt-BR"``, ``"en-US"``)
+            forwarded to the metadata provider for localized
+            biography. The provider falls back to English when the
+            requested language has no bio text — see
+            ``MetadataProvider.get_person``.
     """
 
     tmdb_id: int
+    lang: str = "en-US"
 
 
 @dataclass(frozen=True)
@@ -72,7 +78,10 @@ class GetPersonBioUseCase:
             ``None`` when the provider has no record (404, network
             error, etc.) — caller renders a graceful fallback.
         """
-        metadata = await self._metadata_provider.get_person(input_dto.tmdb_id)
+        metadata = await self._metadata_provider.get_person(
+            input_dto.tmdb_id,
+            language=input_dto.lang,
+        )
         if metadata is None:
             return None
         return PersonBioOutput(

--- a/src/modules/media/application/use_cases/get_person_bio.py
+++ b/src/modules/media/application/use_cases/get_person_bio.py
@@ -1,0 +1,90 @@
+"""GetPersonBioUseCase - fetch biographical metadata for a TMDB person."""
+
+from dataclasses import dataclass
+
+from src.modules.media.application.ports import MetadataProvider
+
+
+@dataclass(frozen=True)
+class GetPersonBioInput:
+    """Input for ``GetPersonBioUseCase``.
+
+    Attributes:
+        tmdb_id: TMDB person id captured during movie enrichment.
+            Provided by the frontend from ``CastMember.tmdb_id``;
+            invalid / unknown ids return ``None`` from the use case.
+    """
+
+    tmdb_id: int
+
+
+@dataclass(frozen=True)
+class PersonBioOutput:
+    """API-shaped representation of a TMDB person's biographical metadata.
+
+    Strict subset of the ``PersonMetadata`` port DTO — only the
+    fields the actor page renders today. Adding a field is additive
+    everywhere (port → use case → API → frontend type).
+
+    Attributes:
+        tmdb_id: TMDB person id (echoed back so the frontend can
+            cache by id).
+        name: Display name.
+        biography: Long-form bio (may be empty when TMDB has none).
+        birthday: ISO date or ``None``.
+        deathday: ISO date or ``None``.
+        place_of_birth: Free-form string or ``None``.
+        known_for_department: Primary department on TMDB (e.g.
+            ``"Acting"``), or ``None``.
+        profile_path: Full URL to profile photo, or ``None``.
+    """
+
+    tmdb_id: int
+    name: str
+    biography: str
+    birthday: str | None
+    deathday: str | None
+    place_of_birth: str | None
+    known_for_department: str | None
+    profile_path: str | None
+
+
+class GetPersonBioUseCase:
+    """Fetch biographical metadata for a person by TMDB id.
+
+    Thin adapter over ``MetadataProvider.get_person``. The actor
+    page calls this on mount with the ``tmdb_id`` forwarded by the
+    cast card; absent / unknown ids degrade to ``None`` and the page
+    keeps a name-only header.
+    """
+
+    def __init__(self, metadata_provider: MetadataProvider) -> None:
+        self._metadata_provider = metadata_provider
+
+    async def execute(self, input_dto: GetPersonBioInput) -> PersonBioOutput | None:
+        """Execute the use case.
+
+        Args:
+            input_dto: ``tmdb_id`` of the person to fetch.
+
+        Returns:
+            ``PersonBioOutput`` when the provider returns metadata,
+            ``None`` when the provider has no record (404, network
+            error, etc.) — caller renders a graceful fallback.
+        """
+        metadata = await self._metadata_provider.get_person(input_dto.tmdb_id)
+        if metadata is None:
+            return None
+        return PersonBioOutput(
+            tmdb_id=metadata.tmdb_id,
+            name=metadata.name,
+            biography=metadata.biography,
+            birthday=metadata.birthday,
+            deathday=metadata.deathday,
+            place_of_birth=metadata.place_of_birth,
+            known_for_department=metadata.known_for_department,
+            profile_path=metadata.profile_path,
+        )
+
+
+__all__ = ["GetPersonBioInput", "GetPersonBioUseCase", "PersonBioOutput"]

--- a/src/modules/media/domain/value_objects/cast_member.py
+++ b/src/modules/media/domain/value_objects/cast_member.py
@@ -7,9 +7,11 @@ class CastMember(CompoundValueObject):
     """A cast entry for a Movie.
 
     Holds the actor's name, the URL of their TMDB profile photo (when
-    available), and the character they played. Replaces the previous
-    plain-string cast list so the detail-page UI can render avatars
-    and roles instead of just names.
+    available), the character they played, and the TMDB person id
+    (when the row was enriched against TMDB). The id unblocks the
+    "browse by actor" page from joining on bio / birth date / known
+    department without ambiguity — name-only matching collides for
+    homonyms.
 
     Attributes:
         name: Actor's display name (always present).
@@ -19,18 +21,24 @@ class CastMember(CompoundValueObject):
         role: Character name played by the actor (e.g. "Cobb",
             "Detective Mills"). ``None`` when the source didn't
             provide one.
+        tmdb_id: TMDB person id. ``None`` for rows enriched before the
+            id was captured — those degrade to a name-only flow on
+            the actor page (no bio / birth date) and pick up the id
+            on the next re-enrichment.
 
     Example:
         >>> CastMember(
         ...     name="Leonardo DiCaprio",
         ...     profile_path="https://image.tmdb.org/t/p/original/abc.jpg",
         ...     role="Cobb",
+        ...     tmdb_id=6193,
         ... )
     """
 
     name: str
     profile_path: str | None = None
     role: str | None = None
+    tmdb_id: int | None = None
 
 
 __all__ = ["CastMember"]

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -8,6 +8,7 @@ from src.modules.media.application.ports import (
     LocalizedFields,
     MediaMetadata,
     MetadataProvider,
+    PersonMetadata,
     SeasonMetadata,
 )
 from src.modules.media.domain.value_objects import ContentRating
@@ -276,6 +277,52 @@ class TmdbClient(MetadataProvider):
             if isinstance(raw, int):
                 ids.append(raw)
         return ids
+
+    async def get_person(self, tmdb_id: int) -> PersonMetadata | None:
+        """Fetch biographical metadata for a person from TMDB.
+
+        Hits ``/person/{id}`` (default English locale — TMDB person
+        bios are typically only authored in English so a localized
+        request would just return the same payload). Network failures
+        and unexpected payloads degrade to ``None`` so the actor page
+        falls back to a name-only header instead of erroring out.
+        """
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/person/{tmdb_id}",
+                params=self._params(),
+            )
+        except httpx.HTTPError:
+            return None
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        if not isinstance(data, dict):
+            return None
+        # ``id`` and ``name`` are required for the UI to render
+        # anything useful; everything else is optional polish.
+        raw_id = data.get("id")
+        if not isinstance(raw_id, int):
+            return None
+        name = str(data.get("name", "")).strip()
+        if not name:
+            return None
+        return PersonMetadata(
+            tmdb_id=raw_id,
+            name=name,
+            biography=str(data.get("biography") or ""),
+            birthday=str(data.get("birthday")) if data.get("birthday") else None,
+            deathday=str(data.get("deathday")) if data.get("deathday") else None,
+            place_of_birth=(
+                str(data.get("place_of_birth")) if data.get("place_of_birth") else None
+            ),
+            known_for_department=(
+                str(data.get("known_for_department")) if data.get("known_for_department") else None
+            ),
+            profile_path=self._image_url(
+                str(data.get("profile_path")) if data.get("profile_path") else None
+            ),
+        )
 
     async def get_series_localized(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch series details in English with pt-BR localization.

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -27,6 +27,15 @@ def _safe_int(value: object, default: int) -> int:
 _TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/original"
 
 
+def _is_english(language: str) -> bool:
+    """Return ``True`` for any English BCP-47 tag (``en``, ``en-US``, ``en-GB``).
+
+    Used by ``get_person`` to decide whether the requested-language
+    fetch already gave us the English bio (no fallback needed).
+    """
+    return language.lower().split("-", 1)[0] == "en"
+
+
 class TmdbClient(MetadataProvider):
     """The Movie Database (TMDB) API client.
 
@@ -278,19 +287,45 @@ class TmdbClient(MetadataProvider):
                 ids.append(raw)
         return ids
 
-    async def get_person(self, tmdb_id: int) -> PersonMetadata | None:
+    async def get_person(
+        self,
+        tmdb_id: int,
+        language: str = "en-US",
+    ) -> PersonMetadata | None:
         """Fetch biographical metadata for a person from TMDB.
 
-        Hits ``/person/{id}`` (default English locale — TMDB person
-        bios are typically only authored in English so a localized
-        request would just return the same payload). Network failures
-        and unexpected payloads degrade to ``None`` so the actor page
-        falls back to a name-only header instead of erroring out.
+        Hits ``/person/{id}?language=<lang>`` and falls back to
+        ``en-US`` for the biography text alone when TMDB returns a
+        blank one in the requested language. The fallback is
+        bio-only because TMDB authors translations field-by-field —
+        a missing Portuguese ``biography`` doesn't mean ``birthday``
+        / ``place_of_birth`` are also missing in pt-BR (they often
+        aren't), so blowing the whole payload away would lose
+        translations the user actually has.
+
+        Network failures and unexpected payloads degrade to ``None``
+        so the actor page falls back to a name-only header instead
+        of erroring out.
         """
+        meta = await self._fetch_person(tmdb_id, language)
+        if meta is None or meta.biography or _is_english(language):
+            return meta
+        # Bio came back empty in a non-English locale — try English
+        # so the panel isn't blank when TMDB only authored the bio
+        # for one language.
+        en_meta = await self._fetch_person(tmdb_id, "en-US")
+        if en_meta is None or not en_meta.biography:
+            return meta
+        from dataclasses import replace
+
+        return replace(meta, biography=en_meta.biography)
+
+    async def _fetch_person(self, tmdb_id: int, language: str) -> PersonMetadata | None:
+        """Single ``/person/{id}`` round-trip in ``language``."""
         try:
             resp = await self._client.get(
                 f"{self._base_url}/person/{tmdb_id}",
-                params=self._params(),
+                params=self._params(language=language),
             )
         except httpx.HTTPError:
             return None

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -27,29 +27,44 @@ from src.modules.media.infrastructure.persistence.models import MediaFileModel, 
 def _serialize_cast(cast: list[CastMember]) -> str | None:
     """Serialize the cast list to the JSON shape stored on disk.
 
-    New shape: ``[{"name": "...", "profile_path": "...", "role": "..."}, ...]``.
-    Always written this way; legacy ``["Name1", "Name2"]`` data is only
-    *read* by ``_deserialize_cast`` and gets converted on the next save.
+    Current shape:
+    ``[{"name": "...", "profile_path": "...", "role": "...", "tmdb_id": 123}, ...]``.
+
+    Always written this way; older shapes (``["Name1", "Name2"]`` and
+    the dict shape without ``tmdb_id``) are only *read* by
+    ``_deserialize_cast`` and get converted on the next save.
     """
     if not cast:
         return None
-    payload = [{"name": m.name, "profile_path": m.profile_path, "role": m.role} for m in cast]
+    payload = [
+        {
+            "name": m.name,
+            "profile_path": m.profile_path,
+            "role": m.role,
+            "tmdb_id": m.tmdb_id,
+        }
+        for m in cast
+    ]
     return json.dumps(payload, ensure_ascii=False)
 
 
 def _deserialize_cast(raw: str | None) -> list[CastMember]:
     """Reconstruct the cast list from the JSON column.
 
-    Accepts both the new dict shape and the legacy ``list[str]`` shape
-    so rows enriched before this feature still load — entries without
-    photo/role just render as initials avatars on the UI side. The
-    next save migrates the row to the new shape implicitly.
+    Accepts every historic shape so rows enriched at any point still
+    load: legacy ``list[str]`` (initials-only fallback), the dict
+    shape without ``tmdb_id`` (no bio link on the actor page —
+    degrades to a name-only flow), and the current dict shape with
+    ``tmdb_id``. The next save migrates the row to the current shape
+    implicitly.
 
     Tolerant of malformed payloads at the storage boundary: a JSON
     value that is not a list (drift from a future migration, manual
     DB edit) collapses to an empty cast rather than iterating dict
     keys as if they were entries; dict entries with no usable
-    ``name`` are skipped so the UI never renders empty cards.
+    ``name`` are skipped so the UI never renders empty cards. A
+    non-int ``tmdb_id`` (string, float, malformed import) is dropped
+    silently rather than raising.
     """
     if not raw:
         return []
@@ -66,11 +81,14 @@ def _deserialize_cast(raw: str | None) -> list[CastMember]:
             name = str(item.get("name") or "").strip()
             if not name:
                 continue
+            raw_tmdb_id = item.get("tmdb_id")
+            tmdb_id = raw_tmdb_id if isinstance(raw_tmdb_id, int) else None
             members.append(
                 CastMember(
                     name=name,
                     profile_path=item.get("profile_path") or None,
                     role=item.get("role") or None,
+                    tmdb_id=tmdb_id,
                 )
             )
     return members

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -4,6 +4,7 @@ from src.modules.media.presentation.routes.catalog_routes import router as catal
 from src.modules.media.presentation.routes.enrichment_routes import router as enrichment_router
 from src.modules.media.presentation.routes.featured_routes import router as featured_router
 from src.modules.media.presentation.routes.movie_routes import router as movie_router
+from src.modules.media.presentation.routes.people_routes import router as people_router
 from src.modules.media.presentation.routes.scan_routes import router as scan_router
 from src.modules.media.presentation.routes.search_routes import router as search_router
 from src.modules.media.presentation.routes.series_routes import router as series_router
@@ -14,6 +15,7 @@ __all__ = [
     "enrichment_router",
     "featured_router",
     "movie_router",
+    "people_router",
     "scan_router",
     "search_router",
     "series_router",

--- a/src/modules/media/presentation/routes/people_routes.py
+++ b/src/modules/media/presentation/routes/people_routes.py
@@ -1,0 +1,44 @@
+"""People (cast bio) REST API routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, HTTPException
+
+from src.building_blocks.presentation import api_single
+from src.config.containers import ApplicationContainer
+from src.modules.media.application.use_cases.get_person_bio import (
+    GetPersonBioInput,
+    GetPersonBioUseCase,
+)
+
+router = APIRouter(prefix="/api/v1/people", tags=["People"])
+
+
+@router.get("/{tmdb_id}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_person(
+    tmdb_id: int,
+    use_case: GetPersonBioUseCase = Depends(
+        Provide[ApplicationContainer.media.get_person_bio],
+    ),
+) -> dict[str, Any]:
+    """Fetch biographical metadata for a TMDB person.
+
+    Used by the actor page to render bio + birth date + known
+    department alongside the catalog filmography. The ``tmdb_id``
+    path param is captured during movie enrichment and forwarded by
+    the cast card via ``location.state``.
+
+    Returns 404 when the provider has no record for the id (deleted
+    person, propagated 404, network error). The actor page degrades
+    gracefully on 404 and keeps a name-only header.
+    """
+    result = await use_case.execute(GetPersonBioInput(tmdb_id=tmdb_id))
+    if result is None:
+        raise HTTPException(status_code=404, detail="Person not found")
+    return api_single("person", asdict(result))
+
+
+__all__ = ["router"]

--- a/src/modules/media/presentation/routes/people_routes.py
+++ b/src/modules/media/presentation/routes/people_routes.py
@@ -20,6 +20,7 @@ router = APIRouter(prefix="/api/v1/people", tags=["People"])
 @inject  # type: ignore[misc]
 async def get_person(
     tmdb_id: int,
+    lang: str = "en-US",
     use_case: GetPersonBioUseCase = Depends(
         Provide[ApplicationContainer.media.get_person_bio],
     ),
@@ -31,11 +32,17 @@ async def get_person(
     path param is captured during movie enrichment and forwarded by
     the cast card via ``location.state``.
 
+    Query params:
+        lang: BCP-47 language tag (default ``en-US``). When the
+            requested language has no biography on TMDB the use case
+            falls back to English bio while keeping the rest of the
+            payload localized.
+
     Returns 404 when the provider has no record for the id (deleted
     person, propagated 404, network error). The actor page degrades
     gracefully on 404 and keeps a name-only header.
     """
-    result = await use_case.execute(GetPersonBioInput(tmdb_id=tmdb_id))
+    result = await use_case.execute(GetPersonBioInput(tmdb_id=tmdb_id, lang=lang))
     if result is None:
         raise HTTPException(status_code=404, detail="Person not found")
     return api_single("person", asdict(result))

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -18,6 +18,7 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import ContentRating, TmdbId
+from src.modules.media.domain.value_objects.cast_member import CastMember
 from tests.modules.media.unit.conftest import MediaUoWMocks, make_media_uow_mock
 
 
@@ -199,6 +200,90 @@ class TestEnrichMovieMetadata:
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is True
+
+
+@pytest.mark.unit
+class TestEnrichMovieMetadataForce:
+    """``force=True`` must bypass the ``not movie.<field>`` guards.
+
+    Motivating use case: backfill ``tmdb_id`` on cast members of
+    movies enriched before the id was captured. Without the force
+    bypass on ``_apply_credits`` the cast field stays untouched and
+    the actor page never gets bio links.
+    """
+
+    @pytest.mark.asyncio
+    async def test_should_overwrite_existing_cast_with_tmdb_id(self) -> None:
+        # Old enrichment shape: cast present but ``tmdb_id`` is None
+        # because the row was saved before we captured the id.
+        movie = _make_movie().with_updates(
+            tmdb_id=TmdbId(27205),
+            cast=[CastMember(name="Leonardo DiCaprio", tmdb_id=None)],
+        )
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_movie_by_id.return_value = MediaMetadata(
+            title="Inception",
+            tmdb_id=27205,
+            cast=[
+                CreditPerson(
+                    name="Leonardo DiCaprio",
+                    role="Cobb",
+                    profile_url="https://image.tmdb.org/t/p/original/leo.jpg",
+                    tmdb_id=6193,
+                ),
+            ],
+        )
+
+        captured: dict[str, Movie] = {}
+
+        async def _capture(m: Movie) -> Movie:
+            captured["saved"] = m
+            return m
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        mocks.movies.save.side_effect = _capture
+
+        result = await use_case.execute(
+            EnrichMediaInput(media_id=str(movie.id), force=True),
+        )
+
+        assert result.enriched is True
+        saved = captured["saved"]
+        assert len(saved.cast) == 1
+        assert saved.cast[0].name == "Leonardo DiCaprio"
+        assert saved.cast[0].tmdb_id == 6193
+        assert saved.cast[0].role == "Cobb"
+
+    @pytest.mark.asyncio
+    async def test_should_preserve_existing_cast_when_not_forced(self) -> None:
+        # Counterpart to the above — without ``force``, the existing
+        # cast (without ``tmdb_id``) must NOT be touched even if the
+        # provider returns a richer payload.
+        original_cast = [CastMember(name="Leonardo DiCaprio", tmdb_id=None)]
+        movie = _make_movie().with_updates(cast=original_cast)
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = MediaMetadata(
+            title="Inception",
+            tmdb_id=27205,
+            cast=[
+                CreditPerson(name="Leonardo DiCaprio", tmdb_id=6193),
+            ],
+        )
+
+        captured: dict[str, Movie] = {}
+
+        async def _capture(m: Movie) -> Movie:
+            captured["saved"] = m
+            return m
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        mocks.movies.save.side_effect = _capture
+
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        # ``tmdb_id`` stays None because the guard skipped the cast
+        # update — the existing list wins.
+        assert captured["saved"].cast[0].tmdb_id is None
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/application/use_cases/test_get_person_bio.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_person_bio.py
@@ -1,0 +1,78 @@
+"""Tests for GetPersonBioUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.application.ports.metadata_provider_port import PersonMetadata
+from src.modules.media.application.use_cases.get_person_bio import (
+    GetPersonBioInput,
+    GetPersonBioUseCase,
+    PersonBioOutput,
+)
+
+
+def _person(
+    *,
+    tmdb_id: int = 6193,
+    name: str = "Leonardo DiCaprio",
+    biography: str = "American actor.",
+    birthday: str | None = "1974-11-11",
+    deathday: str | None = None,
+    place_of_birth: str | None = "Los Angeles, California, USA",
+    known_for_department: str | None = "Acting",
+    profile_path: str | None = "https://image.tmdb.org/t/p/original/leo.jpg",
+) -> PersonMetadata:
+    return PersonMetadata(
+        tmdb_id=tmdb_id,
+        name=name,
+        biography=biography,
+        birthday=birthday,
+        deathday=deathday,
+        place_of_birth=place_of_birth,
+        known_for_department=known_for_department,
+        profile_path=profile_path,
+    )
+
+
+@pytest.mark.unit
+class TestGetPersonBioUseCase:
+    """Tests for GetPersonBioUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_map_provider_metadata_to_output(self) -> None:
+        provider = AsyncMock()
+        provider.get_person.return_value = _person()
+        use_case = GetPersonBioUseCase(metadata_provider=provider)
+
+        result = await use_case.execute(GetPersonBioInput(tmdb_id=6193))
+
+        assert isinstance(result, PersonBioOutput)
+        assert result.tmdb_id == 6193
+        assert result.name == "Leonardo DiCaprio"
+        assert result.biography == "American actor."
+        assert result.birthday == "1974-11-11"
+        assert result.known_for_department == "Acting"
+        provider.get_person.assert_awaited_once_with(6193)
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_when_provider_returns_none(self) -> None:
+        # Network failure / 404 / unknown id all collapse to ``None`` at
+        # the port — the actor page degrades to a name-only header.
+        provider = AsyncMock()
+        provider.get_person.return_value = None
+        use_case = GetPersonBioUseCase(metadata_provider=provider)
+
+        result = await use_case.execute(GetPersonBioInput(tmdb_id=99999999))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_pass_tmdb_id_to_provider_unchanged(self) -> None:
+        provider = AsyncMock()
+        provider.get_person.return_value = _person(tmdb_id=12345)
+        use_case = GetPersonBioUseCase(metadata_provider=provider)
+
+        await use_case.execute(GetPersonBioInput(tmdb_id=12345))
+
+        provider.get_person.assert_awaited_once_with(12345)

--- a/tests/modules/media/unit/application/use_cases/test_get_person_bio.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_person_bio.py
@@ -53,7 +53,17 @@ class TestGetPersonBioUseCase:
         assert result.biography == "American actor."
         assert result.birthday == "1974-11-11"
         assert result.known_for_department == "Acting"
-        provider.get_person.assert_awaited_once_with(6193)
+        provider.get_person.assert_awaited_once_with(6193, language="en-US")
+
+    @pytest.mark.asyncio
+    async def test_should_forward_lang_to_provider(self) -> None:
+        provider = AsyncMock()
+        provider.get_person.return_value = _person()
+        use_case = GetPersonBioUseCase(metadata_provider=provider)
+
+        await use_case.execute(GetPersonBioInput(tmdb_id=6193, lang="pt-BR"))
+
+        provider.get_person.assert_awaited_once_with(6193, language="pt-BR")
 
     @pytest.mark.asyncio
     async def test_should_return_none_when_provider_returns_none(self) -> None:
@@ -75,4 +85,4 @@ class TestGetPersonBioUseCase:
 
         await use_case.execute(GetPersonBioInput(tmdb_id=12345))
 
-        provider.get_person.assert_awaited_once_with(12345)
+        provider.get_person.assert_awaited_once_with(12345, language="en-US")

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -549,6 +549,103 @@ class TestGetSeriesById:
 
 
 @pytest.mark.unit
+class TestGetPerson:
+    """Tests for ``get_person`` (TMDB ``/person/{id}``)."""
+
+    @pytest.mark.asyncio
+    async def test_should_parse_person_payload(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "id": 6193,
+                    "name": "Leonardo DiCaprio",
+                    "biography": "American actor born in 1974.",
+                    "birthday": "1974-11-11",
+                    "deathday": None,
+                    "place_of_birth": "Los Angeles, California, USA",
+                    "known_for_department": "Acting",
+                    "profile_path": "/leo.jpg",
+                }
+            )
+        )
+
+        result = await client.get_person(6193)
+
+        assert result is not None
+        assert result.tmdb_id == 6193
+        assert result.name == "Leonardo DiCaprio"
+        assert result.biography == "American actor born in 1974."
+        assert result.birthday == "1974-11-11"
+        assert result.deathday is None
+        assert result.place_of_birth == "Los Angeles, California, USA"
+        assert result.known_for_department == "Acting"
+        # ``profile_path`` is rewritten to a CDN URL by ``_image_url``.
+        assert result.profile_path == "https://image.tmdb.org/t/p/original/leo.jpg"
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_on_404(self) -> None:
+        client = _make_client(get_responses=_build_response(status_code=404))
+
+        result = await client.get_person(99999999)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_on_network_error(self) -> None:
+        # ``HTTPError`` (e.g. timeout, connection reset) collapses to
+        # ``None`` so the actor page degrades to a name-only header
+        # instead of erroring out.
+        client = TmdbClient(api_key="test-key")
+        mock_http = MagicMock()
+        mock_http.get = AsyncMock(side_effect=httpx.RequestError("boom"))
+        client._client = mock_http
+
+        result = await client.get_person(6193)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_when_payload_missing_id(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={"name": "Leonardo DiCaprio"},  # no id
+            )
+        )
+
+        result = await client.get_person(6193)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_collapse_empty_strings_to_none(self) -> None:
+        # TMDB returns ``""`` for unknown places of birth on some rows;
+        # the parser flattens those to ``None`` so the UI's
+        # ``value && <render>`` guards do the right thing.
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "id": 6193,
+                    "name": "Leonardo DiCaprio",
+                    "biography": "",
+                    "birthday": "",
+                    "place_of_birth": "",
+                    "known_for_department": "",
+                    "profile_path": "",
+                }
+            )
+        )
+
+        result = await client.get_person(6193)
+
+        assert result is not None
+        assert result.biography == ""
+        assert result.birthday is None
+        assert result.place_of_birth is None
+        assert result.known_for_department is None
+        assert result.profile_path is None
+
+
+@pytest.mark.unit
 class TestGetMovieLocalized:
     """Tests for get_movie_localized."""
 

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -644,6 +644,85 @@ class TestGetPerson:
         assert result.known_for_department is None
         assert result.profile_path is None
 
+    @pytest.mark.asyncio
+    async def test_should_fall_back_to_english_when_localized_bio_is_empty(self) -> None:
+        # TMDB has the pt-BR payload but didn't author the bio in pt;
+        # the client should fetch English and use only that bio,
+        # keeping the rest of the localized fields.
+        client = _make_client(
+            get_responses=[
+                _build_response(
+                    json_data={
+                        "id": 6193,
+                        "name": "Leonardo DiCaprio",
+                        "biography": "",
+                        "birthday": "1974-11-11",
+                        "place_of_birth": "Los Angeles, Califórnia, EUA",
+                        "known_for_department": "Acting",
+                        "profile_path": "/leo.jpg",
+                    },
+                ),
+                _build_response(
+                    json_data={
+                        "id": 6193,
+                        "name": "Leonardo DiCaprio",
+                        "biography": "American actor born in 1974.",
+                        "birthday": "1974-11-11",
+                        "place_of_birth": "Los Angeles, California, USA",
+                        "known_for_department": "Acting",
+                        "profile_path": "/leo.jpg",
+                    },
+                ),
+            ]
+        )
+
+        result = await client.get_person(6193, language="pt-BR")
+
+        assert result is not None
+        assert result.biography == "American actor born in 1974."
+        # Localized fields kept — only the empty bio was replaced.
+        assert result.place_of_birth == "Los Angeles, Califórnia, EUA"
+
+    @pytest.mark.asyncio
+    async def test_should_not_fall_back_when_english_request_returned_empty(self) -> None:
+        # English already returned empty — no second call needed; the
+        # ``_is_english`` short-circuit avoids burning an HTTP request
+        # on a guaranteed no-op.
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "id": 6193,
+                    "name": "Leonardo DiCaprio",
+                    "biography": "",
+                    "birthday": "1974-11-11",
+                },
+            )
+        )
+
+        result = await client.get_person(6193, language="en-US")
+
+        assert result is not None
+        assert result.biography == ""
+
+    @pytest.mark.asyncio
+    async def test_should_keep_localized_bio_when_present(self) -> None:
+        # When the localized fetch already has a bio, no fallback fires
+        # — saves an HTTP round-trip when TMDB has translations.
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "id": 6193,
+                    "name": "Leonardo DiCaprio",
+                    "biography": "Ator americano nascido em 1974.",
+                },
+            )
+        )
+
+        result = await client.get_person(6193, language="pt-BR")
+
+        assert result is not None
+        assert result.biography == "Ator americano nascido em 1974."
+
 
 @pytest.mark.unit
 class TestGetMovieLocalized:

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
@@ -195,6 +195,80 @@ class TestMovieMapper:
 
         assert entity.cast == []
 
+    def test_to_entity_reads_cast_dict_with_tmdb_id(self) -> None:
+        """Current cast shape carries ``tmdb_id`` from TMDB enrichment.
+
+        Pinned so the mapper's default-None fallback (for older
+        rows enriched before ``tmdb_id`` was captured) doesn't
+        silently swallow the id when it IS present.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            cast=(
+                '[{"name": "Leonardo DiCaprio", "profile_path": null, '
+                '"role": "Cobb", "tmdb_id": 6193}]'
+            ),
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model, include_files=False)
+
+        assert len(entity.cast) == 1
+        assert entity.cast[0].tmdb_id == 6193
+
+    def test_to_entity_defaults_tmdb_id_to_none_for_pre_id_dict_shape(self) -> None:
+        """Rows enriched before ``tmdb_id`` capture must still load.
+
+        The dict shape without ``tmdb_id`` is the second-generation
+        cast format (``name`` + ``profile_path`` + ``role``); existing
+        libraries holding it should keep working with the actor page
+        falling back to a name-only header.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            cast='[{"name": "Leonardo DiCaprio", "profile_path": null, "role": "Cobb"}]',
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model, include_files=False)
+
+        assert entity.cast[0].tmdb_id is None
+
+    def test_to_entity_drops_non_int_tmdb_id_silently(self) -> None:
+        """A string / float / null ``tmdb_id`` collapses to ``None``.
+
+        Defends against a malformed import or a future provider drift
+        that sends ``"6193"`` instead of ``6193``; without the guard
+        the VO type-check would fail at construction time.
+        """
+        movie_id = MovieId.generate()
+        now = datetime.now(UTC)
+        model = MovieModel(
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            cast='[{"name": "Leonardo DiCaprio", "tmdb_id": "6193"}]',
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(model, include_files=False)
+
+        assert entity.cast[0].tmdb_id is None
+
     def test_to_entity_skips_cast_dicts_without_name(self) -> None:
         """Cast entries with empty / missing ``name`` are skipped.
 


### PR DESCRIPTION
## Summary
- Extend ``CastMember`` with optional ``tmdb_id`` so the new actor page can resolve to a TMDB person without name-collision ambiguity. ``CastMemberOutput`` and the enrichment path are wired through end-to-end (TMDB ``/movie/{id}/credits`` already returns ``id`` per cast member — just propagated).
- Mapper accepts every historic cast shape (legacy ``list[str]``, dict without ``tmdb_id``, current dict with ``tmdb_id``) and migrates rows on next save. Rows enriched before this PR keep working and degrade to a name-only header on the actor page until re-enriched.
- New ``MetadataProvider.get_person`` port + ``TmdbClient`` implementation against ``/person/{id}``, returning ``PersonMetadata`` (bio, birthday, deathday, place_of_birth, known_for_department, profile_path).
- New ``GetPersonBioUseCase`` + ``GET /api/v1/people/{tmdb_id}`` route. Network failures and unknown ids collapse to ``None`` / 404 so the frontend can render a graceful fallback.

## Test plan
- [x] ``test_movie_mapper.py`` — 3 new tests cover (a) the dict shape with ``tmdb_id`` round-trips, (b) the dict shape without ``tmdb_id`` still loads (``tmdb_id is None``), (c) a non-int ``tmdb_id`` collapses silently rather than raising at VO construction.
- [x] ``test_tmdb_client.py::TestGetPerson`` — 5 tests cover happy path, 404, network error, missing ``id``, and empty-string ``→`` ``None`` flattening for optional fields.
- [x] ``test_get_person_bio.py`` — 3 unit tests cover provider passthrough, ``None`` propagation, and id forwarding.
- [x] Full media test suite ``pytest tests/modules/media/`` — 983 passed.
- [x] ``ruff check`` + ``ruff format --check`` clean.

## Migration steps
- Existing rows with cast enriched before this PR don't have ``tmdb_id`` and will degrade to a name-only header on the actor page. To populate the id for existing libraries, re-enrich movies (the enrichment use case still skips movies that already have cast — to force a refresh, the operator clears cast manually or uses an explicit re-enrich tool).

## Summary by Sourcery

Add TMDB-backed person biography support and extend cast metadata to power an actor detail page.

New Features:
- Expose a GET /api/v1/people/{tmdb_id} endpoint that returns biographical metadata for a TMDB person using a new GetPersonBioUseCase.
- Introduce TMDB client support and MetadataProvider port method for fetching person metadata from TMDB's /person/{id} endpoint.

Enhancements:
- Extend cast members across domain, persistence, and API DTOs to persist and expose optional tmdb_id values, while keeping backward compatibility with older cast storage formats.

Tests:
- Add unit tests for TMDB person fetching, cast deserialization with tmdb_id handling, and the GetPersonBioUseCase behavior including provider failures and id forwarding.