### PR TITLE
feat(media): persist intro markers and season detection state

### DIFF
--- a/migrations/versions/2026_04_29_add_intro_columns.py
+++ b/migrations/versions/2026_04_29_add_intro_columns.py
@@ -1,0 +1,69 @@
+"""Add intro-marker columns to episodes and detection-state columns to seasons.
+
+Persists the IntroMarker value object (start/end seconds, source,
+optional confidence, detected_at) on each episode, and the
+intro-detection job state on each season. New columns are nullable on
+``episodes`` (no intro detected/set yet) and seeded with
+``NOT_STARTED`` on ``seasons`` so existing rows enter the detection
+queue automatically on the next job tick.
+
+Revision ID: d0e1f2a3b4c5
+Revises: c9d0e1f2a3b4
+Create Date: 2026-04-29 18:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d0e1f2a3b4c5"
+down_revision: str | Sequence[str] | None = "c9d0e1f2a3b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add intro columns to ``episodes`` and ``seasons``."""
+    with op.batch_alter_table("episodes", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("intro_start_seconds", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("intro_end_seconds", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("intro_source", sa.String(length=20), nullable=True))
+        batch_op.add_column(sa.Column("intro_confidence", sa.Float(), nullable=True))
+        batch_op.add_column(
+            sa.Column("intro_detected_at", sa.DateTime(timezone=True), nullable=True)
+        )
+
+    with op.batch_alter_table("seasons", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "intro_detection_state",
+                sa.String(length=30),
+                nullable=False,
+                server_default="NOT_STARTED",
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "intro_detection_attempted_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            )
+        )
+        batch_op.add_column(sa.Column("intro_detection_error", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop intro columns from ``seasons`` and ``episodes``."""
+    with op.batch_alter_table("seasons", schema=None) as batch_op:
+        batch_op.drop_column("intro_detection_error")
+        batch_op.drop_column("intro_detection_attempted_at")
+        batch_op.drop_column("intro_detection_state")
+
+    with op.batch_alter_table("episodes", schema=None) as batch_op:
+        batch_op.drop_column("intro_detected_at")
+        batch_op.drop_column("intro_confidence")
+        batch_op.drop_column("intro_source")
+        batch_op.drop_column("intro_end_seconds")
+        batch_op.drop_column("intro_start_seconds")

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -2,12 +2,23 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from datetime import datetime
 
 from src.building_blocks.application.pagination import PaginatedResult
 from src.modules.media.domain.entities.episode import Episode
+from src.modules.media.domain.entities.season import Season
 from src.modules.media.domain.entities.series import Series
 from src.modules.media.domain.repositories.movie_repository import GenreRow
-from src.modules.media.domain.value_objects import EpisodeId, FilePath, Genre, SeriesId, Title
+from src.modules.media.domain.value_objects import (
+    EpisodeId,
+    FilePath,
+    Genre,
+    IntroDetectionState,
+    IntroMarker,
+    SeasonId,
+    SeriesId,
+    Title,
+)
 
 
 class SeriesRepository(ABC):
@@ -255,6 +266,89 @@ class SeriesRepository(ABC):
         Args:
             episode_id: External id of the episode to update.
             path: Absolute path to the sprite VTT, or ``None`` to clear.
+
+        Returns:
+            ``True`` if a row was updated, ``False`` if no episode with
+            that id exists.
+        """
+        ...
+
+    @abstractmethod
+    async def find_seasons_pending_intro_detection(self, limit: int) -> Sequence[Season]:
+        """Return seasons whose intro-detection job has not converged yet.
+
+        Filters for seasons in ``NOT_STARTED`` or ``INSUFFICIENT_EPISODES``
+        state (the second so seasons that previously had too few
+        episodes get retried automatically once more land). ``COMPLETED``,
+        ``IN_PROGRESS``, ``FAILED``, and ``DISABLED`` are excluded —
+        ``FAILED`` and ``DISABLED`` require an explicit operator reset
+        before being retried.
+
+        Returned ``Season`` entities have their ``episodes`` collection
+        eagerly loaded (with file variants) so the detection job can
+        iterate file paths without N+1 queries. Soft-deleted seasons
+        and episodes are filtered out.
+
+        Args:
+            limit: Maximum number of seasons to return.
+
+        Returns:
+            Sequence of seasons eligible for the next detection tick.
+        """
+        ...
+
+    @abstractmethod
+    async def update_season_intro_detection(
+        self,
+        season_id: SeasonId,
+        state: IntroDetectionState,
+        *,
+        attempted_at: datetime | None = None,
+        error: str | None = None,
+    ) -> bool:
+        """Persist intro-detection job state for a season.
+
+        Direct UPDATE on the ``seasons`` table — analogous to
+        ``update_episode_scrub_preview_path`` — so the detection job can
+        record progress and outcomes without round-tripping the parent
+        ``Series`` aggregate per season. Domain-side state machine
+        validation belongs on the ``Season`` entity; callers are expected
+        to drive transitions via ``with_detection_started`` etc. and pass
+        the resulting state here.
+
+        Args:
+            season_id: External id of the season (sea_xxx).
+            state: New ``IntroDetectionState`` value.
+            attempted_at: When the job ran. Pass ``None`` to leave the
+                column unchanged for transient transitions like
+                ``IN_PROGRESS``.
+            error: Diagnostic message for ``FAILED`` runs, or ``None`` to
+                clear.
+
+        Returns:
+            ``True`` if a row was updated, ``False`` if no season with
+            that id exists.
+        """
+        ...
+
+    @abstractmethod
+    async def update_episode_intro(
+        self,
+        episode_id: EpisodeId,
+        marker: IntroMarker | None,
+    ) -> bool:
+        """Persist (or clear) the intro marker for a single episode.
+
+        Direct UPDATE on the ``episodes`` table covering all five intro
+        columns at once. The detection job calls this per-episode after
+        cross-correlation; the manual-edit endpoint also uses it to set
+        a ``MANUAL`` marker without rewriting the entire ``Series``
+        aggregate.
+
+        Args:
+            episode_id: External id of the episode (epi_xxx).
+            marker: The marker to persist, or ``None`` to clear all five
+                intro columns.
 
         Returns:
             ``True`` if a row was updated, ``False`` if no episode with

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -13,6 +13,9 @@ from src.modules.media.domain.value_objects import (
     Genre,
     ImageUrl,
     ImdbId,
+    IntroDetectionState,
+    IntroMarker,
+    IntroMarkerSource,
     MediaFile,
     Resolution,
     SeasonId,
@@ -74,6 +77,7 @@ class EpisodeMapper:
             if entity.scrub_preview_path
             else None,
             air_date=entity.air_date.value if entity.air_date else None,
+            **_intro_marker_to_columns(entity.intro),
         )
 
         for file in entity.files:
@@ -123,6 +127,7 @@ class EpisodeMapper:
             if model.scrub_preview_path
             else None,
             air_date=AirDate(model.air_date) if model.air_date else None,
+            intro=_intro_marker_from_columns(model),
             created_at=model.created_at,
             updated_at=model.updated_at,
         )
@@ -154,6 +159,9 @@ class EpisodeMapper:
             entity.scrub_preview_path.value if entity.scrub_preview_path else None
         )
         model.air_date = entity.air_date.value if entity.air_date else None
+
+        for column, value in _intro_marker_to_columns(entity.intro).items():
+            setattr(model, column, value)
 
         _sync_episode_file_variants(model.file_variants, entity.files)
 
@@ -189,6 +197,9 @@ class SeasonMapper:
             synopsis=entity.synopsis,
             poster_path=entity.poster_path.value if entity.poster_path else None,
             air_date=entity.air_date.value if entity.air_date else None,
+            intro_detection_state=entity.intro_detection_state.value,
+            intro_detection_attempted_at=entity.intro_detection_attempted_at,
+            intro_detection_error=entity.intro_detection_error,
         )
 
     @staticmethod
@@ -217,6 +228,9 @@ class SeasonMapper:
             poster_path=ImageUrl(model.poster_path) if model.poster_path else None,
             air_date=AirDate(model.air_date) if model.air_date else None,
             episodes=episode_list,
+            intro_detection_state=IntroDetectionState(model.intro_detection_state),
+            intro_detection_attempted_at=model.intro_detection_attempted_at,
+            intro_detection_error=model.intro_detection_error,
             created_at=model.created_at,
             updated_at=model.updated_at,
         )
@@ -237,6 +251,9 @@ class SeasonMapper:
         model.synopsis = entity.synopsis
         model.poster_path = entity.poster_path.value if entity.poster_path else None
         model.air_date = entity.air_date.value if entity.air_date else None
+        model.intro_detection_state = entity.intro_detection_state.value
+        model.intro_detection_attempted_at = entity.intro_detection_attempted_at
+        model.intro_detection_error = entity.intro_detection_error
 
         return model
 
@@ -349,6 +366,62 @@ class SeriesMapper:
         model.imdb_id = entity.imdb_id.value if entity.imdb_id else None
 
         return model
+
+
+def _intro_marker_to_columns(marker: IntroMarker | None) -> dict[str, object]:
+    """Explode an IntroMarker (or absence of one) into the 5 episode columns.
+
+    Args:
+        marker: The IntroMarker VO to persist, or ``None`` to clear it.
+
+    Returns:
+        A dict suitable for keyword-expansion into ``EpisodeModel`` or
+        ``setattr`` iteration on an existing model. All five columns
+        appear so callers can rely on a complete clear when ``marker``
+        is ``None``.
+    """
+    if marker is None:
+        return {
+            "intro_start_seconds": None,
+            "intro_end_seconds": None,
+            "intro_source": None,
+            "intro_confidence": None,
+            "intro_detected_at": None,
+        }
+
+    return {
+        "intro_start_seconds": marker.start_seconds,
+        "intro_end_seconds": marker.end_seconds,
+        "intro_source": marker.source.value,
+        "intro_confidence": marker.confidence,
+        "intro_detected_at": marker.detected_at,
+    }
+
+
+def _intro_marker_from_columns(model: EpisodeModel) -> IntroMarker | None:
+    """Reconstruct an IntroMarker from the 5 episode columns.
+
+    The intro is considered absent when ``intro_start_seconds`` is
+    ``NULL``; the other columns must be populated together when it is
+    set (a partially-populated row indicates schema corruption and
+    will surface as a Pydantic validation error here).
+
+    Args:
+        model: Source ORM model.
+
+    Returns:
+        The reconstructed VO, or ``None`` if no intro is persisted.
+    """
+    if model.intro_start_seconds is None:
+        return None
+
+    return IntroMarker(
+        start_seconds=model.intro_start_seconds,
+        end_seconds=model.intro_end_seconds,
+        source=IntroMarkerSource(model.intro_source),
+        confidence=model.intro_confidence,
+        detected_at=model.intro_detected_at,
+    )
 
 
 def _sync_episode_file_variants(

--- a/src/modules/media/infrastructure/persistence/models/episode.py
+++ b/src/modules/media/infrastructure/persistence/models/episode.py
@@ -1,9 +1,19 @@
 """Episode ORM model."""
 
-from datetime import date
+from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, Date, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    BigInteger,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.infrastructure.persistence.base import Base
@@ -79,6 +89,19 @@ class EpisodeModel(Base):
 
     # Metadata
     air_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    # Skip-intro support: flat columns persisting the IntroMarker VO. All
+    # fields are NULL when no intro has been set yet (auto job hasn't run
+    # AND no manual override). When ``intro_start_seconds`` is non-NULL,
+    # the remaining columns must form a valid IntroMarker (enforced by the
+    # mapper, not the schema, to keep the migration cheap).
+    intro_start_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    intro_end_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    intro_source: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    intro_confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    intro_detected_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Relationships
     file_variants: Mapped[list["MediaFileModel"]] = relationship(

--- a/src/modules/media/infrastructure/persistence/models/season.py
+++ b/src/modules/media/infrastructure/persistence/models/season.py
@@ -1,9 +1,17 @@
 """Season ORM model."""
 
-from datetime import date
+from datetime import date, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Date, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.infrastructure.persistence.base import Base
@@ -56,6 +64,20 @@ class SeasonModel(Base):
 
     # Metadata
     air_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    # Intro detection job state (per-Season; manual markers on individual
+    # episodes are independent of this column). Default NOT_STARTED so
+    # backfilled rows enter the detection queue automatically.
+    intro_detection_state: Mapped[str] = mapped_column(
+        String(30),
+        nullable=False,
+        default="NOT_STARTED",
+        server_default="NOT_STARTED",
+    )
+    intro_detection_attempted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    intro_detection_error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationships
     series: Mapped["SeriesModel"] = relationship(

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -1,6 +1,7 @@
 """SQLAlchemy implementation of SeriesRepository."""
 
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import distinct, func, or_, select, text, update
@@ -20,6 +21,8 @@ from src.modules.media.domain.value_objects import (
     EpisodeId,
     FilePath,
     Genre,
+    IntroDetectionState,
+    IntroMarker,
     SeasonId,
     SeriesId,
     Title,
@@ -443,6 +446,102 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 EpisodeModel.deleted_at.is_(None),
             )
             .values(scrub_preview_path=path)
+        )
+        result = await self._session.execute(stmt)
+        return bool(result.rowcount)
+
+    async def find_seasons_pending_intro_detection(self, limit: int) -> Sequence[Season]:
+        """Return seasons in NOT_STARTED/INSUFFICIENT_EPISODES with episodes loaded.
+
+        Episodes (and their file_variants) are eager-loaded so the
+        detection job can iterate file paths without N+1 queries.
+        Soft-deleted rows are filtered out at both levels.
+        """
+        eligible_states = (
+            IntroDetectionState.NOT_STARTED.value,
+            IntroDetectionState.INSUFFICIENT_EPISODES.value,
+        )
+        stmt = (
+            select(SeasonModel)
+            .where(
+                SeasonModel.deleted_at.is_(None),
+                SeasonModel.intro_detection_state.in_(eligible_states),
+            )
+            .options(selectinload(SeasonModel.episodes).selectinload(EpisodeModel.file_variants))
+            .order_by(SeasonModel.id.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [SeasonMapper.to_entity(model) for model in result.scalars().all()]
+
+    async def update_season_intro_detection(
+        self,
+        season_id: SeasonId,
+        state: IntroDetectionState,
+        *,
+        attempted_at: datetime | None = None,
+        error: str | None = None,
+    ) -> bool:
+        """Direct UPDATE of intro-detection columns on the seasons row.
+
+        ``attempted_at`` is left untouched when ``None`` so transient
+        transitions (e.g. claiming a season as IN_PROGRESS) do not
+        overwrite the timestamp from the previous successful run.
+        ``error`` is always written through — pass ``None`` to clear.
+        """
+        values: dict[str, Any] = {
+            "intro_detection_state": state.value,
+            "intro_detection_error": error,
+        }
+        if attempted_at is not None:
+            values["intro_detection_attempted_at"] = attempted_at
+
+        stmt = (
+            update(SeasonModel)
+            .where(
+                SeasonModel.external_id == str(season_id),
+                SeasonModel.deleted_at.is_(None),
+            )
+            .values(**values)
+        )
+        result = await self._session.execute(stmt)
+        return bool(result.rowcount)
+
+    async def update_episode_intro(
+        self,
+        episode_id: EpisodeId,
+        marker: IntroMarker | None,
+    ) -> bool:
+        """Direct UPDATE of the 5 intro columns on the episodes row.
+
+        Used by the auto-detection job and the manual-edit endpoint to
+        avoid round-tripping the parent ``Series`` aggregate. Passing
+        ``None`` clears all five columns atomically.
+        """
+        if marker is None:
+            values: dict[str, Any] = {
+                "intro_start_seconds": None,
+                "intro_end_seconds": None,
+                "intro_source": None,
+                "intro_confidence": None,
+                "intro_detected_at": None,
+            }
+        else:
+            values = {
+                "intro_start_seconds": marker.start_seconds,
+                "intro_end_seconds": marker.end_seconds,
+                "intro_source": marker.source.value,
+                "intro_confidence": marker.confidence,
+                "intro_detected_at": marker.detected_at,
+            }
+
+        stmt = (
+            update(EpisodeModel)
+            .where(
+                EpisodeModel.external_id == str(episode_id),
+                EpisodeModel.deleted_at.is_(None),
+            )
+            .values(**values)
         )
         result = await self._session.execute(stmt)
         return bool(result.rowcount)

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -1,5 +1,7 @@
 """Integration tests for SQLAlchemySeriesRepository."""
 
+from datetime import UTC, datetime
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,6 +13,9 @@ from src.modules.media.domain.value_objects import (
     Genre,
     ImageUrl,
     ImdbId,
+    IntroDetectionState,
+    IntroMarker,
+    IntroMarkerSource,
     MediaFile,
     Resolution,
     SeasonId,
@@ -1014,3 +1019,358 @@ class TestSeriesCountUnderPaths:
         await repo.save(_series_with_episode_paths("A", ["/media/tv/a/s01e01.mkv"]))
 
         assert await repo.count_under_paths(["/media/tv/"]) == 1
+
+
+def _series_with_intro(
+    *,
+    intro: IntroMarker | None = None,
+    detection_state: IntroDetectionState = IntroDetectionState.NOT_STARTED,
+    detection_attempted_at: datetime | None = None,
+    detection_error: str | None = None,
+    series_title: str = "Intro Series",
+) -> Series:
+    """Build a single-season, single-episode series with the given intro state.
+
+    The episode file path is derived from the series id so callers can
+    save multiple series in the same test without colliding on the
+    ``episodes.file_path`` unique constraint.
+    """
+    sid = SeriesId.generate()
+    episode = _create_episode(sid, file_path=f"/series/{sid}/s01e01.mkv")
+    if intro is not None:
+        episode = episode.with_intro_marker(intro)
+
+    season = Season(
+        id=SeasonId.generate(),
+        series_id=sid,
+        season_number=1,
+        title=Title("Season 1"),
+        episodes=[episode],
+        intro_detection_state=detection_state,
+        intro_detection_attempted_at=detection_attempted_at,
+        intro_detection_error=detection_error,
+    )
+    return Series(
+        id=sid,
+        title=Title(series_title),
+        start_year=Year(2020),
+        seasons=[season],
+    )
+
+
+@pytest.mark.integration
+class TestSeriesRepositoryIntroPersistence:
+    """Tests covering IntroMarker and Season detection-state persistence."""
+
+    async def test_episode_round_trip_without_intro_keeps_columns_null(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _create_series(season_count=1, episodes_per_season=1)
+        await repo.save(series)
+
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+
+        assert found is not None
+        assert found.seasons[0].episodes[0].intro is None
+
+    async def test_episode_round_trip_with_manual_intro(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        marker = IntroMarker(
+            start_seconds=10,
+            end_seconds=72,
+            source=IntroMarkerSource.MANUAL,
+            detected_at=datetime(2026, 4, 29, 12, 0, tzinfo=UTC),
+        )
+        series = _series_with_intro(intro=marker)
+        await repo.save(series)
+
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+
+        assert found is not None
+        episode = found.seasons[0].episodes[0]
+        assert episode.intro is not None
+        assert episode.intro.start_seconds == 10
+        assert episode.intro.end_seconds == 72
+        assert episode.intro.source == IntroMarkerSource.MANUAL
+        assert episode.intro.confidence is None
+
+    async def test_episode_round_trip_with_auto_detected_intro(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        marker = IntroMarker(
+            start_seconds=12,
+            end_seconds=98,
+            source=IntroMarkerSource.AUTO_DETECTED,
+            confidence=0.91,
+        )
+        series = _series_with_intro(intro=marker)
+        await repo.save(series)
+
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+
+        assert found is not None
+        episode = found.seasons[0].episodes[0]
+        assert episode.intro is not None
+        assert episode.intro.source == IntroMarkerSource.AUTO_DETECTED
+        assert episode.intro.confidence == pytest.approx(0.91)
+
+    async def test_save_clears_intro_when_entity_intro_is_none(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        marker = IntroMarker(
+            start_seconds=0,
+            end_seconds=60,
+            source=IntroMarkerSource.MANUAL,
+        )
+        series = _series_with_intro(intro=marker)
+        await repo.save(series)
+
+        # Round-trip, then clear the intro and persist again.
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert found is not None
+        cleared_episode = found.seasons[0].episodes[0].with_intro_cleared()
+        cleared_season = found.seasons[0].with_updates(episodes=[cleared_episode])
+        cleared_series = found.with_updates(seasons=[cleared_season])
+        await repo.save(cleared_series)
+
+        roundtrip = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert roundtrip is not None
+        assert roundtrip.seasons[0].episodes[0].intro is None
+
+    async def test_season_detection_state_round_trip(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        attempted_at = datetime(2026, 4, 29, 18, 0, tzinfo=UTC)
+        series = _series_with_intro(
+            detection_state=IntroDetectionState.FAILED,
+            detection_attempted_at=attempted_at,
+            detection_error="ffmpeg returned non-zero",
+        )
+        await repo.save(series)
+
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+
+        assert found is not None
+        season = found.seasons[0]
+        assert season.intro_detection_state == IntroDetectionState.FAILED
+        assert season.intro_detection_error == "ffmpeg returned non-zero"
+        assert season.intro_detection_attempted_at is not None
+
+
+@pytest.mark.integration
+class TestFindSeasonsPendingIntroDetection:
+    """Tests for find_seasons_pending_intro_detection."""
+
+    async def test_returns_only_not_started_and_insufficient_seasons(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.NOT_STARTED,
+                series_title="A — pending",
+            )
+        )
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.INSUFFICIENT_EPISODES,
+                series_title="B — retry",
+            )
+        )
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.COMPLETED,
+                series_title="C — done",
+            )
+        )
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.DISABLED,
+                series_title="D — disabled",
+            )
+        )
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.FAILED,
+                series_title="E — failed",
+                detection_error="boom",
+            )
+        )
+
+        pending = await repo.find_seasons_pending_intro_detection(limit=10)
+
+        states = sorted(s.intro_detection_state.value for s in pending)
+        assert states == ["INSUFFICIENT_EPISODES", "NOT_STARTED"]
+
+    async def test_eager_loads_episodes_and_files(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_series_with_intro(detection_state=IntroDetectionState.NOT_STARTED))
+
+        pending = await repo.find_seasons_pending_intro_detection(limit=10)
+
+        assert len(pending) == 1
+        season = pending[0]
+        assert len(season.episodes) == 1
+        assert season.episodes[0].primary_file is not None
+
+    async def test_respects_limit(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        for i in range(3):
+            await repo.save(
+                _series_with_intro(
+                    detection_state=IntroDetectionState.NOT_STARTED,
+                    series_title=f"Series {i}",
+                )
+            )
+
+        pending = await repo.find_seasons_pending_intro_detection(limit=2)
+
+        assert len(pending) == 2
+
+
+@pytest.mark.integration
+class TestUpdateSeasonIntroDetection:
+    """Tests for update_season_intro_detection direct UPDATE."""
+
+    async def test_updates_state_and_error(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _series_with_intro(detection_state=IntroDetectionState.NOT_STARTED)
+        await repo.save(series)
+        season_id = series.seasons[0].id
+        assert season_id is not None
+
+        attempted_at = datetime(2026, 4, 29, 19, 0, tzinfo=UTC)
+        updated = await repo.update_season_intro_detection(
+            season_id,
+            IntroDetectionState.FAILED,
+            attempted_at=attempted_at,
+            error="ffmpeg crashed",
+        )
+        await db_session.commit()
+
+        assert updated is True
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert found is not None
+        season = found.seasons[0]
+        assert season.intro_detection_state == IntroDetectionState.FAILED
+        assert season.intro_detection_error == "ffmpeg crashed"
+
+    async def test_returns_false_for_unknown_season(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+
+        updated = await repo.update_season_intro_detection(
+            SeasonId.generate(),
+            IntroDetectionState.COMPLETED,
+        )
+
+        assert updated is False
+
+    async def test_leaves_attempted_at_untouched_when_none(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        original_attempted = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+        series = _series_with_intro(
+            detection_state=IntroDetectionState.COMPLETED,
+            detection_attempted_at=original_attempted,
+        )
+        await repo.save(series)
+        season_id = series.seasons[0].id
+        assert season_id is not None
+
+        # Transient transition without an attempted_at — must keep the
+        # previous run's timestamp visible for observability.
+        await repo.update_season_intro_detection(
+            season_id,
+            IntroDetectionState.IN_PROGRESS,
+        )
+        await db_session.commit()
+
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert found is not None
+        assert found.seasons[0].intro_detection_attempted_at is not None
+
+
+@pytest.mark.integration
+class TestUpdateEpisodeIntro:
+    """Tests for update_episode_intro direct UPDATE."""
+
+    async def test_sets_marker_on_episode_with_no_intro(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _series_with_intro()
+        await repo.save(series)
+        episode_id = series.seasons[0].episodes[0].id
+        assert episode_id is not None
+        marker = IntroMarker(
+            start_seconds=5,
+            end_seconds=80,
+            source=IntroMarkerSource.AUTO_DETECTED,
+            confidence=0.83,
+        )
+
+        updated = await repo.update_episode_intro(episode_id, marker)
+        await db_session.commit()
+
+        assert updated is True
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert found is not None
+        episode = found.seasons[0].episodes[0]
+        assert episode.intro is not None
+        assert episode.intro.start_seconds == 5
+        assert episode.intro.source == IntroMarkerSource.AUTO_DETECTED
+
+    async def test_clearing_marker_nulls_all_columns(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        marker = IntroMarker(
+            start_seconds=0,
+            end_seconds=60,
+            source=IntroMarkerSource.MANUAL,
+        )
+        series = _series_with_intro(intro=marker)
+        await repo.save(series)
+        episode_id = series.seasons[0].episodes[0].id
+        assert episode_id is not None
+
+        updated = await repo.update_episode_intro(episode_id, None)
+        await db_session.commit()
+
+        assert updated is True
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert found is not None
+        assert found.seasons[0].episodes[0].intro is None
+
+    async def test_returns_false_for_unknown_episode(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+
+        updated = await repo.update_episode_intro(EpisodeId.generate(), None)
+
+        assert updated is False

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
@@ -9,6 +9,9 @@ from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
     FilePath,
+    IntroDetectionState,
+    IntroMarker,
+    IntroMarkerSource,
     MediaFile,
     Resolution,
     SeasonId,
@@ -21,7 +24,11 @@ from src.modules.media.infrastructure.persistence.mappers import (
     SeasonMapper,
     SeriesMapper,
 )
-from src.modules.media.infrastructure.persistence.models import SeriesModel
+from src.modules.media.infrastructure.persistence.models import (
+    EpisodeModel,
+    SeasonModel,
+    SeriesModel,
+)
 
 
 def _create_episode(
@@ -93,6 +100,88 @@ class TestEpisodeMapper:
         assert model.series_external_id == str(series_id)
         assert model.title == "Test Episode"
 
+    def test_to_model_leaves_intro_columns_null_when_intro_absent(self) -> None:
+        episode = _create_episode(episode_id=EpisodeId.generate())
+
+        model = EpisodeMapper.to_model(episode, season_id=1)
+
+        assert model.intro_start_seconds is None
+        assert model.intro_end_seconds is None
+        assert model.intro_source is None
+        assert model.intro_confidence is None
+        assert model.intro_detected_at is None
+
+    def test_to_model_explodes_auto_detected_intro(self) -> None:
+        marker = IntroMarker(
+            start_seconds=12,
+            end_seconds=98,
+            source=IntroMarkerSource.AUTO_DETECTED,
+            confidence=0.92,
+        )
+        episode = _create_episode(episode_id=EpisodeId.generate()).with_intro_marker(marker)
+
+        model = EpisodeMapper.to_model(episode, season_id=1)
+
+        assert model.intro_start_seconds == 12
+        assert model.intro_end_seconds == 98
+        assert model.intro_source == "AUTO_DETECTED"
+        assert model.intro_confidence == pytest.approx(0.92)
+
+    def test_to_entity_reconstructs_manual_intro(self) -> None:
+        episode_id = EpisodeId.generate()
+        series_id = SeriesId.generate()
+        now = datetime.now(UTC)
+        model = EpisodeModel(
+            external_id=str(episode_id),
+            season_id=1,
+            series_external_id=str(series_id),
+            season_number=1,
+            episode_number=1,
+            title="Pilot",
+            duration=2700,
+            file_path="/series/s01e01.mkv",
+            file_size=1_000_000,
+            resolution="1080p",
+            intro_start_seconds=0,
+            intro_end_seconds=60,
+            intro_source="MANUAL",
+            intro_confidence=None,
+            intro_detected_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = EpisodeMapper.to_entity(model)
+
+        assert entity.intro is not None
+        assert entity.intro.source == IntroMarkerSource.MANUAL
+        assert entity.intro.confidence is None
+        assert entity.intro.start_seconds == 0
+        assert entity.intro.end_seconds == 60
+
+    def test_to_entity_returns_none_intro_when_columns_null(self) -> None:
+        episode_id = EpisodeId.generate()
+        series_id = SeriesId.generate()
+        now = datetime.now(UTC)
+        model = EpisodeModel(
+            external_id=str(episode_id),
+            season_id=1,
+            series_external_id=str(series_id),
+            season_number=1,
+            episode_number=1,
+            title="Pilot",
+            duration=2700,
+            file_path="/series/s01e01.mkv",
+            file_size=1_000_000,
+            resolution="1080p",
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = EpisodeMapper.to_entity(model)
+
+        assert entity.intro is None
+
 
 @pytest.mark.unit
 class TestSeasonMapper:
@@ -116,6 +205,44 @@ class TestSeasonMapper:
         assert model.external_id == str(season_id)
         assert model.series_id == 42
         assert model.series_external_id == str(series_id)
+
+    def test_to_model_serializes_detection_state(self) -> None:
+        season = _create_season(season_id=SeasonId.generate())
+        attempted_at = datetime(2026, 4, 29, 12, 0, tzinfo=UTC)
+        season = season.with_updates(
+            intro_detection_state=IntroDetectionState.FAILED,
+            intro_detection_attempted_at=attempted_at,
+            intro_detection_error="boom",
+        )
+
+        model = SeasonMapper.to_model(season, series_db_id=1)
+
+        assert model.intro_detection_state == "FAILED"
+        assert model.intro_detection_attempted_at == attempted_at
+        assert model.intro_detection_error == "boom"
+
+    def test_to_entity_reconstructs_detection_state(self) -> None:
+        season_id = SeasonId.generate()
+        series_id = SeriesId.generate()
+        now = datetime.now(UTC)
+        model = SeasonModel(
+            external_id=str(season_id),
+            series_id=1,
+            series_external_id=str(series_id),
+            season_number=1,
+            title="Season 1",
+            intro_detection_state="COMPLETED",
+            intro_detection_attempted_at=now,
+            intro_detection_error=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = SeasonMapper.to_entity(model)
+
+        assert entity.intro_detection_state == IntroDetectionState.COMPLETED
+        assert entity.intro_detection_attempted_at == now
+        assert entity.intro_detection_error is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Phase 2 of the skip-intro feature — domain primitives from #146 now have a persistent representation. No new endpoints or jobs yet; those land in subsequent phases.

- **Migration** (`d0e1f2a3b4c5`, parent `c9d0e1f2a3b4`) adds five nullable columns to `episodes` (`intro_start_seconds`, `intro_end_seconds`, `intro_source`, `intro_confidence`, `intro_detected_at`) and three to `seasons` (`intro_detection_state` non-null with `NOT_STARTED` server default, `intro_detection_attempted_at`, `intro_detection_error`). Existing rows enter the detection queue automatically because of the default. `batch_alter_table` keeps the migration SQLite-compatible. Down-migration drops everything.
- **Models**: `EpisodeModel` and `SeasonModel` gain the matching mapped columns.
- **Mappers**: `EpisodeMapper.to_model` / `to_entity` / `update_model` explode and reconstruct the `IntroMarker` VO via two helper functions (`_intro_marker_to_columns` / `_intro_marker_from_columns`); `SeasonMapper` round-trips the detection state. `to_model` writes all five intro columns even when the marker is absent so a clear is atomic.
- **Repository contract** gains three methods on `SeriesRepository`:
  - `find_seasons_pending_intro_detection(limit)` — returns seasons in `NOT_STARTED` or `INSUFFICIENT_EPISODES` (so seasons that previously had too few episodes get retried automatically once more land), with episodes and file variants eager-loaded for the job to iterate without N+1.
  - `update_season_intro_detection(season_id, state, attempted_at=None, error=None)` — direct UPDATE; leaves `attempted_at` untouched when `None` so transient `IN_PROGRESS` claims don't overwrite the previous run's timestamp.
  - `update_episode_intro(episode_id, marker_or_none)` — direct UPDATE on the five intro columns; `None` clears all five atomically.
- Both direct updates mirror the existing `update_episode_scrub_preview_path` pattern so the detection job can record progress and outcomes without round-tripping the parent `Series` aggregate.

## Test plan

- [x] 14 new integration tests covering round-trip (no intro / manual / auto-detected / clear), find pending seasons (states filter, eager loading, limit), update season state (sets values, returns False for unknown, leaves attempted_at untouched on None), update episode intro (set, clear, unknown id)
- [x] 7 new mapper unit tests covering the IntroMarker explode/reconstruct and the detection state round-trip
- [x] Full project suite green (1860 tests, +21 from Phase 1)
- [x] Migration round-trip verified locally (`alembic upgrade head` → `downgrade -1` → `upgrade head`)
- [x] `ruff check` clean on changed files
- [x] `ruff format` clean on changed files

## Summary by Sourcery

Persist per-episode intro markers and per-season intro detection state in the media persistence layer and expose repository operations to query and update them.

New Features:
- Store intro marker metadata on episodes and intro detection state on seasons via new database columns and ORM mappings.
- Map IntroMarker and IntroDetectionState between domain entities and persistence models, including handling of absent markers and state.
- Expose repository methods to find seasons pending intro detection and to update season detection state and episode intro markers without loading the full Series aggregate.

Tests:
- Add integration tests for intro marker round-trips, pending-season querying, and direct update methods for season detection state and episode intro markers.
- Add unit tests for episode and season mappers to verify correct serialization and reconstruction of intro markers and detection state.