### PR TITLE
feat(identity): profile e2e tests + accept ADRs (8/8)

### DIFF
--- a/docs/adr/ADR-010-identity-bounded-context.md
+++ b/docs/adr/ADR-010-identity-bounded-context.md
@@ -1,6 +1,6 @@
 # ADR-010: Identity Bounded Context — User, Profile and Context Passing
 
-**Status:** Proposto
+**Status:** Aceito
 **Data:** 2026-05-03
 **Deciders:** Lucas Cristovam
 **Technical Story:** Introdução de autenticação e personalização ao HomeFlix — habilitar múltiplos usuários com login próprio, perfis de personalização (estilo Netflix) e isolamento de dados de uso (`watch_progress`, `collections`, `preferences`) por perfil.
@@ -187,3 +187,4 @@ A sequência de PRs implementando esta decisão (foundation do BC `identity` →
 | Data | Autor | Mudança |
 |------|-------|---------|
 | 2026-05-03 | Lucas Cristovam | Criação inicial |
+| 2026-05-03 | Lucas Cristovam | Promovido para `Aceito` após implementação do BC `identity` (PRs 163-170: domain, models, persistence, use cases, FastAPI Users wiring, routes, e2e). |

--- a/docs/adr/ADR-011-authentication-strategy.md
+++ b/docs/adr/ADR-011-authentication-strategy.md
@@ -1,6 +1,6 @@
 # ADR-011: Authentication Strategy — Server-Side Session via HttpOnly Cookie
 
-**Status:** Proposto
+**Status:** Aceito
 **Data:** 2026-05-03
 **Deciders:** Lucas Cristovam
 **Technical Story:** Descendente direto do ADR-010 — define a estratégia de transport e storage de sessão para o bounded context `identity` introduzido lá.
@@ -212,3 +212,4 @@ Browsers continuam autenticando via cookie; clients que não suportam cookies (e
 | Data | Autor | Mudança |
 |------|-------|---------|
 | 2026-05-03 | Lucas Cristovam | Criação inicial |
+| 2026-05-03 | Lucas Cristovam | Promovido para `Aceito` após implementação do auth backend e e2e tests do fluxo cookie + DB session (login/logout/Set-Cookie/`Max-Age=0`). |

--- a/tests/modules/identity/e2e/test_profile_routes.py
+++ b/tests/modules/identity/e2e/test_profile_routes.py
@@ -1,0 +1,277 @@
+"""End-to-end tests for the profile routes.
+
+Drives ``/api/v1/profiles`` (CRUD + switch) over the same in-process
+ASGI transport set up in ``conftest.py``. Covers the happy path,
+ownership isolation between distinct users, the can't-delete-last
+invariant, and the session-row update on profile switch.
+"""
+
+from collections.abc import Awaitable, Callable
+
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.modules.identity.infrastructure.persistence.models.access_token_model import (
+    AccessTokenModel,
+)
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
+from tests.modules.identity.e2e.conftest import SeededUser
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+PROFILES_PATH = "/api/v1/profiles"
+
+
+async def _login(client: AsyncClient, user: SeededUser) -> None:
+    response = await client.post(
+        LOGIN_PATH,
+        data={"username": user.email, "password": user.password},
+    )
+    assert response.status_code == 204
+
+
+async def _get_active_profile_uuid(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> object | None:
+    async with session_factory() as session:
+        result = await session.execute(select(AccessTokenModel.current_profile_id))
+        return result.scalar_one_or_none()
+
+
+async def _profile_uuid_for_external(
+    session_factory: async_sessionmaker[AsyncSession],
+    external_id: str,
+) -> object | None:
+    async with session_factory() as session:
+        result = await session.execute(
+            select(ProfileModel.id).where(ProfileModel.external_id == external_id)
+        )
+        return result.scalar_one_or_none()
+
+
+class TestListProfiles:
+    async def test_should_return_owned_profiles_with_prefixed_ids(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile(profile_name="Lucas")
+        await _login(client, user)
+
+        response = await client.get(PROFILES_PATH)
+
+        assert response.status_code == 200
+        body = response.json()
+        items = body["data"]
+        assert len(items) == 1
+        assert items[0]["id"] == user.profile_external_id
+        assert items[0]["id"].startswith("prf_")
+        assert items[0]["name"] == "Lucas"
+        assert items[0]["user_id"] == user.user_external_id
+
+    async def test_should_return_401_when_unauthenticated(self, client: AsyncClient):
+        response = await client.get(PROFILES_PATH)
+        assert response.status_code == 401
+
+
+class TestCreateProfile:
+    async def test_should_return_201_and_persist_profile_owned_by_caller(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        response = await client.post(
+            PROFILES_PATH,
+            json={"name": "Kids", "is_kids": True},
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["type"] == "profile"
+        created = body["data"]
+        assert created["id"].startswith("prf_")
+        assert created["user_id"] == user.user_external_id
+        assert created["name"] == "Kids"
+        assert created["is_kids"] is True
+
+        # Listing now returns 2 profiles for this user.
+        listing = (await client.get(PROFILES_PATH)).json()["data"]
+        assert len(listing) == 2
+
+    async def test_should_reject_blank_name(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        response = await client.post(PROFILES_PATH, json={"name": ""})
+
+        # Pydantic schema rejects empty name (min_length=1) -> 422.
+        assert response.status_code == 422
+
+
+class TestUpdateProfile:
+    async def test_should_apply_partial_update(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile(profile_name="Old")
+        await _login(client, user)
+
+        response = await client.put(
+            f"{PROFILES_PATH}/{user.profile_external_id}",
+            json={"name": "New"},
+        )
+
+        assert response.status_code == 200
+        updated = response.json()["data"]
+        assert updated["id"] == user.profile_external_id
+        assert updated["name"] == "New"
+        # is_kids unchanged because it was not supplied
+        assert updated["is_kids"] is False
+
+    async def test_should_return_404_when_profile_does_not_exist(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        response = await client.put(
+            f"{PROFILES_PATH}/prf_xXxXxXxXxXxX",
+            json={"name": "Whatever"},
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteProfile:
+    async def test_should_return_204_when_user_has_more_than_one_profile(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile(profile_name="Keep")
+        await _login(client, user)
+        # Create a second profile so deletion does not hit the last-profile guard.
+        created = (await client.post(PROFILES_PATH, json={"name": "Doomed"})).json()["data"]
+
+        response = await client.delete(f"{PROFILES_PATH}/{created['id']}")
+
+        assert response.status_code == 204
+        listing = (await client.get(PROFILES_PATH)).json()["data"]
+        assert {p["name"] for p in listing} == {"Keep"}
+
+    async def test_should_return_409_when_deleting_last_profile(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        response = await client.delete(f"{PROFILES_PATH}/{user.profile_external_id}")
+
+        # ``CannotDeleteLastProfileError`` -> HTTP 409 (Conflict).
+        assert response.status_code == 409
+
+
+class TestSwitchProfile:
+    async def test_should_persist_current_profile_id_on_session_row(
+        self,
+        client: AsyncClient,
+        session_factory: async_sessionmaker[AsyncSession],
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await _login(client, user)
+        # Sanity: a fresh login row has no active profile yet.
+        assert await _get_active_profile_uuid(session_factory) is None
+
+        response = await client.post(f"{PROFILES_PATH}/{user.profile_external_id}/switch")
+
+        assert response.status_code == 204
+        active_uuid = await _get_active_profile_uuid(session_factory)
+        expected_uuid = await _profile_uuid_for_external(session_factory, user.profile_external_id)
+        assert active_uuid == expected_uuid
+
+    async def test_should_return_404_when_target_profile_does_not_exist(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        response = await client.post(f"{PROFILES_PATH}/prf_xXxXxXxXxXxX/switch")
+        assert response.status_code == 404
+
+
+class TestProfileIsolation:
+    async def test_list_should_not_include_other_users_profiles(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        # Two distinct users, each with one profile.
+        alice = await seed_user_with_profile(email="alice@example.com", profile_name="Alice")
+        bob = await seed_user_with_profile(email="bob@example.com", profile_name="Bob")
+
+        # Log in as Alice and verify she only sees her own profile.
+        await _login(client, alice)
+        listing = (await client.get(PROFILES_PATH)).json()["data"]
+
+        assert len(listing) == 1
+        assert listing[0]["id"] == alice.profile_external_id
+        assert listing[0]["id"] != bob.profile_external_id
+
+    async def test_should_return_403_when_updating_another_users_profile(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        alice = await seed_user_with_profile(email="alice@example.com", profile_name="Alice")
+        bob = await seed_user_with_profile(email="bob@example.com", profile_name="Bob")
+
+        # Alice tries to rename Bob's profile.
+        await _login(client, alice)
+        response = await client.put(
+            f"{PROFILES_PATH}/{bob.profile_external_id}",
+            json={"name": "Hijacked"},
+        )
+
+        assert response.status_code == 403
+
+    async def test_should_return_403_when_deleting_another_users_profile(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        alice = await seed_user_with_profile(email="alice@example.com", profile_name="Alice")
+        bob = await seed_user_with_profile(email="bob@example.com", profile_name="Bob")
+
+        await _login(client, alice)
+        response = await client.delete(f"{PROFILES_PATH}/{bob.profile_external_id}")
+
+        assert response.status_code == 403
+
+    async def test_should_return_403_when_switching_to_another_users_profile(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        alice = await seed_user_with_profile(email="alice@example.com", profile_name="Alice")
+        bob = await seed_user_with_profile(email="bob@example.com", profile_name="Bob")
+
+        await _login(client, alice)
+        response = await client.post(f"{PROFILES_PATH}/{bob.profile_external_id}/switch")
+
+        assert response.status_code == 403

--- a/tests/modules/identity/e2e/test_profile_routes.py
+++ b/tests/modules/identity/e2e/test_profile_routes.py
@@ -6,12 +6,14 @@ ownership isolation between distinct users, the can't-delete-last
 invariant, and the session-row update on profile switch.
 """
 
+import uuid
 from collections.abc import Awaitable, Callable
 
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from src.modules.identity.domain.value_objects.profile_id import ProfileId
 from src.modules.identity.infrastructure.persistence.models.access_token_model import (
     AccessTokenModel,
 )
@@ -34,7 +36,8 @@ async def _login(client: AsyncClient, user: SeededUser) -> None:
 
 async def _get_active_profile_uuid(
     session_factory: async_sessionmaker[AsyncSession],
-) -> object | None:
+) -> uuid.UUID | None:
+    """Return ``access_tokens.current_profile_id`` for the seeded session."""
     async with session_factory() as session:
         result = await session.execute(select(AccessTokenModel.current_profile_id))
         return result.scalar_one_or_none()
@@ -43,7 +46,8 @@ async def _get_active_profile_uuid(
 async def _profile_uuid_for_external(
     session_factory: async_sessionmaker[AsyncSession],
     external_id: str,
-) -> object | None:
+) -> uuid.UUID | None:
+    """Resolve a prefixed ``ProfileId`` to the matching internal UUID."""
     async with session_factory() as session:
         result = await session.execute(
             select(ProfileModel.id).where(ProfileModel.external_id == external_id)
@@ -145,9 +149,12 @@ class TestUpdateProfile:
     ):
         user = await seed_user_with_profile()
         await _login(client, user)
+        # Generate a syntactically valid prefixed ID that is guaranteed
+        # not to collide with any seeded row (12 chars of random base62).
+        unknown_id = ProfileId.generate().value
 
         response = await client.put(
-            f"{PROFILES_PATH}/prf_xXxXxXxXxXxX",
+            f"{PROFILES_PATH}/{unknown_id}",
             json={"name": "Whatever"},
         )
         assert response.status_code == 404
@@ -210,8 +217,9 @@ class TestSwitchProfile:
     ):
         user = await seed_user_with_profile()
         await _login(client, user)
+        unknown_id = ProfileId.generate().value
 
-        response = await client.post(f"{PROFILES_PATH}/prf_xXxXxXxXxXxX/switch")
+        response = await client.post(f"{PROFILES_PATH}/{unknown_id}/switch")
         assert response.status_code == 404
 
 


### PR DESCRIPTION
## Summary

**Slice 8 de 8 — final** da entrega do BC `identity`. Fecha o loop end-to-end com 14 testes HTTP do surface de profiles (CRUD + isolation + switch), e promove **ADR-010** e **ADR-011** de `Proposto` para `Aceito` agora que cada decisão neles está implementada e exercitada em teste.

A implementação completa do BC `identity` foi entregue ao longo de 8 PRs sequenciais (#163 → #170, esta inclusa).

### Conteúdo

**Profile E2E (14 testes)** — drive o mesmo ASGI transport in-process das auth tests:

| Classe | Casos |
|---|---|
| `TestListProfiles` | 200 com `prf_xxx` ids restritos ao caller; 401 sem login |
| `TestCreateProfile` | 201 + persistência + listing reflete novo row; 422 pra name vazio (Pydantic min_length=1) |
| `TestUpdateProfile` | 200 partial update (só campos supplied tocam); 404 pra target desconhecido |
| `TestDeleteProfile` | 204 quando user tem >1 profile; 409 pra last-profile guard |
| `TestSwitchProfile` | 204 + `access_tokens.current_profile_id` atualizado; 404 pra target desconhecido |
| `TestProfileIsolation` | Alice + Bob: lista isolada; update/delete/switch no profile alheio → 403 |

**ADRs promovidos**:
- ADR-010 (identity boundary, ID strategy, explicit `profile_id` propagation): `Proposto` → `Aceito`
- ADR-011 (cookie + DatabaseStrategy + 90d fixed lifetime + HttpOnly + SameSite=Strict): `Proposto` → `Aceito`
- Histórico de revisões aponta pros PRs 163-170

### Test plan

- [x] `poetry run pytest tests/modules/identity/e2e/test_profile_routes.py -v` — **14 passed** primeira tentativa
- [x] `poetry run pytest tests/modules/identity tests/modules/library tests/modules/media` — **1420 passed**, 5 skipped
- [x] `poetry run ruff check ...` + `ruff format --check ...` — clean

**Manual smoke (após merge — pra você executar):**

```bash
# 1. Bootstrap admin
poetry run python scripts/identity_create_admin.py
# (prompt: email, senha 8+ chars, nome do profile)

# 2. Login
curl -i -c /tmp/cookies.txt \
  -X POST http://localhost:8005/api/v1/auth/cookie/login \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "username=<email>&password=<senha>"
# Esperado: 204 + Set-Cookie: homeflix_session=...; HttpOnly; SameSite=strict

# 3. /me retorna prefixed external_id
curl -b /tmp/cookies.txt http://localhost:8005/api/v1/users/me
# Esperado: {"type":"user","data":{"id":"usr_xxx",...}}

# 4. Listar profiles
curl -b /tmp/cookies.txt http://localhost:8005/api/v1/profiles
# Esperado: {"data":[{"id":"prf_xxx","name":"Admin",...}]}

# 5. Switch profile
curl -b /tmp/cookies.txt -X POST \
  http://localhost:8005/api/v1/profiles/prf_xxx/switch
# Esperado: 204; sqlite verifica access_tokens.current_profile_id

# 6. Logout
curl -b /tmp/cookies.txt -X POST http://localhost:8005/api/v1/auth/cookie/logout
# Esperado: 204; access_tokens row deletada
```

## Resumo da entrega completa do BC `identity`

| Slice | PR | Conteúdo |
|---|---|---|
| 1 | #163 | Domain foundation: 5 VOs, 2 entities, errors, rule_codes, `BaseWithUUID`/`BaseSecret` refactor |
| 2 | #164 | Models + alembic migration (users/profiles/access_tokens) |
| 3 | #165 | Repositories + mappers + UoW + integration tests |
| 4 | #166 | 5 use cases (Create/List/Update/Delete/Switch) + unit tests |
| 5 | #167 | FastAPI Users wiring + IdentityContainer + main.py + auth backend |
| 6 | #168 | Custom routes (/me, /profiles/*) + get_current_profile + CLI bootstrap |
| 7 | #169 | E2E scaffolding + auth tests |
| 8 | **esta** | E2E profile tests + ADRs aceitos |

**Tests totais**: 121 unit + integration + 25 e2e = **146 testes do identity** + 1274 outros = **1420 total**, zero regressões.

**Próximos PRs (não nesta entrega)** — começam a integrar identity com os outros BCs:
- PR 2 do plano original: `ProfileLookupPort` em `watch_progress`/`collections`/`preferences`
- PR 3-5: refactor de cada BC consumidor pra ganhar `profile_id` (com feature flags conforme acordado)
- PR 6: library ACL via `allowed_library_ids` no Profile
- PR frontend (`homeflix-web`): tela de login + profile picker

## Related

- ADR-010 (Identity Bounded Context) — agora `Aceito`
- ADR-011 (Authentication Strategy) — agora `Aceito`
- Plano de implementação: `/home/lucas/.claude/plans/crispy-churning-ripple.md`

## Summary by Sourcery

Add end-to-end coverage for profile HTTP routes and formalize identity/authentication architecture decisions as accepted ADRs.

Documentation:
- Promote ADR-010 (identity bounded context) and ADR-011 (authentication strategy) from proposed to accepted, documenting completion of the identity bounded context and cookie-based auth implementation.

Tests:
- Add 14 in-process ASGI end-to-end tests covering profile CRUD, profile switching, last-profile deletion guard, and cross-user isolation for profile routes.