### PR TITLE
feat(identity): add /me, /profiles routes and admin CLI (6/8)

### DIFF
--- a/scripts/identity_create_admin.py
+++ b/scripts/identity_create_admin.py
@@ -1,0 +1,123 @@
+"""Bootstrap an admin user + default profile for the identity BC.
+
+Run from the project root with the virtualenv active:
+
+    poetry run python scripts/identity_create_admin.py
+
+The script prompts for email, password (twice for confirmation), and
+the default profile's display name, then:
+
+1. Initialises the application container (engine + session factory).
+2. Hashes the password using ``pwdlib`` — the same hasher FastAPI
+   Users uses at login, so subsequent ``POST /auth/cookie/login``
+   calls verify against the same bytes.
+3. Creates a ``User`` aggregate with ``role=ADMIN``,
+   ``is_superuser=True``, ``is_verified=True`` and persists it via
+   ``UserRepository``.
+4. Creates a default ``Profile`` for the new admin via the
+   ``CreateProfileUseCase`` so ``get_current_profile`` resolves on
+   the first login.
+
+Bootstrap path lives in ``scripts/`` rather than as a public route
+because PR 1 deliberately does not expose ``/auth/register`` —
+self-service registration UX is undefined and admin-creation is a
+once-per-deployment action. See ADR-010 / ADR-011 for the framing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import getpass
+import sys
+
+from pwdlib import PasswordHash
+
+from src.config.containers import ApplicationContainer
+from src.modules.identity.application.dtos.identity_dtos import CreateProfileInput
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.user_role import UserRole
+
+_password_hash = PasswordHash.recommended()
+
+
+def _read_email() -> Email:
+    while True:
+        raw = input("Email: ").strip()
+        try:
+            return Email(raw)
+        except Exception as e:
+            # Domain validation surfaces as a generic exception; print the
+            # message so the user knows what to fix and re-prompt.
+            print(f"  invalid: {e}")
+
+
+def _read_password() -> str:
+    while True:
+        first = getpass.getpass("Password: ")
+        if len(first) < 8:
+            print("  password must be at least 8 characters")
+            continue
+        second = getpass.getpass("Confirm:  ")
+        if first != second:
+            print("  passwords do not match — try again")
+            continue
+        return first
+
+
+def _read_profile_name() -> str:
+    raw = input("Default profile name [Admin]: ").strip()
+    return raw or "Admin"
+
+
+async def _bootstrap_admin() -> None:
+    email = _read_email()
+    password = _read_password()
+    profile_name = _read_profile_name()
+
+    container = ApplicationContainer()
+    await container.infrastructure.init_resources()
+
+    try:
+        uow_factory = container.identity.identity_unit_of_work_factory()
+        async with uow_factory() as uow:
+            existing = await uow.users.find_by_email(email)
+            if existing is not None:
+                print(f"  refusing to overwrite existing user {existing.id}")
+                sys.exit(1)
+
+            hashed = _password_hash.hash(password)
+            admin = User.create(
+                email=email,
+                role=UserRole.ADMIN,
+                is_superuser=True,
+                is_verified=True,
+                hashed_password=hashed,
+            )
+            saved = await uow.users.save(admin)
+
+        if saved.id is None:
+            raise RuntimeError("user id was not assigned during save")
+
+        create_profile = container.identity.create_profile()
+        profile = await create_profile.execute(
+            CreateProfileInput(user_id=saved.id.value, name=profile_name),
+        )
+
+        print(f"created admin {saved.id}")
+        print(f"created default profile {profile.id} ({profile.name!r})")
+    finally:
+        await container.infrastructure.shutdown_resources()
+
+
+def main() -> None:
+    """Synchronous CLI entry point."""
+    try:
+        asyncio.run(_bootstrap_admin())
+    except KeyboardInterrupt:
+        print("\nAborted.")
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ from src.config.settings import get_settings
 from src.modules.catalog_requests.presentation.routes import catalog_request_router
 from src.modules.collections.presentation.routes import custom_list_router, watchlist_router
 from src.modules.identity.infrastructure.auth import auth_backend, fastapi_users
+from src.modules.identity.presentation.routes import profile_router, users_router
 from src.modules.library.presentation.routes.library_routes import (
     router as library_router,
 )
@@ -90,6 +91,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "src.modules.catalog_requests.presentation.routes.catalog_request_routes",
             "src.modules.library.presentation.routes.library_routes",
             "src.modules.preferences.presentation.routes.preferences_routes",
+            "src.modules.identity.presentation.routes.profile_routes",
         ],
     )
     app.state.container = container
@@ -211,14 +213,16 @@ def create_app() -> FastAPI:
     app.include_router(library_router)
     app.include_router(preferences_router)
 
-    # Identity — FastAPI Users built-in cookie auth (login/logout). Custom
-    # /me and /profiles/* routes ship in the next slice. See ADR-011 for
-    # the cookie + DatabaseStrategy choice.
+    # Identity — FastAPI Users built-in cookie auth (login/logout) plus
+    # the custom users / profiles surface that returns prefixed external
+    # IDs and routes through the IdentityContainer use cases.
     app.include_router(
         fastapi_users.get_auth_router(auth_backend),
         prefix="/api/v1/auth/cookie",
         tags=["Auth"],
     )
+    app.include_router(users_router)
+    app.include_router(profile_router)
 
     return app
 

--- a/src/modules/identity/infrastructure/auth/__init__.py
+++ b/src/modules/identity/infrastructure/auth/__init__.py
@@ -8,9 +8,15 @@ used for our domain use cases. The two coexist: routes import
 """
 
 from src.modules.identity.infrastructure.auth.backend import auth_backend
+from src.modules.identity.infrastructure.auth.dependencies import get_session_token
 from src.modules.identity.infrastructure.auth.fastapi_users import (
     current_active_user,
     fastapi_users,
 )
 
-__all__ = ["auth_backend", "current_active_user", "fastapi_users"]
+__all__ = [
+    "auth_backend",
+    "current_active_user",
+    "fastapi_users",
+    "get_session_token",
+]

--- a/src/modules/identity/infrastructure/auth/dependencies.py
+++ b/src/modules/identity/infrastructure/auth/dependencies.py
@@ -24,11 +24,28 @@ from fastapi_users_db_sqlalchemy.access_token import SQLAlchemyAccessTokenDataba
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config.settings import get_settings
+from src.modules.identity.domain.errors import NoActiveSessionError
 from src.modules.identity.infrastructure.auth.user_manager import UserManager
 from src.modules.identity.infrastructure.persistence.models.access_token_model import (
     AccessTokenModel,
 )
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+def get_session_token(request: Request) -> str:
+    """Return the opaque session token from the configured cookie.
+
+    Single source of truth for the cookie name + missing-cookie error
+    used both by ``get_current_profile`` and by routes that need the
+    raw token (e.g. ``POST /profiles/{id}/switch``). Raises
+    :class:`NoActiveSessionError` (HTTP 401) so the caller does not
+    have to repeat the check.
+    """
+    settings = get_settings()
+    token = request.cookies.get(settings.session_cookie_name)
+    if token is None:
+        raise NoActiveSessionError(message="Session cookie missing")
+    return token
 
 
 async def get_async_session(request: Request) -> AsyncGenerator[AsyncSession, None]:

--- a/src/modules/identity/presentation/__init__.py
+++ b/src/modules/identity/presentation/__init__.py
@@ -1,0 +1,1 @@
+"""Identity presentation layer (FastAPI routes, schemas, dependencies)."""

--- a/src/modules/identity/presentation/dependencies.py
+++ b/src/modules/identity/presentation/dependencies.py
@@ -17,14 +17,16 @@ from dataclasses import dataclass
 
 from fastapi import Depends, Request
 
-from src.config.settings import get_settings
 from src.modules.identity.domain.errors import (
     NoActiveProfileSelectedError,
     NoActiveSessionError,
 )
 from src.modules.identity.domain.value_objects.profile_id import ProfileId
 from src.modules.identity.domain.value_objects.user_id import UserId
-from src.modules.identity.infrastructure.auth import current_active_user
+from src.modules.identity.infrastructure.auth import (
+    current_active_user,
+    get_session_token,
+)
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 
 
@@ -47,6 +49,7 @@ class ProfileContext:
 async def get_current_profile(
     request: Request,
     user: UserModel = Depends(current_active_user),
+    token: str = Depends(get_session_token),
 ) -> ProfileContext:
     """Resolve the active ``ProfileContext`` for the request.
 
@@ -56,23 +59,15 @@ async def get_current_profile(
        cookie and produced the ``UserModel``. If the cookie was
        missing or invalid the dependency raised before reaching this
        function.
-    2. Read the cookie value to recover the opaque session token —
-       FastAPI Users stripped it during auth, so we read it again
-       directly from the request.
+    2. ``Depends(get_session_token)`` recovers the opaque token from
+       the cookie (single source of truth for cookie name + missing
+       cookie → 401 mapping).
     3. Look up the matching ``access_tokens`` row to find the
        ``current_profile_id`` chosen for this session.
     4. Raise :class:`NoActiveProfileSelectedError` (HTTP 409) if the
        user has not yet selected a profile, so the frontend can
        distinguish "logged in, pick a profile" from "not logged in".
     """
-    settings = get_settings()
-    token = request.cookies.get(settings.session_cookie_name)
-    if token is None:
-        # Should not happen — current_active_user already verified the
-        # cookie — but handle defensively rather than relying on an
-        # invariant that lives in another library.
-        raise NoActiveSessionError(message="Session cookie missing")
-
     container = request.app.state.container
     factory = container.identity.identity_unit_of_work_factory()
     async with factory() as uow:

--- a/src/modules/identity/presentation/dependencies.py
+++ b/src/modules/identity/presentation/dependencies.py
@@ -1,0 +1,96 @@
+"""FastAPI dependencies that resolve the caller's identity context.
+
+The single entry point is ``get_current_profile``: it combines the
+authenticated ``UserModel`` from FastAPI Users with the active
+``profile_id`` carried by the session row, returning a
+``ProfileContext`` with both as prefixed external IDs (UUIDs never
+cross into the domain).
+
+Shipped in PR 1 deliberately unused — the consumer BCs
+(``watch_progress``, ``collections``, ``preferences``) pick this up
+in subsequent PRs to enforce per-profile isolation. Adding it now
+means PR 2 can import the dependency on day one without waiting on
+any further wiring.
+"""
+
+from dataclasses import dataclass
+
+from fastapi import Depends, Request
+
+from src.config.settings import get_settings
+from src.modules.identity.domain.errors import (
+    NoActiveProfileSelectedError,
+    NoActiveSessionError,
+)
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.user_id import UserId
+from src.modules.identity.infrastructure.auth import current_active_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+@dataclass(frozen=True)
+class ProfileContext:
+    """Per-request identity context.
+
+    Carries everything a use case needs to act on behalf of the
+    caller: the authenticated user, the active personalization
+    profile, and the opaque session token (so the switch-profile use
+    case can update the same session row that is currently being
+    served).
+    """
+
+    user_id: UserId
+    profile_id: ProfileId
+    session_token: str
+
+
+async def get_current_profile(
+    request: Request,
+    user: UserModel = Depends(current_active_user),
+) -> ProfileContext:
+    """Resolve the active ``ProfileContext`` for the request.
+
+    Steps:
+
+    1. ``Depends(current_active_user)`` already authenticated the
+       cookie and produced the ``UserModel``. If the cookie was
+       missing or invalid the dependency raised before reaching this
+       function.
+    2. Read the cookie value to recover the opaque session token —
+       FastAPI Users stripped it during auth, so we read it again
+       directly from the request.
+    3. Look up the matching ``access_tokens`` row to find the
+       ``current_profile_id`` chosen for this session.
+    4. Raise :class:`NoActiveProfileSelectedError` (HTTP 409) if the
+       user has not yet selected a profile, so the frontend can
+       distinguish "logged in, pick a profile" from "not logged in".
+    """
+    settings = get_settings()
+    token = request.cookies.get(settings.session_cookie_name)
+    if token is None:
+        # Should not happen — current_active_user already verified the
+        # cookie — but handle defensively rather than relying on an
+        # invariant that lives in another library.
+        raise NoActiveSessionError(message="Session cookie missing")
+
+    container = request.app.state.container
+    factory = container.identity.identity_unit_of_work_factory()
+    async with factory() as uow:
+        snapshot = await uow.access_tokens.get_by_token(token)
+
+    if snapshot is None:
+        raise NoActiveSessionError(message="Session token is unknown")
+
+    if snapshot.current_profile_id is None:
+        raise NoActiveProfileSelectedError(
+            message="Select a profile before continuing",
+        )
+
+    return ProfileContext(
+        user_id=UserId(user.external_id),
+        profile_id=snapshot.current_profile_id,
+        session_token=token,
+    )
+
+
+__all__ = ["ProfileContext", "get_current_profile"]

--- a/src/modules/identity/presentation/routes/__init__.py
+++ b/src/modules/identity/presentation/routes/__init__.py
@@ -1,0 +1,10 @@
+"""Identity presentation routers."""
+
+from src.modules.identity.presentation.routes.profile_routes import (
+    router as profile_router,
+)
+from src.modules.identity.presentation.routes.users_routes import (
+    router as users_router,
+)
+
+__all__ = ["profile_router", "users_router"]

--- a/src/modules/identity/presentation/routes/profile_routes.py
+++ b/src/modules/identity/presentation/routes/profile_routes.py
@@ -4,11 +4,10 @@ from dataclasses import asdict
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.config.settings import get_settings
 from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
     DeleteProfileInput,
@@ -31,8 +30,10 @@ from src.modules.identity.application.use_cases.switch_profile import (
 from src.modules.identity.application.use_cases.update_profile import (
     UpdateProfileUseCase,
 )
-from src.modules.identity.domain.errors import NoActiveSessionError
-from src.modules.identity.infrastructure.auth import current_active_user
+from src.modules.identity.infrastructure.auth import (
+    current_active_user,
+    get_session_token,
+)
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.identity.presentation.schemas.profile_schemas import (
     CreateProfileRequest,
@@ -129,26 +130,20 @@ async def delete_profile(
 @inject  # type: ignore[misc]
 async def switch_profile(
     profile_id: str,
-    request: Request,
     user: UserModel = Depends(current_active_user),
+    token: str = Depends(get_session_token),
     use_case: SwitchProfileUseCase = Depends(
         Provide[ApplicationContainer.identity.switch_profile],
     ),
 ) -> None:
     """Set the target profile as the active one in the caller's session.
 
-    Reads the opaque session token straight from the cookie (the
-    ``current_active_user`` dependency stripped it during auth) and
-    passes it to the use case, which updates the matching
+    The session token (read by ``get_session_token`` from the cookie)
+    is passed to the use case so it updates the matching
     ``access_tokens`` row. The cookie itself is not re-emitted —
     multi-device sessions can each carry their own active profile
     per ADR-011.
     """
-    settings = get_settings()
-    token = request.cookies.get(settings.session_cookie_name)
-    if token is None:
-        raise NoActiveSessionError(message="Session cookie missing")
-
     await use_case.execute(
         SwitchProfileInput(
             user_id=user.external_id,

--- a/src/modules/identity/presentation/routes/profile_routes.py
+++ b/src/modules/identity/presentation/routes/profile_routes.py
@@ -1,0 +1,161 @@
+"""Profile CRUD + switch routes."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, Request
+
+from src.building_blocks.presentation import api_list, api_single
+from src.config.containers import ApplicationContainer
+from src.config.settings import get_settings
+from src.modules.identity.application.dtos.identity_dtos import (
+    CreateProfileInput,
+    DeleteProfileInput,
+    ListProfilesForUserInput,
+    SwitchProfileInput,
+    UpdateProfileInput,
+)
+from src.modules.identity.application.use_cases.create_profile import (
+    CreateProfileUseCase,
+)
+from src.modules.identity.application.use_cases.delete_profile import (
+    DeleteProfileUseCase,
+)
+from src.modules.identity.application.use_cases.list_profiles_for_user import (
+    ListProfilesForUserUseCase,
+)
+from src.modules.identity.application.use_cases.switch_profile import (
+    SwitchProfileUseCase,
+)
+from src.modules.identity.application.use_cases.update_profile import (
+    UpdateProfileUseCase,
+)
+from src.modules.identity.domain.errors import NoActiveSessionError
+from src.modules.identity.infrastructure.auth import current_active_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.presentation.schemas.profile_schemas import (
+    CreateProfileRequest,
+    UpdateProfileRequest,
+)
+
+router = APIRouter(prefix="/api/v1/profiles", tags=["Profiles"])
+
+
+@router.get("")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_profiles(
+    user: UserModel = Depends(current_active_user),
+    use_case: ListProfilesForUserUseCase = Depends(
+        Provide[ApplicationContainer.identity.list_profiles_for_user],
+    ),
+) -> dict[str, Any]:
+    """List the authenticated user's profiles."""
+    result = await use_case.execute(
+        ListProfilesForUserInput(user_id=user.external_id),
+    )
+    return api_list([asdict(p) for p in result])
+
+
+@router.post("", status_code=201)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def create_profile(
+    body: CreateProfileRequest,
+    user: UserModel = Depends(current_active_user),
+    use_case: CreateProfileUseCase = Depends(
+        Provide[ApplicationContainer.identity.create_profile],
+    ),
+) -> dict[str, Any]:
+    """Create a new profile owned by the authenticated user."""
+    result = await use_case.execute(
+        CreateProfileInput(
+            user_id=user.external_id,
+            name=body.name,
+            is_kids=body.is_kids,
+            avatar_url=body.avatar_url,
+        ),
+    )
+    return api_single("profile", asdict(result))
+
+
+@router.put("/{profile_id}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def update_profile(
+    profile_id: str,
+    body: UpdateProfileRequest,
+    user: UserModel = Depends(current_active_user),
+    use_case: UpdateProfileUseCase = Depends(
+        Provide[ApplicationContainer.identity.update_profile],
+    ),
+) -> dict[str, Any]:
+    """Partial update; only supplied fields touch the entity.
+
+    Ownership is enforced inside the use case — a caller acting on
+    someone else's profile gets HTTP 403 from
+    ``ProfileOwnershipViolation``.
+    """
+    result = await use_case.execute(
+        UpdateProfileInput(
+            user_id=user.external_id,
+            profile_id=profile_id,
+            name=body.name,
+            is_kids=body.is_kids,
+            avatar_url=body.avatar_url,
+        ),
+    )
+    return api_single("profile", asdict(result))
+
+
+@router.delete("/{profile_id}", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def delete_profile(
+    profile_id: str,
+    user: UserModel = Depends(current_active_user),
+    use_case: DeleteProfileUseCase = Depends(
+        Provide[ApplicationContainer.identity.delete_profile],
+    ),
+) -> None:
+    """Soft-delete a profile.
+
+    Returns 403 if the caller does not own the profile and 409 if
+    deletion would leave the user without any active profile.
+    """
+    await use_case.execute(
+        DeleteProfileInput(user_id=user.external_id, profile_id=profile_id),
+    )
+
+
+@router.post("/{profile_id}/switch", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def switch_profile(
+    profile_id: str,
+    request: Request,
+    user: UserModel = Depends(current_active_user),
+    use_case: SwitchProfileUseCase = Depends(
+        Provide[ApplicationContainer.identity.switch_profile],
+    ),
+) -> None:
+    """Set the target profile as the active one in the caller's session.
+
+    Reads the opaque session token straight from the cookie (the
+    ``current_active_user`` dependency stripped it during auth) and
+    passes it to the use case, which updates the matching
+    ``access_tokens`` row. The cookie itself is not re-emitted —
+    multi-device sessions can each carry their own active profile
+    per ADR-011.
+    """
+    settings = get_settings()
+    token = request.cookies.get(settings.session_cookie_name)
+    if token is None:
+        raise NoActiveSessionError(message="Session cookie missing")
+
+    await use_case.execute(
+        SwitchProfileInput(
+            user_id=user.external_id,
+            target_profile_id=profile_id,
+            session_token=token,
+        ),
+    )
+
+
+__all__ = ["router"]

--- a/src/modules/identity/presentation/routes/users_routes.py
+++ b/src/modules/identity/presentation/routes/users_routes.py
@@ -1,0 +1,29 @@
+"""Custom user routes for the identity bounded context.
+
+The full FastAPI Users users-router (``fastapi_users.get_users_router``)
+exposes ``/me`` and admin CRUD with the database UUID as ``id`` —
+which contradicts ADR-002. We mount only what we need here, with the
+prefixed ``external_id`` returned as ``id``.
+"""
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.presentation import api_single
+from src.modules.identity.infrastructure.auth import current_active_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.presentation.schemas.user_schemas import UserRead
+
+router = APIRouter(prefix="/api/v1/users", tags=["Users"])
+
+
+@router.get("/me")  # type: ignore[misc]
+async def get_me(
+    user: UserModel = Depends(current_active_user),
+) -> dict[str, Any]:
+    """Return the authenticated user with prefixed external IDs."""
+    return api_single("user", UserRead.from_model(user).model_dump())
+
+
+__all__ = ["router"]

--- a/src/modules/identity/presentation/schemas/__init__.py
+++ b/src/modules/identity/presentation/schemas/__init__.py
@@ -1,0 +1,9 @@
+"""Identity presentation schemas (Pydantic request/response models)."""
+
+from src.modules.identity.presentation.schemas.profile_schemas import (
+    CreateProfileRequest,
+    UpdateProfileRequest,
+)
+from src.modules.identity.presentation.schemas.user_schemas import UserRead
+
+__all__ = ["CreateProfileRequest", "UpdateProfileRequest", "UserRead"]

--- a/src/modules/identity/presentation/schemas/profile_schemas.py
+++ b/src/modules/identity/presentation/schemas/profile_schemas.py
@@ -1,0 +1,27 @@
+"""Pydantic schemas for profile request/response validation."""
+
+from pydantic import BaseModel, Field
+
+
+class CreateProfileRequest(BaseModel):
+    """``POST /api/v1/profiles`` body."""
+
+    name: str = Field(min_length=1, max_length=50)
+    is_kids: bool = False
+    avatar_url: str | None = Field(default=None, max_length=500)
+
+
+class UpdateProfileRequest(BaseModel):
+    """``PUT /api/v1/profiles/{id}`` body — partial update.
+
+    All fields optional: only supplied fields are mutated. ``None``
+    is treated as "field omitted", not "clear the value", to keep
+    PATCH-style semantics inside a PUT route.
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=50)
+    is_kids: bool | None = None
+    avatar_url: str | None = Field(default=None, max_length=500)
+
+
+__all__ = ["CreateProfileRequest", "UpdateProfileRequest"]

--- a/src/modules/identity/presentation/schemas/user_schemas.py
+++ b/src/modules/identity/presentation/schemas/user_schemas.py
@@ -1,0 +1,42 @@
+"""Pydantic schemas for the identity user endpoints.
+
+We intentionally do NOT use ``fastapi_users.schemas.BaseUser[UUID]``
+because it serializes the database UUID as ``id`` — that contradicts
+ADR-002, which mandates prefixed external IDs at every API surface.
+``UserRead`` here exposes ``id`` as the prefixed ``external_id`` and
+hides the UUID entirely.
+"""
+
+from typing import Self
+
+from pydantic import BaseModel
+
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+class UserRead(BaseModel):
+    """Public read shape for the authenticated user (``GET /users/me``)."""
+
+    id: str
+    email: str
+    role: str
+    is_active: bool
+    is_verified: bool
+
+    @classmethod
+    def from_model(cls, user: UserModel) -> Self:
+        """Project a ``UserModel`` into the API response shape.
+
+        Only the prefixed ``external_id`` is exposed as ``id`` — the
+        database UUID never leaves infrastructure.
+        """
+        return cls(
+            id=user.external_id,
+            email=user.email,
+            role=user.role,
+            is_active=user.is_active,
+            is_verified=user.is_verified,
+        )
+
+
+__all__ = ["UserRead"]

--- a/tests/modules/identity/unit/presentation/test_user_read_projection.py
+++ b/tests/modules/identity/unit/presentation/test_user_read_projection.py
@@ -1,0 +1,54 @@
+"""Tests for the UserRead projection.
+
+Locks ADR-002 enforcement at the API surface: the database UUID is
+the internal primary key but must NEVER be exposed as ``id`` to API
+clients — they see only the prefixed ``external_id``.
+"""
+
+import uuid
+
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.presentation.schemas.user_schemas import UserRead
+
+
+class TestUserReadFromModel:
+    def test_id_should_be_the_prefixed_external_id_not_uuid(self):
+        # Arrange a model that mirrors what the DB would return after
+        # FastAPI Users created the row.
+        internal_uuid = uuid.uuid4()
+        external = "usr_2xK9mPqR7nL4"
+        model = UserModel(
+            id=internal_uuid,
+            external_id=external,
+            email="admin@homeflix.local",
+            hashed_password="$argon2id$dummy",
+            is_active=True,
+            is_superuser=True,
+            is_verified=True,
+            role="admin",
+        )
+
+        projected = UserRead.from_model(model)
+
+        assert projected.id == external
+        # And critically: the UUID never makes it into the projection
+        assert str(internal_uuid) not in projected.model_dump_json()
+
+    def test_should_carry_email_role_and_flags(self):
+        model = UserModel(
+            id=uuid.uuid4(),
+            external_id="usr_2xK9mPqR7nL4",
+            email="user@example.com",
+            hashed_password="$argon2id$dummy",
+            is_active=False,
+            is_superuser=False,
+            is_verified=True,
+            role="member",
+        )
+
+        projected = UserRead.from_model(model)
+
+        assert projected.email == "user@example.com"
+        assert projected.role == "member"
+        assert projected.is_active is False
+        assert projected.is_verified is True


### PR DESCRIPTION
## Summary

Slice 6 de 8 do BC `identity`. **Esta é a primeira slice em que dá pra logar e gerenciar profile end-to-end via API**: rotas custom `/users/me` e `/profiles/*`, dependency `get_current_profile` (ainda unused em PR 1, consumida em PR 2), e CLI `scripts/identity_create_admin.py` pra bootstrappar o admin inicial.

Continua **puramente aditiva** — nenhuma rota anterior é tocada, nenhum endpoint passa a exigir login.

### Conteúdo

**Presentation**:
- `dependencies.py` — `ProfileContext` + `get_current_profile`: lê o cookie, resolve via `access_tokens` repo, levanta `NoActiveSession` (401) ou `NoActiveProfileSelected` (409). Shipa unused; PR 2 começa a usar.
- `schemas/user_schemas.py` — `UserRead.from_model(user)` projeta apenas o `external_id` prefixado como `id` (não vaza UUID, preservando ADR-002).
- `schemas/profile_schemas.py` — `CreateProfileRequest` (1..50 chars no name) e `UpdateProfileRequest` (partial update, todos opcionais).
- `routes/users_routes.py` — `GET /api/v1/users/me` (custom, retorna prefixed). Deliberadamente **não montei** `fastapi_users.get_users_router(...)` que vazaria UUID via `BaseUser[UUID]`.
- `routes/profile_routes.py` — `GET`, `POST`, `PUT`, `DELETE /api/v1/profiles[/...]` + `POST /api/v1/profiles/{id}/switch`. Todos consomem use cases via `Provide[ApplicationContainer.identity.<usecase>]`. Ownership 403 e last-profile 409 enforced no use case.

**`main.py`**:
- Inclui `users_router` e `profile_router`.
- Adiciona `src.modules.identity.presentation.routes.profile_routes` ao `container.wire(modules=[...])`.

**CLI bootstrap (`scripts/identity_create_admin.py`)**:
- Prompts: email, password (com confirm), default profile name.
- Hash via `pwdlib.PasswordHash.recommended()` — **mesmo hasher do FastAPI Users**, então o bytes resultante é verificável no `POST /auth/cookie/login`.
- Cria `User` via `UserRepository.save()` + default profile via `CreateProfileUseCase`.
- Recusa overwrite se email já existe.

### Test plan

- [x] Smoke: `from src.main import create_app; ...` confirma 8 rotas registradas:
  ```
  POST /api/v1/auth/cookie/login        (slice 5)
  POST /api/v1/auth/cookie/logout       (slice 5)
  GET  /api/v1/users/me                 ← novo
  GET  /api/v1/profiles                 ← novo
  POST /api/v1/profiles                 ← novo
  PUT  /api/v1/profiles/{profile_id}    ← novo
  DELETE /api/v1/profiles/{profile_id}  ← novo
  POST /api/v1/profiles/{profile_id}/switch ← novo
  ```
- [x] `poetry run pytest tests/modules/identity` — **121 passed** (119 + 2 novos UserRead projection)
- [x] `poetry run pytest tests/modules/identity tests/modules/library tests/modules/media` — **1393 passed**, 5 skipped (zero regressão)
- [x] `poetry run ruff check ...` + `ruff format --check ...` — clean
- [ ] Manual smoke (após merge): `python scripts/identity_create_admin.py` → `curl -c cookies -X POST .../auth/cookie/login -d "username=...&password=..."` → `curl -b cookies .../users/me` deve retornar prefixed `usr_xxx`

### Próximas slices

7. E2E test scaffolding (httpx + ASGITransport + DB override conftest) + auth tests (login/logout cookie roundtrip)
8. E2E profile tests (CRUD + isolation) + polish + manual smoke

## Caveats

- Nenhuma rota existente passa a exigir login. Isso muda nas PRs 2-5 (refactor de `watch_progress` + `collections` + `preferences` pra ganhar `profile_id`), conforme acordado no plano.
- `get_current_profile` shippa unused em PR 1 — é a única razão pra inclui-la agora: PR 2 vai consumir e quero que ela exista no momento que a próxima feature começar.
- O CLI bootstrap não tem testes próprios — script de uso uma vez por deploy, será exercitado no smoke manual antes de merge na develop. Se virar caso comum, vale teste com captura de stdin/stdout.

## Related

- ADR-002 — `UserRead.from_model` projeta `external_id` como `id`, UUID nunca cruza pra API
- ADR-010 — `ProfileContext` carrega VOs prefixados; `current_profile_id` resolvido via JOIN no `access_tokens`
- ADR-011 — `SwitchProfileUseCase` atualiza `access_tokens.current_profile_id` da row da sessão atual; cookie não é re-emitido

## Summary by Sourcery

Add identity presentation layer endpoints for authenticated user and profile management and wire them into the main application, along with a one-off CLI script to bootstrap an initial admin user.

New Features:
- Expose a custom `/api/v1/users/me` endpoint that returns the authenticated user using prefixed external IDs instead of database UUIDs.
- Introduce `/api/v1/profiles` CRUD and profile-switching endpoints backed by identity use cases for per-user profile management.
- Add a `get_current_profile` FastAPI dependency that resolves the active user, profile, and session token into a `ProfileContext` for downstream bounded contexts.
- Provide a CLI bootstrap script to create an initial admin user and default profile using the same hashing strategy as the login flow.

Tests:
- Add unit tests to ensure the `UserRead` projection exposes only the prefixed external user ID and never the underlying UUID.