### PR TITLE
feat(media): include cast on series

### DIFF
--- a/migrations/versions/2026_05_01_add_series_cast.py
+++ b/migrations/versions/2026_05_01_add_series_cast.py
@@ -1,0 +1,40 @@
+"""Add cast column to series.
+
+Series gain the same ``cast`` Text column ``movies`` already carries —
+JSON-encoded list of ``{name, profile_path, role, tmdb_id}`` dicts
+filled by the TMDB enrichment path. New column is nullable so
+existing rows keep loading; the next enrichment pass repopulates
+them with the top-billed cast TMDB returns for the series.
+
+Revision ID: f2a3b4c5d6e7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-05-01 09:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "f2a3b4c5d6e7"
+down_revision: str | Sequence[str] | None = "e1f2a3b4c5d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``cast`` column to ``series``."""
+    with op.batch_alter_table("series", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("cast", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop ``cast`` column from ``series``."""
+    with op.batch_alter_table("series", schema=None) as batch_op:
+        batch_op.drop_column("cast")

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -10,6 +10,7 @@ from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
 if TYPE_CHECKING:
     from src.modules.media.application.dtos.intro_dtos import IntroMarkerOutput
     from src.modules.media.application.dtos.media_file_dtos import MediaFileOutput
+    from src.modules.media.application.dtos.movie_dtos import CastMemberOutput
 
 
 @dataclass(frozen=True)
@@ -125,6 +126,7 @@ class SeriesOutput:
     season_count: int
     total_episodes: int
     seasons: list[SeasonOutput]
+    cast: list[CastMemberOutput]
     created_at: str
     updated_at: str
 

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -20,6 +20,7 @@ from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
     AirDate,
+    CastMember,
     ContentRating,
     Duration,
     Genre,
@@ -201,6 +202,22 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
             "trailer_url": ("trailer_url", None),
         },
     )
+
+    # Cast: same fill-if-empty rule as the rest of the don't-overwrite
+    # block, but built outside ``_set_if_missing`` because the
+    # provider DTO uses a different field name (``cast`` ↔ ``cast``)
+    # AND a per-element converter from ``CreditPerson`` to the
+    # domain ``CastMember`` VO.
+    if metadata.cast and not series.cast:
+        updates["cast"] = [
+            CastMember(
+                name=p.name,
+                profile_path=p.profile_url,
+                role=p.role,
+                tmdb_id=p.tmdb_id,
+            )
+            for p in metadata.cast
+        ]
 
     _apply_localized(updates, series.localized, metadata)
 

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -1,6 +1,7 @@
 """GetSeriesByIdUseCase - Retrieve a series with all seasons and episodes."""
 
 from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.movie_dtos import CastMemberOutput
 from src.modules.media.application.dtos.series_dtos import (
     EpisodeOutput,
     GetSeriesByIdInput,
@@ -118,6 +119,15 @@ class GetSeriesByIdUseCase:
             season_count=series.season_count,
             total_episodes=series.total_episodes,
             seasons=[self._to_season_output(s, series_id, progress_map) for s in series.seasons],
+            cast=[
+                CastMemberOutput(
+                    name=m.name,
+                    profile_path=m.profile_path,
+                    role=m.role,
+                    tmdb_id=m.tmdb_id,
+                )
+                for m in series.cast
+            ],
             created_at=series.created_at.isoformat(),
             updated_at=series.updated_at.isoformat(),
         )

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -11,6 +11,7 @@ from src.building_blocks.domain.errors import BusinessRuleViolationException
 from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.rule_codes import MediaRuleCodes
 from src.modules.media.domain.value_objects import (
+    CastMember,
     ContentRating,
     Genre,
     ImageUrl,
@@ -58,6 +59,12 @@ class Series(AggregateRoot[SeriesId]):
     genres: list[Genre] = Field(default_factory=list)
     content_rating: ContentRating | None = None
     trailer_url: str | None = None
+
+    # Credits (top-billed cast pulled from TMDB during enrichment).
+    # Mirrors Movie.cast so the detail page can render the same
+    # actor cards on series and movies, and so the actor browse page
+    # can later filter on series cast as well.
+    cast: list[CastMember] = Field(default_factory=list)
 
     # Localized metadata
     localized: dict[str, dict[str, Any]] = Field(default_factory=dict)

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -459,7 +459,7 @@ class TmdbClient(MetadataProvider):
         resp = await self._client.get(
             f"{self._base_url}/tv/{tmdb_id}",
             params=self._params(
-                append_to_response="external_ids,content_ratings,videos,images",
+                append_to_response="external_ids,content_ratings,videos,images,credits",
                 include_image_language="en,null",
             ),
         )
@@ -467,6 +467,12 @@ class TmdbClient(MetadataProvider):
             return None
         resp.raise_for_status()
         data = resp.json()
+
+        # Top-billed cast comes back nested under ``credits.cast`` thanks
+        # to the ``credits`` append above. Reuse the same parser the
+        # movie path uses so series and movies share the cap/order rules.
+        credits = data.get("credits", {})
+        cast = self._parse_cast(credits.get("cast", []))
 
         start_year = None
         if data.get("first_air_date"):
@@ -499,6 +505,7 @@ class TmdbClient(MetadataProvider):
             backdrop_url=self._image_url(data.get("backdrop_path")),
             logo_url=logo_url,
             genres=[g["name"] for g in data.get("genres", [])],
+            cast=cast,
             tmdb_id=data["id"],
             imdb_id=data.get("external_ids", {}).get("imdb_id"),
             content_rating=content_rating.value if content_rating else None,

--- a/src/modules/media/infrastructure/persistence/mappers/cast_serialization.py
+++ b/src/modules/media/infrastructure/persistence/mappers/cast_serialization.py
@@ -1,0 +1,86 @@
+"""Cast list JSON (de)serialization.
+
+Single source of truth for the shape stored in the ``cast`` Text
+column on every media-owning model (movies and series share the
+schema). Centralizing the helpers keeps the legacy-tolerant decode
+path from drifting between mappers.
+"""
+
+from __future__ import annotations
+
+import json
+
+from src.modules.media.domain.value_objects import CastMember
+
+
+def serialize_cast(cast: list[CastMember]) -> str | None:
+    """Serialize the cast list to the JSON shape stored on disk.
+
+    Current shape:
+    ``[{"name": "...", "profile_path": "...", "role": "...", "tmdb_id": 123}, ...]``.
+
+    Always written this way; older shapes (``["Name1", "Name2"]`` and
+    the dict shape without ``tmdb_id``) are only *read* by
+    :func:`deserialize_cast` and get converted on the next save.
+    """
+    if not cast:
+        return None
+    payload = [
+        {
+            "name": m.name,
+            "profile_path": m.profile_path,
+            "role": m.role,
+            "tmdb_id": m.tmdb_id,
+        }
+        for m in cast
+    ]
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def deserialize_cast(raw: str | None) -> list[CastMember]:
+    """Reconstruct the cast list from the JSON column.
+
+    Accepts every historic shape so rows enriched at any point still
+    load: legacy ``list[str]`` (initials-only fallback), the dict
+    shape without ``tmdb_id`` (no bio link on the actor page —
+    degrades to a name-only flow), and the current dict shape with
+    ``tmdb_id``. The next save migrates the row to the current shape
+    implicitly.
+
+    Tolerant of malformed payloads at the storage boundary: a JSON
+    value that is not a list (drift from a future migration, manual
+    DB edit) collapses to an empty cast rather than iterating dict
+    keys as if they were entries; dict entries with no usable
+    ``name`` are skipped so the UI never renders empty cards. A
+    non-int ``tmdb_id`` (string, float, malformed import) is dropped
+    silently rather than raising.
+    """
+    if not raw:
+        return []
+    items = json.loads(raw)
+    if not isinstance(items, list):
+        return []
+    members: list[CastMember] = []
+    for item in items:
+        if isinstance(item, str):
+            name = item.strip()
+            if name:
+                members.append(CastMember(name=name))
+        elif isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+            if not name:
+                continue
+            raw_tmdb_id = item.get("tmdb_id")
+            tmdb_id = raw_tmdb_id if isinstance(raw_tmdb_id, int) else None
+            members.append(
+                CastMember(
+                    name=name,
+                    profile_path=item.get("profile_path") or None,
+                    role=item.get("role") or None,
+                    tmdb_id=tmdb_id,
+                )
+            )
+    return members
+
+
+__all__ = ["deserialize_cast", "serialize_cast"]

--- a/src/modules/media/infrastructure/persistence/mappers/cast_serialization.py
+++ b/src/modules/media/infrastructure/persistence/mappers/cast_serialization.py
@@ -47,17 +47,20 @@ def deserialize_cast(raw: str | None) -> list[CastMember]:
     ``tmdb_id``. The next save migrates the row to the current shape
     implicitly.
 
-    Tolerant of malformed payloads at the storage boundary: a JSON
-    value that is not a list (drift from a future migration, manual
-    DB edit) collapses to an empty cast rather than iterating dict
-    keys as if they were entries; dict entries with no usable
-    ``name`` are skipped so the UI never renders empty cards. A
-    non-int ``tmdb_id`` (string, float, malformed import) is dropped
-    silently rather than raising.
+    Tolerant of malformed payloads at the storage boundary:
+    unparseable JSON (truncated row, manual DB edit) and a JSON value
+    that is not a list (drift from a future migration) both collapse
+    to an empty cast rather than crashing the read path; dict entries
+    with no usable ``name`` are skipped so the UI never renders empty
+    cards. A non-int ``tmdb_id`` (string, float, malformed import) is
+    dropped silently rather than raising.
     """
     if not raw:
         return []
-    items = json.loads(raw)
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
     if not isinstance(items, list):
         return []
     members: list[CastMember] = []

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -4,7 +4,6 @@ import json
 
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
-    CastMember,
     ContentRating,
     Duration,
     FilePath,
@@ -18,80 +17,14 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.modules.media.infrastructure.persistence.mappers.cast_serialization import (
+    deserialize_cast,
+    serialize_cast,
+)
 from src.modules.media.infrastructure.persistence.mappers.media_file_mapper import (
     MediaFileMapper,
 )
 from src.modules.media.infrastructure.persistence.models import MediaFileModel, MovieModel
-
-
-def _serialize_cast(cast: list[CastMember]) -> str | None:
-    """Serialize the cast list to the JSON shape stored on disk.
-
-    Current shape:
-    ``[{"name": "...", "profile_path": "...", "role": "...", "tmdb_id": 123}, ...]``.
-
-    Always written this way; older shapes (``["Name1", "Name2"]`` and
-    the dict shape without ``tmdb_id``) are only *read* by
-    ``_deserialize_cast`` and get converted on the next save.
-    """
-    if not cast:
-        return None
-    payload = [
-        {
-            "name": m.name,
-            "profile_path": m.profile_path,
-            "role": m.role,
-            "tmdb_id": m.tmdb_id,
-        }
-        for m in cast
-    ]
-    return json.dumps(payload, ensure_ascii=False)
-
-
-def _deserialize_cast(raw: str | None) -> list[CastMember]:
-    """Reconstruct the cast list from the JSON column.
-
-    Accepts every historic shape so rows enriched at any point still
-    load: legacy ``list[str]`` (initials-only fallback), the dict
-    shape without ``tmdb_id`` (no bio link on the actor page —
-    degrades to a name-only flow), and the current dict shape with
-    ``tmdb_id``. The next save migrates the row to the current shape
-    implicitly.
-
-    Tolerant of malformed payloads at the storage boundary: a JSON
-    value that is not a list (drift from a future migration, manual
-    DB edit) collapses to an empty cast rather than iterating dict
-    keys as if they were entries; dict entries with no usable
-    ``name`` are skipped so the UI never renders empty cards. A
-    non-int ``tmdb_id`` (string, float, malformed import) is dropped
-    silently rather than raising.
-    """
-    if not raw:
-        return []
-    items = json.loads(raw)
-    if not isinstance(items, list):
-        return []
-    members: list[CastMember] = []
-    for item in items:
-        if isinstance(item, str):
-            name = item.strip()
-            if name:
-                members.append(CastMember(name=name))
-        elif isinstance(item, dict):
-            name = str(item.get("name") or "").strip()
-            if not name:
-                continue
-            raw_tmdb_id = item.get("tmdb_id")
-            tmdb_id = raw_tmdb_id if isinstance(raw_tmdb_id, int) else None
-            members.append(
-                CastMember(
-                    name=name,
-                    profile_path=item.get("profile_path") or None,
-                    role=item.get("role") or None,
-                    tmdb_id=tmdb_id,
-                )
-            )
-    return members
 
 
 class MovieMapper:
@@ -139,7 +72,7 @@ class MovieMapper:
             if entity.scrub_preview_path
             else None,
             genres=",".join(g.value for g in entity.genres) if entity.genres else None,
-            cast=_serialize_cast(entity.cast),
+            cast=serialize_cast(entity.cast),
             directors=json.dumps(entity.directors, ensure_ascii=False)
             if entity.directors
             else None,
@@ -215,7 +148,7 @@ class MovieMapper:
             if model.scrub_preview_path
             else None,
             genres=genre_list,
-            cast=_deserialize_cast(model.cast),
+            cast=deserialize_cast(model.cast),
             directors=json.loads(model.directors) if model.directors else [],
             writers=json.loads(model.writers) if model.writers else [],
             content_rating=ContentRating(model.content_rating) if model.content_rating else None,
@@ -255,7 +188,7 @@ class MovieMapper:
             entity.scrub_preview_path.value if entity.scrub_preview_path else None
         )
         model.genres = ",".join(g.value for g in entity.genres) if entity.genres else None
-        model.cast = _serialize_cast(entity.cast)
+        model.cast = serialize_cast(entity.cast)
         model.directors = (
             json.dumps(entity.directors, ensure_ascii=False) if entity.directors else None
         )

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -25,6 +25,10 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.modules.media.infrastructure.persistence.mappers.cast_serialization import (
+    deserialize_cast,
+    serialize_cast,
+)
 from src.modules.media.infrastructure.persistence.mappers.media_file_mapper import (
     MediaFileMapper,
 )
@@ -290,6 +294,7 @@ class SeriesMapper:
             genres=",".join(g.value for g in entity.genres) if entity.genres else None,
             content_rating=entity.content_rating.value if entity.content_rating else None,
             trailer_url=entity.trailer_url,
+            cast=serialize_cast(entity.cast),
             localized=json.dumps(entity.localized, ensure_ascii=False)
             if entity.localized
             else None,
@@ -329,6 +334,7 @@ class SeriesMapper:
             genres=genre_list,
             content_rating=ContentRating(model.content_rating) if model.content_rating else None,
             trailer_url=model.trailer_url,
+            cast=deserialize_cast(model.cast),
             localized=json.loads(model.localized) if model.localized else {},
             tmdb_id=TmdbId(model.tmdb_id) if model.tmdb_id else None,
             imdb_id=ImdbId(model.imdb_id) if model.imdb_id else None,
@@ -359,6 +365,7 @@ class SeriesMapper:
         model.genres = ",".join(g.value for g in entity.genres) if entity.genres else None
         model.content_rating = entity.content_rating.value if entity.content_rating else None
         model.trailer_url = entity.trailer_url
+        model.cast = serialize_cast(entity.cast)
         model.localized = (
             json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None
         )

--- a/src/modules/media/infrastructure/persistence/models/series.py
+++ b/src/modules/media/infrastructure/persistence/models/series.py
@@ -48,6 +48,9 @@ class SeriesModel(Base):
     content_rating: Mapped[str | None] = mapped_column(String(20), nullable=True)
     trailer_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
+    # Credits — same JSON-array-of-cast-dicts shape MovieModel uses.
+    cast: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # Localized metadata (JSON)
     localized: Mapped[str | None] = mapped_column(Text, nullable=True)
 

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -7,6 +7,7 @@ import pytest
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
 from src.modules.media.application.ports import (
+    CreditPerson,
     EpisodeMetadata,
     LocalizedFields,
     MediaMetadata,
@@ -497,6 +498,72 @@ class TestApplySeriesFields:
         assert saved.backdrop_path is not None
         assert saved.content_rating == ContentRating("TV-MA")
         assert saved.trailer_url == "https://youtube.com/abc"
+
+    @pytest.mark.asyncio
+    async def test_should_persist_cast_when_metadata_provides_it(self) -> None:
+        """A series enriched for the first time picks up the cast list
+        TMDB returned via the credits append_to_response. Mirrors the
+        movie enrichment path so the detail UI can render an actor
+        carousel on series too."""
+        series = _make_series()
+        metadata = MediaMetadata(
+            title="Breaking Bad",
+            tmdb_id=1396,
+            cast=[
+                CreditPerson(
+                    name="Bryan Cranston",
+                    role="Walter White",
+                    profile_url="https://image.tmdb.org/p/bryan.jpg",
+                    tmdb_id=17419,
+                ),
+                CreditPerson(name="Aaron Paul", role="Jesse Pinkman", tmdb_id=84497),
+            ],
+        )
+
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        saved = mocks.series.save.call_args[0][0]
+        assert [m.name for m in saved.cast] == ["Bryan Cranston", "Aaron Paul"]
+        assert saved.cast[0].role == "Walter White"
+        assert saved.cast[0].tmdb_id == 17419
+        assert saved.cast[0].profile_path == "https://image.tmdb.org/p/bryan.jpg"
+
+    @pytest.mark.asyncio
+    async def test_should_not_overwrite_existing_cast(self) -> None:
+        """Cast follows the same fill-if-empty rule the rest of the
+        series enrichment does — a series that already has cast keeps
+        whatever was there even when the provider returns a different
+        list. Force-refresh on cast is out of scope for this PR; today
+        the user clears it manually if they want a re-pull."""
+        from src.modules.media.domain.value_objects import CastMember
+
+        series = _make_series().with_updates(
+            cast=[CastMember(name="Existing Actor", tmdb_id=1)],
+        )
+        metadata = MediaMetadata(
+            title="Breaking Bad",
+            tmdb_id=1396,
+            cast=[CreditPerson(name="New Actor", tmdb_id=2)],
+        )
+
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        saved = mocks.series.save.call_args[0][0]
+        assert [m.name for m in saved.cast] == ["Existing Actor"]
 
     @pytest.mark.asyncio
     async def test_should_apply_localized_series_fields(self) -> None:

--- a/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
@@ -10,6 +10,7 @@ from src.modules.media.application.ports import ProgressLookupPort
 from src.modules.media.application.use_cases import GetSeriesByIdUseCase
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
+    CastMember,
     Duration,
     EpisodeId,
     FilePath,
@@ -31,6 +32,40 @@ def mock_progress_lookup() -> AsyncMock:
 
 class TestGetSeriesByIdUseCase:
     """Tests for GetSeriesByIdUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_expose_cast_in_output(self, mock_progress_lookup):
+        """The series output mirrors the movie shape: each cast entry
+        carries name, profile_path, role and tmdb_id so the detail UI
+        can render the same actor cards across both media types."""
+        mocks = make_media_uow_mock()
+        series = Series.create(title="Breaking Bad", start_year=2008).with_updates(
+            cast=[
+                CastMember(
+                    name="Bryan Cranston",
+                    profile_path="https://image.tmdb.org/p/bryan.jpg",
+                    role="Walter White",
+                    tmdb_id=17419,
+                ),
+                CastMember(name="Aaron Paul", role="Jesse Pinkman"),
+            ],
+        )
+        mocks.series.find_by_id.return_value = series
+        use_case = GetSeriesByIdUseCase(
+            uow_factory=mocks.factory,
+            progress_lookup=mock_progress_lookup,
+        )
+
+        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
+
+        assert len(result.cast) == 2
+        assert result.cast[0].name == "Bryan Cranston"
+        assert result.cast[0].profile_path == "https://image.tmdb.org/p/bryan.jpg"
+        assert result.cast[0].role == "Walter White"
+        assert result.cast[0].tmdb_id == 17419
+        assert result.cast[1].name == "Aaron Paul"
+        assert result.cast[1].profile_path is None
+        assert result.cast[1].tmdb_id is None
 
     @pytest.mark.asyncio
     async def test_should_return_series_when_found(self, mock_progress_lookup):

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -1184,6 +1184,48 @@ class TestFetchSeriesDetails:
 
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_should_parse_cast_from_credits_append(self) -> None:
+        """The series details fetch appends ``credits`` so TMDB returns
+        a top-billed cast list. Pin that the client surfaces it on
+        ``MediaMetadata.cast`` the same way the movie path does."""
+        data = _series_details()
+        data["credits"] = {
+            "cast": [
+                {
+                    "id": 17419,
+                    "name": "Bryan Cranston",
+                    "character": "Walter White",
+                    "profile_path": "/bryan.jpg",
+                    "order": 0,
+                },
+                {
+                    "id": 84497,
+                    "name": "Aaron Paul",
+                    "character": "Jesse Pinkman",
+                    "profile_path": "/aaron.jpg",
+                    "order": 1,
+                },
+            ],
+            "crew": [],
+        }
+        client = _make_client(
+            get_responses=[
+                _build_response(json_data=data),
+                _build_response(json_data=_season_details()),
+            ]
+        )
+
+        result = await client._fetch_series_details(1396)
+
+        assert result is not None
+        assert len(result.cast) == 2
+        assert result.cast[0].name == "Bryan Cranston"
+        assert result.cast[0].role == "Walter White"
+        assert result.cast[0].tmdb_id == 17419
+        assert result.cast[0].profile_url is not None
+        assert result.cast[1].name == "Aaron Paul"
+
 
 @pytest.mark.unit
 class TestFetchSeason:

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_cast_serialization.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_cast_serialization.py
@@ -1,0 +1,94 @@
+"""Unit tests for cast_serialization helpers.
+
+Covers the legacy-tolerant decode path so a regression in any one
+branch (legacy ``list[str]``, dict without ``tmdb_id``, current dict
+shape, malformed payloads) flips a test red.
+"""
+
+import pytest
+
+from src.modules.media.domain.value_objects import CastMember
+from src.modules.media.infrastructure.persistence.mappers.cast_serialization import (
+    deserialize_cast,
+    serialize_cast,
+)
+
+
+@pytest.mark.unit
+class TestSerializeCast:
+    def test_returns_none_for_empty_list(self) -> None:
+        assert serialize_cast([]) is None
+
+    def test_writes_full_dict_shape_with_tmdb_id(self) -> None:
+        out = serialize_cast(
+            [
+                CastMember(
+                    name="Leo",
+                    profile_path="https://img/leo.jpg",
+                    role="Cobb",
+                    tmdb_id=6193,
+                ),
+            ],
+        )
+        assert out is not None
+        assert '"name": "Leo"' in out
+        assert '"tmdb_id": 6193' in out
+
+
+@pytest.mark.unit
+class TestDeserializeCast:
+    def test_empty_input_returns_empty_list(self) -> None:
+        assert deserialize_cast(None) == []
+        assert deserialize_cast("") == []
+
+    def test_legacy_list_of_strings(self) -> None:
+        result = deserialize_cast('["Leo", "Joseph"]')
+
+        assert [m.name for m in result] == ["Leo", "Joseph"]
+        assert all(m.profile_path is None for m in result)
+        assert all(m.tmdb_id is None for m in result)
+
+    def test_dict_without_tmdb_id(self) -> None:
+        result = deserialize_cast(
+            '[{"name": "Leo", "profile_path": "https://img/leo.jpg", "role": "Cobb"}]',
+        )
+
+        assert len(result) == 1
+        assert result[0].name == "Leo"
+        assert result[0].profile_path == "https://img/leo.jpg"
+        assert result[0].role == "Cobb"
+        assert result[0].tmdb_id is None
+
+    def test_dict_with_tmdb_id(self) -> None:
+        result = deserialize_cast('[{"name": "Leo", "tmdb_id": 6193}]')
+
+        assert result[0].tmdb_id == 6193
+
+    def test_non_list_payload_collapses_to_empty(self) -> None:
+        """Drift from a future migration or a manual DB edit could
+        write a single object instead of a list. Without the guard,
+        ``for item in items`` would iterate dict keys."""
+        assert deserialize_cast('{"name": "Leo"}') == []
+
+    def test_malformed_json_collapses_to_empty(self) -> None:
+        """Truncated rows / corrupted blobs must not crash the read
+        path. The encoder always writes valid JSON, but the column is
+        just Text — anything could end up in there from a manual
+        edit or a botched import."""
+        assert deserialize_cast("not json at all") == []
+        assert deserialize_cast('{"unterminated":') == []
+
+    def test_dict_without_name_is_skipped(self) -> None:
+        result = deserialize_cast(
+            '[{"profile_path": "https://img/leo.jpg"}, {"name": "Joseph"}]',
+        )
+
+        assert [m.name for m in result] == ["Joseph"]
+
+    def test_non_int_tmdb_id_is_dropped(self) -> None:
+        """Strings, floats, or anything else where TMDB ids would be
+        ints get silently dropped — the actor page falls back to a
+        name-only lookup, no crash."""
+        result = deserialize_cast('[{"name": "Leo", "tmdb_id": "6193"}]')
+
+        assert result[0].tmdb_id is None

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
+    CastMember,
     Duration,
     EpisodeId,
     FilePath,
@@ -292,3 +293,57 @@ class TestSeriesMapper:
         assert entity.title.value == "Shallow Series"
         assert entity.start_year.value == 2020
         assert entity.seasons == []
+
+    def test_cast_roundtrips_through_to_model_and_to_entity(self) -> None:
+        """A series carrying a populated cast list survives one
+        ``to_model`` → ``to_entity`` cycle byte-for-byte. Pins that
+        the JSON encoding stays the same shape that the movie-side
+        decoder already understands so shared helpers don't drift."""
+        series = _create_series(series_id=SeriesId.generate()).with_updates(
+            cast=[
+                CastMember(
+                    name="Bryan Cranston",
+                    profile_path="https://image.tmdb.org/t/p/original/bryan.jpg",
+                    role="Walter White",
+                    tmdb_id=17419,
+                ),
+                CastMember(name="Aaron Paul", role="Jesse Pinkman"),
+            ],
+        )
+
+        model = SeriesMapper.to_model(series)
+        # Stamp creation timestamps so to_entity can rebuild without
+        # the DB defaults that aren't applied in unit tests.
+        now = datetime.now(UTC)
+        model.created_at = now
+        model.updated_at = now
+
+        rebuilt = SeriesMapper.to_entity(model, include_seasons=False)
+
+        assert len(rebuilt.cast) == 2
+        assert rebuilt.cast[0].name == "Bryan Cranston"
+        assert rebuilt.cast[0].profile_path == "https://image.tmdb.org/t/p/original/bryan.jpg"
+        assert rebuilt.cast[0].role == "Walter White"
+        assert rebuilt.cast[0].tmdb_id == 17419
+        assert rebuilt.cast[1].name == "Aaron Paul"
+        assert rebuilt.cast[1].profile_path is None
+        assert rebuilt.cast[1].tmdb_id is None
+
+    def test_update_model_overwrites_existing_cast(self) -> None:
+        """``update_model`` replaces the persisted cast wholesale
+        rather than merging — the new entity's list is the source of
+        truth, matching how MovieMapper handles re-enrichment."""
+        series_id = SeriesId.generate()
+        existing = SeriesMapper.to_model(
+            _create_series(series_id=series_id).with_updates(
+                cast=[CastMember(name="Old Actor")],
+            ),
+        )
+
+        refreshed = _create_series(series_id=series_id).with_updates(
+            cast=[CastMember(name="New Actor", tmdb_id=42)],
+        )
+
+        SeriesMapper.update_model(existing, refreshed)
+        assert "New Actor" in (existing.cast or "")
+        assert "Old Actor" not in (existing.cast or "")


### PR DESCRIPTION
## Summary
- Mirror ``Movie.cast`` on the ``Series`` aggregate so the detail UI can render the same actor cards (avatar + name + role + tmdb_id deep-link) on series and movies — first half of the cast/recommendations parity work for series.
- Append ``credits`` to the TMDB ``/tv/{id}`` request and feed the parsed cast into ``MediaMetadata`` via the existing ``_parse_cast`` helper so series and movies share the cap/order rules.
- Apply cast in ``EnrichSeriesMetadataUseCase`` with the same fill-if-empty rule the rest of the series enrichment uses (synopsis, genres, posters). A force-refresh on cast is intentionally out of scope; the user clears the field manually if they want a re-pull.
- Move ``_serialize_cast`` / ``_deserialize_cast`` out of ``movie_mapper`` into a shared ``cast_serialization`` module so series_mapper reuses the legacy-tolerant decoder without duplicating it. ``MovieMapper`` now imports the same helpers.
- Expose ``cast: list[CastMemberOutput]`` on ``SeriesOutput`` and populate it in ``GetSeriesByIdUseCase._to_output``.
- Companion migration ``f2a3b4c5d6e7`` adds the nullable ``cast`` Text column to ``series`` (same shape ``movies.cast`` uses). Existing rows stay ``NULL`` until the next enrich pass.

## Test plan
- [x] ``pytest tests/modules/media/`` — 1104 pass.
- [x] Full backend suite — 1932 pass, 5 skipped.
- [x] ``ruff check`` + ``ruff format --check`` clean on every changed file (``migrations/env.py`` has a pre-existing ``I001`` unrelated to this PR).
- [x] ``alembic upgrade head`` then ``downgrade -1`` then ``upgrade head`` round-trips cleanly.
- [ ] After deploying, force-enrich a series and confirm ``GET /api/v1/series/{id}`` returns a populated ``cast`` array.

## Follow-up
- The frontend (homeflix-web) doesn't render ``SeriesDetail.cast`` yet — that's the next PR in this pair. Once shipped, browse-by-actor extending to series can land as a third step.

## Summary by Sourcery

Add cast support to series metadata and API to align series with movies for actor information and reuse cast serialization across media types.

New Features:
- Introduce cast storage and exposure on the Series aggregate and SeriesOutput so series detail responses include actor information.
- Populate series cast from TMDB credits during metadata enrichment using the same parsing rules as movies.

Enhancements:
- Extract cast JSON (de)serialization into a shared helper so movies and series use a common, legacy-tolerant format.
- Extend the TMDB series details client to request and parse credits into MediaMetadata cast.

Tests:
- Add unit tests covering series cast enrichment behavior, series cast persistence mapping, TMDB cast parsing for series, and cast exposure in GetSeriesById use case.

Chores:
- Add a database migration to introduce a nullable cast Text column on the series table matching the movies schema.