### PR TITLE
feat(identity): add e2e auth tests with httpx scaffolding (7/8)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -41,6 +41,30 @@ from src.modules.preferences.presentation.routes.preferences_routes import (
 )
 from src.modules.watch_progress.presentation.routes import progress_router
 
+#: Module paths whose ``@inject``-decorated callables are wired to the
+#: dependency-injector container. Extracted as a module constant so e2e
+#: tests can build a container with the same wiring without copying the
+#: list (drift between the two would mean tests miss DI-resolved deps).
+WIRED_ROUTE_MODULES: tuple[str, ...] = (
+    "src.modules.media.presentation.routes.catalog_routes",
+    "src.modules.media.presentation.routes.collection_routes",
+    "src.modules.media.presentation.routes.search_routes",
+    "src.modules.media.presentation.routes.enrichment_routes",
+    "src.modules.media.presentation.routes.featured_routes",
+    "src.modules.media.presentation.routes.movie_routes",
+    "src.modules.media.presentation.routes.people_routes",
+    "src.modules.media.presentation.routes.scan_routes",
+    "src.modules.media.presentation.routes.series_routes",
+    "src.modules.media.presentation.routes.stream_routes",
+    "src.modules.watch_progress.presentation.routes.progress_routes",
+    "src.modules.collections.presentation.routes.watchlist_routes",
+    "src.modules.collections.presentation.routes.custom_list_routes",
+    "src.modules.catalog_requests.presentation.routes.catalog_request_routes",
+    "src.modules.library.presentation.routes.library_routes",
+    "src.modules.preferences.presentation.routes.preferences_routes",
+    "src.modules.identity.presentation.routes.profile_routes",
+)
+
 
 def create_container() -> ApplicationContainer:
     """Create and configure the DI container.
@@ -73,27 +97,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Initialize DI container
     container = create_container()
-    container.wire(
-        modules=[
-            "src.modules.media.presentation.routes.catalog_routes",
-            "src.modules.media.presentation.routes.collection_routes",
-            "src.modules.media.presentation.routes.search_routes",
-            "src.modules.media.presentation.routes.enrichment_routes",
-            "src.modules.media.presentation.routes.featured_routes",
-            "src.modules.media.presentation.routes.movie_routes",
-            "src.modules.media.presentation.routes.people_routes",
-            "src.modules.media.presentation.routes.scan_routes",
-            "src.modules.media.presentation.routes.series_routes",
-            "src.modules.media.presentation.routes.stream_routes",
-            "src.modules.watch_progress.presentation.routes.progress_routes",
-            "src.modules.collections.presentation.routes.watchlist_routes",
-            "src.modules.collections.presentation.routes.custom_list_routes",
-            "src.modules.catalog_requests.presentation.routes.catalog_request_routes",
-            "src.modules.library.presentation.routes.library_routes",
-            "src.modules.preferences.presentation.routes.preferences_routes",
-            "src.modules.identity.presentation.routes.profile_routes",
-        ],
-    )
+    container.wire(modules=list(WIRED_ROUTE_MODULES))
     app.state.container = container
 
     # Initialize database

--- a/tests/modules/identity/e2e/conftest.py
+++ b/tests/modules/identity/e2e/conftest.py
@@ -1,0 +1,160 @@
+"""End-to-end test scaffolding for the identity bounded context.
+
+Builds a real ``FastAPI`` app, drives it with ``httpx.AsyncClient`` over
+``ASGITransport`` (in-process, no real network), and points its
+``IdentityUnitOfWork`` at an in-memory SQLite shared via ``StaticPool``
+so seed fixtures and use cases under test see the same rows.
+
+Lifespan is intentionally **not** entered — we wire the container and
+populate ``app.state.container`` ourselves so each test starts with a
+fresh, isolated database. ``container.infrastructure.session_factory``
+is overridden via ``providers.Object`` so the FastAPI Users session
+adapter and our ``IdentityUnitOfWork`` both go through the test
+factory, sharing one in-memory DB per test.
+"""
+
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from dataclasses import dataclass
+
+import pytest
+from dependency_injector import providers
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pwdlib import PasswordHash
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+# Importing the identity models registers them on ``Base.metadata`` so
+# ``create_all`` discovers ``users`` / ``profiles`` / ``access_tokens``.
+import src.modules.identity.infrastructure.persistence.models  # noqa: F401
+from src.config.containers import ApplicationContainer
+from src.infrastructure.persistence import Base
+from src.main import WIRED_ROUTE_MODULES, create_app
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
+from src.modules.identity.domain.value_objects.user_id import UserId
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+@pytest.fixture(scope="function")
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """In-memory SQLite session factory bound to a shared connection.
+
+    ``StaticPool`` is the load-bearing choice — without it every new
+    connection sees a fresh empty ``:memory:`` DB and seed rows would
+    disappear by the time the route handler queries.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+    yield factory
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def app(session_factory: async_sessionmaker[AsyncSession]) -> FastAPI:
+    """FastAPI app wired against the in-memory test session factory."""
+    container = ApplicationContainer()
+    container.wire(modules=list(WIRED_ROUTE_MODULES))
+    container.infrastructure.session_factory.override(
+        providers.Object(session_factory),
+    )
+
+    fastapi_app = create_app()
+    fastapi_app.state.container = container
+    return fastapi_app
+
+
+@pytest.fixture(scope="function")
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+    """In-process ``httpx`` client driving the test app."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+
+
+@dataclass(frozen=True)
+class SeededUser:
+    """Convenience handle returned by ``seed_user_with_profile``.
+
+    Carries everything the test typically needs: the plain password
+    (so it can hit ``/auth/cookie/login``), the prefixed external IDs
+    (so it can assert they appear in API responses), and the email
+    used as the login identifier.
+    """
+
+    email: str
+    password: str
+    user_external_id: str
+    profile_external_id: str
+
+
+# Hash the password with the same library FastAPI Users uses at login,
+# so the verification step accepts what we seed.
+_password_hash = PasswordHash.recommended()
+
+
+@pytest.fixture(scope="function")
+def seed_user_with_profile(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> Callable[..., Awaitable[SeededUser]]:
+    """Factory fixture: insert a verified user + default profile."""
+
+    async def _seed(
+        *,
+        email: str = "alice@example.com",
+        password: str = "password-strong",
+        profile_name: str = "Alice",
+        is_admin: bool = False,
+    ) -> SeededUser:
+        user_external = UserId.generate().value
+        profile_external = ProfileId.generate().value
+
+        async with session_factory() as session:
+            user = UserModel(
+                external_id=user_external,
+                email=email,
+                hashed_password=_password_hash.hash(password),
+                is_active=True,
+                is_verified=True,
+                is_superuser=is_admin,
+                role="admin" if is_admin else "member",
+            )
+            session.add(user)
+            await session.flush()  # populate user.id (UUID)
+
+            profile = ProfileModel(
+                external_id=profile_external,
+                user_id=user.id,
+                name=profile_name,
+                is_kids=False,
+            )
+            session.add(profile)
+            await session.commit()
+
+        return SeededUser(
+            email=email,
+            password=password,
+            user_external_id=user_external,
+            profile_external_id=profile_external,
+        )
+
+    return _seed

--- a/tests/modules/identity/e2e/test_auth_routes.py
+++ b/tests/modules/identity/e2e/test_auth_routes.py
@@ -1,0 +1,165 @@
+"""End-to-end tests for the cookie auth router.
+
+Drives ``POST /api/v1/auth/cookie/login``, ``POST /api/v1/auth/cookie/logout``,
+and ``GET /api/v1/users/me`` over an in-process ASGI transport. Verifies
+the cookie + DB-row contract documented in ADR-011.
+"""
+
+from collections.abc import Awaitable, Callable
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.modules.identity.infrastructure.persistence.models.access_token_model import (
+    AccessTokenModel,
+)
+from tests.modules.identity.e2e.conftest import SeededUser
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+LOGOUT_PATH = "/api/v1/auth/cookie/logout"
+ME_PATH = "/api/v1/users/me"
+COOKIE_NAME = "homeflix_session"
+
+
+async def _count_session_rows(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> int:
+    async with session_factory() as session:
+        result = await session.execute(select(AccessTokenModel))
+        return len(result.scalars().all())
+
+
+class TestLogin:
+    async def test_should_return_204_and_set_session_cookie_on_valid_credentials(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+
+        response = await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+
+        assert response.status_code == 204
+        assert COOKIE_NAME in response.cookies
+
+    async def test_should_persist_an_access_token_row_after_login(
+        self,
+        client: AsyncClient,
+        session_factory: async_sessionmaker[AsyncSession],
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+
+        await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+
+        assert await _count_session_rows(session_factory) == 1
+
+    async def test_should_set_httponly_and_strict_samesite_on_the_cookie(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+
+        response = await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+
+        # httpx exposes the raw Set-Cookie header so we can assert flags.
+        set_cookie = response.headers.get("set-cookie", "")
+        assert "HttpOnly" in set_cookie
+        assert "samesite=strict" in set_cookie.lower()
+
+    async def test_should_return_400_for_unknown_email(
+        self,
+        client: AsyncClient,
+    ):
+        response = await client.post(
+            LOGIN_PATH,
+            data={"username": "ghost@nowhere.com", "password": "anything"},
+        )
+
+        assert response.status_code == 400
+
+    async def test_should_return_400_for_wrong_password(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+
+        response = await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": "definitely-wrong"},
+        )
+
+        assert response.status_code == 400
+
+
+class TestLogout:
+    async def test_should_return_204_and_delete_the_session_row(
+        self,
+        client: AsyncClient,
+        session_factory: async_sessionmaker[AsyncSession],
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+        assert await _count_session_rows(session_factory) == 1
+
+        response = await client.post(LOGOUT_PATH)
+
+        assert response.status_code == 204
+        assert await _count_session_rows(session_factory) == 0
+
+    async def test_should_return_401_when_no_session_cookie_is_present(
+        self,
+        client: AsyncClient,
+    ):
+        response = await client.post(LOGOUT_PATH)
+
+        # FastAPI Users rejects logout without a session.
+        assert response.status_code == 401
+
+
+class TestProtectedRoute:
+    async def test_should_return_401_when_calling_users_me_without_cookie(
+        self,
+        client: AsyncClient,
+    ):
+        response = await client.get(ME_PATH)
+
+        assert response.status_code == 401
+
+    async def test_should_return_user_payload_with_prefixed_external_id_when_logged_in(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile(email="lucas@homeflix.local")
+        await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+
+        response = await client.get(ME_PATH)
+
+        assert response.status_code == 200
+        body = response.json()
+        # api_single envelope: {"type": "user", "data": {...}}
+        assert body["type"] == "user"
+        payload = body["data"]
+        assert payload["id"] == user.user_external_id
+        assert payload["id"].startswith("usr_")
+        assert payload["email"] == "lucas@homeflix.local"

--- a/tests/modules/identity/e2e/test_auth_routes.py
+++ b/tests/modules/identity/e2e/test_auth_routes.py
@@ -123,6 +123,24 @@ class TestLogout:
         assert response.status_code == 204
         assert await _count_session_rows(session_factory) == 0
 
+    async def test_should_clear_the_session_cookie_on_logout(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+
+        response = await client.post(LOGOUT_PATH)
+
+        # FastAPI Users emits Set-Cookie with Max-Age=0 to clear the
+        # cookie client-side, complementing the server-side row delete.
+        set_cookie = response.headers.get("set-cookie", "").lower()
+        assert "max-age=0" in set_cookie
+
     async def test_should_return_401_when_no_session_cookie_is_present(
         self,
         client: AsyncClient,
@@ -163,3 +181,25 @@ class TestProtectedRoute:
         assert payload["id"] == user.user_external_id
         assert payload["id"].startswith("usr_")
         assert payload["email"] == "lucas@homeflix.local"
+
+    async def test_should_return_401_on_users_me_after_logout(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        # Full lifecycle: login succeeds -> /me succeeds -> logout
+        # invalidates the session -> /me must reject the now-stale cookie.
+        user = await seed_user_with_profile()
+        login = await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+        assert login.status_code == 204
+        before = await client.get(ME_PATH)
+        assert before.status_code == 200
+
+        logout = await client.post(LOGOUT_PATH)
+        assert logout.status_code == 204
+
+        after = await client.get(ME_PATH)
+        assert after.status_code == 401


### PR DESCRIPTION
## Summary

Slice 7 de 8 do BC `identity`. Introduz **scaffolding de testes E2E** no projeto (não existia antes) e adiciona cobertura de ponta-a-ponta pro fluxo de cookie auth (`login`, `logout`, `/users/me`).

### Scaffolding (reusável por outros módulos no futuro)

- **`src/main.py` — extrai `WIRED_ROUTE_MODULES`** como tupla pública. Tanto o lifespan quanto os testes wireiam o container com a mesma lista (sem drift entre runtime e teste).
- **`tests/modules/identity/e2e/conftest.py`**:
  - `session_factory` fixture — SQLite in-memory + `StaticPool` (mesma técnica das integration tests; sem `StaticPool` cada conexão veria DB vazio)
  - `app` fixture — instancia `ApplicationContainer`, faz `wire()`, override `infrastructure.session_factory` via `providers.Object(...)`, popula `app.state.container`. **Lifespan não é entrado** — cada teste inicializa fresh sem lifecycle coupling
  - `client` fixture — `httpx.AsyncClient(transport=ASGITransport(app=app))` (in-process, sem rede)
  - `seed_user_with_profile` factory fixture — insere user verified + profile default, hash via `pwdlib.PasswordHash.recommended()` (mesmo hasher do FastAPI Users → verify aceita os bytes seeded)

### Testes (`test_auth_routes.py`)

Travam o contrato do ADR-011 ponta-a-ponta:

**Login (5)**:
- Credenciais válidas → 204 + cookie `homeflix_session` setado
- Persiste 1 row em `access_tokens`
- Set-Cookie com `HttpOnly` e `SameSite=Strict` (asserts no header raw)
- Email desconhecido → 400
- Senha errada → 400

**Logout (2)**:
- Após login → 204 + row deletada hard
- Sem cookie → 401

**Protected route (2)**:
- `GET /users/me` sem cookie → 401
- `GET /users/me` autenticado → 200 + `id == "usr_xxx"` (UUID nunca vaza, ADR-002 enforced)

### Test plan

- [x] `poetry run pytest tests/modules/identity/e2e -v` — **9 passed** primeira tentativa
- [x] `poetry run pytest tests/modules/identity tests/modules/library tests/modules/media` — **1404 passed**, 5 skipped (zero regressão)
- [x] `poetry run ruff check ...` + `ruff format --check ...` — clean

### Próxima slice

8. E2E tests pra `/profiles/*` (CRUD + isolation entre users + switch) + manual smoke (curl roundtrip) + PR de fechamento

## Caveats

- **Lifespan bypass intencional**: testes não entram no `lifespan` do FastAPI; em vez disso, `app.state.container` é populado direto. Tradeoff: cada teste tem DB limpo isolado, ao custo de não exercitar o caminho de startup do container (ex: `init_resources()`). O caminho startup é exercitado no smoke manual + `make dev`.
- **Em-memória single-process**: `StaticPool` mantém a SQLite ":memory:" entre conexões. Não funcionaria em testes paralelos com `pytest-xdist` em workers separados — não é caso atualmente.
- **`WIRED_ROUTE_MODULES` é tupla pública** agora. Se um BC novo adicionar router com `@inject`, **precisa** ser adicionado nessa lista — caso contrário routes funcionam mas `Provide[...]` não resolve. Smoke test em `make test` pega isso porque qualquer route DI-quebrado falha em `e2e/conftest.py` igual em prod.

## Related

- ADR-011 — cookie + DatabaseStrategy + HttpOnly + SameSite=Strict, hard DELETE no logout
- ADR-002 — `GET /users/me` retorna `usr_xxx`, não UUID

## Summary by Sourcery

Introduce reusable end-to-end test scaffolding for the identity bounded context and cover the cookie-based auth flow with E2E tests.

New Features:
- Expose WIRED_ROUTE_MODULES in the main app to share DI wiring between runtime and tests.
- Add httpx-based E2E tests for cookie login, logout, and /users/me in the identity module.

Enhancements:
- Refactor DI container wiring in the FastAPI lifespan to use the shared WIRED_ROUTE_MODULES constant.