### PR TITLE
fix(scheduler): pass FilePath objects to scan use case

### DIFF
--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         VariantDetectorPort,
     )
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.shared_kernel.value_objects.file_path import FilePath
 
 _logger = get_logger()
 
@@ -236,7 +237,7 @@ class LibraryScanScheduler:
             errors=len(result.errors),
         )
 
-    async def _load_library_paths(self, library_id: str) -> list[str] | None:
+    async def _load_library_paths(self, library_id: str) -> list[FilePath] | None:
         """Return the library's configured paths, or ``None`` if it vanished."""
         async with self._library_uow_factory() as uow:
             library = await uow.libraries.find_by_id(LibraryId(library_id))
@@ -246,7 +247,7 @@ class LibraryScanScheduler:
                     library_id=library_id,
                 )
                 return None
-            return [p.value for p in library.paths]
+            return list(library.paths)
 
     async def _mark_library_scanned(self, library_id: str) -> None:
         """Persist the completed-scan timestamp in its own UoW."""

--- a/tests/infrastructure/scheduling/test_scheduler_service.py
+++ b/tests/infrastructure/scheduling/test_scheduler_service.py
@@ -23,6 +23,7 @@ from src.infrastructure.scheduling.scheduler_service import (
 from src.modules.library.domain.entities.library import Library
 from src.modules.library.domain.value_objects.library_id import LibraryId
 from src.modules.library.domain.value_objects.library_type import LibraryType
+from src.shared_kernel.value_objects.file_path import FilePath
 
 
 class _FakeJob:
@@ -252,3 +253,32 @@ class TestRunScan:
         assert kwargs["variant_detector"] is scheduler._variant_detector
         assert kwargs["event_bus"] is scheduler._event_bus
         assert kwargs["probe_service"] is scheduler._probe_service
+
+    @pytest.mark.asyncio
+    async def test_passes_file_path_objects_to_scan_input(
+        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
+    ) -> None:
+        """Library paths must reach the use case as ``FilePath`` instances —
+        the scanner unwraps ``.value`` and crashes if given raw strings."""
+        lib = _make_library("A", "0 * * * *")
+        library_repo.find_by_id.return_value = lib
+        library_repo.save = AsyncMock()
+
+        fake_use_case = AsyncMock()
+        fake_use_case.execute.return_value = MagicMock(
+            movies_created=0,
+            movies_updated=0,
+            episodes_created=0,
+            episodes_updated=0,
+            errors=[],
+        )
+
+        with patch(
+            "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
+            return_value=fake_use_case,
+        ):
+            await scheduler._run_scan(str(lib.id))
+
+        fake_use_case.execute.assert_awaited_once()
+        scan_input = fake_use_case.execute.await_args.args[0]
+        assert all(isinstance(p, FilePath) for p in scan_input.directories)


### PR DESCRIPTION
## Summary
- `LibraryScanScheduler._load_library_paths` unwrapped `FilePath` into raw strings before handing them to `ScanMediaInput`, but `ScanMediaInput.directories` is typed as `list[FilePath]` and the scanner reads `directory.value` — every scheduled scan crashed with `AttributeError: 'str' object has no attribute 'value'`.
- Return the `FilePath` instances directly from `_load_library_paths` and update the return annotation to `list[FilePath] | None`.
- Add a regression test asserting the use case receives `FilePath` instances (existing tests mocked the use case and never exercised the unwrapping).

## Test plan
- [x] `pytest tests/infrastructure/scheduling/test_scheduler_service.py -v`
- [x] `ruff check` + `ruff format --check` on changed files
- [ ] Run `make dev` and confirm a scheduled library scan completes without the `'str' object has no attribute 'value'` traceback

## Summary by Sourcery

Ensure scheduled library scans pass FilePath value objects through to the scan use case instead of raw strings.

Bug Fixes:
- Prevent scheduled library scans from crashing by returning FilePath instances from the scheduler when building scan inputs.

Tests:
- Add an integration-style scheduler test asserting the scan use case receives FilePath instances for library directories.