### PR TITLE
fix(media): tighten intro detection to stop overshooting the title sequence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,41 @@ DEFAULT_LOCALE=en
 SUPPORTED_LOCALES=en,pt-BR
 
 # -----------------------------------------------------------------------------
+# Intro detection (Skip Intro)
+# -----------------------------------------------------------------------------
+# Periodic background job that locates the shared opening sequence of
+# each TV season via Chromaprint audio fingerprinting. Off by default
+# because it requires the `fpcalc` binary on PATH.
+#   Linux:   apt install libchromaprint-tools
+#   macOS:   brew install chromaprint
+#   Windows: scoop install chromaprint  (or drop fpcalc.exe on PATH)
+INTRO_DETECTION_ENABLED=false
+
+# Job scheduling
+INTRO_DETECTION_BATCH_SIZE=1                # seasons processed per tick
+INTRO_DETECTION_INTERVAL_MINUTES=30         # how often the job runs
+INTRO_DETECTION_AUDIO_WINDOW_SECONDS=600    # leading audio scanned per ep
+INTRO_DETECTION_MIN_CONFIDENCE=0.7          # peer-agreement floor [0.0-1.0]
+
+# Algorithm calibration — only adjust if detections come back too long
+# or too short on real episodes. See `docs/roadmap.md` (3.3) and the
+# detector docstring for the trade-offs.
+#
+# Per-hash hamming-distance ceiling (out of 32 bits) considered a
+# "match". Lower values discriminate better and stop runs from
+# overshooting into shared underscore music; higher values absorb
+# more chromaprint noise.
+INTRO_DETECTION_MAX_HASH_HAMMING=10
+# How many CONSECUTIVE non-matching hashes a run can absorb before
+# terminating. A fresh good hash resets the counter.
+INTRO_DETECTION_TOLERANCE_HASHES=2
+# Floor and cap on persisted match length. Anything below the floor
+# is dropped (likely a recurring sting, not the title sequence);
+# anything above the cap is truncated at start + max.
+INTRO_DETECTION_MIN_INTRO_SECONDS=5
+INTRO_DETECTION_MAX_INTRO_SECONDS=120
+
+# -----------------------------------------------------------------------------
 # Security (for future use)
 # -----------------------------------------------------------------------------
 # SECRET_KEY=your-secret-key-here-change-in-production

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -88,6 +88,10 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         hls_cache_directory=config.provided.hls_cache_directory,
         hls_cache_max_size_mb=config.provided.hls_cache_max_size_mb,
         ffmpeg_threads=config.provided.ffmpeg_threads,
+        intro_detection_max_hash_hamming=config.provided.intro_detection_max_hash_hamming,
+        intro_detection_tolerance_hashes=config.provided.intro_detection_tolerance_hashes,
+        intro_detection_min_intro_seconds=config.provided.intro_detection_min_intro_seconds,
+        intro_detection_max_intro_seconds=config.provided.intro_detection_max_intro_seconds,
     )
 
     library = providers.Container(

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -93,6 +93,14 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # auto-default (all cores). Wired from ``Settings.ffmpeg_threads``.
     ffmpeg_threads = providers.Dependency(default=None)
 
+    # Intro-detection algorithm tuning knobs. Defaults match the
+    # detector's own defaults; the composition root overrides via
+    # ``Settings.intro_detection_*``.
+    intro_detection_max_hash_hamming = providers.Dependency(default=10)
+    intro_detection_tolerance_hashes = providers.Dependency(default=2)
+    intro_detection_min_intro_seconds = providers.Dependency(default=5.0)
+    intro_detection_max_intro_seconds = providers.Dependency(default=120.0)
+
     # =========================================================================
     # Unit of Work
     # =========================================================================
@@ -240,7 +248,13 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     chromaprint_service = providers.Singleton(ChromaprintService)
 
-    intro_detector = providers.Singleton(ChromaprintIntroDetector)
+    intro_detector = providers.Singleton(
+        ChromaprintIntroDetector,
+        max_hash_hamming=intro_detection_max_hash_hamming,
+        tolerance_hashes=intro_detection_tolerance_hashes,
+        min_intro_seconds=intro_detection_min_intro_seconds,
+        max_intro_seconds=intro_detection_max_intro_seconds,
+    )
 
     file_streamer = providers.Factory(LocalFileStreamer)
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -191,6 +191,38 @@ class Settings(BaseSettings):  # type: ignore[misc]
         "is the fraction of peer episodes whose fingerprint agreed "
         "with the candidate marker.",
     )
+    intro_detection_max_hash_hamming: int = Field(
+        default=10,
+        ge=0,
+        le=32,
+        description="Per-hash hamming-distance ceiling (out of 32 bits) "
+        "considered a 'match' between two episode fingerprints. Lower "
+        "values reject more borderline hashes — useful when detections "
+        "overshoot into shared underscore music; higher values absorb "
+        "more chromaprint noise.",
+    )
+    intro_detection_tolerance_hashes: int = Field(
+        default=2,
+        ge=0,
+        description="How many CONSECUTIVE non-matching hashes a run "
+        "can absorb before terminating. A fresh good hash resets the "
+        "counter so isolated chromaprint noise is forgiven indefinitely.",
+    )
+    intro_detection_min_intro_seconds: float = Field(
+        default=5.0,
+        ge=0.0,
+        description="Minimum intro length to accept. Shorter matches "
+        "are dropped — usually they are recurring stingers / bumpers "
+        "rather than the title sequence proper.",
+    )
+    intro_detection_max_intro_seconds: float = Field(
+        default=120.0,
+        ge=10.0,
+        description="Hard cap on persisted intro length. Real intros "
+        "rarely exceed two minutes; longer detections almost always "
+        "include shared underscore that bleeds past the title sequence "
+        "and should be truncated to avoid skipping into the episode.",
+    )
 
     ffmpeg_threads: int | None = Field(
         default=None,

--- a/src/modules/media/infrastructure/audio/chromaprint_intro_detector.py
+++ b/src/modules/media/infrastructure/audio/chromaprint_intro_detector.py
@@ -46,9 +46,10 @@ from src.modules.media.domain.value_objects import EpisodeId
 # anime / sitcom seasons. They are exposed as constructor kwargs so
 # operators can adjust without forking the implementation.
 _DEFAULT_MAX_ALIGNMENT_SHIFT_SECONDS = 30.0
-_DEFAULT_MAX_HASH_HAMMING = 14  # bits, out of 32
-_DEFAULT_TOLERANCE_HASHES = 4
+_DEFAULT_MAX_HASH_HAMMING = 10  # bits, out of 32
+_DEFAULT_TOLERANCE_HASHES = 2
 _DEFAULT_MIN_INTRO_SECONDS = 5.0
+_DEFAULT_MAX_INTRO_SECONDS = 120.0
 _DEFAULT_MIN_PAIR_AGREEMENT = 0.5
 _DEFAULT_ALIGNMENT_WINDOW_SECONDS = 60.0
 
@@ -76,13 +77,24 @@ class ChromaprintIntroDetector(IntroDetectorPort):
             two episodes can differ. Wider values cost more search time;
             30s comfortably covers most production patterns.
         max_hash_hamming: Per-hash hamming distance (out of 32 bits)
-            considered "matching". 14 ≈ 44% bit divergence — generous
-            enough to absorb the natural Chromaprint noise floor.
-        tolerance_hashes: How many consecutive non-matching hashes a
-            run can tolerate before terminating. Smooths over isolated
-            spikes inside an otherwise strong match.
+            considered "matching". Tighter values discriminate better
+            but also reject more genuine intro hashes that drifted
+            under encoding noise. ``10`` (≈ 31% bit divergence) is the
+            sweet spot for raw chromaprint hashes from typical TV
+            audio.
+        tolerance_hashes: How many CONSECUTIVE non-matching hashes a
+            run can absorb before terminating. Smooths over isolated
+            spikes inside an otherwise strong match — once a fresh
+            good hash arrives the counter resets, so the run can keep
+            extending. Trailing bad hashes never count toward the
+            reported segment length.
         min_intro_seconds: Discard matches shorter than this. Stops the
             detector from firing on incidental musical stings.
+        max_intro_seconds: Hard cap on the persisted match length.
+            Real intros virtually never exceed two minutes; longer
+            detections almost always include shared underscore /
+            transition music that bleeds past the title sequence and
+            should be truncated rather than persisted as-is.
         min_pair_agreement: Episodes whose match-rate against their
             peers falls below this fraction are dropped.
         alignment_window_seconds: How much of each fingerprint to scan
@@ -97,6 +109,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
         max_hash_hamming: int = _DEFAULT_MAX_HASH_HAMMING,
         tolerance_hashes: int = _DEFAULT_TOLERANCE_HASHES,
         min_intro_seconds: float = _DEFAULT_MIN_INTRO_SECONDS,
+        max_intro_seconds: float = _DEFAULT_MAX_INTRO_SECONDS,
         min_pair_agreement: float = _DEFAULT_MIN_PAIR_AGREEMENT,
         alignment_window_seconds: float = _DEFAULT_ALIGNMENT_WINDOW_SECONDS,
     ) -> None:
@@ -104,6 +117,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
         self._max_hash_hamming = max_hash_hamming
         self._tolerance_hashes = tolerance_hashes
         self._min_intro_seconds = min_intro_seconds
+        self._max_intro_seconds = max_intro_seconds
         self._min_pair_agreement = min_pair_agreement
         self._alignment_window_seconds = alignment_window_seconds
 
@@ -203,43 +217,56 @@ class ChromaprintIntroDetector(IntroDetectorPort):
     def _longest_run(self, distances: list[int]) -> tuple[int, int]:
         """Return (start, length) of the longest tolerant run.
 
-        A "run" is a contiguous span of positions where the running
-        count of "bad" hashes (distance > ``max_hash_hamming``) stays
-        below ``tolerance_hashes``. The tolerance lets a few isolated
-        outliers survive inside an otherwise strong match — chromaprint
-        often emits one or two bit-flipped hashes per second of clean
-        audio. When a run terminates because tolerance was exceeded,
-        the trailing bad streak is trimmed so callers always see a
-        run that ends on a "good" position.
+        A "run" is a contiguous span starting on a good hash and
+        absorbing up to ``tolerance_hashes`` CONSECUTIVE bad hashes
+        before terminating. A fresh good hash resets the consecutive
+        counter, so isolated noise inside an otherwise strong match
+        is forgiven indefinitely.
+
+        Crucially the reported segment always ends on a good hash —
+        ``last_good`` tracks the rightmost good index inside the run
+        and is the bound used when updating the best length, so a
+        trailing bad streak never inflates the reported range. Without
+        this, the previous implementation could overshoot the real end
+        by up to ``tolerance_hashes`` chromaprint frames (a fraction
+        of a second per frame, but noticeable on real episodes when
+        the audio fades out into shared underscore music).
         """
         best_start = 0
         best_length = 0
-        run_start = 0
-        run_bad = 0
-        run_length = 0
+        run_start = -1
+        last_good = -1
+        consecutive_bad = 0
+
         for i, d in enumerate(distances):
             is_bad = d > self._max_hash_hamming
-            if run_length == 0 and is_bad:
-                continue
-            if run_length == 0:
+
+            if run_start < 0:
+                # Outside any run — only a good hash can start a new one.
+                if is_bad:
+                    continue
                 run_start = i
-                run_bad = 0
-            run_length = i - run_start + 1
-            if is_bad:
-                run_bad += 1
-            if run_bad > self._tolerance_hashes:
-                # End this run; record it if it beat the current best,
-                # trimming the trailing bad streak so the reported range
-                # ends on a "good" position.
-                effective_length = run_length - self._tolerance_hashes
-                if effective_length > best_length:
+                last_good = i
+                consecutive_bad = 0
+                if best_length < 1:
                     best_start = run_start
-                    best_length = effective_length
-                run_length = 0
+                    best_length = 1
                 continue
-            if run_length > best_length:
+
+            if is_bad:
+                consecutive_bad += 1
+                if consecutive_bad > self._tolerance_hashes:
+                    run_start = -1
+                continue
+
+            # Good hash: reset the consecutive-bad counter and extend
+            # the accepted region to here.
+            consecutive_bad = 0
+            last_good = i
+            length = last_good - run_start + 1
+            if length > best_length:
                 best_start = run_start
-                best_length = run_length
+                best_length = length
 
         return best_start, best_length
 
@@ -261,6 +288,16 @@ class ChromaprintIntroDetector(IntroDetectorPort):
                 continue
             start_seconds = float(median(s for s, _ in segments))
             end_seconds = float(median(e for _, e in segments))
+            # Cap the segment at ``max_intro_seconds``. A real intro
+            # virtually never exceeds two minutes — runs that come back
+            # longer almost always include shared underscore /
+            # transition music that bleeds past the title sequence.
+            # Truncating the END is preferable to dropping the marker
+            # entirely; the user gets a "Skip Intro" button covering
+            # the shared region without overshooting deep into the
+            # episode.
+            if end_seconds - start_seconds > self._max_intro_seconds:
+                end_seconds = start_seconds + self._max_intro_seconds
             if end_seconds - start_seconds < self._min_intro_seconds:
                 continue
             result[episode_id] = DetectedIntro(

--- a/tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py
+++ b/tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py
@@ -253,6 +253,62 @@ class TestChromaprintIntroDetector:
         for marker in result.values():
             assert 0.0 <= marker.confidence <= 1.0
 
+    def test_max_intro_seconds_clamps_long_matches(self) -> None:
+        # Plant a 60-hash (~7.5 s) shared region but configure the cap
+        # at 5 s. The detector finds the full match, then truncates the
+        # END so the persisted segment never goes past the cap.
+        long_intro = _make_random_hashes(60, seed=99)
+        detector = ChromaprintIntroDetector(max_intro_seconds=5.0)
+        episodes = [
+            _episode(
+                intro_hashes=long_intro,
+                intro_offset_hashes=0,
+                total_hashes=500,
+                seed=seed,
+            )
+            for seed in (1, 2, 3)
+        ]
+
+        result = detector.detect(episodes)
+
+        assert len(result) == len(episodes)
+        for episode in episodes:
+            marker = result[episode.episode_id]
+            assert marker.start_seconds == pytest.approx(0.0, abs=0.5)
+            # End clamped to start + max_intro_seconds (with a hair of
+            # rounding slack for the float median).
+            assert marker.end_seconds - marker.start_seconds <= 5.0 + 0.001
+
+    def test_run_end_does_not_inflate_into_trailing_bad_streak(self) -> None:
+        # Regression: the previous algorithm updated best_length on
+        # every "still good" iteration without trimming, which let the
+        # reported end include positions that hadn't yet exceeded
+        # tolerance but already contained noisy hashes. The new
+        # last_good tracking guarantees the end is always a confirmed
+        # good hash.
+        intro = _make_random_hashes(80, seed=42)
+        detector = ChromaprintIntroDetector()
+        episodes = [
+            _episode(
+                intro_hashes=intro,
+                intro_offset_hashes=0,
+                total_hashes=400,
+                seed=seed,
+            )
+            for seed in (100, 200, 300)
+        ]
+
+        result = detector.detect(episodes)
+
+        for episode in episodes:
+            marker = result[episode.episode_id]
+            # 80 hashes / 8 hashes-per-second = 10 s. Allow at most a
+            # half-second of slack for the float median; the previous
+            # algorithm could overshoot by tolerance_hashes worth of
+            # positions (~0.5 s on its own, much more in real episodes
+            # where shared underscore extended the run).
+            assert marker.end_seconds <= 10.5
+
     def test_misconfigured_alignment_window_does_not_disable_matching(
         self, shared_intro: list[int]
     ) -> None:


### PR DESCRIPTION
## Summary

Calibration fixes for the cross-correlation detector based on real-episode feedback: intros were being marked 10-20 s past their actual end, and shorter recurring stingers (e.g. a bumper at the 2-min mark) were sometimes preferred over the title sequence proper.

### Algorithm

- **\`_longest_run\` overshoot bug**: the previous version updated \`best_length\` on every \"still good\" iteration without trimming, so positions that hadn't yet exceeded tolerance but already contained noisy hashes inflated the reported end. The new version tracks \`last_good\` and only commits run lengths bounded by the rightmost confirmed match.
- **Tolerance semantics**: \`tolerance_hashes\` is now CONSECUTIVE bad hashes (default 2) rather than total bad in run (was 4). A fresh good hash resets the counter, so isolated chromaprint noise is forgiven indefinitely while sustained drift terminates the run quickly. This better matches real chromaprint behaviour (occasional bit-flips, not bursts).
- **\`max_hash_hamming\` 14 → 10**: 44 % bit divergence let too many random unrelated hashes match by chance and extend the run past the real intro end. 31 % discriminates better while still absorbing genuine noise.
- **\`max_intro_seconds\` cap (default 120 s)**: real intros virtually never exceed two minutes; longer detections almost always include shared underscore / transition music that bleeds past the title sequence. The consensus output now truncates the END at the cap rather than dropping the marker, so the user gets a Skip Intro button covering the shared region without skipping deep into the episode.

### Configuration

All four detector knobs flow through new settings so operators can tune without rebuilding:

\`\`\`bash
INTRO_DETECTION_MAX_HASH_HAMMING=10
INTRO_DETECTION_TOLERANCE_HASHES=2
INTRO_DETECTION_MIN_INTRO_SECONDS=5
INTRO_DETECTION_MAX_INTRO_SECONDS=120
\`\`\`

If detections still come back overshot, drop \`INTRO_DETECTION_MAX_HASH_HAMMING\` to 8. If they come back too short / missing, raise it to 12 first; only relax \`TOLERANCE_HASHES\` if the season has heavy encoding noise.

## Test plan

- [x] All 10 existing detector unit tests still pass under the new threshold + tolerance semantics
- [x] New regression test: \`test_run_end_does_not_inflate_into_trailing_bad_streak\` — confirms the reported end stays at the planted intro boundary, not beyond it
- [x] New cap test: \`test_max_intro_seconds_clamps_long_matches\` — confirms a 7.5 s shared region with a 5 s cap produces a 5 s marker (truncated end, untouched start)
- [x] Full project suite green (1924 passed, 5 skipped)
- [x] \`ruff check\` and \`ruff format\` clean
- [ ] **Manual smoke test pending**: rerun the auto-detect on the user's library after merge; the seasons that were overshooting by 10-20 s should now end on the title-sequence boundary (or at \`start + max_intro_seconds\`, whichever is shorter).

## Multi-segment intros (intro + bumper at 2 min)

Out of scope for this PR. The current algorithm picks the single longest shared run per pair, so when a season has both an opening intro and a recurring stinger:
- If intro is longer → it wins (correct)
- If stinger is longer → it wins (incorrect)
- If similar lengths → arbitrary

A follow-up could add an "earliest acceptable run wins" tiebreaker. Holding until we see whether the threshold + tolerance fixes alone reduce the symptom, since false bumper matches often had inflated lengths from the same overshoot bug being fixed here.

## Summary by Sourcery

Tighten chromaprint intro detection to avoid overshooting title sequences and cap overly long matches, while making the detector’s tuning knobs configurable via settings and DI.

New Features:
- Introduce a configurable hard cap on intro length to truncate matches that extend past a realistic intro duration.
- Expose intro detection thresholds (hash hamming distance, tolerance, and min/max intro seconds) as application settings and container dependencies for runtime tuning.

Bug Fixes:
- Fix longest-run calculation so trailing bad hashes do not extend the reported intro past the last confirmed good match, preventing overshoot of the true intro end.

Enhancements:
- Retune default chromaprint matching thresholds to be stricter and redefine tolerance in terms of consecutive bad hashes for more robust intro detection.

Tests:
- Add regression tests covering non-inflating longest-run behavior and max-intro-seconds clamping of long shared regions.