### PR TITLE
feat(identity): add repositories and UoW (3/8)

### DIFF
--- a/src/modules/identity/application/__init__.py
+++ b/src/modules/identity/application/__init__.py
@@ -1,0 +1,1 @@
+"""Identity application layer — Unit of Work, DTOs, use cases."""

--- a/src/modules/identity/application/unit_of_work.py
+++ b/src/modules/identity/application/unit_of_work.py
@@ -1,0 +1,35 @@
+"""Identity bounded-context Unit of Work interface."""
+
+from abc import ABC, abstractmethod
+
+from src.building_blocks.application.unit_of_work import UnitOfWork
+from src.modules.identity.domain.repositories import (
+    AccessTokenRepository,
+    ProfileRepository,
+    UserRepository,
+)
+
+
+class IdentityUnitOfWork(UnitOfWork):
+    """Transactional boundary for identity aggregate operations.
+
+    Subclasses populate ``users``, ``profiles`` and ``access_tokens``
+    on ``__aenter__`` so writes within the same ``async with`` block
+    share a single transaction (e.g. switching profile + updating
+    session state in one atomic step).
+    """
+
+    users: UserRepository
+    profiles: ProfileRepository
+    access_tokens: AccessTokenRepository
+
+
+class IdentityUnitOfWorkFactory(ABC):
+    """Builds fresh ``IdentityUnitOfWork`` instances on demand."""
+
+    @abstractmethod
+    def __call__(self) -> IdentityUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+
+
+__all__ = ["IdentityUnitOfWork", "IdentityUnitOfWorkFactory"]

--- a/src/modules/identity/domain/repositories/__init__.py
+++ b/src/modules/identity/domain/repositories/__init__.py
@@ -1,0 +1,17 @@
+"""Identity domain repository interfaces."""
+
+from src.modules.identity.domain.repositories.access_token_repository import (
+    AccessTokenRepository,
+    AccessTokenSnapshot,
+)
+from src.modules.identity.domain.repositories.profile_repository import (
+    ProfileRepository,
+)
+from src.modules.identity.domain.repositories.user_repository import UserRepository
+
+__all__ = [
+    "AccessTokenRepository",
+    "AccessTokenSnapshot",
+    "ProfileRepository",
+    "UserRepository",
+]

--- a/src/modules/identity/domain/repositories/access_token_repository.py
+++ b/src/modules/identity/domain/repositories/access_token_repository.py
@@ -1,0 +1,102 @@
+"""Access token repository interface and its read DTO."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.user_id import UserId
+
+
+@dataclass(frozen=True)
+class AccessTokenSnapshot:
+    """Read-only projection of a session row exposed to the domain.
+
+    The on-disk ``access_tokens`` table stores UUIDs as foreign keys
+    (so that FastAPI Users' ``DatabaseStrategy`` can use them natively).
+    Domain code consumes prefixed external IDs only — ``user_id`` and
+    ``current_profile_id`` here are the translated VOs. Translation
+    happens in ``SqlAlchemyAccessTokenRepository`` via JOINs on the
+    users / profiles tables, so the rest of the system never sees a
+    raw UUID.
+
+    Attributes:
+        token: The opaque session token (also the row's primary key).
+        user_id: External ID of the user owning this session.
+        current_profile_id: External ID of the active profile, or
+            ``None`` if the user has not selected a profile in this
+            session (post-login, pre-profile-picker).
+        created_at: Session issue time (used for absolute-expiration
+            checks and the cleanup job).
+    """
+
+    token: str
+    user_id: UserId
+    current_profile_id: ProfileId | None
+    created_at: datetime
+
+
+class AccessTokenRepository(ABC):
+    """Repository interface for ``access_tokens``.
+
+    Covers the operations our domain code needs (read snapshot, switch
+    profile, cleanup). FastAPI Users' own auth flow goes through its
+    ``SQLAlchemyAccessTokenDatabase`` adapter directly — the two share
+    the underlying table without conflict.
+    """
+
+    @abstractmethod
+    async def get_by_token(self, token: str) -> AccessTokenSnapshot | None:
+        """Resolve a session token to its (user, current_profile) pair.
+
+        Args:
+            token: The opaque token from the cookie.
+
+        Returns:
+            Snapshot with prefixed external IDs, or ``None`` if the
+            token is unknown.
+        """
+        ...
+
+    @abstractmethod
+    async def update_current_profile(
+        self,
+        token: str,
+        profile_id: ProfileId | None,
+    ) -> bool:
+        """Set the active profile for an existing session.
+
+        Internally resolves ``profile_id`` to the row's internal UUID
+        before issuing the UPDATE. Passing ``None`` clears the current
+        profile (used when a profile is deleted while it was active in
+        a sibling session — enforced via ``ON DELETE SET NULL``, but
+        callable explicitly too).
+
+        Args:
+            token: The session token to update.
+            profile_id: The profile to make active, or ``None``.
+
+        Returns:
+            ``True`` if a row was updated, ``False`` if no session
+            with that token exists.
+        """
+        ...
+
+    @abstractmethod
+    async def delete_older_than(self, cutoff: datetime) -> int:
+        """Remove sessions whose ``created_at`` is older than ``cutoff``.
+
+        Used by the periodic cleanup job (wired in a later PR). Hard
+        DELETE — these rows have no soft-delete semantics.
+
+        Args:
+            cutoff: Sessions strictly older than this timestamp are
+                removed.
+
+        Returns:
+            Number of rows deleted.
+        """
+        ...
+
+
+__all__ = ["AccessTokenRepository", "AccessTokenSnapshot"]

--- a/src/modules/identity/domain/repositories/profile_repository.py
+++ b/src/modules/identity/domain/repositories/profile_repository.py
@@ -1,0 +1,89 @@
+"""Profile repository interface."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from src.modules.identity.domain.entities.profile import Profile
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.user_id import UserId
+
+
+class ProfileRepository(ABC):
+    """Repository interface for the ``Profile`` aggregate.
+
+    Profile is modelled as a separate aggregate (not a child of User)
+    so authentication checks do not pay the cost of hydrating profiles
+    on every request. Cross-BC consumers reference only ``ProfileId``;
+    ownership invariants are enforced at use-case boundaries.
+    """
+
+    @abstractmethod
+    async def save(self, profile: Profile) -> Profile:
+        """Persist a profile (create or update).
+
+        Generates an external ID on insert. Caller's ``user_id`` must
+        reference an existing user — the SQLAlchemy implementation
+        resolves it to the internal UUID before writing.
+
+        Args:
+            profile: The profile to save.
+
+        Returns:
+            The saved profile, re-read from the database.
+        """
+        ...
+
+    @abstractmethod
+    async def find_by_id(self, profile_id: ProfileId) -> Profile | None:
+        """Look up a profile by its prefixed external ID.
+
+        Args:
+            profile_id: The profile's external ID (``prf_xxx``).
+
+        Returns:
+            The profile if found and not soft-deleted, ``None`` otherwise.
+        """
+        ...
+
+    @abstractmethod
+    async def find_by_user(self, user_id: UserId) -> Sequence[Profile]:
+        """List all profiles owned by the given user, ordered by name.
+
+        Args:
+            user_id: The owning user's external ID.
+
+        Returns:
+            Sequence of profiles (may be empty).
+        """
+        ...
+
+    @abstractmethod
+    async def count_for_user(self, user_id: UserId) -> int:
+        """Count non-deleted profiles owned by the user.
+
+        Used by ``DeleteProfileUseCase`` to enforce the "cannot delete
+        the last profile" invariant.
+
+        Args:
+            user_id: The owning user's external ID.
+
+        Returns:
+            Number of active profiles for the user.
+        """
+        ...
+
+    @abstractmethod
+    async def delete(self, profile_id: ProfileId) -> bool:
+        """Soft-delete a profile.
+
+        Args:
+            profile_id: The profile's external ID.
+
+        Returns:
+            ``True`` if the profile was found and deleted, ``False``
+            if it didn't exist or was already deleted.
+        """
+        ...
+
+
+__all__ = ["ProfileRepository"]

--- a/src/modules/identity/domain/repositories/user_repository.py
+++ b/src/modules/identity/domain/repositories/user_repository.py
@@ -1,0 +1,66 @@
+"""User repository interface."""
+
+from abc import ABC, abstractmethod
+
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.user_id import UserId
+
+
+class UserRepository(ABC):
+    """Repository interface for the ``User`` aggregate.
+
+    Note on lifecycle: the user table is also written by FastAPI Users
+    via ``SQLAlchemyUserDatabase`` (registration, password reset, email
+    verification). This repository covers domain-driven reads and the
+    narrow set of fields the domain actually mutates (``role``,
+    ``is_active``). It deliberately does NOT expose ``delete()`` —
+    accounts are deactivated, not removed (preserves attribution of
+    historical data).
+    """
+
+    @abstractmethod
+    async def save(self, user: User) -> User:
+        """Persist a user (create on insert, partial update on existing).
+
+        On insert (``user.id is None``) every domain field is written
+        and a fresh ``UserId`` is generated. On update only the
+        domain-mutable fields (``role``, ``is_active``) are touched —
+        FastAPI Users-owned fields (``hashed_password``,
+        ``is_verified``, ``is_superuser``) stay untouched.
+
+        Args:
+            user: The user to save.
+
+        Returns:
+            The saved user, re-read from the database so callers see
+            any server-generated values.
+        """
+        ...
+
+    @abstractmethod
+    async def find_by_id(self, user_id: UserId) -> User | None:
+        """Look up a user by their prefixed external ID.
+
+        Args:
+            user_id: The user's external ID (``usr_xxx``).
+
+        Returns:
+            The user if found and not soft-deleted, ``None`` otherwise.
+        """
+        ...
+
+    @abstractmethod
+    async def find_by_email(self, email: Email) -> User | None:
+        """Look up a user by email (case-insensitive via the VO).
+
+        Args:
+            email: The normalised email address.
+
+        Returns:
+            The user if found, ``None`` otherwise.
+        """
+        ...
+
+
+__all__ = ["UserRepository"]

--- a/src/modules/identity/infrastructure/persistence/mappers/__init__.py
+++ b/src/modules/identity/infrastructure/persistence/mappers/__init__.py
@@ -1,0 +1,10 @@
+"""Identity persistence mappers (domain entity ↔ SQLAlchemy model)."""
+
+from src.modules.identity.infrastructure.persistence.mappers.profile_mapper import (
+    ProfileMapper,
+)
+from src.modules.identity.infrastructure.persistence.mappers.user_mapper import (
+    UserMapper,
+)
+
+__all__ = ["ProfileMapper", "UserMapper"]

--- a/src/modules/identity/infrastructure/persistence/mappers/profile_mapper.py
+++ b/src/modules/identity/infrastructure/persistence/mappers/profile_mapper.py
@@ -1,0 +1,106 @@
+"""Mapper between Profile domain entity and ProfileModel ORM model.
+
+Profile rows have a UUID primary key (for consistency with the rest of
+the identity BC) and a UUID FK ``user_id`` to ``users.id``. The domain
+only sees prefixed ``ProfileId`` / ``UserId``. The repository is
+responsible for resolving the user's UUID before calling
+``to_model``/``update_model`` — the mapper itself never does the
+lookup, keeping it dependency-free and synchronous.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from src.modules.identity.domain.entities.profile import Profile
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.profile_name import ProfileName
+from src.modules.identity.domain.value_objects.user_id import UserId
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
+
+
+def _ensure_utc(value: datetime | None) -> datetime | None:
+    """Attach UTC tzinfo to naive datetimes loaded from the DB."""
+    if value is None:
+        return None
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+class ProfileMapper:
+    """Bidirectional mapper for ``Profile`` ↔ ``ProfileModel``."""
+
+    @staticmethod
+    def to_model(entity: Profile, user_uuid: uuid.UUID) -> ProfileModel:
+        """Convert a Profile entity to a freshly-constructed ProfileModel.
+
+        Args:
+            entity: The Profile to persist (must have an id assigned).
+            user_uuid: The internal UUID of the owning user, resolved
+                by the repository via a SELECT on ``users.external_id``
+                before calling this method.
+
+        Returns:
+            A new ``ProfileModel`` ready to be added to the session.
+
+        Raises:
+            ValueError: If the entity has no id.
+        """
+        if entity.id is None:
+            raise ValueError("Cannot map Profile entity without ID to model")
+
+        return ProfileModel(
+            external_id=str(entity.id),
+            user_id=user_uuid,
+            name=entity.name.value,
+            avatar_url=entity.avatar_url,
+            is_kids=entity.is_kids,
+        )
+
+    @staticmethod
+    def to_entity(model: ProfileModel, user_external_id: str) -> Profile:
+        """Convert a ProfileModel back into a Profile domain entity.
+
+        Args:
+            model: The SQLAlchemy model loaded from the session.
+            user_external_id: The owning user's external ID, resolved
+                by the repository (typically via a JOIN) so the
+                returned entity carries the prefixed ``UserId`` rather
+                than a UUID.
+
+        Returns:
+            The reconstructed ``Profile`` with prefixed VO IDs.
+        """
+        return Profile(
+            id=ProfileId(model.external_id),
+            user_id=UserId(user_external_id),
+            name=ProfileName(model.name),
+            avatar_url=model.avatar_url,
+            is_kids=model.is_kids,
+            created_at=_ensure_utc(model.created_at) or datetime.now(UTC),
+            updated_at=_ensure_utc(model.updated_at) or datetime.now(UTC),
+        )
+
+    @staticmethod
+    def update_model(model: ProfileModel, entity: Profile) -> ProfileModel:
+        """Apply mutable Profile fields to an existing model.
+
+        ``user_id`` is intentionally NOT touched — transferring profile
+        ownership is not a supported operation. The repository should
+        not attempt to call ``update_model`` on a profile whose
+        ``user_id`` differs from the existing model.
+
+        Args:
+            model: The existing model to mutate in place.
+            entity: The domain entity carrying the new state.
+
+        Returns:
+            The same ``model`` reference, mutated.
+        """
+        model.name = entity.name.value
+        model.avatar_url = entity.avatar_url
+        model.is_kids = entity.is_kids
+        return model
+
+
+__all__ = ["ProfileMapper"]

--- a/src/modules/identity/infrastructure/persistence/mappers/user_mapper.py
+++ b/src/modules/identity/infrastructure/persistence/mappers/user_mapper.py
@@ -1,0 +1,116 @@
+"""Mapper between User domain entity and UserModel ORM model.
+
+The internal database PK is a UUID (FastAPI Users requirement); the
+domain only ever sees ``UserId`` (``usr_xxxxxxxxxxxx``). This mapper
+is the single point that crosses that boundary — UUID never appears
+in any other layer.
+
+On insert the mapper produces a model with all FastAPI Users-managed
+fields populated from the entity (``hashed_password``, ``is_verified``,
+``is_superuser``). On update, the mapper deliberately writes ONLY the
+domain-mutable fields (``role``, ``is_active``); FastAPI Users owns
+the password / verification / superuser flow and writes those columns
+through ``SQLAlchemyUserDatabase`` instead.
+"""
+
+from datetime import UTC, datetime
+
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.user_id import UserId
+from src.modules.identity.domain.value_objects.user_role import UserRole
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+def _ensure_utc(value: datetime | None) -> datetime | None:
+    """Attach UTC tzinfo to naive datetimes loaded from the DB.
+
+    Mirrors the helper in ``library_mapper`` — SQLite drops timezone
+    info even when the column is declared with ``DateTime(timezone=True)``.
+    """
+    if value is None:
+        return None
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+class UserMapper:
+    """Bidirectional mapper for ``User`` ↔ ``UserModel``."""
+
+    @staticmethod
+    def to_model(entity: User) -> UserModel:
+        """Convert a User entity to a freshly-constructed UserModel.
+
+        Used on insert. Every field is populated from the entity; the
+        UUID primary key defaults via the model column (``uuid.uuid4``)
+        if not pre-assigned.
+
+        Args:
+            entity: The User to persist (must have an id assigned).
+
+        Returns:
+            A new ``UserModel`` ready to be added to the session.
+
+        Raises:
+            ValueError: If the entity has no id.
+        """
+        if entity.id is None:
+            raise ValueError("Cannot map User entity without ID to model")
+
+        return UserModel(
+            external_id=str(entity.id),
+            email=entity.email.value,
+            hashed_password=entity.hashed_password or "",
+            is_active=entity.is_active,
+            is_superuser=entity.is_superuser,
+            is_verified=entity.is_verified,
+            role=entity.role.value,
+        )
+
+    @staticmethod
+    def to_entity(model: UserModel) -> User:
+        """Convert a UserModel back into a User domain entity.
+
+        Args:
+            model: The SQLAlchemy model loaded from the session.
+
+        Returns:
+            The reconstructed ``User`` with prefixed ``UserId``.
+        """
+        return User(
+            id=UserId(model.external_id),
+            email=Email(model.email),
+            role=UserRole(model.role),
+            is_active=model.is_active,
+            is_superuser=model.is_superuser,
+            is_verified=model.is_verified,
+            hashed_password=model.hashed_password or None,
+            created_at=_ensure_utc(model.created_at) or datetime.now(UTC),
+            updated_at=_ensure_utc(model.updated_at) or datetime.now(UTC),
+        )
+
+    @staticmethod
+    def update_model(model: UserModel, entity: User) -> UserModel:
+        """Apply ONLY domain-mutable fields onto an existing model.
+
+        Specifically writes ``role`` and ``is_active`` — the columns
+        the domain controls. ``hashed_password``, ``is_verified``,
+        ``is_superuser`` are intentionally left untouched: FastAPI
+        Users owns those via the registration / verification / admin
+        flows and updates them through its own database adapter.
+
+        Email is also left untouched here; admin email change is a
+        deliberate sensitive flow that isn't in scope for this PR.
+
+        Args:
+            model: The existing model to mutate in place.
+            entity: The domain entity carrying the new state.
+
+        Returns:
+            The same ``model`` reference, mutated.
+        """
+        model.role = entity.role.value
+        model.is_active = entity.is_active
+        return model
+
+
+__all__ = ["UserMapper"]

--- a/src/modules/identity/infrastructure/persistence/repositories/__init__.py
+++ b/src/modules/identity/infrastructure/persistence/repositories/__init__.py
@@ -1,0 +1,17 @@
+"""Identity persistence repositories (concrete SQLAlchemy implementations)."""
+
+from src.modules.identity.infrastructure.persistence.repositories.sqlalchemy_access_token_repository import (
+    SqlAlchemyAccessTokenRepository,
+)
+from src.modules.identity.infrastructure.persistence.repositories.sqlalchemy_profile_repository import (
+    SqlAlchemyProfileRepository,
+)
+from src.modules.identity.infrastructure.persistence.repositories.sqlalchemy_user_repository import (
+    SqlAlchemyUserRepository,
+)
+
+__all__ = [
+    "SqlAlchemyAccessTokenRepository",
+    "SqlAlchemyProfileRepository",
+    "SqlAlchemyUserRepository",
+]

--- a/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_access_token_repository.py
+++ b/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_access_token_repository.py
@@ -1,0 +1,115 @@
+"""SQLAlchemy implementation of AccessTokenRepository."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.identity.domain.repositories.access_token_repository import (
+    AccessTokenRepository,
+    AccessTokenSnapshot,
+)
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.user_id import UserId
+from src.modules.identity.infrastructure.persistence.models.access_token_model import (
+    AccessTokenModel,
+)
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+class SqlAlchemyAccessTokenRepository(AccessTokenRepository):
+    """Async SQLAlchemy repository for the ``access_tokens`` table.
+
+    The same table is also accessed by FastAPI Users' built-in
+    ``SQLAlchemyAccessTokenDatabase`` for the auth flow; the two
+    coexist without conflict because they touch the same rows under
+    one transaction. This repository covers the operations the
+    application layer needs (read snapshot, switch profile, cleanup).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_token(self, token: str) -> AccessTokenSnapshot | None:
+        """Resolve a token to its (user, current_profile) prefixed pair.
+
+        Joins ``access_tokens`` with ``users`` (and LEFT-joins
+        ``profiles``) so the returned snapshot carries prefixed
+        external IDs — the rest of the system never sees the
+        underlying UUID.
+        """
+        stmt = (
+            select(
+                AccessTokenModel.token,
+                AccessTokenModel.created_at,
+                UserModel.external_id.label("user_external_id"),
+                ProfileModel.external_id.label("profile_external_id"),
+            )
+            .join(UserModel, AccessTokenModel.user_id == UserModel.id)
+            .join(
+                ProfileModel,
+                AccessTokenModel.current_profile_id == ProfileModel.id,
+                isouter=True,
+            )
+            .where(AccessTokenModel.token == token)
+        )
+        row = (await self._session.execute(stmt)).first()
+        if row is None:
+            return None
+
+        created_at = row.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=UTC)
+
+        return AccessTokenSnapshot(
+            token=row.token,
+            user_id=UserId(row.user_external_id),
+            current_profile_id=(
+                ProfileId(row.profile_external_id) if row.profile_external_id is not None else None
+            ),
+            created_at=created_at,
+        )
+
+    async def update_current_profile(
+        self,
+        token: str,
+        profile_id: ProfileId | None,
+    ) -> bool:
+        """Set ``current_profile_id`` on the session row.
+
+        Resolves ``profile_id`` (prefixed) to its internal UUID via
+        a SELECT before issuing the UPDATE, so the rest of the layer
+        deals only with prefixed VOs. Pass ``None`` to clear.
+        """
+        if profile_id is None:
+            profile_uuid = None
+        else:
+            uuid_stmt = select(ProfileModel.id).where(
+                ProfileModel.external_id == str(profile_id),
+                ProfileModel.deleted_at.is_(None),
+            )
+            profile_uuid = (await self._session.execute(uuid_stmt)).scalar_one_or_none()
+            if profile_uuid is None:
+                raise ValueError(f"Profile {profile_id} does not exist")
+
+        update_stmt = (
+            update(AccessTokenModel)
+            .where(AccessTokenModel.token == token)
+            .values(current_profile_id=profile_uuid)
+        )
+        result = await self._session.execute(update_stmt)
+        await self._session.flush()
+        return bool(result.rowcount and result.rowcount > 0)
+
+    async def delete_older_than(self, cutoff: datetime) -> int:
+        """Remove sessions whose ``created_at`` is strictly older than ``cutoff``."""
+        stmt = delete(AccessTokenModel).where(AccessTokenModel.created_at < cutoff)
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return int(result.rowcount or 0)
+
+
+__all__ = ["SqlAlchemyAccessTokenRepository"]

--- a/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_profile_repository.py
+++ b/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_profile_repository.py
@@ -1,0 +1,149 @@
+"""SQLAlchemy implementation of ProfileRepository."""
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.identity.domain.entities.profile import Profile
+from src.modules.identity.domain.repositories.profile_repository import (
+    ProfileRepository,
+)
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.user_id import UserId
+from src.modules.identity.infrastructure.persistence.mappers.profile_mapper import (
+    ProfileMapper,
+)
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+class SqlAlchemyProfileRepository(ProfileRepository):
+    """Async SQLAlchemy repository for Profile aggregates.
+
+    Bridges prefixed external IDs (domain) to UUIDs (database) for
+    both ``Profile.id`` and ``Profile.user_id``. Soft-deletes on
+    ``delete()``; transaction commit is the UoW's responsibility.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def save(self, profile: Profile) -> Profile:
+        """Persist a profile (create or update).
+
+        Resolves ``profile.user_id`` to the user's internal UUID
+        before passing the entity to the mapper.
+
+        Args:
+            profile: The profile to save.
+
+        Returns:
+            The saved profile, re-read so the caller sees timestamps.
+
+        Raises:
+            ValueError: If the owning user does not exist.
+        """
+        is_insert = profile.id is None
+        profile = profile.with_updates(id=ProfileId.generate_if_absent(profile.id))
+
+        user_uuid = await self._resolve_user_uuid(profile.user_id)
+
+        stmt = select(ProfileModel).where(ProfileModel.external_id == str(profile.id))
+        existing = (await self._session.execute(stmt)).scalar_one_or_none()
+
+        if existing is not None and existing.is_deleted:
+            existing.restore()
+
+        if existing is not None and not is_insert:
+            ProfileMapper.update_model(existing, profile)
+            await self._session.flush()
+        else:
+            model = ProfileMapper.to_model(profile, user_uuid=user_uuid)
+            self._session.add(model)
+            await self._session.flush()
+
+        if profile.id is None:
+            raise RuntimeError("Profile id was not assigned before save")
+        saved = await self.find_by_id(profile.id)
+        if saved is None:
+            raise RuntimeError(
+                f"Profile {profile.id} disappeared between flush and reload",
+            )
+        return saved
+
+    async def find_by_id(self, profile_id: ProfileId) -> Profile | None:
+        """Look up a non-deleted profile by external ID, returning a domain entity."""
+        stmt = (
+            select(ProfileModel, UserModel.external_id)
+            .join(UserModel, ProfileModel.user_id == UserModel.id)
+            .where(
+                ProfileModel.external_id == str(profile_id),
+                ProfileModel.deleted_at.is_(None),
+            )
+        )
+        result = await self._session.execute(stmt)
+        row = result.first()
+        if row is None:
+            return None
+        model, user_external_id = row
+        return ProfileMapper.to_entity(model, user_external_id=user_external_id)
+
+    async def find_by_user(self, user_id: UserId) -> Sequence[Profile]:
+        """List all non-deleted profiles owned by the user, ordered by name."""
+        stmt = (
+            select(ProfileModel, UserModel.external_id)
+            .join(UserModel, ProfileModel.user_id == UserModel.id)
+            .where(
+                UserModel.external_id == str(user_id),
+                ProfileModel.deleted_at.is_(None),
+            )
+            .order_by(ProfileModel.name)
+        )
+        result = await self._session.execute(stmt)
+        rows = result.all()
+        return [
+            ProfileMapper.to_entity(model, user_external_id=user_external_id)
+            for model, user_external_id in rows
+        ]
+
+    async def count_for_user(self, user_id: UserId) -> int:
+        """Count non-deleted profiles owned by the user."""
+        stmt = (
+            select(func.count(ProfileModel.id))
+            .join(UserModel, ProfileModel.user_id == UserModel.id)
+            .where(
+                UserModel.external_id == str(user_id),
+                ProfileModel.deleted_at.is_(None),
+            )
+        )
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
+    async def delete(self, profile_id: ProfileId) -> bool:
+        """Soft-delete a profile by external ID."""
+        stmt = select(ProfileModel).where(
+            ProfileModel.external_id == str(profile_id),
+            ProfileModel.deleted_at.is_(None),
+        )
+        model = (await self._session.execute(stmt)).scalar_one_or_none()
+        if model is None:
+            return False
+        model.soft_delete()
+        await self._session.flush()
+        return True
+
+    async def _resolve_user_uuid(self, user_id: UserId) -> uuid.UUID:
+        """Translate prefixed UserId → internal UUID via SELECT."""
+        stmt = select(UserModel.id).where(UserModel.external_id == str(user_id))
+        result = await self._session.execute(stmt)
+        user_uuid = result.scalar_one_or_none()
+        if user_uuid is None:
+            raise ValueError(f"User {user_id} does not exist")
+        return user_uuid
+
+
+__all__ = ["SqlAlchemyProfileRepository"]

--- a/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_profile_repository.py
+++ b/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_profile_repository.py
@@ -33,10 +33,14 @@ class SqlAlchemyProfileRepository(ProfileRepository):
         self._session = session
 
     async def save(self, profile: Profile) -> Profile:
-        """Persist a profile (create or update).
+        """Persist a profile (insert when missing, update when found).
 
         Resolves ``profile.user_id`` to the user's internal UUID
-        before passing the entity to the mapper.
+        before passing the entity to the mapper. Follows the same
+        shape as ``SqlAlchemyLibraryRepository.save``: always look the
+        row up by ``external_id`` first; restore a soft-deleted row
+        before applying updates; reload via ``find_by_id`` so the
+        returned entity carries the server-assigned timestamps.
 
         Args:
             profile: The profile to save.
@@ -47,7 +51,6 @@ class SqlAlchemyProfileRepository(ProfileRepository):
         Raises:
             ValueError: If the owning user does not exist.
         """
-        is_insert = profile.id is None
         profile = profile.with_updates(id=ProfileId.generate_if_absent(profile.id))
 
         user_uuid = await self._resolve_user_uuid(profile.user_id)
@@ -58,7 +61,7 @@ class SqlAlchemyProfileRepository(ProfileRepository):
         if existing is not None and existing.is_deleted:
             existing.restore()
 
-        if existing is not None and not is_insert:
+        if existing is not None:
             ProfileMapper.update_model(existing, profile)
             await self._session.flush()
         else:

--- a/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_user_repository.py
+++ b/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_user_repository.py
@@ -26,26 +26,28 @@ class SqlAlchemyUserRepository(UserRepository):
         self._session = session
 
     async def save(self, user: User) -> User:
-        """Persist a user (insert when id is missing, partial update otherwise)."""
-        is_insert = user.id is None
+        """Persist a user (insert when missing, partial update when found).
+
+        Follows the same shape as ``SqlAlchemyLibraryRepository.save``:
+        always look the row up by ``external_id`` first; restore a
+        soft-deleted row before applying updates; reload via
+        ``find_by_id`` so the returned entity carries the
+        server-assigned timestamps.
+        """
         user = user.with_updates(id=UserId.generate_if_absent(user.id))
 
-        if is_insert:
-            model = UserMapper.to_model(user)
-            self._session.add(model)
+        stmt = select(UserModel).where(UserModel.external_id == str(user.id))
+        existing = (await self._session.execute(stmt)).scalar_one_or_none()
+
+        if existing is not None and existing.is_deleted:
+            existing.restore()
+
+        if existing is not None:
+            UserMapper.update_model(existing, user)
             await self._session.flush()
         else:
-            stmt = select(UserModel).where(UserModel.external_id == str(user.id))
-            existing = (await self._session.execute(stmt)).scalar_one_or_none()
-            if existing is None:
-                # The caller asked us to update a user that doesn't exist;
-                # treat it as an insert to keep the contract idempotent.
-                model = UserMapper.to_model(user)
-                self._session.add(model)
-            else:
-                if existing.is_deleted:
-                    existing.restore()
-                UserMapper.update_model(existing, user)
+            model = UserMapper.to_model(user)
+            self._session.add(model)
             await self._session.flush()
 
         if user.id is None:

--- a/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_user_repository.py
+++ b/src/modules/identity/infrastructure/persistence/repositories/sqlalchemy_user_repository.py
@@ -1,0 +1,80 @@
+"""SQLAlchemy implementation of UserRepository."""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.repositories.user_repository import UserRepository
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.user_id import UserId
+from src.modules.identity.infrastructure.persistence.mappers.user_mapper import (
+    UserMapper,
+)
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+class SqlAlchemyUserRepository(UserRepository):
+    """Async SQLAlchemy repository for the User aggregate.
+
+    Distinguishes insert vs. update via ``id is None``: a fresh entity
+    is fully written; an existing one only gets its domain-mutable
+    fields touched (``role``, ``is_active``) so FastAPI Users-owned
+    fields stay intact. Transaction commit is the UoW's responsibility.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def save(self, user: User) -> User:
+        """Persist a user (insert when id is missing, partial update otherwise)."""
+        is_insert = user.id is None
+        user = user.with_updates(id=UserId.generate_if_absent(user.id))
+
+        if is_insert:
+            model = UserMapper.to_model(user)
+            self._session.add(model)
+            await self._session.flush()
+        else:
+            stmt = select(UserModel).where(UserModel.external_id == str(user.id))
+            existing = (await self._session.execute(stmt)).scalar_one_or_none()
+            if existing is None:
+                # The caller asked us to update a user that doesn't exist;
+                # treat it as an insert to keep the contract idempotent.
+                model = UserMapper.to_model(user)
+                self._session.add(model)
+            else:
+                if existing.is_deleted:
+                    existing.restore()
+                UserMapper.update_model(existing, user)
+            await self._session.flush()
+
+        if user.id is None:
+            raise RuntimeError("User id was not assigned before save")
+        saved = await self.find_by_id(user.id)
+        if saved is None:
+            raise RuntimeError(f"User {user.id} disappeared between flush and reload")
+        return saved
+
+    async def find_by_id(self, user_id: UserId) -> User | None:
+        """Look up a non-deleted user by external ID."""
+        stmt = select(UserModel).where(
+            UserModel.external_id == str(user_id),
+            UserModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else UserMapper.to_entity(model)
+
+    async def find_by_email(self, email: Email) -> User | None:
+        """Look up a non-deleted user by normalised email."""
+        # Email VO already lower-cases and trims; no further normalisation needed.
+        stmt = select(UserModel).where(
+            UserModel.email == email.value,
+            UserModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else UserMapper.to_entity(model)
+
+
+__all__ = ["SqlAlchemyUserRepository"]

--- a/src/modules/identity/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/identity/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -1,0 +1,42 @@
+"""SQLAlchemy implementation of IdentityUnitOfWork."""
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.building_blocks.infrastructure.sqlalchemy_unit_of_work import (
+    SqlAlchemyUnitOfWork,
+)
+from src.modules.identity.application.unit_of_work import (
+    IdentityUnitOfWork,
+    IdentityUnitOfWorkFactory,
+)
+from src.modules.identity.infrastructure.persistence.repositories import (
+    SqlAlchemyAccessTokenRepository,
+    SqlAlchemyProfileRepository,
+    SqlAlchemyUserRepository,
+)
+
+
+class SqlAlchemyIdentityUnitOfWork(SqlAlchemyUnitOfWork, IdentityUnitOfWork):
+    """SQLAlchemy-backed Unit of Work for the identity bounded context."""
+
+    def _build_repositories(self, session: AsyncSession) -> None:
+        self.users = SqlAlchemyUserRepository(session)
+        self.profiles = SqlAlchemyProfileRepository(session)
+        self.access_tokens = SqlAlchemyAccessTokenRepository(session)
+
+
+class SqlAlchemyIdentityUnitOfWorkFactory(IdentityUnitOfWorkFactory):
+    """Produce fresh :class:`SqlAlchemyIdentityUnitOfWork` instances."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    def __call__(self) -> IdentityUnitOfWork:
+        """Return a brand-new, not-yet-entered UoW."""
+        return SqlAlchemyIdentityUnitOfWork(self._session_factory)
+
+
+__all__ = [
+    "SqlAlchemyIdentityUnitOfWork",
+    "SqlAlchemyIdentityUnitOfWorkFactory",
+]

--- a/tests/modules/identity/integration/conftest.py
+++ b/tests/modules/identity/integration/conftest.py
@@ -1,0 +1,66 @@
+"""Integration test fixtures for identity persistence."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+# Importing the identity models registers them on ``Base.metadata`` so the
+# ``create_all`` call below knows about ``users``, ``profiles`` and
+# ``access_tokens`` even though no test file references the modules directly.
+import src.modules.identity.infrastructure.persistence.models  # noqa: F401
+from src.infrastructure.persistence import Base
+from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyIdentityUnitOfWorkFactory,
+)
+
+
+@pytest.fixture(scope="function")
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """Expose an ``async_sessionmaker`` bound to an in-memory SQLite database.
+
+    ``StaticPool`` pins every connection to the same underlying SQLite
+    instance so sessions opened from seeding fixtures and Units of Work
+    under test see the same schema and rows.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+    yield factory
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+async def db_session(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[AsyncSession, None]:
+    """Seed-time session sharing the ``session_factory`` engine."""
+    async with session_factory() as session:
+        yield session
+
+
+@pytest.fixture(scope="function")
+def uow_factory(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> SqlAlchemyIdentityUnitOfWorkFactory:
+    """Identity Unit of Work factory backed by the in-memory database."""
+    return SqlAlchemyIdentityUnitOfWorkFactory(session_factory)

--- a/tests/modules/identity/integration/persistence/test_sqlalchemy_access_token_repository.py
+++ b/tests/modules/identity/integration/persistence/test_sqlalchemy_access_token_repository.py
@@ -1,0 +1,261 @@
+"""Integration tests for SqlAlchemyAccessTokenRepository."""
+
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.identity.domain.entities.profile import Profile
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.profile_name import ProfileName
+from src.modules.identity.infrastructure.persistence.models.access_token_model import (
+    AccessTokenModel,
+)
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+def _new_token() -> str:
+    """Mimic FastAPI Users' default token generation (43 base64url chars)."""
+    return secrets.token_urlsafe(32)
+
+
+async def _seed_user(
+    uow_factory: IdentityUnitOfWorkFactory,
+    email: str = "owner@example.com",
+) -> User:
+    async with uow_factory() as uow:
+        return await uow.users.save(User.create(email=Email(email), hashed_password="hp"))
+
+
+async def _user_uuid(db_session: AsyncSession, external_id: str) -> uuid.UUID:
+    result = await db_session.execute(
+        select(UserModel.id).where(UserModel.external_id == external_id)
+    )
+    return result.scalar_one()
+
+
+async def _profile_uuid(db_session: AsyncSession, external_id: str) -> uuid.UUID:
+    result = await db_session.execute(
+        select(ProfileModel.id).where(ProfileModel.external_id == external_id)
+    )
+    return result.scalar_one()
+
+
+async def _insert_access_token(
+    db_session: AsyncSession,
+    *,
+    token: str,
+    user_uuid: uuid.UUID,
+    current_profile_uuid: uuid.UUID | None = None,
+    created_at: datetime | None = None,
+) -> None:
+    row = AccessTokenModel(
+        token=token,
+        user_id=user_uuid,
+        current_profile_id=current_profile_uuid,
+    )
+    if created_at is not None:
+        row.created_at = created_at
+    db_session.add(row)
+    await db_session.commit()
+
+
+class TestGetByToken:
+    async def test_should_return_snapshot_with_prefixed_user_id(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        db_session: AsyncSession,
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+        owner_uuid = await _user_uuid(db_session, owner.id.value)
+        token = _new_token()
+        await _insert_access_token(db_session, token=token, user_uuid=owner_uuid)
+
+        async with uow_factory() as uow:
+            snap = await uow.access_tokens.get_by_token(token)
+
+        assert snap is not None
+        assert snap.token == token
+        assert snap.user_id == owner.id
+        assert snap.current_profile_id is None
+        assert snap.created_at.tzinfo is not None
+
+    async def test_should_resolve_current_profile_to_prefixed_id(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        db_session: AsyncSession,
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            profile = await uow.profiles.save(
+                Profile.create(user_id=owner.id, name=ProfileName("Lucas"))
+            )
+
+        owner_uuid = await _user_uuid(db_session, owner.id.value)
+        assert profile.id is not None
+        profile_uuid = await _profile_uuid(db_session, profile.id.value)
+        token = _new_token()
+        await _insert_access_token(
+            db_session,
+            token=token,
+            user_uuid=owner_uuid,
+            current_profile_uuid=profile_uuid,
+        )
+
+        async with uow_factory() as uow:
+            snap = await uow.access_tokens.get_by_token(token)
+
+        assert snap is not None
+        assert snap.current_profile_id == profile.id
+
+    async def test_should_return_none_for_unknown_token(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            snap = await uow.access_tokens.get_by_token("nonexistent")
+
+        assert snap is None
+
+
+class TestUpdateCurrentProfile:
+    async def test_should_set_active_profile_on_existing_session(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        db_session: AsyncSession,
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            profile = await uow.profiles.save(
+                Profile.create(user_id=owner.id, name=ProfileName("Lucas"))
+            )
+
+        owner_uuid = await _user_uuid(db_session, owner.id.value)
+        token = _new_token()
+        await _insert_access_token(db_session, token=token, user_uuid=owner_uuid)
+
+        assert profile.id is not None
+        async with uow_factory() as uow:
+            ok = await uow.access_tokens.update_current_profile(token, profile.id)
+
+        assert ok is True
+        async with uow_factory() as uow:
+            snap = await uow.access_tokens.get_by_token(token)
+        assert snap is not None
+        assert snap.current_profile_id == profile.id
+
+    async def test_should_clear_active_profile_when_passing_none(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        db_session: AsyncSession,
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            profile = await uow.profiles.save(
+                Profile.create(user_id=owner.id, name=ProfileName("Lucas"))
+            )
+
+        owner_uuid = await _user_uuid(db_session, owner.id.value)
+        assert profile.id is not None
+        profile_uuid = await _profile_uuid(db_session, profile.id.value)
+        token = _new_token()
+        await _insert_access_token(
+            db_session,
+            token=token,
+            user_uuid=owner_uuid,
+            current_profile_uuid=profile_uuid,
+        )
+
+        async with uow_factory() as uow:
+            ok = await uow.access_tokens.update_current_profile(token, None)
+
+        assert ok is True
+        async with uow_factory() as uow:
+            snap = await uow.access_tokens.get_by_token(token)
+        assert snap is not None
+        assert snap.current_profile_id is None
+
+    async def test_should_return_false_when_token_does_not_exist(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            ok = await uow.access_tokens.update_current_profile("ghost-token", profile_id=None)
+
+        assert ok is False
+
+    async def test_should_raise_when_profile_does_not_exist(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        db_session: AsyncSession,
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+        owner_uuid = await _user_uuid(db_session, owner.id.value)
+        token = _new_token()
+        await _insert_access_token(db_session, token=token, user_uuid=owner_uuid)
+
+        with pytest.raises(ValueError, match="does not exist"):
+            async with uow_factory() as uow:
+                await uow.access_tokens.update_current_profile(token, ProfileId.generate())
+
+
+class TestDeleteOlderThan:
+    async def test_should_remove_sessions_older_than_cutoff(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        db_session: AsyncSession,
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+        owner_uuid = await _user_uuid(db_session, owner.id.value)
+
+        now = datetime.now(UTC)
+        old_token = _new_token()
+        recent_token = _new_token()
+        await _insert_access_token(
+            db_session,
+            token=old_token,
+            user_uuid=owner_uuid,
+            created_at=now - timedelta(days=100),
+        )
+        await _insert_access_token(
+            db_session,
+            token=recent_token,
+            user_uuid=owner_uuid,
+            created_at=now - timedelta(days=10),
+        )
+
+        cutoff = now - timedelta(days=90)
+        async with uow_factory() as uow:
+            removed = await uow.access_tokens.delete_older_than(cutoff)
+
+        assert removed == 1
+
+        async with uow_factory() as uow:
+            assert await uow.access_tokens.get_by_token(old_token) is None
+            assert await uow.access_tokens.get_by_token(recent_token) is not None
+
+    async def test_should_return_zero_when_no_sessions_match(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            removed = await uow.access_tokens.delete_older_than(
+                datetime.now(UTC) - timedelta(days=365)
+            )
+
+        assert removed == 0

--- a/tests/modules/identity/integration/persistence/test_sqlalchemy_profile_repository.py
+++ b/tests/modules/identity/integration/persistence/test_sqlalchemy_profile_repository.py
@@ -1,0 +1,195 @@
+"""Integration tests for SqlAlchemyProfileRepository."""
+
+import pytest
+
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.identity.domain.entities.profile import Profile
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.profile_name import ProfileName
+from src.modules.identity.domain.value_objects.user_id import UserId
+
+
+async def _seed_user(
+    uow_factory: IdentityUnitOfWorkFactory, email: str = "owner@example.com"
+) -> User:
+    """Create and return a persisted user (helper for profile tests)."""
+    async with uow_factory() as uow:
+        return await uow.users.save(User.create(email=Email(email), hashed_password="hp"))
+
+
+class TestSqlAlchemyProfileRepositorySave:
+    async def test_should_persist_a_new_profile_and_assign_external_id(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            saved = await uow.profiles.save(
+                Profile.create(user_id=owner.id, name=ProfileName("Lucas")),
+            )
+
+        assert saved.id is not None
+        assert saved.id.prefix == "prf"
+        assert saved.user_id == owner.id
+        assert saved.name == ProfileName("Lucas")
+        assert saved.is_kids is False
+
+    async def test_should_round_trip_through_find_by_id(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            saved = await uow.profiles.save(
+                Profile.create(
+                    user_id=owner.id,
+                    name=ProfileName("Kids"),
+                    is_kids=True,
+                    avatar_url="https://example.com/k.png",
+                )
+            )
+
+        async with uow_factory() as uow:
+            assert saved.id is not None
+            found = await uow.profiles.find_by_id(saved.id)
+
+        assert found is not None
+        assert found.id == saved.id
+        assert found.user_id == owner.id
+        assert found.is_kids is True
+        assert found.avatar_url == "https://example.com/k.png"
+
+    async def test_save_should_update_existing_profile(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            original = await uow.profiles.save(
+                Profile.create(user_id=owner.id, name=ProfileName("Old"))
+            )
+
+        renamed = original.with_name(ProfileName("New"))
+
+        async with uow_factory() as uow:
+            await uow.profiles.save(renamed)
+
+        async with uow_factory() as uow:
+            assert original.id is not None
+            after = await uow.profiles.find_by_id(original.id)
+
+        assert after is not None
+        assert after.name == ProfileName("New")
+
+    async def test_save_should_reject_when_owning_user_does_not_exist(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        ghost_user_id = UserId.generate()
+
+        with pytest.raises(ValueError, match="does not exist"):
+            async with uow_factory() as uow:
+                await uow.profiles.save(
+                    Profile.create(user_id=ghost_user_id, name=ProfileName("Ghost"))
+                )
+
+
+class TestSqlAlchemyProfileRepositoryReads:
+    async def test_find_by_id_should_return_none_for_unknown_profile(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            found = await uow.profiles.find_by_id(ProfileId.generate())
+
+        assert found is None
+
+    async def test_find_by_user_should_isolate_by_owner(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        alice = await _seed_user(uow_factory, email="alice@example.com")
+        bob = await _seed_user(uow_factory, email="bob@example.com")
+        assert alice.id is not None and bob.id is not None
+
+        async with uow_factory() as uow:
+            await uow.profiles.save(Profile.create(user_id=alice.id, name=ProfileName("Alice")))
+            await uow.profiles.save(
+                Profile.create(user_id=alice.id, name=ProfileName("Alice Kids"))
+            )
+            await uow.profiles.save(Profile.create(user_id=bob.id, name=ProfileName("Bob")))
+
+        async with uow_factory() as uow:
+            alice_profiles = await uow.profiles.find_by_user(alice.id)
+            bob_profiles = await uow.profiles.find_by_user(bob.id)
+
+        assert len(alice_profiles) == 2
+        assert len(bob_profiles) == 1
+        assert {p.name.value for p in alice_profiles} == {"Alice", "Alice Kids"}
+        assert {p.name.value for p in bob_profiles} == {"Bob"}
+
+    async def test_find_by_user_should_order_by_name(self, uow_factory: IdentityUnitOfWorkFactory):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            for n in ("Charlie", "Alice", "Bob"):
+                await uow.profiles.save(Profile.create(user_id=owner.id, name=ProfileName(n)))
+
+        async with uow_factory() as uow:
+            profiles = await uow.profiles.find_by_user(owner.id)
+
+        assert [p.name.value for p in profiles] == ["Alice", "Bob", "Charlie"]
+
+    async def test_count_for_user_should_return_active_profile_count(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            for n in ("A", "B", "C"):
+                await uow.profiles.save(Profile.create(user_id=owner.id, name=ProfileName(n)))
+
+        async with uow_factory() as uow:
+            count = await uow.profiles.count_for_user(owner.id)
+
+        assert count == 3
+
+
+class TestSqlAlchemyProfileRepositoryDelete:
+    async def test_delete_should_soft_delete_an_existing_profile(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            saved = await uow.profiles.save(
+                Profile.create(user_id=owner.id, name=ProfileName("Doomed"))
+            )
+
+        async with uow_factory() as uow:
+            assert saved.id is not None
+            ok = await uow.profiles.delete(saved.id)
+
+        assert ok is True
+
+        # find_by_id excludes soft-deleted rows
+        async with uow_factory() as uow:
+            assert saved.id is not None
+            assert await uow.profiles.find_by_id(saved.id) is None
+
+        # count_for_user does NOT include soft-deleted rows
+        async with uow_factory() as uow:
+            assert await uow.profiles.count_for_user(owner.id) == 0
+
+    async def test_delete_should_return_false_for_unknown_profile(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            ok = await uow.profiles.delete(ProfileId.generate())
+
+        assert ok is False

--- a/tests/modules/identity/integration/persistence/test_sqlalchemy_user_repository.py
+++ b/tests/modules/identity/integration/persistence/test_sqlalchemy_user_repository.py
@@ -1,0 +1,157 @@
+"""Integration tests for SqlAlchemyUserRepository."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.user_id import UserId
+from src.modules.identity.domain.value_objects.user_role import UserRole
+
+
+class TestSqlAlchemyUserRepositorySave:
+    async def test_should_persist_a_new_user_and_assign_external_id(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            saved = await uow.users.save(
+                User.create(
+                    email=Email("admin@homeflix.local"),
+                    role=UserRole.ADMIN,
+                    is_superuser=True,
+                    is_verified=True,
+                    hashed_password="$argon2id$dummy",
+                )
+            )
+
+        assert saved.id is not None
+        assert saved.id.prefix == "usr"
+        assert saved.email == Email("admin@homeflix.local")
+        assert saved.role == UserRole.ADMIN
+        assert saved.is_superuser is True
+        assert saved.is_verified is True
+
+    async def test_save_should_round_trip_through_find_by_id(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            saved = await uow.users.save(User.create(email=Email("a@b.com"), hashed_password="hp"))
+
+        async with uow_factory() as uow:
+            assert saved.id is not None
+            found = await uow.users.find_by_id(saved.id)
+
+        assert found is not None
+        assert found.id == saved.id
+        assert found.email == Email("a@b.com")
+
+    async def test_save_should_round_trip_through_find_by_email(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            await uow.users.save(
+                User.create(email=Email("Lookup@Example.com"), hashed_password="hp")
+            )
+
+        async with uow_factory() as uow:
+            # Email VO normalises to lowercase before any compare
+            found = await uow.users.find_by_email(Email("LOOKUP@example.COM"))
+
+        assert found is not None
+        assert found.email == Email("lookup@example.com")
+
+    async def test_save_should_only_update_domain_mutable_fields_on_existing_user(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        # Insert with hashed_password + is_verified set (CLI bootstrap path)
+        async with uow_factory() as uow:
+            inserted = await uow.users.save(
+                User.create(
+                    email=Email("admin@homeflix.local"),
+                    role=UserRole.ADMIN,
+                    is_superuser=True,
+                    is_verified=True,
+                    hashed_password="ORIGINAL_HASH",
+                )
+            )
+
+        # Now update with hashed_password=None and is_verified=False; the
+        # repository must NOT clobber the FastAPI Users-owned fields.
+        modified = inserted.with_updates(
+            role=UserRole.MEMBER,
+            is_active=False,
+            hashed_password=None,
+            is_verified=False,
+            is_superuser=False,
+        )
+        async with uow_factory() as uow:
+            await uow.users.save(modified)
+
+        # Re-read directly from the DB and confirm domain-mutable fields
+        # changed, FastAPI Users-owned fields stayed intact.
+        async with uow_factory() as uow:
+            assert inserted.id is not None
+            after = await uow.users.find_by_id(inserted.id)
+
+        assert after is not None
+        assert after.role == UserRole.MEMBER  # changed
+        assert after.is_active is False  # changed
+        assert after.hashed_password == "ORIGINAL_HASH"  # untouched
+        assert after.is_verified is True  # untouched
+        assert after.is_superuser is True  # untouched
+
+
+class TestSqlAlchemyUserRepositoryReads:
+    async def test_find_by_id_should_return_none_for_unknown_user(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            found = await uow.users.find_by_id(UserId.generate())
+
+        assert found is None
+
+    async def test_find_by_email_should_return_none_for_unknown_user(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            found = await uow.users.find_by_email(Email("nobody@nowhere.com"))
+
+        assert found is None
+
+    async def test_save_should_reject_when_id_is_provided_and_user_missing(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        # Documenting the "treat unknown id as insert" fallback — calling
+        # save with a fabricated id creates the row rather than failing.
+        # This keeps the contract idempotent for callers that may have
+        # received an id elsewhere (e.g. CLI tools, replays).
+        fabricated = User(
+            id=UserId.generate(),
+            email=Email("idempotent@example.com"),
+            hashed_password="hp",
+        )
+        async with uow_factory() as uow:
+            saved = await uow.users.save(fabricated)
+
+        assert saved.id == fabricated.id
+        assert saved.email == fabricated.email
+
+
+@pytest.mark.usefixtures("uow_factory")
+class TestSqlAlchemyUserRepositoryUniqueness:
+    async def test_inserting_two_users_with_same_email_should_fail(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        async with uow_factory() as uow:
+            await uow.users.save(User.create(email=Email("dup@example.com"), hashed_password="hp"))
+
+        # Second insert with same email must violate the unique index
+        with pytest.raises(IntegrityError):
+            async with uow_factory() as uow:
+                await uow.users.save(
+                    User.create(
+                        email=Email("dup@example.com"),
+                        hashed_password="other",
+                    )
+                )


### PR DESCRIPTION
## Summary

Slice 3 de 8 da entrega do BC `identity`. Adiciona a camada de persistence completa: 3 repository ABCs no domínio, `IdentityUnitOfWork`, 2 mappers, 3 implementações SQLAlchemy concretas, e 27 integration tests.

Continua **puramente aditiva** — nenhuma rota/use case/wiring existente é tocado. Após merge, classes existem, podem ser instanciadas em testes, mas nada chama elas em produção ainda (PR 4 começa a usar via use cases).

### Conteúdo

**Domain (interfaces de repo)**:
- `UserRepository`: `save` (insert ou update parcial), `find_by_id`, `find_by_email`. Sem `delete` — contas são desativadas, não removidas (aligned com FastAPI Users que owna o lifecycle).
- `ProfileRepository`: `save`, `find_by_id`, `find_by_user` (ordenado por name), `count_for_user` (pra futura guard "cannot delete last profile" no use case), `delete` (soft).
- `AccessTokenRepository`: `get_by_token` retorna `AccessTokenSnapshot` com VOs prefixados (UUID do DB nunca cruza pro domínio — JOINs internos resolvem); `update_current_profile`; `delete_older_than` pro cleanup job futuro.

**Application**:
- `IdentityUnitOfWork` (interface) declara `users`/`profiles`/`access_tokens`.
- `IdentityUnitOfWorkFactory` (interface) abstrai construção.

**Infra (mappers)**:
- `UserMapper`: insert escreve tudo; **update toca apenas `role` + `is_active`** — `hashed_password`, `is_verified`, `is_superuser` são FastAPI Users-owned e protegidos contra clobber.
- `ProfileMapper`: caller resolve UUID do user via SELECT antes de chamar `to_model` — mapper fica dependency-free e síncrono.

**Infra (repos SQLAlchemy)**:
- `SqlAlchemyUserRepository`: bridge UUID↔external_id; insert vs update via `id is None`.
- `SqlAlchemyProfileRepository`: JOINs em `users` na leitura pra retornar entity com prefixed `UserId`; `count_for_user` exclui soft-deleted.
- `SqlAlchemyAccessTokenRepository`: JOIN duplo (`users` + LEFT `profiles`) em `get_by_token`; resolve `ProfileId`→UUID antes do UPDATE em `update_current_profile`; bulk DELETE em `delete_older_than`.

**Infra (UoW)**:
- `SqlAlchemyIdentityUnitOfWork` compõe os 3 repos no `__aenter__` usando o shared `SqlAlchemyUnitOfWork` base.

### Test plan

- [x] `poetry run pytest tests/modules/identity` — **90 passed** (63 unit + 27 integration), 1.23s
- [x] `poetry run pytest tests/modules/identity tests/modules/library tests/modules/media` — **1364 passed**, 5 skipped (zero regressão)
- [x] `poetry run ruff check ...` — clean
- [x] `poetry run ruff format --check ...` — clean

Cobertura específica das integration tests:
- Insert/update round-trip via `save`
- `save` em update preserva `hashed_password`, `is_verified`, `is_superuser` (asserção explícita de não-clobber)
- Owner isolation em `find_by_user` (Alice vê só profiles dela, não os do Bob)
- Soft-delete: `find_by_id` exclui rows deletadas, `count_for_user` também
- `update_current_profile` round-trip + clear via `None`
- `delete_older_than` com cutoff só remove rows mais antigas que o cutoff
- Unique constraint violation em email duplicado (`IntegrityError`)
- Erros explícitos: profile/user inexistente em `save`/`update_current_profile`

### Próximas slices

4. Use cases (`CreateProfile`, `ListProfilesForUser`, `UpdateProfile`, `DeleteProfile`, `SwitchProfile`)
5. FastAPI Users wiring + `IdentityContainer` + settings + `main.py`
6. Routes (`/auth/cookie/*`, `/users/me`, `/profiles/*`) + CLI bootstrap
7. E2E test scaffolding + auth tests
8. E2E profile tests + polish

## Related

- ADR-010 — UUID interno + prefixed external_id mapper preservado
- ADR-011 — `AccessTokenSnapshot` carrega VOs prefixados, JOINs internos

## Summary by Sourcery

Introduce the identity bounded context persistence layer with SQLAlchemy-based repositories and a dedicated Unit of Work, keeping existing runtime behavior unchanged.

New Features:
- Add domain repository interfaces for users, profiles, and access tokens, including an access token snapshot DTO.
- Introduce an IdentityUnitOfWork abstraction and SQLAlchemy-backed implementation/factory for coordinating identity transactions.
- Provide SQLAlchemy repository implementations and mappers for users, profiles, and access tokens, translating between prefixed external IDs and internal UUIDs.

Tests:
- Add in-memory SQLite integration test setup for identity persistence using a shared async session factory and Identity UoW factory.
- Add comprehensive integration tests covering user repository behavior, including inserts, partial updates, lookups, and email uniqueness constraints.
- Add integration tests for profile repository behavior, including CRUD with soft delete, owner isolation, ordering, and active-profile counting.
- Add integration tests for access token repository behavior, including token lookup, current-profile switching, and time-based cleanup deletions.