### PR TITLE
feat(media): background job that auto-detects intro markers

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -15,7 +15,11 @@ from src.config.containers.media import MediaContainer
 from src.config.containers.preferences import PreferencesContainer
 from src.config.containers.watch_progress import WatchProgressContainer
 from src.config.settings import Settings
-from src.infrastructure.scheduling import LibraryScanScheduler, ThumbnailBackfillJob
+from src.infrastructure.scheduling import (
+    IntroDetectionJob,
+    LibraryScanScheduler,
+    ThumbnailBackfillJob,
+)
 from src.modules.media.infrastructure.acl import ProgressLookupAdapter
 from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyWatchProgressUnitOfWorkFactory,
@@ -132,6 +136,17 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         thumbnail_service=media.thumbnail_generation_service,
         batch_size=config.provided.thumbnail_backfill_batch_size,
         sprite_subdir=config.provided.thumbnail_backfill_subdir,
+    )
+
+    intro_detection_job = providers.Singleton(
+        IntroDetectionJob,
+        media_uow_factory=media.media_unit_of_work_factory,
+        audio_extractor=media.audio_extractor,
+        chromaprint_service=media.chromaprint_service,
+        intro_detector=media.intro_detector,
+        batch_size=config.provided.intro_detection_batch_size,
+        audio_window_seconds=config.provided.intro_detection_audio_window_seconds,
+        min_confidence=config.provided.intro_detection_min_confidence,
     )
 
 

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -43,6 +43,11 @@ from src.modules.media.application.use_cases.serve_hls_file import ServeHlsFileU
 from src.modules.media.application.use_cases.set_episode_intro import SetEpisodeIntroUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
 from src.modules.media.application.use_cases.stream_file_range import StreamFileRangeUseCase
+from src.modules.media.infrastructure.audio import (
+    AudioExtractor,
+    ChromaprintIntroDetector,
+    ChromaprintService,
+)
 from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
 from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
@@ -223,6 +228,19 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         ThumbnailGenerationService,
         ffmpeg_threads=ffmpeg_threads,
     )
+
+    # Audio analysis primitives — shared by the periodic intro detection
+    # job. Singletons because each wrapper is stateless apart from the
+    # configured ffmpeg threads / fpcalc timeout, and the job runs them
+    # serially per tick.
+    audio_extractor = providers.Singleton(
+        AudioExtractor,
+        ffmpeg_threads=ffmpeg_threads,
+    )
+
+    chromaprint_service = providers.Singleton(ChromaprintService)
+
+    intro_detector = providers.Singleton(ChromaprintIntroDetector)
 
     file_streamer = providers.Factory(LocalFileStreamer)
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -153,6 +153,45 @@ class Settings(BaseSettings):  # type: ignore[misc]
         "folder) where backfilled sprite + VTT files are written.",
     )
 
+    intro_detection_enabled: bool = Field(
+        default=False,
+        description="Enable the periodic intro-detection job that locates "
+        "the shared opening sequence for each season via Chromaprint "
+        "audio fingerprinting. Off by default because it requires the "
+        "``fpcalc`` binary on PATH; turn it on once Chromaprint is "
+        "installed (``apt install libchromaprint-tools`` / "
+        "``brew install chromaprint``).",
+    )
+    intro_detection_batch_size: int = Field(
+        default=1,
+        ge=1,
+        description="Maximum number of seasons processed per detection "
+        "tick. Each season triggers ffmpeg + fpcalc per episode, so "
+        "values above 2 can saturate the host on large seasons.",
+    )
+    intro_detection_interval_minutes: int = Field(
+        default=30,
+        ge=1,
+        description="How often the intro-detection job runs.",
+    )
+    intro_detection_audio_window_seconds: int = Field(
+        default=600,
+        ge=60,
+        description="How many seconds of leading audio to analyse per "
+        "episode. 600s (10 min) covers all common cold-open + intro "
+        "lengths; trimming this lower speeds up the job at the cost "
+        "of missing intros that start late.",
+    )
+    intro_detection_min_confidence: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=1.0,
+        description="Minimum detector confidence (in ``[0.0, 1.0]``) "
+        "required before an auto-detected intro is persisted. Confidence "
+        "is the fraction of peer episodes whose fingerprint agreed "
+        "with the candidate marker.",
+    )
+
     ffmpeg_threads: int | None = Field(
         default=None,
         ge=1,

--- a/src/infrastructure/scheduling/__init__.py
+++ b/src/infrastructure/scheduling/__init__.py
@@ -1,11 +1,12 @@
 """Background scheduling infrastructure.
 
 The scheduler coordinates recurring work (library scans, scrub-preview
-thumbnail backfill) without coupling the domain or application layers
-to any specific scheduling backend.
+thumbnail backfill, intro detection) without coupling the domain or
+application layers to any specific scheduling backend.
 """
 
+from src.infrastructure.scheduling.intro_detection_job import IntroDetectionJob
 from src.infrastructure.scheduling.scheduler_service import LibraryScanScheduler
 from src.infrastructure.scheduling.thumbnail_backfill_job import ThumbnailBackfillJob
 
-__all__ = ["LibraryScanScheduler", "ThumbnailBackfillJob"]
+__all__ = ["IntroDetectionJob", "LibraryScanScheduler", "ThumbnailBackfillJob"]

--- a/src/infrastructure/scheduling/intro_detection_job.py
+++ b/src/infrastructure/scheduling/intro_detection_job.py
@@ -129,10 +129,20 @@ class IntroDetectionJob:
         """Drive one season through the detection pipeline.
 
         Returns the state the season was transitioned to (used by
-        ``run`` for the per-tick log line).
+        ``run`` for the per-tick log line). The caller relies on this
+        method never raising — a single bad season must not abort the
+        rest of the tick.
         """
         season_id = season.id
         if season_id is None:
+            # Defensive: the repository fetches persisted seasons, so a
+            # missing id would mean the entity was hand-built somewhere
+            # downstream. Surface it instead of silently dropping the
+            # season from the batch counters.
+            _logger.error(
+                "[intro-detection] skipping season with no id; cannot "
+                "transition state without a primary key",
+            )
             return IntroDetectionState.FAILED
 
         try:
@@ -152,11 +162,21 @@ class IntroDetectionJob:
                 season_id=str(season_id),
             )
             error_message = f"{type(exc).__name__}: {exc}"[:_MAX_ERROR_MESSAGE_LENGTH]
-            await self._mark_state(
-                season_id,
-                IntroDetectionState.FAILED,
-                error=error_message,
-            )
+            # Best-effort recording of the failure: if even the FAILED
+            # transition itself raises (DB hiccup mid-tick), swallow it
+            # so the batch loop in ``run`` can keep processing the rest
+            # of the seasons.
+            try:
+                await self._mark_state(
+                    season_id,
+                    IntroDetectionState.FAILED,
+                    error=error_message,
+                )
+            except Exception:
+                _logger.exception(
+                    "[intro-detection] failed to record FAILED state",
+                    season_id=str(season_id),
+                )
             return IntroDetectionState.FAILED
 
     async def _detect_and_persist(self, season: Season, season_id: SeasonId) -> IntroDetectionState:
@@ -202,19 +222,32 @@ class IntroDetectionJob:
         window = self._audio_window_seconds
 
         def _extract_and_fingerprint() -> EpisodeFingerprint | None:
-            with self._audio_extractor.extract_temporary(
-                file_path, duration_seconds=window
-            ) as wav_path:
-                if wav_path is None:
-                    return None
-                fingerprint = self._chromaprint_service.fingerprint(wav_path)
-                if fingerprint is None:
-                    return None
-                return EpisodeFingerprint(
-                    episode_id=episode_id,
-                    hashes=list(fingerprint.hashes),
-                    duration_seconds=fingerprint.duration_seconds,
+            # Per the docstring: any failure here just drops the
+            # episode from the detection pool. An unexpected exception
+            # from the audio stack must NOT promote into a season-level
+            # FAILED — the rest of the episodes might still produce a
+            # quorum. Swallow + log instead of letting it bubble.
+            try:
+                with self._audio_extractor.extract_temporary(
+                    file_path, duration_seconds=window
+                ) as wav_path:
+                    if wav_path is None:
+                        return None
+                    fingerprint = self._chromaprint_service.fingerprint(wav_path)
+            except Exception:
+                _logger.exception(
+                    "[intro-detection] fingerprinting episode failed; skipping",
+                    episode_id=str(episode_id),
+                    file_path=file_path,
                 )
+                return None
+            if fingerprint is None:
+                return None
+            return EpisodeFingerprint(
+                episode_id=episode_id,
+                hashes=list(fingerprint.hashes),
+                duration_seconds=fingerprint.duration_seconds,
+            )
 
         return await asyncio.to_thread(_extract_and_fingerprint)
 

--- a/src/infrastructure/scheduling/intro_detection_job.py
+++ b/src/infrastructure/scheduling/intro_detection_job.py
@@ -1,0 +1,271 @@
+"""Periodic background job that locates per-season opening sequences.
+
+Each tick:
+
+1. Pulls a small batch of seasons whose ``intro_detection_state`` is
+   ``NOT_STARTED`` or ``INSUFFICIENT_EPISODES``.
+2. For each season, marks it ``IN_PROGRESS``, then in turn:
+   * skips episodes that already carry a ``MANUAL`` marker (operators
+     opt out of automatic detection by editing the marker manually);
+   * extracts the leading audio window of every other episode and
+     hands it to fpcalc;
+   * runs the cross-correlation detector on the resulting
+     fingerprints;
+   * persists auto-detected markers whose confidence clears
+     ``min_confidence``;
+   * transitions the season to ``COMPLETED``,
+     ``INSUFFICIENT_EPISODES``, or ``FAILED``.
+
+A single bad season is logged and marked ``FAILED``; the rest of the
+batch continues. Episodes whose audio cannot be extracted (missing
+file, missing binary, unreadable codec) are quietly excluded from the
+detection pool — the job is best-effort by design.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from src.config.logging import get_logger
+from src.modules.media.application.ports import EpisodeFingerprint
+from src.modules.media.domain.value_objects import (
+    IntroDetectionState,
+    IntroMarker,
+    IntroMarkerSource,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from src.modules.media.application.ports import DetectedIntro, IntroDetectorPort
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.domain.entities import Episode, Season
+    from src.modules.media.domain.value_objects import EpisodeId, SeasonId
+    from src.modules.media.infrastructure.audio import (
+        AudioExtractor,
+        ChromaprintService,
+    )
+
+_logger = get_logger()
+
+_MIN_EPISODES_FOR_DETECTION = 2
+# Cap the persisted error message; matches the field-level cap on the
+# Season entity but applied here too so the orchestrator never hands
+# the entity an oversized payload.
+_MAX_ERROR_MESSAGE_LENGTH = 2000
+
+
+class IntroDetectionJob:
+    """Run a single batch of audio-fingerprint intro detection.
+
+    Args:
+        media_uow_factory: Builds fresh media UoWs. The job opens one
+            UoW per state transition so a failure on a single season
+            rolls back only that season's progress.
+        audio_extractor: ffmpeg wrapper that produces a leading WAV
+            window per episode.
+        chromaprint_service: fpcalc wrapper that turns each WAV into a
+            raw fingerprint.
+        intro_detector: Cross-correlation algorithm that locates the
+            shared intro across the season's fingerprints.
+        batch_size: Maximum number of seasons processed per tick.
+        audio_window_seconds: How many leading seconds of each episode
+            to feed into fpcalc.
+        min_confidence: Auto-detected markers with confidence below
+            this floor are discarded — the season is still flagged
+            ``COMPLETED`` so it is not reprocessed indefinitely.
+    """
+
+    def __init__(
+        self,
+        media_uow_factory: MediaUnitOfWorkFactory,
+        audio_extractor: AudioExtractor,
+        chromaprint_service: ChromaprintService,
+        intro_detector: IntroDetectorPort,
+        *,
+        batch_size: int = 1,
+        audio_window_seconds: int = 600,
+        min_confidence: float = 0.7,
+    ) -> None:
+        self._media_uow_factory = media_uow_factory
+        self._audio_extractor = audio_extractor
+        self._chromaprint_service = chromaprint_service
+        self._intro_detector = intro_detector
+        self._batch_size = batch_size
+        self._audio_window_seconds = audio_window_seconds
+        self._min_confidence = min_confidence
+
+    async def run(self) -> None:
+        """Process one batch of pending seasons."""
+        async with self._media_uow_factory() as uow:
+            seasons = list(await uow.series.find_seasons_pending_intro_detection(self._batch_size))
+
+        if not seasons:
+            return
+
+        completed = 0
+        insufficient = 0
+        failed = 0
+        for season in seasons:
+            outcome = await self._process_season(season)
+            if outcome == IntroDetectionState.COMPLETED:
+                completed += 1
+            elif outcome == IntroDetectionState.INSUFFICIENT_EPISODES:
+                insufficient += 1
+            elif outcome == IntroDetectionState.FAILED:
+                failed += 1
+
+        _logger.info(
+            "[intro-detection] tick complete",
+            seasons_completed=completed,
+            seasons_insufficient=insufficient,
+            seasons_failed=failed,
+            batch_size=self._batch_size,
+        )
+
+    async def _process_season(self, season: Season) -> IntroDetectionState:
+        """Drive one season through the detection pipeline.
+
+        Returns the state the season was transitioned to (used by
+        ``run`` for the per-tick log line).
+        """
+        season_id = season.id
+        if season_id is None:
+            return IntroDetectionState.FAILED
+
+        try:
+            await self._mark_state(season_id, IntroDetectionState.IN_PROGRESS)
+        except Exception:
+            _logger.exception(
+                "[intro-detection] failed to claim season",
+                season_id=str(season_id),
+            )
+            return IntroDetectionState.FAILED
+
+        try:
+            return await self._detect_and_persist(season, season_id)
+        except Exception as exc:
+            _logger.exception(
+                "[intro-detection] season processing failed",
+                season_id=str(season_id),
+            )
+            error_message = f"{type(exc).__name__}: {exc}"[:_MAX_ERROR_MESSAGE_LENGTH]
+            await self._mark_state(
+                season_id,
+                IntroDetectionState.FAILED,
+                error=error_message,
+            )
+            return IntroDetectionState.FAILED
+
+    async def _detect_and_persist(self, season: Season, season_id: SeasonId) -> IntroDetectionState:
+        candidates = [ep for ep in season.episodes if not _has_manual_marker(ep)]
+        if len(candidates) < _MIN_EPISODES_FOR_DETECTION:
+            await self._mark_state(season_id, IntroDetectionState.INSUFFICIENT_EPISODES)
+            return IntroDetectionState.INSUFFICIENT_EPISODES
+
+        fingerprints = await self._build_fingerprints(candidates)
+        if len(fingerprints) < _MIN_EPISODES_FOR_DETECTION:
+            await self._mark_state(season_id, IntroDetectionState.INSUFFICIENT_EPISODES)
+            return IntroDetectionState.INSUFFICIENT_EPISODES
+
+        detections = await asyncio.to_thread(self._intro_detector.detect, fingerprints)
+        await self._persist_detections(detections)
+        await self._mark_state(season_id, IntroDetectionState.COMPLETED)
+        return IntroDetectionState.COMPLETED
+
+    async def _build_fingerprints(self, episodes: list[Episode]) -> list[EpisodeFingerprint]:
+        """Extract audio + fingerprint each episode, dropping failures."""
+        results: list[EpisodeFingerprint] = []
+        for episode in episodes:
+            fingerprint = await self._fingerprint_episode(episode)
+            if fingerprint is not None:
+                results.append(fingerprint)
+        return results
+
+    async def _fingerprint_episode(self, episode: Episode) -> EpisodeFingerprint | None:
+        """Run ffmpeg + fpcalc against a single episode.
+
+        Returns ``None`` when any step degrades — missing primary file,
+        ffmpeg or fpcalc absent, malformed output. A ``None`` here just
+        means this episode does not contribute to detection on this
+        tick; nothing is persisted as failed.
+        """
+        if episode.id is None:
+            return None
+        primary = episode.primary_file
+        if primary is None:
+            return None
+        episode_id = episode.id
+        file_path = primary.file_path.value
+        window = self._audio_window_seconds
+
+        def _extract_and_fingerprint() -> EpisodeFingerprint | None:
+            with self._audio_extractor.extract_temporary(
+                file_path, duration_seconds=window
+            ) as wav_path:
+                if wav_path is None:
+                    return None
+                fingerprint = self._chromaprint_service.fingerprint(wav_path)
+                if fingerprint is None:
+                    return None
+                return EpisodeFingerprint(
+                    episode_id=episode_id,
+                    hashes=list(fingerprint.hashes),
+                    duration_seconds=fingerprint.duration_seconds,
+                )
+
+        return await asyncio.to_thread(_extract_and_fingerprint)
+
+    async def _persist_detections(self, detections: Mapping[EpisodeId, DetectedIntro]) -> None:
+        """Persist the auto-detected markers that clear the confidence floor."""
+        if not detections:
+            return
+        async with self._media_uow_factory() as uow:
+            for episode_id, detected in detections.items():
+                if detected.confidence < self._min_confidence:
+                    continue
+                marker = _build_auto_marker(detected)
+                await uow.series.update_episode_intro(episode_id, marker)
+
+    async def _mark_state(
+        self,
+        season_id: SeasonId,
+        state: IntroDetectionState,
+        *,
+        error: str | None = None,
+    ) -> None:
+        async with self._media_uow_factory() as uow:
+            await uow.series.update_season_intro_detection(
+                season_id,
+                state,
+                attempted_at=datetime.now(UTC),
+                error=error,
+            )
+
+
+def _build_auto_marker(detected: DetectedIntro) -> IntroMarker:
+    """Convert a detector result into a persistable AUTO_DETECTED marker.
+
+    Domain validation requires ``end > start``; the detector's float
+    timestamps round to integer seconds for the persisted marker, and
+    a 1-second floor on duration prevents the rounding from flattening
+    a sub-second match into an invalid range.
+    """
+    start = max(0, int(detected.start_seconds))
+    end = max(start + 1, int(detected.end_seconds))
+    return IntroMarker(
+        start_seconds=start,
+        end_seconds=end,
+        source=IntroMarkerSource.AUTO_DETECTED,
+        confidence=detected.confidence,
+    )
+
+
+def _has_manual_marker(episode: Episode) -> bool:
+    """Return ``True`` when the episode's intro was set manually."""
+    return episode.intro is not None and episode.intro.is_manual
+
+
+__all__ = ["IntroDetectionJob"]

--- a/src/main.py
+++ b/src/main.py
@@ -95,10 +95,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # Subscribe domain event handlers
     _subscribe_event_handlers(container)
 
-    # Start background scheduler (library scans + thumbnail backfill).
-    # The provider depends on the session_factory Resource, so it
-    # resolves asynchronously — must be awaited. Always pin a slot on
-    # app.state so the shutdown handler can do a single truthy check.
+    # Start background scheduler (library scans + thumbnail backfill +
+    # intro detection). The provider depends on the session_factory
+    # Resource, so it resolves asynchronously — must be awaited. Always
+    # pin a slot on app.state so the shutdown handler can do a single
+    # truthy check.
     app.state.scheduler = None
     if settings.scheduler_enabled:
         scheduler = await container.library_scan_scheduler()
@@ -109,6 +110,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 backfill_job.run,
                 minutes=settings.thumbnail_backfill_interval_minutes,
                 job_id="homeflix:thumbnail-backfill",
+            )
+        if settings.intro_detection_enabled:
+            intro_job = await container.intro_detection_job()
+            scheduler.add_interval_job(
+                intro_job.run,
+                minutes=settings.intro_detection_interval_minutes,
+                job_id="homeflix:intro-detection",
             )
         app.state.scheduler = scheduler
 

--- a/tests/infrastructure/scheduling/test_intro_detection_job.py
+++ b/tests/infrastructure/scheduling/test_intro_detection_job.py
@@ -1,0 +1,376 @@
+"""Tests for IntroDetectionJob.
+
+Mocks the media UoW factory and the three audio services so the
+tests exercise orchestration (state transitions, episode filtering,
+confidence floor, error handling) without touching ffmpeg, fpcalc, or
+the database.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.infrastructure.scheduling.intro_detection_job import IntroDetectionJob
+from src.modules.media.application.ports import DetectedIntro
+from src.modules.media.domain.entities import Episode, Season
+from src.modules.media.domain.value_objects import (
+    Duration,
+    EpisodeId,
+    EpisodeNumber,
+    FilePath,
+    IntroDetectionState,
+    IntroMarker,
+    IntroMarkerSource,
+    MediaFile,
+    Resolution,
+    SeasonId,
+    SeasonNumber,
+    SeriesId,
+    Title,
+)
+from src.modules.media.infrastructure.audio import ChromaprintFingerprint
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _make_episode(
+    *,
+    series_id: SeriesId,
+    episode_number: int = 1,
+    file_path: str | None = None,
+    intro: IntroMarker | None = None,
+) -> Episode:
+    path = file_path or f"/series/show/s01e{episode_number:02d}.mkv"
+    episode = Episode(
+        id=EpisodeId.generate(),
+        series_id=series_id,
+        season_number=SeasonNumber(1),
+        episode_number=EpisodeNumber(episode_number),
+        title=Title(f"Episode {episode_number}"),
+        duration=Duration(2700),
+        files=[
+            MediaFile(
+                file_path=FilePath(path),
+                file_size=1_000_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            )
+        ],
+    )
+    if intro is not None:
+        episode = episode.with_intro_marker(intro)
+    return episode
+
+
+def _make_season(*, episodes: list[Episode], series_id: SeriesId) -> Season:
+    return Season(
+        id=SeasonId.generate(),
+        series_id=series_id,
+        season_number=SeasonNumber(1),
+        title=Title("Season 1"),
+        episodes=episodes,
+    )
+
+
+def _build_uow(*, pending_seasons: list[Season]) -> AsyncMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.series = AsyncMock()
+    uow.series.find_seasons_pending_intro_detection = AsyncMock(return_value=pending_seasons)
+    uow.series.update_season_intro_detection = AsyncMock(return_value=True)
+    uow.series.update_episode_intro = AsyncMock(return_value=True)
+    return uow
+
+
+def _make_audio_extractor(*, returns: list[Path | None] | None = None) -> MagicMock:
+    """Return a stub AudioExtractor whose ``extract_temporary`` yields paths.
+
+    ``returns`` is consumed in order — one path per call. A single
+    ``None`` triggers the "extraction failed" branch in the job.
+    """
+    queue: list[Path | None] = list(returns) if returns is not None else []
+    extractor = MagicMock()
+
+    @contextmanager
+    def extract_temporary(_file_path: str, *, duration_seconds: int) -> Iterator[Path | None]:
+        del duration_seconds
+        if queue:
+            yield queue.pop(0)
+        else:
+            yield Path("/tmp/fake.wav")
+
+    extractor.extract_temporary.side_effect = extract_temporary
+    return extractor
+
+
+def _make_chromaprint(*, returns: list[ChromaprintFingerprint | None] | None = None) -> MagicMock:
+    queue: list[ChromaprintFingerprint | None] = list(returns) if returns is not None else []
+    service = MagicMock()
+
+    def fingerprint(_path: object) -> ChromaprintFingerprint | None:
+        if queue:
+            return queue.pop(0)
+        return ChromaprintFingerprint(duration_seconds=300.0, hashes=[1, 2, 3])
+
+    service.fingerprint.side_effect = fingerprint
+    return service
+
+
+def _make_detector(*, detections: dict[EpisodeId, DetectedIntro]) -> MagicMock:
+    detector = MagicMock()
+    detector.detect.return_value = detections
+    return detector
+
+
+@pytest.mark.unit
+class TestIntroDetectionJob:
+    """Orchestration tests for IntroDetectionJob.run."""
+
+    @pytest.mark.asyncio
+    async def test_does_nothing_when_no_pending_seasons(self) -> None:
+        uow = _build_uow(pending_seasons=[])
+        factory = MagicMock(return_value=uow)
+        detector = _make_detector(detections={})
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=_make_audio_extractor(),
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=detector,
+        )
+        await job.run()
+
+        detector.detect.assert_not_called()
+        uow.series.update_season_intro_detection.assert_not_awaited()
+        uow.series.update_episode_intro.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_persists_high_confidence_detections_and_marks_completed(self) -> None:
+        sid = SeriesId.generate()
+        episodes = [_make_episode(series_id=sid, episode_number=i) for i in (1, 2, 3)]
+        season = _make_season(episodes=episodes, series_id=sid)
+        uow = _build_uow(pending_seasons=[season])
+        factory = MagicMock(return_value=uow)
+        detections = {
+            ep.id: DetectedIntro(
+                start_seconds=10.0,
+                end_seconds=80.0,
+                confidence=0.9,
+            )
+            for ep in episodes
+            if ep.id is not None
+        }
+        detector = _make_detector(detections=detections)
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=_make_audio_extractor(),
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=detector,
+            min_confidence=0.7,
+        )
+        await job.run()
+
+        assert uow.series.update_episode_intro.await_count == 3
+        for call_args in uow.series.update_episode_intro.await_args_list:
+            persisted = call_args.args[1]
+            assert isinstance(persisted, IntroMarker)
+            assert persisted.source == IntroMarkerSource.AUTO_DETECTED
+            assert persisted.confidence == pytest.approx(0.9)
+        # IN_PROGRESS then COMPLETED.
+        states_used = [
+            call.args[1] for call in uow.series.update_season_intro_detection.await_args_list
+        ]
+        assert states_used == [
+            IntroDetectionState.IN_PROGRESS,
+            IntroDetectionState.COMPLETED,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_skips_low_confidence_detections_but_still_completes(self) -> None:
+        sid = SeriesId.generate()
+        episodes = [_make_episode(series_id=sid, episode_number=i) for i in (1, 2)]
+        season = _make_season(episodes=episodes, series_id=sid)
+        uow = _build_uow(pending_seasons=[season])
+        factory = MagicMock(return_value=uow)
+        detections = {
+            ep.id: DetectedIntro(start_seconds=0.0, end_seconds=60.0, confidence=0.4)
+            for ep in episodes
+            if ep.id is not None
+        }
+        detector = _make_detector(detections=detections)
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=_make_audio_extractor(),
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=detector,
+            min_confidence=0.7,
+        )
+        await job.run()
+
+        # Below the floor — no markers persisted.
+        uow.series.update_episode_intro.assert_not_awaited()
+        # Season still flagged as completed so it isn't reprocessed.
+        terminal_state = uow.series.update_season_intro_detection.await_args_list[-1].args[1]
+        assert terminal_state == IntroDetectionState.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_filters_episodes_with_manual_markers_from_detection_pool(
+        self,
+    ) -> None:
+        sid = SeriesId.generate()
+        manual_marker = IntroMarker(
+            start_seconds=5,
+            end_seconds=60,
+            source=IntroMarkerSource.MANUAL,
+        )
+        # Two of three episodes carry a MANUAL marker → only one
+        # auto-detection candidate left, which is below the
+        # 2-episode floor.
+        episodes = [
+            _make_episode(series_id=sid, episode_number=1, intro=manual_marker),
+            _make_episode(series_id=sid, episode_number=2, intro=manual_marker),
+            _make_episode(series_id=sid, episode_number=3),
+        ]
+        season = _make_season(episodes=episodes, series_id=sid)
+        uow = _build_uow(pending_seasons=[season])
+        factory = MagicMock(return_value=uow)
+        detector = _make_detector(detections={})
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=_make_audio_extractor(),
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=detector,
+        )
+        await job.run()
+
+        detector.detect.assert_not_called()
+        terminal_state = uow.series.update_season_intro_detection.await_args_list[-1].args[1]
+        assert terminal_state == IntroDetectionState.INSUFFICIENT_EPISODES
+
+    @pytest.mark.asyncio
+    async def test_drops_to_insufficient_when_extraction_fails_for_most(self) -> None:
+        sid = SeriesId.generate()
+        episodes = [_make_episode(series_id=sid, episode_number=i) for i in (1, 2, 3)]
+        season = _make_season(episodes=episodes, series_id=sid)
+        uow = _build_uow(pending_seasons=[season])
+        factory = MagicMock(return_value=uow)
+        # Two of three extractions fail (None) — only one usable
+        # fingerprint, which is below the 2-episode floor.
+        extractor = _make_audio_extractor(returns=[None, None, Path("/tmp/fake.wav")])
+        detector = _make_detector(detections={})
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=extractor,
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=detector,
+        )
+        await job.run()
+
+        detector.detect.assert_not_called()
+        terminal_state = uow.series.update_season_intro_detection.await_args_list[-1].args[1]
+        assert terminal_state == IntroDetectionState.INSUFFICIENT_EPISODES
+
+    @pytest.mark.asyncio
+    async def test_marks_failed_when_detector_raises(self) -> None:
+        sid = SeriesId.generate()
+        episodes = [_make_episode(series_id=sid, episode_number=i) for i in (1, 2)]
+        season = _make_season(episodes=episodes, series_id=sid)
+        uow = _build_uow(pending_seasons=[season])
+        factory = MagicMock(return_value=uow)
+
+        broken_detector = MagicMock()
+        broken_detector.detect.side_effect = RuntimeError("kaboom")
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=_make_audio_extractor(),
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=broken_detector,
+        )
+        await job.run()
+
+        # IN_PROGRESS then FAILED with a captured error message.
+        calls = uow.series.update_season_intro_detection.await_args_list
+        assert calls[0].args[1] == IntroDetectionState.IN_PROGRESS
+        terminal_call = calls[-1]
+        assert terminal_call.args[1] == IntroDetectionState.FAILED
+        assert "kaboom" in terminal_call.kwargs["error"]
+        uow.series.update_episode_intro.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_episodes_whose_fingerprint_fails(self) -> None:
+        sid = SeriesId.generate()
+        episodes = [_make_episode(series_id=sid, episode_number=i) for i in (1, 2, 3)]
+        season = _make_season(episodes=episodes, series_id=sid)
+        uow = _build_uow(pending_seasons=[season])
+        factory = MagicMock(return_value=uow)
+        # The middle episode's fingerprint fails — the detector still
+        # gets the other two and produces a result.
+        chromaprint = _make_chromaprint(
+            returns=[
+                ChromaprintFingerprint(duration_seconds=300.0, hashes=[1, 2, 3]),
+                None,
+                ChromaprintFingerprint(duration_seconds=300.0, hashes=[1, 2, 3]),
+            ]
+        )
+        detector = _make_detector(detections={})
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=_make_audio_extractor(),
+            chromaprint_service=chromaprint,
+            intro_detector=detector,
+        )
+        await job.run()
+
+        # Detector saw two fingerprints, one was dropped.
+        passed_to_detector = detector.detect.call_args.args[0]
+        assert len(passed_to_detector) == 2
+        terminal_state = uow.series.update_season_intro_detection.await_args_list[-1].args[1]
+        assert terminal_state == IntroDetectionState.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_respects_batch_size(self) -> None:
+        sid = SeriesId.generate()
+        seasons = [
+            _make_season(
+                episodes=[
+                    _make_episode(
+                        series_id=sid,
+                        episode_number=i,
+                        file_path=f"/series/show/s0{n}e{i:02d}.mkv",
+                    )
+                    for i in (1, 2)
+                ],
+                series_id=sid,
+            )
+            for n in range(3)
+        ]
+        # Even though 3 are pending, the batch_size=1 contract means
+        # find_seasons_pending_intro_detection is called with limit=1
+        # and only the first is processed.
+        uow = _build_uow(pending_seasons=seasons[:1])
+        factory = MagicMock(return_value=uow)
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=_make_audio_extractor(),
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=_make_detector(detections={}),
+            batch_size=1,
+        )
+        await job.run()
+
+        called_with = uow.series.find_seasons_pending_intro_detection.await_args
+        assert called_with.args[0] == 1

--- a/tests/infrastructure/scheduling/test_intro_detection_job.py
+++ b/tests/infrastructure/scheduling/test_intro_detection_job.py
@@ -341,6 +341,117 @@ class TestIntroDetectionJob:
         assert terminal_state == IntroDetectionState.COMPLETED
 
     @pytest.mark.asyncio
+    async def test_unexpected_extractor_exception_drops_only_that_episode(
+        self,
+    ) -> None:
+        # The first episode's extraction raises an unexpected exception
+        # — the contract is best-effort: drop that episode, keep the
+        # season alive on the remaining ones rather than failing it.
+        sid = SeriesId.generate()
+        episodes = [_make_episode(series_id=sid, episode_number=i) for i in (1, 2, 3)]
+        season = _make_season(episodes=episodes, series_id=sid)
+        uow = _build_uow(pending_seasons=[season])
+        factory = MagicMock(return_value=uow)
+
+        crashing_extractor = MagicMock()
+        call_counter = {"n": 0}
+
+        @contextmanager
+        def extract_temporary(_file_path: str, *, duration_seconds: int) -> Iterator[Path | None]:
+            del duration_seconds
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                raise RuntimeError("unexpected ffmpeg failure")
+            yield Path("/tmp/fake.wav")
+
+        crashing_extractor.extract_temporary.side_effect = extract_temporary
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=crashing_extractor,
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=_make_detector(detections={}),
+        )
+        await job.run()
+
+        # Detector still ran with the two surviving fingerprints.
+        passed_to_detector = job._intro_detector.detect.call_args.args[0]  # type: ignore[attr-defined]
+        assert len(passed_to_detector) == 2
+        terminal_state = uow.series.update_season_intro_detection.await_args_list[-1].args[1]
+        assert terminal_state == IntroDetectionState.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_does_not_abort_batch_when_failed_state_recording_raises(
+        self,
+    ) -> None:
+        # If the FAILED transition itself raises (e.g. DB hiccup mid-tick)
+        # the batch loop must continue to the next season rather than
+        # aborting silently.
+        sid = SeriesId.generate()
+        eps_a = [_make_episode(series_id=sid, episode_number=i) for i in (1, 2)]
+        season_a = _make_season(episodes=eps_a, series_id=sid)
+        eps_b = [
+            _make_episode(series_id=sid, episode_number=i, file_path=f"/series/s02e{i:02d}.mkv")
+            for i in (1, 2)
+        ]
+        season_b = _make_season(episodes=eps_b, series_id=sid)
+
+        # update_season_intro_detection raises on the second call
+        # (which is the FAILED transition for season_a after the
+        # detector raised). Subsequent calls succeed so season_b can
+        # complete.
+        uow = AsyncMock()
+        uow.__aenter__.return_value = uow
+        uow.__aexit__.return_value = None
+        uow.series = AsyncMock()
+        uow.series.find_seasons_pending_intro_detection = AsyncMock(
+            return_value=[season_a, season_b]
+        )
+        update_outcomes: list[bool | Exception] = [
+            True,  # season_a IN_PROGRESS → ok
+            RuntimeError("db hiccup"),  # season_a FAILED → boom
+            True,  # season_b IN_PROGRESS → ok
+            True,  # season_b COMPLETED → ok
+        ]
+
+        async def update_state(*_args: object, **_kwargs: object) -> bool:
+            outcome = update_outcomes.pop(0)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        uow.series.update_season_intro_detection.side_effect = update_state
+        uow.series.update_episode_intro = AsyncMock(return_value=True)
+        factory = MagicMock(return_value=uow)
+
+        broken_detector = MagicMock()
+        # First call (season_a) raises; second call (season_b) returns
+        # an empty mapping so the season completes cleanly.
+        broken_detector.detect.side_effect = [RuntimeError("kaboom"), {}]
+
+        job = IntroDetectionJob(
+            media_uow_factory=factory,
+            audio_extractor=_make_audio_extractor(),
+            chromaprint_service=_make_chromaprint(),
+            intro_detector=broken_detector,
+        )
+        # Must not raise — the batch loop survives the failed
+        # state-recording on season_a.
+        await job.run()
+
+        # Both seasons walked the IN_PROGRESS path; season_b reached
+        # COMPLETED despite season_a's recording failure.
+        states_used = [
+            call.args[1] for call in uow.series.update_season_intro_detection.await_args_list
+        ]
+        assert states_used == [
+            IntroDetectionState.IN_PROGRESS,
+            IntroDetectionState.FAILED,
+            IntroDetectionState.IN_PROGRESS,
+            IntroDetectionState.COMPLETED,
+        ]
+
+    @pytest.mark.asyncio
     async def test_respects_batch_size(self) -> None:
         sid = SeriesId.generate()
         seasons = [


### PR DESCRIPTION
## Summary

Final phase of the skip-intro feature — the background job that ties together the audio primitives, the detection algorithm, and the persistence layer added in #146 / #147 / #148 / #149 / #150 into something a deployment can actually run.

- **\`IntroDetectionJob\`** (\`src/infrastructure/scheduling/intro_detection_job.py\`) — APScheduler-driven job that mirrors \`ThumbnailBackfillJob\`. Per tick: claims a small batch of seasons in \`NOT_STARTED\` / \`INSUFFICIENT_EPISODES\`, marks them \`IN_PROGRESS\`, filters out episodes already carrying a \`MANUAL\` marker (operators opt out by editing manually), extracts the leading audio window with \`AudioExtractor\`, fingerprints each WAV via \`ChromaprintService\`, runs \`ChromaprintIntroDetector\` on the resulting fingerprints, persists \`AUTO_DETECTED\` markers above \`min_confidence\` via \`update_episode_intro\`, and transitions the season to \`COMPLETED\` / \`INSUFFICIENT_EPISODES\` / \`FAILED\`. Per-season failures are caught, logged, and recorded on the entity — they do not abort the rest of the batch.
- **5 new settings** in \`Settings\` — \`intro_detection_enabled\` (default \`False\`), \`intro_detection_batch_size\` (default 1), \`intro_detection_interval_minutes\` (default 30), \`intro_detection_audio_window_seconds\` (default 600), \`intro_detection_min_confidence\` (default 0.7).
- **DI wiring** — \`AudioExtractor\` / \`ChromaprintService\` / \`ChromaprintIntroDetector\` exposed as singletons in \`MediaContainer\`; \`IntroDetectionJob\` registered as a singleton in \`ApplicationContainer\` pulling its config from \`Settings\`.
- **Scheduler registration** in \`src/main.py\` is conditional on \`intro_detection_enabled\` so existing deployments without fpcalc are unaffected. Operators flip the flag once \`apt install libchromaprint-tools\` (or equivalent) is in place.
- The job uses \`asyncio.to_thread\` for the synchronous audio + fingerprinting path so it never blocks the event loop, mirrors the per-item-UoW commit pattern from \`ThumbnailBackfillJob\`, and rounds detector floats to integer seconds with a 1-second floor before handing the marker to the domain (which requires \`end > start\`).

This closes the skip-intro feature: domain primitives → persistence → manual-edit endpoints → audio primitives → detection algorithm → background job.

## Test plan

- [x] 8 unit tests covering orchestration: no work when no pending seasons; happy path persists \`AUTO_DETECTED\` markers and transitions to \`COMPLETED\`; below-threshold detections are dropped but the season still completes; episodes with \`MANUAL\` markers are filtered out; extraction failures reduce the pool to \`INSUFFICIENT_EPISODES\`; detector raising leaves the season \`FAILED\` with the captured error; per-episode fingerprint failures don't kill the run; \`batch_size\` flows through to the repository limit.
- [x] No production \`assert\` statements (per project memory rule); type-narrowing done via local variable + early return.
- [x] Full project suite green (1920 passed, 5 skipped — the 5 skips are still the opt-in ffmpeg / fpcalc integration tests from #149).
- [x] \`ruff check\` and \`ruff format\` clean on changed files.
- [ ] **Manual smoke test pending operator action**: install \`fpcalc\` on the host, set \`intro_detection_enabled=true\`, watch the job pick up a real season and produce markers in the database. The integration tests gated on \`shutil.which("fpcalc")\` (#149) cover the binary side.

## Summary by Sourcery

Introduce a background intro-detection job that periodically analyzes season audio to auto-generate intro markers and wire it into the application scheduler behind configuration flags.

New Features:
- Add configurable intro-detection background job that scans pending seasons and persists auto-detected intro markers using Chromaprint-based audio fingerprints.
- Expose audio analysis primitives (audio extraction, Chromaprint service, intro detector) as shared singletons in the media DI container.

Enhancements:
- Extend application scheduling setup to register the intro-detection job conditionally based on new settings so deployments can opt in once dependencies are installed.
- Add configuration options controlling intro detection enablement, batch size, schedule interval, audio window length, and minimum confidence threshold.

Tests:
- Add unit test suite for the intro-detection job covering orchestration, batching, filtering, error handling, and confidence-based persistence behavior.