### PR TITLE
feat(watch_progress): scope WatchProgress per profile (PR 3)

### DIFF
--- a/migrations/versions/2026_05_03_add_profile_id_to_watch_progress.py
+++ b/migrations/versions/2026_05_03_add_profile_id_to_watch_progress.py
@@ -1,0 +1,138 @@
+"""Add profile_id to watch_progresses, scope by (profile_id, media_id).
+
+Per ADR-010, every personalisation row is scoped to a profile. This
+migration adds ``watch_progresses.profile_id`` (the prefixed external
+ID — no FK because cross-BC references travel as strings, not UUIDs)
+and replaces the single-column UNIQUE(media_id) with a composite
+UNIQUE(profile_id, media_id) so multiple profiles in the same
+household can watch the same title independently.
+
+Sequence (so existing dev data survives):
+
+1. ADD COLUMN profile_id NULLABLE — schema accepts NULL for the
+   handful of legacy rows already present.
+2. UPDATE the legacy rows with the first profile's external_id —
+   requires that ``scripts/identity_create_admin.py`` was run before
+   the upgrade so at least one profile exists. Migration aborts with
+   a clear message if not.
+3. ALTER COLUMN profile_id NOT NULL.
+4. DROP UNIQUE(media_id) and CREATE UNIQUE(profile_id, media_id).
+
+Revision ID: d6e7f8a9b0c1
+Revises: c5d6e7f8a9b0
+Create Date: 2026-05-03 18:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "d6e7f8a9b0c1"
+down_revision: str | Sequence[str] | None = "c5d6e7f8a9b0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _resolve_default_profile_external_id(connection: sa.Connection) -> str:
+    """Return the prefixed external_id of the oldest active profile.
+
+    Aborts with a clear ``RuntimeError`` if no profile exists so the
+    operator runs ``scripts/identity_create_admin.py`` first instead
+    of getting a generic NOT NULL violation.
+    """
+    row = connection.execute(
+        sa.text(
+            "SELECT external_id "
+            "FROM profiles "
+            "WHERE deleted_at IS NULL "
+            "ORDER BY created_at ASC "
+            "LIMIT 1"
+        )
+    ).first()
+    if row is None:
+        msg = (
+            "Cannot backfill watch_progresses.profile_id: no active profile "
+            "exists. Run `python scripts/identity_create_admin.py` to create "
+            "an admin user and default profile, then re-run this migration."
+        )
+        raise RuntimeError(msg)
+    return row[0]
+
+
+def upgrade() -> None:
+    """Add profile_id, backfill, drop legacy unique, add composite unique."""
+    bind = op.get_bind()
+
+    # Step 1: ADD COLUMN NULLABLE so existing rows survive the schema change.
+    with op.batch_alter_table("watch_progresses") as batch_op:
+        batch_op.add_column(
+            sa.Column("profile_id", sa.String(length=50), nullable=True),
+        )
+
+    # Step 2: backfill legacy rows with the oldest active profile.
+    legacy_rows = bind.execute(
+        sa.text("SELECT COUNT(*) FROM watch_progresses WHERE profile_id IS NULL")
+    ).scalar_one()
+    if legacy_rows:
+        default_profile = _resolve_default_profile_external_id(bind)
+        bind.execute(
+            sa.text("UPDATE watch_progresses " "SET profile_id = :pid " "WHERE profile_id IS NULL"),
+            {"pid": default_profile},
+        )
+
+    # Step 3: tighten the column + replace the legacy media_id unique with a
+    # composite (profile_id, media_id) unique so multiple profiles can watch
+    # the same title independently.
+    with op.batch_alter_table("watch_progresses") as batch_op:
+        batch_op.alter_column(
+            "profile_id",
+            existing_type=sa.String(length=50),
+            nullable=False,
+        )
+        # The legacy schema declared media_id as UNIQUE; SQLAlchemy named the
+        # implicit constraint after the column but the original column had
+        # ``unique=True`` so dialects vary. Drop both shapes defensively.
+        batch_op.drop_index("ix_watch_progresses_media_id")
+        batch_op.create_index(
+            "ix_watch_progresses_media_id",
+            ["media_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "ix_watch_progresses_profile_id",
+            ["profile_id"],
+            unique=False,
+        )
+        batch_op.create_unique_constraint(
+            "uq_watch_progresses_profile_media",
+            ["profile_id", "media_id"],
+        )
+
+
+def downgrade() -> None:
+    """Reverse the schema change.
+
+    Drops the composite unique, restores the single-column unique on
+    media_id, and removes the profile_id column. Note: this loses
+    profile scoping data — only safe in dev.
+    """
+    with op.batch_alter_table("watch_progresses") as batch_op:
+        batch_op.drop_constraint(
+            "uq_watch_progresses_profile_media",
+            type_="unique",
+        )
+        batch_op.drop_index("ix_watch_progresses_profile_id")
+        batch_op.drop_index("ix_watch_progresses_media_id")
+        batch_op.create_index(
+            "ix_watch_progresses_media_id",
+            ["media_id"],
+            unique=True,
+        )
+        batch_op.drop_column("profile_id")

--- a/migrations/versions/2026_05_03_add_profile_id_to_watch_progress.py
+++ b/migrations/versions/2026_05_03_add_profile_id_to_watch_progress.py
@@ -87,19 +87,38 @@ def upgrade() -> None:
             {"pid": default_profile},
         )
 
-    # Step 3: tighten the column + replace the legacy media_id unique with a
-    # composite (profile_id, media_id) unique so multiple profiles can watch
-    # the same title independently.
+    # Step 3: tighten the column and replace the legacy single-column
+    # uniqueness with a composite ``(profile_id, media_id)`` so multiple
+    # profiles can watch the same title independently.
+    #
+    # The legacy model had ``media_id`` declared with ``unique=True,
+    # index=True``. How that resolved to DDL depends on the dialect:
+    #
+    # - SQLite: an implicit UNIQUE inside the CREATE TABLE plus a
+    #   separate ``ix_watch_progresses_media_id`` index. ``batch_alter_table``
+    #   on SQLite does a table-rebuild against the current model, so the
+    #   legacy UNIQUE is effectively dropped automatically; the explicit
+    #   ``DROP INDEX IF EXISTS`` here only handles the secondary index.
+    # - Postgres: a named UNIQUE constraint plus the index. ``DROP INDEX
+    #   IF EXISTS`` is necessary; the UNIQUE is dropped by name. We don't
+    #   know what alembic auto-named the constraint historically, so the
+    #   ``execute(...)`` block below tries the conventional names.
+    op.execute("DROP INDEX IF EXISTS ix_watch_progresses_media_id")
+    if op.get_context().dialect.name == "postgresql":
+        op.execute(
+            "ALTER TABLE watch_progresses "
+            "DROP CONSTRAINT IF EXISTS watch_progresses_media_id_key"
+        )
+        op.execute(
+            "ALTER TABLE watch_progresses " "DROP CONSTRAINT IF EXISTS uq_watch_progresses_media_id"
+        )
+
     with op.batch_alter_table("watch_progresses") as batch_op:
         batch_op.alter_column(
             "profile_id",
             existing_type=sa.String(length=50),
             nullable=False,
         )
-        # The legacy schema declared media_id as UNIQUE; SQLAlchemy named the
-        # implicit constraint after the column but the original column had
-        # ``unique=True`` so dialects vary. Drop both shapes defensively.
-        batch_op.drop_index("ix_watch_progresses_media_id")
         batch_op.create_index(
             "ix_watch_progresses_media_id",
             ["media_id"],

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -79,6 +79,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     _progress_lookup_adapter = providers.Factory(
         ProgressLookupAdapter,
         watch_progress_uow_factory=_watch_progress_uow_factory_for_progress_lookup,
+        default_profile_id=config.provided.watch_progress_default_profile_id,
     )
 
     # Catalog Requests is built before Media so its ACL adapter can be

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -270,6 +270,16 @@ class Settings(BaseSettings):  # type: ignore[misc]
     )
     session_cookie_name: str = Field(default="homeflix_session")
 
+    watch_progress_default_profile_id: str | None = Field(
+        default=None,
+        description="Optional fallback ``profile_id`` (``prf_xxx``) used "
+        "by watch-progress/media routes when the request has no session "
+        "cookie. Lets the backend keep serving consumers that have not "
+        "shipped login yet during the per-profile rollout. Unset = strict "
+        "mode (no cookie -> 401). Remove the env var once every consumer "
+        "is sending the session cookie.",
+    )
+
     # =========================================================================
     # Internationalization
     # =========================================================================

--- a/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
+++ b/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
@@ -3,6 +3,19 @@
 This is the only file in the Media BC that imports from the Watch
 Progress BC. Above the adapter, the use cases only see
 ``ProgressSummary``.
+
+Per ADR-010, watch_progress is now scoped per profile. The
+``ProgressLookupPort`` interface still doesn't carry a profile
+parameter (Media routes have not been refactored to thread
+``profile_id`` through their use cases yet), so the adapter applies
+``settings.watch_progress_default_profile_id`` to every query during
+the transition. When the setting is unset, the adapter degrades
+gracefully — every call returns an empty map so Media routes simply
+do not enrich responses with progress information.
+
+Once Media's use cases gain ``profile_id`` in their inputs (a follow-up
+PR), the port and this adapter will gain a ``profile_id`` parameter
+and the default fallback will be removed.
 """
 
 from collections.abc import Sequence
@@ -14,23 +27,35 @@ from src.modules.media.application.ports.progress_lookup_port import (
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class ProgressLookupAdapter(ProgressLookupPort):
     """Resolve progress snapshots via the Watch Progress Unit of Work."""
 
-    def __init__(self, watch_progress_uow_factory: WatchProgressUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        watch_progress_uow_factory: WatchProgressUnitOfWorkFactory,
+        default_profile_id: str | None,
+    ) -> None:
         self._watch_progress_uow_factory = watch_progress_uow_factory
+        self._default_profile_id = default_profile_id
 
     async def find_for_media_ids(
         self,
         media_ids: Sequence[str],
     ) -> dict[str, ProgressSummary]:
-        """Fetch progress rows and project each into a ``ProgressSummary``."""
-        if not media_ids:
+        """Fetch progress rows scoped to the configured default profile.
+
+        Returns an empty map when the default profile is unset so the
+        consumer can still serve responses without progress
+        enrichment during strict-mode rollout.
+        """
+        if not media_ids or self._default_profile_id is None:
             return {}
+        profile_id = ProfileId(self._default_profile_id)
         async with self._watch_progress_uow_factory() as uow:
-            progress_map = await uow.progress.find_by_media_ids(list(media_ids))
+            progress_map = await uow.progress.find_by_media_ids(list(media_ids), profile_id)
         return {
             media_id: ProgressSummary(
                 media_id=media_id,

--- a/src/modules/watch_progress/application/dtos/progress_dtos.py
+++ b/src/modules/watch_progress/application/dtos/progress_dtos.py
@@ -14,6 +14,9 @@ class SaveProgressInput:
     """Input for SaveProgressUseCase.
 
     Attributes:
+        profile_id: Owning profile (``prf_xxx``) — every row is scoped
+            to a single profile so multi-profile households watch
+            independently.
         media_id: External ID of the media (mov_xxx or epi_xxx).
         media_type: Type of media ("movie" or "episode").
         position_seconds: Current playback position in seconds.
@@ -22,6 +25,7 @@ class SaveProgressInput:
         subtitle_track: Selected subtitle track index (-1 = off).
     """
 
+    profile_id: str
     media_id: str
     media_type: str
     position_seconds: int
@@ -32,30 +36,15 @@ class SaveProgressInput:
 
 @dataclass(frozen=True)
 class GetProgressInput:
-    """Input for GetProgressUseCase.
+    """Input for GetProgressUseCase."""
 
-    Attributes:
-        media_id: External ID of the media.
-    """
-
+    profile_id: str
     media_id: str
 
 
 @dataclass(frozen=True)
 class ProgressOutput:
-    """Output representing watch progress for a media item.
-
-    Attributes:
-        media_id: External ID of the media.
-        media_type: Type of media.
-        position_seconds: Current playback position.
-        duration_seconds: Total duration.
-        percentage: Watch percentage (0-100).
-        status: Watch status ("in_progress" or "completed").
-        audio_track: Selected audio track index.
-        subtitle_track: Selected subtitle track index.
-        last_watched_at: ISO timestamp of last update.
-    """
+    """Output representing watch progress for a media item."""
 
     media_id: str
     media_type: str
@@ -85,31 +74,16 @@ class ProgressOutput:
 
 @dataclass(frozen=True)
 class GetContinueWatchingInput:
-    """Input for GetContinueWatchingUseCase.
+    """Input for GetContinueWatchingUseCase."""
 
-    Attributes:
-        limit: Maximum number of items to return.
-        lang: Language code for localized metadata.
-    """
-
+    profile_id: str
     limit: int = 20
     lang: str = "en"
 
 
 @dataclass(frozen=True)
 class ContinueWatchingItem:
-    """A single item in the continue watching list.
-
-    Attributes:
-        media_id: External ID of the media.
-        media_type: Type of media.
-        title: Display title (localized).
-        poster_path: URL to poster image.
-        position_seconds: Current playback position.
-        duration_seconds: Total duration.
-        percentage: Watch percentage.
-        last_watched_at: ISO timestamp of last update.
-    """
+    """A single item in the continue watching list."""
 
     media_id: str
     media_type: str
@@ -128,10 +102,6 @@ class ContinueWatchingItem:
 
 @dataclass(frozen=True)
 class ContinueWatchingOutput:
-    """Output for GetContinueWatchingUseCase.
-
-    Attributes:
-        items: List of continue watching items.
-    """
+    """Output for GetContinueWatchingUseCase."""
 
     items: list[ContinueWatchingItem]

--- a/src/modules/watch_progress/application/use_cases/clear_progress.py
+++ b/src/modules/watch_progress/application/use_cases/clear_progress.py
@@ -5,41 +5,30 @@ from dataclasses import dataclass
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 @dataclass(frozen=True)
 class ClearProgressInput:
-    """Input for ClearProgressUseCase.
+    """Input for ClearProgressUseCase."""
 
-    Attributes:
-        media_id: External ID of the media.
-    """
-
+    profile_id: str
     media_id: str
 
 
 class ClearProgressUseCase:
-    """Clear (soft-delete) watch progress for a media item."""
+    """Clear (soft-delete) watch progress for a media item in one profile."""
 
     def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh watch progress UoW.
-        """
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ClearProgressInput) -> bool:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains the media_id to clear.
-
-        Returns:
-            True if progress was found and deleted, False otherwise.
-        """
+        """Soft-delete the row, returning ``True`` when one was found."""
         async with self._uow_factory() as uow:
-            return await uow.progress.delete(input_dto.media_id)
+            return await uow.progress.delete(
+                input_dto.media_id,
+                ProfileId(input_dto.profile_id),
+            )
 
 
-__all__ = ["ClearProgressUseCase"]
+__all__ = ["ClearProgressInput", "ClearProgressUseCase"]

--- a/src/modules/watch_progress/application/use_cases/clear_series_progress.py
+++ b/src/modules/watch_progress/application/use_cases/clear_series_progress.py
@@ -5,42 +5,37 @@ from dataclasses import dataclass
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 @dataclass(frozen=True)
 class ClearSeriesProgressInput:
-    """Input for ClearSeriesProgressUseCase.
+    """Input for ClearSeriesProgressUseCase."""
 
-    Attributes:
-        series_id: External series ID (``ser_xxx`` format).
-    """
-
+    profile_id: str
     series_id: str
 
 
 class ClearSeriesProgressUseCase:
-    """Soft-delete all episode progress entries for a series.
+    """Soft-delete every episode progress for a series in one profile.
 
     Used by the "dismiss from Continue Watching" action so that
     removing a series clears ALL its episode progress at once —
     otherwise deleting one episode's progress just surfaces the
-    next in-progress episode and the series reappears.
+    next in-progress episode and the series reappears. The deletion
+    only touches rows owned by the caller's profile.
     """
 
     def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ClearSeriesProgressInput) -> int:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains the series_id.
-
-        Returns:
-            Number of episode progress records soft-deleted.
-        """
+        """Soft-delete every episode-progress row for the series, return count."""
         async with self._uow_factory() as uow:
-            return await uow.progress.delete_by_series(input_dto.series_id)
+            return await uow.progress.delete_by_series(
+                input_dto.series_id,
+                ProfileId(input_dto.profile_id),
+            )
 
 
-__all__ = ["ClearSeriesProgressUseCase"]
+__all__ = ["ClearSeriesProgressInput", "ClearSeriesProgressUseCase"]

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -17,6 +17,7 @@ from src.modules.watch_progress.domain.value_objects import (
     WatchStatus,
 )
 from src.shared_kernel.episode_composite_id import EpisodeCompositeId
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -70,19 +71,15 @@ class GetContinueWatchingUseCase:
         self._selector = selector or ContinueWatchingSelector()
 
     async def execute(self, input_dto: GetContinueWatchingInput) -> ContinueWatchingOutput:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains limit and language.
-
-        Returns:
-            ContinueWatchingOutput with items including media metadata.
-        """
+        """Execute the use case for the caller's profile."""
+        profile_id = ProfileId(input_dto.profile_id)
         items: list[ContinueWatchingItem] = []
         seen_series: set[str] = set()
 
         async with self._uow_factory() as uow:
-            progress_list = await uow.progress.list_recently_watched(limit=input_dto.limit)
+            progress_list = await uow.progress.list_recently_watched(
+                profile_id, limit=input_dto.limit
+            )
 
             for progress in progress_list:
                 if progress.media_type == WatchableMediaType.MOVIE:
@@ -100,6 +97,7 @@ class GetContinueWatchingUseCase:
                         uow,
                         parsed.series_id,
                         input_dto.lang,
+                        profile_id,
                     )
                     if item:
                         items.append(item)
@@ -111,13 +109,14 @@ class GetContinueWatchingUseCase:
         uow: WatchProgressUnitOfWork,
         series_id: str,
         lang: str,
+        profile_id: ProfileId,
     ) -> ContinueWatchingItem | None:
         """Fetch series metadata, build candidates, pick one, project to a DTO."""
         series = await self._media_lookup.get_series_with_episodes(series_id, lang)
         if not series:
             return None
 
-        candidates = await self._build_candidates(uow, series_id, series)
+        candidates = await self._build_candidates(uow, series_id, series, profile_id)
         if not candidates:
             return None
 
@@ -132,6 +131,7 @@ class GetContinueWatchingUseCase:
         uow: WatchProgressUnitOfWork,
         series_id: str,
         series: SeriesWithEpisodesInfo,
+        profile_id: ProfileId,
     ) -> list[EpisodeCandidate]:
         """Translate series episodes + their progress into selector inputs.
 
@@ -151,7 +151,7 @@ class GetContinueWatchingUseCase:
             for ep in series.episodes
         ]
 
-        progress_map = await uow.progress.find_by_media_ids(media_ids)
+        progress_map = await uow.progress.find_by_media_ids(media_ids, profile_id)
 
         return [
             EpisodeCandidate(

--- a/src/modules/watch_progress/application/use_cases/get_progress.py
+++ b/src/modules/watch_progress/application/use_cases/get_progress.py
@@ -2,37 +2,27 @@
 
 from src.modules.watch_progress.application.dtos import GetProgressInput, ProgressOutput
 from src.modules.watch_progress.application.unit_of_work import WatchProgressUnitOfWorkFactory
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class GetProgressUseCase:
-    """Retrieve watch progress for a single media item.
+    """Retrieve watch progress for a single media item, scoped to one profile.
 
-    Returns None if no progress exists (does not raise 404).
-
-    Example:
-        >>> use_case = GetProgressUseCase(uow_factory)
-        >>> result = await use_case.execute(GetProgressInput("mov_abc123def456"))
+    Returns ``None`` if the profile has no progress record for the
+    media — does not raise 404. Other profiles' rows are never
+    visible.
     """
 
     def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh watch progress UoW.
-        """
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: GetProgressInput) -> ProgressOutput | None:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains the media_id to look up.
-
-        Returns:
-            ProgressOutput if found, None otherwise.
-        """
+        """Return the caller's progress for the media, or ``None`` if absent."""
         async with self._uow_factory() as uow:
-            progress = await uow.progress.find_by_media_id(input_dto.media_id)
+            progress = await uow.progress.find_by_media_id(
+                input_dto.media_id,
+                ProfileId(input_dto.profile_id),
+            )
         if progress is None:
             return None
         return ProgressOutput.from_entity(progress)

--- a/src/modules/watch_progress/application/use_cases/save_progress.py
+++ b/src/modules/watch_progress/application/use_cases/save_progress.py
@@ -6,34 +6,20 @@ from src.modules.watch_progress.application.unit_of_work import (
 )
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class SaveProgressUseCase:
-    """Save or update watch progress for a media item.
-
-    Creates a new progress record if none exists, or updates the
-    existing one. Automatically marks as completed at ≥90%.
-    """
+    """Save or update watch progress for a media item, scoped to one profile."""
 
     def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh watch progress UoW.
-        """
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: SaveProgressInput) -> ProgressOutput:
-        """Execute the use case.
-
-        Args:
-            input_dto: Progress data to save.
-
-        Returns:
-            The saved progress output.
-        """
+        """Persist progress for the caller's profile."""
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            existing = await uow.progress.find_by_media_id(input_dto.media_id)
+            existing = await uow.progress.find_by_media_id(input_dto.media_id, profile_id)
 
             if existing:
                 progress = existing.update_position(
@@ -44,6 +30,7 @@ class SaveProgressUseCase:
                 )
             else:
                 progress = WatchProgress.create(
+                    profile_id=profile_id,
                     media_id=input_dto.media_id,
                     media_type=WatchableMediaType(input_dto.media_type),
                     position_seconds=input_dto.position_seconds,

--- a/src/modules/watch_progress/domain/entities/watch_progress.py
+++ b/src/modules/watch_progress/domain/entities/watch_progress.py
@@ -13,6 +13,7 @@ from src.modules.watch_progress.domain.value_objects import (
     WatchableMediaType,
     WatchStatus,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
 _COMPLETION_THRESHOLD = 0.9
 
@@ -35,6 +36,9 @@ class WatchProgress(AggregateRoot[ProgressId]):
     """
 
     id: ProgressId | None = Field(default=None)
+
+    # Owner — every progress row belongs to exactly one profile
+    profile_id: ProfileId
 
     # What is being watched
     media_id: str
@@ -111,6 +115,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
     @classmethod
     def create(
         cls,
+        profile_id: ProfileId,
         media_id: str,
         media_type: WatchableMediaType,
         position_seconds: int,
@@ -121,6 +126,9 @@ class WatchProgress(AggregateRoot[ProgressId]):
         """Factory method with automatic ID generation.
 
         Args:
+            profile_id: Owning profile (``prf_xxx``). Every progress
+                row is scoped to a single profile so multi-profile
+                households watch independently.
             media_id: External ID of the media (mov_xxx or epi_xxx).
             media_type: Type of media ("movie" or "episode").
             position_seconds: Current playback position in seconds.
@@ -137,6 +145,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
 
         return cls(
             id=ProgressId.generate(),
+            profile_id=profile_id,
             media_id=media_id,
             media_type=media_type,
             position_seconds=position_seconds,

--- a/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
@@ -3,29 +3,47 @@
 from abc import ABC, abstractmethod
 
 from src.modules.watch_progress.domain.entities import WatchProgress
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class WatchProgressRepository(ABC):
     """Abstract repository for WatchProgress persistence.
 
+    Every read/delete method takes ``profile_id`` so rows from one
+    profile never leak into another's view (e.g. Continue Watching
+    only shows the caller's own progress). ``save`` reads the
+    ``profile_id`` directly from the entity.
+
     Example:
-        >>> progress = await repo.find_by_media_id("mov_abc123def456")
+        >>> progress = await repo.find_by_media_id(
+        ...     "mov_abc123def456", caller_profile_id
+        ... )
     """
 
     @abstractmethod
-    async def find_by_media_id(self, media_id: str) -> WatchProgress | None:
-        """Find progress by media external ID.
+    async def find_by_media_id(
+        self,
+        media_id: str,
+        profile_id: ProfileId,
+    ) -> WatchProgress | None:
+        """Find progress by media + profile.
 
         Args:
-            media_id: External ID of the media (mov_xxx or epi_xxx).
+            media_id: External ID of the media (``mov_xxx`` or
+                ``epi_xxx``).
+            profile_id: The caller's profile.
 
         Returns:
-            WatchProgress if found, None otherwise.
+            WatchProgress if a row exists for this profile/media,
+            ``None`` otherwise.
         """
 
     @abstractmethod
     async def save(self, progress: WatchProgress) -> WatchProgress:
         """Create or update a watch progress record.
+
+        Profile scoping comes from ``progress.profile_id`` — the
+        caller does not pass it separately.
 
         Args:
             progress: The WatchProgress entity to persist.
@@ -35,59 +53,66 @@ class WatchProgressRepository(ABC):
         """
 
     @abstractmethod
-    async def list_in_progress(self, limit: int = 20) -> list[WatchProgress]:
-        """List in-progress items ordered by last watched (most recent first).
-
-        Args:
-            limit: Maximum number of items to return.
-
-        Returns:
-            List of WatchProgress with status "in_progress".
-        """
+    async def list_in_progress(
+        self,
+        profile_id: ProfileId,
+        limit: int = 20,
+    ) -> list[WatchProgress]:
+        """List in-progress items for the profile, most recent first."""
 
     @abstractmethod
-    async def list_recently_watched(self, limit: int = 20) -> list[WatchProgress]:
-        """List recently watched items (in_progress + completed) ordered by last watched.
-
-        Args:
-            limit: Maximum number of items to return.
-
-        Returns:
-            List of WatchProgress with status "in_progress" or "completed".
-        """
+    async def list_recently_watched(
+        self,
+        profile_id: ProfileId,
+        limit: int = 20,
+    ) -> list[WatchProgress]:
+        """List in-progress + completed items for the profile, recent first."""
 
     @abstractmethod
-    async def find_by_media_ids(self, media_ids: list[str]) -> dict[str, WatchProgress]:
+    async def find_by_media_ids(
+        self,
+        media_ids: list[str],
+        profile_id: ProfileId,
+    ) -> dict[str, WatchProgress]:
         """Find progress for multiple media items in a single query.
 
         Args:
-            media_ids: List of external media IDs.
+            media_ids: List of external media IDs to look up.
+            profile_id: The caller's profile — only their rows match.
 
         Returns:
-            Dict mapping media_id to WatchProgress for found records.
+            Dict mapping ``media_id`` to ``WatchProgress`` for found
+            rows. Missing keys mean no progress exists for that
+            media in this profile.
         """
 
     @abstractmethod
-    async def delete(self, media_id: str) -> bool:
-        """Soft-delete progress for a media item.
+    async def delete(self, media_id: str, profile_id: ProfileId) -> bool:
+        """Soft-delete progress for a media item in this profile.
 
         Args:
             media_id: External ID of the media.
+            profile_id: The caller's profile.
 
         Returns:
-            True if deleted, False if not found.
+            True if a row was deleted, False if not found.
         """
 
     @abstractmethod
-    async def delete_by_series(self, series_id: str) -> int:
-        """Soft-delete all episode progress for a series.
+    async def delete_by_series(
+        self,
+        series_id: str,
+        profile_id: ProfileId,
+    ) -> int:
+        """Soft-delete every episode progress for a series in this profile.
 
         Matches every row whose ``media_id`` starts with
-        ``epi_{series_id}_``, which is the composite-id format
-        produced by ``EpisodeCompositeId.build()``.
+        ``epi_{series_id}_`` (the composite-id format produced by
+        ``EpisodeCompositeId.build()``) and belongs to ``profile_id``.
 
         Args:
             series_id: External series ID (``ser_xxx`` format).
+            profile_id: The caller's profile.
 
         Returns:
             Number of rows soft-deleted.

--- a/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
+++ b/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
@@ -9,10 +9,15 @@ from src.modules.watch_progress.domain.value_objects import (
 from src.modules.watch_progress.infrastructure.persistence.models import (
     WatchProgressModel,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class WatchProgressMapper:
     """Bidirectional mapper between WatchProgress entity and ORM model.
+
+    ``profile_id`` round-trips as the prefixed external ID (``prf_xxx``)
+    on both sides — no UUID translation needed because watch_progress
+    references identity by external ID only (no FK to ``profiles``).
 
     Example:
         >>> model = WatchProgressMapper.to_model(entity)
@@ -21,20 +26,14 @@ class WatchProgressMapper:
 
     @staticmethod
     def to_model(entity: WatchProgress) -> WatchProgressModel:
-        """Convert WatchProgress entity to ORM model.
-
-        Args:
-            entity: The domain entity.
-
-        Returns:
-            SQLAlchemy model ready for persistence.
-        """
+        """Convert WatchProgress entity to ORM model."""
         if entity.id is None:
             msg = "Cannot map entity without ID to model"
             raise ValueError(msg)
 
         return WatchProgressModel(
             external_id=str(entity.id),
+            profile_id=str(entity.profile_id),
             media_id=entity.media_id,
             media_type=entity.media_type,
             position_seconds=entity.position_seconds,
@@ -48,16 +47,10 @@ class WatchProgressMapper:
 
     @staticmethod
     def to_entity(model: WatchProgressModel) -> WatchProgress:
-        """Convert ORM model to WatchProgress entity.
-
-        Args:
-            model: The SQLAlchemy model.
-
-        Returns:
-            Domain WatchProgress entity.
-        """
+        """Convert ORM model to WatchProgress entity."""
         return WatchProgress(
             id=ProgressId(model.external_id),
+            profile_id=ProfileId(model.profile_id),
             media_id=model.media_id,
             media_type=WatchableMediaType(model.media_type),
             position_seconds=model.position_seconds,
@@ -73,14 +66,11 @@ class WatchProgressMapper:
 
     @staticmethod
     def update_model(model: WatchProgressModel, entity: WatchProgress) -> WatchProgressModel:
-        """Update existing ORM model with entity data.
+        """Update existing ORM model with mutable entity fields.
 
-        Args:
-            model: The existing model.
-            entity: The updated entity.
-
-        Returns:
-            The updated model.
+        ``profile_id`` is intentionally not mutated — moving a row
+        between profiles is not a supported operation; the caller
+        should delete and re-create instead.
         """
         model.position_seconds = entity.position_seconds
         model.duration_seconds = entity.duration_seconds

--- a/src/modules/watch_progress/infrastructure/persistence/models/watch_progress_model.py
+++ b/src/modules/watch_progress/infrastructure/persistence/models/watch_progress_model.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Integer, String
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.infrastructure.persistence.base import Base
@@ -11,9 +11,17 @@ from src.infrastructure.persistence.base import Base
 class WatchProgressModel(Base):
     """SQLAlchemy model for WatchProgress.
 
-    Maps to the 'watch_progresses' table. One row per media item.
+    Maps to the 'watch_progresses' table. One row per (profile, media)
+    pair — different profiles in the same household watch the same
+    title independently.
+
+    ``profile_id`` is stored as the prefixed external ID (``prf_xxx``)
+    rather than the database UUID — cross-BC references never traverse
+    UUIDs (per ADR-008), and watch_progress only needs the string
+    identity for scoping queries (no JOIN to ``profiles`` is required).
 
     Attributes:
+        profile_id: Owning profile's prefixed external ID.
         media_id: External ID of the media (mov_xxx or epi_xxx).
         media_type: Type of media ("movie" or "episode").
         position_seconds: Current playback position.
@@ -25,7 +33,16 @@ class WatchProgressModel(Base):
         completed_at: Timestamp when marked as completed.
     """
 
-    media_id: Mapped[str] = mapped_column(String(50), nullable=False, unique=True, index=True)
+    __table_args__ = (
+        UniqueConstraint(
+            "profile_id",
+            "media_id",
+            name="uq_watch_progresses_profile_media",
+        ),
+    )
+
+    profile_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    media_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     media_type: Mapped[str] = mapped_column(String(20), nullable=False)
     position_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     duration_seconds: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -38,8 +55,9 @@ class WatchProgressModel(Base):
     def __repr__(self) -> str:
         """Return string representation."""
         return (
-            f"<WatchProgressModel(id={self.id}, media_id={self.media_id!r}, "
-            f"status={self.status!r}, position={self.position_seconds})>"
+            f"<WatchProgressModel(id={self.id}, profile_id={self.profile_id!r}, "
+            f"media_id={self.media_id!r}, status={self.status!r}, "
+            f"position={self.position_seconds})>"
         )
 
 

--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -11,28 +11,37 @@ from src.modules.watch_progress.infrastructure.persistence.mappers import (
 from src.modules.watch_progress.infrastructure.persistence.models import (
     WatchProgressModel,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
     """SQLAlchemy implementation of WatchProgressRepository.
 
+    Every query is scoped by ``profile_id`` so rows from one profile
+    never leak into another profile's view. The soft-delete-aware
+    ``save`` lookup also matches on ``profile_id`` to avoid colliding
+    with the composite ``(profile_id, media_id)`` unique constraint
+    when a previously dismissed item is resumed.
+
     Example:
         >>> repo = SQLAlchemyWatchProgressRepository(session)
-        >>> progress = await repo.find_by_media_id("mov_abc123def456")
+        >>> progress = await repo.find_by_media_id(
+        ...     "mov_abc123def456", caller_profile_id
+        ... )
     """
 
     def __init__(self, session: AsyncSession) -> None:
-        """Initialize repository with database session.
-
-        Args:
-            session: SQLAlchemy async session.
-        """
         self._session = session
 
-    async def find_by_media_id(self, media_id: str) -> WatchProgress | None:
-        """Find progress by media external ID."""
+    async def find_by_media_id(
+        self,
+        media_id: str,
+        profile_id: ProfileId,
+    ) -> WatchProgress | None:
+        """Look up a non-deleted row scoped to ``(media_id, profile_id)``."""
         stmt = select(WatchProgressModel).where(
             WatchProgressModel.media_id == media_id,
+            WatchProgressModel.profile_id == str(profile_id),
             WatchProgressModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -42,12 +51,14 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
     async def save(self, progress: WatchProgress) -> WatchProgress:
         """Create or update a watch progress record.
 
-        Looks up by ``media_id`` including soft-deleted rows so that
-        resuming a previously dismissed item reuses the original row
-        instead of colliding with the UNIQUE(media_id) index.
+        Looks up by (profile_id, media_id) including soft-deleted rows
+        so resuming a previously dismissed item reuses the original
+        row instead of colliding with the UNIQUE(profile_id, media_id)
+        index.
         """
         stmt = select(WatchProgressModel).where(
             WatchProgressModel.media_id == progress.media_id,
+            WatchProgressModel.profile_id == str(progress.profile_id),
         )
         result = await self._session.execute(stmt)
         existing = result.scalar_one_or_none()
@@ -65,11 +76,16 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         await self._session.refresh(model)
         return WatchProgressMapper.to_entity(model)
 
-    async def list_in_progress(self, limit: int = 20) -> list[WatchProgress]:
-        """List in-progress items ordered by last watched."""
+    async def list_in_progress(
+        self,
+        profile_id: ProfileId,
+        limit: int = 20,
+    ) -> list[WatchProgress]:
+        """List in-progress rows for the profile, ordered by last watched."""
         stmt = (
             select(WatchProgressModel)
             .where(
+                WatchProgressModel.profile_id == str(profile_id),
                 WatchProgressModel.status == "in_progress",
                 WatchProgressModel.deleted_at.is_(None),
             )
@@ -79,11 +95,16 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         result = await self._session.execute(stmt)
         return [WatchProgressMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def list_recently_watched(self, limit: int = 20) -> list[WatchProgress]:
-        """List recently watched items (in_progress + completed)."""
+    async def list_recently_watched(
+        self,
+        profile_id: ProfileId,
+        limit: int = 20,
+    ) -> list[WatchProgress]:
+        """List in-progress + completed rows for the profile, recent first."""
         stmt = (
             select(WatchProgressModel)
             .where(
+                WatchProgressModel.profile_id == str(profile_id),
                 WatchProgressModel.status.in_(["in_progress", "completed"]),
                 WatchProgressModel.deleted_at.is_(None),
             )
@@ -93,21 +114,27 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         result = await self._session.execute(stmt)
         return [WatchProgressMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def find_by_media_ids(self, media_ids: list[str]) -> dict[str, WatchProgress]:
-        """Find progress for multiple media items in a single query."""
+    async def find_by_media_ids(
+        self,
+        media_ids: list[str],
+        profile_id: ProfileId,
+    ) -> dict[str, WatchProgress]:
+        """Bulk-look-up rows for the profile, returned as ``{media_id: progress}``."""
         if not media_ids:
             return {}
         stmt = select(WatchProgressModel).where(
+            WatchProgressModel.profile_id == str(profile_id),
             WatchProgressModel.media_id.in_(media_ids),
             WatchProgressModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
         return {m.media_id: WatchProgressMapper.to_entity(m) for m in result.scalars().all()}
 
-    async def delete(self, media_id: str) -> bool:
-        """Soft-delete progress for a media item."""
+    async def delete(self, media_id: str, profile_id: ProfileId) -> bool:
+        """Soft-delete the row for (profile_id, media_id), if any."""
         stmt = select(WatchProgressModel).where(
             WatchProgressModel.media_id == media_id,
+            WatchProgressModel.profile_id == str(profile_id),
             WatchProgressModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -120,10 +147,15 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         await self._session.flush()
         return True
 
-    async def delete_by_series(self, series_id: str) -> int:
-        """Soft-delete all episode progress for a series."""
+    async def delete_by_series(
+        self,
+        series_id: str,
+        profile_id: ProfileId,
+    ) -> int:
+        """Soft-delete every episode-progress row for this series in the profile."""
         prefix = f"epi_{series_id}_"
         stmt = select(WatchProgressModel).where(
+            WatchProgressModel.profile_id == str(profile_id),
             WatchProgressModel.media_id.startswith(prefix),
             WatchProgressModel.deleted_at.is_(None),
         )

--- a/src/modules/watch_progress/presentation/dependencies.py
+++ b/src/modules/watch_progress/presentation/dependencies.py
@@ -14,8 +14,6 @@ strictly — at that point we can also collapse this dep into a direct
 re-export of ``identity.presentation.dependencies.get_current_profile``.
 """
 
-from contextlib import suppress
-
 from fastapi import Request
 
 from src.config.settings import get_settings
@@ -30,21 +28,25 @@ async def resolve_profile_id(request: Request) -> str:
     1. Session cookie present → look up the matching access_tokens row
        in the identity BC's UoW. If a ``current_profile_id`` exists,
        return it.
-    2. No usable cookie + ``watch_progress_default_profile_id`` setting
-       configured → return that fallback (transition mode).
+    2. No usable cookie or unknown token + ``watch_progress_default_profile_id``
+       setting configured → return that fallback (transition mode).
     3. Otherwise → raise :class:`NoActiveSessionError` (HTTP 401).
+
+    Errors raised by the identity UoW (container not wired, DB
+    unreachable, etc.) propagate as 500 by design — silently falling
+    back to anonymous on real misconfigurations would mask bugs and
+    let authenticated requests be served as anonymous data.
     """
     settings = get_settings()
 
     token = request.cookies.get(settings.session_cookie_name)
     if token is not None:
-        with suppress(Exception):
-            container = request.app.state.container
-            factory = container.identity.identity_unit_of_work_factory()
-            async with factory() as uow:
-                snap = await uow.access_tokens.get_by_token(token)
-            if snap is not None and snap.current_profile_id is not None:
-                return str(snap.current_profile_id)
+        container = request.app.state.container
+        factory = container.identity.identity_unit_of_work_factory()
+        async with factory() as uow:
+            snap = await uow.access_tokens.get_by_token(token)
+        if snap is not None and snap.current_profile_id is not None:
+            return str(snap.current_profile_id)
 
     if settings.watch_progress_default_profile_id:
         return settings.watch_progress_default_profile_id

--- a/src/modules/watch_progress/presentation/dependencies.py
+++ b/src/modules/watch_progress/presentation/dependencies.py
@@ -1,0 +1,55 @@
+"""FastAPI dependencies that resolve the caller's ``profile_id``.
+
+During the per-profile rollout (see ADR-010), watch_progress routes
+need a way to scope data by profile *before* every consumer is sending
+the session cookie. ``resolve_profile_id`` implements the transition
+strategy: try the authenticated path first, fall back to the
+configured ``watch_progress_default_profile_id`` setting when no
+cookie is present, and finally raise ``NoActiveSessionError`` (HTTP
+401) if neither works.
+
+Once every consumer ships login support, unset the
+``WATCH_PROGRESS_DEFAULT_PROFILE_ID`` env var so the dependency runs
+strictly — at that point we can also collapse this dep into a direct
+re-export of ``identity.presentation.dependencies.get_current_profile``.
+"""
+
+from contextlib import suppress
+
+from fastapi import Request
+
+from src.config.settings import get_settings
+from src.modules.identity.domain.errors import NoActiveSessionError
+
+
+async def resolve_profile_id(request: Request) -> str:
+    """Return the caller's profile_id (prefixed external ID).
+
+    Resolution order:
+
+    1. Session cookie present → look up the matching access_tokens row
+       in the identity BC's UoW. If a ``current_profile_id`` exists,
+       return it.
+    2. No usable cookie + ``watch_progress_default_profile_id`` setting
+       configured → return that fallback (transition mode).
+    3. Otherwise → raise :class:`NoActiveSessionError` (HTTP 401).
+    """
+    settings = get_settings()
+
+    token = request.cookies.get(settings.session_cookie_name)
+    if token is not None:
+        with suppress(Exception):
+            container = request.app.state.container
+            factory = container.identity.identity_unit_of_work_factory()
+            async with factory() as uow:
+                snap = await uow.access_tokens.get_by_token(token)
+            if snap is not None and snap.current_profile_id is not None:
+                return str(snap.current_profile_id)
+
+    if settings.watch_progress_default_profile_id:
+        return settings.watch_progress_default_profile_id
+
+    raise NoActiveSessionError(message="Authentication required to access watch progress")
+
+
+__all__ = ["resolve_profile_id"]

--- a/src/modules/watch_progress/presentation/routes/progress_routes.py
+++ b/src/modules/watch_progress/presentation/routes/progress_routes.py
@@ -28,6 +28,7 @@ from src.modules.watch_progress.application.use_cases.clear_series_progress impo
     ClearSeriesProgressInput,
     ClearSeriesProgressUseCase,
 )
+from src.modules.watch_progress.presentation.dependencies import resolve_profile_id
 
 router = APIRouter(prefix="/api/v1/progress", tags=["Watch Progress"])
 
@@ -54,12 +55,15 @@ class SaveProgressRequest(BaseModel):
 async def continue_watching(
     limit: int = Query(20, ge=1, le=100),
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetContinueWatchingUseCase = Depends(
         Provide[ApplicationContainer.watch_progress.get_continue_watching],
     ),
 ) -> dict[str, Any]:
     """List in-progress items for the Continue Watching section."""
-    result = await use_case.execute(GetContinueWatchingInput(limit=limit, lang=lang))
+    result = await use_case.execute(
+        GetContinueWatchingInput(profile_id=profile_id, limit=limit, lang=lang)
+    )
     return api_list([asdict(item) for item in result.items])
 
 
@@ -67,6 +71,7 @@ async def continue_watching(
 @inject  # type: ignore[misc]
 async def save_progress(
     body: SaveProgressRequest,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: SaveProgressUseCase = Depends(
         Provide[ApplicationContainer.watch_progress.save_progress],
     ),
@@ -74,6 +79,7 @@ async def save_progress(
     """Save or update watch progress for a media item."""
     result = await use_case.execute(
         SaveProgressInput(
+            profile_id=profile_id,
             media_id=body.media_id,
             media_type=body.media_type,
             position_seconds=body.position_seconds,
@@ -89,12 +95,13 @@ async def save_progress(
 @inject  # type: ignore[misc]
 async def get_progress(
     media_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetProgressUseCase = Depends(
         Provide[ApplicationContainer.watch_progress.get_progress],
     ),
 ) -> dict[str, Any]:
     """Get watch progress for a media item."""
-    result = await use_case.execute(GetProgressInput(media_id=media_id))
+    result = await use_case.execute(GetProgressInput(profile_id=profile_id, media_id=media_id))
     if result is None:
         return api_single("progress", None)
     return api_single("progress", asdict(result))
@@ -104,17 +111,18 @@ async def get_progress(
 @inject  # type: ignore[misc]
 async def clear_series_progress(
     series_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ClearSeriesProgressUseCase = Depends(
         Provide[ApplicationContainer.watch_progress.clear_series_progress],
     ),
 ) -> Response:
-    """Clear all episode progress for a series.
+    """Clear all episode progress for a series in the caller's profile.
 
     Used by the "dismiss from Continue Watching" action so removing
     a series clears ALL its episode progress at once — otherwise
     deleting one episode's progress just surfaces the next.
     """
-    await use_case.execute(ClearSeriesProgressInput(series_id=series_id))
+    await use_case.execute(ClearSeriesProgressInput(profile_id=profile_id, series_id=series_id))
     return Response(status_code=204)
 
 
@@ -122,12 +130,13 @@ async def clear_series_progress(
 @inject  # type: ignore[misc]
 async def clear_progress(
     media_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ClearProgressUseCase = Depends(
         Provide[ApplicationContainer.watch_progress.clear_progress],
     ),
 ) -> Response:
-    """Clear watch progress for a media item."""
-    await use_case.execute(ClearProgressInput(media_id=media_id))
+    """Clear watch progress for a media item in the caller's profile."""
+    await use_case.execute(ClearProgressInput(profile_id=profile_id, media_id=media_id))
     return Response(status_code=204)
 
 

--- a/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
+++ b/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
@@ -12,6 +12,9 @@ from src.modules.watch_progress.infrastructure.persistence.repositories import (
 from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyWatchProgressUnitOfWorkFactory,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 def _progress(
@@ -21,10 +24,22 @@ def _progress(
     media_type: WatchableMediaType = WatchableMediaType.EPISODE,
 ) -> WatchProgress:
     return WatchProgress.create(
+        profile_id=_PROFILE_ID,
         media_id=media_id,
         media_type=media_type,
         position_seconds=position,
         duration_seconds=duration,
+    )
+
+
+def _make_adapter(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    default_profile_id: str | None = _PROFILE_ID.value,
+) -> ProgressLookupAdapter:
+    return ProgressLookupAdapter(
+        SqlAlchemyWatchProgressUnitOfWorkFactory(session_factory),
+        default_profile_id=default_profile_id,
     )
 
 
@@ -42,9 +57,7 @@ class TestProgressLookupAdapter:
         await progress_repo.save(_progress("epi_ser_ABC_1_2", position=3300))
         await db_session.commit()
 
-        adapter = ProgressLookupAdapter(
-            SqlAlchemyWatchProgressUnitOfWorkFactory(session_factory),
-        )
+        adapter = _make_adapter(session_factory)
 
         result = await adapter.find_for_media_ids(
             ["epi_ser_ABC_1_1", "epi_ser_ABC_1_2", "epi_ser_ABC_1_3"],
@@ -59,11 +72,24 @@ class TestProgressLookupAdapter:
         self,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        adapter = ProgressLookupAdapter(
-            SqlAlchemyWatchProgressUnitOfWorkFactory(session_factory),
-        )
+        adapter = _make_adapter(session_factory)
 
         assert await adapter.find_for_media_ids([]) == {}
+
+    async def test_find_for_media_ids_returns_empty_when_no_default_profile(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Strict transition mode: no default_profile_id -> graceful
+        # degradation, even when matching rows exist.
+        progress_repo = SQLAlchemyWatchProgressRepository(db_session)
+        await progress_repo.save(_progress("epi_ser_ABC_1_1"))
+        await db_session.commit()
+
+        adapter = _make_adapter(session_factory, default_profile_id=None)
+
+        assert await adapter.find_for_media_ids(["epi_ser_ABC_1_1"]) == {}
 
     async def test_progress_summary_includes_last_watched_at(
         self,
@@ -74,9 +100,7 @@ class TestProgressLookupAdapter:
         await progress_repo.save(_progress("epi_ser_ABC_1_1"))
         await db_session.commit()
 
-        adapter = ProgressLookupAdapter(
-            SqlAlchemyWatchProgressUnitOfWorkFactory(session_factory),
-        )
+        adapter = _make_adapter(session_factory)
         result = await adapter.find_for_media_ids(["epi_ser_ABC_1_1"])
 
         summary = result["epi_ser_ABC_1_1"]

--- a/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
+++ b/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
@@ -8,10 +8,12 @@ from src.modules.watch_progress.domain.value_objects import WatchableMediaType
 from src.modules.watch_progress.infrastructure.persistence.repositories import (
     SQLAlchemyWatchProgressRepository,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 SAMPLE_MOVIE_ID = "mov_abc123def456"
 SAMPLE_EPISODE_ID = "epi_xyz789abc123"
 MISSING_MEDIA_ID = "mov_missing00000"
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 def _create_progress(
@@ -19,8 +21,10 @@ def _create_progress(
     media_type: WatchableMediaType = WatchableMediaType.MOVIE,
     position: int = 1800,
     duration: int = 7200,
+    profile_id: ProfileId = _PROFILE_ID,
 ) -> WatchProgress:
     return WatchProgress.create(
+        profile_id=profile_id,
         media_id=media_id,
         media_type=media_type,
         position_seconds=position,
@@ -41,6 +45,7 @@ class TestSQLAlchemyWatchProgressRepositorySave:
         assert saved.media_id == SAMPLE_MOVIE_ID
         assert saved.position_seconds == 1800
         assert saved.status == "in_progress"
+        assert saved.profile_id == _PROFILE_ID
 
     async def test_save_should_update_existing_progress(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
@@ -50,7 +55,7 @@ class TestSQLAlchemyWatchProgressRepositorySave:
         updated_entity = original.update_position(position_seconds=3000)
         await repo.save(updated_entity)
 
-        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
         assert found is not None
         assert found.position_seconds == 3000
 
@@ -60,18 +65,19 @@ class TestSQLAlchemyWatchProgressRepositorySave:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         original = _create_progress(position=500)
         await repo.save(original)
-        await repo.delete(SAMPLE_MOVIE_ID)
+        await repo.delete(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         resumed = _create_progress(position=750)
         await repo.save(resumed)
 
-        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
         assert found is not None
         assert found.position_seconds == 750
 
     async def test_save_should_auto_complete_at_90_percent(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         progress = WatchProgress.create(
+            profile_id=_PROFILE_ID,
             media_id=SAMPLE_MOVIE_ID,
             media_type=WatchableMediaType.MOVIE,
             position_seconds=6500,
@@ -92,7 +98,7 @@ class TestSQLAlchemyWatchProgressRepositoryFind:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         await repo.save(_create_progress())
 
-        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert found is not None
         assert found.media_id == SAMPLE_MOVIE_ID
@@ -102,9 +108,26 @@ class TestSQLAlchemyWatchProgressRepositoryFind:
     ) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
 
-        found = await repo.find_by_media_id(MISSING_MEDIA_ID)
+        found = await repo.find_by_media_id(MISSING_MEDIA_ID, _PROFILE_ID)
 
         assert found is None
+
+    async def test_find_by_media_id_should_isolate_by_profile(
+        self, db_session: AsyncSession
+    ) -> None:
+        # Two profiles, same media: each sees only their own row.
+        other_profile = ProfileId("prf_otherprofile")
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress(position=100))
+        await repo.save(_create_progress(position=500, profile_id=other_profile))
+
+        first = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
+        other = await repo.find_by_media_id(SAMPLE_MOVIE_ID, other_profile)
+
+        assert first is not None
+        assert other is not None
+        assert first.position_seconds == 100
+        assert other.position_seconds == 500
 
     async def test_find_by_media_ids_should_return_mapping(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
@@ -113,7 +136,7 @@ class TestSQLAlchemyWatchProgressRepositoryFind:
             _create_progress(media_id=SAMPLE_EPISODE_ID, media_type=WatchableMediaType.EPISODE),
         )
 
-        result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, SAMPLE_EPISODE_ID])
+        result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, SAMPLE_EPISODE_ID], _PROFILE_ID)
 
         assert len(result) == 2
         assert SAMPLE_MOVIE_ID in result
@@ -124,7 +147,7 @@ class TestSQLAlchemyWatchProgressRepositoryFind:
     ) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
 
-        result = await repo.find_by_media_ids([])
+        result = await repo.find_by_media_ids([], _PROFILE_ID)
 
         assert result == {}
 
@@ -132,7 +155,7 @@ class TestSQLAlchemyWatchProgressRepositoryFind:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         await repo.save(_create_progress(media_id=SAMPLE_MOVIE_ID))
 
-        result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, MISSING_MEDIA_ID])
+        result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, MISSING_MEDIA_ID], _PROFILE_ID)
 
         assert list(result.keys()) == [SAMPLE_MOVIE_ID]
 
@@ -148,6 +171,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         await repo.save(_create_progress(media_id="mov_aaaaaaaaaaaa"))
         await repo.save(
             WatchProgress.create(
+                profile_id=_PROFILE_ID,
                 media_id="mov_bbbbbbbbbbbb",
                 media_type=WatchableMediaType.MOVIE,
                 position_seconds=7200,
@@ -155,7 +179,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
             ),
         )
 
-        result = await repo.list_in_progress()
+        result = await repo.list_in_progress(_PROFILE_ID)
 
         assert len(result) == 1
         assert result[0].media_id == "mov_aaaaaaaaaaaa"
@@ -164,12 +188,11 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
-        # Save in a specific order; last saved should appear first
         await repo.save(_create_progress(media_id="mov_first0000000"))
         await repo.save(_create_progress(media_id="mov_second000000"))
         await repo.save(_create_progress(media_id="mov_third0000000"))
 
-        result = await repo.list_in_progress()
+        result = await repo.list_in_progress(_PROFILE_ID)
 
         assert [p.media_id for p in result] == [
             "mov_third0000000",
@@ -182,9 +205,23 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         for i in range(5):
             await repo.save(_create_progress(media_id=f"mov_{i}aaaaaaaaaaa"))
 
-        result = await repo.list_in_progress(limit=2)
+        result = await repo.list_in_progress(_PROFILE_ID, limit=2)
 
         assert len(result) == 2
+
+    async def test_list_in_progress_should_isolate_by_profile(
+        self, db_session: AsyncSession
+    ) -> None:
+        other_profile = ProfileId("prf_otherprofile")
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress(media_id="mov_aaaaaaaaaaaa"))
+        await repo.save(_create_progress(media_id="mov_bbbbbbbbbbbb", profile_id=other_profile))
+
+        first_view = await repo.list_in_progress(_PROFILE_ID)
+        other_view = await repo.list_in_progress(other_profile)
+
+        assert {p.media_id for p in first_view} == {"mov_aaaaaaaaaaaa"}
+        assert {p.media_id for p in other_view} == {"mov_bbbbbbbbbbbb"}
 
     async def test_list_recently_watched_should_include_completed(
         self, db_session: AsyncSession
@@ -193,6 +230,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         await repo.save(_create_progress(media_id="mov_aaaaaaaaaaaa"))
         await repo.save(
             WatchProgress.create(
+                profile_id=_PROFILE_ID,
                 media_id="mov_bbbbbbbbbbbb",
                 media_type=WatchableMediaType.MOVIE,
                 position_seconds=7200,
@@ -200,7 +238,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
             ),
         )
 
-        result = await repo.list_recently_watched()
+        result = await repo.list_recently_watched(_PROFILE_ID)
 
         assert len(result) == 2
 
@@ -210,9 +248,9 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         await repo.save(_create_progress(media_id="mov_kept000000000"))
         await repo.save(_create_progress(media_id="mov_deleted000000"))
-        await repo.delete("mov_deleted000000")
+        await repo.delete("mov_deleted000000", _PROFILE_ID)
 
-        result = await repo.list_recently_watched()
+        result = await repo.list_recently_watched(_PROFILE_ID)
 
         assert len(result) == 1
         assert result[0].media_id == "mov_kept000000000"
@@ -224,7 +262,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         for i in range(5):
             await repo.save(_create_progress(media_id=f"mov_{i}aaaaaaaaaaa"))
 
-        result = await repo.list_recently_watched(limit=3)
+        result = await repo.list_recently_watched(_PROFILE_ID, limit=3)
 
         assert len(result) == 3
 
@@ -237,10 +275,10 @@ class TestSQLAlchemyWatchProgressRepositoryDelete:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         await repo.save(_create_progress())
 
-        deleted = await repo.delete(SAMPLE_MOVIE_ID)
+        deleted = await repo.delete(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert deleted is True
-        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
         assert found is None
 
     async def test_delete_should_return_false_when_not_found(
@@ -248,17 +286,33 @@ class TestSQLAlchemyWatchProgressRepositoryDelete:
     ) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
 
-        deleted = await repo.delete(MISSING_MEDIA_ID)
+        deleted = await repo.delete(MISSING_MEDIA_ID, _PROFILE_ID)
 
         assert deleted is False
+
+    async def test_delete_should_not_remove_other_profiles_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        # Per-profile delete must not affect another profile's row for the
+        # same media — the unique constraint is composite, but the WHERE
+        # clause must filter explicitly too.
+        other_profile = ProfileId("prf_otherprofile")
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress())
+        await repo.save(_create_progress(profile_id=other_profile))
+
+        await repo.delete(SAMPLE_MOVIE_ID, _PROFILE_ID)
+
+        assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)) is None
+        assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, other_profile)) is not None
 
     async def test_delete_should_exclude_from_in_progress_list(
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
         await repo.save(_create_progress(media_id=SAMPLE_MOVIE_ID))
-        await repo.delete(SAMPLE_MOVIE_ID)
+        await repo.delete(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
-        result = await repo.list_in_progress()
+        result = await repo.list_in_progress(_PROFILE_ID)
 
         assert result == []

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -17,10 +17,18 @@ from src.modules.watch_progress.application.ports import (
 from src.modules.watch_progress.application.use_cases import GetContinueWatchingUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 from tests.modules.watch_progress.unit.conftest import (
     WatchProgressUoWMocks,
     make_watch_progress_uow_mock,
 )
+
+_PROFILE_ID = ProfileId("prf_test12345678")
+
+
+def _input(*, limit: int = 10, lang: str = "en") -> GetContinueWatchingInput:
+    """Build the use case input scoped to the test profile."""
+    return GetContinueWatchingInput(profile_id=_PROFILE_ID.value, limit=limit, lang=lang)
 
 
 def _make_progress(
@@ -33,6 +41,7 @@ def _make_progress(
 ) -> WatchProgress:
     """Create a WatchProgress entity for testing."""
     return WatchProgress(
+        profile_id=_PROFILE_ID,
         media_id=media_id,
         media_type=media_type,
         position_seconds=position,
@@ -47,13 +56,6 @@ def _make_series_info(
     episodes_per_season: dict[int, list[int]],
     title: str = "Test Series",
 ) -> SeriesWithEpisodesInfo:
-    """Create a ``SeriesWithEpisodesInfo`` with specified seasons/episodes.
-
-    Args:
-        series_id: External series ID.
-        episodes_per_season: Mapping of season_number to list of episode_numbers.
-        title: Series title.
-    """
     episodes: list[EpisodeInfo] = []
     for season_num in sorted(episodes_per_season):
         for ep_num in sorted(episodes_per_season[season_num]):
@@ -76,7 +78,6 @@ def _make_series_info(
 
 @pytest.fixture()
 def repos() -> tuple[WatchProgressUoWMocks, AsyncMock]:
-    """Create mock UoW and media lookup port."""
     mocks = make_watch_progress_uow_mock()
     media_lookup = AsyncMock(spec=MediaLookupPort)
     return mocks, media_lookup
@@ -106,7 +107,7 @@ class TestEnrichEpisode:
         }
         media_lookup.get_series_with_episodes.return_value = series
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
 
         assert len(result.items) == 1
         item = result.items[0]
@@ -123,7 +124,7 @@ class TestEnrichEpisode:
             _make_progress("epi_03ZzYaQ77FaB"),
         ]
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
@@ -134,7 +135,7 @@ class TestEnrichEpisode:
         ]
         media_lookup.get_series_with_episodes.return_value = None
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
@@ -148,7 +149,7 @@ class TestEnrichEpisode:
         }
         media_lookup.get_series_with_episodes.return_value = series
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
@@ -162,7 +163,7 @@ class TestEnrichEpisode:
         }
         media_lookup.get_series_with_episodes.return_value = series
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
@@ -172,7 +173,7 @@ class TestEnrichEpisode:
             _make_progress("epi_ser_broken"),
         ]
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
         assert len(result.items) == 0
 
 
@@ -181,7 +182,6 @@ class TestSeriesDeduplication:
 
     @pytest.mark.asyncio
     async def test_multiple_episodes_same_series_returns_one_item(self, repos):
-        """Multiple in-progress episodes from same series → single item."""
         mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
         media_lookup.get_series_with_episodes.return_value = series
@@ -196,13 +196,12 @@ class TestSeriesDeduplication:
             "epi_ser_AAAAAAAAAAAA_1_3": p3,
         }
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
 
         assert len(result.items) == 1
 
     @pytest.mark.asyncio
     async def test_picks_highest_in_progress_episode(self, repos):
-        """Should pick the highest-numbered in-progress episode."""
         mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3], 2: [1, 2]})
         media_lookup.get_series_with_episodes.return_value = series
@@ -225,7 +224,7 @@ class TestSeriesDeduplication:
             ),
         }
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
 
         assert len(result.items) == 1
         assert result.items[0].season_number == 2
@@ -233,7 +232,6 @@ class TestSeriesDeduplication:
 
     @pytest.mark.asyncio
     async def test_picks_next_unwatched_when_all_completed(self, repos):
-        """Completed episodes + unwatched episodes → next unwatched."""
         mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2, 3]})
         media_lookup.get_series_with_episodes.return_value = series
@@ -252,7 +250,7 @@ class TestSeriesDeduplication:
             ),
         }
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
 
         assert len(result.items) == 1
         assert result.items[0].season_number == 1
@@ -261,7 +259,6 @@ class TestSeriesDeduplication:
 
     @pytest.mark.asyncio
     async def test_returns_nothing_when_all_episodes_completed(self, repos):
-        """All episodes completed, none unwatched → no item."""
         mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2]})
         media_lookup.get_series_with_episodes.return_value = series
@@ -280,12 +277,11 @@ class TestSeriesDeduplication:
             ),
         }
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
         assert len(result.items) == 0
 
     @pytest.mark.asyncio
     async def test_two_series_return_one_item_each(self, repos):
-        """Two different series → two items, one per series."""
         mocks, media_lookup = repos
         series_a = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2]}, title="Series A")
         series_b = _make_series_info("ser_BBBBBBBBBBBB", {1: [1]}, title="Series B")
@@ -303,8 +299,8 @@ class TestSeriesDeduplication:
         pb = _make_progress("epi_ser_BBBBBBBBBBBB_1_1")
         mocks.progress.list_recently_watched.return_value = [pa, pb]
 
-        def find_by_media_ids_side_effect(ids):
-            result = {}
+        def find_by_media_ids_side_effect(ids, profile_id):
+            result: dict[str, WatchProgress] = {}
             if "epi_ser_AAAAAAAAAAAA_1_1" in ids:
                 result["epi_ser_AAAAAAAAAAAA_1_1"] = pa
             if "epi_ser_BBBBBBBBBBBB_1_1" in ids:
@@ -313,7 +309,7 @@ class TestSeriesDeduplication:
 
         mocks.progress.find_by_media_ids.side_effect = find_by_media_ids_side_effect
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
 
         assert len(result.items) == 2
         series_ids = {item.series_id for item in result.items}
@@ -321,7 +317,6 @@ class TestSeriesDeduplication:
 
     @pytest.mark.asyncio
     async def test_mixed_in_progress_and_completed_across_seasons(self, repos):
-        """S1 completed, S2E1 in-progress → picks S2E1."""
         mocks, media_lookup = repos
         series = _make_series_info("ser_AAAAAAAAAAAA", {1: [1, 2], 2: [1, 2]})
         media_lookup.get_series_with_episodes.return_value = series
@@ -344,7 +339,7 @@ class TestSeriesDeduplication:
             ),
         }
 
-        result = await _make_use_case(repos).execute(GetContinueWatchingInput(limit=10))
+        result = await _make_use_case(repos).execute(_input())
 
         assert len(result.items) == 1
         assert result.items[0].season_number == 2

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_progress.py
@@ -6,7 +6,10 @@ from src.modules.watch_progress.application.dtos import GetProgressInput, Progre
 from src.modules.watch_progress.application.use_cases import GetProgressUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 from tests.modules.watch_progress.unit.conftest import make_watch_progress_uow_mock
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 class TestGetProgressUseCase:
@@ -15,6 +18,7 @@ class TestGetProgressUseCase:
     @pytest.mark.asyncio
     async def test_returns_progress_when_found(self):
         existing = WatchProgress.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
             position_seconds=1800,
@@ -24,11 +28,17 @@ class TestGetProgressUseCase:
         mocks.progress.find_by_media_id.return_value = existing
         use_case = GetProgressUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute(GetProgressInput(media_id="mov_abc123def456"))
+        result = await use_case.execute(
+            GetProgressInput(
+                profile_id=_PROFILE_ID.value,
+                media_id="mov_abc123def456",
+            )
+        )
 
         assert isinstance(result, ProgressOutput)
         assert result.position_seconds == 1800
         assert result.percentage == 25.0
+        mocks.progress.find_by_media_id.assert_called_once_with("mov_abc123def456", _PROFILE_ID)
 
     @pytest.mark.asyncio
     async def test_returns_none_when_not_found(self):
@@ -36,6 +46,11 @@ class TestGetProgressUseCase:
         mocks.progress.find_by_media_id.return_value = None
         use_case = GetProgressUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute(GetProgressInput(media_id="mov_abc123def456"))
+        result = await use_case.execute(
+            GetProgressInput(
+                profile_id=_PROFILE_ID.value,
+                media_id="mov_abc123def456",
+            )
+        )
 
         assert result is None

--- a/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
@@ -1,13 +1,15 @@
 """Tests for SaveProgressUseCase."""
 
-
 import pytest
 
 from src.modules.watch_progress.application.dtos import ProgressOutput, SaveProgressInput
 from src.modules.watch_progress.application.use_cases import SaveProgressUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 from tests.modules.watch_progress.unit.conftest import make_watch_progress_uow_mock
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 class TestSaveProgressUseCase:
@@ -23,6 +25,7 @@ class TestSaveProgressUseCase:
 
         result = await use_case.execute(
             SaveProgressInput(
+                profile_id=_PROFILE_ID.value,
                 media_id="mov_abc123def456",
                 media_type="movie",
                 position_seconds=1800,
@@ -35,10 +38,13 @@ class TestSaveProgressUseCase:
         assert result.position_seconds == 1800
         assert result.status == "in_progress"
         mock_repo.save.assert_called_once()
+        # The repo find lookup was scoped by profile.
+        mock_repo.find_by_media_id.assert_called_once_with("mov_abc123def456", _PROFILE_ID)
 
     @pytest.mark.asyncio
     async def test_updates_existing_progress(self):
         existing = WatchProgress.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
             position_seconds=1000,
@@ -52,6 +58,7 @@ class TestSaveProgressUseCase:
 
         result = await use_case.execute(
             SaveProgressInput(
+                profile_id=_PROFILE_ID.value,
                 media_id="mov_abc123def456",
                 media_type="movie",
                 position_seconds=3600,
@@ -72,6 +79,7 @@ class TestSaveProgressUseCase:
 
         result = await use_case.execute(
             SaveProgressInput(
+                profile_id=_PROFILE_ID.value,
                 media_id="mov_abc123def456",
                 media_type="movie",
                 position_seconds=6500,
@@ -91,6 +99,7 @@ class TestSaveProgressUseCase:
 
         result = await use_case.execute(
             SaveProgressInput(
+                profile_id=_PROFILE_ID.value,
                 media_id="mov_abc123def456",
                 media_type="movie",
                 position_seconds=100,

--- a/tests/modules/watch_progress/unit/domain/entities/test_watch_progress.py
+++ b/tests/modules/watch_progress/unit/domain/entities/test_watch_progress.py
@@ -1,80 +1,69 @@
 """Tests for WatchProgress entity."""
 
-
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
+
+
+def _create_progress(
+    *,
+    media_id: str = "mov_abc123def456",
+    media_type: WatchableMediaType = WatchableMediaType.MOVIE,
+    position_seconds: int = 100,
+    duration_seconds: int = 7200,
+    audio_track: int | None = None,
+    subtitle_track: int | None = None,
+) -> WatchProgress:
+    return WatchProgress.create(
+        profile_id=_PROFILE_ID,
+        media_id=media_id,
+        media_type=media_type,
+        position_seconds=position_seconds,
+        duration_seconds=duration_seconds,
+        audio_track=audio_track,
+        subtitle_track=subtitle_track,
+    )
 
 
 class TestWatchProgress:
     """Tests for WatchProgress entity."""
 
     def test_create_sets_in_progress_status(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=1800,
-            duration_seconds=7200,
-        )
+        progress = _create_progress(position_seconds=1800)
         assert progress.status == "in_progress"
         assert progress.id is not None
         assert str(progress.id).startswith("prg_")
+        assert progress.profile_id == _PROFILE_ID
 
     def test_create_auto_completes_at_90_percent(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=6500,
-            duration_seconds=7200,
-        )
+        progress = _create_progress(position_seconds=6500)
         assert progress.status == "completed"
         assert progress.completed_at is not None
 
     def test_percentage_calculation(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=3600,
-            duration_seconds=7200,
-        )
+        progress = _create_progress(position_seconds=3600)
         assert progress.percentage == 50.0
 
     def test_percentage_zero_position(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=0,
-            duration_seconds=7200,
-        )
+        progress = _create_progress(position_seconds=0)
         assert progress.percentage == 0.0
 
     def test_percentage_capped_at_100(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=8000,
-            duration_seconds=7200,
-        )
+        progress = _create_progress(position_seconds=8000)
         assert progress.percentage == 100.0
 
     def test_update_position_preserves_identity(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=100,
-            duration_seconds=7200,
-        )
+        progress = _create_progress()
         updated = progress.update_position(200)
         assert updated.position_seconds == 200
         assert updated.id == progress.id
         assert updated.media_id == progress.media_id
+        assert updated.profile_id == progress.profile_id
 
     def test_update_position_auto_completes(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=100,
-            duration_seconds=7200,
-        )
+        progress = _create_progress()
         assert progress.status == "in_progress"
 
         updated = progress.update_position(6600)
@@ -82,39 +71,24 @@ class TestWatchProgress:
         assert updated.completed_at is not None
 
     def test_update_position_saves_audio_track(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=100,
-            duration_seconds=7200,
-        )
+        progress = _create_progress()
         updated = progress.update_position(200, audio_track=2)
         assert updated.audio_track == 2
 
     def test_update_position_saves_subtitle_track(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=100,
-            duration_seconds=7200,
-        )
+        progress = _create_progress()
         updated = progress.update_position(200, subtitle_track=1)
         assert updated.subtitle_track == 1
 
     def test_is_completed_property(self):
-        progress = WatchProgress.create(
-            media_id="mov_abc123def456",
-            media_type=WatchableMediaType.MOVIE,
-            position_seconds=100,
-            duration_seconds=7200,
-        )
+        progress = _create_progress()
         assert not progress.is_completed
 
         completed = progress.update_position(6600)
         assert completed.is_completed
 
     def test_create_with_episode(self):
-        progress = WatchProgress.create(
+        progress = _create_progress(
             media_id="epi_abc123def456",
             media_type=WatchableMediaType.EPISODE,
             position_seconds=300,

--- a/tests/modules/watch_progress/unit/domain/services/test_continue_watching_selector.py
+++ b/tests/modules/watch_progress/unit/domain/services/test_continue_watching_selector.py
@@ -14,6 +14,9 @@ from src.modules.watch_progress.domain.value_objects import (
     WatchableMediaType,
     WatchStatus,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 def _progress(
@@ -23,6 +26,7 @@ def _progress(
 ) -> WatchProgress:
     """Build a ``WatchProgress`` with the given status and timestamp."""
     return WatchProgress(
+        profile_id=_PROFILE_ID,
         media_id=media_id,
         media_type=WatchableMediaType.EPISODE,
         position_seconds=900,

--- a/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
+++ b/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
@@ -12,6 +12,9 @@ from src.modules.watch_progress.infrastructure.persistence.mappers import (
 from src.modules.watch_progress.infrastructure.persistence.models import (
     WatchProgressModel,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 def _make_progress(
@@ -23,6 +26,7 @@ def _make_progress(
 ) -> WatchProgress:
     return WatchProgress(
         id=progress_id or ProgressId.generate(),
+        profile_id=_PROFILE_ID,
         media_id=media_id,
         media_type=media_type,
         position_seconds=position,
@@ -37,6 +41,7 @@ class TestWatchProgressMapperToModel:
     def test_should_raise_when_id_is_none(self) -> None:
         progress = WatchProgress(
             id=None,
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
@@ -53,6 +58,7 @@ class TestWatchProgressMapperToModel:
         model = WatchProgressMapper.to_model(progress)
 
         assert model.external_id == str(progress_id)
+        assert model.profile_id == str(_PROFILE_ID)
         assert model.media_id == "mov_abc123def456"
         assert model.media_type == "movie"
         assert model.position_seconds == 1800
@@ -62,6 +68,7 @@ class TestWatchProgressMapperToModel:
     def test_should_preserve_optional_tracks(self) -> None:
         progress = WatchProgress(
             id=ProgressId.generate(),
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
             position_seconds=100,
@@ -79,6 +86,7 @@ class TestWatchProgressMapperToModel:
         now = datetime.now(UTC)
         progress = WatchProgress(
             id=ProgressId.generate(),
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
             position_seconds=7200,
@@ -102,6 +110,7 @@ class TestWatchProgressMapperToEntity:
         now = datetime.now(UTC)
         model = WatchProgressModel(
             external_id=str(progress_id),
+            profile_id=str(_PROFILE_ID),
             media_id="epi_xyz789abc123",
             media_type="episode",
             position_seconds=900,
@@ -118,6 +127,7 @@ class TestWatchProgressMapperToEntity:
         entity = WatchProgressMapper.to_entity(model)
 
         assert entity.id == progress_id
+        assert entity.profile_id == _PROFILE_ID
         assert entity.media_id == "epi_xyz789abc123"
         assert entity.media_type == "episode"
         assert entity.position_seconds == 900
@@ -135,6 +145,7 @@ class TestWatchProgressMapperToEntity:
         result = WatchProgressMapper.to_entity(model)
 
         assert result.id == original.id
+        assert result.profile_id == original.profile_id
         assert result.media_id == original.media_id
         assert result.position_seconds == original.position_seconds
         assert result.duration_seconds == original.duration_seconds
@@ -149,6 +160,7 @@ class TestWatchProgressMapperUpdateModel:
         now = datetime.now(UTC)
         model = WatchProgressModel(
             external_id=str(progress_id),
+            profile_id=str(_PROFILE_ID),
             media_id="mov_abc123def456",
             media_type="movie",
             position_seconds=100,
@@ -163,6 +175,7 @@ class TestWatchProgressMapperUpdateModel:
         later = datetime.now(UTC)
         updated = WatchProgress(
             id=progress_id,
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
             position_seconds=6500,
@@ -187,6 +200,7 @@ class TestWatchProgressMapperUpdateModel:
         progress_id = ProgressId.generate()
         model = WatchProgressModel(
             external_id=str(progress_id),
+            profile_id=str(_PROFILE_ID),
             media_id="mov_original00000",
             media_type="movie",
             position_seconds=100,
@@ -197,6 +211,7 @@ class TestWatchProgressMapperUpdateModel:
 
         updated = WatchProgress(
             id=progress_id,
+            profile_id=_PROFILE_ID,
             media_id="mov_different000",
             media_type=WatchableMediaType.MOVIE,
             position_seconds=200,
@@ -208,3 +223,4 @@ class TestWatchProgressMapperUpdateModel:
         # media_id and external_id are not touched by update_model
         assert result.external_id == str(progress_id)
         assert result.media_id == "mov_original00000"
+        assert result.profile_id == str(_PROFILE_ID)


### PR DESCRIPTION
## Summary

PR 3 do plano (per-profile rollout do `watch_progress`). Adiciona `profile_id` ao agregado `WatchProgress` pra que cada profile da casa veja só seu próprio histórico — Continue Watching deixa de ser global. Inclui migration de 3 passos com backfill seguro e a estratégia de feature flag (`watch_progress_default_profile_id`) acordada na PR 2.

### Conteúdo

**Domain**
- `WatchProgress` ganha `profile_id: ProfileId` (de `shared_kernel`).
- `WatchProgressRepository` interface: todos os métodos read/delete recebem `profile_id`; `save` lê do entity.

**Persistence**
- Coluna `profile_id VARCHAR(50)` na tabela. **Drop** do `UNIQUE(media_id)` legado, **replace** por composite `UNIQUE(profile_id, media_id)` + index em `profile_id`.
- Sem FK pra `profiles.id` (cross-BC references viajam como string per ADR-008).
- Migration de 3 passos: ADD nullable → backfill via SQL (pega o profile mais antigo) → ALTER NOT NULL + replace unique. Falha clara se não houver profile (operator roda CLI bootstrap primeiro).

**Application**
- 5 use cases (Save / Get / GetContinueWatching / ClearProgress / ClearSeriesProgress) recebem `profile_id` no Input, passam ProfileId VO pro repo.

**Presentation + Feature Flag (Decision A+I do escopo)**
- Nova dep `resolve_profile_id` em `watch_progress/presentation/dependencies.py`:
  - Cookie válido → resolve via identity's UoW (`access_tokens.current_profile_id`)
  - Cookie ausente + `WATCH_PROGRESS_DEFAULT_PROFILE_ID` setado → fallback pra essa string
  - Caso contrário → `NoActiveSessionError` (401)
- 5 rotas adotam a dep + forward pro use case.

**Cross-BC cascade (Media)**
- `ProgressLookupAdapter` agora recebe `default_profile_id` no construtor.
- Quando o setting está unset, retorna mapa vazio (graceful degradation — Media routes seguem servindo, só sem enrich de progress).
- Container wireia o setting via `config.provided.watch_progress_default_profile_id`.
- `ProgressLookupPort` signature **inalterada** — Media routes não foram tocadas. Um PR futuro pode refatorar pra passar profile_id explicitamente e remover o default.

### Test plan

- [x] `poetry run pytest tests/modules/watch_progress` — **82 passed** (era 63 + adicionei testes de isolamento)
- [x] `poetry run pytest tests/modules/media tests/modules/identity tests/modules/library tests/modules/collections tests/modules/preferences tests/modules/catalog_requests tests/shared_kernel tests/building_blocks tests/modules/watch_progress` — **2106 passed**, 5 skipped (zero regressão em todo o projeto)
- [x] `ruff check` + `ruff format --check` — clean
- [x] Migration smoke: seed temp SQLite com user + profile + 1 row legacy de watch_progress, run `alembic upgrade head` — backfill popula `profile_id="prf_seed12345678"`, NOT NULL aplicado, schema final mostra `UNIQUE(profile_id, media_id)`

Novos testes de isolamento (chave da garantia de privacy entre profiles):
- `find_by_media_id` retorna apenas a row do profile chamador (Alice e Bob com mesmo `media_id` veem rows distintas)
- `list_in_progress` isola por profile
- `delete` NÃO afeta a row do outro profile pra mesma mídia
- ProgressLookupAdapter retorna `{}` quando `default_profile_id` é None (strict transition)

### Próximas PRs (PRs 4-5 do plano)

4. `collections` per-profile — mesmo padrão pra `CustomList`
5. `preferences` per-profile — substitui chave `"default"` por `profile_id`
6. Library ACL — `allowed_library_ids` no Profile
7. Frontend (`homeflix-web`) — login + profile picker

## Caveats

- **Pré-requisito de operação**: a migration aborta se nenhum profile existir no DB. Operator precisa ter rodado `scripts/identity_create_admin.py` antes de `make migrate` numa base com dados pré-existentes.
- **`ProgressLookupAdapter` mantém port unchanged** intencionalmente — Media routes não conhecem profile ainda. Quando elas forem refatoradas (PR futura ou junto com 4/5), a port ganha `profile_id` parâmetro e o `default_profile_id` desaparece.
- **`watch_progress_default_profile_id`** é o "feature flag" de transição. Set pra um `prf_xxx` enquanto o frontend não ship login; unset depois (= strict mode).

## Related

- ADR-010 — `profile_id` propagado explicitamente via Input dataclass; cross-BC refs como string em VARCHAR
- ADR-008 — sem FK cross-BC; sem JOIN com `profiles`
- ADR-009 — `ProgressLookupAdapter` é o único ponto que importa de watch_progress no Media BC

## Summary by Sourcery

Scope watch-progress data by profile instead of globally, wiring profile identifiers through domain, persistence, application, and presentation layers, and adding a safe migration plus a transitional default-profile feature flag for media ACL lookups.

New Features:
- Introduce per-profile watch progress by adding a profile_id owner to the WatchProgress aggregate and related DTOs/use cases.
- Expose a FastAPI dependency to resolve the caller's profile_id, with an optional default-profile fallback controlled by configuration.
- Allow the media ProgressLookupAdapter to enrich responses using a configured default profile while remaining compatible with existing ProgressLookupPort callers.

Enhancements:
- Scope all WatchProgress repository queries and deletions by profile_id and enforce a composite UNIQUE(profile_id, media_id) constraint at the ORM/model level.
- Update Get/Save/Clear/Continue Watching use cases and routes to operate on per-profile data, ensuring isolation between profiles in the same household.
- Refine mappers and domain entities to round-trip profile_id alongside progress metadata without cross-BC foreign keys.

Build:
- Add an Alembic migration that backfills and enforces non-null profile_id on watch_progresses and replaces the legacy unique(media_id) with a composite unique(profile_id, media_id).

Tests:
- Extend and adjust unit and integration tests across watch_progress and media modules to cover per-profile scoping, repository isolation guarantees, and strict-mode behavior when no default profile is configured.