### PR TITLE
feat(preferences): scope playback preferences per profile (PR 5)

### DIFF
--- a/migrations/versions/2026_05_03_add_profile_id_to_preferences.py
+++ b/migrations/versions/2026_05_03_add_profile_id_to_preferences.py
@@ -1,0 +1,135 @@
+"""Replace user_key with profile_id on preferences (singleton-per-profile).
+
+Per ADR-010, every personalisation row is scoped to a profile. The
+``preferences`` table predates identity and used a placeholder
+``user_key`` column whose only value was ``"default"``. This
+migration introduces ``profile_id`` (the prefixed external ID — no
+FK because cross-BC references travel as strings, not UUIDs) and
+drops ``user_key`` once the legacy rows have been backfilled.
+
+Sequence (so existing dev data survives):
+
+1. ADD COLUMN profile_id NULLABLE — schema accepts NULL for the
+   handful of legacy rows already present.
+2. UPDATE the legacy rows with the first profile's external_id —
+   requires that ``scripts/identity_create_admin.py`` was run before
+   the upgrade so at least one profile exists. Migration aborts with
+   a clear message if not.
+3. DROP UNIQUE(user_key) and DROP COLUMN user_key.
+4. ALTER COLUMN profile_id NOT NULL + UNIQUE.
+
+Revision ID: f8a9b0c1d2e3
+Revises: d6e7f8a9b0c1
+Create Date: 2026-05-03 19:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "f8a9b0c1d2e3"
+down_revision: str | Sequence[str] | None = "d6e7f8a9b0c1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _resolve_default_profile_external_id(connection: sa.Connection) -> str:
+    """Return the prefixed external_id of the oldest active profile.
+
+    Aborts with a clear ``RuntimeError`` if no profile exists so the
+    operator runs ``scripts/identity_create_admin.py`` first instead
+    of getting a generic NOT NULL violation.
+    """
+    row = connection.execute(
+        sa.text(
+            "SELECT external_id "
+            "FROM profiles "
+            "WHERE deleted_at IS NULL "
+            "ORDER BY created_at ASC "
+            "LIMIT 1"
+        )
+    ).first()
+    if row is None:
+        msg = (
+            "Cannot backfill preferences.profile_id: no active profile "
+            "exists. Run `python scripts/identity_create_admin.py` to create "
+            "an admin user and default profile, then re-run this migration."
+        )
+        raise RuntimeError(msg)
+    return row[0]
+
+
+def upgrade() -> None:
+    """Add profile_id, backfill, drop legacy user_key, tighten the column."""
+    bind = op.get_bind()
+
+    # Step 1: ADD COLUMN NULLABLE so existing rows survive the schema change.
+    with op.batch_alter_table("preferences") as batch_op:
+        batch_op.add_column(
+            sa.Column("profile_id", sa.String(length=50), nullable=True),
+        )
+
+    # Step 2: backfill legacy rows with the oldest active profile.
+    legacy_rows = bind.execute(
+        sa.text("SELECT COUNT(*) FROM preferences WHERE profile_id IS NULL")
+    ).scalar_one()
+    if legacy_rows:
+        default_profile = _resolve_default_profile_external_id(bind)
+        bind.execute(
+            sa.text("UPDATE preferences SET profile_id = :pid WHERE profile_id IS NULL"),
+            {"pid": default_profile},
+        )
+
+    # Step 3: drop the legacy user_key column. The unique index travels
+    # with the column on SQLite (table-rebuild via batch_alter_table)
+    # and on Postgres an explicit DROP INDEX IF EXISTS keeps the path
+    # idempotent against partially-applied prior runs.
+    op.execute("DROP INDEX IF EXISTS ix_preferences_user_key")
+    if op.get_context().dialect.name == "postgresql":
+        op.execute("ALTER TABLE preferences DROP CONSTRAINT IF EXISTS preferences_user_key_key")
+        op.execute("ALTER TABLE preferences DROP CONSTRAINT IF EXISTS uq_preferences_user_key")
+
+    with op.batch_alter_table("preferences") as batch_op:
+        batch_op.drop_column("user_key")
+        batch_op.alter_column(
+            "profile_id",
+            existing_type=sa.String(length=50),
+            nullable=False,
+        )
+        batch_op.create_index(
+            "ix_preferences_profile_id",
+            ["profile_id"],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    """Reverse the schema change.
+
+    Restores ``user_key`` (server_default ``'default'``) and drops
+    ``profile_id``. Note: this loses per-profile scoping data — only
+    safe in dev.
+    """
+    with op.batch_alter_table("preferences") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "user_key",
+                sa.String(length=50),
+                nullable=False,
+                server_default="default",
+            ),
+        )
+        batch_op.drop_index("ix_preferences_profile_id")
+        batch_op.drop_column("profile_id")
+        batch_op.create_index(
+            "ix_preferences_user_key",
+            ["user_key"],
+            unique=True,
+        )

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -279,6 +279,15 @@ class Settings(BaseSettings):  # type: ignore[misc]
         "mode (no cookie -> 401). Remove the env var once every consumer "
         "is sending the session cookie.",
     )
+    preferences_default_profile_id: str | None = Field(
+        default=None,
+        description="Optional fallback ``profile_id`` for the playback "
+        "preferences routes during the per-profile rollout. Same "
+        "semantics as ``watch_progress_default_profile_id`` — the "
+        "operator typically sets all *_default_profile_id env vars "
+        "together while the frontend is being migrated, then removes "
+        "them to enter strict mode.",
+    )
 
     # =========================================================================
     # Internationalization

--- a/src/modules/preferences/application/dtos/preferences_dtos.py
+++ b/src/modules/preferences/application/dtos/preferences_dtos.py
@@ -6,8 +6,15 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+class GetPreferencesInput:
+    """Input for ``GetPreferencesUseCase``."""
+
+    profile_id: str
+
+
+@dataclass(frozen=True)
 class PreferencesOutput:
-    """Current playback preferences for the user."""
+    """Current playback preferences for the profile."""
 
     audio_lang: str
     subtitle_lang: str
@@ -20,6 +27,7 @@ class PreferencesOutput:
 class UpdatePreferencesInput:
     """Partial update — only non-``None`` fields are applied."""
 
+    profile_id: str
     audio_lang: str | None = None
     subtitle_lang: str | None = None
     subtitle_mode: str | None = None
@@ -27,4 +35,4 @@ class UpdatePreferencesInput:
     speed: float | None = None
 
 
-__all__ = ["PreferencesOutput", "UpdatePreferencesInput"]
+__all__ = ["GetPreferencesInput", "PreferencesOutput", "UpdatePreferencesInput"]

--- a/src/modules/preferences/application/use_cases/get_preferences.py
+++ b/src/modules/preferences/application/use_cases/get_preferences.py
@@ -1,12 +1,16 @@
 """GetPreferencesUseCase."""
 
-from src.modules.preferences.application.dtos.preferences_dtos import PreferencesOutput
+from src.modules.preferences.application.dtos.preferences_dtos import (
+    GetPreferencesInput,
+    PreferencesOutput,
+)
 from src.modules.preferences.application.unit_of_work import PreferencesUnitOfWorkFactory
-from src.modules.preferences.domain.entities import DEFAULT_USER_KEY, PlaybackPreferences
+from src.modules.preferences.domain.entities import PlaybackPreferences
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class GetPreferencesUseCase:
-    """Return the current user's playback preferences.
+    """Return the current profile's playback preferences.
 
     On first access (no row persisted yet) the domain factory
     ``PlaybackPreferences.default_for`` supplies the defaults — the
@@ -16,12 +20,13 @@ class GetPreferencesUseCase:
     def __init__(self, uow_factory: PreferencesUnitOfWorkFactory) -> None:
         self._uow_factory = uow_factory
 
-    async def execute(self) -> PreferencesOutput:
-        """Fetch or default the user's playback preferences."""
+    async def execute(self, input_dto: GetPreferencesInput) -> PreferencesOutput:
+        """Fetch or default the profile's playback preferences."""
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            entity = await uow.preferences.find_by_user_key(DEFAULT_USER_KEY)
+            entity = await uow.preferences.find_by_profile_id(profile_id)
         if entity is None:
-            entity = PlaybackPreferences.default_for(DEFAULT_USER_KEY)
+            entity = PlaybackPreferences.default_for(profile_id)
         return _to_output(entity)
 
 

--- a/src/modules/preferences/application/use_cases/update_preferences.py
+++ b/src/modules/preferences/application/use_cases/update_preferences.py
@@ -5,27 +5,29 @@ from src.modules.preferences.application.dtos.preferences_dtos import (
     UpdatePreferencesInput,
 )
 from src.modules.preferences.application.unit_of_work import PreferencesUnitOfWorkFactory
-from src.modules.preferences.domain.entities import DEFAULT_USER_KEY, PlaybackPreferences
+from src.modules.preferences.domain.entities import PlaybackPreferences
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class UpdatePreferencesUseCase:
-    """Partially update (or create) the user's playback preferences."""
+    """Partially update (or create) the profile's playback preferences."""
 
     def __init__(self, uow_factory: PreferencesUnitOfWorkFactory) -> None:
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: UpdatePreferencesInput) -> PreferencesOutput:
-        """Upsert the user's playback preferences.
+        """Upsert the profile's playback preferences.
 
         Loads the current record (or builds defaults on first save),
         applies only the non-``None`` fields, and persists the result
         inside a UoW so the transaction boundary lives in the use case
         rather than the repository.
         """
+        profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
-            current = await uow.preferences.find_by_user_key(DEFAULT_USER_KEY)
+            current = await uow.preferences.find_by_profile_id(profile_id)
             if current is None:
-                current = PlaybackPreferences.default_for(DEFAULT_USER_KEY)
+                current = PlaybackPreferences.default_for(profile_id)
 
             updated = current.apply_updates(
                 audio_lang=input_dto.audio_lang,

--- a/src/modules/preferences/domain/entities/__init__.py
+++ b/src/modules/preferences/domain/entities/__init__.py
@@ -1,8 +1,7 @@
 """Playback preferences domain entities."""
 
 from src.modules.preferences.domain.entities.playback_preferences import (
-    DEFAULT_USER_KEY,
     PlaybackPreferences,
 )
 
-__all__ = ["DEFAULT_USER_KEY", "PlaybackPreferences"]
+__all__ = ["PlaybackPreferences"]

--- a/src/modules/preferences/domain/entities/playback_preferences.py
+++ b/src/modules/preferences/domain/entities/playback_preferences.py
@@ -13,8 +13,8 @@ from src.modules.preferences.domain.value_objects import (
     Speed,
     SubtitleMode,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
-DEFAULT_USER_KEY = "default"
 DEFAULT_AUDIO_LANG = "pt-BR"
 DEFAULT_SUBTITLE_LANG = "pt-BR"
 DEFAULT_SUBTITLE_MODE = SubtitleMode.FOREIGN_ONLY
@@ -23,18 +23,21 @@ DEFAULT_SPEED = 1.0
 
 
 class PlaybackPreferences(AggregateRoot[PreferencesId]):
-    """Per-user playback defaults the video player applies on startup.
+    """Per-profile playback defaults the video player applies on startup.
 
-    Singleton-per-``user_key`` — there is exactly one record per user.
-    Until an auth system lands the only key is ``"default"``; every
-    browser session shares the same row.
+    Singleton-per-``profile_id`` — there is exactly one record per
+    profile. The row's external_id mirrors the owning profile id so
+    the natural key (``profile_id``) and the surrogate identity
+    (``PreferencesId``) stay in lockstep without an extra mapping
+    table.
 
     Languages are kept as plain strings (not ``LanguageCode``) because
     the frontend persists IETF tags like ``"pt-BR"``/``"en-US"`` that
     don't match the shared kernel's strict ISO 639-1 shape.
 
     Example:
-        >>> prefs = PlaybackPreferences.default_for()
+        >>> profile = ProfileId("prf_test12345678")
+        >>> prefs = PlaybackPreferences.default_for(profile)
         >>> prefs.speed.value
         1.0
         >>> prefs.subtitle_mode
@@ -43,7 +46,7 @@ class PlaybackPreferences(AggregateRoot[PreferencesId]):
 
     id: PreferencesId | None = Field(default=None)
 
-    user_key: str = DEFAULT_USER_KEY
+    profile_id: ProfileId
     audio_lang: str = DEFAULT_AUDIO_LANG
     subtitle_lang: str = DEFAULT_SUBTITLE_LANG
     subtitle_mode: SubtitleMode = DEFAULT_SUBTITLE_MODE
@@ -69,11 +72,11 @@ class PlaybackPreferences(AggregateRoot[PreferencesId]):
         return value if isinstance(value, Quality) else Quality(value)
 
     @classmethod
-    def default_for(cls, user_key: str = DEFAULT_USER_KEY) -> Self:
+    def default_for(cls, profile_id: ProfileId) -> Self:
         """Build a fresh preferences record with all factory defaults."""
         return cls(
-            id=PreferencesId.for_user_key(user_key),
-            user_key=user_key,
+            id=PreferencesId.for_profile(profile_id),
+            profile_id=profile_id,
         )
 
     def apply_updates(
@@ -112,6 +115,5 @@ __all__ = [
     "DEFAULT_SPEED",
     "DEFAULT_SUBTITLE_LANG",
     "DEFAULT_SUBTITLE_MODE",
-    "DEFAULT_USER_KEY",
     "PlaybackPreferences",
 ]

--- a/src/modules/preferences/domain/repositories/preferences_repository.py
+++ b/src/modules/preferences/domain/repositories/preferences_repository.py
@@ -3,14 +3,15 @@
 from abc import ABC, abstractmethod
 
 from src.modules.preferences.domain.entities import PlaybackPreferences
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class PreferencesRepository(ABC):
-    """Read/persist playback preferences keyed by user."""
+    """Read/persist playback preferences keyed by profile."""
 
     @abstractmethod
-    async def find_by_user_key(self, user_key: str) -> PlaybackPreferences | None:
-        """Return the preferences record for ``user_key`` or ``None``.
+    async def find_by_profile_id(self, profile_id: ProfileId) -> PlaybackPreferences | None:
+        """Return the preferences record for ``profile_id`` or ``None``.
 
         A ``None`` result is expected and normal on first access — the
         caller typically falls back to ``PlaybackPreferences.default_for``.

--- a/src/modules/preferences/domain/value_objects/preferences_id.py
+++ b/src/modules/preferences/domain/value_objects/preferences_id.py
@@ -1,27 +1,33 @@
 """Preferences external ID value object.
 
 Unlike the catalog IDs that follow the 12-char base62 scheme
-(see ADR-002), a preferences row is singleton-per-user and its
-external ID encodes the user_key itself (``prf_<user_key>``).
-Until an auth system lands the only key is ``default``; the VO
-just guards the ``prf_<slug>`` shape so arbitrary strings can't
-be persisted as ids.
+(see ADR-002), a preferences row is singleton-per-profile and its
+external ID mirrors the owning ``ProfileId``. The VO guards the
+``prf_<slug>`` shape so arbitrary strings can't be persisted as ids
+while keeping legacy ``prf_default`` rows readable until they are
+migrated away.
 """
 
+from __future__ import annotations
+
 import re
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import model_validator
 
 from src.building_blocks.domain.value_objects import StringValueObject
 from src.modules.preferences.domain.rule_codes import PreferencesRuleCodes
 
+if TYPE_CHECKING:
+    from src.shared_kernel.value_objects.profile_id import ProfileId
+
 
 class PreferencesId(StringValueObject):
     """External id of a playback preferences record.
 
-    Format: ``prf_<user_key>`` where ``user_key`` is 1-64 chars of
-    ``[a-zA-Z0-9_-]``.
+    Format: ``prf_<slug>`` where ``slug`` is 1-64 chars of
+    ``[a-zA-Z0-9_-]``. New rows mirror the owning ``ProfileId``
+    so the surrogate key never drifts from the natural key.
 
     Example:
         >>> PreferencesId("prf_default").value
@@ -34,7 +40,7 @@ class PreferencesId(StringValueObject):
     @model_validator(mode="before")
     @classmethod
     def validate_format(cls, value: Any) -> str:
-        """Validate the ``prf_<user_key>`` shape."""
+        """Validate the ``prf_<slug>`` shape."""
         if not isinstance(value, str):
             raise ValueError("PreferencesId must be a string")
 
@@ -49,9 +55,16 @@ class PreferencesId(StringValueObject):
         return value
 
     @classmethod
-    def for_user_key(cls, user_key: str) -> "PreferencesId":
-        """Build the canonical id for a given user key."""
-        return cls(f"{cls.PREFIX}_{user_key}")
+    def for_profile(cls, profile_id: ProfileId) -> PreferencesId:
+        """Build the canonical id mirroring ``profile_id``.
+
+        Reusing the profile_id string as the preferences external_id
+        keeps the singleton-per-profile invariant explicit at the
+        identity level — no separate id allocation is needed and the
+        DB unique on ``profile_id`` doubles as a uniqueness guarantee
+        on ``external_id``.
+        """
+        return cls(profile_id.value)
 
 
 __all__ = ["PreferencesId"]

--- a/src/modules/preferences/infrastructure/persistence/mappers/preferences_mapper.py
+++ b/src/modules/preferences/infrastructure/persistence/mappers/preferences_mapper.py
@@ -10,6 +10,7 @@ from src.modules.preferences.domain.value_objects import (
 from src.modules.preferences.infrastructure.persistence.models.preferences_model import (
     PreferencesModel,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class PreferencesMapper:
@@ -20,7 +21,7 @@ class PreferencesMapper:
         """Project a row into a fully-validated ``PlaybackPreferences``."""
         return PlaybackPreferences(
             id=PreferencesId(model.external_id),
-            user_key=model.user_key,
+            profile_id=ProfileId(model.profile_id),
             audio_lang=model.audio_lang,
             subtitle_lang=model.subtitle_lang,
             subtitle_mode=SubtitleMode(model.subtitle_mode),
@@ -38,7 +39,7 @@ class PreferencesMapper:
             raise ValueError(msg)
         return PreferencesModel(
             external_id=str(entity.id),
-            user_key=entity.user_key,
+            profile_id=str(entity.profile_id),
             audio_lang=entity.audio_lang,
             subtitle_lang=entity.subtitle_lang,
             subtitle_mode=entity.subtitle_mode.value,
@@ -51,7 +52,12 @@ class PreferencesMapper:
         model: PreferencesModel,
         entity: PlaybackPreferences,
     ) -> PreferencesModel:
-        """Copy mutable fields from the entity into an existing row."""
+        """Refresh the mutable fields on an existing row.
+
+        ``profile_id`` is not touched — the caller used it to locate
+        ``model`` in the first place, and it's part of the singleton
+        invariant enforced by the unique index.
+        """
         model.audio_lang = entity.audio_lang
         model.subtitle_lang = entity.subtitle_lang
         model.subtitle_mode = entity.subtitle_mode.value

--- a/src/modules/preferences/infrastructure/persistence/models/preferences_model.py
+++ b/src/modules/preferences/infrastructure/persistence/models/preferences_model.py
@@ -7,21 +7,21 @@ from src.infrastructure.persistence.base import Base
 
 
 class PreferencesModel(Base):
-    """SQLAlchemy model for user playback preferences.
+    """SQLAlchemy model for per-profile playback preferences.
 
-    Singleton-per-user design: there's exactly one row per
-    ``user_key``. Until an auth system lands the only key is
-    ``"default"`` — all browser sessions share the same prefs.
+    Singleton-per-profile design: there's exactly one row per
+    ``profile_id``. The unique index on ``profile_id`` enforces it
+    at the DB level so a race between two concurrent first-saves
+    can't materialise two rows.
 
     Maps to the ``preferences`` table.
     """
 
-    user_key: Mapped[str] = mapped_column(
+    profile_id: Mapped[str] = mapped_column(
         String(50),
         nullable=False,
         unique=True,
         index=True,
-        default="default",
     )
     audio_lang: Mapped[str] = mapped_column(String(10), nullable=False, default="pt-BR")
     subtitle_lang: Mapped[str] = mapped_column(String(10), nullable=False, default="pt-BR")

--- a/src/modules/preferences/infrastructure/persistence/repositories/preferences_repository.py
+++ b/src/modules/preferences/infrastructure/persistence/repositories/preferences_repository.py
@@ -9,6 +9,7 @@ from src.modules.preferences.infrastructure.persistence.mappers import Preferenc
 from src.modules.preferences.infrastructure.persistence.models.preferences_model import (
     PreferencesModel,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 class SQLAlchemyPreferencesRepository(PreferencesRepository):
@@ -21,14 +22,14 @@ class SQLAlchemyPreferencesRepository(PreferencesRepository):
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def find_by_user_key(self, user_key: str) -> PlaybackPreferences | None:
+    async def find_by_profile_id(self, profile_id: ProfileId) -> PlaybackPreferences | None:
         """Map the persisted row (if any) back into a domain entity."""
-        model = await self._fetch_model(user_key)
+        model = await self._fetch_model(profile_id)
         return PreferencesMapper.to_entity(model) if model else None
 
     async def save(self, preferences: PlaybackPreferences) -> PlaybackPreferences:
         """Upsert the row; flush but leave the commit to the Unit of Work."""
-        existing = await self._fetch_model(preferences.user_key)
+        existing = await self._fetch_model(preferences.profile_id)
         if existing is None:
             model = PreferencesMapper.new_model(preferences)
             self._session.add(model)
@@ -41,9 +42,9 @@ class SQLAlchemyPreferencesRepository(PreferencesRepository):
         await self._session.refresh(model)
         return PreferencesMapper.to_entity(model)
 
-    async def _fetch_model(self, user_key: str) -> PreferencesModel | None:
+    async def _fetch_model(self, profile_id: ProfileId) -> PreferencesModel | None:
         stmt = select(PreferencesModel).where(
-            PreferencesModel.user_key == user_key,
+            PreferencesModel.profile_id == str(profile_id),
             PreferencesModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)

--- a/src/modules/preferences/presentation/dependencies.py
+++ b/src/modules/preferences/presentation/dependencies.py
@@ -1,0 +1,44 @@
+"""FastAPI dependency that resolves the caller's ``profile_id`` for preferences.
+
+Same per-profile rollout pattern documented in
+``watch_progress/presentation/dependencies.py`` and
+``collections/presentation/dependencies.py``: try the authenticated
+path first, fall back to ``settings.preferences_default_profile_id``
+when no cookie is present, raise 401 otherwise. Once strict mode is
+acceptable project-wide this dep, along with its siblings, can be
+collapsed into a direct re-export of
+``identity.presentation.dependencies.get_current_profile``.
+"""
+
+from fastapi import Request
+
+from src.config.settings import get_settings
+from src.modules.identity.domain.errors import NoActiveSessionError
+
+
+async def resolve_profile_id(request: Request) -> str:
+    """Return the caller's profile_id (prefixed external ID).
+
+    Errors raised by the identity UoW (container not wired, DB
+    unreachable, etc.) propagate as 500 by design — silently falling
+    back to anonymous on real misconfigurations would mask bugs and
+    serve authenticated requests as anonymous.
+    """
+    settings = get_settings()
+
+    token = request.cookies.get(settings.session_cookie_name)
+    if token is not None:
+        container = request.app.state.container
+        factory = container.identity.identity_unit_of_work_factory()
+        async with factory() as uow:
+            snap = await uow.access_tokens.get_by_token(token)
+        if snap is not None and snap.current_profile_id is not None:
+            return str(snap.current_profile_id)
+
+    if settings.preferences_default_profile_id:
+        return settings.preferences_default_profile_id
+
+    raise NoActiveSessionError(message="Authentication required to access preferences")
+
+
+__all__ = ["resolve_profile_id"]

--- a/src/modules/preferences/presentation/routes/preferences_routes.py
+++ b/src/modules/preferences/presentation/routes/preferences_routes.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
 from src.modules.preferences.application.dtos.preferences_dtos import (
+    GetPreferencesInput,
     UpdatePreferencesInput,
 )
 from src.modules.preferences.application.use_cases.get_preferences import (
@@ -17,6 +18,7 @@ from src.modules.preferences.application.use_cases.get_preferences import (
 from src.modules.preferences.application.use_cases.update_preferences import (
     UpdatePreferencesUseCase,
 )
+from src.modules.preferences.presentation.dependencies import resolve_profile_id
 from src.modules.preferences.presentation.schemas.preferences_schemas import (
     UpdatePreferencesRequest,
 )
@@ -27,12 +29,13 @@ router = APIRouter(prefix="/api/v1/preferences", tags=["Preferences"])
 @router.get("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def get_preferences(
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetPreferencesUseCase = Depends(
         Provide[ApplicationContainer.preferences.get_preferences],
     ),
 ) -> dict[str, Any]:
-    """Return the current user's playback preferences."""
-    result = await use_case.execute()
+    """Return the current profile's playback preferences."""
+    result = await use_case.execute(GetPreferencesInput(profile_id=profile_id))
     return api_single("preferences", asdict(result))
 
 
@@ -40,6 +43,7 @@ async def get_preferences(
 @inject  # type: ignore[misc]
 async def update_preferences(
     body: UpdatePreferencesRequest,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: UpdatePreferencesUseCase = Depends(
         Provide[ApplicationContainer.preferences.update_preferences],
     ),
@@ -47,6 +51,7 @@ async def update_preferences(
     """Partially update (or create) playback preferences."""
     result = await use_case.execute(
         UpdatePreferencesInput(
+            profile_id=profile_id,
             audio_lang=body.audio_lang,
             subtitle_lang=body.subtitle_lang,
             subtitle_mode=body.subtitle_mode,

--- a/tests/modules/preferences/integration/persistence/test_preferences_repository.py
+++ b/tests/modules/preferences/integration/persistence/test_preferences_repository.py
@@ -3,39 +3,40 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.modules.preferences.domain.entities import (
-    DEFAULT_USER_KEY,
-    PlaybackPreferences,
-)
+from src.modules.preferences.domain.entities import PlaybackPreferences
 from src.modules.preferences.domain.value_objects import Quality, SubtitleMode
 from src.modules.preferences.infrastructure.persistence.repositories import (
     SQLAlchemyPreferencesRepository,
 )
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
+_OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
 
 
 @pytest.mark.integration
 class TestSQLAlchemyPreferencesRepository:
-    async def test_find_by_user_key_returns_none_on_empty_table(
+    async def test_find_by_profile_id_returns_none_on_empty_table(
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemyPreferencesRepository(db_session)
-        assert await repo.find_by_user_key(DEFAULT_USER_KEY) is None
+        assert await repo.find_by_profile_id(_PROFILE_ID) is None
 
     async def test_save_persists_new_row(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyPreferencesRepository(db_session)
-        prefs = PlaybackPreferences.default_for().apply_updates(
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(
             subtitle_mode="always",
             speed=1.25,
         )
 
         saved = await repo.save(prefs)
 
-        assert saved.user_key == DEFAULT_USER_KEY
+        assert saved.profile_id == _PROFILE_ID
         assert saved.subtitle_mode is SubtitleMode.ALWAYS
         assert saved.speed.value == 1.25
         assert saved.created_at is not None
 
-        found = await repo.find_by_user_key(DEFAULT_USER_KEY)
+        found = await repo.find_by_profile_id(_PROFILE_ID)
         assert found is not None
         assert found.subtitle_mode is SubtitleMode.ALWAYS
         assert found.speed.value == 1.25
@@ -44,9 +45,9 @@ class TestSQLAlchemyPreferencesRepository:
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemyPreferencesRepository(db_session)
-        await repo.save(PlaybackPreferences.default_for())
+        await repo.save(PlaybackPreferences.default_for(_PROFILE_ID))
 
-        existing = await repo.find_by_user_key(DEFAULT_USER_KEY)
+        existing = await repo.find_by_profile_id(_PROFILE_ID)
         assert existing is not None
         updated = existing.apply_updates(default_quality="1080p")
 
@@ -54,6 +55,30 @@ class TestSQLAlchemyPreferencesRepository:
 
         assert saved.default_quality is Quality.P1080
         # Still just one row — second find resolves to the same record.
-        second = await repo.find_by_user_key(DEFAULT_USER_KEY)
+        second = await repo.find_by_profile_id(_PROFILE_ID)
         assert second is not None
         assert second.default_quality is Quality.P1080
+
+    async def test_find_by_profile_id_isolates_across_profiles(
+        self, db_session: AsyncSession
+    ) -> None:
+        # Two profiles, each with their own preferences row: each lookup
+        # must see only its own row. The DB unique on ``profile_id`` plus
+        # the explicit WHERE filter guarantee no cross-profile leakage.
+        repo = SQLAlchemyPreferencesRepository(db_session)
+        await repo.save(
+            PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(speed=1.5),
+        )
+        await repo.save(
+            PlaybackPreferences.default_for(_OTHER_PROFILE_ID).apply_updates(speed=0.75),
+        )
+
+        first = await repo.find_by_profile_id(_PROFILE_ID)
+        other = await repo.find_by_profile_id(_OTHER_PROFILE_ID)
+
+        assert first is not None
+        assert other is not None
+        assert first.profile_id == _PROFILE_ID
+        assert other.profile_id == _OTHER_PROFILE_ID
+        assert first.speed.value == 1.5
+        assert other.speed.value == 0.75

--- a/tests/modules/preferences/unit/application/use_cases/test_get_preferences.py
+++ b/tests/modules/preferences/unit/application/use_cases/test_get_preferences.py
@@ -2,12 +2,16 @@
 
 import pytest
 
+from src.modules.preferences.application.dtos.preferences_dtos import GetPreferencesInput
 from src.modules.preferences.application.use_cases.get_preferences import (
     GetPreferencesUseCase,
 )
-from src.modules.preferences.domain.entities import DEFAULT_USER_KEY, PlaybackPreferences
+from src.modules.preferences.domain.entities import PlaybackPreferences
 from src.modules.preferences.domain.value_objects import Quality, Speed, SubtitleMode
+from src.shared_kernel.value_objects.profile_id import ProfileId
 from tests.modules.preferences.unit.application.conftest import make_preferences_uow_mock
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -15,31 +19,31 @@ class TestGetPreferencesUseCase:
     @pytest.mark.asyncio
     async def test_should_return_defaults_when_no_row_exists(self) -> None:
         mocks = make_preferences_uow_mock()
-        mocks.preferences.find_by_user_key.return_value = None
+        mocks.preferences.find_by_profile_id.return_value = None
         use_case = GetPreferencesUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute()
+        result = await use_case.execute(GetPreferencesInput(profile_id=_PROFILE_ID.value))
 
         assert result.audio_lang == "pt-BR"
         assert result.subtitle_lang == "pt-BR"
         assert result.subtitle_mode == "foreignOnly"
         assert result.default_quality == "best"
         assert result.speed == 1.0
-        mocks.preferences.find_by_user_key.assert_awaited_once_with(DEFAULT_USER_KEY)
+        mocks.preferences.find_by_profile_id.assert_awaited_once_with(_PROFILE_ID)
 
     @pytest.mark.asyncio
     async def test_should_project_persisted_entity(self) -> None:
         mocks = make_preferences_uow_mock()
-        mocks.preferences.find_by_user_key.return_value = (
-            PlaybackPreferences.default_for().apply_updates(
-                subtitle_mode="always",
-                default_quality="1080p",
-                speed=1.5,
-            )
+        mocks.preferences.find_by_profile_id.return_value = PlaybackPreferences.default_for(
+            _PROFILE_ID
+        ).apply_updates(
+            subtitle_mode="always",
+            default_quality="1080p",
+            speed=1.5,
         )
         use_case = GetPreferencesUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute()
+        result = await use_case.execute(GetPreferencesInput(profile_id=_PROFILE_ID.value))
 
         assert result.subtitle_mode == SubtitleMode.ALWAYS.value
         assert result.default_quality == Quality.P1080.value

--- a/tests/modules/preferences/unit/application/use_cases/test_update_preferences.py
+++ b/tests/modules/preferences/unit/application/use_cases/test_update_preferences.py
@@ -8,7 +8,10 @@ from src.modules.preferences.application.use_cases.update_preferences import (
     UpdatePreferencesUseCase,
 )
 from src.modules.preferences.domain.entities import PlaybackPreferences
+from src.shared_kernel.value_objects.profile_id import ProfileId
 from tests.modules.preferences.unit.application.conftest import make_preferences_uow_mock
+
+_PROFILE_ID = ProfileId("prf_test12345678")
 
 
 @pytest.mark.unit
@@ -16,11 +19,13 @@ class TestUpdatePreferencesUseCase:
     @pytest.mark.asyncio
     async def test_should_create_defaults_on_first_update(self) -> None:
         mocks = make_preferences_uow_mock()
-        mocks.preferences.find_by_user_key.return_value = None
+        mocks.preferences.find_by_profile_id.return_value = None
         mocks.preferences.save.side_effect = lambda prefs: prefs
         use_case = UpdatePreferencesUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute(UpdatePreferencesInput(speed=1.5))
+        result = await use_case.execute(
+            UpdatePreferencesInput(profile_id=_PROFILE_ID.value, speed=1.5),
+        )
 
         assert result.speed == 1.5
         # Untouched fields keep the domain defaults.
@@ -35,16 +40,18 @@ class TestUpdatePreferencesUseCase:
 
     @pytest.mark.asyncio
     async def test_should_update_existing_entity_without_touching_unset_fields(self) -> None:
-        existing = PlaybackPreferences.default_for().apply_updates(
+        existing = PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(
             audio_lang="en-US",
             subtitle_lang="en-US",
         )
         mocks = make_preferences_uow_mock()
-        mocks.preferences.find_by_user_key.return_value = existing
+        mocks.preferences.find_by_profile_id.return_value = existing
         mocks.preferences.save.side_effect = lambda prefs: prefs
         use_case = UpdatePreferencesUseCase(uow_factory=mocks.factory)
 
-        result = await use_case.execute(UpdatePreferencesInput(subtitle_mode="always"))
+        result = await use_case.execute(
+            UpdatePreferencesInput(profile_id=_PROFILE_ID.value, subtitle_mode="always"),
+        )
 
         assert result.subtitle_mode == "always"
         assert result.audio_lang == "en-US"
@@ -53,32 +60,38 @@ class TestUpdatePreferencesUseCase:
     @pytest.mark.asyncio
     async def test_should_reject_invalid_speed(self) -> None:
         mocks = make_preferences_uow_mock()
-        mocks.preferences.find_by_user_key.return_value = None
+        mocks.preferences.find_by_profile_id.return_value = None
         use_case = UpdatePreferencesUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(DomainValidationException):
-            await use_case.execute(UpdatePreferencesInput(speed=10.0))
+            await use_case.execute(
+                UpdatePreferencesInput(profile_id=_PROFILE_ID.value, speed=10.0),
+            )
 
         mocks.preferences.save.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_should_reject_invalid_quality_value(self) -> None:
         mocks = make_preferences_uow_mock()
-        mocks.preferences.find_by_user_key.return_value = None
+        mocks.preferences.find_by_profile_id.return_value = None
         use_case = UpdatePreferencesUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(DomainValidationException):
-            await use_case.execute(UpdatePreferencesInput(default_quality="ultra"))
+            await use_case.execute(
+                UpdatePreferencesInput(profile_id=_PROFILE_ID.value, default_quality="ultra"),
+            )
 
         mocks.preferences.save.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_should_reject_invalid_subtitle_mode(self) -> None:
         mocks = make_preferences_uow_mock()
-        mocks.preferences.find_by_user_key.return_value = None
+        mocks.preferences.find_by_profile_id.return_value = None
         use_case = UpdatePreferencesUseCase(uow_factory=mocks.factory)
 
         with pytest.raises(DomainValidationException):
-            await use_case.execute(UpdatePreferencesInput(subtitle_mode="invalid"))
+            await use_case.execute(
+                UpdatePreferencesInput(profile_id=_PROFILE_ID.value, subtitle_mode="invalid"),
+            )
 
         mocks.preferences.save.assert_not_awaited()

--- a/tests/modules/preferences/unit/domain/entities/test_playback_preferences.py
+++ b/tests/modules/preferences/unit/domain/entities/test_playback_preferences.py
@@ -3,43 +3,44 @@
 import pytest
 
 from src.building_blocks.domain.errors import DomainValidationException
-from src.modules.preferences.domain.entities import (
-    DEFAULT_USER_KEY,
-    PlaybackPreferences,
-)
+from src.modules.preferences.domain.entities import PlaybackPreferences
 from src.modules.preferences.domain.value_objects import Quality, Speed, SubtitleMode
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
+_OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
 
 
 @pytest.mark.unit
 class TestDefaultFactory:
     def test_default_for_uses_canonical_values(self) -> None:
-        prefs = PlaybackPreferences.default_for()
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
 
-        assert prefs.user_key == DEFAULT_USER_KEY
+        assert prefs.profile_id == _PROFILE_ID
         assert prefs.audio_lang == "pt-BR"
         assert prefs.subtitle_lang == "pt-BR"
         assert prefs.subtitle_mode is SubtitleMode.FOREIGN_ONLY
         assert prefs.default_quality is Quality.BEST
         assert prefs.speed == Speed(1.0)
         assert prefs.id is not None
-        assert prefs.id.value == "prf_default"
+        assert prefs.id.value == _PROFILE_ID.value
 
-    def test_default_for_custom_user_key(self) -> None:
-        prefs = PlaybackPreferences.default_for("alice")
-        assert prefs.user_key == "alice"
+    def test_default_for_mirrors_arbitrary_profile_id(self) -> None:
+        prefs = PlaybackPreferences.default_for(_OTHER_PROFILE_ID)
+        assert prefs.profile_id == _OTHER_PROFILE_ID
         assert prefs.id is not None
-        assert prefs.id.value == "prf_alice"
+        assert prefs.id.value == _OTHER_PROFILE_ID.value
 
 
 @pytest.mark.unit
 class TestApplyUpdates:
     def test_should_return_same_instance_when_no_updates_provided(self) -> None:
-        prefs = PlaybackPreferences.default_for()
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
         result = prefs.apply_updates()
         assert result is prefs
 
     def test_should_update_only_provided_fields(self) -> None:
-        prefs = PlaybackPreferences.default_for()
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
 
         updated = prefs.apply_updates(speed=1.5, subtitle_mode="always")
 
@@ -50,21 +51,21 @@ class TestApplyUpdates:
         assert updated.default_quality is Quality.BEST
 
     def test_should_coerce_quality_from_string(self) -> None:
-        prefs = PlaybackPreferences.default_for()
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
         updated = prefs.apply_updates(default_quality="1080p")
         assert updated.default_quality is Quality.P1080
 
     def test_should_reject_invalid_speed(self) -> None:
-        prefs = PlaybackPreferences.default_for()
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
         with pytest.raises(DomainValidationException):
             prefs.apply_updates(speed=10.0)
 
     def test_should_reject_invalid_subtitle_mode(self) -> None:
-        prefs = PlaybackPreferences.default_for()
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
         with pytest.raises(DomainValidationException):
             prefs.apply_updates(subtitle_mode="invalid")
 
     def test_should_reject_invalid_quality(self) -> None:
-        prefs = PlaybackPreferences.default_for()
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
         with pytest.raises(DomainValidationException):
             prefs.apply_updates(default_quality="ultra")

--- a/tests/modules/preferences/unit/domain/value_objects/test_preferences_id.py
+++ b/tests/modules/preferences/unit/domain/value_objects/test_preferences_id.py
@@ -4,21 +4,28 @@ import pytest
 
 from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.preferences.domain.value_objects import PreferencesId
+from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
 @pytest.mark.unit
 class TestPreferencesId:
-    def test_should_accept_canonical_default_id(self) -> None:
+    def test_should_accept_legacy_default_id(self) -> None:
+        # The regex still allows the historical ``prf_default`` shape so
+        # rows persisted before the per-profile migration stay readable.
         assert PreferencesId("prf_default").value == "prf_default"
 
-    def test_for_user_key_builds_prefixed_id(self) -> None:
-        assert PreferencesId.for_user_key("alice").value == "prf_alice"
+    def test_should_accept_profile_mirroring_id(self) -> None:
+        assert PreferencesId("prf_test12345678").value == "prf_test12345678"
+
+    def test_for_profile_mirrors_profile_id_value(self) -> None:
+        profile_id = ProfileId("prf_test12345678")
+        assert PreferencesId.for_profile(profile_id).value == profile_id.value
 
     def test_should_reject_missing_prefix(self) -> None:
         with pytest.raises(DomainValidationException):
             PreferencesId("default")
 
-    def test_should_reject_empty_user_key(self) -> None:
+    def test_should_reject_empty_slug(self) -> None:
         with pytest.raises(DomainValidationException):
             PreferencesId("prf_")
 


### PR DESCRIPTION
## Summary

- Replaces the legacy ``user_key='default'`` placeholder on ``PlaybackPreferences`` with a real ``profile_id: ProfileId`` foreign reference, completing the per-profile rollout for the third personalisation BC after watch_progress (PR #172) and collections (PR #173).
- ``PreferencesId.for_profile(profile_id)`` mirrors the owning profile id, so the row's surrogate identity stays in lockstep with the natural key — no separate id allocation, no drift between ``external_id`` and ``profile_id`` over time.
- Migration ``f8a9b0c1d2e3`` follows the standard 3-step pattern: nullable add, SQL backfill from the oldest active profile, then drop the legacy ``user_key`` column and tighten ``profile_id`` to ``NOT NULL UNIQUE``. Defensive ``DROP INDEX IF EXISTS`` and Postgres-specific constraint cleanup keep it idempotent.
- Routes resolve the caller's profile via a new ``resolve_profile_id`` dep gated on ``preferences_default_profile_id``; unset = strict mode (401). Same pattern as the other two BCs (Sourcery flagged the duplication on PR #173 — extraction is queued as a follow-up rather than mixed into this PR).

## Migration ordering

Branched from current ``develop`` head (``d6e7f8a9b0c1`` — watch_progress profile_id). If the collections PR (#173, ``e7f8a9b0c1d2``) lands first, this migration's ``down_revision`` will need a one-line rebase to chain it after collections — straightforward.

## Test plan

- [x] ``poetry run pytest tests/modules/preferences -q`` → 45 passed.
- [x] ``poetry run pytest -q`` → 2148 passed, 5 skipped — no regressions in other BCs.
- [x] ``poetry run ruff check`` and ``ruff format --check`` clean across the diff.
- [x] Migration smoke against fresh SQLite: ``alembic upgrade head`` lands ``profile_id VARCHAR(50) NOT NULL UNIQUE``, ``user_key`` removed.
- [x] Backfill smoke: downgrade one revision, seed a profile + a legacy ``preferences`` row with ``user_key='default'``, upgrade — the row picks up the seeded profile's ``external_id`` and the column is dropped.
- [x] Cross-profile isolation: an integration test creates rows for two profiles and asserts ``find_by_profile_id`` never leaks across them.
- [ ] Manual end-to-end with the existing frontend (will exercise post-merge with the env var set).

## Summary by Sourcery

Scope playback preferences to individual profiles instead of a global default and wire profile-scoped access through the API, domain, persistence, and a new database migration.

New Features:
- Introduce per-profile playback preferences keyed by ProfileId, including a FastAPI dependency to resolve the caller's profile and env-configurable default profile during rollout.
- Add GetPreferencesInput and require profile_id in both get and update preferences use cases and routes.

Enhancements:
- Align PreferencesId with ProfileId so preferences external IDs mirror owning profiles instead of user_key-based slugs.
- Refine preferences repository, mapper, and model to use profile_id as the singleton key and enforce a unique index at the DB level.
- Update tests across application, domain, persistence, and value objects to reflect profile-scoped preferences and verify cross-profile isolation.

Build:
- Add alembic migration to replace preferences.user_key with profile_id, backfill legacy rows from the oldest active profile, and enforce NOT NULL UNIQUE constraints on profile_id.