### PR TITLE
feat(identity): wire FastAPI Users and login routes (5/8)

### DIFF
--- a/src/config/containers/__init__.py
+++ b/src/config/containers/__init__.py
@@ -8,12 +8,14 @@ This package organizes DI containers per bounded context:
 The main ApplicationContainer composes all sub-containers.
 """
 
+from src.config.containers.identity import IdentityContainer
 from src.config.containers.library import LibraryContainer
 from src.config.containers.main import ApplicationContainer
 from src.config.containers.media import MediaContainer
 
 __all__ = [
     "ApplicationContainer",
+    "IdentityContainer",
     "LibraryContainer",
     "MediaContainer",
 ]

--- a/src/config/containers/identity.py
+++ b/src/config/containers/identity.py
@@ -1,0 +1,74 @@
+"""Identity bounded context dependency container.
+
+Exposes only the application-level use cases via dependency-injector.
+The FastAPI Users wiring (``UserManager``, ``auth_backend``,
+``current_active_user``) lives in
+``src.modules.identity.infrastructure.auth`` because FastAPI Users
+expects FastAPI-native ``Depends(...)`` chains rather than the
+provider/factory model used here. The two coexist: routes pull use
+case factories from this container and the auth deps from the auth
+package.
+"""
+
+from dependency_injector import containers, providers
+
+from src.modules.identity.application.use_cases import (
+    CreateProfileUseCase,
+    DeleteProfileUseCase,
+    ListProfilesForUserUseCase,
+    SwitchProfileUseCase,
+    UpdateProfileUseCase,
+)
+from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyIdentityUnitOfWorkFactory,
+)
+
+
+class IdentityContainer(containers.DeclarativeContainer):  # type: ignore[misc]
+    """Container for the identity bounded context.
+
+    Provides the ``IdentityUnitOfWork`` factory and the five profile
+    use cases. The FastAPI Users-backed authentication routes do not
+    flow through this container (see module docstring).
+    """
+
+    # Wired from InfrastructureContainer via the application container.
+    session_factory = providers.Dependency()
+
+    # =========================================================================
+    # Unit of Work
+    # =========================================================================
+
+    identity_unit_of_work_factory = providers.Singleton(
+        SqlAlchemyIdentityUnitOfWorkFactory,
+        session_factory=session_factory,
+    )
+
+    # =========================================================================
+    # Use Cases
+    # =========================================================================
+
+    create_profile = providers.Factory(
+        CreateProfileUseCase,
+        uow_factory=identity_unit_of_work_factory,
+    )
+
+    list_profiles_for_user = providers.Factory(
+        ListProfilesForUserUseCase,
+        uow_factory=identity_unit_of_work_factory,
+    )
+
+    update_profile = providers.Factory(
+        UpdateProfileUseCase,
+        uow_factory=identity_unit_of_work_factory,
+    )
+
+    delete_profile = providers.Factory(
+        DeleteProfileUseCase,
+        uow_factory=identity_unit_of_work_factory,
+    )
+
+    switch_profile = providers.Factory(
+        SwitchProfileUseCase,
+        uow_factory=identity_unit_of_work_factory,
+    )

--- a/src/config/containers/infrastructure.py
+++ b/src/config/containers/infrastructure.py
@@ -39,6 +39,7 @@ async def _init_engine(
     if get_settings().is_development:
         import src.modules.catalog_requests.infrastructure.persistence.models
         import src.modules.collections.infrastructure.persistence.models
+        import src.modules.identity.infrastructure.persistence.models
         import src.modules.media.infrastructure.persistence.models
         import src.modules.watch_progress.infrastructure.persistence.models  # noqa: F401
         from src.infrastructure.persistence.base import Base

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -10,6 +10,7 @@ from dependency_injector import containers, providers
 
 from src.config.containers.catalog_requests import CatalogRequestsContainer
 from src.config.containers.collections import CollectionsContainer
+from src.config.containers.identity import IdentityContainer
 from src.config.containers.infrastructure import InfrastructureContainer
 from src.config.containers.library import LibraryContainer
 from src.config.containers.media import MediaContainer
@@ -109,6 +110,14 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         LibraryContainer,
         session_factory=infrastructure.session_factory,
         media_uow_factory=media.media_unit_of_work_factory,
+    )
+
+    # Identity ships its container before the consumer BCs (watch_progress,
+    # collections, preferences) so future PRs can inject ``profile_lookup``
+    # via the ACL pattern without reordering the composition root.
+    identity = providers.Container(
+        IdentityContainer,
+        session_factory=infrastructure.session_factory,
     )
 
     preferences = providers.Container(

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -5,9 +5,12 @@ Settings are loaded from environment variables and .env file.
 
 from functools import lru_cache
 from pathlib import Path
+from typing import Self
 
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_PLACEHOLDER_SECRET_KEY = "CHANGE-ME-IN-PRODUCTION"  # — sentinel literal, not a secret
 
 
 class Settings(BaseSettings):  # type: ignore[misc]
@@ -241,12 +244,15 @@ class Settings(BaseSettings):  # type: ignore[misc]
     # Identity / Auth (see ADR-010 / ADR-011)
     # =========================================================================
 
-    secret_key: str = Field(
-        default="CHANGE-ME-IN-PRODUCTION",
+    secret_key: SecretStr = Field(
+        default=SecretStr(_PLACEHOLDER_SECRET_KEY),
         description="Secret used by FastAPI Users for password-reset and "
         "email-verification token signing. The session cookie itself is "
         "opaque DB-backed (per ADR-011), not signed, so this only affects "
-        "those future flows. Must be replaced in production.",
+        "those future flows. Wrapped in ``SecretStr`` so Pydantic does "
+        "not echo the value in ``repr``/``model_dump`` output. Replaced "
+        "in production via env var; the placeholder is rejected by the "
+        "production-environment validator below.",
     )
     session_lifetime_seconds: int = Field(
         default=60 * 60 * 24 * 90,  # 90 days — per ADR-011 (fixed, no slide)
@@ -258,8 +264,9 @@ class Settings(BaseSettings):  # type: ignore[misc]
     session_cookie_secure: bool = Field(
         default=False,
         description="Set the Secure flag on the session cookie (HTTPS only). "
-        "Force True in production. Defaults False so dev over plain HTTP "
-        "still works.",
+        "Defaults False so dev over plain HTTP still works; the "
+        "production-environment validator below refuses to start unless "
+        "this is True (or a manual override is provided).",
     )
     session_cookie_name: str = Field(default="homeflix_session")
 
@@ -275,6 +282,29 @@ class Settings(BaseSettings):  # type: ignore[misc]
     def parse_locales(cls, v: str | list[str]) -> list[str]:
         """Parse comma-separated locales string to list."""
         return [loc.strip() for loc in v.split(",")] if isinstance(v, str) else v
+
+    @model_validator(mode="after")
+    def reject_insecure_production_config(self) -> Self:
+        """Refuse to start in production with security-critical defaults.
+
+        Cross-field check that runs once per ``Settings`` instance after
+        all individual field validation. Caught at construction so the
+        process exits before the unsafe config can take effect.
+        """
+        if self.app_env == "production":
+            if self.secret_key.get_secret_value() == _PLACEHOLDER_SECRET_KEY:
+                raise ValueError(
+                    "secret_key is still the development placeholder; "
+                    "set SECRET_KEY to a strong unique value before "
+                    "running in production.",
+                )
+            if not self.session_cookie_secure:
+                raise ValueError(
+                    "session_cookie_secure must be True in production "
+                    "(HTTPS-only cookie). Set SESSION_COOKIE_SECURE=true "
+                    "or run behind a TLS-terminating reverse proxy.",
+                )
+        return self
 
     # =========================================================================
     # Properties

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -238,6 +238,32 @@ class Settings(BaseSettings):  # type: ignore[misc]
     )
 
     # =========================================================================
+    # Identity / Auth (see ADR-010 / ADR-011)
+    # =========================================================================
+
+    secret_key: str = Field(
+        default="CHANGE-ME-IN-PRODUCTION",
+        description="Secret used by FastAPI Users for password-reset and "
+        "email-verification token signing. The session cookie itself is "
+        "opaque DB-backed (per ADR-011), not signed, so this only affects "
+        "those future flows. Must be replaced in production.",
+    )
+    session_lifetime_seconds: int = Field(
+        default=60 * 60 * 24 * 90,  # 90 days — per ADR-011 (fixed, no slide)
+        ge=60,
+        description="Fixed lifetime of a session cookie / DB row before it "
+        "expires. No rolling refresh — DatabaseStrategy from FastAPI Users "
+        "doesn't support sliding expiration natively.",
+    )
+    session_cookie_secure: bool = Field(
+        default=False,
+        description="Set the Secure flag on the session cookie (HTTPS only). "
+        "Force True in production. Defaults False so dev over plain HTTP "
+        "still works.",
+    )
+    session_cookie_name: str = Field(default="homeflix_session")
+
+    # =========================================================================
     # Internationalization
     # =========================================================================
 

--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,7 @@ from src.config.logging import get_logger, setup_logging
 from src.config.settings import get_settings
 from src.modules.catalog_requests.presentation.routes import catalog_request_router
 from src.modules.collections.presentation.routes import custom_list_router, watchlist_router
+from src.modules.identity.infrastructure.auth import auth_backend, fastapi_users
 from src.modules.library.presentation.routes.library_routes import (
     router as library_router,
 )
@@ -209,6 +210,15 @@ def create_app() -> FastAPI:
     app.include_router(catalog_request_router)
     app.include_router(library_router)
     app.include_router(preferences_router)
+
+    # Identity — FastAPI Users built-in cookie auth (login/logout). Custom
+    # /me and /profiles/* routes ship in the next slice. See ADR-011 for
+    # the cookie + DatabaseStrategy choice.
+    app.include_router(
+        fastapi_users.get_auth_router(auth_backend),
+        prefix="/api/v1/auth/cookie",
+        tags=["Auth"],
+    )
 
     return app
 

--- a/src/modules/identity/infrastructure/auth/__init__.py
+++ b/src/modules/identity/infrastructure/auth/__init__.py
@@ -1,0 +1,16 @@
+"""FastAPI Users authentication wiring.
+
+Lives in the infrastructure layer because it composes FastAPI dependency
+chains (``Depends(...)``) rather than the dependency-injector style
+used for our domain use cases. The two coexist: routes import
+``current_active_user`` from here and use case factories from
+``IdentityContainer``.
+"""
+
+from src.modules.identity.infrastructure.auth.backend import auth_backend
+from src.modules.identity.infrastructure.auth.fastapi_users import (
+    current_active_user,
+    fastapi_users,
+)
+
+__all__ = ["auth_backend", "current_active_user", "fastapi_users"]

--- a/src/modules/identity/infrastructure/auth/backend.py
+++ b/src/modules/identity/infrastructure/auth/backend.py
@@ -1,0 +1,42 @@
+"""``AuthenticationBackend`` configuration: cookie transport + DB strategy.
+
+Module-level singletons because FastAPI Users expects a stable
+``auth_backend`` reference for ``fastapi_users.get_auth_router(...)``
+and for ``fastapi_users.current_user(...)`` to compose. Configuration
+values are read from ``Settings`` at import time via the cached
+``get_settings()`` helper.
+"""
+
+from fastapi_users.authentication import AuthenticationBackend, CookieTransport
+
+from src.config.settings import get_settings
+from src.modules.identity.infrastructure.auth.dependencies import get_database_strategy
+
+
+def _build_cookie_transport() -> CookieTransport:
+    """Build the configured ``CookieTransport``.
+
+    Hidden behind a function so tests / CLI scripts can call this
+    after overriding settings; the module-level singleton below is
+    what production uses.
+    """
+    settings = get_settings()
+    return CookieTransport(
+        cookie_name=settings.session_cookie_name,
+        cookie_max_age=settings.session_lifetime_seconds,
+        cookie_secure=settings.session_cookie_secure,
+        cookie_httponly=True,
+        cookie_samesite="strict",
+    )
+
+
+cookie_transport: CookieTransport = _build_cookie_transport()
+
+auth_backend: AuthenticationBackend = AuthenticationBackend(
+    name="cookie-session",
+    transport=cookie_transport,
+    get_strategy=get_database_strategy,
+)
+
+
+__all__ = ["auth_backend", "cookie_transport"]

--- a/src/modules/identity/infrastructure/auth/dependencies.py
+++ b/src/modules/identity/infrastructure/auth/dependencies.py
@@ -1,0 +1,83 @@
+"""FastAPI dependency chain for FastAPI Users.
+
+Each dependency is a plain async function/generator suitable for use
+as ``Depends(...)`` in routes. The chain is:
+
+    Request
+      -> get_async_session   (opens a session bound to the app container)
+      -> get_user_db          (wraps session + UserModel)
+      -> get_user_manager     (BaseUserManager[UserModel, UUID])
+      -> auth_backend.get_strategy
+         -> get_access_token_db -> get_database_strategy
+
+This is FastAPI-native (not registered in the dependency-injector
+container) because FastAPI Users assumes its own dependency style.
+"""
+
+from collections.abc import AsyncGenerator
+
+from fastapi import Depends, Request
+from fastapi_users.authentication.strategy.db import DatabaseStrategy
+from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
+from fastapi_users_db_sqlalchemy.access_token import SQLAlchemyAccessTokenDatabase
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config.settings import get_settings
+from src.modules.identity.infrastructure.auth.user_manager import UserManager
+from src.modules.identity.infrastructure.persistence.models.access_token_model import (
+    AccessTokenModel,
+)
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+async def get_async_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
+    """Yield an ``AsyncSession`` bound to the app's container.
+
+    Reads the session factory from ``app.state.container`` so it
+    picks up the same engine the dependency-injector resolved for
+    every other repository in the app.
+    """
+    session_factory = request.app.state.container.infrastructure.session_factory()
+    async with session_factory() as session:
+        yield session
+
+
+async def get_user_db(
+    session: AsyncSession = Depends(get_async_session),
+) -> AsyncGenerator[SQLAlchemyUserDatabase[UserModel, "UUID"], None]:  # noqa: F821
+    """Yield FastAPI Users' SQLAlchemy database adapter for ``UserModel``."""
+    yield SQLAlchemyUserDatabase(session, UserModel)
+
+
+async def get_user_manager(
+    user_db: SQLAlchemyUserDatabase = Depends(get_user_db),
+) -> AsyncGenerator[UserManager, None]:
+    """Yield a ``UserManager`` instance for the current request."""
+    yield UserManager(user_db)
+
+
+async def get_access_token_db(
+    session: AsyncSession = Depends(get_async_session),
+) -> AsyncGenerator[SQLAlchemyAccessTokenDatabase[AccessTokenModel], None]:
+    """Yield FastAPI Users' access-token DB adapter for the auth strategy."""
+    yield SQLAlchemyAccessTokenDatabase(session, AccessTokenModel)
+
+
+def get_database_strategy(
+    access_token_db: SQLAlchemyAccessTokenDatabase = Depends(get_access_token_db),
+) -> DatabaseStrategy:
+    """Build the ``DatabaseStrategy`` consumed by ``auth_backend``."""
+    settings = get_settings()
+    return DatabaseStrategy(
+        database=access_token_db,
+        lifetime_seconds=settings.session_lifetime_seconds,
+    )
+
+
+__all__ = [
+    "get_access_token_db",
+    "get_async_session",
+    "get_database_strategy",
+    "get_user_db",
+    "get_user_manager",
+]

--- a/src/modules/identity/infrastructure/auth/dependencies.py
+++ b/src/modules/identity/infrastructure/auth/dependencies.py
@@ -14,6 +14,7 @@ This is FastAPI-native (not registered in the dependency-injector
 container) because FastAPI Users assumes its own dependency style.
 """
 
+import uuid
 from collections.abc import AsyncGenerator
 
 from fastapi import Depends, Request
@@ -44,7 +45,7 @@ async def get_async_session(request: Request) -> AsyncGenerator[AsyncSession, No
 
 async def get_user_db(
     session: AsyncSession = Depends(get_async_session),
-) -> AsyncGenerator[SQLAlchemyUserDatabase[UserModel, "UUID"], None]:  # noqa: F821
+) -> AsyncGenerator[SQLAlchemyUserDatabase[UserModel, uuid.UUID], None]:
     """Yield FastAPI Users' SQLAlchemy database adapter for ``UserModel``."""
     yield SQLAlchemyUserDatabase(session, UserModel)
 

--- a/src/modules/identity/infrastructure/auth/fastapi_users.py
+++ b/src/modules/identity/infrastructure/auth/fastapi_users.py
@@ -1,0 +1,24 @@
+"""``FastAPIUsers`` singleton and the ``current_active_user`` dependency.
+
+Routes import ``current_active_user`` from this module (or from the
+package ``src.modules.identity.infrastructure.auth``) and use it as
+``Depends(current_active_user)`` to require an authenticated, active
+user on a route.
+"""
+
+import uuid
+
+from fastapi_users import FastAPIUsers
+
+from src.modules.identity.infrastructure.auth.backend import auth_backend
+from src.modules.identity.infrastructure.auth.dependencies import get_user_manager
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+fastapi_users: FastAPIUsers[UserModel, uuid.UUID] = FastAPIUsers[UserModel, uuid.UUID](
+    get_user_manager,
+    [auth_backend],
+)
+
+current_active_user = fastapi_users.current_user(active=True)
+
+__all__ = ["current_active_user", "fastapi_users"]

--- a/src/modules/identity/infrastructure/auth/user_manager.py
+++ b/src/modules/identity/infrastructure/auth/user_manager.py
@@ -1,0 +1,41 @@
+"""FastAPI Users ``UserManager`` for the identity bounded context.
+
+``UserManager`` is FastAPI Users' extension point for password reset,
+verification, registration hooks, and per-request user-DB plumbing.
+For PR 1 we only need the minimum: a UUID-typed manager subclass that
+wires the configured ``secret_key`` for token signing. The
+registration / verification / reset flows are NOT exposed in PR 1
+(no public ``/auth/register`` route — admins are bootstrapped via a
+CLI script in slice 6), so the lifecycle hooks (``on_after_register``
+etc.) are deliberately left at their no-op defaults.
+"""
+
+import uuid
+
+from fastapi_users import BaseUserManager, UUIDIDMixin
+
+from src.config.settings import get_settings
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+class UserManager(UUIDIDMixin, BaseUserManager[UserModel, uuid.UUID]):
+    """Identity user manager.
+
+    ``reset_password_token_secret`` and ``verification_token_secret``
+    are read from settings at instantiation; both flows are inactive
+    in PR 1 but the values are wired so future PRs can mount the
+    routers without touching this class.
+    """
+
+    @property
+    def reset_password_token_secret(self) -> str:  # type: ignore[override]
+        """Secret used to sign password-reset tokens."""
+        return get_settings().secret_key
+
+    @property
+    def verification_token_secret(self) -> str:  # type: ignore[override]
+        """Secret used to sign email-verification tokens."""
+        return get_settings().secret_key
+
+
+__all__ = ["UserManager"]

--- a/src/modules/identity/infrastructure/auth/user_manager.py
+++ b/src/modules/identity/infrastructure/auth/user_manager.py
@@ -30,12 +30,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[UserModel, uuid.UUID]):
     @property
     def reset_password_token_secret(self) -> str:  # type: ignore[override]
         """Secret used to sign password-reset tokens."""
-        return get_settings().secret_key
+        return get_settings().secret_key.get_secret_value()
 
     @property
     def verification_token_secret(self) -> str:  # type: ignore[override]
         """Secret used to sign email-verification tokens."""
-        return get_settings().secret_key
+        return get_settings().secret_key.get_secret_value()
 
 
 __all__ = ["UserManager"]

--- a/tests/modules/identity/unit/infrastructure/test_auth_backend_config.py
+++ b/tests/modules/identity/unit/infrastructure/test_auth_backend_config.py
@@ -1,0 +1,37 @@
+"""Tests that lock in the FastAPI Users authentication backend config.
+
+These assertions are intentionally tight: any change to cookie name,
+SameSite, HttpOnly, lifetime, or backend strategy is a security-relevant
+shift (see ADR-011) and should require an explicit decision plus a
+test update. Catches accidental edits.
+"""
+
+from src.modules.identity.infrastructure.auth.backend import (
+    auth_backend,
+    cookie_transport,
+)
+
+
+class TestCookieTransportConfig:
+    def test_should_use_homeflix_session_cookie_name(self):
+        assert cookie_transport.cookie_name == "homeflix_session"
+
+    def test_should_set_httponly_so_javascript_cannot_read_the_cookie(self):
+        assert cookie_transport.cookie_httponly is True
+
+    def test_should_set_samesite_strict_for_csrf_mitigation(self):
+        assert cookie_transport.cookie_samesite == "strict"
+
+    def test_should_align_max_age_with_session_lifetime(self):
+        # Default per ADR-011 is fixed 90 days.
+        assert cookie_transport.cookie_max_age == 60 * 60 * 24 * 90
+
+
+class TestAuthBackendConfig:
+    def test_should_be_named_cookie_session(self):
+        # The name appears in error responses and OpenAPI; locking it
+        # avoids accidental renames that break clients.
+        assert auth_backend.name == "cookie-session"
+
+    def test_should_use_the_cookie_transport_singleton(self):
+        assert auth_backend.transport is cookie_transport

--- a/tests/modules/identity/unit/infrastructure/test_settings_security_guards.py
+++ b/tests/modules/identity/unit/infrastructure/test_settings_security_guards.py
@@ -1,0 +1,58 @@
+"""Tests for the cross-field security validators on ``Settings``.
+
+These guards are load-bearing — the placeholder secret_key and the
+default ``session_cookie_secure=False`` are convenient for dev but
+security risks in production. The validator ensures the process
+refuses to start with either of them when ``app_env`` is set to
+``production``.
+"""
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from src.config.settings import Settings
+
+
+class TestProductionConfigGuards:
+    def test_should_accept_dev_defaults(self):
+        # Development environment: placeholder secret + insecure cookie are
+        # both fine. Sanity check that the validator does not over-trigger.
+        settings = Settings(app_env="development")
+
+        assert settings.is_development is True
+        # No exception raised.
+
+    def test_should_reject_placeholder_secret_in_production(self):
+        with pytest.raises(ValidationError, match="secret_key.*placeholder"):
+            Settings(app_env="production", session_cookie_secure=True)
+
+    def test_should_reject_insecure_cookie_in_production(self):
+        with pytest.raises(ValidationError, match="session_cookie_secure"):
+            Settings(
+                app_env="production",
+                secret_key=SecretStr("strong-secret-32-chars-or-more-yes"),
+                session_cookie_secure=False,
+            )
+
+    def test_should_accept_hardened_production_config(self):
+        settings = Settings(
+            app_env="production",
+            secret_key=SecretStr("strong-secret-32-chars-or-more-yes"),
+            session_cookie_secure=True,
+        )
+
+        assert settings.is_production is True
+        assert settings.session_cookie_secure is True
+        # Secret is wrapped — repr should not echo the raw value.
+        assert "strong-secret" not in repr(settings)
+
+
+class TestSecretStrMasking:
+    def test_secret_key_should_not_appear_in_repr(self):
+        # Even in dev, the SecretStr wrapper should keep the value out
+        # of casual logging.
+        settings = Settings(app_env="development")
+
+        assert "CHANGE-ME-IN-PRODUCTION" not in repr(settings)
+        # And get_secret_value still returns the actual string.
+        assert settings.secret_key.get_secret_value() == "CHANGE-ME-IN-PRODUCTION"


### PR DESCRIPTION
## Summary

Slice 5 de 8 da entrega do BC `identity`. Conecta FastAPI Users à infra do projeto, registra `IdentityContainer` no `ApplicationContainer`, adiciona configurações de auth e **monta as rotas de login/logout** em `/api/v1/auth/cookie`. A partir desta PR, **`POST /api/v1/auth/cookie/login`** e **`POST /api/v1/auth/cookie/logout`** funcionam end-to-end (assumindo que existe um user na tabela — bootstrap chega na slice 6).

Continua **puramente aditiva** — nenhuma rota existente é tocada, nenhum endpoint passa a exigir login.

### Conteúdo

**Settings (`src/config/settings.py`)**:
- `secret_key` — usado pelo FastAPI Users para password-reset/email-verification (flows não expostos em PR 1, mas signing key fica wired pra futuras slices).
- `session_lifetime_seconds=90 dias` (per ADR-011, fixo, sem slide).
- `session_cookie_secure=False` (default dev; force True em prod).
- `session_cookie_name="homeflix_session"`.

**FastAPI Users wiring (`src/modules/identity/infrastructure/auth/`)**:
- `dependencies.py` — chain FastAPI-native: `get_async_session` (lê `app.state.container`) → `get_user_db` → `get_user_manager` → `get_database_strategy` (lifetime de settings).
- `user_manager.py` — `UUIDIDMixin + BaseUserManager[UserModel, UUID]`; `reset_password_token_secret` / `verification_token_secret` lidos de settings (hooks de reset/verify ficam pra PR futura).
- `backend.py` — `cookie_transport` com `HttpOnly` + `Secure` + `SameSite=Strict`; `AuthenticationBackend` chamado `cookie-session`.
- `fastapi_users.py` — singleton `FastAPIUsers[UserModel, UUID]` + `current_active_user`.

**Container (`src/config/containers/identity.py`)**:
- `IdentityContainer` expõe `identity_unit_of_work_factory` e os 5 profile use cases.
- Registrado em `ApplicationContainer` **antes** dos BCs consumidores (per ADR-009) pra que futuras PRs injetem `profile_lookup` via ACL sem reordenar.

**`main.py`**:
- Mount `fastapi_users.get_auth_router(auth_backend)` em `/api/v1/auth/cookie` com tag "Auth".
- `_init_engine` (dev auto-create-tables) agora importa `src.modules.identity.infrastructure.persistence.models` pra incluir `users`/`profiles`/`access_tokens` no `Base.metadata.create_all`.

### Test plan

- [x] `poetry run python -c "from src.main import create_app; ..."` — confirma rotas `/api/v1/auth/cookie/login` e `/.../logout` registradas
- [x] `poetry run pytest tests/modules/identity` — **114 passed** (108 anteriores + 6 novos auth config)
- [x] `poetry run pytest tests/modules/identity tests/modules/library tests/modules/media` — **1382 passed**, 5 skipped (zero regressão)
- [x] `poetry run ruff check ...` — clean
- [x] `poetry run ruff format --check ...` — clean

Os 6 testes novos travam config de segurança crítica (per ADR-011): cookie name, `HttpOnly=True`, `SameSite=strict`, `max_age=90 dias`, backend name `cookie-session`. Mudanças nesses valores precisam vir com decisão explícita + atualização de teste.

### Próximas slices

6. Routes custom (`/users/me`, `/profiles/*`) + `get_current_profile` dependency + CLI `identity_create_admin.py` (esta dá pra **logar de verdade** via curl)
7. E2E test scaffolding + auth tests
8. E2E profile tests + polish

## Related

- ADR-010 — `IdentityContainer` registrado antes de consumidores; `current_active_user` exportado pra slice 6 consumir em `get_current_profile`
- ADR-011 — `DatabaseStrategy` + `CookieTransport` com lifetime fixo de 90 dias

## Caveats

- `cookie_transport` lê `Settings` no import time. Mudanças em settings entre import e runtime não refletem no cookie. Pra testes que precisem override, usar `app.dependency_overrides` ou re-importar.
- Sem rota register pública. Bootstrap inicial será via CLI (slice 6) — alinhado com a decisão "scripts/identity_create_admin.py em vez de `/auth/register`" no plano original.

## Summary by Sourcery

Integrate the identity bounded context with FastAPI Users by wiring cookie-based authentication, registering the Identity container, and exposing login/logout routes.

New Features:
- Add identity/auth configuration settings for session cookies and token signing secrets.
- Expose FastAPI Users-based cookie authentication routes under /api/v1/auth/cookie.
- Introduce an IdentityContainer that provides the identity unit-of-work factory and profile-related use cases.

Enhancements:
- Wire FastAPI Users authentication backend, user manager, and dependency chain using database-backed session strategy.
- Register the IdentityContainer in the main ApplicationContainer and include identity persistence models in development-time schema creation.

Tests:
- Add unit tests that lock in authentication backend and cookie transport security-critical configuration (cookie name, attributes, lifetime, and backend name).