### PR TITLE
feat(media): add related series recommendations

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -28,6 +28,7 @@ from src.modules.media.application.use_cases.get_file_variants import GetFileVar
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_person_bio import GetPersonBioUseCase
 from src.modules.media.application.use_cases.get_related_movies import GetRelatedMoviesUseCase
+from src.modules.media.application.use_cases.get_related_series import GetRelatedSeriesUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
@@ -334,6 +335,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         EnrichSeriesMetadataUseCase,
         uow_factory=media_unit_of_work_factory,
         primary_provider=tmdb_client,
+    )
+
+    get_related_series = providers.Factory(
+        GetRelatedSeriesUseCase,
+        uow_factory=media_unit_of_work_factory,
+        metadata_provider=tmdb_client,
     )
 
     bulk_enrich_metadata = providers.Factory(

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -262,6 +262,23 @@ class MetadataProvider(ABC):
         """
         ...
 
+    @abstractmethod
+    async def get_series_recommendations(self, tmdb_id: int) -> list[int]:
+        """Return TMDB ids of series recommended for ``tmdb_id``.
+
+        Mirrors :meth:`get_movie_recommendations` for the series catalog.
+        Order matters: the first item is the most relevant recommendation
+        according to the provider; callers preserve this order so the UI
+        renders by descending relevance. Returns an empty list when the
+        provider has no recommendations or the call fails — recommendation
+        rendering is best-effort polish, never load-bearing.
+
+        The returned ids are TMDB tv ids; callers cross-reference them
+        with their own catalog to filter to series that actually exist
+        locally.
+        """
+        ...
+
 
 __all__ = [
     "CreditPerson",

--- a/src/modules/media/application/use_cases/_series_summary_helpers.py
+++ b/src/modules/media/application/use_cases/_series_summary_helpers.py
@@ -1,0 +1,31 @@
+"""Shared converters for ``SeriesSummaryOutput``.
+
+Several use cases (``ListSeriesUseCase``, ``GetRelatedSeriesUseCase``,
+future genre / search variants) build the same lightweight series
+summary the catalog UI consumes. Keeping the converter in one place
+avoids the inevitable drift where one site adds a new field and
+others render an older shape.
+"""
+
+from src.modules.media.application.dtos.series_dtos import SeriesSummaryOutput
+from src.modules.media.domain.entities.series import Series
+
+
+def to_series_summary(series: Series, lang: str = "en") -> SeriesSummaryOutput:
+    """Convert a ``Series`` entity to its catalog-card DTO."""
+    return SeriesSummaryOutput(
+        id=str(series.id),
+        title=series.get_title(lang),
+        start_year=series.start_year.value,
+        end_year=series.end_year.value if series.end_year else None,
+        is_ongoing=series.is_ongoing,
+        synopsis=series.get_synopsis(lang),
+        poster_path=series.poster_path.value if series.poster_path else None,
+        backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
+        season_count=series.season_count,
+        total_episodes=series.total_episodes,
+        genres=series.get_genres(lang),
+    )
+
+
+__all__ = ["to_series_summary"]

--- a/src/modules/media/application/use_cases/get_related_series.py
+++ b/src/modules/media/application/use_cases/get_related_series.py
@@ -1,0 +1,86 @@
+"""GetRelatedSeriesUseCase — TMDB recommendations filtered by library."""
+
+from dataclasses import dataclass
+
+from src.modules.media.application.dtos.series_dtos import SeriesSummaryOutput
+from src.modules.media.application.ports import MetadataProvider
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases._series_summary_helpers import to_series_summary
+from src.modules.media.domain.value_objects import SeriesId
+
+
+@dataclass(frozen=True)
+class GetRelatedSeriesInput:
+    """Input for ``GetRelatedSeriesUseCase``.
+
+    Attributes:
+        series_id: External id of the series to look up recommendations for.
+        lang: Language for localized fields on the response.
+        limit: Maximum number of related series to return.
+    """
+
+    series_id: str
+    lang: str = "en"
+    limit: int = 12
+
+
+class GetRelatedSeriesUseCase:
+    """Return series in the library that TMDB recommends for the input.
+
+    Pulls TMDB's recommendation list for the input series (falling back
+    to TMDB's "similar" endpoint when recommendations is empty), then
+    intersects with the local catalog by ``tmdb_id``. The TMDB ordering
+    (by relevance) is preserved on the way out.
+
+    The feature is best-effort polish: any failure (series not found,
+    series not enriched with TMDB id, provider unavailable, no overlap
+    with local catalog) yields an empty list rather than raising — the
+    UI simply doesn't render the carousel.
+
+    Example:
+        >>> use_case = GetRelatedSeriesUseCase(uow_factory, tmdb_client)
+        >>> result = await use_case.execute(GetRelatedSeriesInput("ser_abc"))
+        >>> [s.title for s in result]
+        ['Breaking Bad', 'Better Call Saul', ...]
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        metadata_provider: MetadataProvider,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._metadata = metadata_provider
+
+    async def execute(self, input_dto: GetRelatedSeriesInput) -> list[SeriesSummaryOutput]:
+        """Run the lookup."""
+        async with self._uow_factory() as uow:
+            source = await uow.series.find_by_id(SeriesId(input_dto.series_id))
+            if source is None or source.tmdb_id is None:
+                return []
+
+            tmdb_ids = await self._metadata.get_series_recommendations(source.tmdb_id.value)
+            if not tmdb_ids:
+                return []
+
+            # Trim before hitting the DB so a TMDB result of 50 doesn't
+            # cost us 50 rows when the carousel only shows ``limit``.
+            # Slight over-fetch (2x) so a few catalog gaps don't leave
+            # the carousel sparse.
+            candidate_ids = tmdb_ids[: input_dto.limit * 2]
+            local = await uow.series.find_by_tmdb_ids(candidate_ids)
+
+        # Preserve TMDB's relevance ordering by iterating the request
+        # list rather than the dict's insertion order.
+        ordered: list[SeriesSummaryOutput] = []
+        for tid in candidate_ids:
+            series = local.get(tid)
+            if series is None:
+                continue
+            ordered.append(to_series_summary(series, input_dto.lang))
+            if len(ordered) >= input_dto.limit:
+                break
+        return ordered
+
+
+__all__ = ["GetRelatedSeriesInput", "GetRelatedSeriesUseCase"]

--- a/src/modules/media/application/use_cases/list_series.py
+++ b/src/modules/media/application/use_cases/list_series.py
@@ -3,10 +3,9 @@
 from src.modules.media.application.dtos.series_dtos import (
     ListSeriesInput,
     ListSeriesOutput,
-    SeriesSummaryOutput,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-from src.modules.media.domain.entities import Series
+from src.modules.media.application.use_cases._series_summary_helpers import to_series_summary
 
 
 class ListSeriesUseCase:
@@ -54,35 +53,10 @@ class ListSeriesUseCase:
             )
 
         return ListSeriesOutput(
-            series=[self._to_summary(s, input_dto.lang) for s in page.items],
+            series=[to_series_summary(s, input_dto.lang) for s in page.items],
             next_cursor=page.pagination.next_cursor,
             has_more=page.pagination.has_more,
             total_count=page.total_count,
-        )
-
-    @staticmethod
-    def _to_summary(series: Series, lang: str = "en") -> SeriesSummaryOutput:
-        """Convert Series entity to summary output.
-
-        Args:
-            series: The Series entity to convert.
-            lang: Language code for localized fields.
-
-        Returns:
-            SeriesSummaryOutput with essential fields.
-        """
-        return SeriesSummaryOutput(
-            id=str(series.id),
-            title=series.get_title(lang),
-            start_year=series.start_year.value,
-            end_year=series.end_year.value if series.end_year else None,
-            is_ongoing=series.is_ongoing,
-            synopsis=series.get_synopsis(lang),
-            poster_path=series.poster_path.value if series.poster_path else None,
-            backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
-            season_count=series.season_count,
-            total_episodes=series.total_episodes,
-            genres=series.get_genres(lang),
         )
 
 

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -181,6 +181,24 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_by_tmdb_ids(self, tmdb_ids: Sequence[int]) -> dict[int, Series]:
+        """Find series whose ``tmdb_id`` matches any of ``tmdb_ids``.
+
+        Used by ``GetRelatedSeries`` to resolve the subset of TMDB's
+        recommendation list that exists locally. Returning a dict
+        keyed by ``tmdb_id`` lets the caller preserve TMDB's
+        relevance ordering by iterating the request list.
+
+        Args:
+            tmdb_ids: TMDB tv ids to look up.
+
+        Returns:
+            Dict mapping ``tmdb_id`` to the matching ``Series``. Empty
+            when ``tmdb_ids`` is empty or no rows match.
+        """
+        ...
+
+    @abstractmethod
     async def find_by_episode_id(self, episode_id: EpisodeId) -> Series | None:
         """Find a series containing an episode with this ID.
 

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -1,5 +1,7 @@
 """TMDB API client implementing MetadataProvider port."""
 
+from typing import Literal
+
 import httpx
 
 from src.modules.media.application.ports import (
@@ -292,8 +294,8 @@ class TmdbClient(MetadataProvider):
     async def _fetch_related_ids(
         self,
         tmdb_id: int,
-        media_type: str,
-        endpoint: str,
+        media_type: Literal["movie", "tv"],
+        endpoint: Literal["recommendations", "similar"],
     ) -> list[int]:
         """Hit a single ``/{media_type}/{id}/<endpoint>`` and extract numeric ids.
 

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -200,13 +200,40 @@ class TmdbClient(MetadataProvider):
         never load-bearing.
         """
         collection_ids = await self._fetch_collection_movie_ids(tmdb_id)
-        other_ids = await self._fetch_related_movie_ids(tmdb_id, "recommendations")
+        other_ids = await self._fetch_related_ids(tmdb_id, "movie", "recommendations")
         if not other_ids:
-            other_ids = await self._fetch_related_movie_ids(tmdb_id, "similar")
+            other_ids = await self._fetch_related_ids(tmdb_id, "movie", "similar")
 
         seen: set[int] = {tmdb_id}
         ordered: list[int] = []
         for tid in [*collection_ids, *other_ids]:
+            if tid in seen:
+                continue
+            seen.add(tid)
+            ordered.append(tid)
+        return ordered
+
+    async def get_series_recommendations(self, tmdb_id: int) -> list[int]:
+        """Return TMDB ids of series related to ``tmdb_id``.
+
+        Series have no collection equivalent on TMDB (no ``parts``
+        list akin to movie franchises), so the source list is just:
+
+        1. **``/recommendations``** — ML-based.
+        2. **``/similar``** — heuristic fallback, only used when
+           recommendations is empty.
+
+        Network failures and unexpected payload shapes degrade to an
+        empty list — recommendation rendering is best-effort polish,
+        never load-bearing.
+        """
+        ids = await self._fetch_related_ids(tmdb_id, "tv", "recommendations")
+        if not ids:
+            ids = await self._fetch_related_ids(tmdb_id, "tv", "similar")
+
+        seen: set[int] = {tmdb_id}
+        ordered: list[int] = []
+        for tid in ids:
             if tid in seen:
                 continue
             seen.add(tid)
@@ -262,17 +289,23 @@ class TmdbClient(MetadataProvider):
                 ids.append(pid)
         return ids
 
-    async def _fetch_related_movie_ids(self, tmdb_id: int, endpoint: str) -> list[int]:
-        """Hit a single ``/movie/{id}/<endpoint>`` and extract numeric ids.
+    async def _fetch_related_ids(
+        self,
+        tmdb_id: int,
+        media_type: str,
+        endpoint: str,
+    ) -> list[int]:
+        """Hit a single ``/{media_type}/{id}/<endpoint>`` and extract numeric ids.
 
-        ``endpoint`` is ``"recommendations"`` or ``"similar"``; both
-        paginate but page 1 already carries enough candidates for the
-        UI's ~10-item carousel and a second request would just burn
-        latency on results we'd discard.
+        ``media_type`` is ``"movie"`` or ``"tv"``; ``endpoint`` is
+        ``"recommendations"`` or ``"similar"``. Both endpoints paginate
+        but page 1 already carries enough candidates for the UI's
+        ~10-item carousel and a second request would just burn latency
+        on results we'd discard.
         """
         try:
             resp = await self._client.get(
-                f"{self._base_url}/movie/{tmdb_id}/{endpoint}",
+                f"{self._base_url}/{media_type}/{tmdb_id}/{endpoint}",
                 params=self._params(),
             )
         except httpx.HTTPError:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -332,6 +332,32 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             model.external_id: SeriesMapper.to_entity(model) for model in result.scalars().all()
         }
 
+    async def find_by_tmdb_ids(self, tmdb_ids: Sequence[int]) -> dict[int, Series]:
+        """Find series whose ``tmdb_id`` matches any of ``tmdb_ids``.
+
+        Used by ``GetRelatedSeries`` to resolve the subset of TMDB's
+        recommendation list that exists locally. Returning a dict
+        keyed by ``tmdb_id`` lets the caller preserve TMDB's
+        relevance ordering by iterating the request list.
+        """
+        if not tmdb_ids:
+            return {}
+        stmt = (
+            select(SeriesModel)
+            .where(
+                SeriesModel.tmdb_id.in_(tmdb_ids),
+                SeriesModel.deleted_at.is_(None),
+            )
+            .options(*self._series_load_options())
+            .execution_options(populate_existing=True)
+        )
+        result = await self._session.execute(stmt)
+        return {
+            model.tmdb_id: SeriesMapper.to_entity(model)
+            for model in result.scalars().all()
+            if model.tmdb_id is not None
+        }
+
     async def find_by_episode_id(self, episode_id: EpisodeId) -> Series | None:
         """Find a series containing an episode with this ID.
 

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -22,6 +22,10 @@ from src.modules.media.application.dtos.series_dtos import GetSeriesByIdInput, L
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
 from src.modules.media.application.use_cases.clear_episode_intro import ClearEpisodeIntroUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
+from src.modules.media.application.use_cases.get_related_series import (
+    GetRelatedSeriesInput,
+    GetRelatedSeriesUseCase,
+)
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
 from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
@@ -88,6 +92,29 @@ async def get_series(
     """Get a series by ID (includes full season/episode hierarchy)."""
     result = await use_case.execute(GetSeriesByIdInput(series_id=series_id, lang=lang))
     return api_single("series", _dataclass_to_dict(result))
+
+
+@router.get("/{series_id}/related")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_related_series(
+    series_id: str,
+    lang: str = "en",
+    limit: int = 12,
+    use_case: GetRelatedSeriesUseCase = Depends(
+        Provide[ApplicationContainer.media.get_related_series],
+    ),
+) -> dict[str, Any]:
+    """Return series in the local catalog that TMDB recommends for ``series_id``.
+
+    Best-effort polish for the "you might also like" carousel: the
+    response is an empty list whenever the series has no TMDB id, the
+    provider returns nothing, or no recommendation overlaps with the
+    local catalog. The route never raises.
+    """
+    items = await use_case.execute(
+        GetRelatedSeriesInput(series_id=series_id, lang=lang, limit=max(1, min(limit, 30))),
+    )
+    return api_list([_dataclass_to_dict(item) for item in items])
 
 
 # ── Episode file variant endpoints ──────────────────────────────────

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -600,6 +600,52 @@ class TestSQLAlchemySeriesRepositoryFindByIds:
 
 
 @pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryFindByTmdbIds:
+    """Tests for ``find_by_tmdb_ids`` — used by ``GetRelatedSeries``."""
+
+    async def test_returns_empty_dict_for_empty_input(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        assert await repo.find_by_tmdb_ids([]) == {}
+
+    async def test_returns_mapping_by_tmdb_id(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        a = _create_series(title="A", tmdb_id=TmdbId(100))
+        b = _create_series(title="B", tmdb_id=TmdbId(200))
+        await repo.save(a)
+        await repo.save(b)
+
+        result = await repo.find_by_tmdb_ids([100, 200])
+
+        assert set(result.keys()) == {100, 200}
+        assert result[100].title.value == "A"
+        assert result[200].title.value == "B"
+
+    async def test_skips_ids_not_in_catalog(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        present = _create_series(title="Present", tmdb_id=TmdbId(42))
+        await repo.save(present)
+
+        result = await repo.find_by_tmdb_ids([42, 9999])
+
+        assert set(result.keys()) == {42}
+
+    async def test_excludes_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _create_series(title="Trashed", tmdb_id=TmdbId(7))
+        await repo.save(series)
+        await repo.delete(_id_of(series))
+
+        assert await repo.find_by_tmdb_ids([7]) == {}
+
+    async def test_skips_series_with_null_tmdb_id(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        no_tmdb = _create_series(title="Manual")
+        await repo.save(no_tmdb)
+
+        assert await repo.find_by_tmdb_ids([1, 2, 3]) == {}
+
+
+@pytest.mark.integration
 class TestSQLAlchemySeriesRepositoryFindByTitle:
     """Tests for find_by_title."""
 

--- a/tests/modules/media/unit/application/use_cases/test_get_related_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_related_movies.py
@@ -23,7 +23,7 @@ def _movie(*, title: str, tmdb_id: int | None) -> Movie:
         file_size=1_000_000_000,
         resolution="1080p",
     )
-    return movie.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id else movie
+    return movie.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id is not None else movie
 
 
 class TestGetRelatedMoviesUseCase:

--- a/tests/modules/media/unit/application/use_cases/test_get_related_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_related_series.py
@@ -16,7 +16,7 @@ from tests.modules.media.unit.conftest import make_media_uow_mock
 
 def _series(*, title: str, tmdb_id: int | None) -> Series:
     series = Series.create(title=title, start_year=2010)
-    return series.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id else series
+    return series.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id is not None else series
 
 
 class TestGetRelatedSeriesUseCase:

--- a/tests/modules/media/unit/application/use_cases/test_get_related_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_related_series.py
@@ -1,0 +1,127 @@
+"""Tests for ``GetRelatedSeriesUseCase``."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.application.ports import MetadataProvider
+from src.modules.media.application.use_cases.get_related_series import (
+    GetRelatedSeriesInput,
+    GetRelatedSeriesUseCase,
+)
+from src.modules.media.domain.entities import Series
+from src.modules.media.domain.value_objects import SeriesId, TmdbId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+
+def _series(*, title: str, tmdb_id: int | None) -> Series:
+    series = Series.create(title=title, start_year=2010)
+    return series.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id else series
+
+
+class TestGetRelatedSeriesUseCase:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_source_series_missing(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = None
+        provider = AsyncMock(spec=MetadataProvider)
+
+        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedSeriesInput(series_id=str(SeriesId.generate())),
+        )
+
+        assert result == []
+        provider.get_series_recommendations.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_source_has_no_tmdb_id(self) -> None:
+        # Series was added manually (no enrich) — no way to look up
+        # recommendations. Bail before hitting the provider.
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = _series(title="Manual", tmdb_id=None)
+        provider = AsyncMock(spec=MetadataProvider)
+
+        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedSeriesInput(series_id=str(SeriesId.generate())),
+        )
+
+        assert result == []
+        provider.get_series_recommendations.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_filters_to_local_catalog_preserving_tmdb_order(self) -> None:
+        # TMDB returns 4 ids in relevance order. Only ids 1396 and 60625
+        # exist locally; the response must be ordered [1396, 60625] —
+        # TMDB's relevance ranking, NOT the dict's insertion order.
+        mocks = make_media_uow_mock()
+        source = _series(title="Better Call Saul", tmdb_id=60059)
+        mocks.series.find_by_id.return_value = source
+        mocks.series.find_by_tmdb_ids.return_value = {
+            60625: _series(title="Rick and Morty", tmdb_id=60625),
+            1396: _series(title="Breaking Bad", tmdb_id=1396),
+        }
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_recommendations.return_value = [
+            1396,
+            999999,
+            60625,
+            888888,
+        ]
+
+        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedSeriesInput(series_id=str(SeriesId.generate()), limit=10),
+        )
+
+        assert [s.title for s in result] == ["Breaking Bad", "Rick and Morty"]
+
+    @pytest.mark.asyncio
+    async def test_truncates_to_limit(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = _series(title="Source", tmdb_id=1)
+        mocks.series.find_by_tmdb_ids.return_value = {
+            i: _series(title=f"S{i}", tmdb_id=i) for i in (10, 11, 12, 13, 14)
+        }
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_recommendations.return_value = [10, 11, 12, 13, 14]
+
+        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedSeriesInput(series_id=str(SeriesId.generate()), limit=3),
+        )
+
+        assert len(result) == 3
+        assert [s.title for s in result] == ["S10", "S11", "S12"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_local_overlap(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = _series(title="Source", tmdb_id=1)
+        mocks.series.find_by_tmdb_ids.return_value = {}
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_recommendations.return_value = [99, 100, 101]
+
+        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedSeriesInput(series_id=str(SeriesId.generate())),
+        )
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_provider_returns_nothing(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = _series(title="Source", tmdb_id=1)
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_recommendations.return_value = []
+
+        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        result = await use_case.execute(
+            GetRelatedSeriesInput(series_id=str(SeriesId.generate())),
+        )
+
+        assert result == []
+        # Should not even hit the repo on an empty TMDB result.
+        mocks.series.find_by_tmdb_ids.assert_not_called()

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -995,6 +995,96 @@ class TestGetMovieRecommendations:
 
 
 @pytest.mark.unit
+class TestGetSeriesRecommendations:
+    """``get_series_recommendations`` — ML / heuristic merge.
+
+    Series have no collection equivalent on TMDB, so the call sequence
+    is just:
+
+    1. ``/tv/{id}/recommendations`` for ML-based recs.
+    2. ``/tv/{id}/similar`` only when recommendations is empty.
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_recommended_ids_in_order(self) -> None:
+        client = _make_client(
+            get_responses=[
+                _build_response(  # /tv/{id}/recommendations
+                    json_data={"results": [{"id": 60059}, {"id": 1396}, {"id": 60625}]},
+                ),
+            ],
+        )
+
+        ids = await client.get_series_recommendations(1396)
+
+        # 1396 is the input series itself — must be skipped.
+        assert ids == [60059, 60625]
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_similar_when_recommendations_empty(self) -> None:
+        client = _make_client(
+            get_responses=[
+                _build_response(json_data={"results": []}),  # /recommendations
+                _build_response(  # /similar
+                    json_data={"results": [{"id": 99}, {"id": 100}]},
+                ),
+            ],
+        )
+
+        ids = await client.get_series_recommendations(42)
+
+        assert ids == [99, 100]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_all_sources_empty(self) -> None:
+        client = _make_client(
+            get_responses=[
+                _build_response(json_data={"results": []}),  # /recommendations
+                _build_response(json_data={"results": []}),  # /similar
+            ],
+        )
+
+        ids = await client.get_series_recommendations(42)
+
+        assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_http_error(self) -> None:
+        client = _make_client(
+            get_responses=[
+                _build_response(status_code=500),  # /recommendations
+                _build_response(status_code=500),  # /similar
+            ],
+        )
+
+        ids = await client.get_series_recommendations(42)
+
+        assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_skips_non_int_ids_in_payload(self) -> None:
+        # Defensive: a malformed TMDB row shouldn't crash the parser.
+        client = _make_client(
+            get_responses=[
+                _build_response(  # /recommendations
+                    json_data={
+                        "results": [
+                            {"id": 1},
+                            {"id": "not-an-int"},
+                            {"name": "no id here"},
+                            {"id": 2},
+                        ]
+                    },
+                ),
+            ],
+        )
+
+        ids = await client.get_series_recommendations(1396)
+
+        assert ids == [1, 2]
+
+
+@pytest.mark.unit
 class TestPickBestLogoUrl:
     """Priority order for the ``_pick_best_logo_url`` parser.
 


### PR DESCRIPTION
## Summary

- New `GetRelatedSeriesUseCase` mirrors `GetRelatedMoviesUseCase`: pulls TMDB recommendations for the series' `tmdb_id` (with `/similar` fallback) and intersects with the local catalog, preserving TMDB's relevance ordering.
- Surfaces as `GET /api/v1/series/{id}/related`. Best-effort polish: returns an empty list whenever the series has no `tmdb_id`, the provider returns nothing, or no recommendation overlaps with the local catalog.
- Series have no collection equivalent on TMDB, so no franchise-sibling step — just `/tv/{id}/recommendations` + `/tv/{id}/similar`. Generalized the existing `_fetch_related_movie_ids` into `_fetch_related_ids(media_type, endpoint)` so the helper is shared between movies and series.
- Extracted `to_series_summary` into `_series_summary_helpers.py` (mirroring `to_movie_summary`) for consistent catalog DTOs across `list_series`, `get_related_series`, and future genre / search variants.
- New port abstract method `MetadataProvider.get_series_recommendations(tmdb_id)` and `SeriesRepository.find_by_tmdb_ids(tmdb_ids)` (with concrete SQLAlchemy impl).

## Test plan

- [x] `poetry run ruff check src/ tests/`
- [x] `poetry run ruff format --check src/ tests/`
- [x] `poetry run pytest` — 1958 passed, 5 skipped
- [x] New unit tests for `GetRelatedSeriesUseCase` (5 cases + provider-empty short-circuit)
- [x] New unit tests for `TmdbClient.get_series_recommendations` (recommendations / similar fallback / both empty / HTTP error / malformed payload)
- [x] New integration tests for `SQLAlchemySeriesRepository.find_by_tmdb_ids` (empty input / mapping / missing ids / soft-deleted / null tmdb_id)
- [ ] Smoke test: hit `GET /api/v1/series/{id}/related` against a series enriched with TMDB id (frontend follow-up will wire the carousel)

## Summary by Sourcery

Add TMDB-backed related-series recommendations and share series summary mapping across use cases.

New Features:
- Expose a GET /api/v1/series/{id}/related endpoint backed by a GetRelatedSeriesUseCase that returns locally available series recommended by TMDB.
- Introduce MetadataProvider.get_series_recommendations and SeriesRepository.find_by_tmdb_ids to support series recommendation lookups via TMDB ids.

Enhancements:
- Generalize TMDB related-content fetching into a reusable _fetch_related_ids helper that supports both movies and series.
- Extract series-to-summary conversion into a shared to_series_summary helper used by list and related series flows.

Tests:
- Add unit tests for GetRelatedSeriesUseCase covering empty states, catalog filtering, ordering, and limiting.
- Add unit tests for TmdbClient.get_series_recommendations including fallback behavior, malformed payloads, and error handling.
- Add integration tests for SQLAlchemySeriesRepository.find_by_tmdb_ids covering empty input, soft deletes, missing ids, and null tmdb_id handling.