### PR TITLE
docs(adr): add ADR-010 (identity) and ADR-011 (authentication)

### DIFF
--- a/.claude/skills/homeflix-arch/references/adr_index.md
+++ b/.claude/skills/homeflix-arch/references/adr_index.md
@@ -1,0 +1,207 @@
+# ADR Index — HomeFlix
+
+Roteador "tópico/sintoma → qual ADR ler". Use quando precisar de detalhe sobre uma decisão específica.
+
+Os ADRs vivem em `docs/adr/` no repositório do HomeFlix. **Sempre consulte o ADR completo no repo** antes de propor mudança que conflita com a decisão.
+
+## Por tópico
+
+### Domain Models (Pydantic, validação, estrutura)
+
+→ **ADR-001** (`docs/adr/ADR-001-pydantic-domain-models.md`)
+
+Cobre:
+- Por que Pydantic encapsulado em vez de dataclass puro ou attrs
+- Hierarquia: `DomainModel` → `ValueObject` / `CompoundValueObject` / `StringValueObject` / `IntValueObject` / `DomainEntity` / `AggregateRoot`
+- Configuração padrão (`validate_assignment`, `extra='forbid'`, `frozen=True`)
+- `DomainValidationError` encapsulando `pydantic.ValidationError`
+- Protocol `SupportsUpdates` para tipagem de objetos com `with_updates()`
+
+Consultar quando: criar novo VO, entity, ou aggregate. Decidir entre `StringValueObject` e `CompoundValueObject`. Tipar funções que aceitam objetos com `with_updates`.
+
+### IDs de agregados (formato, geração, persistência)
+
+→ **ADR-002** (`docs/adr/ADR-002-prefixed-external-ids.md`)
+
+Cobre:
+- Formato `{prefix}_{base62_12chars}` (16 chars total)
+- Por que prefixed em vez de UUID, auto-increment, ULID, hashids
+- Mapeamento de prefixos: `mov`, `ser`, `ssn`, `epi`, `prg`, `wls`, `fav`, `lst`, `gnr`, `scn`, `lib`
+- `external_id` separado de `internal_id` na persistência
+- Implementação de `ExternalId` e typed aliases (`MovieId`, `SeriesId`, etc.)
+
+Consultar quando: adicionar novo tipo de agregado (precisa de novo prefixo). Decidir como expor IDs em rotas. Implementar mapper entity ↔ SQLAlchemy model.
+
+### Estrutura de pastas / organização do projeto
+
+→ **ADR-008** (`docs/adr/ADR-008-screaming-architecture.md`) — **substitui ADR-003**
+
+Cobre:
+- Por que migrar de "camadas na raiz" para "módulos como eixo primário"
+- `building_blocks/` (técnico) vs `shared_kernel/` (negócio cross-module)
+- Estrutura interna de cada módulo: `domain/`, `application/`, `infrastructure/`, `presentation/`
+- Regra: módulos não importam entre si
+- Onde fica infraestrutura compartilhada (`src/infrastructure/`)
+- Imports permitidos vs proibidos
+
+Consultar quando: criar novo bounded context. Decidir onde colocar uma classe nova (qual módulo, qual camada). Refatorar import cross-module.
+
+⚠️ ADR-003 ainda existe no repo mas está marcado como **Substituído**. Sempre referencie ADR-008.
+
+### Dependency Injection / Composition Root
+
+→ **ADR-004** (`docs/adr/ADR-004-dependency-injection.md`)
+
+Cobre:
+- Por que `dependency-injector` em vez de `python-injector` ou Depends puro
+- Use cases puros (sem `@inject` no construtor)
+- Wiring `@inject`/`Provide` **somente** em routes
+- Containers organizados por responsabilidade: `infrastructure`, `repositories`, `use_cases/<bc>`
+- Composition root em `config/containers/main.py`
+- Como testar use cases (sem container, mock direto no construtor)
+
+Consultar quando: adicionar nova dependência. Criar novo bounded context (precisa de novo container). Testar use case. Decidir lifecycle (Singleton vs Factory).
+
+### Library como entidade (configuração de fontes de mídia)
+
+→ **ADR-005** (`docs/adr/ADR-005-library-as-configuration-entity.md`)
+
+Cobre:
+- Por que Library é entidade de domínio, não config global
+- `LibraryType` (movies/series/mixed), `MetadataProvider` (TMDB/OMDB/TVDB), `SubtitleMode`
+- `LibrarySettings` (preferred audio/subtitle, scan schedule)
+- `AudioTrack` e `SubtitleTrack` como VOs
+- Lógica de seleção de faixas (`TrackSelector`)
+- Posicionamento: BC `library` separado de `media`
+
+Consultar quando: criar feature relacionada a configuração de bibliotecas. Adicionar novo provedor de metadados. Lidar com seleção de faixas de áudio/legenda. Adicionar novo tipo de scan.
+
+### Variantes de arquivos (múltiplas resoluções por mídia)
+
+→ **ADR-006** (`docs/adr/ADR-006-media-file-variants.md`)
+
+Cobre:
+- Como uma mídia (Movie/Episode) pode ter múltiplos `MediaFile` (720p, 1080p, 4K)
+- `AudioTrack`/`SubtitleTrack` ficam dentro de `MediaFile`, não direto na entity
+- Resolution, VideoCodec, HDRFormat como VOs
+
+Consultar quando: trabalhar com player/streaming. Adicionar suporte a novo codec/HDR. Importar mídia que tem múltiplas versões.
+
+### Imutabilidade `with_*`/`without_*`
+
+→ **ADR-007** (`docs/adr/ADR-007-immutable-entities-with-convention.md`)
+
+Cobre:
+- Por que `frozen=True` em entidades (não só VOs)
+- Convenção `with_X` para adicionar/modificar, `without_X` para remover
+- Retorno de `Self` em todos os métodos de mutação
+- `with_atomic_updates()` faz bump automático de `updated_at` via `setdefault`
+- `touch()` foi removido (incompatível com imutabilidade)
+- Comportamento `no-op`: retornar `self` quando não há mudança (duplicata, item inexistente)
+
+Consultar quando: criar entity nova. Adicionar método de modificação em entity existente. Refatorar método imperativo herdado. Decidir comportamento de borda (duplicata, item ausente).
+
+### Cross-BC Read Ports + ACL
+
+→ **ADR-009** (`docs/adr/ADR-009-cross-bc-read-ports.md`)
+
+Cobre:
+- Por que módulos não importam entre si direto
+- Estrutura: port em `application/ports/`, adapter em `infrastructure/acl/`
+- DTOs locais ao consumidor (não promover pra `shared_kernel` sem evidência)
+- Wiring: receber repo do provider via `providers.Dependency()` no container do consumidor
+- Quando aceitar import direto entre infras (ciclo de wiring inviável)
+- Por que NÃO usar domain events agora (complexidade desnecessária)
+
+Consultar quando: detectar import cross-module. Implementar feature que exibe dado de múltiplos BCs (ex: home screen). Decidir se uma leitura cross-BC vale port ou se é caso de mover responsabilidade.
+
+### Identity / User / Profile / Auth context
+
+→ **ADR-010** (`docs/adr/ADR-010-identity-bounded-context.md`)
+
+Cobre:
+- Novo BC `identity` com `User` (auth root) e `Profile` (personalization context, referenciado cross-BC)
+- FastAPI Users como base de autenticação (signup, login, JWT, reset, verify)
+- ID strategy: UUID interno no DB (compat FastAPI Users) + prefixed `external_id` no domain/API (`usr_xxx`, `prf_xxx`) via mapper
+- Prefixos `usr` e `prf` adicionados ao `ExternalId.VALID_PREFIXES`
+- `profile_id` propagado **explicitamente** via Input dataclass — proibido `contextvars`/middleware mágico
+- `get_current_profile` FastAPI dependency resolve `profile_id` uma vez por request (validando ownership user↔profile)
+- BCs consumidores (`watch_progress`, `collections`, `preferences`) ganham `profile_id` em agregado e usam `ProfileLookupPort` (ADR-009)
+
+Consultar quando: criar feature que toca dados pessoais (precisa de `profile_id` no Input). Adicionar autorização/role check. Decidir como passar contexto de request a um use case. Implementar endpoint que requer login. Adicionar novo prefixo de ID ao registro.
+
+### Authentication Strategy / Session Storage / Cookie
+
+→ **ADR-011** (`docs/adr/ADR-011-authentication-strategy.md`)
+
+Cobre:
+- FastAPI Users `AuthenticationBackend` = `DatabaseStrategy` + `CookieTransport`
+- Sessão server-side em tabela `access_tokens` (token opaco, não JWT)
+- Cookie `homeflix_session` com `HttpOnly` + `Secure` + `SameSite=Strict`
+- Slidable expiration (30 dias), max absolute lifetime (90 dias)
+- `current_profile_id` armazenado na sessão (suporta multi-device com profiles independentes)
+- Revogação imediata via `DELETE FROM access_tokens` (logout, kill switch, admin "deslogar dispositivo")
+- CSRF mitigado por `SameSite=Strict` + CORS allowlist; double-submit token diferido para se relaxar SameSite
+- Schema permite OAuth providers (Google etc.) e bearer JWT (mobile) como adições paralelas no futuro
+
+Consultar quando: implementar login/logout/session. Tocar config de cookies. Mudar config CORS (revalidar exposição CSRF). Adicionar provider OAuth. Adicionar cliente não-browser (mobile, desktop). Implementar admin "ver/revogar sessões".
+
+## Por sintoma no código
+
+| Sintoma | ADR(s) relevante(s) |
+|---|---|
+| `from pydantic import BaseModel` em domain | ADR-001 |
+| `id: UUID` ou `id: int` em entidade | ADR-002 |
+| `from src.domain...` ou `from src.application...` (estrutura antiga) | ADR-008 |
+| `from src.modules.X` em código de `src/modules/Y/` | ADR-009 |
+| `from src.config.containers` em código de módulo | ADR-008 + ADR-004 |
+| `@inject` em use case | ADR-004 |
+| Método `add_X`, `mark_X`, `set_X`, `remove_X` em agregado | ADR-007 |
+| Método `transition_to_*` em agregado | ADR-007 |
+| `journey.touch()` (método removido) | ADR-007 |
+| Adapter de port retornando VO de domínio (ex: `-> EnrichedIdentityData`) | ADR-009 (filosofia ACL) |
+| Use case com lógica de scan/biblioteca embutida sem usar `Library` | ADR-005 |
+| `AudioTrack` direto em `Movie` (em vez de em `MediaFile`) | ADR-006 |
+| `contextvars.ContextVar` ou middleware setando `profile_id`/`user_id` global | ADR-010 |
+| `id: UUID` exposto em rota ou DTO de identity (deveria ser `usr_xxx`/`prf_xxx`) | ADR-010 |
+| Use case que mexe em `WatchProgress`/`CustomList`/`PlaybackPreferences` sem `profile_id` no Input | ADR-010 |
+| `from fastapi_users` em código fora de `src/modules/identity/infrastructure/` | ADR-010 |
+| Token JWT armazenado em `localStorage` no frontend ou retornado em response body | ADR-011 |
+| `cookie_httponly=False` ou `cookie_samesite="none"` sem justificativa registrada | ADR-011 |
+| Blacklist de JWT, refresh token rotation, `exp`/`iat` claims customizados | ADR-011 |
+
+## Por pergunta comum
+
+**"Onde coloco essa classe nova?"** → ADR-008
+
+**"Como faço o ID desse novo agregado?"** → ADR-002 (definir prefixo + criar typed alias herdando `ExternalId`)
+
+**"Como esse use case acessa dados de outro BC?"** → ADR-009
+
+**"Como mockar essa dependência no teste?"** → ADR-004 (injetar direto no construtor, sem container)
+
+**"Posso modificar este agregado in-place?"** → Não. ADR-007.
+
+**"Posso usar BaseModel direto aqui?"** → Não. ADR-001.
+
+**"Preciso de novo bounded context?"** → ADR-008 (critérios de quando criar BC novo)
+
+**"Como esse use case sabe qual perfil está logado?"** → ADR-010 (`profile_id` explícito no Input dataclass; resolver via `get_current_profile` na route)
+
+**"Posso usar contextvar pra propagar `user_id`/`profile_id`?"** → Não. ADR-010.
+
+**"Como o usuário se mantém logado entre requests?"** → ADR-011 (sessão server-side em cookie HttpOnly, não JWT)
+
+**"Como deslogo um usuário/dispositivo?"** → ADR-011 (`DELETE FROM access_tokens WHERE token = ?` ou `WHERE user_id = ?`)
+
+## Adicionando novo ADR
+
+Quando você (ou o usuário) tomar uma decisão arquitetural significativa que não está coberta:
+
+1. Use `docs/adr/TEMPLATE.md` como base
+2. Numere sequencialmente (próximo: ADR-012 ou superior)
+3. Status inicial: `Proposto` → após implementação e validação: `Aceito`
+4. Atualize **este índice** (`adr_index.md`) com o novo tópico
+5. Se substitui ADR existente, marque o antigo como `Substituído` e referencie
+
+Bom indicador de "isso merece ADR": a decisão vai impactar múltiplos arquivos/módulos OU envolve trade-off não-óbvio que outro dev questionaria daqui a 6 meses.

--- a/.claude/skills/homeflix-arch/references/adr_index.md
+++ b/.claude/skills/homeflix-arch/references/adr_index.md
@@ -121,7 +121,7 @@ Consultar quando: detectar import cross-module. Implementar feature que exibe da
 
 Cobre:
 - Novo BC `identity` com `User` (auth root) e `Profile` (personalization context, referenciado cross-BC)
-- FastAPI Users como base de autenticação (signup, login, JWT, reset, verify)
+- FastAPI Users como **biblioteca base** de autenticação (signup, login, password reset, email verification) — estratégia concreta de transport/storage de sessão definida em ADR-011
 - ID strategy: UUID interno no DB (compat FastAPI Users) + prefixed `external_id` no domain/API (`usr_xxx`, `prf_xxx`) via mapper
 - Prefixos `usr` e `prf` adicionados ao `ExternalId.VALID_PREFIXES`
 - `profile_id` propagado **explicitamente** via Input dataclass — proibido `contextvars`/middleware mágico
@@ -138,7 +138,7 @@ Cobre:
 - FastAPI Users `AuthenticationBackend` = `DatabaseStrategy` + `CookieTransport`
 - Sessão server-side em tabela `access_tokens` (token opaco, não JWT)
 - Cookie `homeflix_session` com `HttpOnly` + `Secure` + `SameSite=Strict`
-- Slidable expiration (30 dias), max absolute lifetime (90 dias)
+- Expiração fixa de 90 dias desde a criação (sem slidable — `DatabaseStrategy` não suporta nativo; trade-off aceito para uso doméstico)
 - `current_profile_id` armazenado na sessão (suporta multi-device com profiles independentes)
 - Revogação imediata via `DELETE FROM access_tokens` (logout, kill switch, admin "deslogar dispositivo")
 - CSRF mitigado por `SameSite=Strict` + CORS allowlist; double-submit token diferido para se relaxar SameSite

--- a/docs/adr/ADR-010-identity-bounded-context.md
+++ b/docs/adr/ADR-010-identity-bounded-context.md
@@ -1,0 +1,184 @@
+# ADR-010: Identity Bounded Context — User, Profile and Context Passing
+
+**Status:** Proposto
+**Data:** 2026-05-03
+**Deciders:** Lucas Cristovam
+**Technical Story:** Introdução de autenticação e personalização ao HomeFlix — habilitar múltiplos usuários com login próprio, perfis de personalização (estilo Netflix) e isolamento de dados de uso (`watch_progress`, `collections`, `preferences`) por perfil.
+
+---
+
+## Contexto
+
+O HomeFlix opera hoje sem qualquer conceito de usuário ou perfil: agregados como `WatchProgress`, `CustomList` e `PlaybackPreferences` são globais (singletons de fato). À medida que o produto evolui para uso doméstico real (múltiplos membros da casa) e potencialmente extra-doméstico (compartilhamento controlado com família/amigos), torna-se necessário introduzir identidade.
+
+A introdução de identidade é uma decisão atípica em sistemas brownfield porque o estado atual ("nada") permite desenho limpo, sem migração legada complexa. Isso aumenta a barra de qualidade: não há desculpa de "não dá pra fazer certo agora".
+
+A decisão precisa equilibrar três forças:
+
+1. **Aproveitar bibliotecas maduras** (FastAPI Users) para não reimplementar autenticação, signup, reset de senha e JWT do zero — economia de semanas de trabalho e redução de superfície de bug em código de segurança.
+2. **Preservar princípios já estabelecidos** — em particular ADR-002 (prefixed external IDs), ADR-008 (screaming architecture / módulos isolados) e ADR-009 (cross-BC reads via port + ACL). Bibliotecas externas frequentemente assumem padrões (UUIDs, ID inteiro auto-increment) que conflitam com convenções do projeto.
+3. **Não fechar portas para crescimento** — o HomeFlix é simultaneamente lab de arquitetura e ferramenta funcional. A modelagem de identidade precisa servir tanto ao caso de uso doméstico imediato quanto à eventual evolução para multi-tenant ou serviço separado, sem refactor cross-cutting.
+
+Restrições relevantes: o frontend (`homeflix-web`) precisa de mudança coordenada (tela de login, seletor de perfil); três bounded contexts existentes (`watch_progress`, `collections`, `preferences`) precisam ganhar `profile_id` em seus agregados; e o admin panel já planejado depende do conceito de role/permissão que esta decisão estabelece.
+
+## Decisão
+
+Nós iremos introduzir um novo bounded context **`identity`** (em `src/modules/identity/`) responsável por autenticação de usuários e gestão de perfis de personalização, com os seguintes contornos:
+
+### (1) Modelagem — User e Profile como agregados separados
+
+- `User` é o **aggregate root de autenticação e ciclo de vida**. Possui credenciais (email, senha hasheada), role (`admin` | `member`), flags de ativação e verificação, e referência aos seus perfis.
+- `Profile` é a **entidade de contexto de personalização**, filha de `User`. Carrega nome, avatar, flag `is_kids`, e (futuramente) `allowed_library_ids`.
+- Outros bounded contexts (`watch_progress`, `collections`, `preferences`) referenciam **apenas `ProfileId`** — nunca `UserId`. `User` controla CRUD de profiles, `Profile` é o ponto de ancoragem de toda telemetria de uso.
+
+### (2) Identificação — UUID interno + prefixed external_id
+
+- O banco armazena `User.id` como `UUID` (mantendo compatibilidade nativa com FastAPI Users) e adiciona uma coluna `external_id VARCHAR` indexada no formato `usr_xxxxxxxxxxxx`.
+- O domínio expõe somente o prefixed ID via Value Object `UserId` (e `ProfileId` análogo, com prefixo `prf`). FastAPI Users opera no UUID interno; nenhum código de domínio ou API vê UUID.
+- O mapeamento UUID↔prefixed acontece exclusivamente no SQLAlchemy mapper do BC `identity`. Os prefixos `usr` e `prf` são adicionados ao registro `ExternalId.VALID_PREFIXES`.
+
+### (3) Propagação de contexto — explicit profile_id
+
+- O `profile_id` da request é resolvido **uma única vez** na presentation layer via FastAPI dependency `get_current_profile` (que valida o JWT, carrega o profile e checa que pertence ao usuário autenticado).
+- O `profile_id` é então **passado explicitamente** como campo de Input dataclass para todo use case que dele depende. Use cases repassam para repositories quando necessário.
+- **Está proibido** armazenar `profile_id` em `contextvars.ContextVar`, em atributo de middleware, ou em qualquer state global acessível de baixo. Toda dependência de contexto é declarada na assinatura.
+
+A implementação se dá em uma sequência de PRs sequenciais começando pelo foundation do BC `identity` (entidades, repos, FastAPI Users wiring, rotas `/auth/*` e `/profiles/*`), seguida pela introdução de `profile_id` em cada um dos três BCs consumidores via migrations Alembic com backfill (NULLABLE → seed → NOT NULL).
+
+## Consequências
+
+### Positivas
+
+- **Aproveitamento de biblioteca madura** — FastAPI Users entrega signup, login, JWT, reset de senha, verificação por email com código de produção testado por terceiros. Reduz semanas de implementação e elimina superfície de bug em código de segurança crítico.
+- **Preservação dos princípios já estabelecidos** — ADR-002 (prefixed IDs), ADR-007 (imutabilidade `with_*`), ADR-008 (módulos isolados), ADR-009 (cross-BC via port + ACL) continuam válidos sem exceção. Identity entra como cidadão de primeira classe da arquitetura.
+- **Boundary alinhado a DDD** — separar `User` (auth identity, ciclo de vida) de `Profile` (contexto de personalização referenciado cross-BC) reflete uma distinção real e impede a conflagração de duas responsabilidades distintas em um único agregado.
+- **Habilita admin panel sem refactor** — `role` no `User` já fornece a base de autorização que o admin panel planejado precisa, sem revisitar a modelagem.
+- **Migration limpa** — como nenhum BC consumidor tem `profile_id` hoje, a introdução é um refactor *forward-only*, sem dívida técnica de coexistência entre dados antigos sem profile e dados novos com profile.
+- **Explicit context preserva qualidade arquitetural** — use cases continuam testáveis sem fixtures globais, cada chamada é rastreável via log estruturado, e bugs sob async ficam impossíveis por construção.
+
+### Negativas
+
+- **Refactor cross-cutting em 3 BCs existentes** — `watch_progress`, `collections` e `preferences` precisam adicionar `profile_id` em agregado, repo, use case input e route. PRs sequenciais com dependência explícita.
+- **Coordenação obrigatória com `homeflix-web`** — frontend precisa ganhar tela de login, seletor de perfil e propagação de `profile_id` em todas as chamadas. Lançamento backend não pode preceder frontend sem feature flag.
+- **Custo de manutenção do mapper UUID↔prefixed** — qualquer mudança em assinaturas internas do FastAPI Users que envolva ID type pode demandar ajuste no mapper. Custo localizado, mas existe.
+- **Boilerplate de `ProfileLookupPort` em 3 BCs** — cada BC consumidor adiciona port + DTO + adapter ACL (padrão ADR-009). Repetitivo, mas isso é o preço do isolamento entre bounded contexts.
+- **Carga de implementação inicial alta** — sequência completa de PRs (foundation + 3 refactors + ACL + frontend) é trabalho de várias semanas antes de funcionalidade nova ser entregue ao usuário final.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Esquecer `profile_id` em algum use case durante refactor cross-BC, gerando vazamento de dados entre perfis | Média | Alto | `profile_id` como campo obrigatório (não-opcional) em Input dataclass; testes de integração por BC validando isolamento antes do merge; review manual de cada PR de refactor |
+| Upgrade breaking de FastAPI Users que altere o contrato interno de ID type | Baixa | Médio | Mapper UUID↔prefixed isolado em uma única classe no SQLAlchemy mapper do BC `identity`; pinned version no Poetry; ajuste pontual quando upgrade ocorrer |
+| Frontend desincronizado com backend durante a transição (uma versão merge antes da outra) | Média | Alto | Backend mantém endpoints legados sem profile durante fase de transição via feature flag; release notes de cada PR documenta dependência com versão correspondente do `homeflix-web` |
+| Decisão de role binário (`admin` \| `member`) ficar insuficiente conforme produto evolui (ex: `viewer`, `kids-only`) | Média | Baixo | `UserRole` modelado como enum VO, refactorable para RBAC mais granular sem mudar boundary do BC |
+| Performance degradada por carregar/validar profile a cada request | Baixa | Baixo | Profile resolvido uma vez por request via FastAPI dependency `Depends(get_current_profile)`, cache implícito do framework no escopo da request |
+
+## Alternativas Consideradas
+
+### 1. Caminho A — Single-Account + Profiles (estilo Netflix puro)
+
+Modelar uma única conta da casa (`Account`) com N perfis aninhados, sem conceito de múltiplos usuários distintos com login próprio.
+
+**Rejeitado porque:** não comporta o caso de uso de compartilhamento extra-doméstico com isolamento real (família/amigos com bibliotecas separadas), não oferece granularidade de role/permissão necessária para o admin panel já planejado, e não fecha portas que o caminho adotado fecha — qualquer evolução futura exigiria refactor cross-cutting do BC inteiro.
+
+### 2. Implementar autenticação do zero (sem FastAPI Users)
+
+Construir signup, login, JWT, reset de senha e verificação de email manualmente.
+
+**Rejeitado porque:** semanas de trabalho para reimplementar capacidades amplamente disponíveis em biblioteca madura, superfície grande para bugs em código de segurança crítico, e zero ganho funcional. Lab de arquitetura não justifica reinventar primitivas resolvidas.
+
+### 3. Pure UUID para User (exceção ao ADR-002)
+
+Aceitar que `User`/`Profile` usem UUID v4 nativo do FastAPI Users, abrindo exceção formal ao ADR-002 só para o BC `identity`.
+
+**Rejeitado porque:** quebra consistência da linguagem ubíqua — clientes da API precisariam saber que IDs de identity são UUIDs e os demais são prefixed, criando carga cognitiva permanente. Exceções a princípios fundamentais de design pagam juros para sempre.
+
+### 4. Pure prefixed ID com custom ID type no FastAPI Users
+
+Configurar FastAPI Users com `ID = str` e usar o prefixed `usr_xxx` direto como PK do banco.
+
+**Rejeitado porque:** tecnicamente viável, mas exige customizar partes internas da lib (transformers, dependency factories) que esperam UUID em assinaturas. Aumenta custo de manutenção em cada upgrade da lib. Wrapper UUID↔prefixed mantém a lib idiomática e isola a tradução em uma camada bem definida.
+
+### 5. SecurityContext via ContextVars / middleware
+
+Armazenar `profile_id` da request em `contextvars.ContextVar` setado por middleware, acessível de qualquer ponto sem propagação explícita.
+
+**Rejeitado porque:** viola o princípio "explicit > implicit" listado como anti-padrão no núcleo de Clean Architecture do projeto. Quebra testabilidade (use cases precisariam de fixture global de contexto), quebra rastreabilidade (`profile_id` deixa de aparecer no log estruturado de cada use case), e introduz bugs sutis sob concorrência async (propagação inconsistente em background tasks e event handlers). O ganho — evitar passar `profile_id` em Input dataclasses — é cosmético; use cases têm 1 ponto de entrada, não há prop drilling real.
+
+### 6. Domain Events + mirror tables para reads cross-BC
+
+Cada BC consumidor (`watch_progress`, `collections`, `preferences`) manteria sua própria tabela de profiles, alimentada via eventos de domínio (`ProfileCreated`, `ProfileUpdated`).
+
+**Rejeitado porque:** over-engineering para MVP. `ProfileLookupPort` (port + ACL síncrona via repository) atende ao requisito atual com complexidade muito menor. Revisitar quando/se `identity` for extraído para serviço separado, que é cenário hipotético sem demanda concreta hoje.
+
+### 7. Serviços de autenticação gerenciados ou SSO self-hosted
+
+Usar Auth0, Clerk, Supabase Auth (managed) ou Keycloak, Authentik (SSO self-hosted) como provedor de identidade.
+
+**Rejeitado porque:** desproporcional ao escopo. Managed services adicionam dependência externa, custo recorrente e latência de rede para um produto que roda em rede doméstica. SSO self-hosted (Keycloak) é mais robusto que necessário — voltado a federar identidade entre múltiplas aplicações corporativas, não a servir uma aplicação única. Ambos contradizem o princípio de auto-hospedagem leve da arquitetura HomeFlix e desviam o foco do propósito de lab arquitetural (não há aprendizado em terceirizar a modelagem de identidade).
+
+## Referências
+
+- **ADRs relacionados**:
+  - ADR-002 (Prefixed External IDs) — esta decisão preserva o padrão via mapper UUID↔prefixed
+  - ADR-007 (Entidades Imutáveis) — `User` e `Profile` seguem convenção `with_*`
+  - ADR-008 (Screaming Architecture) — `identity` entra como novo módulo em `src/modules/`
+  - ADR-009 (Cross-BC Read Ports) — `ProfileLookupPort` em `watch_progress`, `collections`, `preferences`
+- **Documentação externa**:
+  - [FastAPI Users](https://fastapi-users.github.io/fastapi-users/) — biblioteca de autenticação adotada
+  - [DDD Reference — Bounded Context](https://www.domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf) — Eric Evans, base conceitual da separação User/Profile
+- **Padrões aplicados**:
+  - Anti-Corruption Layer (ACL) — para reads cross-BC do `Profile`
+  - Mapper Pattern — para tradução UUID↔prefixed ID na infra layer
+
+---
+
+## Notas de Implementação
+
+```python
+# src/modules/identity/domain/value_objects/user_id.py
+class UserId(ExternalId):
+    EXPECTED_PREFIX = "usr"
+
+class ProfileId(ExternalId):
+    EXPECTED_PREFIX = "prf"
+
+
+# src/modules/identity/infrastructure/persistence/user_mapper.py
+# Mapeia UUID interno (FastAPI Users) <-> external_id prefixed (domain).
+# UUID nunca cruza para o domain.
+def to_domain(row: UserRow) -> User:
+    return User(
+        id=UserId(row.external_id),  # usr_xxx
+        email=Email(row.email),
+        role=UserRole(row.role),
+        ...
+    )
+
+
+# src/modules/watch_progress/presentation/dependencies.py
+async def get_current_profile(
+    token: str = Depends(oauth2_scheme),
+    profile_repo: ProfileLookupPort = Depends(Provide[...]),
+) -> ProfileContext:
+    # 1. Decode JWT -> user_id, profile_id
+    # 2. Verify profile.user_id == user_id (ownership check)
+    # 3. Return ProfileContext(profile_id=...)
+    ...
+
+
+# Use case recebe profile_id explícito (proibido contextvar).
+@dataclass(frozen=True)
+class GetContinueWatchingInput:
+    profile_id: ProfileId  # campo obrigatório, não-opcional
+    limit: int = 20
+```
+
+A sequência de PRs implementando esta decisão (foundation do BC `identity` → `ProfileLookupPort` → refactor dos 3 BCs consumidores → library ACL → frontend) é planejada na conversa que motivou este ADR e será detalhada em plan mode antes de cada PR.
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-05-03 | Lucas Cristovam | Criação inicial |

--- a/docs/adr/ADR-010-identity-bounded-context.md
+++ b/docs/adr/ADR-010-identity-bounded-context.md
@@ -157,15 +157,20 @@ def to_domain(row: UserRow) -> User:
     )
 
 
-# src/modules/watch_progress/presentation/dependencies.py
+# src/modules/identity/presentation/dependencies.py
+# Sessão é resolvida via cookie HttpOnly + DatabaseStrategy (ADR-011).
+# FastAPI Users injeta o `User` autenticado a partir do cookie; o
+# `current_profile_id` é lido da row de access_tokens correspondente.
 async def get_current_profile(
-    token: str = Depends(oauth2_scheme),
-    profile_repo: ProfileLookupPort = Depends(Provide[...]),
+    user: User = Depends(current_active_user),       # FastAPI Users
+    session: AccessTokenRow = Depends(get_current_session),
 ) -> ProfileContext:
-    # 1. Decode JWT -> user_id, profile_id
-    # 2. Verify profile.user_id == user_id (ownership check)
-    # 3. Return ProfileContext(profile_id=...)
-    ...
+    if session.current_profile_id is None:
+        raise NoActiveProfileSelected()
+    return ProfileContext(
+        user_id=user.id,
+        profile_id=ProfileId.from_uuid(session.current_profile_id),
+    )
 
 
 # Use case recebe profile_id explícito (proibido contextvar).

--- a/docs/adr/ADR-011-authentication-strategy.md
+++ b/docs/adr/ADR-011-authentication-strategy.md
@@ -27,14 +27,14 @@ Restrições: a decisão precisa ser compatível com o admin panel planejado (qu
 
 Nós iremos adotar **autenticação por sessão server-side em cookie HttpOnly**, implementada via FastAPI Users com `AuthenticationBackend` configurado como `DatabaseStrategy` + `CookieTransport`.
 
-**Storage de sessão**: tabela `access_tokens` no mesmo banco do BC `identity`, com schema `(token: str primary key, user_id: UUID, created_at: datetime)`. O token é uma string opaca aleatória (32+ bytes, base64url-safe), não um JWT — não carrega claims, é apenas a chave para lookup. Expiração configurável (padrão: 30 dias, slidable a cada request).
+**Storage de sessão**: tabela `access_tokens` no mesmo banco do BC `identity`, com schema `(token: str primary key, user_id: UUID, created_at: datetime)`. O token é uma string opaca aleatória (32+ bytes, base64url-safe), não um JWT — não carrega claims, é apenas a chave para lookup. **Expiração fixa de 90 dias desde a criação do token**, sem rolling refresh — `DatabaseStrategy` do FastAPI Users não atualiza `created_at` automaticamente em cada acesso, então sessão "slidable" exigiria custom strategy. Para uso doméstico (família re-loga ~4x/ano), expiração fixa é suficiente.
 
 **Transport**: cookie HTTP com nome `homeflix_session`, atributos:
 
 - `HttpOnly` — invisível a JavaScript, mitiga roubo via XSS
 - `Secure` — enviado apenas sobre HTTPS (no dev local, configurável via env var)
 - `SameSite=Strict` — bloqueia envio em requests cross-site, mitiga CSRF
-- `Max-Age` alinhado com a expiração do token (renovado a cada login bem-sucedido)
+- `Max-Age` alinhado com a expiração do token (emitido a cada login bem-sucedido)
 
 **Fluxo de revogação**: logout deleta a row de `access_tokens`. Não há janela entre "usuário pediu logout" e "token deixa de ser válido" — é instantâneo. Admin panel futuro consulta a tabela para listar sessões ativas por usuário e oferece operação "revogar dispositivo", que também é apenas `DELETE WHERE token = ?`.
 
@@ -59,7 +59,7 @@ Nós iremos adotar **autenticação por sessão server-side em cookie HttpOnly**
 
 - **Stateful por design** — todo request bate na tabela `access_tokens`. Em DB local single-process é sub-milissegundo, mas é uma operação que JWT stateless não precisaria fazer. Custo aceito conscientemente em troca dos benefícios acima.
 - **CSRF precisa atenção contínua** — qualquer mudança futura nas configurações de CORS ou origin allowlist precisa reavaliar se `SameSite=Strict` ainda é suficiente. Se um dia for relaxado, double-submit token CSRF vira obrigatório.
-- **Sessão pode viver indefinidamente** com slidable expiration — usuário ativo nunca é deslogado por timeout. Para uso doméstico isso é UX correta, mas é trade-off de segurança consciente.
+- **Sessão fixa de 90 dias força re-login trimestral** — usuário ativo é deslogado independentemente de uso recente. UX inferior a slidable expiration, mas tolerável para uso doméstico. Slidable foi rejeitada por exigir custom strategy não-nativa do FastAPI Users.
 - **Cliente não-browser exige trabalho adicional** — quando/se app mobile entrar no roadmap, é necessário adicionar segundo `AuthenticationBackend` (bearer) em paralelo. Não é refactor, mas é trabalho futuro identificado.
 - **DB bloat se cleanup falhar** — `access_tokens` cresce a cada login e só encolhe em logout/revogação/expiração. Sem job de limpeza, sessões expiradas acumulam.
 
@@ -69,7 +69,7 @@ Nós iremos adotar **autenticação por sessão server-side em cookie HttpOnly**
 |-------|---------------|---------|-----------|
 | Cookie de sessão interceptado em conexão HTTP não-criptografada | Baixa | Alto | Atributo `Secure` obrigatório em produção (env var); deploy doméstico atrás de TLS (Caddy/Traefik com Let's Encrypt ou self-signed); documentar no setup |
 | `access_tokens` cresce indefinidamente por falta de cleanup de sessões expiradas | Média | Baixo | Background job (APScheduler — já em uso) com cleanup periódico de tokens com `created_at + lifetime < now()`; também cleanup oportunístico durante validação de token |
-| Slidable expiration permite sessão "imortal" se atacante mantiver token ativo continuamente | Baixa | Médio | Limite absoluto de vida da sessão (ex: 90 dias desde criação, independente de atividade); admin panel oferece "revogar todas as sessões do usuário" como mitigação reativa |
+| Token comprometido permanece válido até 90 dias se usuário não fizer logout explícito | Baixa | Médio | Admin panel oferece "revogar todas as sessões do usuário" como mitigação reativa; documentar logout explícito em dispositivos não confiáveis (kiosks, dispositivos compartilhados) como prática recomendada |
 | Mudança futura de configuração CORS/origin relaxando `SameSite` reintroduz exposição CSRF | Baixa | Alto | Registrar nas Notas de Implementação que `SameSite=Strict` é load-bearing; checklist de revisão de PRs que tocam config de CORS deve revalidar exposição CSRF |
 | `current_profile_id` na sessão fica orfão se profile for deletado pelo user | Média | Baixo | `FOREIGN KEY ... ON DELETE SET NULL` na coluna; `get_current_profile` trata `None` como "precisa selecionar profile" e redireciona para `/profiles` |
 
@@ -144,7 +144,7 @@ class AccessTokenModel(Base):
 # src/modules/identity/infrastructure/auth/backend.py
 cookie_transport = CookieTransport(
     cookie_name="homeflix_session",
-    cookie_max_age=60 * 60 * 24 * 30,    # 30 dias slidable
+    cookie_max_age=60 * 60 * 24 * 90,    # 90 dias fixos desde a emissão
     cookie_secure=settings.is_production,  # True em prod, configurável em dev
     cookie_httponly=True,
     cookie_samesite="strict",
@@ -155,7 +155,7 @@ def get_database_strategy(
 ) -> DatabaseStrategy:
     return DatabaseStrategy(
         database=access_token_db,
-        lifetime_seconds=60 * 60 * 24 * 30,  # alinhado com cookie
+        lifetime_seconds=60 * 60 * 24 * 90,  # alinhado com cookie
     )
 
 auth_backend = AuthenticationBackend(

--- a/docs/adr/ADR-011-authentication-strategy.md
+++ b/docs/adr/ADR-011-authentication-strategy.md
@@ -1,0 +1,214 @@
+# ADR-011: Authentication Strategy — Server-Side Session via HttpOnly Cookie
+
+**Status:** Proposto
+**Data:** 2026-05-03
+**Deciders:** Lucas Cristovam
+**Technical Story:** Descendente direto do ADR-010 — define a estratégia de transport e storage de sessão para o bounded context `identity` introduzido lá.
+
+---
+
+## Contexto
+
+O ADR-010 introduz o bounded context `identity` e adota FastAPI Users como base de autenticação, mas deixa em aberto **como** as credenciais validadas se tornam contexto de request — qual transport (cookie vs header), qual storage de sessão (stateless JWT vs sessão server-side), e como o cliente persiste o estado de "logado".
+
+A escolha não é trivial porque os trade-offs clássicos da literatura (JWT vs Session) assumem cenários que **não correspondem ao HomeFlix**. Argumentos pró-JWT como "stateless escala horizontalmente sem Redis" ou "BCs em microserviços diferentes podem validar a mesma chave" pressupõem um SaaS multi-tenant rodando em múltiplos pods — o oposto do HomeFlix, que é monólito self-hosted rodando em um único processo na rede doméstica do usuário.
+
+Os fatores que efetivamente importam para esta decisão:
+
+1. **Topologia de deploy**: single-server, single-process, banco local (SQLite em dev, possivelmente PostgreSQL em prod doméstica). Lookups de sessão em DB são sub-milissegundo e não criam pressão arquitetural.
+2. **Cliente principal é uma SPA React** (`homeflix-web`). SPAs grandes têm superfície real para XSS — qualquer dependência npm comprometida pode tentar acessar `localStorage`. Tokens em `localStorage` são exfiltráveis; cookies `HttpOnly` não são acessíveis a JavaScript.
+3. **Caso de uso doméstico cria demanda real por revogação imediata**. Cenários concretos: "deslogar a TV da sala que ficou com a sessão aberta", "remover acesso de um membro da casa que saiu", "kill switch via admin panel". Com JWT stateless, revogação só acontece na expiração do token (ou exige introduzir blacklist, o que recria stateful por baixo dos panos).
+4. **API hoje é privada**, consumida exclusivamente pelo `homeflix-web`. Não há cliente mobile, integração de terceiros ou app desktop separado planejado para o curto prazo.
+5. **Complexidade adicional sem benefício concreto é dívida**: refresh tokens, blacklists, rotação de signing key e gestão de exp/iat são custo real de manutenção. Se o ganho que justificaria esse custo (escala stateless, federação cross-service) não se materializa, o saldo é negativo.
+
+Restrições: a decisão precisa ser compatível com o admin panel planejado (que vai expor "ver dispositivos logados" e "revogar sessão"), e não pode fechar a porta para a hipotética introdução futura de cliente mobile (caso em que bearer token em header passa a fazer sentido).
+
+## Decisão
+
+Nós iremos adotar **autenticação por sessão server-side em cookie HttpOnly**, implementada via FastAPI Users com `AuthenticationBackend` configurado como `DatabaseStrategy` + `CookieTransport`.
+
+**Storage de sessão**: tabela `access_tokens` no mesmo banco do BC `identity`, com schema `(token: str primary key, user_id: UUID, created_at: datetime)`. O token é uma string opaca aleatória (32+ bytes, base64url-safe), não um JWT — não carrega claims, é apenas a chave para lookup. Expiração configurável (padrão: 30 dias, slidable a cada request).
+
+**Transport**: cookie HTTP com nome `homeflix_session`, atributos:
+
+- `HttpOnly` — invisível a JavaScript, mitiga roubo via XSS
+- `Secure` — enviado apenas sobre HTTPS (no dev local, configurável via env var)
+- `SameSite=Strict` — bloqueia envio em requests cross-site, mitiga CSRF
+- `Max-Age` alinhado com a expiração do token (renovado a cada login bem-sucedido)
+
+**Fluxo de revogação**: logout deleta a row de `access_tokens`. Não há janela entre "usuário pediu logout" e "token deixa de ser válido" — é instantâneo. Admin panel futuro consulta a tabela para listar sessões ativas por usuário e oferece operação "revogar dispositivo", que também é apenas `DELETE WHERE token = ?`.
+
+**Fluxo de profile switch** (referente ao ADR-010): a troca de profile **não invalida a sessão** — a sessão pertence ao `User`. O `profile_id` ativo é armazenado em uma segunda coluna `current_profile_id` em `access_tokens`, atualizada via `POST /profiles/{id}/switch` (após validação de ownership). O cookie em si não muda. Cada request resolve `(user, current_profile)` em um único lookup pela `token`.
+
+**CSRF**: a combinação `SameSite=Strict` + CORS configurado com origin allowlist específica do `homeflix-web` é suficiente para o threat model atual. Se no futuro forem adicionados origins múltiplos (ex: app desktop com origem `tauri://`) que exijam relaxar `SameSite`, será necessário introduzir double-submit token CSRF — registrado como decisão diferida.
+
+**Compatibilidade com clientes não-browser** (cenário hipotético: app mobile no futuro): adicionar um segundo `AuthenticationBackend` em paralelo com `BearerTransport` + `JWTStrategy` na biblioteca FastAPI Users, sem alterar nem migrar o backend de cookie atual. Browsers continuam usando cookie, mobile usa bearer. **Esta decisão não fecha essa porta.**
+
+## Consequências
+
+### Positivas
+
+- **Revogação imediata é primitiva, não feature** — `DELETE FROM access_tokens WHERE token = ?` é a operação. Logout, kill switch via admin panel, "deslogar todos os dispositivos" e "remover acesso de membro" são todos a mesma operação SQL com WHERE diferente. Zero complexidade adicional para suportar cada um.
+- **Mitigação nativa de XSS** — cookie `HttpOnly` é invisível a JavaScript. Mesmo cenário pessimista de dependência npm comprometida não consegue exfiltrar a sessão.
+- **Sem complexidade de JWT** — sem refresh tokens, sem blacklist para revogação, sem rotação de signing key, sem gestão de exp/iat no cliente. O cliente não tem nenhuma responsabilidade sobre o token; o navegador cuida do cookie automaticamente.
+- **Multi-device com profiles independentes por device** — armazenar `current_profile_id` na própria sessão permite TV exibir perfil A enquanto celular exibe perfil B, simultaneamente, sem conflito.
+- **Lookup barato e atômico** — uma única query resolve `(token → user_id, current_profile_id)` por request. Em DB local, sub-milissegundo.
+- **Porta aberta para evolução** — `RedisStrategy` (multi-pod) e `BearerTransport`+`JWTStrategy` (cliente mobile) são adições paralelas, não substituições. Decisão atual não fecha caminhos futuros.
+
+### Negativas
+
+- **Stateful por design** — todo request bate na tabela `access_tokens`. Em DB local single-process é sub-milissegundo, mas é uma operação que JWT stateless não precisaria fazer. Custo aceito conscientemente em troca dos benefícios acima.
+- **CSRF precisa atenção contínua** — qualquer mudança futura nas configurações de CORS ou origin allowlist precisa reavaliar se `SameSite=Strict` ainda é suficiente. Se um dia for relaxado, double-submit token CSRF vira obrigatório.
+- **Sessão pode viver indefinidamente** com slidable expiration — usuário ativo nunca é deslogado por timeout. Para uso doméstico isso é UX correta, mas é trade-off de segurança consciente.
+- **Cliente não-browser exige trabalho adicional** — quando/se app mobile entrar no roadmap, é necessário adicionar segundo `AuthenticationBackend` (bearer) em paralelo. Não é refactor, mas é trabalho futuro identificado.
+- **DB bloat se cleanup falhar** — `access_tokens` cresce a cada login e só encolhe em logout/revogação/expiração. Sem job de limpeza, sessões expiradas acumulam.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Cookie de sessão interceptado em conexão HTTP não-criptografada | Baixa | Alto | Atributo `Secure` obrigatório em produção (env var); deploy doméstico atrás de TLS (Caddy/Traefik com Let's Encrypt ou self-signed); documentar no setup |
+| `access_tokens` cresce indefinidamente por falta de cleanup de sessões expiradas | Média | Baixo | Background job (APScheduler — já em uso) com cleanup periódico de tokens com `created_at + lifetime < now()`; também cleanup oportunístico durante validação de token |
+| Slidable expiration permite sessão "imortal" se atacante mantiver token ativo continuamente | Baixa | Médio | Limite absoluto de vida da sessão (ex: 90 dias desde criação, independente de atividade); admin panel oferece "revogar todas as sessões do usuário" como mitigação reativa |
+| Mudança futura de configuração CORS/origin relaxando `SameSite` reintroduz exposição CSRF | Baixa | Alto | Registrar nas Notas de Implementação que `SameSite=Strict` é load-bearing; checklist de revisão de PRs que tocam config de CORS deve revalidar exposição CSRF |
+| `current_profile_id` na sessão fica orfão se profile for deletado pelo user | Média | Baixo | `FOREIGN KEY ... ON DELETE SET NULL` na coluna; `get_current_profile` trata `None` como "precisa selecionar profile" e redireciona para `/profiles` |
+
+## Alternativas Consideradas
+
+### 1. Stateless JWT em header `Authorization: Bearer`
+
+Modelo "JWT puro": servidor assina token com claims (`sub`, `exp`, `iat`, `profile_id`), cliente armazena em `localStorage` (ou memória) e envia em header `Authorization`. Backend valida só pela assinatura, sem hit no DB.
+
+**Rejeitado porque:**
+
+- Tokens em `localStorage` são acessíveis a qualquer script no contexto da SPA — uma dependência npm comprometida (cenário não-hipotético: incidentes recentes de supply chain attack em pacotes JS) consegue exfiltrar a sessão. HttpOnly cookies eliminam essa classe inteira de ataque.
+- Revogação imediata, que é requisito real do produto (kill switch, "deslogar TV", remoção de membro da casa), exige introduzir blacklist server-side — o que reintroduz statefulness pelos fundos sem dar nenhum dos benefícios reais de "ser stateful por design" (controle, simplicidade, observabilidade).
+- A vantagem central de JWT (validação stateless, sem DB lookup) só se materializa em arquiteturas multi-instância ou multi-serviço. HomeFlix é monólito single-process — o "ganho" não existe na topologia real.
+
+### 2. JWT em HttpOnly cookie
+
+Variação do anterior onde o JWT é entregue via cookie `HttpOnly` em vez de exposto ao JavaScript. Resolve o problema de XSS mantendo a validação por assinatura.
+
+**Rejeitado porque:**
+
+- Mantém todo o overhead operacional do JWT (refresh tokens, rotação de signing key, gestão de exp/iat, blacklist para revogação imediata) sem usar a vantagem que justifica esse overhead. Como sempre vai haver hit no DB (para revogação ou para validar `is_active` do user), não há economia real de I/O.
+- Em um BC monolítico onde "validar sessão" e "carregar user" acontecem na mesma transação, a diferença de custo entre `SELECT FROM access_tokens WHERE token = ?` e `verify_signature(jwt) + SELECT FROM users WHERE id = ?` é nula. O JWT só adiciona complexidade.
+- Trade-off entre complexidade adicional e benefício concreto é claramente negativo na topologia atual.
+
+### 3. Sessão server-side em Redis + HttpOnly cookie
+
+Mesma estratégia escolhida (`DatabaseStrategy` + `CookieTransport`) mas com Redis como storage do token de sessão em vez de tabela em DB relacional.
+
+**Rejeitado porque:**
+
+- Adiciona uma dependência de infraestrutura nova ao stack (Redis), sem benefício correspondente na topologia atual. Lookup em SQLite/PostgreSQL local com PK indexada já é sub-milissegundo — Redis não move a agulha em latência percebida.
+- Custo de operação: usuário doméstico passa a precisar manter Redis rodando, configurar persistência (ou aceitar perda de sessões em restart), monitorar duas instâncias de armazenamento. Para zero ganho prático.
+- Migração futura é trivial: FastAPI Users tem `RedisStrategy` com a mesma interface de `DatabaseStrategy` — se um dia HomeFlix rodar em múltiplos processos ou demandar throughput maior, troca-se a strategy em uma linha. Não há razão para pré-otimizar agora.
+
+## Referências
+
+- **ADRs relacionados**:
+  - ADR-010 (Identity Bounded Context) — esta decisão complementa ADR-010 definindo o transport e storage de sessão para o BC `identity` introduzido lá
+  - ADR-002 (Prefixed External IDs) — `access_tokens.token` é secret opaco, não identificador de domínio; não segue o padrão `prefix_xxx` (e nunca deve ser exposto em logs ou rotas)
+- **Documentação externa**:
+  - [FastAPI Users — Authentication Backends](https://fastapi-users.github.io/fastapi-users/latest/configuration/authentication/) — documentação de `Strategy` e `Transport`
+  - [FastAPI Users — DatabaseStrategy](https://fastapi-users.github.io/fastapi-users/latest/configuration/authentication/strategies/database/) — strategy adotada
+  - [OWASP — Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html) — boas práticas de cookies de sessão (HttpOnly, Secure, SameSite)
+- **Padrões aplicados**:
+  - Server-side session storage (clássico, anterior ao JWT)
+  - Defense in depth — `HttpOnly` + `Secure` + `SameSite=Strict` em camadas
+
+---
+
+## Notas de Implementação
+
+**Schema da tabela `access_tokens`** (BC `identity`):
+
+```python
+# src/modules/identity/infrastructure/persistence/access_token_model.py
+class AccessTokenModel(Base):
+    __tablename__ = "access_tokens"
+
+    token: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    current_profile_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("profiles.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+```
+
+**Configuração do `AuthenticationBackend`**:
+
+```python
+# src/modules/identity/infrastructure/auth/backend.py
+cookie_transport = CookieTransport(
+    cookie_name="homeflix_session",
+    cookie_max_age=60 * 60 * 24 * 30,    # 30 dias slidable
+    cookie_secure=settings.is_production,  # True em prod, configurável em dev
+    cookie_httponly=True,
+    cookie_samesite="strict",
+)
+
+def get_database_strategy(
+    access_token_db: AccessTokenDatabase = Depends(get_access_token_db),
+) -> DatabaseStrategy:
+    return DatabaseStrategy(
+        database=access_token_db,
+        lifetime_seconds=60 * 60 * 24 * 30,  # alinhado com cookie
+    )
+
+auth_backend = AuthenticationBackend(
+    name="cookie-session",
+    transport=cookie_transport,
+    get_strategy=get_database_strategy,
+)
+```
+
+**Profile switch** (atualiza `current_profile_id` na sessão atual sem reemitir cookie):
+
+```python
+# src/modules/identity/application/use_cases/switch_profile.py
+@dataclass(frozen=True)
+class SwitchProfileInput:
+    user_id: UserId
+    target_profile_id: ProfileId
+    session_token: str
+
+class SwitchProfileUseCase:
+    async def execute(self, input: SwitchProfileInput) -> None:
+        profile = await self._profile_repo.get(input.target_profile_id)
+        if profile.user_id != input.user_id:
+            raise ProfileOwnershipViolation(input.user_id, input.target_profile_id)
+        await self._access_token_repo.update_current_profile(
+            input.session_token, input.target_profile_id,
+        )
+```
+
+**Cleanup de sessões expiradas** (job APScheduler em `src/infrastructure/scheduling/`):
+
+```python
+# Roda diariamente às 3am
+async def cleanup_expired_sessions(repo: AccessTokenRepository) -> int:
+    cutoff = datetime.utcnow() - timedelta(seconds=settings.session_lifetime_seconds)
+    return await repo.delete_older_than(cutoff)
+```
+
+**Compatibilidade futura com OAuth providers** (Google, GitHub, etc.): o schema do `User` permite `hashed_password` opcional, e FastAPI Users suporta nativamente vincular `User` a `OAuthAccount`. Adicionar provider externo no futuro **não exige nenhuma mudança neste ADR** — a sessão emitida no callback OAuth usa exatamente o mesmo `auth_backend` (`DatabaseStrategy` + `CookieTransport`).
+
+**Compatibilidade futura com cliente não-browser** (mobile, desktop): adicionar segundo backend em paralelo, ambos ativos:
+
+```python
+fastapi_users = FastAPIUsers[User, UUID](
+    user_manager_dependency,
+    [auth_backend, bearer_jwt_backend],  # cookie e bearer coexistem
+)
+```
+
+Browsers continuam autenticando via cookie; clients que não suportam cookies (ex: mobile nativo) usam bearer JWT. Decisão diferida para o momento em que primeiro cliente não-browser aparecer.
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-05-03 | Lucas Cristovam | Criação inicial |


### PR DESCRIPTION
## Summary

- **ADR-010 — Identity Bounded Context**: introduce o BC `identity` com separação User (auth root) / Profile (personalization context referenciado cross-BC), define ID strategy (UUID interno + prefixed `external_id` via mapper para preservar ADR-002 com FastAPI Users), e estabelece propagação explícita de `profile_id` via Input dataclasses (proibindo ContextVars/middleware mágico)
- **ADR-011 — Authentication Strategy**: adota FastAPI Users com `DatabaseStrategy` + `CookieTransport` — sessão server-side em tabela `access_tokens`, cookie `HttpOnly` + `Secure` + `SameSite=Strict`, slidable expiration, suporte a multi-device com profiles independentes via `current_profile_id` na sessão
- **Index update**: `adr_index.md` da skill `homeflix-arch` ganha entradas em "Por tópico", "Por sintoma no código" e "Por pergunta comum" para ambos os ADRs

Ambos os ADRs estão em status `Proposto` — promovem para `Aceito` quando o PR 1 do BC `identity` (foundation) merge na develop. Sequência completa de PRs de implementação detalhada nos próprios documentos.

## Test plan

- [ ] Verificar que `docs/adr/ADR-010-identity-bounded-context.md` renderiza corretamente no GitHub (tabelas, blocos de código, lista numerada de alternativas)
- [ ] Verificar que `docs/adr/ADR-011-authentication-strategy.md` renderiza corretamente
- [ ] Conferir que links cruzados entre ADRs (010 ↔ 011) e para ADRs anteriores (001, 002, 007, 008, 009) estão coerentes
- [ ] Validar que entradas novas em `adr_index.md` apontam para os arquivos corretos e a numeração "próximo ADR" foi atualizada para 012
- [ ] Revisão de conteúdo: alinhamento com princípios já estabelecidos (Clean Arch + DDD + ADRs anteriores), ausência de contradições internas, completude das alternativas consideradas

## Related decisions

- ADR-010 referencia: ADR-002 (prefixed IDs), ADR-007 (imutabilidade), ADR-008 (screaming architecture), ADR-009 (cross-BC ports)
- ADR-011 referencia: ADR-010 (BC identity), ADR-002 (token opaco fora do registro de prefixed IDs)

## Summary by Sourcery

Document identity and authentication architecture decisions and update the ADR index with references to the new ADRs.

Documentation:
- Add ADR-010 describing the Identity bounded context, including separation of User and Profile and explicit profile-based context passing across bounded contexts.
- Add ADR-011 defining the authentication strategy based on server-side sessions stored in a database and propagated via secure HttpOnly cookies, including session revocation and future extensibility considerations.
- Extend the ADR index with entries for identity and authentication, and improve topic- and symptom-based navigation to existing ADRs.