### PR TITLE
feat(identity): add ORM models and migration (2/8)

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -9,12 +9,13 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 # Import all models so they register on Base.metadata
-import src.modules.catalog_requests.infrastructure.persistence.models  # noqa: F401
-import src.modules.collections.infrastructure.persistence.models  # noqa: F401
-import src.modules.media.infrastructure.persistence.models  # noqa: F401
+import src.modules.catalog_requests.infrastructure.persistence.models
+import src.modules.collections.infrastructure.persistence.models
+import src.modules.identity.infrastructure.persistence.models
+import src.modules.media.infrastructure.persistence.models
 import src.modules.watch_progress.infrastructure.persistence.models  # noqa: F401
-from src.infrastructure.persistence.base import Base
 from src.config.settings import get_settings
+from src.infrastructure.persistence.base import Base
 
 config = context.config
 

--- a/migrations/versions/2026_05_03_add_identity.py
+++ b/migrations/versions/2026_05_03_add_identity.py
@@ -1,0 +1,199 @@
+"""Create users, profiles, and access_tokens for the identity BC.
+
+Introduces the identity bounded context tables per ADR-010 (User/Profile
+boundary, UUID interno + prefixed external_id) and ADR-011 (server-side
+sessions via cookie + DatabaseStrategy).
+
+Schema notes:
+- UUID primary keys via ``fastapi_users_db_sqlalchemy.GUID`` (CHAR(36)
+  on SQLite, UUID on Postgres).
+- ``external_id`` columns on ``users`` and ``profiles`` for the prefixed
+  domain ID exposed to clients. ``access_tokens`` has no external_id —
+  the token is a secret, never exposed.
+- ``profiles.user_id`` ``ON DELETE CASCADE``: deleting an account
+  removes its profiles.
+- ``access_tokens.user_id`` ``ON DELETE CASCADE``: deleting an account
+  invalidates its sessions.
+- ``access_tokens.current_profile_id`` ``ON DELETE SET NULL``: deleting
+  a profile clears it from any session that had it active, prompting
+  the user to pick a new one rather than failing the session.
+
+Revision ID: c5d6e7f8a9b0
+Revises: b4c5d6e7f8a9
+Create Date: 2026-05-03 17:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from fastapi_users_db_sqlalchemy.generics import GUID
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "c5d6e7f8a9b0"
+down_revision: str | Sequence[str] | None = "b4c5d6e7f8a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``users``, ``profiles``, and ``access_tokens`` tables."""
+    op.create_table(
+        "users",
+        sa.Column("id", GUID(), primary_key=True),
+        sa.Column("external_id", sa.String(length=50), nullable=False),
+        sa.Column("email", sa.String(length=320), nullable=False),
+        sa.Column("hashed_password", sa.String(length=1024), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column(
+            "is_superuser",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "is_verified",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "role",
+            sa.String(length=20),
+            nullable=False,
+            server_default="member",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_users_external_id",
+        "users",
+        ["external_id"],
+        unique=True,
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+    op.create_index("ix_users_role", "users", ["role"], unique=False)
+    op.create_index(
+        "ix_users_deleted_at",
+        "users",
+        ["deleted_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "profiles",
+        sa.Column("id", GUID(), primary_key=True),
+        sa.Column("external_id", sa.String(length=50), nullable=False),
+        sa.Column(
+            "user_id",
+            GUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("avatar_url", sa.String(length=500), nullable=True),
+        sa.Column(
+            "is_kids",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_profiles_external_id",
+        "profiles",
+        ["external_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_profiles_user_id",
+        "profiles",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_profiles_deleted_at",
+        "profiles",
+        ["deleted_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "access_tokens",
+        sa.Column("token", sa.String(length=43), primary_key=True),
+        sa.Column(
+            "user_id",
+            GUID(),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "current_profile_id",
+            GUID(),
+            sa.ForeignKey("profiles.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+            index=True,
+        ),
+    )
+    op.create_index(
+        "ix_access_tokens_user_id",
+        "access_tokens",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the identity tables in dependency order (FKs first)."""
+    op.drop_index("ix_access_tokens_user_id", table_name="access_tokens")
+    op.drop_table("access_tokens")
+    op.drop_index("ix_profiles_deleted_at", table_name="profiles")
+    op.drop_index("ix_profiles_user_id", table_name="profiles")
+    op.drop_index("ix_profiles_external_id", table_name="profiles")
+    op.drop_table("profiles")
+    op.drop_index("ix_users_deleted_at", table_name="users")
+    op.drop_index("ix_users_role", table_name="users")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_index("ix_users_external_id", table_name="users")
+    op.drop_table("users")

--- a/src/modules/identity/infrastructure/__init__.py
+++ b/src/modules/identity/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Identity infrastructure layer."""

--- a/src/modules/identity/infrastructure/persistence/__init__.py
+++ b/src/modules/identity/infrastructure/persistence/__init__.py
@@ -1,0 +1,1 @@
+"""Identity persistence — SQLAlchemy models, mappers, repositories."""

--- a/src/modules/identity/infrastructure/persistence/models/__init__.py
+++ b/src/modules/identity/infrastructure/persistence/models/__init__.py
@@ -1,0 +1,15 @@
+"""Identity SQLAlchemy ORM models.
+
+Importing this module registers the models on the shared SQLAlchemy
+metadata so alembic ``autogenerate`` and ``upgrade`` discover them.
+"""
+
+from src.modules.identity.infrastructure.persistence.models.access_token_model import (
+    AccessTokenModel,
+)
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+__all__ = ["AccessTokenModel", "ProfileModel", "UserModel"]

--- a/src/modules/identity/infrastructure/persistence/models/access_token_model.py
+++ b/src/modules/identity/infrastructure/persistence/models/access_token_model.py
@@ -1,0 +1,59 @@
+"""AccessToken SQLAlchemy ORM model — server-side session storage.
+
+Implements the session storage decided in ADR-011 (server-side session
+via ``DatabaseStrategy`` + ``CookieTransport``). The opaque token is
+the primary key; revocation is hard ``DELETE``. There is no
+``external_id`` (the secret must never be exposed) and no soft-delete
+(logout = removal).
+
+The user_id FK declared on ``SQLAlchemyBaseAccessTokenTableUUID``
+points to ``"user.id"`` by default — we override it to target our
+own ``users`` table.
+"""
+
+import uuid
+
+from fastapi_users_db_sqlalchemy.access_token import (
+    SQLAlchemyBaseAccessTokenTableUUID,
+)
+from fastapi_users_db_sqlalchemy.generics import GUID
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.base import BaseSecret
+
+
+class AccessTokenModel(SQLAlchemyBaseAccessTokenTableUUID, BaseSecret):
+    """SQLAlchemy model for the ``access_tokens`` table.
+
+    Inherited from ``SQLAlchemyBaseAccessTokenTableUUID``:
+        - ``token`` (String(43), primary key — opaque secret)
+        - ``created_at`` (TIMESTAMPAware, server-default ``now_utc``)
+
+    Overridden:
+        - ``user_id``: FK retargeted from default ``"user.id"`` to
+          ``"users.id"`` (our table is named ``users``, not ``user``).
+
+    Added:
+        - ``current_profile_id``: nullable FK to ``profiles.id``,
+          ``ON DELETE SET NULL``. Updated by the profile-switch use
+          case; lets each session carry its own active profile so
+          multi-device usage with different profiles works correctly.
+    """
+
+    __tablename__ = "access_tokens"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        GUID,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    current_profile_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID,
+        ForeignKey("profiles.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+
+__all__ = ["AccessTokenModel"]

--- a/src/modules/identity/infrastructure/persistence/models/profile_model.py
+++ b/src/modules/identity/infrastructure/persistence/models/profile_model.py
@@ -1,0 +1,48 @@
+"""Profile SQLAlchemy ORM model."""
+
+import uuid
+
+from fastapi_users_db_sqlalchemy.generics import GUID
+from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.base import BaseWithUUID
+
+
+class ProfileModel(BaseWithUUID):
+    """SQLAlchemy model for the ``Profile`` aggregate.
+
+    Profiles are personalization contexts owned by a ``User`` (FK
+    ``user_id``). The PK is a UUID for consistency with the identity
+    BC's UUID-PK convention; clients reference profiles by their
+    prefixed ``external_id`` (``prf_xxxxxxxxxxxx``) — translation
+    happens in ``ProfileMapper``.
+
+    Attributes:
+        user_id: UUID of the owning ``UserModel``. ``ON DELETE CASCADE``
+            so deleting an account also removes its profiles.
+        name: Display name shown in the profile picker (1..50 chars).
+        avatar_url: Optional URL to an avatar image.
+        is_kids: Marks the profile as kids-mode (used by future library
+            ACL — see ADR-010 PR 6).
+    """
+
+    __tablename__ = "profiles"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        GUID,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(50), nullable=False)
+    avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    is_kids: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+    )
+
+
+__all__ = ["ProfileModel"]

--- a/src/modules/identity/infrastructure/persistence/models/user_model.py
+++ b/src/modules/identity/infrastructure/persistence/models/user_model.py
@@ -1,0 +1,51 @@
+"""User SQLAlchemy ORM model.
+
+Combines ``BaseWithUUID`` (project conventions: ``external_id``,
+timestamps, soft-delete, snake_case ``__tablename__`` from
+``_CommonColumnsMixin``) with FastAPI Users' ``SQLAlchemyBaseUserTableUUID``
+(UUID primary key, ``email``, ``hashed_password``, ``is_active``,
+``is_superuser``, ``is_verified``).
+
+The internal database PK is the UUID — that's what FastAPI Users
+operates on. ``external_id`` (``usr_xxxxxxxxxxxx``) is what every other
+layer (domain, application, presentation) sees, so the API never leaks
+UUIDs (preserves ADR-002). Translation happens in ``UserMapper``.
+"""
+
+from fastapi_users_db_sqlalchemy import SQLAlchemyBaseUserTableUUID
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.base import BaseWithUUID
+
+
+class UserModel(BaseWithUUID, SQLAlchemyBaseUserTableUUID):
+    """SQLAlchemy model for the ``User`` aggregate.
+
+    Inherited from ``BaseWithUUID`` (via ``_CommonColumnsMixin``):
+        - ``external_id``, ``created_at``, ``updated_at``, ``deleted_at``
+        - Soft-delete helpers (``is_deleted``, ``soft_delete``, ``restore``)
+
+    Inherited from ``SQLAlchemyBaseUserTableUUID``:
+        - ``id`` (UUID primary key, default ``uuid.uuid4``)
+        - ``email`` (String(320), unique, indexed)
+        - ``hashed_password`` (String(1024))
+        - ``is_active``, ``is_superuser``, ``is_verified`` (Boolean)
+
+    Attributes:
+        role: One of ``admin`` / ``member`` (``UserRole`` enum). Stored
+            as a plain string for flexibility — the domain VO converts
+            it back to the enum.
+    """
+
+    __tablename__ = "users"
+
+    role: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="member",
+        index=True,
+    )
+
+
+__all__ = ["UserModel"]


### PR DESCRIPTION
## Summary

Slice 2 de 8 da entrega do BC `identity` (foundation per ADR-010 / ADR-011). Esta PR adiciona os 3 modelos SQLAlchemy (User, Profile, AccessToken) e a migration que cria as tabelas. Depende da slice 1 (já mergeada — VOs, entities, `BaseWithUUID`/`BaseSecret`).

Continua **puramente aditiva** — após `make migrate` as 3 tabelas existem vazias, nenhuma rota existente é alterada, app continua funcional.

### Conteúdo

- **`UserModel`** (`src/modules/identity/infrastructure/persistence/models/user_model.py`):
  - Multi-inheritance `BaseWithUUID` (project `external_id` + timestamps + soft-delete) + `SQLAlchemyBaseUserTableUUID` (UUID PK, `email`, `hashed_password`, `is_active`, `is_superuser`, `is_verified`)
  - Coluna `role` (`admin` | `member`) com index pra futuros filtros admin
- **`ProfileModel`**: extends `BaseWithUUID`, declara seu próprio `id: UUID`; FK `user_id` → `users.id` `ON DELETE CASCADE`
- **`AccessTokenModel`**: combines `SQLAlchemyBaseAccessTokenTableUUID` + `BaseSecret`; override do FK `user_id` (mixin aponta pra `"user.id"`, retargeted pra `"users.id"`); adiciona `current_profile_id` FK → `profiles.id` `ON DELETE SET NULL` (suporta multi-device com profiles distintos por sessão per ADR-011)
- **Migration** `2026_05_03_add_identity.py`: usa `fastapi_users_db_sqlalchemy.GUID` (portátil SQLite/Postgres). Indexes em `external_id` (unique), `email` (unique), `role`, `user_id`, `deleted_at`. Downgrade dropa em ordem reversa de FK.
- **`migrations/env.py`**: registra os modelos do identity pra autogenerate

### Smoke verifications

- [x] `alembic upgrade head` em DB limpo: rodou sem erro do `b4c5d6e7f8a9` → `c5d6e7f8a9b0`
- [x] `alembic downgrade b4c5d6e7f8a9` + `alembic upgrade head`: round-trip limpo (migration é reversível)
- [x] Schema inspecionado: 3 tabelas com colunas, PKs, FKs (cascade/set null) e indexes corretos
- [x] `poetry run pytest tests/modules/identity tests/modules/library tests/modules/media`: **1337 passed**, 5 skipped (regressão zero)
- [x] `ruff check` + `ruff format --check`: clean

### Próximas slices

3. Repositories + mappers + `IdentityUnitOfWork` + integration tests
4. Use cases (`CreateProfile`, `ListProfilesForUser`, `UpdateProfile`, `DeleteProfile`, `SwitchProfile`)
5. FastAPI Users wiring + `IdentityContainer` + settings + `main.py`
6. Routes (`/auth/cookie/*`, `/users/me`, `/profiles/*`) + CLI `identity_create_admin.py`
7. E2E test scaffolding + auth tests
8. E2E profile tests + polish

## Related

- ADR-010 — UUID interno + prefixed external_id mapper preserva ADR-002
- ADR-011 — `access_tokens` schema (token PK opaco, `current_profile_id` na sessão)

## Summary by Sourcery

Introduce identity bounded context persistence by adding ORM models and migrations for users, profiles, and access tokens.

New Features:
- Add SQLAlchemy ORM models for users, profiles, and access tokens in the identity module.
- Create Alembic migration to create users, profiles, and access_tokens tables with appropriate keys and indexes.
- Register identity models in Alembic env so they are included in autogeneration and schema management.

Enhancements:
- Clean up Alembic env imports to align with other modules and ensure consistent Base metadata registration.