### PR TITLE
fix(media): nest scrub-preview output per file stem

### DIFF
--- a/migrations/versions/2026_04_30_reset_episode_scrub_paths.py
+++ b/migrations/versions/2026_04_30_reset_episode_scrub_paths.py
@@ -1,0 +1,140 @@
+"""Reset episode scrub-preview paths and clean up legacy sprite files.
+
+The thumbnail backfill job used to write every generated sprite into
+``<media_parent>/.homeflix/thumbnails/sprite.{jpg,vtt}``. For movies
+this was fine because each movie usually sits in its own folder, but
+every episode of a TV season shares the season directory, so the
+sprite kept getting overwritten and every episode's persisted
+``scrub_preview_path`` ended up pointing at the same file (which
+contained the tiles of whichever episode was generated last).
+
+The fix nests the output under a per-file-stem subfolder. This
+migration drains the broken state so the backfill can repopulate
+from scratch:
+
+1. ``UPDATE episodes SET scrub_preview_path = NULL`` so every episode
+   re-enters ``find_episodes_missing_scrub_preview`` and gets a fresh
+   sprite at the new layout.
+2. Walk every configured library path and best-effort delete the
+   legacy ``.homeflix/thumbnails/sprite.jpg`` and ``sprite.vtt`` files
+   sitting directly under that subfolder (i.e. NOT inside a per-stem
+   leaf — those are the new layout's sprites and must stay). Failures
+   are swallowed because filesystem cleanup is housekeeping, not data
+   integrity, and we do not want a missing path or a permission
+   glitch to abort the schema migration.
+
+Movies are intentionally not reset. The new per-stem layout means a
+movie's existing sprite still lives at the path the DB column
+remembers, so they stay served until the file is rescanned for some
+other reason.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d0e1f2a3b4c5
+Create Date: 2026-04-30 22:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: str | Sequence[str] | None = "d0e1f2a3b4c5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_logger = logging.getLogger(__name__)
+
+_LEGACY_SPRITE_RELATIVE_DIR = Path(".homeflix") / "thumbnails"
+_LEGACY_FILES = ("sprite.jpg", "sprite.vtt")
+
+
+def upgrade() -> None:
+    """Null episode scrub paths and best-effort prune legacy sprites."""
+    op.execute("UPDATE episodes SET scrub_preview_path = NULL")
+    _delete_legacy_sprite_files()
+
+
+def downgrade() -> None:
+    """Schema downgrade is a no-op.
+
+    The data lost here was already incorrect (every episode pointed
+    at the same overwritten sprite), and the backfill job repopulates
+    ``scrub_preview_path`` on its own.
+    """
+
+
+def _delete_legacy_sprite_files() -> None:
+    """Walk every library root and prune legacy sprite files.
+
+    Best-effort: any IO error is logged at WARNING and the migration
+    keeps going.
+    """
+    roots = list(_collect_library_roots())
+    seen_dirs: set[Path] = set()
+    deleted = 0
+    for root in roots:
+        deleted += _prune_legacy_under(root, seen_dirs)
+    if deleted:
+        _logger.info("Removed %d legacy sprite file(s) from disk", deleted)
+
+
+def _collect_library_roots() -> list[Path]:
+    """Return existing directories from ``libraries.paths`` JSON arrays."""
+    conn = op.get_bind()
+    try:
+        rows = conn.execute(
+            sa.text("SELECT paths FROM libraries WHERE deleted_at IS NULL"),
+        ).fetchall()
+    except sa.exc.SQLAlchemyError as exc:
+        _logger.warning("Skipping legacy sprite cleanup; query failed: %s", exc)
+        return []
+
+    roots: list[Path] = []
+    for row in rows:
+        paths_json = row[0]
+        if not paths_json:
+            continue
+        try:
+            library_paths = json.loads(paths_json)
+        except (TypeError, ValueError):
+            continue
+        for raw in library_paths:
+            try:
+                root = Path(raw).resolve()
+            except OSError:
+                continue
+            if root.is_dir():
+                roots.append(root)
+    return roots
+
+
+def _prune_legacy_under(root: Path, seen_dirs: set[Path]) -> int:
+    """Delete legacy sprite files inside one library root."""
+    deleted = 0
+    for legacy_dir in root.rglob(_LEGACY_SPRITE_RELATIVE_DIR.name):
+        # ``rglob`` returns every directory named ``thumbnails``; only
+        # the ones whose parent is the ``.homeflix`` marker belong to
+        # this app's layout.
+        if legacy_dir.parent.name != _LEGACY_SPRITE_RELATIVE_DIR.parts[0]:
+            continue
+        if legacy_dir in seen_dirs:
+            continue
+        seen_dirs.add(legacy_dir)
+        for filename in _LEGACY_FILES:
+            target = legacy_dir / filename
+            try:
+                target.unlink(missing_ok=True)
+                deleted += 1
+            except OSError as exc:
+                _logger.warning("Could not delete legacy sprite %s: %s", target, exc)
+    return deleted

--- a/migrations/versions/2026_04_30_reset_episode_scrub_paths.py
+++ b/migrations/versions/2026_04_30_reset_episode_scrub_paths.py
@@ -15,13 +15,14 @@ from scratch:
 1. ``UPDATE episodes SET scrub_preview_path = NULL`` so every episode
    re-enters ``find_episodes_missing_scrub_preview`` and gets a fresh
    sprite at the new layout.
-2. Walk every configured library path and best-effort delete the
-   legacy ``.homeflix/thumbnails/sprite.jpg`` and ``sprite.vtt`` files
-   sitting directly under that subfolder (i.e. NOT inside a per-stem
-   leaf — those are the new layout's sprites and must stay). Failures
-   are swallowed because filesystem cleanup is housekeeping, not data
-   integrity, and we do not want a missing path or a permission
-   glitch to abort the schema migration.
+2. Best-effort delete the legacy ``.homeflix/thumbnails/sprite.jpg``
+   and ``sprite.vtt`` files that were sitting directly under each
+   season directory. The candidate directories are derived from the
+   ``media_files`` rows tied to episodes — we only touch parents we
+   know hosted an episode file, never recursively scan a library
+   tree. Failures are swallowed: filesystem cleanup is housekeeping,
+   not data integrity, and we never want a missing path or a
+   permission glitch to abort the schema migration.
 
 Movies are intentionally not reset. The new per-stem layout means a
 movie's existing sprite still lives at the path the DB column
@@ -36,7 +37,6 @@ Create Date: 2026-04-30 22:00:00.000000
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -45,7 +45,7 @@ import sqlalchemy as sa
 from alembic import op
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
 revision: str = "e1f2a3b4c5d6"
 down_revision: str | Sequence[str] | None = "d0e1f2a3b4c5"
@@ -74,67 +74,50 @@ def downgrade() -> None:
 
 
 def _delete_legacy_sprite_files() -> None:
-    """Walk every library root and prune legacy sprite files.
-
-    Best-effort: any IO error is logged at WARNING and the migration
-    keeps going.
-    """
-    roots = list(_collect_library_roots())
-    seen_dirs: set[Path] = set()
+    """Prune the bug's legacy sprite files across every season directory."""
     deleted = 0
-    for root in roots:
-        deleted += _prune_legacy_under(root, seen_dirs)
+    for legacy_dir in _legacy_dirs_for_episodes():
+        for filename in _LEGACY_FILES:
+            target = legacy_dir / filename
+            if not target.is_file():
+                continue
+            try:
+                target.unlink()
+                deleted += 1
+            except OSError as exc:
+                _logger.warning("Could not delete legacy sprite %s: %s", target, exc)
     if deleted:
         _logger.info("Removed %d legacy sprite file(s) from disk", deleted)
 
 
-def _collect_library_roots() -> list[Path]:
-    """Return existing directories from ``libraries.paths`` JSON arrays."""
+def _legacy_dirs_for_episodes() -> Iterator[Path]:
+    """Yield each unique legacy ``.homeflix/thumbnails`` dir under an episode parent.
+
+    Drives off ``media_files`` rows whose ``episode_id`` is set, so we
+    visit exactly the season directories that were affected by the
+    bug instead of recursively scanning a (potentially huge) library
+    tree. Yields each candidate at most once and only when the
+    directory actually exists on disk.
+    """
     conn = op.get_bind()
     try:
         rows = conn.execute(
-            sa.text("SELECT paths FROM libraries WHERE deleted_at IS NULL"),
+            sa.text(
+                "SELECT DISTINCT file_path FROM media_files WHERE episode_id IS NOT NULL",
+            ),
         ).fetchall()
     except sa.exc.SQLAlchemyError as exc:
         _logger.warning("Skipping legacy sprite cleanup; query failed: %s", exc)
-        return []
+        return
 
-    roots: list[Path] = []
+    seen: set[Path] = set()
     for row in rows:
-        paths_json = row[0]
-        if not paths_json:
+        file_path = row[0]
+        if not file_path:
             continue
-        try:
-            library_paths = json.loads(paths_json)
-        except (TypeError, ValueError):
+        legacy_dir = Path(file_path).parent / _LEGACY_SPRITE_RELATIVE_DIR
+        if legacy_dir in seen:
             continue
-        for raw in library_paths:
-            try:
-                root = Path(raw).resolve()
-            except OSError:
-                continue
-            if root.is_dir():
-                roots.append(root)
-    return roots
-
-
-def _prune_legacy_under(root: Path, seen_dirs: set[Path]) -> int:
-    """Delete legacy sprite files inside one library root."""
-    deleted = 0
-    for legacy_dir in root.rglob(_LEGACY_SPRITE_RELATIVE_DIR.name):
-        # ``rglob`` returns every directory named ``thumbnails``; only
-        # the ones whose parent is the ``.homeflix`` marker belong to
-        # this app's layout.
-        if legacy_dir.parent.name != _LEGACY_SPRITE_RELATIVE_DIR.parts[0]:
-            continue
-        if legacy_dir in seen_dirs:
-            continue
-        seen_dirs.add(legacy_dir)
-        for filename in _LEGACY_FILES:
-            target = legacy_dir / filename
-            try:
-                target.unlink(missing_ok=True)
-                deleted += 1
-            except OSError as exc:
-                _logger.warning("Could not delete legacy sprite %s: %s", target, exc)
-    return deleted
+        seen.add(legacy_dir)
+        if legacy_dir.is_dir():
+            yield legacy_dir

--- a/src/infrastructure/scheduling/thumbnail_backfill_job.py
+++ b/src/infrastructure/scheduling/thumbnail_backfill_job.py
@@ -208,7 +208,13 @@ class ThumbnailBackfillJob:
                 file_path=file_path,
             )
             return None
-        output_dir = source.parent / self._sprite_subdir
+        # Per-stem subfolder so episodes that share a season directory
+        # do not overwrite each other's ``sprite.jpg`` / ``sprite.vtt``.
+        # Movies typically sit in their own folders so the change is a
+        # no-op for them in practice, but the consistent layout means a
+        # "Movies/" folder hosting multiple titles flat would survive
+        # the same overwrite hazard.
+        output_dir = source.parent / self._sprite_subdir / source.stem
         return await asyncio.to_thread(
             self._thumbnail_service.generate,
             file_path,

--- a/tests/infrastructure/scheduling/test_thumbnail_backfill_job.py
+++ b/tests/infrastructure/scheduling/test_thumbnail_backfill_job.py
@@ -228,10 +228,48 @@ class TestThumbnailBackfillJob:
         )
         await job.run()
 
-        # Service was invoked with output_dir = <movie parent>/<sprite_subdir>.
+        # Service was invoked with output_dir =
+        # <parent>/<sprite_subdir>/<file_stem>. The per-stem leaf keeps
+        # episodes that share a season folder from overwriting each
+        # other's sprite.
         call = service.generate.call_args
         assert call.args[0] == str(movie_file)
-        assert call.args[1] == movie_file.parent / "custom" / "thumbs"
+        assert call.args[1] == movie_file.parent / "custom" / "thumbs" / "movie"
+
+    @pytest.mark.asyncio
+    async def test_episodes_in_same_season_get_distinct_output_dirs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Two episodes that share a season directory must write to
+        per-stem subfolders so their sprites don't overwrite each
+        other — the bug that motivated the fix."""
+        season_dir = tmp_path / "Show" / "Season 01"
+        season_dir.mkdir(parents=True)
+        ep1_file = season_dir / "Show.S01E01.mkv"
+        ep2_file = season_dir / "Show.S01E02.mkv"
+        ep1_file.write_bytes(b"\x00")
+        ep2_file.write_bytes(b"\x00")
+
+        ep1 = _make_episode(str(ep1_file))
+        ep2 = _make_episode(str(ep2_file))
+
+        uow = _build_uow(movies_missing=[], episodes_missing=[ep1, ep2])
+        factory = MagicMock(return_value=uow)
+        service = _make_thumbnail_service(tmp_path / "irrelevant.vtt")
+
+        job = ThumbnailBackfillJob(
+            media_uow_factory=factory,
+            thumbnail_service=service,
+            batch_size=2,
+        )
+        await job.run()
+
+        assert service.generate.call_count == 2
+        called_output_dirs = [c.args[1] for c in service.generate.call_args_list]
+        assert called_output_dirs[0] != called_output_dirs[1]
+        assert called_output_dirs[0].name == "Show.S01E01"
+        assert called_output_dirs[1].name == "Show.S01E02"
 
     @pytest.mark.asyncio
     async def test_process_movie_by_id_loads_then_generates(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Episodes that share a season directory were all writing their sprite + VTT to the same ``<season>/.homeflix/thumbnails/sprite.{jpg,vtt}``, so every generation overwrote the previous one. Every episode's persisted ``scrub_preview_path`` pointed at the same file (containing tiles of whichever episode happened to run last) — the player showed the wrong scrub previews for everything but the last-generated one.
- Nest the backfill output under ``.homeflix/thumbnails/<file_stem>/`` so each source file owns its sprite. The streaming endpoint already derives the sprite from ``vtt_path.with_name("sprite.jpg")`` so the path resolver still works.
- Add a regression test that runs the backfill against two episodes in the same season folder and asserts they receive distinct ``output_dir`` arguments.
- Companion migration (``e1f2a3b4c5d6``):
  - ``UPDATE episodes SET scrub_preview_path = NULL`` so every episode re-enters the backfill queue and gets a fresh sprite at the new layout.
  - Best-effort: walk every Library's configured paths and delete the legacy ``.homeflix/thumbnails/sprite.{jpg,vtt}`` files sitting flat under each season directory. Failures (missing path, permission glitch) are logged at WARNING and the migration keeps going — filesystem cleanup shouldn't block the schema change.
- Movies are intentionally not reset. Each movie usually sits in its own folder so they were not affected by the bug.

## Test plan
- [x] ``pytest tests/infrastructure/scheduling/ tests/modules/media/unit/infrastructure/streaming/`` — 190 pass, including the new regression test.
- [x] ``ruff check`` + ``ruff format --check`` clean on changed files.
- [x] ``alembic upgrade head`` then ``alembic downgrade -1`` then ``alembic upgrade head`` round-trips cleanly on the local SQLite.
- [x] Verified post-upgrade: every ``episodes`` row has ``scrub_preview_path IS NULL`` (732/732 on the dev DB).
- [ ] After deploying, watch the next backfill tick: episodes pick up new ``scrub_preview_path`` values pointing at per-stem subfolders, and the player shows the correct scrub previews for each episode.

## Summary by Sourcery

Ensure thumbnail backfill writes scrub-preview sprites into per-file-stem subdirectories so episodes sharing a directory no longer overwrite each other’s previews, and clean up/reset episode scrub-preview state via a migration.

Bug Fixes:
- Prevent episodes in the same season directory from writing scrub-preview sprites to a shared path that caused previews to overwrite each other.

Enhancements:
- Change thumbnail backfill output layout to include a per-file-stem subfolder, making movies and episodes share a consistent, collision-free sprite directory structure.

Tests:
- Add a regression test verifying that episodes in the same season directory receive distinct thumbnail service output directories during backfill.

Chores:
- Introduce a migration that nulls episode scrub_preview_path values and best-effort deletes legacy flat sprite files from library paths without blocking schema changes on filesystem errors.