### PR TITLE
feat(media): capture movie tagline and franchise collection

### DIFF
--- a/migrations/versions/2026_05_01_add_movie_tagline_and_collection.py
+++ b/migrations/versions/2026_05_01_add_movie_tagline_and_collection.py
@@ -1,0 +1,54 @@
+"""Add tagline and collection columns to movies.
+
+``tagline`` is the short marketing line TMDB exposes per movie
+(``"In space no one can hear you scream."``). The collection
+fields denormalize the franchise the movie belongs to so the
+detail page can render a "Part of <name> · N movies" pill
+without a separate Collection aggregate. All three columns are
+nullable so existing rows keep loading and the next enrichment
+pass populates them.
+
+Revision ID: a3b4c5d6e7f8
+Revises: f2a3b4c5d6e7
+Create Date: 2026-05-01 21:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "a3b4c5d6e7f8"
+down_revision: str | Sequence[str] | None = "f2a3b4c5d6e7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``tagline`` and ``collection_*`` columns to ``movies``."""
+    with op.batch_alter_table("movies", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("tagline", sa.String(length=500), nullable=True))
+        batch_op.add_column(sa.Column("collection_tmdb_id", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("collection_name", sa.String(length=255), nullable=True))
+        batch_op.add_column(sa.Column("collection_parts_count", sa.Integer(), nullable=True))
+        batch_op.create_index(
+            "ix_movies_collection_tmdb_id",
+            ["collection_tmdb_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Drop ``tagline`` and ``collection_*`` columns from ``movies``."""
+    with op.batch_alter_table("movies", schema=None) as batch_op:
+        batch_op.drop_index("ix_movies_collection_tmdb_id")
+        batch_op.drop_column("collection_parts_count")
+        batch_op.drop_column("collection_name")
+        batch_op.drop_column("collection_tmdb_id")
+        batch_op.drop_column("tagline")

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -62,6 +62,21 @@ class CastMemberOutput:
 
 
 @dataclass(frozen=True)
+class CollectionOutput:
+    """Collection (franchise) the movie belongs to.
+
+    Attributes:
+        tmdb_id: TMDB collection id.
+        name: Display name (e.g. ``"Alien Collection"``).
+        parts_count: Number of titles in the collection per TMDB.
+    """
+
+    tmdb_id: int
+    name: str
+    parts_count: int
+
+
+@dataclass(frozen=True)
 class MovieOutput:
     """Output representation of a Movie.
 
@@ -101,6 +116,7 @@ class MovieOutput:
     duration_seconds: int
     duration_formatted: str
     synopsis: str | None
+    tagline: str | None
     poster_path: str | None
     backdrop_path: str | None
     logo_path: str | None
@@ -111,6 +127,7 @@ class MovieOutput:
     writers: list[str]
     content_rating: str | None
     trailer_url: str | None
+    collection: CollectionOutput | None
     file_path: str | None
     file_size: int | None
     resolution: str | None
@@ -197,6 +214,7 @@ class ListMoviesOutput:
 
 
 __all__ = [
+    "CollectionOutput",
     "GetMovieByIdInput",
     "ListMoviesInput",
     "ListMoviesOutput",

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -17,6 +17,7 @@ from src.modules.media.application.ports.media_probe_port import (
     ProbeResult,
 )
 from src.modules.media.application.ports.metadata_provider_port import (
+    CollectionMetadata,
     CreditPerson,
     EpisodeMetadata,
     LocalizedFields,
@@ -34,6 +35,7 @@ from src.modules.media.application.ports.variant_detector_port import (
 )
 
 __all__ = [
+    "CollectionMetadata",
     "CreditPerson",
     "DetectedIntro",
     "EpisodeFingerprint",

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -114,8 +114,24 @@ class LocalizedFields:
 
     title: str | None = None
     synopsis: str | None = None
+    tagline: str | None = None
     genres: list[str] = field(default_factory=list)
     logo_url: str | None = None
+
+
+@dataclass(frozen=True)
+class CollectionMetadata:
+    """TMDB collection (franchise) metadata.
+
+    Attributes:
+        tmdb_id: TMDB collection id.
+        name: Display name (e.g. ``"Alien Collection"``).
+        parts_count: Number of titles in the collection per TMDB.
+    """
+
+    tmdb_id: int
+    name: str
+    parts_count: int
 
 
 @dataclass(frozen=True)
@@ -161,6 +177,8 @@ class MediaMetadata:
     writers: list[CreditPerson] = field(default_factory=list)
     content_rating: str | None = None
     trailer_url: str | None = None
+    tagline: str | None = None
+    collection: CollectionMetadata | None = None
     localized: dict[str, LocalizedFields] = field(default_factory=dict)
 
 
@@ -281,10 +299,11 @@ class MetadataProvider(ABC):
 
 
 __all__ = [
+    "CollectionMetadata",
     "CreditPerson",
     "EpisodeMetadata",
-    "PersonMetadata",
     "MediaMetadata",
     "MetadataProvider",
+    "PersonMetadata",
     "SeasonMetadata",
 ]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -12,6 +12,7 @@ from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
     CastMember,
+    Collection,
     ContentRating,
     Duration,
     Genre,
@@ -177,6 +178,7 @@ def _apply_movie_metadata(
         updates["title"] = Title(metadata.title)
     if metadata.synopsis and (force or not movie.synopsis):
         updates["synopsis"] = metadata.synopsis
+    _apply_franchise_metadata(updates, movie, metadata, force=force)
     if metadata.tmdb_id:
         updates["tmdb_id"] = TmdbId(metadata.tmdb_id)
     if metadata.imdb_id:
@@ -202,6 +204,30 @@ def _apply_movie_metadata(
         movie = movie.with_updates(**updates)
 
     return movie
+
+
+def _apply_franchise_metadata(
+    updates: dict[str, object],
+    movie: Movie,
+    metadata: MediaMetadata,
+    *,
+    force: bool = False,
+) -> None:
+    """Apply tagline + collection (franchise) metadata.
+
+    Both fields follow the same "fill if empty" guard as the rest of
+    ``_apply_movie_metadata`` so re-enrichment doesn't clobber a
+    user-edited tagline or a manually-cleared collection. Extracted
+    out so the parent function stays under ``PLR0912``'s branch cap.
+    """
+    if metadata.tagline and (force or not movie.tagline):
+        updates["tagline"] = metadata.tagline
+    if metadata.collection and (force or not movie.collection):
+        updates["collection"] = Collection(
+            tmdb_id=metadata.collection.tmdb_id,
+            name=metadata.collection.name,
+            parts_count=metadata.collection.parts_count,
+        )
 
 
 def _apply_credits(
@@ -252,6 +278,7 @@ def _apply_localized(
         candidates = {
             "title": fields.title,
             "synopsis": fields.synopsis,
+            "tagline": fields.tagline,
             "genres": fields.genres or None,
             "logo_path": fields.logo_url,
         }

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -3,6 +3,7 @@
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.movie_dtos import (
     CastMemberOutput,
+    CollectionOutput,
     GetMovieByIdInput,
     MovieOutput,
 )
@@ -76,6 +77,7 @@ class GetMovieByIdUseCase:
             duration_seconds=movie.duration.value,
             duration_formatted=movie.duration.format_hms(),
             synopsis=movie.get_synopsis(lang),
+            tagline=movie.get_tagline(lang),
             poster_path=movie.poster_path.value if movie.poster_path else None,
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
             logo_path=movie.get_logo_path(lang),
@@ -94,6 +96,13 @@ class GetMovieByIdUseCase:
             writers=movie.writers,
             content_rating=movie.content_rating.value if movie.content_rating else None,
             trailer_url=movie.trailer_url,
+            collection=CollectionOutput(
+                tmdb_id=movie.collection.tmdb_id,
+                name=movie.collection.name,
+                parts_count=movie.collection.parts_count,
+            )
+            if movie.collection
+            else None,
             file_path=primary.file_path.value if primary else None,
             file_size=primary.file_size if primary else None,
             resolution=primary.resolution.value if primary else None,

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -11,6 +11,7 @@ from src.modules.media.domain.entities.file_variant_mixin import FileVariantMixi
 from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.value_objects import (
     CastMember,
+    Collection,
     ContentRating,
     Duration,
     FilePath,
@@ -52,6 +53,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
     year: Year
     duration: Duration
     synopsis: str | None = Field(default=None, max_length=10000)
+    tagline: str | None = Field(default=None, max_length=500)
 
     # Images
     poster_path: ImageUrl | None = None
@@ -75,6 +77,9 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
 
     # Trailer
     trailer_url: str | None = None
+
+    # Collection / franchise on TMDB (Alien Collection, MCU, ...)
+    collection: Collection | None = None
 
     # Localized metadata: {"pt-BR": {"title": "...", "synopsis": "...", "genres": [...]}}
     localized: dict[str, dict[str, Any]] = Field(default_factory=dict)
@@ -110,6 +115,11 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
         """Get synopsis in the requested language, falling back to default."""
         loc = self.localized.get(lang, {})
         return str(loc["synopsis"]) if loc.get("synopsis") else self.synopsis
+
+    def get_tagline(self, lang: str = "en") -> str | None:
+        """Get tagline in the requested language, falling back to default."""
+        loc = self.localized.get(lang, {})
+        return str(loc["tagline"]) if loc.get("tagline") else self.tagline
 
     def get_genres(self, lang: str = "en") -> list[str]:
         """Get genres in the requested language, falling back to default."""

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -2,6 +2,7 @@
 
 from src.modules.media.domain.value_objects.air_date import AirDate
 from src.modules.media.domain.value_objects.cast_member import CastMember
+from src.modules.media.domain.value_objects.collection import Collection
 from src.modules.media.domain.value_objects.content_rating import ContentRating
 from src.modules.media.domain.value_objects.duration import Duration
 from src.modules.media.domain.value_objects.episode_number import EpisodeNumber
@@ -33,6 +34,7 @@ __all__ = [
     "AirDate",
     "AudioTrack",
     "CastMember",
+    "Collection",
     "ContentRating",
     "Duration",
     "EpisodeId",

--- a/src/modules/media/domain/value_objects/collection.py
+++ b/src/modules/media/domain/value_objects/collection.py
@@ -1,0 +1,29 @@
+"""Collection value object — TMDB franchise/series a movie belongs to."""
+
+from src.building_blocks.domain import CompoundValueObject
+
+
+class Collection(CompoundValueObject):
+    """A TMDB collection (franchise) a movie belongs to.
+
+    Captures just enough metadata to render a "Part of <name> · N
+    movies" pill on the detail page and link out to a future
+    collection-browse view. ``parts_count`` reflects the size of the
+    collection on TMDB at enrichment time, not how many of those
+    titles exist in the local catalog.
+
+    Attributes:
+        tmdb_id: TMDB collection id (e.g. ``8091`` for Alien Collection).
+        name: Display name (e.g. ``"Alien Collection"``).
+        parts_count: Number of titles in the collection per TMDB.
+
+    Example:
+        >>> Collection(tmdb_id=8091, name="Alien Collection", parts_count=6)
+    """
+
+    tmdb_id: int
+    name: str
+    parts_count: int
+
+
+__all__ = ["Collection"]

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -5,6 +5,7 @@ from typing import Literal
 import httpx
 
 from src.modules.media.application.ports import (
+    CollectionMetadata,
     CreditPerson,
     EpisodeMetadata,
     LocalizedFields,
@@ -167,6 +168,7 @@ class TmdbClient(MetadataProvider):
         pt_fields = LocalizedFields(
             title=pt_data.get("title"),
             synopsis=pt_data.get("overview"),
+            tagline=pt_data.get("tagline") or None,
             genres=[g["name"] for g in pt_data.get("genres", [])],
             logo_url=self._pick_best_logo_url(pt_data.get("images", {}).get("logos"), "pt-BR"),
         )
@@ -464,12 +466,14 @@ class TmdbClient(MetadataProvider):
         trailer_url = self._parse_trailer(data.get("videos", {}))
 
         logo_url = self._pick_best_logo_url(data.get("images", {}).get("logos"), language)
+        collection = await self._fetch_collection_metadata(data.get("belongs_to_collection"))
         return MediaMetadata(
             title=data.get("title", ""),
             original_title=data.get("original_title"),
             year=year,
             duration_seconds=(data.get("runtime") or 0) * 60,
             synopsis=data.get("overview"),
+            tagline=data.get("tagline") or None,
             poster_url=self._image_url(data.get("poster_path")),
             backdrop_url=self._image_url(data.get("backdrop_path")),
             logo_url=logo_url,
@@ -481,7 +485,37 @@ class TmdbClient(MetadataProvider):
             writers=writers,
             content_rating=content_rating.value if content_rating else None,
             trailer_url=trailer_url,
+            collection=collection,
         )
+
+    async def _fetch_collection_metadata(
+        self,
+        belongs_to: dict[str, object] | None,
+    ) -> CollectionMetadata | None:
+        """Build a ``CollectionMetadata`` from the ``belongs_to_collection`` payload.
+
+        Hits ``/collection/{id}`` once for ``parts_count``. Best-effort polish
+        — any HTTP/parse error degrades to ``None`` so a flaky collection
+        lookup never breaks movie enrichment.
+        """
+        if not isinstance(belongs_to, dict):
+            return None
+        coll_id = belongs_to.get("id")
+        name = belongs_to.get("name")
+        if not isinstance(coll_id, int) or not isinstance(name, str):
+            return None
+
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/collection/{coll_id}",
+                params=self._params(),
+            )
+        except httpx.HTTPError:
+            return None
+        if resp.status_code != 200:
+            return None
+        parts = resp.json().get("parts") or []
+        return CollectionMetadata(tmdb_id=coll_id, name=name, parts_count=len(parts))
 
     async def _fetch_series_details(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch full series details including seasons and episodes.

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -4,6 +4,7 @@ import json
 
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
+    Collection,
     ContentRating,
     Duration,
     FilePath,
@@ -65,6 +66,7 @@ class MovieMapper:
             year=entity.year.value,
             duration=entity.duration.value,
             synopsis=entity.synopsis,
+            tagline=entity.tagline,
             poster_path=entity.poster_path.value if entity.poster_path else None,
             backdrop_path=entity.backdrop_path.value if entity.backdrop_path else None,
             logo_path=entity.logo_path.value if entity.logo_path else None,
@@ -79,6 +81,9 @@ class MovieMapper:
             writers=json.dumps(entity.writers, ensure_ascii=False) if entity.writers else None,
             content_rating=entity.content_rating.value if entity.content_rating else None,
             trailer_url=entity.trailer_url,
+            collection_tmdb_id=entity.collection.tmdb_id if entity.collection else None,
+            collection_name=entity.collection.name if entity.collection else None,
+            collection_parts_count=entity.collection.parts_count if entity.collection else None,
             localized=json.dumps(entity.localized, ensure_ascii=False)
             if entity.localized
             else None,
@@ -134,6 +139,18 @@ class MovieMapper:
                     )
                 ]
 
+        collection = None
+        if (
+            model.collection_tmdb_id is not None
+            and model.collection_name
+            and model.collection_parts_count is not None
+        ):
+            collection = Collection(
+                tmdb_id=model.collection_tmdb_id,
+                name=model.collection_name,
+                parts_count=model.collection_parts_count,
+            )
+
         return Movie(
             id=MovieId(model.external_id),
             title=Title(model.title),
@@ -141,6 +158,7 @@ class MovieMapper:
             year=Year(model.year),
             duration=Duration(model.duration),
             synopsis=model.synopsis,
+            tagline=model.tagline,
             poster_path=ImageUrl(model.poster_path) if model.poster_path else None,
             backdrop_path=ImageUrl(model.backdrop_path) if model.backdrop_path else None,
             logo_path=ImageUrl(model.logo_path) if model.logo_path else None,
@@ -153,6 +171,7 @@ class MovieMapper:
             writers=json.loads(model.writers) if model.writers else [],
             content_rating=ContentRating(model.content_rating) if model.content_rating else None,
             trailer_url=model.trailer_url,
+            collection=collection,
             localized=json.loads(model.localized) if model.localized else {},
             files=files,
             tmdb_id=TmdbId(model.tmdb_id) if model.tmdb_id else None,
@@ -181,6 +200,7 @@ class MovieMapper:
         model.year = entity.year.value
         model.duration = entity.duration.value
         model.synopsis = entity.synopsis
+        model.tagline = entity.tagline
         model.poster_path = entity.poster_path.value if entity.poster_path else None
         model.backdrop_path = entity.backdrop_path.value if entity.backdrop_path else None
         model.logo_path = entity.logo_path.value if entity.logo_path else None
@@ -195,6 +215,9 @@ class MovieMapper:
         model.writers = json.dumps(entity.writers, ensure_ascii=False) if entity.writers else None
         model.content_rating = entity.content_rating.value if entity.content_rating else None
         model.trailer_url = entity.trailer_url
+        model.collection_tmdb_id = entity.collection.tmdb_id if entity.collection else None
+        model.collection_name = entity.collection.name if entity.collection else None
+        model.collection_parts_count = entity.collection.parts_count if entity.collection else None
         model.localized = (
             json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None
         )

--- a/src/modules/media/infrastructure/persistence/models/movie.py
+++ b/src/modules/media/infrastructure/persistence/models/movie.py
@@ -38,6 +38,7 @@ class MovieModel(Base):
     year: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     duration: Mapped[int] = mapped_column(Integer, nullable=False)  # seconds
     synopsis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tagline: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     # Images
     poster_path: Mapped[str | None] = mapped_column(String(1000), nullable=True)
@@ -68,6 +69,12 @@ class MovieModel(Base):
 
     # Trailer (YouTube URL)
     trailer_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+    # Collection / franchise on TMDB (denormalized as 3 columns since
+    # we don't have a Collection aggregate of our own yet)
+    collection_tmdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
+    collection_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    collection_parts_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # Localized metadata (JSON: {"pt-BR": {"title": "...", "synopsis": "...", "genres": [...]}})
     localized: Mapped[str | None] = mapped_column(Text, nullable=True)


### PR DESCRIPTION
## Summary
- Add ``tagline`` (localized) and ``collection`` (TMDB franchise) to the ``Movie`` aggregate. ``tagline`` honours the same per-language fallback pattern as title/synopsis; ``collection`` is a new ``Collection`` value object (``tmdb_id``, ``name``, ``parts_count``).
- ``MediaMetadata`` (port) gains ``tagline`` + a ``CollectionMetadata`` sub-dataclass, and ``LocalizedFields`` gains ``tagline`` so pt-BR taglines override the en default.
- TMDB client captures ``data["tagline"]`` from ``/movie/{id}`` and adds one extra ``/collection/{id}`` call to fetch ``parts_count``. Collection lookup is best-effort — any HTTP/parse error degrades to ``None``.
- Persistence: three nullable columns on ``movies`` (``tagline``, ``collection_tmdb_id``, ``collection_name``, ``collection_parts_count``) plus a migration. Indexed ``collection_tmdb_id`` so a future "browse this franchise" query can scan by collection.
- ``MovieOutput`` DTO exposes ``tagline`` and a ``CollectionOutput`` so the detail endpoint surfaces both fields to the frontend.

## Test plan
- [ ] ``poetry run alembic upgrade head`` runs the migration cleanly on a copy of the prod DB
- [ ] Re-enrich an existing movie that belongs to a TMDB collection (e.g. Alien) with ``force=true`` — verify the new columns populate
- [ ] ``GET /api/v1/movies/{id}`` returns ``tagline`` and ``collection`` fields (``null`` for movies with no franchise)
- [ ] Re-enrich a movie that has a tagline only in en — pt-BR localized fetch returns the pt-BR tagline if TMDB has it, otherwise the en fallback wins
- [ ] Existing ``test_get_movie_by_id``, ``test_enrich_movie_metadata``, and ``test_movie_repository`` suites still pass (272 media tests pass locally)

## Out of scope
- Frontend rendering of the tagline + collection chip — follow-up PR on ``homeflix-web`` consuming the new fields.
- A dedicated ``Collection`` aggregate / ``/collections/{id}`` endpoint. The denormalized columns are enough for the "Part of X · N movies" pill; promoting collection to an aggregate is a separate decision once we have a use case for it.

## Summary by Sourcery

Capture TMDB movie taglines and franchise collection data end-to-end, from metadata ingestion through persistence and API exposure.

New Features:
- Add tagline and collection fields to the Movie domain entity with localized tagline accessors.
- Introduce Collection value object, metadata type, and API DTOs to represent a movie’s TMDB collection/franchise.
- Extend TMDB metadata fetching to retrieve movie taglines and collection details, including collection size, with graceful degradation on errors.

Enhancements:
- Propagate tagline and collection metadata through enrichment logic and localized field application without overwriting user edits unless forced.
- Persist tagline and denormalized collection information on movies, including mapping between domain entities and database models.

Build:
- Add a database migration to create tagline and collection columns on the movies table and index collection_tmdb_id for future franchise queries.