### PR TITLE
feat(media): cross-correlation intro detection algorithm

### DIFF
--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -7,6 +7,11 @@ from src.modules.media.application.ports.file_scanner_port import (
 )
 from src.modules.media.application.ports.file_streamer_port import FileStreamerPort
 from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.ports.intro_detector_port import (
+    DetectedIntro,
+    EpisodeFingerprint,
+    IntroDetectorPort,
+)
 from src.modules.media.application.ports.media_probe_port import (
     MediaProbePort,
     ProbeResult,
@@ -30,10 +35,13 @@ from src.modules.media.application.ports.variant_detector_port import (
 
 __all__ = [
     "CreditPerson",
+    "DetectedIntro",
+    "EpisodeFingerprint",
     "EpisodeMetadata",
     "FileStreamerPort",
     "FileSystemScanner",
     "HlsPlaylistPort",
+    "IntroDetectorPort",
     "LocalizedFields",
     "MediaMetadata",
     "MediaProbePort",

--- a/src/modules/media/application/ports/intro_detector_port.py
+++ b/src/modules/media/application/ports/intro_detector_port.py
@@ -1,0 +1,85 @@
+"""Port for detecting per-episode intro segments from audio fingerprints.
+
+The intro-detection job feeds the port a season's worth of episode
+fingerprints and receives, when convergence is reached, a marker per
+episode pointing to the shared opening sequence. Implementations
+(``ChromaprintIntroDetector``) live in the infrastructure layer; the
+application uses only the abstraction so the algorithm can evolve
+without touching the orchestrating use case.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from src.modules.media.domain.value_objects import EpisodeId
+
+
+@dataclass(frozen=True)
+class EpisodeFingerprint:
+    """One episode's audio fingerprint, ready for cross-correlation.
+
+    Attributes:
+        episode_id: External id of the episode the fingerprint was
+            computed for.
+        hashes: Raw 32-bit Chromaprint fingerprint values, in the same
+            order ``fpcalc`` emits them. The first hash corresponds to
+            the start of the audio window analysed.
+        duration_seconds: Length of audio that produced ``hashes``,
+            as reported by fpcalc. Used to translate hash indices back
+            to seconds without baking the Chromaprint hash rate into
+            the port's contract.
+    """
+
+    episode_id: EpisodeId
+    hashes: list[int]
+    duration_seconds: float
+
+
+@dataclass(frozen=True)
+class DetectedIntro:
+    """Result of running the detector against a single episode.
+
+    Attributes:
+        start_seconds: Offset from the start of the audio window where
+            the shared intro begins.
+        end_seconds: Offset where the intro ends. Always strictly
+            greater than ``start_seconds``.
+        confidence: ``[0.0, 1.0]`` — the share of pair-comparisons
+            that agreed on this segment. The orchestrator can apply a
+            minimum threshold before persisting.
+    """
+
+    start_seconds: float
+    end_seconds: float
+    confidence: float
+
+
+class IntroDetectorPort(ABC):
+    """Cross-correlate fingerprints to find a shared opening sequence."""
+
+    @abstractmethod
+    def detect(
+        self, fingerprints: Sequence[EpisodeFingerprint]
+    ) -> Mapping[EpisodeId, DetectedIntro]:
+        """Return a marker per episode where detection converged.
+
+        Implementations may return a partial map — episodes whose
+        fingerprint did not align with enough peers are omitted rather
+        than being given a low-confidence guess. The orchestrator
+        treats a missing entry as "no intro detected for this episode".
+
+        Args:
+            fingerprints: One per episode in the season under analysis.
+                Order is not significant; episodes are matched by id.
+
+        Returns:
+            A mapping keyed by episode id. May be empty when the season
+            does not have enough episodes for cross-correlation, or when
+            no shared segment crossed the implementation's confidence
+            threshold.
+        """
+        ...
+
+
+__all__ = ["DetectedIntro", "EpisodeFingerprint", "IntroDetectorPort"]

--- a/src/modules/media/infrastructure/audio/__init__.py
+++ b/src/modules/media/infrastructure/audio/__init__.py
@@ -7,9 +7,17 @@ host on minimal Docker images.
 """
 
 from src.modules.media.infrastructure.audio.audio_extractor import AudioExtractor
+from src.modules.media.infrastructure.audio.chromaprint_intro_detector import (
+    ChromaprintIntroDetector,
+)
 from src.modules.media.infrastructure.audio.chromaprint_service import (
     ChromaprintFingerprint,
     ChromaprintService,
 )
 
-__all__ = ["AudioExtractor", "ChromaprintFingerprint", "ChromaprintService"]
+__all__ = [
+    "AudioExtractor",
+    "ChromaprintFingerprint",
+    "ChromaprintIntroDetector",
+    "ChromaprintService",
+]

--- a/src/modules/media/infrastructure/audio/chromaprint_intro_detector.py
+++ b/src/modules/media/infrastructure/audio/chromaprint_intro_detector.py
@@ -1,0 +1,294 @@
+"""Cross-correlate Chromaprint fingerprints to find a season's shared intro.
+
+Algorithm overview
+------------------
+
+For every pair of episodes (A, B):
+
+1. **Find the best alignment shift.** Cold-opens vary in length, so the
+   intro typically starts at different offsets in A and B. We sweep
+   shift values ``s`` within ±``max_alignment_shift_seconds`` and, for
+   each shift, compute the per-hash hamming distance series between
+   the aligned portions of the two fingerprints.
+
+2. **Find the longest matching segment for that shift.** Within the
+   distance series we look for the longest contiguous run of
+   low-distance positions. A small tolerance lets a few isolated bad
+   hashes survive inside an otherwise strong run (chromaprint output
+   is mildly noisy). The shift that produces the longest run wins.
+
+3. Return the matched range projected back into A and B: that pair
+   "agrees" on those time spans being the intro.
+
+Each episode then accumulates votes from every pair it appears in:
+
+* ``confidence`` = fraction of other episodes that agreed.
+* ``start`` / ``end`` = median across the pair contributions.
+
+Episodes whose confidence falls below ``min_pair_agreement`` or whose
+median segment is shorter than ``min_intro_seconds`` are dropped — the
+caller treats a missing entry as "no intro detected".
+"""
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from statistics import median
+
+from src.modules.media.application.ports.intro_detector_port import (
+    DetectedIntro,
+    EpisodeFingerprint,
+    IntroDetectorPort,
+)
+from src.modules.media.domain.value_objects import EpisodeId
+
+# Defaults tuned against synthetic fixtures and a couple of real
+# anime / sitcom seasons. They are exposed as constructor kwargs so
+# operators can adjust without forking the implementation.
+_DEFAULT_MAX_ALIGNMENT_SHIFT_SECONDS = 30.0
+_DEFAULT_MAX_HASH_HAMMING = 14  # bits, out of 32
+_DEFAULT_TOLERANCE_HASHES = 4
+_DEFAULT_MIN_INTRO_SECONDS = 5.0
+_DEFAULT_MIN_PAIR_AGREEMENT = 0.5
+_DEFAULT_ALIGNMENT_WINDOW_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class _PairwiseMatch:
+    """A range two fingerprints agree on."""
+
+    start_a: int
+    end_a: int  # exclusive
+    start_b: int
+    end_b: int  # exclusive
+    avg_distance: float
+
+    @property
+    def length_hashes(self) -> int:
+        """Length of the matched segment in hash positions."""
+        return self.end_a - self.start_a
+
+
+class ChromaprintIntroDetector(IntroDetectorPort):
+    """Cross-correlation detector backed by Chromaprint raw hashes.
+
+    Attributes:
+        max_alignment_shift_seconds: How far cold-open lengths between
+            two episodes can differ. Wider values cost more search time;
+            30s comfortably covers most production patterns.
+        max_hash_hamming: Per-hash hamming distance (out of 32 bits)
+            considered "matching". 14 ≈ 44% bit divergence — generous
+            enough to absorb the natural Chromaprint noise floor.
+        tolerance_hashes: How many consecutive non-matching hashes a
+            run can tolerate before terminating. Smooths over isolated
+            spikes inside an otherwise strong match.
+        min_intro_seconds: Discard matches shorter than this. Stops the
+            detector from firing on incidental musical stings.
+        min_pair_agreement: Episodes whose match-rate against their
+            peers falls below this fraction are dropped.
+        alignment_window_seconds: How much of each fingerprint to scan
+            when picking the alignment shift. Search is bounded so the
+            algorithm stays linear in fingerprint length.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_alignment_shift_seconds: float = _DEFAULT_MAX_ALIGNMENT_SHIFT_SECONDS,
+        max_hash_hamming: int = _DEFAULT_MAX_HASH_HAMMING,
+        tolerance_hashes: int = _DEFAULT_TOLERANCE_HASHES,
+        min_intro_seconds: float = _DEFAULT_MIN_INTRO_SECONDS,
+        min_pair_agreement: float = _DEFAULT_MIN_PAIR_AGREEMENT,
+        alignment_window_seconds: float = _DEFAULT_ALIGNMENT_WINDOW_SECONDS,
+    ) -> None:
+        self._max_alignment_shift_seconds = max_alignment_shift_seconds
+        self._max_hash_hamming = max_hash_hamming
+        self._tolerance_hashes = tolerance_hashes
+        self._min_intro_seconds = min_intro_seconds
+        self._min_pair_agreement = min_pair_agreement
+        self._alignment_window_seconds = alignment_window_seconds
+
+    def detect(
+        self, fingerprints: Sequence[EpisodeFingerprint]
+    ) -> Mapping[EpisodeId, DetectedIntro]:
+        """Run the full pairwise + voting pipeline.
+
+        See module docstring for the algorithm.
+        """
+        if len(fingerprints) < 2:
+            return {}
+
+        # Per-episode hash rate — derived rather than hard-coded so the
+        # detector survives chromaprint version changes.
+        hash_rates = {fp.episode_id: _hash_rate(fp) for fp in fingerprints}
+        # Fingerprints with too little audio to host a real intro fall
+        # out of the pool entirely; otherwise they would confuse voting.
+        usable = [fp for fp in fingerprints if hash_rates[fp.episode_id] > 0]
+        if len(usable) < 2:
+            return {}
+
+        per_episode_segments: dict[EpisodeId, list[tuple[float, float]]] = defaultdict(list)
+
+        for i, fp_a in enumerate(usable):
+            for fp_b in usable[i + 1 :]:
+                match = self._pairwise_match(fp_a, fp_b, hash_rates)
+                if match is None:
+                    continue
+                rate_a = hash_rates[fp_a.episode_id]
+                rate_b = hash_rates[fp_b.episode_id]
+                per_episode_segments[fp_a.episode_id].append(
+                    (match.start_a / rate_a, match.end_a / rate_a)
+                )
+                per_episode_segments[fp_b.episode_id].append(
+                    (match.start_b / rate_b, match.end_b / rate_b)
+                )
+
+        return self._build_consensus(usable, per_episode_segments)
+
+    # ── pairwise matching ─────────────────────────────────────────────
+
+    def _pairwise_match(
+        self,
+        fp_a: EpisodeFingerprint,
+        fp_b: EpisodeFingerprint,
+        hash_rates: Mapping[EpisodeId, float],
+    ) -> _PairwiseMatch | None:
+        """Return the best matching range between two fingerprints, or ``None``."""
+        a_hashes = fp_a.hashes
+        b_hashes = fp_b.hashes
+
+        rate = (hash_rates[fp_a.episode_id] + hash_rates[fp_b.episode_id]) / 2
+        max_shift = max(1, int(self._max_alignment_shift_seconds * rate))
+        window_cap = int(self._alignment_window_seconds * rate)
+
+        best: _PairwiseMatch | None = None
+        for shift in range(-max_shift, max_shift + 1):
+            a_start = max(0, -shift)
+            b_start = max(0, shift)
+            scan_len = min(
+                len(a_hashes) - a_start,
+                len(b_hashes) - b_start,
+                window_cap,
+            )
+            if scan_len <= 0:
+                continue
+
+            distances = [
+                _popcount(a_hashes[a_start + k] ^ b_hashes[b_start + k]) for k in range(scan_len)
+            ]
+            run_start, run_length, avg = self._longest_run(distances)
+            if run_length == 0:
+                continue
+
+            if best is None or run_length > best.length_hashes:
+                best = _PairwiseMatch(
+                    start_a=a_start + run_start,
+                    end_a=a_start + run_start + run_length,
+                    start_b=b_start + run_start,
+                    end_b=b_start + run_start + run_length,
+                    avg_distance=avg,
+                )
+
+        if best is None:
+            return None
+        # Reject the match if its projected duration falls below the
+        # floor — the consensus step would drop it anyway, but doing it
+        # here keeps the per-episode segment list cleaner.
+        seconds = best.length_hashes / rate
+        if seconds < self._min_intro_seconds:
+            return None
+        return best
+
+    def _longest_run(self, distances: list[int]) -> tuple[int, int, float]:
+        """Return (start, length, avg_distance) of the longest tolerant run.
+
+        A "run" is a contiguous span of positions where the running
+        count of "bad" hashes (distance > ``max_hash_hamming``) stays
+        below ``tolerance_hashes``. The tolerance lets a few isolated
+        outliers survive inside an otherwise strong match — chromaprint
+        often emits one or two bit-flipped hashes per second of clean
+        audio.
+        """
+        best_start = 0
+        best_length = 0
+        best_sum = 0
+        run_start = 0
+        run_bad = 0
+        run_sum = 0
+        run_length = 0
+        for i, d in enumerate(distances):
+            is_bad = d > self._max_hash_hamming
+            if run_length == 0 and is_bad:
+                continue
+            if run_length == 0:
+                run_start = i
+                run_bad = 0
+                run_sum = 0
+            run_length = i - run_start + 1
+            run_sum += d
+            if is_bad:
+                run_bad += 1
+            if run_bad > self._tolerance_hashes:
+                # End this run; record it if it beat the current best
+                # without counting the trailing bad streak.
+                trim = self._tolerance_hashes
+                effective_length = run_length - trim
+                if effective_length > best_length:
+                    best_start = run_start
+                    best_length = effective_length
+                    best_sum = run_sum
+                run_length = 0
+                continue
+            if run_length > best_length:
+                best_start = run_start
+                best_length = run_length
+                best_sum = run_sum
+
+        avg = (best_sum / best_length) if best_length else 0.0
+        return best_start, best_length, avg
+
+    # ── consensus voting ──────────────────────────────────────────────
+
+    def _build_consensus(
+        self,
+        fingerprints: Sequence[EpisodeFingerprint],
+        per_episode_segments: Mapping[EpisodeId, list[tuple[float, float]]],
+    ) -> Mapping[EpisodeId, DetectedIntro]:
+        """Aggregate per-pair matches into one marker per episode."""
+        result: dict[EpisodeId, DetectedIntro] = {}
+        peer_count = len(fingerprints) - 1
+        for episode_id, segments in per_episode_segments.items():
+            if not segments:
+                continue
+            confidence = len(segments) / peer_count
+            if confidence < self._min_pair_agreement:
+                continue
+            start_seconds = float(median(s for s, _ in segments))
+            end_seconds = float(median(e for _, e in segments))
+            if end_seconds - start_seconds < self._min_intro_seconds:
+                continue
+            result[episode_id] = DetectedIntro(
+                start_seconds=start_seconds,
+                end_seconds=end_seconds,
+                confidence=min(1.0, confidence),
+            )
+        return result
+
+
+def _popcount(value: int) -> int:
+    """Hamming weight of a 32-bit integer."""
+    # Mask down to 32 bits in case a caller hands us a Python int that
+    # overflowed the unsigned range — bit_count works on the absolute
+    # value, but XOR'ing two large negatives could otherwise return a
+    # surprising count.
+    return (value & 0xFFFFFFFF).bit_count()
+
+
+def _hash_rate(fp: EpisodeFingerprint) -> float:
+    """Return hashes per second for ``fp``, or 0.0 when inapplicable."""
+    if fp.duration_seconds <= 0 or not fp.hashes:
+        return 0.0
+    return len(fp.hashes) / fp.duration_seconds
+
+
+__all__ = ["ChromaprintIntroDetector"]

--- a/src/modules/media/infrastructure/audio/chromaprint_intro_detector.py
+++ b/src/modules/media/infrastructure/audio/chromaprint_intro_detector.py
@@ -61,7 +61,6 @@ class _PairwiseMatch:
     end_a: int  # exclusive
     start_b: int
     end_b: int  # exclusive
-    avg_distance: float
 
     @property
     def length_hashes(self) -> int:
@@ -159,7 +158,10 @@ class ChromaprintIntroDetector(IntroDetectorPort):
 
         rate = (hash_rates[fp_a.episode_id] + hash_rates[fp_b.episode_id]) / 2
         max_shift = max(1, int(self._max_alignment_shift_seconds * rate))
-        window_cap = int(self._alignment_window_seconds * rate)
+        # Floor at 1 so a misconfigured ``alignment_window_seconds`` (or
+        # an unusually low hash rate) cannot collapse the scan window
+        # to zero and silently disable matching for the pair.
+        window_cap = max(1, int(self._alignment_window_seconds * rate))
 
         best: _PairwiseMatch | None = None
         for shift in range(-max_shift, max_shift + 1):
@@ -176,7 +178,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
             distances = [
                 _popcount(a_hashes[a_start + k] ^ b_hashes[b_start + k]) for k in range(scan_len)
             ]
-            run_start, run_length, avg = self._longest_run(distances)
+            run_start, run_length = self._longest_run(distances)
             if run_length == 0:
                 continue
 
@@ -186,7 +188,6 @@ class ChromaprintIntroDetector(IntroDetectorPort):
                     end_a=a_start + run_start + run_length,
                     start_b=b_start + run_start,
                     end_b=b_start + run_start + run_length,
-                    avg_distance=avg,
                 )
 
         if best is None:
@@ -199,22 +200,22 @@ class ChromaprintIntroDetector(IntroDetectorPort):
             return None
         return best
 
-    def _longest_run(self, distances: list[int]) -> tuple[int, int, float]:
-        """Return (start, length, avg_distance) of the longest tolerant run.
+    def _longest_run(self, distances: list[int]) -> tuple[int, int]:
+        """Return (start, length) of the longest tolerant run.
 
         A "run" is a contiguous span of positions where the running
         count of "bad" hashes (distance > ``max_hash_hamming``) stays
         below ``tolerance_hashes``. The tolerance lets a few isolated
         outliers survive inside an otherwise strong match — chromaprint
         often emits one or two bit-flipped hashes per second of clean
-        audio.
+        audio. When a run terminates because tolerance was exceeded,
+        the trailing bad streak is trimmed so callers always see a
+        run that ends on a "good" position.
         """
         best_start = 0
         best_length = 0
-        best_sum = 0
         run_start = 0
         run_bad = 0
-        run_sum = 0
         run_length = 0
         for i, d in enumerate(distances):
             is_bad = d > self._max_hash_hamming
@@ -223,29 +224,24 @@ class ChromaprintIntroDetector(IntroDetectorPort):
             if run_length == 0:
                 run_start = i
                 run_bad = 0
-                run_sum = 0
             run_length = i - run_start + 1
-            run_sum += d
             if is_bad:
                 run_bad += 1
             if run_bad > self._tolerance_hashes:
-                # End this run; record it if it beat the current best
-                # without counting the trailing bad streak.
-                trim = self._tolerance_hashes
-                effective_length = run_length - trim
+                # End this run; record it if it beat the current best,
+                # trimming the trailing bad streak so the reported range
+                # ends on a "good" position.
+                effective_length = run_length - self._tolerance_hashes
                 if effective_length > best_length:
                     best_start = run_start
                     best_length = effective_length
-                    best_sum = run_sum
                 run_length = 0
                 continue
             if run_length > best_length:
                 best_start = run_start
                 best_length = run_length
-                best_sum = run_sum
 
-        avg = (best_sum / best_length) if best_length else 0.0
-        return best_start, best_length, avg
+        return best_start, best_length
 
     # ── consensus voting ──────────────────────────────────────────────
 

--- a/tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py
+++ b/tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py
@@ -1,0 +1,254 @@
+"""Tests for ChromaprintIntroDetector.
+
+The detector is an algorithm; tests build synthetic fingerprints
+(deterministic intro prefixes + random tails) and assert the algorithm
+recovers the planted intro within tolerance. No real fpcalc is
+required.
+"""
+
+import random
+
+import pytest
+
+from src.modules.media.application.ports import (
+    DetectedIntro,
+    EpisodeFingerprint,
+)
+from src.modules.media.domain.value_objects import EpisodeId
+from src.modules.media.infrastructure.audio.chromaprint_intro_detector import (
+    ChromaprintIntroDetector,
+)
+
+_HASH_RATE = 8.0  # roughly the Chromaprint default; keeps math tidy
+_BIT_MASK = 0xFFFFFFFF
+
+
+def _make_random_hashes(count: int, *, seed: int) -> list[int]:
+    """Return ``count`` deterministic 32-bit hashes."""
+    rng = random.Random(seed)
+    return [rng.randint(0, _BIT_MASK) for _ in range(count)]
+
+
+def _flip_bits(value: int, count: int, *, seed: int) -> int:
+    """Flip ``count`` random bits in a 32-bit integer for noise simulation."""
+    rng = random.Random(seed)
+    bit_positions = rng.sample(range(32), count)
+    mask = 0
+    for pos in bit_positions:
+        mask |= 1 << pos
+    return (value ^ mask) & _BIT_MASK
+
+
+def _episode(
+    *,
+    intro_hashes: list[int],
+    intro_offset_hashes: int,
+    total_hashes: int,
+    seed: int,
+    noise_bits: int = 0,
+    episode_id: EpisodeId | None = None,
+) -> EpisodeFingerprint:
+    """Build a fingerprint with ``intro_hashes`` planted at ``intro_offset_hashes``."""
+    tail_hashes = _make_random_hashes(total_hashes, seed=seed)
+    payload = list(tail_hashes)
+    for i, intro_hash in enumerate(intro_hashes):
+        position = intro_offset_hashes + i
+        if position >= total_hashes:
+            break
+        if noise_bits > 0:
+            payload[position] = _flip_bits(intro_hash, noise_bits, seed=seed * 1000 + i)
+        else:
+            payload[position] = intro_hash
+    return EpisodeFingerprint(
+        episode_id=episode_id or EpisodeId.generate(),
+        hashes=payload,
+        duration_seconds=total_hashes / _HASH_RATE,
+    )
+
+
+@pytest.fixture
+def shared_intro() -> list[int]:
+    """Deterministic intro segment shared across the synthetic episodes.
+
+    ~80 hashes ≈ 10 seconds at 8 hashes/sec — comfortably above the
+    default ``min_intro_seconds`` floor of 5.
+    """
+    return _make_random_hashes(80, seed=4242)
+
+
+@pytest.mark.unit
+class TestChromaprintIntroDetector:
+    """Algorithm-level tests using synthetic fingerprints."""
+
+    def test_returns_empty_when_fewer_than_two_fingerprints(self, shared_intro: list[int]) -> None:
+        detector = ChromaprintIntroDetector()
+        single = _episode(
+            intro_hashes=shared_intro,
+            intro_offset_hashes=0,
+            total_hashes=400,
+            seed=1,
+        )
+
+        assert detector.detect([single]) == {}
+
+    def test_returns_empty_when_episodes_share_nothing(self) -> None:
+        detector = ChromaprintIntroDetector()
+        episodes = [
+            EpisodeFingerprint(
+                episode_id=EpisodeId.generate(),
+                hashes=_make_random_hashes(400, seed=seed),
+                duration_seconds=400 / _HASH_RATE,
+            )
+            for seed in range(3)
+        ]
+
+        result = detector.detect(episodes)
+
+        assert result == {}
+
+    def test_detects_shared_intro_at_zero_offset(self, shared_intro: list[int]) -> None:
+        detector = ChromaprintIntroDetector()
+        episodes = [
+            _episode(
+                intro_hashes=shared_intro,
+                intro_offset_hashes=0,
+                total_hashes=400,
+                seed=seed,
+            )
+            for seed in (1, 2, 3, 4)
+        ]
+
+        result = detector.detect(episodes)
+
+        assert len(result) == len(episodes)
+        for episode in episodes:
+            marker = result[episode.episode_id]
+            assert isinstance(marker, DetectedIntro)
+            # Intro starts at 0s, lasts ≈ 80/8 = 10s.
+            assert marker.start_seconds == pytest.approx(0.0, abs=0.5)
+            assert marker.end_seconds == pytest.approx(10.0, abs=1.5)
+            assert marker.confidence == pytest.approx(1.0, abs=1e-6)
+
+    def test_detects_intro_with_varying_cold_open_lengths(self, shared_intro: list[int]) -> None:
+        detector = ChromaprintIntroDetector()
+        # Each episode has a different cold-open length, so the intro
+        # starts at a different offset in each fingerprint. The
+        # detector must align them via shift search.
+        offsets = [0, 16, 40, 24]  # in hashes — i.e. 0s, 2s, 5s, 3s of cold-open
+        episodes = [
+            _episode(
+                intro_hashes=shared_intro,
+                intro_offset_hashes=offset,
+                total_hashes=500,
+                seed=seed,
+            )
+            for seed, offset in enumerate(offsets, start=10)
+        ]
+
+        result = detector.detect(episodes)
+
+        assert len(result) == len(episodes)
+        for episode, offset in zip(episodes, offsets, strict=True):
+            marker = result[episode.episode_id]
+            expected_start = offset / _HASH_RATE
+            expected_end = (offset + len(shared_intro)) / _HASH_RATE
+            assert marker.start_seconds == pytest.approx(expected_start, abs=1.0)
+            assert marker.end_seconds == pytest.approx(expected_end, abs=1.5)
+
+    def test_tolerates_mild_per_hash_bit_noise(self, shared_intro: list[int]) -> None:
+        detector = ChromaprintIntroDetector()
+        # Real Chromaprint output has 0-6 bits of jitter even on the
+        # same source; flip 4 bits per intro hash and confirm the
+        # detector still locks onto the segment.
+        episodes = [
+            _episode(
+                intro_hashes=shared_intro,
+                intro_offset_hashes=0,
+                total_hashes=500,
+                seed=seed,
+                noise_bits=4,
+            )
+            for seed in (1, 2, 3)
+        ]
+
+        result = detector.detect(episodes)
+
+        assert len(result) == len(episodes)
+        for episode in episodes:
+            marker = result[episode.episode_id]
+            assert marker.start_seconds == pytest.approx(0.0, abs=1.0)
+            assert marker.end_seconds == pytest.approx(10.0, abs=1.5)
+
+    def test_drops_episode_below_pair_agreement_threshold(self, shared_intro: list[int]) -> None:
+        # Two episodes share the intro; the third has unique audio
+        # throughout. The third must be omitted from the result, the
+        # first two emitted with confidence < 1 (only one peer agreed).
+        detector = ChromaprintIntroDetector(min_pair_agreement=0.5)
+        with_intro = [
+            _episode(
+                intro_hashes=shared_intro,
+                intro_offset_hashes=0,
+                total_hashes=400,
+                seed=seed,
+            )
+            for seed in (1, 2)
+        ]
+        outlier = EpisodeFingerprint(
+            episode_id=EpisodeId.generate(),
+            hashes=_make_random_hashes(400, seed=99),
+            duration_seconds=400 / _HASH_RATE,
+        )
+
+        result = detector.detect([*with_intro, outlier])
+
+        assert outlier.episode_id not in result
+        # 1 agreeing peer out of 2 possible → confidence == 0.5
+        for episode in with_intro:
+            assert result[episode.episode_id].confidence == pytest.approx(0.5, abs=0.01)
+
+    def test_drops_short_matches_below_min_intro_seconds(self) -> None:
+        # Plant a 3-second match — under the 5s default floor. The
+        # detector should skip it entirely.
+        short_intro = _make_random_hashes(int(3 * _HASH_RATE), seed=7)
+        detector = ChromaprintIntroDetector()
+        episodes = [
+            _episode(
+                intro_hashes=short_intro,
+                intro_offset_hashes=0,
+                total_hashes=400,
+                seed=seed,
+            )
+            for seed in (1, 2, 3)
+        ]
+
+        assert detector.detect(episodes) == {}
+
+    def test_returns_empty_for_zero_duration_fingerprints(self) -> None:
+        detector = ChromaprintIntroDetector()
+        empty = [
+            EpisodeFingerprint(
+                episode_id=EpisodeId.generate(),
+                hashes=[],
+                duration_seconds=0.0,
+            )
+            for _ in range(3)
+        ]
+
+        assert detector.detect(empty) == {}
+
+    def test_confidence_is_capped_at_one(self, shared_intro: list[int]) -> None:
+        detector = ChromaprintIntroDetector()
+        episodes = [
+            _episode(
+                intro_hashes=shared_intro,
+                intro_offset_hashes=0,
+                total_hashes=400,
+                seed=seed,
+            )
+            for seed in range(3)
+        ]
+
+        result = detector.detect(episodes)
+
+        for marker in result.values():
+            assert 0.0 <= marker.confidence <= 1.0

--- a/tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py
+++ b/tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py
@@ -252,3 +252,34 @@ class TestChromaprintIntroDetector:
 
         for marker in result.values():
             assert 0.0 <= marker.confidence <= 1.0
+
+    def test_misconfigured_alignment_window_does_not_disable_matching(
+        self, shared_intro: list[int]
+    ) -> None:
+        # alignment_window_seconds * hash_rate < 1 would round down to
+        # 0 without the floor in _pairwise_match, silently skipping
+        # every shift. The detector must still fall back to a 1-hash
+        # window so misconfiguration becomes "low quality matches" and
+        # not "matching disabled".
+        detector = ChromaprintIntroDetector(
+            alignment_window_seconds=0.05,
+            min_intro_seconds=0.1,
+        )
+        episodes = [
+            _episode(
+                intro_hashes=shared_intro,
+                intro_offset_hashes=0,
+                total_hashes=400,
+                seed=seed,
+            )
+            for seed in range(3)
+        ]
+
+        result = detector.detect(episodes)
+
+        # The 1-hash floor cannot detect a 10s intro, but we explicitly
+        # do not require correctness here — just that the loop is not
+        # short-circuited into producing an empty result for a sane
+        # input pair. As long as the floor is in place, len(result)
+        # should be 3 (some segment was identified for each episode).
+        assert len(result) == len(episodes)


### PR DESCRIPTION
## Summary

Phase 4b of the skip-intro feature — the algorithm that turns a season's worth of Chromaprint fingerprints into per-episode \`DetectedIntro\` markers. **Pure algorithm + port, no orchestration**: Phase 4c will wire this together with the audio-extraction primitives (#149) and the persistence layer (#147) into a background job.

- **\`IntroDetectorPort\`** (\`src/modules/media/application/ports/intro_detector_port.py\`) — abstract port with \`EpisodeFingerprint\` (input) and \`DetectedIntro\` (output, with \`start_seconds\` / \`end_seconds\` / \`confidence\`) DTOs.
- **\`ChromaprintIntroDetector\`** (\`src/modules/media/infrastructure/audio/chromaprint_intro_detector.py\`) — implementation:
  - **Pairwise cross-correlation:** for each pair of episodes, sweeps shift values within ±\`max_alignment_shift_seconds\` (default 30s — covers cold-open length differences) and computes per-hash hamming distance.
  - **Longest tolerant run:** within each shift's distance series, finds the longest contiguous span where bad hashes (distance > \`max_hash_hamming\`, default 14 of 32 bits) stay below \`tolerance_hashes\`. The tolerance smooths over isolated noisy hashes that real Chromaprint output produces even on identical audio.
  - **Voting:** each episode collects matched ranges from every pair it appears in. \`confidence\` = fraction of peers that agreed. \`start\` / \`end\` = median across pair contributions. Episodes below \`min_pair_agreement\` (default 0.5) or with median segments shorter than \`min_intro_seconds\` (default 5s) are dropped — the orchestrator treats a missing entry as "no intro detected".
  - Hash rate is derived from each \`EpisodeFingerprint.duration_seconds / len(hashes)\` rather than hard-coded, so the detector survives Chromaprint version changes.
  - Thresholds exposed as constructor kwargs for operator tuning.

## Test plan

- [x] 9 unit tests with synthetic fingerprints (deterministic intro prefixes + random tails, no fpcalc invocation):
  - returns empty for fewer than 2 episodes
  - returns empty when episodes share no audio
  - detects shared intro at zero offset across all episodes (confidence == 1.0)
  - detects intro with varying cold-open lengths (alignment shift search)
  - tolerates 4-bit-per-hash chromaprint-style noise
  - drops outlier episode that doesn't share the intro and reflects partial agreement in confidence (0.5)
  - drops sub-floor segments shorter than \`min_intro_seconds\`
  - returns empty for zero-duration fingerprints
  - confidence stays in [0.0, 1.0]
- [x] Full project suite green (1911 passed, 5 skipped)
- [x] \`ruff check\` and \`ruff format\` clean on changed files

## Summary by Sourcery

Introduce an intro detection port and Chromaprint-based implementation to derive shared intro segments from episode audio fingerprints, along with unit tests for the detection algorithm.

New Features:
- Add IntroDetectorPort abstraction with EpisodeFingerprint and DetectedIntro DTOs for intro detection from audio fingerprints.
- Provide ChromaprintIntroDetector implementation that cross-correlates Chromaprint hashes to detect shared intro segments across episodes and exposes it via the audio infrastructure package.

Tests:
- Add unit test suite for ChromaprintIntroDetector using synthetic fingerprints to cover detection behavior, thresholds, noise tolerance, and edge cases.