### PR TITLE
chore(config): sync .env.example with current Settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ LOG_LEVEL=DEBUG  # DEBUG, INFO, WARNING, ERROR
 # Server
 # -----------------------------------------------------------------------------
 HOST=0.0.0.0
-PORT=8000
+PORT=8005
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
 
 # -----------------------------------------------------------------------------
@@ -37,6 +37,19 @@ MEDIA_DIRECTORIES=/path/to/movies,/path/to/series
 THUMBNAILS_DIRECTORY=./thumbnails
 
 # -----------------------------------------------------------------------------
+# HLS streaming cache
+# -----------------------------------------------------------------------------
+# Where the HLS service writes per-file segment buckets. The directory
+# is created on first stream and grows as users play media.
+HLS_CACHE_DIRECTORY=./hls_cache
+
+# Cache cap in megabytes. When the directory exceeds this size, the
+# least-recently-accessed buckets are deleted until it fits. Default
+# 5 GB; bump it on large catalogs to avoid re-transcoding popular
+# titles on every visit.
+HLS_CACHE_MAX_SIZE_MB=5120
+
+# -----------------------------------------------------------------------------
 # External APIs
 # -----------------------------------------------------------------------------
 # TMDB - The Movie Database (https://www.themoviedb.org/settings/api)
@@ -46,6 +59,47 @@ TMDB_BASE_URL=https://api.themoviedb.org/3
 # OMDb - Open Movie Database (https://www.omdbapi.com/apikey.aspx)
 # Optional: used as fallback when TMDB doesn't have data
 OMDB_API_KEY=your_omdb_api_key_here
+
+# -----------------------------------------------------------------------------
+# Scheduler
+# -----------------------------------------------------------------------------
+# Master switch for the background scheduler that runs library scans
+# and the periodic backfill jobs below. Turn off only when something
+# is broken — every job is also gated by its own *_ENABLED flag.
+SCHEDULER_ENABLED=true
+
+# How often the scheduler re-reads libraries from the database to
+# sync cron jobs with their configured schedules. Lower values pick
+# up schedule edits sooner; higher values reduce idle DB chatter.
+SCHEDULER_RECONCILE_INTERVAL_MINUTES=5
+
+# -----------------------------------------------------------------------------
+# Thumbnail backfill
+# -----------------------------------------------------------------------------
+# Periodic job that fills in scrub-preview sprites for movies and
+# episodes that don't have one yet (e.g. items added by a scan but
+# never streamed).
+THUMBNAIL_BACKFILL_ENABLED=true
+THUMBNAIL_BACKFILL_BATCH_SIZE=10        # items per tick
+THUMBNAIL_BACKFILL_INTERVAL_MINUTES=20  # how often the job runs
+
+# Subdirectory (relative to each media file's parent folder) where the
+# generated sprite + VTT pair is written, nested under a per-stem
+# leaf so episodes that share a season folder don't overwrite each
+# other.
+THUMBNAIL_BACKFILL_SUBDIR=.homeflix/thumbnails
+
+# -----------------------------------------------------------------------------
+# FFmpeg
+# -----------------------------------------------------------------------------
+# Maximum worker threads ffmpeg may use per invocation (applied as
+# `-threads N` on every ffmpeg call). Leave unset to let ffmpeg use
+# all logical cores. Set to roughly `cpu_count // 2` to cap
+# transcoding to ~50% of the host. Caps parallelism, not absolute
+# CPU — use cgroups or equivalent for a hard limit. Applies to HLS
+# transcoding, subtitle extraction, and scrub-preview sprite
+# generation.
+# FFMPEG_THREADS=4
 
 # -----------------------------------------------------------------------------
 # Internationalization


### PR DESCRIPTION
## Summary
- ``.env.example`` had drifted: nine ``Settings`` fields shipped after the file was last touched (HLS cache, scheduler toggles, thumbnail backfill, ``FFMPEG_THREADS``) and ``PORT`` still showed the old ``8000`` while the actual default is ``8005``.
- Add a section per group (HLS cache, Scheduler, Thumbnail backfill, FFmpeg) with the same documentation tone as the existing intro-detection block, fix ``PORT=8005``, and leave ``FFMPEG_THREADS`` commented because the default (``None`` = ffmpeg auto) is what most operators want.
- Verified against the live ``Settings`` model: every declared field has a matching line in ``.env.example`` (active or commented), and no stale keys are left over.

## Test plan
- [x] Cross-check loop against ``Settings.model_fields`` — only ``ffmpeg_threads`` is "missing", and it's the intentionally commented one.
- [x] No code paths touched, runtime behaviour unchanged.

## Summary by Sourcery

Documentation:
- Update .env.example to document all current Settings fields, including HLS cache, scheduler toggles, thumbnail backfill, and FFmpeg options, and correct the documented default PORT to 8005.