### PR TITLE
feat(collections): scope custom lists and watchlist per profile (PR 4)

### DIFF
--- a/migrations/versions/2026_05_03_add_profile_id_to_collections.py
+++ b/migrations/versions/2026_05_03_add_profile_id_to_collections.py
@@ -18,7 +18,7 @@ Sequence (so existing dev data survives):
 4. Drop legacy ``UNIQUE(media_id)`` on watchlist + create composite.
 
 Revision ID: e7f8a9b0c1d2
-Revises: d6e7f8a9b0c1
+Revises: f8a9b0c1d2e3
 Create Date: 2026-05-03 19:00:00.000000
 
 """
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 revision: str = "e7f8a9b0c1d2"
-down_revision: str | Sequence[str] | None = "d6e7f8a9b0c1"
+down_revision: str | Sequence[str] | None = "f8a9b0c1d2e3"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/2026_05_03_add_profile_id_to_collections.py
+++ b/migrations/versions/2026_05_03_add_profile_id_to_collections.py
@@ -1,0 +1,172 @@
+"""Add profile_id to collections (custom_lists, watchlist_items).
+
+Per ADR-010, every personalisation row is scoped to a profile. This
+migration adds ``profile_id`` to both ``custom_lists`` and
+``watchlist_items``, and replaces the legacy ``UNIQUE(media_id)`` on
+watchlist with a composite ``UNIQUE(profile_id, media_id)`` so each
+profile has its own watchlist row per title.
+
+``custom_list_items`` does not get its own ``profile_id`` column —
+items inherit profile scoping through the FK to ``custom_lists``,
+which the repository joins through.
+
+Sequence (so existing dev data survives):
+
+1. ADD COLUMN profile_id NULLABLE on both tables.
+2. UPDATE legacy rows with the oldest active profile's external_id.
+3. ALTER COLUMN profile_id NOT NULL.
+4. Drop legacy ``UNIQUE(media_id)`` on watchlist + create composite.
+
+Revision ID: e7f8a9b0c1d2
+Revises: d6e7f8a9b0c1
+Create Date: 2026-05-03 19:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "e7f8a9b0c1d2"
+down_revision: str | Sequence[str] | None = "d6e7f8a9b0c1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _resolve_default_profile_external_id(connection: sa.Connection) -> str:
+    """Return the prefixed external_id of the oldest active profile.
+
+    Aborts with a clear ``RuntimeError`` if no profile exists so the
+    operator runs ``scripts/identity_create_admin.py`` first instead
+    of getting a generic NOT NULL violation.
+    """
+    row = connection.execute(
+        sa.text(
+            "SELECT external_id "
+            "FROM profiles "
+            "WHERE deleted_at IS NULL "
+            "ORDER BY created_at ASC "
+            "LIMIT 1"
+        )
+    ).first()
+    if row is None:
+        msg = (
+            "Cannot backfill collections.profile_id: no active profile "
+            "exists. Run `python scripts/identity_create_admin.py` to create "
+            "an admin user and default profile, then re-run this migration."
+        )
+        raise RuntimeError(msg)
+    return row[0]
+
+
+def upgrade() -> None:
+    """Add profile_id to collections + replace legacy unique on watchlist."""
+    bind = op.get_bind()
+
+    # Step 1: ADD COLUMN NULLABLE on both tables.
+    with op.batch_alter_table("custom_lists") as batch_op:
+        batch_op.add_column(
+            sa.Column("profile_id", sa.String(length=50), nullable=True),
+        )
+    with op.batch_alter_table("watchlist_items") as batch_op:
+        batch_op.add_column(
+            sa.Column("profile_id", sa.String(length=50), nullable=True),
+        )
+
+    # Step 2: backfill legacy rows.
+    legacy_lists = bind.execute(
+        sa.text("SELECT COUNT(*) FROM custom_lists WHERE profile_id IS NULL")
+    ).scalar_one()
+    legacy_watchlist = bind.execute(
+        sa.text("SELECT COUNT(*) FROM watchlist_items WHERE profile_id IS NULL")
+    ).scalar_one()
+    if legacy_lists or legacy_watchlist:
+        default_profile = _resolve_default_profile_external_id(bind)
+        if legacy_lists:
+            bind.execute(
+                sa.text("UPDATE custom_lists SET profile_id = :pid " "WHERE profile_id IS NULL"),
+                {"pid": default_profile},
+            )
+        if legacy_watchlist:
+            bind.execute(
+                sa.text("UPDATE watchlist_items SET profile_id = :pid " "WHERE profile_id IS NULL"),
+                {"pid": default_profile},
+            )
+
+    # Step 3: tighten custom_lists.
+    with op.batch_alter_table("custom_lists") as batch_op:
+        batch_op.alter_column(
+            "profile_id",
+            existing_type=sa.String(length=50),
+            nullable=False,
+        )
+        batch_op.create_index(
+            "ix_custom_lists_profile_id",
+            ["profile_id"],
+            unique=False,
+        )
+
+    # Step 4: tighten watchlist_items + replace single-column unique.
+    # The legacy schema declared ``media_id`` as ``unique=True, index=True``.
+    # Same dialect-dependent shapes as PR 3 — handle defensively.
+    op.execute("DROP INDEX IF EXISTS ix_watchlist_items_media_id")
+    if op.get_context().dialect.name == "postgresql":
+        op.execute(
+            "ALTER TABLE watchlist_items " "DROP CONSTRAINT IF EXISTS watchlist_items_media_id_key"
+        )
+        op.execute(
+            "ALTER TABLE watchlist_items " "DROP CONSTRAINT IF EXISTS uq_watchlist_items_media_id"
+        )
+
+    with op.batch_alter_table("watchlist_items") as batch_op:
+        batch_op.alter_column(
+            "profile_id",
+            existing_type=sa.String(length=50),
+            nullable=False,
+        )
+        batch_op.create_index(
+            "ix_watchlist_items_media_id",
+            ["media_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "ix_watchlist_items_profile_id",
+            ["profile_id"],
+            unique=False,
+        )
+        batch_op.create_unique_constraint(
+            "uq_watchlist_items_profile_media",
+            ["profile_id", "media_id"],
+        )
+
+
+def downgrade() -> None:
+    """Reverse the schema change.
+
+    Drops the composite uniques, restores single-column UNIQUE on
+    watchlist_items.media_id, and removes the profile_id columns.
+    Loses profile scoping data — only safe in dev.
+    """
+    with op.batch_alter_table("watchlist_items") as batch_op:
+        batch_op.drop_constraint(
+            "uq_watchlist_items_profile_media",
+            type_="unique",
+        )
+        batch_op.drop_index("ix_watchlist_items_profile_id")
+        batch_op.drop_index("ix_watchlist_items_media_id")
+        batch_op.create_index(
+            "ix_watchlist_items_media_id",
+            ["media_id"],
+            unique=True,
+        )
+        batch_op.drop_column("profile_id")
+
+    with op.batch_alter_table("custom_lists") as batch_op:
+        batch_op.drop_index("ix_custom_lists_profile_id")
+        batch_op.drop_column("profile_id")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -288,6 +288,14 @@ class Settings(BaseSettings):  # type: ignore[misc]
         "together while the frontend is being migrated, then removes "
         "them to enter strict mode.",
     )
+    collections_default_profile_id: str | None = Field(
+        default=None,
+        description="Optional fallback ``profile_id`` for the collections "
+        "routes (``/custom-lists``, ``/watchlist``) during the per-profile "
+        "rollout. Same semantics as ``watch_progress_default_profile_id`` — "
+        "in practice the operator sets both together while the frontend "
+        "is being migrated, then removes both to enter strict mode.",
+    )
 
     # =========================================================================
     # Internationalization

--- a/src/modules/collections/application/dtos/__init__.py
+++ b/src/modules/collections/application/dtos/__init__.py
@@ -5,11 +5,13 @@ from src.modules.collections.application.dtos.custom_list_dtos import (
     CreateCustomListInput,
     CustomListItemOutput,
     CustomListOutput,
+    DeleteCustomListInput,
     GetCustomListItemsInput,
     RemoveItemFromCustomListInput,
     RenameCustomListInput,
 )
 from src.modules.collections.application.dtos.watchlist_dtos import (
+    CheckWatchlistInput,
     GetWatchlistInput,
     ToggleWatchlistInput,
     ToggleWatchlistOutput,
@@ -18,9 +20,11 @@ from src.modules.collections.application.dtos.watchlist_dtos import (
 
 __all__ = [
     "AddItemToCustomListInput",
+    "CheckWatchlistInput",
     "CreateCustomListInput",
     "CustomListItemOutput",
     "CustomListOutput",
+    "DeleteCustomListInput",
     "GetCustomListItemsInput",
     "GetWatchlistInput",
     "RemoveItemFromCustomListInput",

--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -12,26 +12,15 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class CreateCustomListInput:
-    """Input for CreateCustomListUseCase.
+    """Input for CreateCustomListUseCase."""
 
-    Attributes:
-        name: Display name for the new list.
-    """
-
+    profile_id: str
     name: str
 
 
 @dataclass(frozen=True)
 class CustomListOutput:
-    """Output representing a custom list.
-
-    Attributes:
-        id: External ID (lst_xxx format).
-        name: Display name of the list.
-        item_count: Number of items in the list.
-        created_at: ISO timestamp when the list was created.
-        updated_at: ISO timestamp when the list was last updated.
-    """
+    """Output representing a custom list."""
 
     id: str
     name: str
@@ -41,14 +30,7 @@ class CustomListOutput:
 
     @classmethod
     def from_entity(cls, entity: CustomList) -> CustomListOutput:
-        """Create output DTO from a CustomList entity.
-
-        Args:
-            entity: The CustomList domain entity.
-
-        Returns:
-            CustomListOutput DTO.
-        """
+        """Create output DTO from a CustomList entity."""
         return cls(
             id=str(entity.id),
             name=entity.name.value,
@@ -60,27 +42,26 @@ class CustomListOutput:
 
 @dataclass(frozen=True)
 class RenameCustomListInput:
-    """Input for RenameCustomListUseCase.
+    """Input for RenameCustomListUseCase."""
 
-    Attributes:
-        list_id: External ID of the list.
-        name: New display name.
-    """
-
+    profile_id: str
     list_id: str
     name: str
 
 
 @dataclass(frozen=True)
+class DeleteCustomListInput:
+    """Input for DeleteCustomListUseCase."""
+
+    profile_id: str
+    list_id: str
+
+
+@dataclass(frozen=True)
 class AddItemToCustomListInput:
-    """Input for AddItemToCustomListUseCase.
+    """Input for AddItemToCustomListUseCase."""
 
-    Attributes:
-        list_id: External ID of the list.
-        media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media ("movie" or "series").
-    """
-
+    profile_id: str
     list_id: str
     media_id: str
     media_type: CollectionMediaType
@@ -88,42 +69,25 @@ class AddItemToCustomListInput:
 
 @dataclass(frozen=True)
 class RemoveItemFromCustomListInput:
-    """Input for RemoveItemFromCustomListUseCase.
+    """Input for RemoveItemFromCustomListUseCase."""
 
-    Attributes:
-        list_id: External ID of the list.
-        media_id: External ID of the media.
-    """
-
+    profile_id: str
     list_id: str
     media_id: str
 
 
 @dataclass(frozen=True)
 class GetCustomListItemsInput:
-    """Input for GetCustomListItemsUseCase.
+    """Input for GetCustomListItemsUseCase."""
 
-    Attributes:
-        list_id: External ID of the list.
-        lang: Language code for localized metadata.
-    """
-
+    profile_id: str
     list_id: str
     lang: str = "en"
 
 
 @dataclass(frozen=True)
 class CustomListItemOutput:
-    """Output representing an item in a custom list with media metadata.
-
-    Attributes:
-        media_id: External ID of the media.
-        media_type: Type of media.
-        title: Display title (localized).
-        poster_path: URL to poster image.
-        position: Ordering position within the list.
-        added_at: ISO timestamp when added to the list.
-    """
+    """Output representing an item in a custom list with media metadata."""
 
     media_id: str
     media_type: CollectionMediaType
@@ -139,16 +103,7 @@ class CustomListItemOutput:
         title: str,
         poster_path: str | None,
     ) -> CustomListItemOutput:
-        """Create output DTO from a CustomListItem entity with metadata.
-
-        Args:
-            entity: The CustomListItem domain entity.
-            title: Localized display title.
-            poster_path: URL to poster image.
-
-        Returns:
-            CustomListItemOutput DTO.
-        """
+        """Create output DTO from a CustomListItem entity with metadata."""
         return cls(
             media_id=entity.media_id,
             media_type=entity.media_type,

--- a/src/modules/collections/application/dtos/watchlist_dtos.py
+++ b/src/modules/collections/application/dtos/watchlist_dtos.py
@@ -12,41 +12,32 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class ToggleWatchlistInput:
-    """Input for ToggleWatchlistUseCase.
+    """Input for ToggleWatchlistUseCase."""
 
-    Attributes:
-        media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media (movie or series).
-    """
-
+    profile_id: str
     media_id: str
     media_type: CollectionMediaType
 
 
 @dataclass(frozen=True)
 class ToggleWatchlistOutput:
-    """Output for ToggleWatchlistUseCase.
-
-    Attributes:
-        media_id: External ID of the media.
-        added: True if added to list, False if removed.
-    """
+    """Output for ToggleWatchlistUseCase."""
 
     media_id: str
     added: bool
 
 
 @dataclass(frozen=True)
-class WatchlistItemOutput:
-    """Output representing a single watchlist item with media metadata.
+class CheckWatchlistInput:
+    """Input for CheckWatchlistUseCase."""
 
-    Attributes:
-        media_id: External ID of the media.
-        media_type: Type of media.
-        title: Display title (localized).
-        poster_path: URL to poster image.
-        added_at: ISO timestamp when added to watchlist.
-    """
+    profile_id: str
+    media_id: str
+
+
+@dataclass(frozen=True)
+class WatchlistItemOutput:
+    """Output representing a single watchlist item with media metadata."""
 
     media_id: str
     media_type: CollectionMediaType
@@ -61,16 +52,7 @@ class WatchlistItemOutput:
         title: str,
         poster_path: str | None,
     ) -> WatchlistItemOutput:
-        """Create output DTO from a WatchlistItem entity with metadata.
-
-        Args:
-            entity: The WatchlistItem domain entity.
-            title: Localized display title.
-            poster_path: URL to poster image.
-
-        Returns:
-            WatchlistItemOutput DTO.
-        """
+        """Create output DTO from a WatchlistItem entity with metadata."""
         return cls(
             media_id=entity.media_id,
             media_type=entity.media_type,
@@ -82,12 +64,8 @@ class WatchlistItemOutput:
 
 @dataclass(frozen=True)
 class GetWatchlistInput:
-    """Input for GetWatchlistUseCase.
+    """Input for GetWatchlistUseCase."""
 
-    Attributes:
-        limit: Maximum number of items to return.
-        lang: Language code for localized metadata.
-    """
-
+    profile_id: str
     limit: int = 100
     lang: str = "en"

--- a/src/modules/collections/application/use_cases/add_item_to_custom_list.py
+++ b/src/modules/collections/application/use_cases/add_item_to_custom_list.py
@@ -5,38 +5,30 @@ from src.building_blocks.domain import BusinessRuleViolationException
 from src.modules.collections.application.dtos import AddItemToCustomListInput
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.modules.collections.domain.entities import CustomListItem
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class AddItemToCustomListUseCase:
-    """Add a movie or series to a custom list.
+    """Add a movie or series to a custom list owned by the caller's profile.
 
-    Enforces item limit per list and prevents duplicates.
+    Enforces the per-list item limit and prevents duplicates within the
+    list.
     """
 
     def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh collections Unit of Work.
-        """
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: AddItemToCustomListInput) -> None:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains list_id, media_id, and media_type.
-
-        Raises:
-            ResourceNotFoundException: If the list does not exist.
-            BusinessRuleViolationException: If item already in list or list is full.
-        """
+        """Add the item, enforcing list ownership + limits."""
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id)
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id, profile_id)
             if not custom_list:
                 raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-            existing_item = await uow.custom_lists.find_item(input_dto.list_id, input_dto.media_id)
+            existing_item = await uow.custom_lists.find_item(
+                input_dto.list_id, input_dto.media_id, profile_id
+            )
             if existing_item:
                 raise BusinessRuleViolationException(
                     message="Item already exists in this list",
@@ -47,7 +39,7 @@ class AddItemToCustomListUseCase:
             # Validate item limit via domain entity
             updated_list = custom_list.increment_item_count()
 
-            next_position = await uow.custom_lists.get_next_position(input_dto.list_id)
+            next_position = await uow.custom_lists.get_next_position(input_dto.list_id, profile_id)
 
             item = CustomListItem.create(
                 media_id=input_dto.media_id,
@@ -55,7 +47,7 @@ class AddItemToCustomListUseCase:
                 position=next_position,
             )
 
-            await uow.custom_lists.add_item(input_dto.list_id, item)
+            await uow.custom_lists.add_item(input_dto.list_id, item, profile_id)
             await uow.custom_lists.update(updated_list)
 
 

--- a/src/modules/collections/application/use_cases/check_watchlist.py
+++ b/src/modules/collections/application/use_cases/check_watchlist.py
@@ -1,37 +1,20 @@
 """CheckWatchlistUseCase - Check if a media item is in the watchlist."""
 
+from src.modules.collections.application.dtos import CheckWatchlistInput
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class CheckWatchlistUseCase:
-    """Check whether a media item exists in the user's watchlist.
-
-    Example:
-        >>> use_case = CheckWatchlistUseCase(uow_factory)
-        >>> in_list = await use_case.execute("mov_abc123def456")
-        >>> in_list
-        True
-    """
+    """Check whether a media item is in the caller's watchlist."""
 
     def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh collections Unit of Work.
-        """
         self._uow_factory = uow_factory
 
-    async def execute(self, media_id: str) -> bool:
-        """Execute the use case.
-
-        Args:
-            media_id: External ID of the media to check.
-
-        Returns:
-            True if the item is in the watchlist, False otherwise.
-        """
+    async def execute(self, input_dto: CheckWatchlistInput) -> bool:
+        """Return True if the profile has the item on its watchlist."""
         async with self._uow_factory() as uow:
-            return await uow.watchlist.exists(media_id)
+            return await uow.watchlist.exists(input_dto.media_id, ProfileId(input_dto.profile_id))
 
 
 __all__ = ["CheckWatchlistUseCase"]

--- a/src/modules/collections/application/use_cases/create_custom_list.py
+++ b/src/modules/collections/application/use_cases/create_custom_list.py
@@ -7,40 +7,24 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.modules.collections.domain.entities import MAX_LISTS, CustomList
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class CreateCustomListUseCase:
-    """Create a new user-defined custom list.
+    """Create a new user-defined custom list, scoped to one profile.
 
-    Enforces the maximum list limit and unique name constraint.
-
-    Example:
-        >>> use_case = CreateCustomListUseCase(uow_factory)
-        >>> result = await use_case.execute(CreateCustomListInput(name="Action Movies"))
+    Enforces the per-profile maximum list limit and unique-name
+    constraint within the profile.
     """
 
     def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh collections Unit of Work.
-        """
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: CreateCustomListInput) -> CustomListOutput:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains the list name.
-
-        Returns:
-            CustomListOutput with the created list data.
-
-        Raises:
-            BusinessRuleViolationException: If list limit reached or name already exists.
-        """
+        """Create the list, enforcing per-profile limits and uniqueness."""
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            current_count = await uow.custom_lists.count()
+            current_count = await uow.custom_lists.count(profile_id)
             if current_count >= MAX_LISTS:
                 raise BusinessRuleViolationException(
                     message=f"Cannot create more than {MAX_LISTS} custom lists",
@@ -48,7 +32,7 @@ class CreateCustomListUseCase:
                     rule_code="CUSTOM_LIST_LIMIT_EXCEEDED",
                 )
 
-            existing = await uow.custom_lists.find_by_name(input_dto.name.strip())
+            existing = await uow.custom_lists.find_by_name(input_dto.name.strip(), profile_id)
             if existing:
                 raise BusinessRuleViolationException(
                     message=f"A list named '{input_dto.name.strip()}' already exists",
@@ -56,7 +40,7 @@ class CreateCustomListUseCase:
                     rule_code="CUSTOM_LIST_NAME_DUPLICATE",
                 )
 
-            custom_list = CustomList.create(name=input_dto.name)
+            custom_list = CustomList.create(profile_id=profile_id, name=input_dto.name)
             saved = await uow.custom_lists.add(custom_list)
         return CustomListOutput.from_entity(saved)
 

--- a/src/modules/collections/application/use_cases/delete_custom_list.py
+++ b/src/modules/collections/application/use_cases/delete_custom_list.py
@@ -1,33 +1,31 @@
 """DeleteCustomListUseCase - Delete a custom list."""
 
 from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.collections.application.dtos import DeleteCustomListInput
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class DeleteCustomListUseCase:
-    """Delete a custom list and all its items."""
+    """Delete a custom list (and its items) owned by the caller's profile."""
 
     def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh collections Unit of Work.
-        """
         self._uow_factory = uow_factory
 
-    async def execute(self, list_id: str) -> None:
-        """Execute the use case.
+    async def execute(self, input_dto: DeleteCustomListInput) -> None:
+        """Soft-delete the list and its items, scoped to the caller's profile.
 
-        Args:
-            list_id: External ID of the list to delete.
-
-        Raises:
-            ResourceNotFoundException: If the list does not exist.
+        Raises ``ResourceNotFoundException`` (HTTP 404) when the list
+        either doesn't exist or doesn't belong to ``profile_id``;
+        ownership leakage is impossible because the repository scopes
+        every query.
         """
         async with self._uow_factory() as uow:
-            removed = await uow.custom_lists.remove(list_id)
+            removed = await uow.custom_lists.remove(
+                input_dto.list_id, ProfileId(input_dto.profile_id)
+            )
         if not removed:
-            raise ResourceNotFoundException.for_resource("CustomList", list_id)
+            raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
 
 __all__ = ["DeleteCustomListUseCase"]

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -10,6 +10,7 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _logger = logging.getLogger(__name__)
 
@@ -56,12 +57,13 @@ class GetCustomListItemsUseCase:
         Raises:
             ResourceNotFoundException: If the list does not exist.
         """
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id)
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id, profile_id)
             if not custom_list:
                 raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-            items = await uow.custom_lists.list_items(input_dto.list_id)
+            items = await uow.custom_lists.list_items(input_dto.list_id, profile_id)
         _logger.info("Found %d items in custom list %s", len(items), input_dto.list_id)
 
         if not items:

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -9,6 +9,7 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _logger = logging.getLogger(__name__)
 
@@ -49,8 +50,9 @@ class GetWatchlistUseCase:
         Returns:
             List of WatchlistItemOutput with media metadata.
         """
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            items = await uow.watchlist.list_all(limit=input_dto.limit)
+            items = await uow.watchlist.list_all(profile_id, limit=input_dto.limit)
         _logger.info("Found %d watchlist items", len(items))
 
         if not items:

--- a/src/modules/collections/application/use_cases/list_custom_lists.py
+++ b/src/modules/collections/application/use_cases/list_custom_lists.py
@@ -1,34 +1,30 @@
-"""ListCustomListsUseCase - List all custom lists."""
+"""ListCustomListsUseCase - List custom lists for a profile."""
+
+from dataclasses import dataclass
 
 from src.modules.collections.application.dtos import CustomListOutput
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+
+@dataclass(frozen=True)
+class ListCustomListsInput:
+    """Input for ListCustomListsUseCase."""
+
+    profile_id: str
 
 
 class ListCustomListsUseCase:
-    """List all user-created custom lists.
-
-    Example:
-        >>> use_case = ListCustomListsUseCase(uow_factory)
-        >>> lists = await use_case.execute()
-    """
+    """List all custom lists owned by the caller's profile."""
 
     def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh collections Unit of Work.
-        """
         self._uow_factory = uow_factory
 
-    async def execute(self) -> list[CustomListOutput]:
-        """Execute the use case.
-
-        Returns:
-            List of CustomListOutput DTOs.
-        """
+    async def execute(self, input_dto: ListCustomListsInput) -> list[CustomListOutput]:
+        """Return the profile's lists ordered by most recently updated."""
         async with self._uow_factory() as uow:
-            lists = await uow.custom_lists.list_all()
+            lists = await uow.custom_lists.list_all(ProfileId(input_dto.profile_id))
         return [CustomListOutput.from_entity(cl) for cl in lists]
 
 
-__all__ = ["ListCustomListsUseCase"]
+__all__ = ["ListCustomListsInput", "ListCustomListsUseCase"]

--- a/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
+++ b/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
@@ -3,34 +3,26 @@
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.collections.application.dtos import RemoveItemFromCustomListInput
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class RemoveItemFromCustomListUseCase:
-    """Remove a movie or series from a custom list."""
+    """Remove a movie or series from a custom list owned by the caller."""
 
     def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh collections Unit of Work.
-        """
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: RemoveItemFromCustomListInput) -> None:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains list_id and media_id.
-
-        Raises:
-            ResourceNotFoundException: If the list or item does not exist.
-        """
+        """Soft-delete the item from a list owned by the caller's profile."""
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id)
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id, profile_id)
             if not custom_list:
                 raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
-            removed = await uow.custom_lists.remove_item(input_dto.list_id, input_dto.media_id)
+            removed = await uow.custom_lists.remove_item(
+                input_dto.list_id, input_dto.media_id, profile_id
+            )
             if not removed:
                 raise ResourceNotFoundException.for_resource("CustomListItem", input_dto.media_id)
 

--- a/src/modules/collections/application/use_cases/rename_custom_list.py
+++ b/src/modules/collections/application/use_cases/rename_custom_list.py
@@ -7,39 +7,25 @@ from src.modules.collections.application.dtos import (
     RenameCustomListInput,
 )
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class RenameCustomListUseCase:
-    """Rename an existing custom list."""
+    """Rename an existing custom list owned by the caller's profile."""
 
     def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh collections Unit of Work.
-        """
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: RenameCustomListInput) -> CustomListOutput:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains list_id and new name.
-
-        Returns:
-            CustomListOutput with the updated list data.
-
-        Raises:
-            ResourceNotFoundException: If the list does not exist.
-            BusinessRuleViolationException: If the name is already taken.
-        """
+        """Rename the list, enforcing per-profile uniqueness."""
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id)
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id, profile_id)
             if not custom_list:
                 raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
             new_name = input_dto.name.strip()
-            existing = await uow.custom_lists.find_by_name(new_name)
+            existing = await uow.custom_lists.find_by_name(new_name, profile_id)
             if existing and str(existing.id) != input_dto.list_id:
                 raise BusinessRuleViolationException(
                     message=f"A list named '{new_name}' already exists",

--- a/src/modules/collections/application/use_cases/toggle_watchlist.py
+++ b/src/modules/collections/application/use_cases/toggle_watchlist.py
@@ -6,49 +6,31 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.modules.collections.domain.entities import WatchlistItem
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class ToggleWatchlistUseCase:
-    """Toggle a media item in the user's watchlist.
+    """Toggle a media item in the caller's watchlist.
 
-    If the item is already in the watchlist, it is removed.
-    If it is not in the watchlist, it is added.
-
-    Example:
-        >>> use_case = ToggleWatchlistUseCase(uow_factory)
-        >>> result = await use_case.execute(ToggleWatchlistInput(
-        ...     media_id="mov_abc123def456",
-        ...     media_type="movie",
-        ... ))
-        >>> result.added
-        True
+    If the item is already in the profile's watchlist, it is removed.
+    If it is not, it is added.
     """
 
     def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
-        """Initialize the use case.
-
-        Args:
-            uow_factory: Factory that opens a fresh collections Unit of Work.
-        """
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ToggleWatchlistInput) -> ToggleWatchlistOutput:
-        """Execute the use case.
-
-        Args:
-            input_dto: Contains media_id and media_type.
-
-        Returns:
-            ToggleWatchlistOutput with added=True if added, False if removed.
-        """
+        """Toggle the entry, scoped to the caller's profile."""
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            exists = await uow.watchlist.exists(input_dto.media_id)
+            exists = await uow.watchlist.exists(input_dto.media_id, profile_id)
 
             if exists:
-                await uow.watchlist.remove(input_dto.media_id)
+                await uow.watchlist.remove(input_dto.media_id, profile_id)
                 return ToggleWatchlistOutput(media_id=input_dto.media_id, added=False)
 
             item = WatchlistItem.create(
+                profile_id=profile_id,
                 media_id=input_dto.media_id,
                 media_type=input_dto.media_type,
             )

--- a/src/modules/collections/domain/entities/custom_list.py
+++ b/src/modules/collections/domain/entities/custom_list.py
@@ -19,6 +19,7 @@ from src.modules.collections.domain.value_objects import (
 from src.shared_kernel.value_objects import (
     CollectionMediaType,  # noqa: TCH001 — runtime for Pydantic
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
 MAX_LISTS = 10
 MAX_ITEMS_PER_LIST = 100
@@ -95,6 +96,7 @@ class CustomList(AggregateRoot[ListId]):
 
     id: ListId | None = Field(default=None)
 
+    profile_id: ProfileId
     name: ListName
     item_count: int = 0
 
@@ -105,10 +107,13 @@ class CustomList(AggregateRoot[ListId]):
         return ListName(v) if isinstance(v, str) else v
 
     @classmethod
-    def create(cls, name: str | ListName) -> CustomList:
+    def create(cls, profile_id: ProfileId, name: str | ListName) -> CustomList:
         """Factory method with automatic ID generation.
 
         Args:
+            profile_id: Owning profile (``prf_xxx``). Every list is scoped
+                to a single profile so multi-profile households keep
+                their lists separate.
             name: Display name for the list.
 
         Returns:
@@ -116,6 +121,7 @@ class CustomList(AggregateRoot[ListId]):
         """
         return cls(
             id=ListId.generate(),
+            profile_id=profile_id,
             name=name,
             item_count=0,
         )

--- a/src/modules/collections/domain/entities/watchlist_item.py
+++ b/src/modules/collections/domain/entities/watchlist_item.py
@@ -11,21 +11,24 @@ from src.modules.collections.domain.value_objects import ListId
 from src.shared_kernel.value_objects import (
     CollectionMediaType,  # noqa: TCH001 — runtime for Pydantic
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
 
 class WatchlistItem(AggregateRoot[ListId]):
-    """An item saved to the user's watchlist (My List).
+    """An item saved to a profile's watchlist (My List).
 
-    Represents a movie or series that the user wants to watch later.
+    Represents a movie or series that the profile wants to watch later.
 
     Attributes:
         id: External ID (lst_xxx format).
+        profile_id: Owning profile (``prf_xxx``).
         media_id: External ID of the media (mov_xxx or ser_xxx).
         media_type: Type of media (movie or series).
         added_at: Timestamp when the item was added.
 
     Example:
         >>> item = WatchlistItem.create(
+        ...     profile_id=caller_profile_id,
         ...     media_id="mov_abc123def456",
         ...     media_type=CollectionMediaType.MOVIE,
         ... )
@@ -33,6 +36,7 @@ class WatchlistItem(AggregateRoot[ListId]):
 
     id: ListId | None = Field(default=None)
 
+    profile_id: ProfileId
     media_id: str
     media_type: CollectionMediaType
     added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -40,20 +44,14 @@ class WatchlistItem(AggregateRoot[ListId]):
     @classmethod
     def create(
         cls,
+        profile_id: ProfileId,
         media_id: str,
         media_type: CollectionMediaType,
     ) -> WatchlistItem:
-        """Factory method with automatic ID generation.
-
-        Args:
-            media_id: External ID of the media (mov_xxx or ser_xxx).
-            media_type: Type of media (movie or series).
-
-        Returns:
-            A new WatchlistItem instance.
-        """
+        """Factory method with automatic ID generation."""
         return cls(
             id=ListId.generate(),
+            profile_id=profile_id,
             media_id=media_id,
             media_type=media_type,
             added_at=datetime.now(UTC),

--- a/src/modules/collections/domain/repositories/custom_list_repository.py
+++ b/src/modules/collections/domain/repositories/custom_list_repository.py
@@ -3,150 +3,103 @@
 from abc import ABC, abstractmethod
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class CustomListRepository(ABC):
     """Abstract repository for CustomList persistence.
 
+    Every read/delete method takes ``profile_id`` so a caller can never
+    reach another profile's list — even with a known ``list_id``.
+    ``add`` and ``update`` read the profile straight off the entity.
+
     Example:
-        >>> lists = await repo.list_all()
-        >>> items = await repo.list_items("lst_abc123def456")
+        >>> lists = await repo.list_all(caller_profile_id)
+        >>> items = await repo.list_items("lst_abc123def456", caller_profile_id)
     """
 
     # -- List CRUD -------------------------------------------------------------
 
     @abstractmethod
-    async def find_by_id(self, list_id: str) -> CustomList | None:
-        """Find a custom list by its external ID.
-
-        Args:
-            list_id: External ID of the list (lst_xxx).
-
-        Returns:
-            CustomList if found, None otherwise.
-        """
+    async def find_by_id(
+        self,
+        list_id: str,
+        profile_id: ProfileId,
+    ) -> CustomList | None:
+        """Find a list owned by ``profile_id`` with the given external ID."""
 
     @abstractmethod
-    async def find_by_name(self, name: str) -> CustomList | None:
-        """Find a custom list by name (case-insensitive).
-
-        Args:
-            name: Name of the list.
-
-        Returns:
-            CustomList if found, None otherwise.
-        """
+    async def find_by_name(
+        self,
+        name: str,
+        profile_id: ProfileId,
+    ) -> CustomList | None:
+        """Find a list (case-insensitive name match) within the profile."""
 
     @abstractmethod
     async def add(self, custom_list: CustomList) -> CustomList:
-        """Persist a new custom list.
-
-        Args:
-            custom_list: The CustomList entity to persist.
-
-        Returns:
-            The persisted CustomList.
-        """
+        """Persist a new custom list (profile is read from the entity)."""
 
     @abstractmethod
     async def update(self, custom_list: CustomList) -> CustomList:
-        """Update an existing custom list.
-
-        Args:
-            custom_list: The CustomList entity with updates.
-
-        Returns:
-            The updated CustomList.
-        """
+        """Update an existing custom list (profile is read from the entity)."""
 
     @abstractmethod
-    async def remove(self, list_id: str) -> bool:
-        """Soft-delete a custom list and all its items.
-
-        Args:
-            list_id: External ID of the list.
-
-        Returns:
-            True if removed, False if not found.
-        """
+    async def remove(self, list_id: str, profile_id: ProfileId) -> bool:
+        """Soft-delete a list and its items, scoped to the profile."""
 
     @abstractmethod
-    async def list_all(self) -> list[CustomList]:
-        """List all custom lists ordered by most recently updated.
-
-        Returns:
-            List of CustomList entities.
-        """
+    async def list_all(self, profile_id: ProfileId) -> list[CustomList]:
+        """List the profile's custom lists, most recently updated first."""
 
     @abstractmethod
-    async def count(self) -> int:
-        """Count total active custom lists.
-
-        Returns:
-            Number of non-deleted custom lists.
-        """
+    async def count(self, profile_id: ProfileId) -> int:
+        """Count active custom lists for the profile (for MAX_LISTS check)."""
 
     # -- Item management -------------------------------------------------------
 
     @abstractmethod
-    async def find_item(self, list_id: str, media_id: str) -> CustomListItem | None:
-        """Find an item in a custom list.
-
-        Args:
-            list_id: External ID of the list.
-            media_id: External ID of the media.
-
-        Returns:
-            CustomListItem if found, None otherwise.
-        """
+    async def find_item(
+        self,
+        list_id: str,
+        media_id: str,
+        profile_id: ProfileId,
+    ) -> CustomListItem | None:
+        """Find an item in a list, scoped to the profile owning that list."""
 
     @abstractmethod
-    async def add_item(self, list_id: str, item: CustomListItem) -> CustomListItem:
-        """Add an item to a custom list.
-
-        Args:
-            list_id: External ID of the list.
-            item: The CustomListItem entity to persist.
-
-        Returns:
-            The persisted CustomListItem.
-        """
+    async def add_item(
+        self,
+        list_id: str,
+        item: CustomListItem,
+        profile_id: ProfileId,
+    ) -> CustomListItem:
+        """Persist an item under a list owned by ``profile_id``."""
 
     @abstractmethod
-    async def remove_item(self, list_id: str, media_id: str) -> bool:
-        """Remove an item from a custom list.
-
-        Args:
-            list_id: External ID of the list.
-            media_id: External ID of the media.
-
-        Returns:
-            True if removed, False if not found.
-        """
+    async def remove_item(
+        self,
+        list_id: str,
+        media_id: str,
+        profile_id: ProfileId,
+    ) -> bool:
+        """Remove an item from a list owned by ``profile_id``."""
 
     @abstractmethod
-    async def list_items(self, list_id: str) -> list[CustomListItem]:
-        """List all items in a custom list ordered by position.
-
-        Args:
-            list_id: External ID of the list.
-
-        Returns:
-            List of CustomListItem entities.
-        """
+    async def list_items(
+        self,
+        list_id: str,
+        profile_id: ProfileId,
+    ) -> list[CustomListItem]:
+        """List items in a list owned by ``profile_id``, ordered by position."""
 
     @abstractmethod
-    async def get_next_position(self, list_id: str) -> int:
-        """Get the next available position for a new item in a list.
-
-        Uses a DB-level MAX query to avoid loading all items.
-
-        Args:
-            list_id: External ID of the list.
-
-        Returns:
-            The next position value (0-based).
-        """
+    async def get_next_position(
+        self,
+        list_id: str,
+        profile_id: ProfileId,
+    ) -> int:
+        """Return the next 0-based position to use for a new item."""
 
 
 __all__ = ["CustomListRepository"]

--- a/src/modules/collections/domain/repositories/watchlist_repository.py
+++ b/src/modules/collections/domain/repositories/watchlist_repository.py
@@ -3,69 +3,48 @@
 from abc import ABC, abstractmethod
 
 from src.modules.collections.domain.entities import WatchlistItem
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class WatchlistRepository(ABC):
-    """Abstract repository for WatchlistItem persistence.
+    """Abstract repository for ``WatchlistItem`` persistence.
+
+    Every read/delete operation takes ``profile_id`` so a profile only
+    sees its own watchlist. ``add`` reads the profile from the entity.
 
     Example:
-        >>> item = await repo.find_by_media_id("mov_abc123def456")
+        >>> item = await repo.find_by_media_id(
+        ...     "mov_abc123def456", caller_profile_id
+        ... )
     """
 
     @abstractmethod
-    async def find_by_media_id(self, media_id: str) -> WatchlistItem | None:
-        """Find a watchlist item by media external ID.
-
-        Args:
-            media_id: External ID of the media (mov_xxx or ser_xxx).
-
-        Returns:
-            WatchlistItem if found, None otherwise.
-        """
+    async def find_by_media_id(
+        self,
+        media_id: str,
+        profile_id: ProfileId,
+    ) -> WatchlistItem | None:
+        """Find an entry for ``media_id`` in ``profile_id``'s watchlist."""
 
     @abstractmethod
     async def add(self, item: WatchlistItem) -> WatchlistItem:
-        """Add an item to the watchlist.
-
-        Args:
-            item: The WatchlistItem entity to persist.
-
-        Returns:
-            The persisted WatchlistItem.
-        """
+        """Add an item (profile is read from the entity)."""
 
     @abstractmethod
-    async def remove(self, media_id: str) -> bool:
-        """Soft-delete an item from the watchlist.
-
-        Args:
-            media_id: External ID of the media.
-
-        Returns:
-            True if removed, False if not found.
-        """
+    async def remove(self, media_id: str, profile_id: ProfileId) -> bool:
+        """Soft-delete an item from ``profile_id``'s watchlist."""
 
     @abstractmethod
-    async def list_all(self, limit: int = 100) -> list[WatchlistItem]:
-        """List all watchlist items ordered by most recently added.
-
-        Args:
-            limit: Maximum number of items to return.
-
-        Returns:
-            List of WatchlistItem entities.
-        """
+    async def list_all(
+        self,
+        profile_id: ProfileId,
+        limit: int = 100,
+    ) -> list[WatchlistItem]:
+        """List the profile's watchlist items, most recently added first."""
 
     @abstractmethod
-    async def exists(self, media_id: str) -> bool:
-        """Check if a media item is in the watchlist.
-
-        Args:
-            media_id: External ID of the media.
-
-        Returns:
-            True if the item exists, False otherwise.
-        """
+    async def exists(self, media_id: str, profile_id: ProfileId) -> bool:
+        """Check whether ``media_id`` is on ``profile_id``'s watchlist."""
 
 
 __all__ = ["WatchlistRepository"]

--- a/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
@@ -7,48 +7,32 @@ from src.modules.collections.infrastructure.persistence.models import (
     CustomListModel,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class CustomListMapper:
-    """Bidirectional mapper between CustomList entity and ORM model.
-
-    Example:
-        >>> model = CustomListMapper.to_model(entity)
-        >>> entity = CustomListMapper.to_entity(model)
-    """
+    """Bidirectional mapper between CustomList entity and ORM model."""
 
     @staticmethod
     def to_model(entity: CustomList) -> CustomListModel:
-        """Convert CustomList entity to ORM model.
-
-        Args:
-            entity: The domain entity.
-
-        Returns:
-            SQLAlchemy model ready for persistence.
-        """
+        """Convert CustomList entity to ORM model."""
         if entity.id is None:
             msg = "Cannot map entity without ID to model"
             raise ValueError(msg)
 
         return CustomListModel(
             external_id=str(entity.id),
+            profile_id=str(entity.profile_id),
             name=entity.name.value,
             item_count=entity.item_count,
         )
 
     @staticmethod
     def to_entity(model: CustomListModel) -> CustomList:
-        """Convert ORM model to CustomList entity.
-
-        Args:
-            model: The SQLAlchemy model.
-
-        Returns:
-            Domain CustomList entity.
-        """
+        """Convert ORM model to CustomList entity."""
         return CustomList(
             id=ListId(model.external_id),
+            profile_id=ProfileId(model.profile_id),
             name=model.name,
             item_count=model.item_count,
             created_at=model.created_at,
@@ -57,39 +41,18 @@ class CustomListMapper:
 
     @staticmethod
     def update_model(model: CustomListModel, entity: CustomList) -> CustomListModel:
-        """Update existing ORM model with entity data.
-
-        Args:
-            model: The existing model.
-            entity: The updated entity.
-
-        Returns:
-            The updated model.
-        """
+        """Update mutable fields. ``profile_id`` is intentionally not touched."""
         model.name = entity.name.value
         model.item_count = entity.item_count
         return model
 
 
 class CustomListItemMapper:
-    """Bidirectional mapper between CustomListItem entity and ORM model.
-
-    Example:
-        >>> model = CustomListItemMapper.to_model(entity, list_internal_id=1)
-        >>> entity = CustomListItemMapper.to_entity(model)
-    """
+    """Bidirectional mapper between CustomListItem entity and ORM model."""
 
     @staticmethod
     def to_model(entity: CustomListItem, list_internal_id: int) -> CustomListItemModel:
-        """Convert CustomListItem entity to ORM model.
-
-        Args:
-            entity: The domain entity.
-            list_internal_id: Internal DB ID of the parent custom list.
-
-        Returns:
-            SQLAlchemy model ready for persistence.
-        """
+        """Convert CustomListItem entity to ORM model."""
         if entity.id is None:
             msg = "Cannot map entity without ID to model"
             raise ValueError(msg)
@@ -105,14 +68,7 @@ class CustomListItemMapper:
 
     @staticmethod
     def to_entity(model: CustomListItemModel) -> CustomListItem:
-        """Convert ORM model to CustomListItem entity.
-
-        Args:
-            model: The SQLAlchemy model.
-
-        Returns:
-            Domain CustomListItem entity.
-        """
+        """Convert ORM model to CustomListItem entity."""
         return CustomListItem(
             id=CustomListItemId(model.external_id),
             media_id=model.media_id,

--- a/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
@@ -42,9 +42,16 @@ class WatchlistItemMapper:
 
     @staticmethod
     def update_model(model: WatchlistItemModel, entity: WatchlistItem) -> WatchlistItemModel:
-        """Update mutable fields; ``profile_id`` is not touched."""
-        model.media_id = entity.media_id
-        model.media_type = entity.media_type
+        """Refresh the mutable fields on restore (soft-delete reactivation).
+
+        ``profile_id`` and ``media_id`` form the composite uniqueness
+        key (``uq_watchlist_items_profile_media``); the caller used
+        that pair to locate ``model`` in the first place, so any
+        attempt to overwrite them here would either be a no-op or
+        smuggle in a unique-constraint violation. ``media_type`` is
+        a property of the media itself, not of the watchlist entry,
+        and is also left untouched.
+        """
         model.added_at = entity.added_at
         return model
 

--- a/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
@@ -6,32 +6,22 @@ from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class WatchlistItemMapper:
-    """Bidirectional mapper between WatchlistItem entity and ORM model.
-
-    Example:
-        >>> model = WatchlistItemMapper.to_model(entity)
-        >>> entity = WatchlistItemMapper.to_entity(model)
-    """
+    """Bidirectional mapper between WatchlistItem entity and ORM model."""
 
     @staticmethod
     def to_model(entity: WatchlistItem) -> WatchlistItemModel:
-        """Convert WatchlistItem entity to ORM model.
-
-        Args:
-            entity: The domain entity.
-
-        Returns:
-            SQLAlchemy model ready for persistence.
-        """
+        """Convert WatchlistItem entity to ORM model."""
         if entity.id is None:
             msg = "Cannot map entity without ID to model"
             raise ValueError(msg)
 
         return WatchlistItemModel(
             external_id=str(entity.id),
+            profile_id=str(entity.profile_id),
             media_id=entity.media_id,
             media_type=entity.media_type,
             added_at=entity.added_at,
@@ -39,16 +29,10 @@ class WatchlistItemMapper:
 
     @staticmethod
     def to_entity(model: WatchlistItemModel) -> WatchlistItem:
-        """Convert ORM model to WatchlistItem entity.
-
-        Args:
-            model: The SQLAlchemy model.
-
-        Returns:
-            Domain WatchlistItem entity.
-        """
+        """Convert ORM model to WatchlistItem entity."""
         return WatchlistItem(
             id=ListId(model.external_id),
+            profile_id=ProfileId(model.profile_id),
             media_id=model.media_id,
             media_type=CollectionMediaType(model.media_type),
             added_at=model.added_at,
@@ -58,15 +42,7 @@ class WatchlistItemMapper:
 
     @staticmethod
     def update_model(model: WatchlistItemModel, entity: WatchlistItem) -> WatchlistItemModel:
-        """Update existing ORM model with entity data.
-
-        Args:
-            model: The existing model.
-            entity: The updated entity.
-
-        Returns:
-            The updated model.
-        """
+        """Update mutable fields; ``profile_id`` is not touched."""
         model.media_id = entity.media_id
         model.media_type = entity.media_type
         model.added_at = entity.added_at

--- a/src/modules/collections/infrastructure/persistence/models/custom_list_model.py
+++ b/src/modules/collections/infrastructure/persistence/models/custom_list_model.py
@@ -11,14 +11,14 @@ from src.infrastructure.persistence.base import Base
 class CustomListModel(Base):
     """SQLAlchemy model for CustomList.
 
-    Maps to the 'custom_lists' table. One row per user-created list.
+    Maps to the 'custom_lists' table. One row per (profile, list).
 
-    Attributes:
-        name: Display name of the list.
-        item_count: Number of items in the list.
-        items: Relationship to CustomListItemModel.
+    ``profile_id`` is stored as the prefixed external ID (``prf_xxx``)
+    so every list query can scope by profile without joining ``profiles``.
+    Cross-BC references travel as strings, not UUIDs (per ADR-008).
     """
 
+    profile_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(200), nullable=False)
     item_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
@@ -31,7 +31,8 @@ class CustomListModel(Base):
     def __repr__(self) -> str:
         """Return string representation."""
         return (
-            f"<CustomListModel(id={self.id}, name={self.name!r}, " f"item_count={self.item_count})>"
+            f"<CustomListModel(id={self.id}, profile_id={self.profile_id!r}, "
+            f"name={self.name!r}, item_count={self.item_count})>"
         )
 
 
@@ -40,12 +41,10 @@ class CustomListItemModel(Base):
 
     Maps to the 'custom_list_items' table. One row per item in a list.
 
-    Attributes:
-        custom_list_id: Foreign key to the parent custom list (internal ID).
-        media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media ("movie" or "series").
-        position: Ordering position within the list.
-        added_at: Timestamp when the item was added.
+    Items inherit profile scoping from their parent ``CustomListModel``
+    via the ``custom_list_id`` FK; the repository joins on the parent
+    to enforce per-profile isolation rather than denormalising
+    ``profile_id`` here.
     """
 
     custom_list_id: Mapped[int] = mapped_column(

--- a/src/modules/collections/infrastructure/persistence/models/watchlist_item_model.py
+++ b/src/modules/collections/infrastructure/persistence/models/watchlist_item_model.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, String
+from sqlalchemy import DateTime, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.infrastructure.persistence.base import Base
@@ -11,23 +11,31 @@ from src.infrastructure.persistence.base import Base
 class WatchlistItemModel(Base):
     """SQLAlchemy model for WatchlistItem.
 
-    Maps to the 'watchlist_items' table. One row per media item.
+    Maps to the 'watchlist_items' table. One row per (profile, media) —
+    different profiles in the same household keep their own watchlists.
 
-    Attributes:
-        media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media ("movie" or "series").
-        added_at: Timestamp when the item was added.
+    ``profile_id`` is stored as the prefixed external ID; cross-BC
+    references are strings, not UUIDs (per ADR-008).
     """
 
-    media_id: Mapped[str] = mapped_column(String(50), nullable=False, unique=True, index=True)
+    __table_args__ = (
+        UniqueConstraint(
+            "profile_id",
+            "media_id",
+            name="uq_watchlist_items_profile_media",
+        ),
+    )
+
+    profile_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    media_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     media_type: Mapped[str] = mapped_column(String(20), nullable=False)
     added_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 
     def __repr__(self) -> str:
         """Return string representation."""
         return (
-            f"<WatchlistItemModel(id={self.id}, media_id={self.media_id!r}, "
-            f"media_type={self.media_type!r})>"
+            f"<WatchlistItemModel(id={self.id}, profile_id={self.profile_id!r}, "
+            f"media_id={self.media_id!r}, media_type={self.media_type!r})>"
         )
 
 

--- a/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
@@ -13,40 +13,47 @@ from src.modules.collections.infrastructure.persistence.models import (
     CustomListItemModel,
     CustomListModel,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class SQLAlchemyCustomListRepository(CustomListRepository):
     """SQLAlchemy implementation of CustomListRepository.
 
-    Example:
-        >>> repo = SQLAlchemyCustomListRepository(session)
-        >>> lists = await repo.list_all()
+    Every read/delete query is scoped by ``profile_id`` so a profile
+    can never see (or accidentally mutate) another profile's lists,
+    even when armed with a known ``list_id``. ``add``/``update`` derive
+    the profile from the entity, matching the contract.
     """
 
     def __init__(self, session: AsyncSession) -> None:
-        """Initialize repository with database session.
-
-        Args:
-            session: SQLAlchemy async session.
-        """
         self._session = session
 
     # -- List CRUD -------------------------------------------------------------
 
-    async def find_by_id(self, list_id: str) -> CustomList | None:
-        """Find a custom list by its external ID."""
+    async def find_by_id(
+        self,
+        list_id: str,
+        profile_id: ProfileId,
+    ) -> CustomList | None:
+        """Find a non-deleted list owned by ``profile_id``."""
         stmt = select(CustomListModel).where(
             CustomListModel.external_id == list_id,
+            CustomListModel.profile_id == str(profile_id),
             CustomListModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
         model = result.scalar_one_or_none()
         return None if model is None else CustomListMapper.to_entity(model)
 
-    async def find_by_name(self, name: str) -> CustomList | None:
-        """Find a custom list by name (case-insensitive)."""
+    async def find_by_name(
+        self,
+        name: str,
+        profile_id: ProfileId,
+    ) -> CustomList | None:
+        """Find by name (case-insensitive) within the profile."""
         stmt = select(CustomListModel).where(
             func.lower(CustomListModel.name) == name.strip().lower(),
+            CustomListModel.profile_id == str(profile_id),
             CustomListModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -62,9 +69,10 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         return CustomListMapper.to_entity(model)
 
     async def update(self, custom_list: CustomList) -> CustomList:
-        """Update an existing custom list."""
+        """Update an existing custom list (scoped to its own profile)."""
         stmt = select(CustomListModel).where(
             CustomListModel.external_id == str(custom_list.id),
+            CustomListModel.profile_id == str(custom_list.profile_id),
             CustomListModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -79,10 +87,11 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         await self._session.refresh(model)
         return CustomListMapper.to_entity(model)
 
-    async def remove(self, list_id: str) -> bool:
-        """Soft-delete a custom list and all its items."""
+    async def remove(self, list_id: str, profile_id: ProfileId) -> bool:
+        """Soft-delete a list and its items, scoped to ``profile_id``."""
         stmt = select(CustomListModel).where(
             CustomListModel.external_id == list_id,
+            CustomListModel.profile_id == str(profile_id),
             CustomListModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -104,47 +113,56 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         await self._session.flush()
         return True
 
-    async def list_all(self) -> list[CustomList]:
-        """List all custom lists ordered by most recently updated."""
+    async def list_all(self, profile_id: ProfileId) -> list[CustomList]:
+        """List the profile's custom lists ordered by most recently updated."""
         stmt = (
             select(CustomListModel)
-            .where(CustomListModel.deleted_at.is_(None))
+            .where(
+                CustomListModel.profile_id == str(profile_id),
+                CustomListModel.deleted_at.is_(None),
+            )
             .order_by(CustomListModel.updated_at.desc())
         )
         result = await self._session.execute(stmt)
         return [CustomListMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def count(self) -> int:
-        """Count total active custom lists."""
+    async def count(self, profile_id: ProfileId) -> int:
+        """Count active custom lists for the profile."""
         stmt = (
             select(func.count())
             .select_from(CustomListModel)
-            .where(CustomListModel.deleted_at.is_(None))
+            .where(
+                CustomListModel.profile_id == str(profile_id),
+                CustomListModel.deleted_at.is_(None),
+            )
         )
         result = await self._session.execute(stmt)
         return result.scalar() or 0
 
     # -- Item management -------------------------------------------------------
 
-    async def _get_list_internal_id(self, list_id: str) -> int | None:
-        """Get the internal DB ID for a custom list by external ID.
-
-        Args:
-            list_id: External ID of the list.
-
-        Returns:
-            Internal ID if found, None otherwise.
-        """
+    async def _get_list_internal_id(
+        self,
+        list_id: str,
+        profile_id: ProfileId,
+    ) -> int | None:
+        """Resolve internal DB id, scoped to the owning profile."""
         stmt = select(CustomListModel.id).where(
             CustomListModel.external_id == list_id,
+            CustomListModel.profile_id == str(profile_id),
             CustomListModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
 
-    async def find_item(self, list_id: str, media_id: str) -> CustomListItem | None:
-        """Find an item in a custom list."""
-        internal_id = await self._get_list_internal_id(list_id)
+    async def find_item(
+        self,
+        list_id: str,
+        media_id: str,
+        profile_id: ProfileId,
+    ) -> CustomListItem | None:
+        """Find an item, only if the parent list belongs to the profile."""
+        internal_id = await self._get_list_internal_id(list_id, profile_id)
         if internal_id is None:
             return None
 
@@ -157,9 +175,14 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         model = result.scalar_one_or_none()
         return None if model is None else CustomListItemMapper.to_entity(model)
 
-    async def add_item(self, list_id: str, item: CustomListItem) -> CustomListItem:
-        """Add an item to a custom list."""
-        internal_id = await self._get_list_internal_id(list_id)
+    async def add_item(
+        self,
+        list_id: str,
+        item: CustomListItem,
+        profile_id: ProfileId,
+    ) -> CustomListItem:
+        """Persist an item under a list owned by ``profile_id``."""
+        internal_id = await self._get_list_internal_id(list_id, profile_id)
         if internal_id is None:
             msg = f"CustomList {list_id} not found"
             raise ValueError(msg)
@@ -187,9 +210,14 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         await self._session.refresh(model)
         return CustomListItemMapper.to_entity(model)
 
-    async def remove_item(self, list_id: str, media_id: str) -> bool:
-        """Remove an item from a custom list."""
-        internal_id = await self._get_list_internal_id(list_id)
+    async def remove_item(
+        self,
+        list_id: str,
+        media_id: str,
+        profile_id: ProfileId,
+    ) -> bool:
+        """Soft-delete an item from a list owned by ``profile_id``."""
+        internal_id = await self._get_list_internal_id(list_id, profile_id)
         if internal_id is None:
             return False
 
@@ -208,9 +236,13 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         await self._session.flush()
         return True
 
-    async def list_items(self, list_id: str) -> list[CustomListItem]:
-        """List all items in a custom list ordered by position."""
-        internal_id = await self._get_list_internal_id(list_id)
+    async def list_items(
+        self,
+        list_id: str,
+        profile_id: ProfileId,
+    ) -> list[CustomListItem]:
+        """List items in a list, scoped to the owning profile."""
+        internal_id = await self._get_list_internal_id(list_id, profile_id)
         if internal_id is None:
             return []
 
@@ -225,9 +257,13 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         result = await self._session.execute(stmt)
         return [CustomListItemMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def get_next_position(self, list_id: str) -> int:
-        """Get the next available position via DB MAX query."""
-        internal_id = await self._get_list_internal_id(list_id)
+    async def get_next_position(
+        self,
+        list_id: str,
+        profile_id: ProfileId,
+    ) -> int:
+        """Compute next position via MAX query, scoped to the owning profile."""
+        internal_id = await self._get_list_internal_id(list_id, profile_id)
         if internal_id is None:
             return 0
 

--- a/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
@@ -11,28 +11,29 @@ from src.modules.collections.infrastructure.persistence.mappers import (
 from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class SQLAlchemyWatchlistRepository(WatchlistRepository):
     """SQLAlchemy implementation of WatchlistRepository.
 
-    Example:
-        >>> repo = SQLAlchemyWatchlistRepository(session)
-        >>> item = await repo.find_by_media_id("mov_abc123def456")
+    Every read/delete query is scoped by ``profile_id`` so a profile
+    only sees its own watchlist. ``add`` derives the profile from the
+    entity, matching the contract.
     """
 
     def __init__(self, session: AsyncSession) -> None:
-        """Initialize repository with database session.
-
-        Args:
-            session: SQLAlchemy async session.
-        """
         self._session = session
 
-    async def find_by_media_id(self, media_id: str) -> WatchlistItem | None:
-        """Find a watchlist item by media external ID."""
+    async def find_by_media_id(
+        self,
+        media_id: str,
+        profile_id: ProfileId,
+    ) -> WatchlistItem | None:
+        """Find a row scoped to ``(media_id, profile_id)``."""
         stmt = select(WatchlistItemModel).where(
             WatchlistItemModel.media_id == media_id,
+            WatchlistItemModel.profile_id == str(profile_id),
             WatchlistItemModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -42,12 +43,14 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
     async def add(self, item: WatchlistItem) -> WatchlistItem:
         """Add an item to the watchlist.
 
-        If a soft-deleted record exists for the same media_id,
-        restores it instead of creating a duplicate.
+        If a soft-deleted record exists for the same
+        ``(profile_id, media_id)`` pair, restore it instead of
+        creating a duplicate (otherwise the composite UNIQUE
+        constraint would refuse the insert).
         """
-        # Check for soft-deleted record to restore
         stmt = select(WatchlistItemModel).where(
             WatchlistItemModel.media_id == item.media_id,
+            WatchlistItemModel.profile_id == str(item.profile_id),
             WatchlistItemModel.deleted_at.is_not(None),
         )
         result = await self._session.execute(stmt)
@@ -66,10 +69,11 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         await self._session.refresh(model)
         return WatchlistItemMapper.to_entity(model)
 
-    async def remove(self, media_id: str) -> bool:
-        """Soft-delete an item from the watchlist."""
+    async def remove(self, media_id: str, profile_id: ProfileId) -> bool:
+        """Soft-delete the row for (media_id, profile_id)."""
         stmt = select(WatchlistItemModel).where(
             WatchlistItemModel.media_id == media_id,
+            WatchlistItemModel.profile_id == str(profile_id),
             WatchlistItemModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -82,24 +86,32 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         await self._session.flush()
         return True
 
-    async def list_all(self, limit: int = 100) -> list[WatchlistItem]:
-        """List all watchlist items ordered by most recently added."""
+    async def list_all(
+        self,
+        profile_id: ProfileId,
+        limit: int = 100,
+    ) -> list[WatchlistItem]:
+        """List the profile's watchlist entries ordered by most recently added."""
         stmt = (
             select(WatchlistItemModel)
-            .where(WatchlistItemModel.deleted_at.is_(None))
+            .where(
+                WatchlistItemModel.profile_id == str(profile_id),
+                WatchlistItemModel.deleted_at.is_(None),
+            )
             .order_by(WatchlistItemModel.added_at.desc())
             .limit(limit)
         )
         result = await self._session.execute(stmt)
         return [WatchlistItemMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def exists(self, media_id: str) -> bool:
-        """Check if a media item is in the watchlist."""
+    async def exists(self, media_id: str, profile_id: ProfileId) -> bool:
+        """Check whether ``media_id`` is on ``profile_id``'s watchlist."""
         stmt = (
             select(func.count())
             .select_from(WatchlistItemModel)
             .where(
                 WatchlistItemModel.media_id == media_id,
+                WatchlistItemModel.profile_id == str(profile_id),
                 WatchlistItemModel.deleted_at.is_(None),
             )
         )

--- a/src/modules/collections/presentation/dependencies.py
+++ b/src/modules/collections/presentation/dependencies.py
@@ -1,0 +1,43 @@
+"""FastAPI dependency that resolves the caller's ``profile_id`` for collections.
+
+Same per-profile rollout pattern documented in
+``watch_progress/presentation/dependencies.py``: try the
+authenticated path first, fall back to
+``settings.collections_default_profile_id`` when no cookie is
+present, raise 401 otherwise. Once strict mode is acceptable
+project-wide, this dep can be replaced by a direct re-export of
+``identity.presentation.dependencies.get_current_profile``.
+"""
+
+from fastapi import Request
+
+from src.config.settings import get_settings
+from src.modules.identity.domain.errors import NoActiveSessionError
+
+
+async def resolve_profile_id(request: Request) -> str:
+    """Return the caller's profile_id (prefixed external ID).
+
+    Errors raised by the identity UoW (container not wired, DB
+    unreachable, etc.) propagate as 500 by design — silently falling
+    back to anonymous on real misconfigurations would mask bugs and
+    serve authenticated requests as anonymous.
+    """
+    settings = get_settings()
+
+    token = request.cookies.get(settings.session_cookie_name)
+    if token is not None:
+        container = request.app.state.container
+        factory = container.identity.identity_unit_of_work_factory()
+        async with factory() as uow:
+            snap = await uow.access_tokens.get_by_token(token)
+        if snap is not None and snap.current_profile_id is not None:
+            return str(snap.current_profile_id)
+
+    if settings.collections_default_profile_id:
+        return settings.collections_default_profile_id
+
+    raise NoActiveSessionError(message="Authentication required to access collections")
+
+
+__all__ = ["resolve_profile_id"]

--- a/src/modules/collections/presentation/routes/custom_list_routes.py
+++ b/src/modules/collections/presentation/routes/custom_list_routes.py
@@ -11,6 +11,7 @@ from src.config.containers import ApplicationContainer
 from src.modules.collections.application.dtos import (
     AddItemToCustomListInput,
     CreateCustomListInput,
+    DeleteCustomListInput,
     GetCustomListItemsInput,
     RemoveItemFromCustomListInput,
     RenameCustomListInput,
@@ -24,6 +25,10 @@ from src.modules.collections.application.use_cases import (
     RemoveItemFromCustomListUseCase,
     RenameCustomListUseCase,
 )
+from src.modules.collections.application.use_cases.list_custom_lists import (
+    ListCustomListsInput,
+)
+from src.modules.collections.presentation.dependencies import resolve_profile_id
 from src.modules.collections.presentation.schemas import (
     AddItemToCustomListRequest,
     CreateCustomListRequest,
@@ -40,24 +45,26 @@ router = APIRouter(prefix="/api/v1/custom-lists", tags=["Custom Lists"])
 @inject  # type: ignore[misc]
 async def create_custom_list(
     body: CreateCustomListRequest,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: CreateCustomListUseCase = Depends(
         Provide[ApplicationContainer.collections.create_custom_list],
     ),
 ) -> dict[str, Any]:
     """Create a new custom list."""
-    result = await use_case.execute(CreateCustomListInput(name=body.name))
+    result = await use_case.execute(CreateCustomListInput(profile_id=profile_id, name=body.name))
     return api_single("custom_list", asdict(result))
 
 
 @router.get("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_custom_lists(
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListCustomListsUseCase = Depends(
         Provide[ApplicationContainer.collections.list_custom_lists],
     ),
 ) -> dict[str, Any]:
-    """List all custom lists."""
-    items = await use_case.execute()
+    """List custom lists owned by the caller's profile."""
+    items = await use_case.execute(ListCustomListsInput(profile_id=profile_id))
     return api_list([asdict(item) for item in items])
 
 
@@ -66,12 +73,15 @@ async def list_custom_lists(
 async def rename_custom_list(
     list_id: str,
     body: RenameCustomListRequest,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: RenameCustomListUseCase = Depends(
         Provide[ApplicationContainer.collections.rename_custom_list],
     ),
 ) -> dict[str, Any]:
-    """Rename a custom list."""
-    result = await use_case.execute(RenameCustomListInput(list_id=list_id, name=body.name))
+    """Rename a custom list owned by the caller."""
+    result = await use_case.execute(
+        RenameCustomListInput(profile_id=profile_id, list_id=list_id, name=body.name)
+    )
     return api_single("custom_list", asdict(result))
 
 
@@ -79,12 +89,13 @@ async def rename_custom_list(
 @inject  # type: ignore[misc]
 async def delete_custom_list(
     list_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: DeleteCustomListUseCase = Depends(
         Provide[ApplicationContainer.collections.delete_custom_list],
     ),
 ) -> None:
-    """Delete a custom list and all its items."""
-    await use_case.execute(list_id)
+    """Delete a custom list and all its items, scoped to the profile."""
+    await use_case.execute(DeleteCustomListInput(profile_id=profile_id, list_id=list_id))
 
 
 # -- Item management -----------------------------------------------------------
@@ -95,12 +106,15 @@ async def delete_custom_list(
 async def get_custom_list_items(
     list_id: str,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetCustomListItemsUseCase = Depends(
         Provide[ApplicationContainer.collections.get_custom_list_items],
     ),
 ) -> dict[str, Any]:
-    """List all items in a custom list with media metadata."""
-    items = await use_case.execute(GetCustomListItemsInput(list_id=list_id, lang=lang))
+    """List items in a custom list with media metadata."""
+    items = await use_case.execute(
+        GetCustomListItemsInput(profile_id=profile_id, list_id=list_id, lang=lang)
+    )
     return api_list([asdict(item) for item in items])
 
 
@@ -109,13 +123,15 @@ async def get_custom_list_items(
 async def add_item_to_custom_list(
     list_id: str,
     body: AddItemToCustomListRequest,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: AddItemToCustomListUseCase = Depends(
         Provide[ApplicationContainer.collections.add_item_to_custom_list],
     ),
 ) -> dict[str, Any]:
-    """Add a media item to a custom list."""
+    """Add a media item to a custom list owned by the caller."""
     await use_case.execute(
         AddItemToCustomListInput(
+            profile_id=profile_id,
             list_id=list_id,
             media_id=body.media_id,
             media_type=body.media_type,
@@ -132,12 +148,15 @@ async def add_item_to_custom_list(
 async def remove_item_from_custom_list(
     list_id: str,
     media_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: RemoveItemFromCustomListUseCase = Depends(
         Provide[ApplicationContainer.collections.remove_item_from_custom_list],
     ),
 ) -> None:
-    """Remove a media item from a custom list."""
-    await use_case.execute(RemoveItemFromCustomListInput(list_id=list_id, media_id=media_id))
+    """Remove a media item from a custom list owned by the caller."""
+    await use_case.execute(
+        RemoveItemFromCustomListInput(profile_id=profile_id, list_id=list_id, media_id=media_id)
+    )
 
 
 __all__ = ["router"]

--- a/src/modules/collections/presentation/routes/watchlist_routes.py
+++ b/src/modules/collections/presentation/routes/watchlist_routes.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.collections.application.dtos import (
+    CheckWatchlistInput,
     GetWatchlistInput,
     ToggleWatchlistInput,
 )
@@ -18,6 +19,7 @@ from src.modules.collections.application.use_cases import (
     GetWatchlistUseCase,
     ToggleWatchlistUseCase,
 )
+from src.modules.collections.presentation.dependencies import resolve_profile_id
 from src.shared_kernel.value_objects import CollectionMediaType
 
 router = APIRouter(prefix="/api/v1/watchlist", tags=["Watchlist"])
@@ -40,13 +42,15 @@ class ToggleWatchlistRequest(BaseModel):
 @inject  # type: ignore[misc]
 async def toggle_watchlist(
     body: ToggleWatchlistRequest,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ToggleWatchlistUseCase = Depends(
         Provide[ApplicationContainer.collections.toggle_watchlist],
     ),
 ) -> dict[str, Any]:
-    """Add or remove a media item from the watchlist."""
+    """Add or remove a media item from the caller's watchlist."""
     result = await use_case.execute(
         ToggleWatchlistInput(
+            profile_id=profile_id,
             media_id=body.media_id,
             media_type=body.media_type,
         ),
@@ -59,12 +63,13 @@ async def toggle_watchlist(
 async def get_watchlist(
     limit: int = Query(100, ge=1, le=500),
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetWatchlistUseCase = Depends(
         Provide[ApplicationContainer.collections.get_watchlist],
     ),
 ) -> dict[str, Any]:
-    """List all items in the user's watchlist."""
-    items = await use_case.execute(GetWatchlistInput(limit=limit, lang=lang))
+    """List items in the caller's watchlist."""
+    items = await use_case.execute(GetWatchlistInput(profile_id=profile_id, limit=limit, lang=lang))
     return api_list([asdict(item) for item in items])
 
 
@@ -72,12 +77,13 @@ async def get_watchlist(
 @inject  # type: ignore[misc]
 async def check_watchlist(
     media_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: CheckWatchlistUseCase = Depends(
         Provide[ApplicationContainer.collections.check_watchlist],
     ),
 ) -> dict[str, Any]:
-    """Check if a media item is in the watchlist."""
-    in_list = await use_case.execute(media_id)
+    """Check if a media item is in the caller's watchlist."""
+    in_list = await use_case.execute(CheckWatchlistInput(profile_id=profile_id, media_id=media_id))
     return api_single("watchlist", {"in_list": in_list})
 
 

--- a/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
@@ -8,14 +8,20 @@ from src.modules.collections.infrastructure.persistence.repositories import (
     SQLAlchemyCustomListRepository,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 SAMPLE_MOVIE_ID = "mov_abc123def456"
 MISSING_LIST_ID = "lst_nonexistent00"
 MISSING_ITEM_ID = "mov_notinlist0000"
+_PROFILE_ID = ProfileId("prf_test12345678")
+_OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
 
 
-def _create_list(name: str = "Test List") -> CustomList:
-    return CustomList.create(name=name)
+def _create_list(
+    name: str = "Test List",
+    profile_id: ProfileId = _PROFILE_ID,
+) -> CustomList:
+    return CustomList.create(profile_id=profile_id, name=name)
 
 
 def _create_item(
@@ -43,13 +49,14 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
         assert saved.id == custom_list.id
         assert saved.name.value == "Action Movies"
         assert saved.item_count == 0
+        assert saved.profile_id == _PROFILE_ID
 
     async def test_find_by_id_should_return_list(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
         custom_list = _create_list(name="Comedy")
         await repo.add(custom_list)
 
-        found = await repo.find_by_id(str(custom_list.id))
+        found = await repo.find_by_id(str(custom_list.id), _PROFILE_ID)
 
         assert found is not None
         assert found.id == custom_list.id
@@ -60,15 +67,24 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
     ) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
 
-        found = await repo.find_by_id(MISSING_LIST_ID)
+        found = await repo.find_by_id(MISSING_LIST_ID, _PROFILE_ID)
 
         assert found is None
+
+    async def test_find_by_id_should_isolate_by_profile(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        owner_list = _create_list(name="Owned", profile_id=_PROFILE_ID)
+        await repo.add(owner_list)
+
+        other_view = await repo.find_by_id(str(owner_list.id), _OTHER_PROFILE_ID)
+
+        assert other_view is None
 
     async def test_find_by_name_should_be_case_insensitive(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
         await repo.add(_create_list(name="Action Movies"))
 
-        found = await repo.find_by_name("action movies")
+        found = await repo.find_by_name("action movies", _PROFILE_ID)
 
         assert found is not None
         assert found.name.value == "Action Movies"
@@ -77,7 +93,7 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
         repo = SQLAlchemyCustomListRepository(db_session)
         await repo.add(_create_list(name="Action"))
 
-        found = await repo.find_by_name("  Action  ")
+        found = await repo.find_by_name("  Action  ", _PROFILE_ID)
 
         assert found is not None
 
@@ -86,9 +102,24 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
     ) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
 
-        found = await repo.find_by_name("nonexistent")
+        found = await repo.find_by_name("nonexistent", _PROFILE_ID)
 
         assert found is None
+
+    async def test_find_by_name_should_isolate_by_profile(self, db_session: AsyncSession) -> None:
+        # Same name in two profiles must not collide.
+        repo = SQLAlchemyCustomListRepository(db_session)
+        await repo.add(_create_list(name="Shared", profile_id=_PROFILE_ID))
+        await repo.add(_create_list(name="Shared", profile_id=_OTHER_PROFILE_ID))
+
+        owner_view = await repo.find_by_name("Shared", _PROFILE_ID)
+        other_view = await repo.find_by_name("Shared", _OTHER_PROFILE_ID)
+
+        assert owner_view is not None
+        assert other_view is not None
+        assert owner_view.profile_id == _PROFILE_ID
+        assert other_view.profile_id == _OTHER_PROFILE_ID
+        assert owner_view.id != other_view.id
 
     async def test_update_should_persist_changes(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
@@ -100,7 +131,7 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
 
         assert updated.name.value == "Renamed"
 
-        found = await repo.find_by_id(str(custom_list.id))
+        found = await repo.find_by_id(str(custom_list.id), _PROFILE_ID)
         assert found is not None
         assert found.name.value == "Renamed"
 
@@ -116,10 +147,10 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
         custom_list = _create_list(name="To Delete")
         await repo.add(custom_list)
 
-        removed = await repo.remove(str(custom_list.id))
+        removed = await repo.remove(str(custom_list.id), _PROFILE_ID)
 
         assert removed is True
-        found = await repo.find_by_id(str(custom_list.id))
+        found = await repo.find_by_id(str(custom_list.id), _PROFILE_ID)
         assert found is None
 
     async def test_remove_should_return_false_when_not_found(
@@ -127,9 +158,24 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
     ) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
 
-        removed = await repo.remove(MISSING_LIST_ID)
+        removed = await repo.remove(MISSING_LIST_ID, _PROFILE_ID)
 
         assert removed is False
+
+    async def test_remove_should_not_touch_other_profiles_list(
+        self, db_session: AsyncSession
+    ) -> None:
+        # A profile cannot delete another profile's list, even with its id.
+        repo = SQLAlchemyCustomListRepository(db_session)
+        owner_list = _create_list(name="Owned", profile_id=_PROFILE_ID)
+        await repo.add(owner_list)
+
+        removed = await repo.remove(str(owner_list.id), _OTHER_PROFILE_ID)
+
+        assert removed is False
+        # Original owner can still see it.
+        still_there = await repo.find_by_id(str(owner_list.id), _PROFILE_ID)
+        assert still_there is not None
 
     async def test_list_all_should_return_all_lists(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
@@ -137,7 +183,7 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
         await repo.add(_create_list(name="B"))
         await repo.add(_create_list(name="C"))
 
-        result = await repo.list_all()
+        result = await repo.list_all(_PROFILE_ID)
 
         assert len(result) == 3
         names = {c.name.value for c in result}
@@ -149,19 +195,30 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
         deleted = _create_list(name="Deleted")
         await repo.add(active)
         await repo.add(deleted)
-        await repo.remove(str(deleted.id))
+        await repo.remove(str(deleted.id), _PROFILE_ID)
 
-        result = await repo.list_all()
+        result = await repo.list_all(_PROFILE_ID)
 
         assert len(result) == 1
         assert result[0].name.value == "Active"
+
+    async def test_list_all_should_isolate_by_profile(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        await repo.add(_create_list(name="Mine", profile_id=_PROFILE_ID))
+        await repo.add(_create_list(name="Theirs", profile_id=_OTHER_PROFILE_ID))
+
+        owner_view = await repo.list_all(_PROFILE_ID)
+        other_view = await repo.list_all(_OTHER_PROFILE_ID)
+
+        assert {c.name.value for c in owner_view} == {"Mine"}
+        assert {c.name.value for c in other_view} == {"Theirs"}
 
     async def test_count_should_return_active_lists(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
         await repo.add(_create_list(name="A"))
         await repo.add(_create_list(name="B"))
 
-        count = await repo.count()
+        count = await repo.count(_PROFILE_ID)
 
         assert count == 2
 
@@ -170,11 +227,23 @@ class TestSQLAlchemyCustomListRepositoryCRUD:
         deleted = _create_list(name="Deleted")
         await repo.add(_create_list(name="Active"))
         await repo.add(deleted)
-        await repo.remove(str(deleted.id))
+        await repo.remove(str(deleted.id), _PROFILE_ID)
 
-        count = await repo.count()
+        count = await repo.count(_PROFILE_ID)
 
         assert count == 1
+
+    async def test_count_should_isolate_by_profile(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        await repo.add(_create_list(name="A", profile_id=_PROFILE_ID))
+        await repo.add(_create_list(name="B", profile_id=_PROFILE_ID))
+        await repo.add(_create_list(name="C", profile_id=_OTHER_PROFILE_ID))
+
+        owner_count = await repo.count(_PROFILE_ID)
+        other_count = await repo.count(_OTHER_PROFILE_ID)
+
+        assert owner_count == 2
+        assert other_count == 1
 
 
 @pytest.mark.integration
@@ -187,7 +256,7 @@ class TestSQLAlchemyCustomListRepositoryItems:
         await repo.add(custom_list)
         item = _create_item()
 
-        saved = await repo.add_item(str(custom_list.id), item)
+        saved = await repo.add_item(str(custom_list.id), item, _PROFILE_ID)
 
         assert saved.media_id == item.media_id
 
@@ -198,16 +267,27 @@ class TestSQLAlchemyCustomListRepositoryItems:
         item = _create_item()
 
         with pytest.raises(ValueError, match="not found"):
-            await repo.add_item(MISSING_LIST_ID, item)
+            await repo.add_item(MISSING_LIST_ID, item, _PROFILE_ID)
+
+    async def test_add_item_should_raise_when_list_belongs_to_other_profile(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        owner_list = _create_list(profile_id=_PROFILE_ID)
+        await repo.add(owner_list)
+        item = _create_item()
+
+        with pytest.raises(ValueError, match="not found"):
+            await repo.add_item(str(owner_list.id), item, _OTHER_PROFILE_ID)
 
     async def test_find_item_should_return_item(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
         custom_list = _create_list()
         await repo.add(custom_list)
         item = _create_item(media_id=SAMPLE_MOVIE_ID)
-        await repo.add_item(str(custom_list.id), item)
+        await repo.add_item(str(custom_list.id), item, _PROFILE_ID)
 
-        found = await repo.find_item(str(custom_list.id), SAMPLE_MOVIE_ID)
+        found = await repo.find_item(str(custom_list.id), SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert found is not None
         assert found.media_id == SAMPLE_MOVIE_ID
@@ -217,7 +297,7 @@ class TestSQLAlchemyCustomListRepositoryItems:
     ) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
 
-        found = await repo.find_item(MISSING_LIST_ID, SAMPLE_MOVIE_ID)
+        found = await repo.find_item(MISSING_LIST_ID, SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert found is None
 
@@ -228,7 +308,18 @@ class TestSQLAlchemyCustomListRepositoryItems:
         custom_list = _create_list()
         await repo.add(custom_list)
 
-        found = await repo.find_item(str(custom_list.id), MISSING_ITEM_ID)
+        found = await repo.find_item(str(custom_list.id), MISSING_ITEM_ID, _PROFILE_ID)
+
+        assert found is None
+
+    async def test_find_item_should_isolate_by_profile(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        owner_list = _create_list(profile_id=_PROFILE_ID)
+        await repo.add(owner_list)
+        await repo.add_item(str(owner_list.id), _create_item(), _PROFILE_ID)
+
+        # Another profile can't see the item even with the right list_id.
+        found = await repo.find_item(str(owner_list.id), SAMPLE_MOVIE_ID, _OTHER_PROFILE_ID)
 
         assert found is None
 
@@ -237,12 +328,12 @@ class TestSQLAlchemyCustomListRepositoryItems:
         custom_list = _create_list()
         await repo.add(custom_list)
         item = _create_item(media_id=SAMPLE_MOVIE_ID)
-        await repo.add_item(str(custom_list.id), item)
+        await repo.add_item(str(custom_list.id), item, _PROFILE_ID)
 
-        removed = await repo.remove_item(str(custom_list.id), SAMPLE_MOVIE_ID)
+        removed = await repo.remove_item(str(custom_list.id), SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert removed is True
-        found = await repo.find_item(str(custom_list.id), SAMPLE_MOVIE_ID)
+        found = await repo.find_item(str(custom_list.id), SAMPLE_MOVIE_ID, _PROFILE_ID)
         assert found is None
 
     async def test_remove_item_should_return_false_when_not_found(
@@ -252,9 +343,24 @@ class TestSQLAlchemyCustomListRepositoryItems:
         custom_list = _create_list()
         await repo.add(custom_list)
 
-        removed = await repo.remove_item(str(custom_list.id), MISSING_ITEM_ID)
+        removed = await repo.remove_item(str(custom_list.id), MISSING_ITEM_ID, _PROFILE_ID)
 
         assert removed is False
+
+    async def test_remove_item_should_not_touch_other_profiles_item(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        owner_list = _create_list(profile_id=_PROFILE_ID)
+        await repo.add(owner_list)
+        await repo.add_item(str(owner_list.id), _create_item(), _PROFILE_ID)
+
+        removed = await repo.remove_item(str(owner_list.id), SAMPLE_MOVIE_ID, _OTHER_PROFILE_ID)
+
+        assert removed is False
+        # Original owner still sees it.
+        still_there = await repo.find_item(str(owner_list.id), SAMPLE_MOVIE_ID, _PROFILE_ID)
+        assert still_there is not None
 
     async def test_list_items_should_return_items_ordered_by_position(
         self, db_session: AsyncSession
@@ -265,17 +371,20 @@ class TestSQLAlchemyCustomListRepositoryItems:
         await repo.add_item(
             str(custom_list.id),
             _create_item(media_id="mov_third0000000", position=2),
+            _PROFILE_ID,
         )
         await repo.add_item(
             str(custom_list.id),
             _create_item(media_id="mov_first0000000", position=0),
+            _PROFILE_ID,
         )
         await repo.add_item(
             str(custom_list.id),
             _create_item(media_id="mov_second000000", position=1),
+            _PROFILE_ID,
         )
 
-        items = await repo.list_items(str(custom_list.id))
+        items = await repo.list_items(str(custom_list.id), _PROFILE_ID)
 
         assert [item.media_id for item in items] == [
             "mov_first0000000",
@@ -288,9 +397,19 @@ class TestSQLAlchemyCustomListRepositoryItems:
     ) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
 
-        items = await repo.list_items(MISSING_LIST_ID)
+        items = await repo.list_items(MISSING_LIST_ID, _PROFILE_ID)
 
         assert items == []
+
+    async def test_list_items_should_isolate_by_profile(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        owner_list = _create_list(profile_id=_PROFILE_ID)
+        await repo.add(owner_list)
+        await repo.add_item(str(owner_list.id), _create_item(), _PROFILE_ID)
+
+        other_view = await repo.list_items(str(owner_list.id), _OTHER_PROFILE_ID)
+
+        assert other_view == []
 
     async def test_get_next_position_should_return_zero_when_empty(
         self, db_session: AsyncSession
@@ -299,7 +418,7 @@ class TestSQLAlchemyCustomListRepositoryItems:
         custom_list = _create_list()
         await repo.add(custom_list)
 
-        position = await repo.get_next_position(str(custom_list.id))
+        position = await repo.get_next_position(str(custom_list.id), _PROFILE_ID)
 
         assert position == 0
 
@@ -310,13 +429,15 @@ class TestSQLAlchemyCustomListRepositoryItems:
         await repo.add_item(
             str(custom_list.id),
             _create_item(media_id="mov_first0000000", position=0),
+            _PROFILE_ID,
         )
         await repo.add_item(
             str(custom_list.id),
             _create_item(media_id="mov_second000000", position=1),
+            _PROFILE_ID,
         )
 
-        position = await repo.get_next_position(str(custom_list.id))
+        position = await repo.get_next_position(str(custom_list.id), _PROFILE_ID)
 
         assert position == 2
 
@@ -325,7 +446,7 @@ class TestSQLAlchemyCustomListRepositoryItems:
     ) -> None:
         repo = SQLAlchemyCustomListRepository(db_session)
 
-        position = await repo.get_next_position(MISSING_LIST_ID)
+        position = await repo.get_next_position(MISSING_LIST_ID, _PROFILE_ID)
 
         assert position == 0
 
@@ -334,11 +455,11 @@ class TestSQLAlchemyCustomListRepositoryItems:
         custom_list = _create_list()
         await repo.add(custom_list)
         original_item = _create_item(media_id=SAMPLE_MOVIE_ID, position=0)
-        await repo.add_item(str(custom_list.id), original_item)
-        await repo.remove_item(str(custom_list.id), SAMPLE_MOVIE_ID)
+        await repo.add_item(str(custom_list.id), original_item, _PROFILE_ID)
+        await repo.remove_item(str(custom_list.id), SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         new_item = _create_item(media_id=SAMPLE_MOVIE_ID, position=5)
-        restored = await repo.add_item(str(custom_list.id), new_item)
+        restored = await repo.add_item(str(custom_list.id), new_item, _PROFILE_ID)
 
         assert restored.media_id == SAMPLE_MOVIE_ID
         assert restored.position == 5

--- a/tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py
@@ -8,15 +8,19 @@ from src.modules.collections.infrastructure.persistence.repositories import (
     SQLAlchemyWatchlistRepository,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 SAMPLE_MOVIE_ID = "mov_abc123def456"
+_PROFILE_ID = ProfileId("prf_test12345678")
+_OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
 
 
 def _create_item(
     media_id: str = SAMPLE_MOVIE_ID,
     media_type: CollectionMediaType = CollectionMediaType.MOVIE,
+    profile_id: ProfileId = _PROFILE_ID,
 ) -> WatchlistItem:
-    return WatchlistItem.create(media_id=media_id, media_type=media_type)
+    return WatchlistItem.create(profile_id=profile_id, media_id=media_id, media_type=media_type)
 
 
 @pytest.mark.integration
@@ -31,13 +35,14 @@ class TestSQLAlchemyWatchlistRepository:
 
         assert saved.media_id == item.media_id
         assert saved.media_type == item.media_type
+        assert saved.profile_id == _PROFILE_ID
 
     async def test_find_by_media_id_should_return_item(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
         item = _create_item(media_id=SAMPLE_MOVIE_ID)
         await repo.add(item)
 
-        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert found is not None
         assert found.media_id == SAMPLE_MOVIE_ID
@@ -47,18 +52,34 @@ class TestSQLAlchemyWatchlistRepository:
     ) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
 
-        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert found is None
+
+    async def test_find_by_media_id_should_isolate_by_profile(
+        self, db_session: AsyncSession
+    ) -> None:
+        # Same media on two profiles' watchlists are independent rows.
+        repo = SQLAlchemyWatchlistRepository(db_session)
+        await repo.add(_create_item())
+        await repo.add(_create_item(profile_id=_OTHER_PROFILE_ID))
+
+        owner_view = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
+        other_view = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _OTHER_PROFILE_ID)
+
+        assert owner_view is not None
+        assert other_view is not None
+        assert owner_view.profile_id == _PROFILE_ID
+        assert other_view.profile_id == _OTHER_PROFILE_ID
 
     async def test_remove_should_soft_delete(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
         await repo.add(_create_item(media_id=SAMPLE_MOVIE_ID))
 
-        removed = await repo.remove(SAMPLE_MOVIE_ID)
+        removed = await repo.remove(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert removed is True
-        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
         assert found is None
 
     async def test_remove_should_return_false_when_not_found(
@@ -66,22 +87,34 @@ class TestSQLAlchemyWatchlistRepository:
     ) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
 
-        removed = await repo.remove(SAMPLE_MOVIE_ID)
+        removed = await repo.remove(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert removed is False
+
+    async def test_remove_should_not_touch_other_profiles_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchlistRepository(db_session)
+        await repo.add(_create_item())
+        await repo.add(_create_item(profile_id=_OTHER_PROFILE_ID))
+
+        await repo.remove(SAMPLE_MOVIE_ID, _PROFILE_ID)
+
+        assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)) is None
+        assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, _OTHER_PROFILE_ID)) is not None
 
     async def test_exists_should_return_true_when_present(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
         await repo.add(_create_item(media_id=SAMPLE_MOVIE_ID))
 
-        exists = await repo.exists(SAMPLE_MOVIE_ID)
+        exists = await repo.exists(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert exists is True
 
     async def test_exists_should_return_false_when_absent(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
 
-        exists = await repo.exists(SAMPLE_MOVIE_ID)
+        exists = await repo.exists(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert exists is False
 
@@ -90,11 +123,18 @@ class TestSQLAlchemyWatchlistRepository:
     ) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
         await repo.add(_create_item(media_id=SAMPLE_MOVIE_ID))
-        await repo.remove(SAMPLE_MOVIE_ID)
+        await repo.remove(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
-        exists = await repo.exists(SAMPLE_MOVIE_ID)
+        exists = await repo.exists(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         assert exists is False
+
+    async def test_exists_should_isolate_by_profile(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchlistRepository(db_session)
+        await repo.add(_create_item(profile_id=_PROFILE_ID))
+
+        assert await repo.exists(SAMPLE_MOVIE_ID, _PROFILE_ID) is True
+        assert await repo.exists(SAMPLE_MOVIE_ID, _OTHER_PROFILE_ID) is False
 
     async def test_list_all_should_return_all_items(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
@@ -102,7 +142,7 @@ class TestSQLAlchemyWatchlistRepository:
         await repo.add(_create_item(media_id="mov_bbbbbbbbbbbb"))
         await repo.add(_create_item(media_id="mov_cccccccccccc"))
 
-        result = await repo.list_all()
+        result = await repo.list_all(_PROFILE_ID)
 
         assert len(result) == 3
 
@@ -110,9 +150,9 @@ class TestSQLAlchemyWatchlistRepository:
         repo = SQLAlchemyWatchlistRepository(db_session)
         await repo.add(_create_item(media_id="mov_kept000000000"))
         await repo.add(_create_item(media_id="mov_removed00000"))
-        await repo.remove("mov_removed00000")
+        await repo.remove("mov_removed00000", _PROFILE_ID)
 
-        result = await repo.list_all()
+        result = await repo.list_all(_PROFILE_ID)
 
         assert len(result) == 1
         assert result[0].media_id == "mov_kept000000000"
@@ -123,21 +163,32 @@ class TestSQLAlchemyWatchlistRepository:
         await repo.add(_create_item(media_id="mov_bbbbbbbbbbbb"))
         await repo.add(_create_item(media_id="mov_cccccccccccc"))
 
-        result = await repo.list_all(limit=2)
+        result = await repo.list_all(_PROFILE_ID, limit=2)
 
         assert len(result) == 2
+
+    async def test_list_all_should_isolate_by_profile(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchlistRepository(db_session)
+        await repo.add(_create_item(media_id="mov_aaaaaaaaaaaa", profile_id=_PROFILE_ID))
+        await repo.add(_create_item(media_id="mov_bbbbbbbbbbbb", profile_id=_OTHER_PROFILE_ID))
+
+        owner_view = await repo.list_all(_PROFILE_ID)
+        other_view = await repo.list_all(_OTHER_PROFILE_ID)
+
+        assert {i.media_id for i in owner_view} == {"mov_aaaaaaaaaaaa"}
+        assert {i.media_id for i in other_view} == {"mov_bbbbbbbbbbbb"}
 
     async def test_add_should_restore_soft_deleted(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
         await repo.add(_create_item(media_id=SAMPLE_MOVIE_ID))
-        await repo.remove(SAMPLE_MOVIE_ID)
+        await repo.remove(SAMPLE_MOVIE_ID, _PROFILE_ID)
 
         # Re-add the same media_id
         restored = await repo.add(_create_item(media_id=SAMPLE_MOVIE_ID))
 
         assert restored.media_id == SAMPLE_MOVIE_ID
         # Should be findable again
-        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID)
+        found = await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)
         assert found is not None
 
     async def test_should_handle_series_type(self, db_session: AsyncSession) -> None:

--- a/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
@@ -14,10 +14,13 @@ from src.modules.collections.domain.entities import (
     CustomListItem,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 def _create_list(name: str = "Test List", item_count: int = 0) -> CustomList:
-    return CustomList.create(name=name).with_updates(item_count=item_count)
+    return CustomList.create(profile_id=_PROFILE_ID, name=name).with_updates(item_count=item_count)
 
 
 @pytest.mark.unit
@@ -42,6 +45,7 @@ class TestAddItemToCustomListUseCase:
 
         await use_case.execute(
             AddItemToCustomListInput(
+                profile_id=_PROFILE_ID.value,
                 list_id=str(custom_list.id),
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
@@ -61,6 +65,7 @@ class TestAddItemToCustomListUseCase:
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
                 AddItemToCustomListInput(
+                    profile_id=_PROFILE_ID.value,
                     list_id="lst_nonexistent00",
                     media_id="mov_abc123def456",
                     media_type=CollectionMediaType.MOVIE,
@@ -85,6 +90,7 @@ class TestAddItemToCustomListUseCase:
         with pytest.raises(BusinessRuleViolationException) as exc_info:
             await use_case.execute(
                 AddItemToCustomListInput(
+                    profile_id=_PROFILE_ID.value,
                     list_id=str(custom_list.id),
                     media_id="mov_abc123def456",
                     media_type=CollectionMediaType.MOVIE,
@@ -105,6 +111,7 @@ class TestAddItemToCustomListUseCase:
         with pytest.raises(BusinessRuleViolationException) as exc_info:
             await use_case.execute(
                 AddItemToCustomListInput(
+                    profile_id=_PROFILE_ID.value,
                     list_id=str(custom_list.id),
                     media_id="mov_abc123def456",
                     media_type=CollectionMediaType.MOVIE,
@@ -131,10 +138,11 @@ class TestAddItemToCustomListUseCase:
 
         await use_case.execute(
             AddItemToCustomListInput(
+                profile_id=_PROFILE_ID.value,
                 list_id=str(custom_list.id),
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
             )
         )
 
-        mock_repo.get_next_position.assert_called_once_with(str(custom_list.id))
+        mock_repo.get_next_position.assert_called_once_with(str(custom_list.id), _PROFILE_ID)

--- a/tests/modules/collections/unit/application/use_cases/test_check_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_check_watchlist.py
@@ -4,7 +4,11 @@
 import pytest
 from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
+from src.modules.collections.application.dtos import CheckWatchlistInput
 from src.modules.collections.application.use_cases import CheckWatchlistUseCase
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -17,10 +21,15 @@ class TestCheckWatchlistUseCase:
         mocks.watchlist.exists.return_value = True
         use_case = CheckWatchlistUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute("mov_abc123def456")
+        result = await use_case.execute(
+            CheckWatchlistInput(
+                profile_id=_PROFILE_ID.value,
+                media_id="mov_abc123def456",
+            )
+        )
 
         assert result is True
-        mocks.watchlist.exists.assert_called_once_with("mov_abc123def456")
+        mocks.watchlist.exists.assert_called_once_with("mov_abc123def456", _PROFILE_ID)
 
     @pytest.mark.asyncio
     async def test_should_return_false_when_not_in_watchlist(self) -> None:
@@ -28,6 +37,11 @@ class TestCheckWatchlistUseCase:
         mocks.watchlist.exists.return_value = False
         use_case = CheckWatchlistUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute("mov_abc123def456")
+        result = await use_case.execute(
+            CheckWatchlistInput(
+                profile_id=_PROFILE_ID.value,
+                media_id="mov_abc123def456",
+            )
+        )
 
         assert result is False

--- a/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
@@ -11,6 +11,9 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.use_cases import CreateCustomListUseCase
 from src.modules.collections.domain.entities import MAX_LISTS, CustomList
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -23,11 +26,13 @@ class TestCreateCustomListUseCase:
         mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 0
         mock_repo.find_by_name.return_value = None
-        saved_list = CustomList.create(name="Action Movies")
+        saved_list = CustomList.create(profile_id=_PROFILE_ID, name="Action Movies")
         mock_repo.add.return_value = saved_list
         use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute(CreateCustomListInput(name="Action Movies"))
+        result = await use_case.execute(
+            CreateCustomListInput(profile_id=_PROFILE_ID.value, name="Action Movies")
+        )
 
         assert isinstance(result, CustomListOutput)
         assert result.name == "Action Movies"
@@ -42,7 +47,9 @@ class TestCreateCustomListUseCase:
         use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(BusinessRuleViolationException) as exc_info:
-            await use_case.execute(CreateCustomListInput(name="New List"))
+            await use_case.execute(
+                CreateCustomListInput(profile_id=_PROFILE_ID.value, name="New List")
+            )
 
         assert exc_info.value.message_code == "CUSTOM_LIST_LIMIT_EXCEEDED"
         mock_repo.add.assert_not_called()
@@ -52,11 +59,15 @@ class TestCreateCustomListUseCase:
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 1
-        mock_repo.find_by_name.return_value = CustomList.create(name="Action Movies")
+        mock_repo.find_by_name.return_value = CustomList.create(
+            profile_id=_PROFILE_ID, name="Action Movies"
+        )
         use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(BusinessRuleViolationException) as exc_info:
-            await use_case.execute(CreateCustomListInput(name="Action Movies"))
+            await use_case.execute(
+                CreateCustomListInput(profile_id=_PROFILE_ID.value, name="Action Movies")
+            )
 
         assert exc_info.value.message_code == "CUSTOM_LIST_NAME_DUPLICATE"
         mock_repo.add.assert_not_called()
@@ -67,10 +78,12 @@ class TestCreateCustomListUseCase:
         mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 0
         mock_repo.find_by_name.return_value = None
-        saved_list = CustomList.create(name="Action Movies")
+        saved_list = CustomList.create(profile_id=_PROFILE_ID, name="Action Movies")
         mock_repo.add.return_value = saved_list
         use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
-        await use_case.execute(CreateCustomListInput(name="  Action Movies  "))
+        await use_case.execute(
+            CreateCustomListInput(profile_id=_PROFILE_ID.value, name="  Action Movies  ")
+        )
 
-        mock_repo.find_by_name.assert_called_once_with("Action Movies")
+        mock_repo.find_by_name.assert_called_once_with("Action Movies", _PROFILE_ID)

--- a/tests/modules/collections/unit/application/use_cases/test_delete_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_delete_custom_list.py
@@ -5,8 +5,12 @@ import pytest
 from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.collections.application.dtos import DeleteCustomListInput
 from src.modules.collections.application.use_cases import DeleteCustomListUseCase
 from src.modules.collections.domain.entities import CustomList
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -15,15 +19,20 @@ class TestDeleteCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_delete_successfully(self) -> None:
-        custom_list = CustomList.create(name="To Delete")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="To Delete")
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.remove.return_value = True
         use_case = DeleteCustomListUseCase(uow_factory=mocks.factory)
 
-        await use_case.execute(str(custom_list.id))
+        await use_case.execute(
+            DeleteCustomListInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+            )
+        )
 
-        mock_repo.remove.assert_called_once_with(str(custom_list.id))
+        mock_repo.remove.assert_called_once_with(str(custom_list.id), _PROFILE_ID)
 
     @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:
@@ -33,6 +42,11 @@ class TestDeleteCustomListUseCase:
         use_case = DeleteCustomListUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
-            await use_case.execute("lst_nonexistent00")
+            await use_case.execute(
+                DeleteCustomListInput(
+                    profile_id=_PROFILE_ID.value,
+                    list_id="lst_nonexistent00",
+                )
+            )
 
         assert exc_info.value.resource_type == "CustomList"

--- a/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
@@ -20,11 +20,14 @@ from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetCustomListItemsUseCase
 from src.modules.collections.domain.entities import CustomList, CustomListItem
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 if TYPE_CHECKING:
     from tests.modules.collections.unit.application.use_cases.conftest import (
         MediaSummaryFactory,
     )
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -35,7 +38,7 @@ class TestGetCustomListItemsUseCase:
     async def test_should_return_items_with_metadata(
         self, movie_summary: MediaSummaryFactory
     ) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",
@@ -56,7 +59,12 @@ class TestGetCustomListItemsUseCase:
             media_lookup=media_lookup,
         )
 
-        result = await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id)))
+        result = await use_case.execute(
+            GetCustomListItemsInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+            )
+        )
 
         assert len(result) == 1
         assert isinstance(result[0], CustomListItemOutput)
@@ -73,13 +81,18 @@ class TestGetCustomListItemsUseCase:
         )
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
-            await use_case.execute(GetCustomListItemsInput(list_id="lst_nonexistent00"))
+            await use_case.execute(
+                GetCustomListItemsInput(
+                    profile_id=_PROFILE_ID.value,
+                    list_id="lst_nonexistent00",
+                )
+            )
 
         assert exc_info.value.resource_type == "CustomList"
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_no_items(self) -> None:
-        custom_list = CustomList.create(name="Empty List")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Empty List")
         mocks = make_collections_uow_mock()
         mocks.custom_lists.find_by_id.return_value = custom_list
         mocks.custom_lists.list_items.return_value = []
@@ -88,13 +101,18 @@ class TestGetCustomListItemsUseCase:
             media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
-        result = await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id)))
+        result = await use_case.execute(
+            GetCustomListItemsInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+            )
+        )
 
         assert result == []
 
     @pytest.mark.asyncio
     async def test_should_skip_missing_media(self) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
         items = [
             CustomListItem.create(
                 media_id="mov_missing00000",
@@ -111,7 +129,12 @@ class TestGetCustomListItemsUseCase:
             media_lookup=make_media_lookup_mock(),
         )
 
-        result = await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id)))
+        result = await use_case.execute(
+            GetCustomListItemsInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+            )
+        )
 
         assert result == []
 
@@ -121,7 +144,7 @@ class TestGetCustomListItemsUseCase:
         movie_summary: MediaSummaryFactory,
         series_summary: MediaSummaryFactory,
     ) -> None:
-        custom_list = CustomList.create(name="Mixed")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Mixed")
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",
@@ -148,7 +171,12 @@ class TestGetCustomListItemsUseCase:
             media_lookup=media_lookup,
         )
 
-        result = await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id)))
+        result = await use_case.execute(
+            GetCustomListItemsInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+            )
+        )
 
         assert len(result) == 2
         assert result[0].title == "Inception"
@@ -158,7 +186,7 @@ class TestGetCustomListItemsUseCase:
     async def test_should_pass_language_to_media_lookup(
         self, movie_summary: MediaSummaryFactory
     ) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",
@@ -177,7 +205,13 @@ class TestGetCustomListItemsUseCase:
             media_lookup=media_lookup,
         )
 
-        await use_case.execute(GetCustomListItemsInput(list_id=str(custom_list.id), lang="pt-BR"))
+        await use_case.execute(
+            GetCustomListItemsInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+                lang="pt-BR",
+            )
+        )
 
         media_lookup.get_many.assert_awaited_once_with(
             ["mov_abc123def456"],

--- a/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
@@ -19,11 +19,14 @@ from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 if TYPE_CHECKING:
     from tests.modules.collections.unit.application.use_cases.conftest import (
         MediaSummaryFactory,
     )
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -36,6 +39,7 @@ class TestGetWatchlistUseCase:
     ) -> None:
         items = [
             WatchlistItem.create(
+                profile_id=_PROFILE_ID,
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
             ),
@@ -52,7 +56,7 @@ class TestGetWatchlistUseCase:
             media_lookup=media_lookup,
         )
 
-        result = await use_case.execute(GetWatchlistInput())
+        result = await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value))
 
         assert len(result) == 1
         assert isinstance(result[0], WatchlistItemOutput)
@@ -67,7 +71,7 @@ class TestGetWatchlistUseCase:
             media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
-        result = await use_case.execute(GetWatchlistInput())
+        result = await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value))
 
         assert result == []
 
@@ -75,6 +79,7 @@ class TestGetWatchlistUseCase:
     async def test_should_skip_missing_media(self) -> None:
         items = [
             WatchlistItem.create(
+                profile_id=_PROFILE_ID,
                 media_id="mov_missing00000",
                 media_type=CollectionMediaType.MOVIE,
             ),
@@ -87,7 +92,7 @@ class TestGetWatchlistUseCase:
             media_lookup=make_media_lookup_mock(),  # no summaries
         )
 
-        result = await use_case.execute(GetWatchlistInput())
+        result = await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value))
 
         assert result == []
 
@@ -99,10 +104,12 @@ class TestGetWatchlistUseCase:
     ) -> None:
         items = [
             WatchlistItem.create(
+                profile_id=_PROFILE_ID,
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
             ),
             WatchlistItem.create(
+                profile_id=_PROFILE_ID,
                 media_id="ser_xyz789abc123",
                 media_type=CollectionMediaType.SERIES,
             ),
@@ -120,7 +127,7 @@ class TestGetWatchlistUseCase:
             media_lookup=media_lookup,
         )
 
-        result = await use_case.execute(GetWatchlistInput())
+        result = await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value))
 
         assert len(result) == 2
         assert result[0].title == "Inception"
@@ -135,9 +142,9 @@ class TestGetWatchlistUseCase:
             media_lookup=AsyncMock(spec=MediaLookupPort),
         )
 
-        await use_case.execute(GetWatchlistInput(limit=25))
+        await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value, limit=25))
 
-        mocks.watchlist.list_all.assert_called_once_with(limit=25)
+        mocks.watchlist.list_all.assert_called_once_with(_PROFILE_ID, limit=25)
 
     @pytest.mark.asyncio
     async def test_should_pass_language_to_media_lookup(
@@ -145,6 +152,7 @@ class TestGetWatchlistUseCase:
     ) -> None:
         items = [
             WatchlistItem.create(
+                profile_id=_PROFILE_ID,
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
             ),
@@ -159,7 +167,7 @@ class TestGetWatchlistUseCase:
             media_lookup=media_lookup,
         )
 
-        await use_case.execute(GetWatchlistInput(lang="pt-BR"))
+        await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value, lang="pt-BR"))
 
         media_lookup.get_many.assert_awaited_once_with(
             ["mov_abc123def456"],

--- a/tests/modules/collections/unit/application/use_cases/test_list_custom_lists.py
+++ b/tests/modules/collections/unit/application/use_cases/test_list_custom_lists.py
@@ -6,7 +6,13 @@ from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.modules.collections.application.dtos import CustomListOutput
 from src.modules.collections.application.use_cases import ListCustomListsUseCase
+from src.modules.collections.application.use_cases.list_custom_lists import (
+    ListCustomListsInput,
+)
 from src.modules.collections.domain.entities import CustomList
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -16,19 +22,20 @@ class TestListCustomListsUseCase:
     @pytest.mark.asyncio
     async def test_should_return_all_lists(self) -> None:
         lists = [
-            CustomList.create(name="Action"),
-            CustomList.create(name="Comedy"),
+            CustomList.create(profile_id=_PROFILE_ID, name="Action"),
+            CustomList.create(profile_id=_PROFILE_ID, name="Comedy"),
         ]
         mocks = make_collections_uow_mock()
         mocks.custom_lists.list_all.return_value = lists
         use_case = ListCustomListsUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute()
+        result = await use_case.execute(ListCustomListsInput(profile_id=_PROFILE_ID.value))
 
         assert len(result) == 2
         assert all(isinstance(item, CustomListOutput) for item in result)
         assert result[0].name == "Action"
         assert result[1].name == "Comedy"
+        mocks.custom_lists.list_all.assert_called_once_with(_PROFILE_ID)
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_none_exist(self) -> None:
@@ -36,6 +43,6 @@ class TestListCustomListsUseCase:
         mocks.custom_lists.list_all.return_value = []
         use_case = ListCustomListsUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute()
+        result = await use_case.execute(ListCustomListsInput(profile_id=_PROFILE_ID.value))
 
         assert result == []

--- a/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
@@ -10,6 +10,9 @@ from src.modules.collections.application.use_cases import (
     RemoveItemFromCustomListUseCase,
 )
 from src.modules.collections.domain.entities import CustomList
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -18,7 +21,9 @@ class TestRemoveItemFromCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_remove_item_successfully(self) -> None:
-        custom_list = CustomList.create(name="Test").with_updates(item_count=3)
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test").with_updates(
+            item_count=3
+        )
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
@@ -28,12 +33,15 @@ class TestRemoveItemFromCustomListUseCase:
 
         await use_case.execute(
             RemoveItemFromCustomListInput(
+                profile_id=_PROFILE_ID.value,
                 list_id=str(custom_list.id),
                 media_id="mov_abc123def456",
             )
         )
 
-        mock_repo.remove_item.assert_called_once_with(str(custom_list.id), "mov_abc123def456")
+        mock_repo.remove_item.assert_called_once_with(
+            str(custom_list.id), "mov_abc123def456", _PROFILE_ID
+        )
         mock_repo.update.assert_called_once()
 
     @pytest.mark.asyncio
@@ -46,6 +54,7 @@ class TestRemoveItemFromCustomListUseCase:
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
                 RemoveItemFromCustomListInput(
+                    profile_id=_PROFILE_ID.value,
                     list_id="lst_nonexistent00",
                     media_id="mov_abc123def456",
                 )
@@ -55,7 +64,7 @@ class TestRemoveItemFromCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_item_not_in_list(self) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
@@ -65,6 +74,7 @@ class TestRemoveItemFromCustomListUseCase:
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
                 RemoveItemFromCustomListInput(
+                    profile_id=_PROFILE_ID.value,
                     list_id=str(custom_list.id),
                     media_id="mov_notinlist0000",
                 )
@@ -74,7 +84,9 @@ class TestRemoveItemFromCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_decrement_item_count_after_removal(self) -> None:
-        custom_list = CustomList.create(name="Test").with_updates(item_count=5)
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test").with_updates(
+            item_count=5
+        )
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
@@ -84,6 +96,7 @@ class TestRemoveItemFromCustomListUseCase:
 
         await use_case.execute(
             RemoveItemFromCustomListInput(
+                profile_id=_PROFILE_ID.value,
                 list_id=str(custom_list.id),
                 media_id="mov_abc123def456",
             )

--- a/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
@@ -12,6 +12,9 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.use_cases import RenameCustomListUseCase
 from src.modules.collections.domain.entities import CustomList
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -20,7 +23,7 @@ class TestRenameCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_rename_successfully(self) -> None:
-        custom_list = CustomList.create(name="Old Name")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Old Name")
         renamed = custom_list.rename("New Name")
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
@@ -30,7 +33,11 @@ class TestRenameCustomListUseCase:
         use_case = RenameCustomListUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
-            RenameCustomListInput(list_id=str(custom_list.id), name="New Name")
+            RenameCustomListInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+                name="New Name",
+            )
         )
 
         assert isinstance(result, CustomListOutput)
@@ -46,15 +53,19 @@ class TestRenameCustomListUseCase:
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
             await use_case.execute(
-                RenameCustomListInput(list_id="lst_nonexistent00", name="New Name")
+                RenameCustomListInput(
+                    profile_id=_PROFILE_ID.value,
+                    list_id="lst_nonexistent00",
+                    name="New Name",
+                )
             )
 
         assert exc_info.value.resource_type == "CustomList"
 
     @pytest.mark.asyncio
     async def test_should_raise_when_name_taken_by_other_list(self) -> None:
-        custom_list = CustomList.create(name="My List")
-        other_list = CustomList.create(name="Taken Name")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="My List")
+        other_list = CustomList.create(profile_id=_PROFILE_ID, name="Taken Name")
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
@@ -63,14 +74,18 @@ class TestRenameCustomListUseCase:
 
         with pytest.raises(BusinessRuleViolationException) as exc_info:
             await use_case.execute(
-                RenameCustomListInput(list_id=str(custom_list.id), name="Taken Name")
+                RenameCustomListInput(
+                    profile_id=_PROFILE_ID.value,
+                    list_id=str(custom_list.id),
+                    name="Taken Name",
+                )
             )
 
         assert exc_info.value.message_code == "CUSTOM_LIST_NAME_DUPLICATE"
 
     @pytest.mark.asyncio
     async def test_should_allow_renaming_to_same_name(self) -> None:
-        custom_list = CustomList.create(name="Same Name")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Same Name")
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
@@ -79,7 +94,11 @@ class TestRenameCustomListUseCase:
         use_case = RenameCustomListUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
-            RenameCustomListInput(list_id=str(custom_list.id), name="Same Name")
+            RenameCustomListInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+                name="Same Name",
+            )
         )
 
         assert result.name == "Same Name"

--- a/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
@@ -11,6 +11,9 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.use_cases import ToggleWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -23,6 +26,7 @@ class TestToggleWatchlistUseCase:
         mock_repo = mocks.watchlist
         mock_repo.exists.return_value = False
         mock_repo.add.return_value = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
@@ -30,6 +34,7 @@ class TestToggleWatchlistUseCase:
 
         result = await use_case.execute(
             ToggleWatchlistInput(
+                profile_id=_PROFILE_ID.value,
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
             )
@@ -50,6 +55,7 @@ class TestToggleWatchlistUseCase:
 
         result = await use_case.execute(
             ToggleWatchlistInput(
+                profile_id=_PROFILE_ID.value,
                 media_id="mov_abc123def456",
                 media_type=CollectionMediaType.MOVIE,
             )
@@ -57,7 +63,7 @@ class TestToggleWatchlistUseCase:
 
         assert result.added is False
         assert result.media_id == "mov_abc123def456"
-        mock_repo.remove.assert_called_once_with("mov_abc123def456")
+        mock_repo.remove.assert_called_once_with("mov_abc123def456", _PROFILE_ID)
 
     @pytest.mark.asyncio
     async def test_should_toggle_series(self) -> None:
@@ -65,6 +71,7 @@ class TestToggleWatchlistUseCase:
         mock_repo = mocks.watchlist
         mock_repo.exists.return_value = False
         mock_repo.add.return_value = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="ser_abc123def456",
             media_type=CollectionMediaType.SERIES,
         )
@@ -72,6 +79,7 @@ class TestToggleWatchlistUseCase:
 
         result = await use_case.execute(
             ToggleWatchlistInput(
+                profile_id=_PROFILE_ID.value,
                 media_id="ser_abc123def456",
                 media_type=CollectionMediaType.SERIES,
             )

--- a/tests/modules/collections/unit/domain/entities/test_custom_list.py
+++ b/tests/modules/collections/unit/domain/entities/test_custom_list.py
@@ -15,6 +15,9 @@ from src.modules.collections.domain.value_objects import (
     ListName,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -22,22 +25,23 @@ class TestCustomListCreation:
     """Tests for CustomList instantiation."""
 
     def test_should_create_with_string_name(self) -> None:
-        custom_list = CustomList(name="Action Movies")
+        custom_list = CustomList(profile_id=_PROFILE_ID, name="Action Movies")
 
         assert custom_list.id is None
         assert isinstance(custom_list.name, ListName)
         assert custom_list.name.value == "Action Movies"
         assert custom_list.item_count == 0
+        assert custom_list.profile_id == _PROFILE_ID
 
     def test_should_create_with_list_name_instance(self) -> None:
         name = ListName("Action Movies")
-        custom_list = CustomList(name=name)
+        custom_list = CustomList(profile_id=_PROFILE_ID, name=name)
 
         assert custom_list.name is name
         assert custom_list.name.value == "Action Movies"
 
     def test_should_create_via_factory_with_auto_id(self) -> None:
-        custom_list = CustomList.create(name="Action Movies")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Action Movies")
 
         assert custom_list.id is not None
         assert isinstance(custom_list.id, ListId)
@@ -45,34 +49,34 @@ class TestCustomListCreation:
 
     def test_factory_should_accept_list_name_instance(self) -> None:
         name = ListName("Action Movies")
-        custom_list = CustomList.create(name=name)
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name=name)
 
         assert custom_list.name.value == "Action Movies"
 
     def test_factory_should_strip_name_whitespace(self) -> None:
-        custom_list = CustomList.create(name="  Action Movies  ")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="  Action Movies  ")
 
         assert custom_list.name.value == "Action Movies"
 
     def test_factory_should_initialize_item_count_to_zero(self) -> None:
-        custom_list = CustomList.create(name="My List")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="My List")
 
         assert custom_list.item_count == 0
 
     def test_should_accept_string_id(self) -> None:
         list_id = ListId.generate()
-        custom_list = CustomList(id=list_id, name="Test")
+        custom_list = CustomList(id=list_id, profile_id=_PROFILE_ID, name="Test")
 
         assert custom_list.id == list_id
 
     def test_should_be_frozen(self) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
 
         with pytest.raises(DomainValidationException):
             custom_list.name = "New Name"  # type: ignore[misc, assignment]
 
     def test_should_have_timestamps(self) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
 
         assert custom_list.created_at is not None
         assert custom_list.updated_at is not None
@@ -83,33 +87,33 @@ class TestCustomListRename:
     """Tests for CustomList.rename()."""
 
     def test_should_return_new_instance_with_updated_name(self) -> None:
-        original = CustomList.create(name="Old Name")
+        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name")
         renamed = original.rename("New Name")
 
         assert renamed.name.value == "New Name"
         assert original.name.value == "Old Name"
 
     def test_should_accept_list_name_instance(self) -> None:
-        original = CustomList.create(name="Old Name")
+        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name")
         new_name = ListName("New Name")
         renamed = original.rename(new_name)
 
         assert renamed.name.value == "New Name"
 
     def test_should_preserve_id(self) -> None:
-        original = CustomList.create(name="Old Name")
+        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name")
         renamed = original.rename("New Name")
 
         assert renamed.id == original.id
 
     def test_should_strip_new_name_whitespace(self) -> None:
-        custom_list = CustomList.create(name="Original")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Original")
         renamed = custom_list.rename("  Renamed  ")
 
         assert renamed.name.value == "Renamed"
 
     def test_should_preserve_item_count(self) -> None:
-        custom_list = CustomList.create(name="Original")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Original")
         incremented = custom_list.increment_item_count()
         renamed = incremented.rename("Renamed")
 
@@ -121,14 +125,14 @@ class TestCustomListItemCount:
     """Tests for increment/decrement item count."""
 
     def test_should_increment_item_count(self) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
         updated = custom_list.increment_item_count()
 
         assert updated.item_count == 1
         assert custom_list.item_count == 0
 
     def test_should_increment_multiple_times(self) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
         updated = custom_list.increment_item_count()
         updated = updated.increment_item_count()
         updated = updated.increment_item_count()
@@ -138,6 +142,7 @@ class TestCustomListItemCount:
     def test_should_raise_when_exceeding_max_items(self) -> None:
         custom_list = CustomList(
             id=ListId.generate(),
+            profile_id=_PROFILE_ID,
             name="Full List",
             item_count=MAX_ITEMS_PER_LIST,
         )
@@ -150,6 +155,7 @@ class TestCustomListItemCount:
     def test_should_allow_increment_at_max_minus_one(self) -> None:
         custom_list = CustomList(
             id=ListId.generate(),
+            profile_id=_PROFILE_ID,
             name="Almost Full",
             item_count=MAX_ITEMS_PER_LIST - 1,
         )
@@ -161,6 +167,7 @@ class TestCustomListItemCount:
     def test_should_decrement_item_count(self) -> None:
         custom_list = CustomList(
             id=ListId.generate(),
+            profile_id=_PROFILE_ID,
             name="Test",
             item_count=5,
         )
@@ -169,7 +176,7 @@ class TestCustomListItemCount:
         assert updated.item_count == 4
 
     def test_should_not_go_below_zero_on_decrement(self) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
         updated = custom_list.decrement_item_count()
 
         assert updated.item_count == 0
@@ -181,25 +188,25 @@ class TestCustomListEquality:
 
     def test_should_be_equal_by_id(self) -> None:
         list_id = ListId.generate()
-        list_a = CustomList(id=list_id, name="A")
-        list_b = CustomList(id=list_id, name="B")
+        list_a = CustomList(id=list_id, profile_id=_PROFILE_ID, name="A")
+        list_b = CustomList(id=list_id, profile_id=_PROFILE_ID, name="B")
 
         assert list_a == list_b
 
     def test_should_not_be_equal_with_different_ids(self) -> None:
-        list_a = CustomList.create(name="A")
-        list_b = CustomList.create(name="A")
+        list_a = CustomList.create(profile_id=_PROFILE_ID, name="A")
+        list_b = CustomList.create(profile_id=_PROFILE_ID, name="A")
 
         assert list_a != list_b
 
     def test_should_not_be_equal_when_id_is_none(self) -> None:
-        list_a = CustomList(name="A")
-        list_b = CustomList(name="A")
+        list_a = CustomList(profile_id=_PROFILE_ID, name="A")
+        list_b = CustomList(profile_id=_PROFILE_ID, name="A")
 
         assert list_a != list_b
 
     def test_should_be_hashable(self) -> None:
-        custom_list = CustomList.create(name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
 
         assert hash(custom_list) is not None
         assert {custom_list}

--- a/tests/modules/collections/unit/domain/entities/test_watchlist_item.py
+++ b/tests/modules/collections/unit/domain/entities/test_watchlist_item.py
@@ -6,6 +6,9 @@ from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.collections.domain.entities import WatchlistItem
 from src.modules.collections.domain.value_objects import ListId
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -14,6 +17,7 @@ class TestWatchlistItemCreation:
 
     def test_should_create_with_required_fields(self) -> None:
         item = WatchlistItem(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
@@ -21,9 +25,11 @@ class TestWatchlistItemCreation:
         assert item.id is None
         assert item.media_id == "mov_abc123def456"
         assert item.media_type == CollectionMediaType.MOVIE
+        assert item.profile_id == _PROFILE_ID
 
     def test_should_create_via_factory_with_auto_id(self) -> None:
         item = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
@@ -34,6 +40,7 @@ class TestWatchlistItemCreation:
 
     def test_should_create_with_series_media_type(self) -> None:
         item = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="ser_abc123def456",
             media_type=CollectionMediaType.SERIES,
         )
@@ -42,6 +49,7 @@ class TestWatchlistItemCreation:
 
     def test_should_have_added_at_timestamp(self) -> None:
         item = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
@@ -55,6 +63,7 @@ class TestWatchlistItemImmutability:
 
     def test_should_be_frozen(self) -> None:
         item = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
@@ -64,6 +73,7 @@ class TestWatchlistItemImmutability:
 
     def test_should_not_allow_media_type_change(self) -> None:
         item = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
@@ -80,11 +90,13 @@ class TestWatchlistItemEquality:
         list_id = ListId.generate()
         item_a = WatchlistItem(
             id=list_id,
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
         item_b = WatchlistItem(
             id=list_id,
+            profile_id=_PROFILE_ID,
             media_id="ser_xyz789abc123",
             media_type=CollectionMediaType.SERIES,
         )
@@ -93,10 +105,12 @@ class TestWatchlistItemEquality:
 
     def test_should_not_be_equal_with_different_ids(self) -> None:
         item_a = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
         item_b = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
@@ -105,6 +119,7 @@ class TestWatchlistItemEquality:
 
     def test_should_be_hashable(self) -> None:
         item = WatchlistItem.create(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )

--- a/tests/modules/collections/unit/infrastructure/persistence/mappers/test_custom_list_mapper.py
+++ b/tests/modules/collections/unit/infrastructure/persistence/mappers/test_custom_list_mapper.py
@@ -15,6 +15,9 @@ from src.modules.collections.infrastructure.persistence.models import (
     CustomListModel,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -22,18 +25,24 @@ class TestCustomListMapper:
     """Tests for CustomListMapper."""
 
     def test_to_model_should_raise_when_id_is_none(self) -> None:
-        custom_list = CustomList(name="Test")
+        custom_list = CustomList(profile_id=_PROFILE_ID, name="Test")
 
         with pytest.raises(ValueError, match="Cannot map entity without ID"):
             CustomListMapper.to_model(custom_list)
 
     def test_to_model_should_convert_entity_correctly(self) -> None:
         list_id = ListId.generate()
-        custom_list = CustomList(id=list_id, name="Action Movies", item_count=5)
+        custom_list = CustomList(
+            id=list_id,
+            profile_id=_PROFILE_ID,
+            name="Action Movies",
+            item_count=5,
+        )
 
         model = CustomListMapper.to_model(custom_list)
 
         assert model.external_id == str(list_id)
+        assert model.profile_id == _PROFILE_ID.value
         assert model.name == "Action Movies"
         assert model.item_count == 5
 
@@ -42,6 +51,7 @@ class TestCustomListMapper:
         now = datetime.now(UTC)
         model = CustomListModel(
             external_id=str(list_id),
+            profile_id=_PROFILE_ID.value,
             name="Comedy",
             item_count=3,
         )
@@ -51,6 +61,7 @@ class TestCustomListMapper:
         entity = CustomListMapper.to_entity(model)
 
         assert entity.id == list_id
+        assert entity.profile_id == _PROFILE_ID
         assert entity.name.value == "Comedy"
         assert entity.item_count == 3
         assert entity.created_at == now
@@ -58,7 +69,12 @@ class TestCustomListMapper:
 
     def test_round_trip_should_preserve_fields(self) -> None:
         list_id = ListId.generate()
-        original = CustomList(id=list_id, name="Sci-Fi", item_count=2)
+        original = CustomList(
+            id=list_id,
+            profile_id=_PROFILE_ID,
+            name="Sci-Fi",
+            item_count=2,
+        )
         model = CustomListMapper.to_model(original)
         model.created_at = original.created_at
         model.updated_at = original.updated_at
@@ -66,6 +82,7 @@ class TestCustomListMapper:
         result = CustomListMapper.to_entity(model)
 
         assert result.id == original.id
+        assert result.profile_id == original.profile_id
         assert result.name == original.name
         assert result.item_count == original.item_count
 
@@ -73,10 +90,16 @@ class TestCustomListMapper:
         list_id = ListId.generate()
         model = CustomListModel(
             external_id=str(list_id),
+            profile_id=_PROFILE_ID.value,
             name="Old Name",
             item_count=1,
         )
-        updated = CustomList(id=list_id, name="New Name", item_count=5)
+        updated = CustomList(
+            id=list_id,
+            profile_id=_PROFILE_ID,
+            name="New Name",
+            item_count=5,
+        )
 
         result = CustomListMapper.update_model(model, updated)
 

--- a/tests/modules/collections/unit/infrastructure/persistence/mappers/test_watchlist_item_mapper.py
+++ b/tests/modules/collections/unit/infrastructure/persistence/mappers/test_watchlist_item_mapper.py
@@ -13,6 +13,9 @@ from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -21,6 +24,7 @@ class TestWatchlistItemMapper:
 
     def test_to_model_should_raise_when_id_is_none(self) -> None:
         item = WatchlistItem(
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
         )
@@ -33,6 +37,7 @@ class TestWatchlistItemMapper:
         added_at = datetime.now(UTC)
         item = WatchlistItem(
             id=list_id,
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
             added_at=added_at,
@@ -41,6 +46,7 @@ class TestWatchlistItemMapper:
         model = WatchlistItemMapper.to_model(item)
 
         assert model.external_id == str(list_id)
+        assert model.profile_id == _PROFILE_ID.value
         assert model.media_id == "mov_abc123def456"
         assert model.media_type == CollectionMediaType.MOVIE
         assert model.added_at == added_at
@@ -51,6 +57,7 @@ class TestWatchlistItemMapper:
         now = datetime.now(UTC)
         model = WatchlistItemModel(
             external_id=str(list_id),
+            profile_id=_PROFILE_ID.value,
             media_id="ser_xyz789abc123",
             media_type="series",
             added_at=added_at,
@@ -61,6 +68,7 @@ class TestWatchlistItemMapper:
         entity = WatchlistItemMapper.to_entity(model)
 
         assert entity.id == list_id
+        assert entity.profile_id == _PROFILE_ID
         assert entity.media_id == "ser_xyz789abc123"
         assert entity.media_type == CollectionMediaType.SERIES
         assert entity.added_at == added_at
@@ -70,6 +78,7 @@ class TestWatchlistItemMapper:
         added_at = datetime.now(UTC)
         original = WatchlistItem(
             id=list_id,
+            profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=CollectionMediaType.MOVIE,
             added_at=added_at,
@@ -81,6 +90,7 @@ class TestWatchlistItemMapper:
         result = WatchlistItemMapper.to_entity(model)
 
         assert result.id == original.id
+        assert result.profile_id == original.profile_id
         assert result.media_id == original.media_id
         assert result.media_type == original.media_type
         assert result.added_at == original.added_at
@@ -91,12 +101,14 @@ class TestWatchlistItemMapper:
         new_added_at = datetime(2025, 6, 1, tzinfo=UTC)
         model = WatchlistItemModel(
             external_id=str(list_id),
+            profile_id=_PROFILE_ID.value,
             media_id="mov_old00000000",
             media_type="movie",
             added_at=old_added_at,
         )
         updated_entity = WatchlistItem(
             id=list_id,
+            profile_id=_PROFILE_ID,
             media_id="ser_new00000000",
             media_type=CollectionMediaType.SERIES,
             added_at=new_added_at,

--- a/tests/modules/collections/unit/infrastructure/persistence/mappers/test_watchlist_item_mapper.py
+++ b/tests/modules/collections/unit/infrastructure/persistence/mappers/test_watchlist_item_mapper.py
@@ -95,7 +95,13 @@ class TestWatchlistItemMapper:
         assert result.media_type == original.media_type
         assert result.added_at == original.added_at
 
-    def test_update_model_should_update_fields(self) -> None:
+    def test_update_model_refreshes_added_at_only(self) -> None:
+        # update_model is only called from the soft-delete restore
+        # path, where the caller has already located ``model`` by
+        # the (profile_id, media_id) composite key. Refreshing the
+        # added_at is the only mutation that makes sense — leaving
+        # the identity-shaping fields intact prevents accidental
+        # unique-constraint violations.
         list_id = ListId.generate()
         old_added_at = datetime(2024, 1, 1, tzinfo=UTC)
         new_added_at = datetime(2025, 6, 1, tzinfo=UTC)
@@ -106,16 +112,42 @@ class TestWatchlistItemMapper:
             media_type="movie",
             added_at=old_added_at,
         )
-        updated_entity = WatchlistItem(
+        same_key_entity = WatchlistItem(
+            id=list_id,
+            profile_id=_PROFILE_ID,
+            media_id="mov_old00000000",
+            media_type=CollectionMediaType.MOVIE,
+            added_at=new_added_at,
+        )
+
+        result = WatchlistItemMapper.update_model(model, same_key_entity)
+
+        assert result.added_at == new_added_at
+        assert result.media_id == "mov_old00000000"
+        assert result.media_type == "movie"
+
+    def test_update_model_does_not_overwrite_identity_fields(self) -> None:
+        # If a caller (incorrectly) hands an entity whose
+        # ``media_id`` or ``media_type`` differs from the model's,
+        # the mapper must not propagate the change — those fields
+        # are part of the composite uniqueness contract.
+        list_id = ListId.generate()
+        model = WatchlistItemModel(
+            external_id=str(list_id),
+            profile_id=_PROFILE_ID.value,
+            media_id="mov_old00000000",
+            media_type="movie",
+            added_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        mismatched_entity = WatchlistItem(
             id=list_id,
             profile_id=_PROFILE_ID,
             media_id="ser_new00000000",
             media_type=CollectionMediaType.SERIES,
-            added_at=new_added_at,
+            added_at=datetime(2025, 6, 1, tzinfo=UTC),
         )
 
-        result = WatchlistItemMapper.update_model(model, updated_entity)
+        result = WatchlistItemMapper.update_model(model, mismatched_entity)
 
-        assert result.media_id == "ser_new00000000"
-        assert result.media_type == CollectionMediaType.SERIES
-        assert result.added_at == new_added_at
+        assert result.media_id == "mov_old00000000"
+        assert result.media_type == "movie"


### PR DESCRIPTION
## Summary

- Adds `profile_id` to the `CustomList` and `WatchlistItem` aggregates so each profile owns its own custom lists and watchlist. `CustomListItem` is unchanged because items inherit profile scoping through their parent list FK.
- Repository methods now require a `ProfileId`; writes (`add` / `update`) read it from the entity. Soft-deleted lookups are also scoped per profile so recreate-after-delete flows stay correct.
- Migration `e7f8a9b0c1d2` follows the same 3-step pattern used in PR #172 (watch_progress): nullable add, SQL backfill from the oldest active profile, then `ALTER NOT NULL`. Watchlist replaces the legacy `media_id` unique with a composite `(profile_id, media_id)` unique so two profiles can independently bookmark the same title.
- Use cases + DTOs propagate `profile_id` end-to-end. New `DeleteCustomListInput`, `CheckWatchlistInput`, and `ListCustomListsInput` dataclasses replace previous raw-param signatures.
- Routes gate on a new `resolve_profile_id` dependency that uses the new `collections_default_profile_id` setting as a transitional fallback. Unset = strict mode (401). No broad `suppress(Exception)` — misconfigurations surface as 500.

## Rollout

Feature-flag-style transition matching PR #172:
- `COLLECTIONS_DEFAULT_PROFILE_ID=prf_xxx` lets the existing frontend keep working without sending a session cookie.
- Once the frontend (`homeflix-web`) starts forwarding the cookie / explicit profile id, unset the env var to enter strict mode.

## Test plan

- [x] `poetry run pytest tests/modules/collections -q` → 175 passed (was 41 passed / 121 failed before the test sweep).
- [x] `poetry run pytest -q` → 2159 passed, 5 skipped — no regressions in other BCs.
- [x] `poetry run ruff check` and `ruff format --check` clean across the diff.
- [x] Migration smoke against fresh SQLite: `alembic upgrade head` succeeds, `custom_lists.profile_id` and `watchlist_items.profile_id` are `NOT NULL` with index, watchlist gets the composite unique, the legacy single-column unique is dropped.
- [x] Backfill smoke: downgrade one revision, seed a profile + a legacy `custom_list` and `watchlist_item` without `profile_id`, upgrade — both rows pick up the seeded `profile_id`.
- [x] Cross-profile isolation: integration tests construct a second `prf_otherprofile` and assert that `find_by_id`, `list_all`, `count`, `remove`, `find_item`, `list_items`, `find_by_media_id`, `exists`, etc. never leak across profiles.
- [ ] Manual end-to-end with the existing frontend (will exercise post-merge with the env var set).

## Summary by Sourcery

Scope collections (custom lists and watchlist) data per profile and propagate profile ownership throughout repositories, use cases, routes, and persistence, including a migration and rollout helper dependency.

New Features:
- Introduce per-profile ownership for custom lists and watchlist items so each profile maintains isolated collections.
- Add a FastAPI dependency to resolve the caller's profile_id with an optional transitional default for collections routes.

Enhancements:
- Update repositories, domain entities, DTOs, and use cases to require and propagate profile_id for all collections operations, enforcing per-profile isolation and uniqueness constraints.
- Extend persistence models and mappers to store profile_id on custom_lists and watchlist_items while keeping custom_list_items scoped via their parent list.
- Refine collections routes to operate strictly on the caller's profile and improve docstrings and comments for the new per-profile behaviour.

Deployment:
- Add an Alembic migration to backfill and enforce profile_id on collections tables and to replace the legacy watchlist media_id unique with a composite (profile_id, media_id) constraint.

Tests:
- Expand and update unit and integration tests for collections repositories, use cases, entities, and mappers to cover profile scoping, isolation, and the new DTO shapes.