### PR TITLE
feat(media): add library_id to Movie/Series for catalog scoping (PR 6a)

### DIFF
--- a/migrations/versions/2026_05_04_add_library_id_to_movies_and_series.py
+++ b/migrations/versions/2026_05_04_add_library_id_to_movies_and_series.py
@@ -1,0 +1,255 @@
+"""Add library_id to movies and series, backfilled by file-path matching.
+
+Per ADR-010 + the per-profile rollout, the catalog needs to be
+filterable per-profile via ``Profile.allowed_library_ids``. That
+filter has nowhere to land today because Movie/Series have no
+foreign reference to their owning Library — the relationship is
+implicit (the scanner happens to write paths under directories that
+match a library's configured paths).
+
+This migration materialises the relationship as a plain string column
+on both ``movies`` and ``series`` (no FK because the catalog and
+library tables live in different bounded contexts and ADR-008
+forbids cross-BC FKs).
+
+Sequence (so existing dev data survives):
+
+1. ADD COLUMN library_id NULLABLE on both tables.
+2. Backfill per-row by matching each movie's ``file_path`` (or each
+   series' first episode's file_path) against every library's
+   ``paths`` JSON array. First library whose path is a prefix of
+   the file path wins. Orphans (rows whose file_path matches no
+   library) abort the migration with a clear message — manual
+   intervention beats persisting NULLs that would later violate the
+   NOT NULL alteration.
+3. ALTER COLUMN library_id NOT NULL.
+
+Revision ID: b09c1d2e3f4a
+Revises: e7f8a9b0c1d2
+Create Date: 2026-05-04 09:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "b09c1d2e3f4a"
+down_revision: str | Sequence[str] | None = "e7f8a9b0c1d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _load_libraries(connection: sa.Connection) -> list[tuple[str, list[str]]]:
+    """Return ``[(library_external_id, [path1, path2, ...]), ...]``.
+
+    Excludes soft-deleted libraries — backfilling against a deleted
+    library would silently re-attach catalog rows to data the
+    operator chose to retire.
+    """
+    rows = connection.execute(
+        sa.text(
+            "SELECT external_id, paths FROM libraries "
+            "WHERE deleted_at IS NULL "
+            "ORDER BY created_at ASC"
+        )
+    ).fetchall()
+    libraries: list[tuple[str, list[str]]] = []
+    for external_id, paths_json in rows:
+        try:
+            paths = json.loads(paths_json) if paths_json else []
+        except (TypeError, ValueError) as exc:
+            msg = f"Library {external_id} has malformed paths JSON: {paths_json!r}"
+            raise RuntimeError(msg) from exc
+        libraries.append((external_id, list(paths)))
+    return libraries
+
+
+def _match_library(
+    file_path: str | None,
+    libraries: list[tuple[str, list[str]]],
+) -> str | None:
+    """Return the first library whose path is a prefix of ``file_path``.
+
+    Path matching uses naive prefix comparison after normalising
+    trailing slashes — the catalog runs on whatever filesystem the
+    operator scans, and SQLite stores raw strings, so we don't try
+    to be platform-clever here. ``None`` for ``file_path`` always
+    returns ``None`` (no anchor to match against).
+    """
+    if file_path is None:
+        return None
+    for library_id, paths in libraries:
+        for raw_path in paths:
+            anchor = raw_path.rstrip("/").rstrip("\\")
+            if (
+                file_path == anchor
+                or file_path.startswith(anchor + "/")
+                or file_path.startswith(anchor + "\\")
+            ):
+                return library_id
+    return None
+
+
+def _series_anchor_path(connection: sa.Connection, series_id: int) -> str | None:
+    """Return any episode file_path under ``series_id``, or ``None``.
+
+    The earliest-recorded episode is the most stable choice — newer
+    episodes can be added after the series gets its library_id, so
+    using the first-seen one keeps backfills deterministic across
+    re-runs.
+    """
+    row = connection.execute(
+        sa.text(
+            "SELECT e.file_path "
+            "FROM episodes e "
+            "JOIN seasons sn ON sn.id = e.season_id "
+            "WHERE sn.series_id = :series_id "
+            "  AND e.file_path IS NOT NULL "
+            "  AND e.deleted_at IS NULL "
+            "ORDER BY e.created_at ASC "
+            "LIMIT 1"
+        ),
+        {"series_id": series_id},
+    ).first()
+    return row[0] if row else None
+
+
+def _backfill_movies(
+    connection: sa.Connection,
+    libraries: list[tuple[str, list[str]]],
+) -> None:
+    rows = connection.execute(
+        sa.text(
+            "SELECT id, external_id, file_path "
+            "FROM movies "
+            "WHERE library_id IS NULL "
+            "  AND deleted_at IS NULL"
+        )
+    ).fetchall()
+    orphans: list[str] = []
+    for movie_id, external_id, file_path in rows:
+        match = _match_library(file_path, libraries)
+        if match is None:
+            orphans.append(f"{external_id} (file_path={file_path!r})")
+            continue
+        connection.execute(
+            sa.text("UPDATE movies SET library_id = :lid WHERE id = :mid"),
+            {"lid": match, "mid": movie_id},
+        )
+    if orphans:
+        msg = (
+            "Cannot backfill movies.library_id: the following movies are "
+            "not under any active library's configured paths. Either "
+            "register a library that owns them or soft-delete the rows "
+            "before re-running the migration:\n  - " + "\n  - ".join(orphans)
+        )
+        raise RuntimeError(msg)
+
+
+def _backfill_series(
+    connection: sa.Connection,
+    libraries: list[tuple[str, list[str]]],
+) -> None:
+    rows = connection.execute(
+        sa.text(
+            "SELECT id, external_id "
+            "FROM series "
+            "WHERE library_id IS NULL "
+            "  AND deleted_at IS NULL"
+        )
+    ).fetchall()
+    orphans: list[str] = []
+    for series_id, external_id in rows:
+        anchor = _series_anchor_path(connection, series_id)
+        match = _match_library(anchor, libraries)
+        if match is None:
+            orphans.append(
+                f"{external_id} (anchor_episode_path={anchor!r})"
+                if anchor
+                else f"{external_id} (no episodes with file_path yet)"
+            )
+            continue
+        connection.execute(
+            sa.text("UPDATE series SET library_id = :lid WHERE id = :sid"),
+            {"lid": match, "sid": series_id},
+        )
+    if orphans:
+        msg = (
+            "Cannot backfill series.library_id: the following series have "
+            "no episodes whose file_path is under any active library. "
+            "Either register a library that owns them, scan to populate "
+            "episode paths, or soft-delete the rows before re-running "
+            "the migration:\n  - " + "\n  - ".join(orphans)
+        )
+        raise RuntimeError(msg)
+
+
+def upgrade() -> None:
+    """Add library_id, backfill, then tighten to NOT NULL."""
+    bind = op.get_bind()
+
+    # Step 1: ADD COLUMN NULLABLE so existing rows survive the schema change.
+    with op.batch_alter_table("movies") as batch_op:
+        batch_op.add_column(
+            sa.Column("library_id", sa.String(length=50), nullable=True),
+        )
+    with op.batch_alter_table("series") as batch_op:
+        batch_op.add_column(
+            sa.Column("library_id", sa.String(length=50), nullable=True),
+        )
+
+    # Step 2: backfill via path matching against the libraries table.
+    libraries = _load_libraries(bind)
+    movies_count = bind.execute(
+        sa.text("SELECT COUNT(*) FROM movies WHERE library_id IS NULL AND deleted_at IS NULL")
+    ).scalar_one()
+    series_count = bind.execute(
+        sa.text("SELECT COUNT(*) FROM series WHERE library_id IS NULL AND deleted_at IS NULL")
+    ).scalar_one()
+    if (movies_count or series_count) and not libraries:
+        msg = (
+            f"Cannot backfill library_id: {movies_count} movies and "
+            f"{series_count} series exist but no active library is "
+            "registered. Create a library that covers their paths "
+            "before re-running this migration."
+        )
+        raise RuntimeError(msg)
+    if movies_count:
+        _backfill_movies(bind, libraries)
+    if series_count:
+        _backfill_series(bind, libraries)
+
+    # Step 3: tighten the columns now that every active row has a value
+    # and create the supporting index for upcoming per-profile filters.
+    with op.batch_alter_table("movies") as batch_op:
+        batch_op.alter_column(
+            "library_id",
+            existing_type=sa.String(length=50),
+            nullable=False,
+        )
+        batch_op.create_index("ix_movies_library_id", ["library_id"], unique=False)
+    with op.batch_alter_table("series") as batch_op:
+        batch_op.alter_column(
+            "library_id",
+            existing_type=sa.String(length=50),
+            nullable=False,
+        )
+        batch_op.create_index("ix_series_library_id", ["library_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Drop library_id from movies and series. Loses scoping data — dev only."""
+    with op.batch_alter_table("series") as batch_op:
+        batch_op.drop_index("ix_series_library_id")
+        batch_op.drop_column("library_id")
+    with op.batch_alter_table("movies") as batch_op:
+        batch_op.drop_index("ix_movies_library_id")
+        batch_op.drop_column("library_id")

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -215,7 +215,9 @@ class LibraryScanScheduler:
             event_bus=self._event_bus,
         )
         try:
-            result = await use_case.execute(ScanMediaInput(directories=paths))
+            result = await use_case.execute(
+                ScanMediaInput(library_id=library_id, directories=paths)
+            )
         except Exception as exc:
             _logger.error(
                 "[scheduler] Scan failed",

--- a/src/modules/media/application/dtos/scan_dtos.py
+++ b/src/modules/media/application/dtos/scan_dtos.py
@@ -10,9 +10,14 @@ class ScanMediaInput:
     """Input for media directory scanning.
 
     Attributes:
-        directories: Directories to scan. If empty, uses settings defaults.
+        library_id: External id (``lib_xxx``) of the owning library.
+            Every Movie/Series the scan creates inherits this value
+            so the catalog can be filtered per-profile downstream.
+        directories: Directories to scan within the library. Empty
+            means the caller already validated there's nothing to do.
     """
 
+    library_id: str
     directories: list[FilePath] = field(default_factory=list)
 
 

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -82,9 +82,12 @@ class ScanMediaDirectoriesUseCase:
         movies = [f for f in scanned_files if f.media_type == MediaType.MOVIE]
         episodes = [f for f in scanned_files if f.media_type == MediaType.EPISODE]
 
-        movies_created, movies_updated, movie_errors = await self._process_movies(movies)
+        movies_created, movies_updated, movie_errors = await self._process_movies(
+            movies, library_id=input_dto.library_id
+        )
         episodes_created, episodes_updated, episode_errors = await self._process_episodes(
             episodes,
+            library_id=input_dto.library_id,
         )
 
         return ScanMediaOutput(
@@ -183,6 +186,8 @@ class ScanMediaDirectoriesUseCase:
     async def _process_movies(
         self,
         files: list[ScannedFile],
+        *,
+        library_id: str,
     ) -> tuple[int, int, list[str]]:
         """Process scanned movie files."""
         created = 0
@@ -195,7 +200,7 @@ class ScanMediaDirectoriesUseCase:
 
         for _base_name, paths in groups.items():
             try:
-                c, u = await self._process_movie_group(paths, by_path)
+                c, u = await self._process_movie_group(paths, by_path, library_id=library_id)
                 created += c
                 updated += u
             except Exception as e:
@@ -207,6 +212,8 @@ class ScanMediaDirectoriesUseCase:
         self,
         paths: list[str],
         by_path: dict[str, ScannedFile],
+        *,
+        library_id: str,
     ) -> tuple[int, int]:
         """Process a single group of movie file variants in its own UoW."""
         async with self._uow_factory() as uow:
@@ -214,7 +221,9 @@ class ScanMediaDirectoriesUseCase:
             if existing:
                 created, updated, events = await self._update_movie(uow, existing, paths, by_path)
             else:
-                created, updated, events = await self._create_movie(uow, paths, by_path)
+                created, updated, events = await self._create_movie(
+                    uow, paths, by_path, library_id=library_id
+                )
         await self._dispatch_events(events)
         return created, updated
 
@@ -270,6 +279,8 @@ class ScanMediaDirectoriesUseCase:
         uow: MediaUnitOfWork,
         paths: list[str],
         by_path: dict[str, ScannedFile],
+        *,
+        library_id: str,
     ) -> tuple[int, int, list[DomainEvent]]:
         """Create a new movie from a group of file variants."""
         first = by_path[paths[0]]
@@ -277,6 +288,7 @@ class ScanMediaDirectoriesUseCase:
         movie_id = MovieId.generate()
         movie = Movie(
             id=movie_id,
+            library_id=library_id,
             title=Title(first.title),
             year=Year(first.year or _current_year()),
             duration=Duration(0),
@@ -298,6 +310,8 @@ class ScanMediaDirectoriesUseCase:
     async def _process_episodes(
         self,
         files: list[ScannedFile],
+        *,
+        library_id: str,
     ) -> tuple[int, int, list[str]]:
         """Process scanned episode files."""
         created = 0
@@ -311,7 +325,7 @@ class ScanMediaDirectoriesUseCase:
 
         for series_name, series_files in by_series.items():
             try:
-                c, u = await self._process_series(series_name, series_files)
+                c, u = await self._process_series(series_name, series_files, library_id=library_id)
                 created += c
                 updated += u
             except Exception as e:
@@ -323,6 +337,8 @@ class ScanMediaDirectoriesUseCase:
         self,
         series_name: str,
         files: list[ScannedFile],
+        *,
+        library_id: str,
     ) -> tuple[int, int]:
         """Process all episodes of a single series in its own UoW."""
         created = 0
@@ -332,7 +348,7 @@ class ScanMediaDirectoriesUseCase:
             series = await uow.series.find_by_title(Title(series_name))
             if not series:
                 year = min((f.year for f in files if f.year), default=_current_year())
-                series = Series.create(title=series_name, start_year=year)
+                series = Series.create(title=series_name, start_year=year, library_id=library_id)
 
             ep_groups: dict[tuple[int, int], list[ScannedFile]] = defaultdict(list)
             for f in files:

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -47,6 +47,11 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
     # Identity
     id: MovieId | None = Field(default=None)
 
+    # Library scoping (the lib_xxx external id of the owning Library;
+    # held as ``str`` because Library lives in another bounded context
+    # and ADR-008 forbids the cross-BC import).
+    library_id: str
+
     # Core info
     title: Title
     original_title: Title | None = None
@@ -171,6 +176,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
         file_path: str | FilePath,
         file_size: int,
         resolution: str | Resolution,
+        library_id: str,
         **kwargs: Any,
     ) -> Movie:
         """Factory method with automatic ID generation.
@@ -182,6 +188,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
             file_path: Path to the video file.
             file_size: File size in bytes.
             resolution: Video resolution.
+            library_id: External id (``lib_xxx``) of the owning Library.
             **kwargs: Additional optional fields.
 
         Returns:
@@ -209,6 +216,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
 
         movie = cls(
             id=movie_id,
+            library_id=library_id,
             title=title,
             year=year,
             duration=duration,

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -43,6 +43,13 @@ class Series(AggregateRoot[SeriesId]):
     # Identity
     id: SeriesId | None = Field(default=None)
 
+    # Library scoping (the lib_xxx external id of the owning Library;
+    # held as ``str`` because Library lives in another bounded context
+    # and ADR-008 forbids the cross-BC import). Episodes inherit
+    # scoping through their parent Series — they do not carry their
+    # own ``library_id``.
+    library_id: str
+
     # Core info
     title: Title
     original_title: Title | None = None
@@ -199,6 +206,7 @@ class Series(AggregateRoot[SeriesId]):
         cls,
         title: str | Title,
         start_year: int | Year,
+        library_id: str,
         **kwargs: Any,
     ) -> Series:
         """Factory method with automatic ID generation.
@@ -206,6 +214,7 @@ class Series(AggregateRoot[SeriesId]):
         Args:
             title: Series title.
             start_year: First season year.
+            library_id: External id (``lib_xxx``) of the owning Library.
             **kwargs: Additional optional fields.
 
         Returns:
@@ -220,6 +229,7 @@ class Series(AggregateRoot[SeriesId]):
 
         series = cls(
             id=series_id,
+            library_id=library_id,
             title=title,
             start_year=start_year,
             **kwargs,

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -61,6 +61,7 @@ class MovieMapper:
         primary = entity.primary_file
         model = MovieModel(
             external_id=str(entity.id),
+            library_id=entity.library_id,
             title=entity.title.value,
             original_title=entity.original_title.value if entity.original_title else None,
             year=entity.year.value,
@@ -153,6 +154,7 @@ class MovieMapper:
 
         return Movie(
             id=MovieId(model.external_id),
+            library_id=model.library_id,
             title=Title(model.title),
             original_title=Title(model.original_title) if model.original_title else None,
             year=Year(model.year),
@@ -195,6 +197,9 @@ class MovieMapper:
             The updated MovieModel.
         """
         primary = entity.primary_file
+        # ``library_id`` is the immutable owning-library reference; the
+        # scanner picks it once at creation time and never changes it,
+        # so update_model deliberately leaves it alone.
         model.title = entity.title.value
         model.original_title = entity.original_title.value if entity.original_title else None
         model.year = entity.year.value

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -283,6 +283,7 @@ class SeriesMapper:
 
         return SeriesModel(
             external_id=str(entity.id),
+            library_id=entity.library_id,
             title=entity.title.value,
             original_title=entity.original_title.value if entity.original_title else None,
             start_year=entity.start_year.value,
@@ -323,6 +324,7 @@ class SeriesMapper:
 
         return Series(
             id=SeriesId(model.external_id),
+            library_id=model.library_id,
             title=Title(model.title),
             original_title=Title(model.original_title) if model.original_title else None,
             start_year=Year(model.start_year),
@@ -354,6 +356,9 @@ class SeriesMapper:
         Returns:
             The updated SeriesModel.
         """
+        # ``library_id`` is the immutable owning-library reference; it
+        # gets set once at creation time and never changes, so the
+        # update path leaves it alone.
         model.title = entity.title.value
         model.original_title = entity.original_title.value if entity.original_title else None
         model.start_year = entity.start_year.value

--- a/src/modules/media/infrastructure/persistence/models/movie.py
+++ b/src/modules/media/infrastructure/persistence/models/movie.py
@@ -32,6 +32,11 @@ class MovieModel(Base):
         imdb_id: IMDb ID (e.g., "tt1234567").
     """
 
+    # Library scoping (lib_xxx prefixed external id; cross-BC string
+    # reference, no FK because the catalog and library tables live in
+    # different bounded contexts).
+    library_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+
     # Core info
     title: Mapped[str] = mapped_column(String(500), nullable=False, index=True)
     original_title: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/src/modules/media/infrastructure/persistence/models/series.py
+++ b/src/modules/media/infrastructure/persistence/models/series.py
@@ -31,6 +31,11 @@ class SeriesModel(Base):
         seasons: Related season records.
     """
 
+    # Library scoping (lib_xxx prefixed external id; cross-BC string
+    # reference, no FK because the catalog and library tables live in
+    # different bounded contexts).
+    library_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+
     # Core info
     title: Mapped[str] = mapped_column(String(500), nullable=False, index=True)
     original_title: Mapped[str | None] = mapped_column(String(500), nullable=True)

--- a/src/modules/media/presentation/routes/scan_routes.py
+++ b/src/modules/media/presentation/routes/scan_routes.py
@@ -4,17 +4,17 @@ from dataclasses import asdict
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.config.settings import get_settings
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
+from src.modules.library.domain.value_objects.library_id import LibraryId
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
 from src.modules.media.presentation.schemas import ScanMediaRequest
-from src.shared_kernel.value_objects.file_path import FilePath
 
 router = APIRouter(prefix="/api/v1/scan", tags=["Scan"])
 
@@ -22,19 +22,32 @@ router = APIRouter(prefix="/api/v1/scan", tags=["Scan"])
 @router.post("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def scan_media(
-    body: ScanMediaRequest | None = None,
+    body: ScanMediaRequest,
     use_case: ScanMediaDirectoriesUseCase = Depends(
         Provide[ApplicationContainer.media.scan_media_directories],
     ),
+    library_uow_factory: LibraryUnitOfWorkFactory = Depends(
+        Provide[ApplicationContainer.library.library_unit_of_work_factory],
+    ),
 ) -> dict[str, Any]:
-    """Trigger a media directory scan.
+    """Trigger a scan of the named library's configured paths.
 
-    Scans configured directories (or overrides from request body)
-    for movie and episode files, registering them in the database.
+    The route loads the library to get its paths so the operator
+    only has to know the ``lib_xxx`` id — paths and the per-Movie /
+    per-Series ``library_id`` propagate from a single source of truth.
     """
-    raw_dirs = body.directories if body and body.directories else get_settings().media_directories
-    directories = [FilePath(d) for d in raw_dirs]
-    input_dto = ScanMediaInput(directories=directories)
+    async with library_uow_factory() as uow:
+        library = await uow.libraries.find_by_id(LibraryId(body.library_id))
+    if library is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Library {body.library_id} not found",
+        )
+
+    input_dto = ScanMediaInput(
+        library_id=str(library.id),
+        directories=list(library.paths),
+    )
     output = await use_case.execute(input_dto)
     return api_single("scan", asdict(output))
 

--- a/src/modules/media/presentation/schemas/scan_schemas.py
+++ b/src/modules/media/presentation/schemas/scan_schemas.py
@@ -4,11 +4,18 @@ from pydantic import BaseModel, Field
 
 
 class ScanMediaRequest(BaseModel):
-    """Request body for triggering a media scan."""
+    """Request body for triggering a media scan.
 
-    directories: list[str] = Field(
-        default_factory=list,
-        description="Directories to scan. If empty, uses configured media_directories.",
+    Every scan now belongs to a specific library — the catalog
+    persists the owning ``library_id`` per Movie / Series so reads
+    can be filtered per-profile downstream. Manual scans must
+    therefore name a library; the route loads its configured paths
+    and forwards them to the scan use case.
+    """
+
+    library_id: str = Field(
+        ...,
+        description="External id (lib_xxx) of the library to scan.",
     )
 
 

--- a/tests/infrastructure/scheduling/test_thumbnail_backfill_job.py
+++ b/tests/infrastructure/scheduling/test_thumbnail_backfill_job.py
@@ -31,9 +31,12 @@ from src.modules.media.infrastructure.streaming.thumbnail_service import Thumbna
 if TYPE_CHECKING:
     from pathlib import Path
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_movie(file_path: str = "/media/movies/inception/inception.mkv") -> Movie:
     return Movie.create(
+        library_id=_LIBRARY_ID,
         title="Inception",
         year=2010,
         duration=8880,

--- a/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
+++ b/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
@@ -25,9 +25,12 @@ from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import
 )
 from src.shared_kernel.value_objects import CollectionMediaType
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _movie(movie_id: MovieId, title: str, poster: str | None = None) -> Movie:
     return Movie(
+        library_id=_LIBRARY_ID,
         id=movie_id,
         title=Title(title),
         year=Year(2024),
@@ -46,6 +49,7 @@ def _movie(movie_id: MovieId, title: str, poster: str | None = None) -> Movie:
 
 def _series(series_id: SeriesId, title: str, poster: str | None = None) -> Series:
     return Series(
+        library_id=_LIBRARY_ID,
         id=series_id,
         title=Title(title),
         start_year=Year(2024),

--- a/tests/modules/library/integration/acl/test_media_count_query_adapter.py
+++ b/tests/modules/library/integration/acl/test_media_count_query_adapter.py
@@ -24,9 +24,12 @@ from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import
     SqlAlchemyMediaUnitOfWorkFactory,
 )
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _movie(title: str, file_path: str) -> Movie:
     return Movie(
+        library_id=_LIBRARY_ID,
         id=MovieId.generate(),
         title=Title(title),
         year=Year(2024),
@@ -43,7 +46,7 @@ def _movie(title: str, file_path: str) -> Movie:
 
 
 def _series_with_episode(title: str, file_path: str) -> Series:
-    series = Series.create(title=title, start_year=2024)
+    series = Series.create(library_id=_LIBRARY_ID, title=title, start_year=2024)
     assert series.id is not None
     season = Season(id=SeasonId.generate(), series_id=series.id, season_number=1)
     episode = Episode(

--- a/tests/modules/media/integration/application/use_cases/test_intro_use_cases.py
+++ b/tests/modules/media/integration/application/use_cases/test_intro_use_cases.py
@@ -45,6 +45,8 @@ from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import
     SqlAlchemyMediaUnitOfWorkFactory,
 )
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_series_with_episode(*, duration_seconds: int = 2700) -> Series:
     sid = SeriesId.generate()
@@ -72,6 +74,7 @@ def _make_series_with_episode(*, duration_seconds: int = 2700) -> Series:
         episodes=[episode],
     )
     return Series(
+        library_id=_LIBRARY_ID,
         id=sid,
         title=Title("Test Series"),
         start_year=Year(2020),

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -1,6 +1,7 @@
 """Integration tests for SQLAlchemyMovieRepository."""
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.media.domain.entities import Movie
@@ -18,7 +19,11 @@ from src.modules.media.domain.value_objects import (
     Year,
 )
 from src.modules.media.domain.value_objects.cast_member import CastMember
+from src.modules.media.infrastructure.persistence.models import MovieModel
 from src.modules.media.infrastructure.persistence.repositories import SQLAlchemyMovieRepository
+
+_LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
 
 
 def _create_movie(
@@ -33,6 +38,7 @@ def _create_movie(
 ) -> Movie:
     """Create a Movie entity for testing."""
     return Movie(
+        library_id=_LIBRARY_ID,
         id=movie_id or MovieId.generate(),
         title=Title(title),
         year=Year(year),
@@ -88,6 +94,7 @@ class TestSQLAlchemyMovieRepository:
 
         # Update the movie
         updated_movie = Movie(
+            library_id=_LIBRARY_ID,
             id=movie.id,
             title=Title("Updated Title"),
             year=movie.year,
@@ -1016,3 +1023,81 @@ class TestCountUnderPaths:
         await repo.save(_create_movie(title="B", file_path="/other/b.mkv"))
 
         assert await repo.count_under_paths(["/"]) == 2
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryLibraryIsolation:
+    """Cross-library isolation at the persistence layer.
+
+    The repository doesn't filter by ``library_id`` itself yet — that's
+    a higher-layer responsibility wired in PR 6b — but the column has
+    to persist accurately so a manual filter never leaks rows across
+    libraries. Mirrors the cross-key isolation tests in
+    ``tests/modules/watch_progress/integration/persistence/repositories/``.
+    """
+
+    async def test_two_libraries_can_coexist_and_be_filtered_by_column(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+
+        # Library A: two movies
+        await repo.save(_create_movie(title="A1", file_path="/libA/m1.mkv"))
+        await repo.save(_create_movie(title="A2", file_path="/libA/m2.mkv"))
+
+        # Library B (different library_id): one movie
+        movie_b = Movie(
+            library_id=_LIBRARY_ID_OTHER,
+            id=MovieId.generate(),
+            title=Title("B1"),
+            year=Year(2024),
+            duration=Duration(7200),
+            files=[
+                MediaFile(
+                    file_path=FilePath("/libB/m1.mkv"),
+                    file_size=1_000_000_000,
+                    resolution=Resolution("1080p"),
+                    is_primary=True,
+                )
+            ],
+        )
+        await repo.save(movie_b)
+
+        # Direct queries by library_id never leak across.
+        rows_a = (
+            (
+                await db_session.execute(
+                    select(MovieModel).where(MovieModel.library_id == _LIBRARY_ID)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        rows_b = (
+            (
+                await db_session.execute(
+                    select(MovieModel).where(MovieModel.library_id == _LIBRARY_ID_OTHER)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        assert {r.title for r in rows_a} == {"A1", "A2"}
+        assert {r.title for r in rows_b} == {"B1"}
+        assert all(r.library_id == _LIBRARY_ID for r in rows_a)
+        assert all(r.library_id == _LIBRARY_ID_OTHER for r in rows_b)
+
+    async def test_library_id_persists_through_save_and_reload(
+        self, db_session: AsyncSession
+    ) -> None:
+        """``library_id`` round-trips through save + find_by_id."""
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _create_movie(title="Scoped", file_path="/libA/scoped.mkv")
+
+        await repo.save(movie)
+        assert movie.id is not None
+        found = await repo.find_by_id(movie.id)
+
+        assert found is not None
+        assert found.library_id == _LIBRARY_ID

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.media.domain.entities import Episode, Season, Series
@@ -25,7 +26,11 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.modules.media.infrastructure.persistence.models import SeriesModel
 from src.modules.media.infrastructure.persistence.repositories import SQLAlchemySeriesRepository
+
+_LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
 
 
 def _create_episode(
@@ -84,6 +89,7 @@ def _create_series(
     sid = series_id or SeriesId.generate()
     seasons = [_create_season(sid, i + 1, episodes_per_season) for i in range(season_count)]
     return Series(
+        library_id=_LIBRARY_ID,
         id=sid,
         title=Title(title),
         start_year=Year(start_year),
@@ -167,6 +173,7 @@ class TestSQLAlchemySeriesRepository:
         await repo.save(series)
 
         updated = Series(
+            library_id=_LIBRARY_ID,
             id=series.id,
             title=Title("Updated Title"),
             start_year=series.start_year,
@@ -285,6 +292,7 @@ class TestSQLAlchemySeriesRepository:
             episodes=[episode],
         )
         series = Series(
+            library_id=_LIBRARY_ID,
             id=series_id,
             title=Title("My Show"),
             start_year=Year(2020),
@@ -348,6 +356,7 @@ class TestSQLAlchemySeriesRepository:
         # Add a second season
         new_season = _create_season(series.id, season_number=2, episode_count=2)  # type: ignore[arg-type]
         updated_series = Series(
+            library_id=_LIBRARY_ID,
             id=series.id,
             title=series.title,
             start_year=series.start_year,
@@ -366,6 +375,7 @@ class TestSQLAlchemySeriesRepository:
 
         # Remove the second season
         updated_series = Series(
+            library_id=_LIBRARY_ID,
             id=series.id,
             title=series.title,
             start_year=series.start_year,
@@ -423,6 +433,7 @@ class TestSQLAlchemySeriesRepository:
             episodes=[*saved.seasons[0].episodes, new_episode],
         )
         updated_series = Series(
+            library_id=_LIBRARY_ID,
             id=saved.id,
             title=saved.title,
             start_year=saved.start_year,
@@ -455,6 +466,7 @@ class TestSQLAlchemySeriesRepository:
             episodes=[saved.seasons[0].episodes[0]],
         )
         updated_series = Series(
+            library_id=_LIBRARY_ID,
             id=saved.id,
             title=saved.title,
             start_year=saved.start_year,
@@ -497,6 +509,7 @@ class TestSQLAlchemySeriesRepository:
             episodes=[updated_episode],
         )
         updated_series = Series(
+            library_id=_LIBRARY_ID,
             id=saved.id,
             title=saved.title,
             start_year=saved.start_year,
@@ -1049,6 +1062,7 @@ def _series_with_episode_paths(
         episodes=episodes,
     )
     return Series(
+        library_id=_LIBRARY_ID,
         id=sid,
         title=Title(title),
         start_year=Year(start_year),
@@ -1147,6 +1161,7 @@ def _series_with_intro(
         intro_detection_error=detection_error,
     )
     return Series(
+        library_id=_LIBRARY_ID,
         id=sid,
         title=Title(series_title),
         start_year=Year(2020),
@@ -1470,3 +1485,72 @@ class TestUpdateEpisodeIntro:
         updated = await repo.update_episode_intro(EpisodeId.generate(), None)
 
         assert updated is False
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryLibraryIsolation:
+    """Cross-library isolation at the persistence layer.
+
+    The repository doesn't filter by ``library_id`` itself yet — that's
+    a higher-layer responsibility wired in PR 6b — but the column has
+    to persist accurately so a manual filter never leaks rows across
+    libraries. Mirrors the cross-key isolation tests in
+    ``tests/modules/watch_progress/integration/persistence/repositories/``.
+    """
+
+    async def test_two_libraries_can_coexist_and_be_filtered_by_column(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+
+        # Library A: two series
+        await repo.save(_create_series(title="A1"))
+        await repo.save(_create_series(title="A2"))
+
+        # Library B (different library_id): one series
+        series_b = Series(
+            library_id=_LIBRARY_ID_OTHER,
+            id=SeriesId.generate(),
+            title=Title("B1"),
+            start_year=Year(2024),
+        )
+        await repo.save(series_b)
+
+        # Direct queries by library_id never leak across.
+        rows_a = (
+            (
+                await db_session.execute(
+                    select(SeriesModel).where(SeriesModel.library_id == _LIBRARY_ID)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        rows_b = (
+            (
+                await db_session.execute(
+                    select(SeriesModel).where(SeriesModel.library_id == _LIBRARY_ID_OTHER)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        assert {r.title for r in rows_a} == {"A1", "A2"}
+        assert {r.title for r in rows_b} == {"B1"}
+        assert all(r.library_id == _LIBRARY_ID for r in rows_a)
+        assert all(r.library_id == _LIBRARY_ID_OTHER for r in rows_b)
+
+    async def test_library_id_persists_through_save_and_reload(
+        self, db_session: AsyncSession
+    ) -> None:
+        """``library_id`` round-trips through save + find_by_id."""
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _create_series(title="Scoped")
+
+        await repo.save(series)
+        assert series.id is not None
+        found = await repo.find_by_id(series.id)
+
+        assert found is not None
+        assert found.library_id == _LIBRARY_ID

--- a/tests/modules/media/integration/persistence/test_sqlalchemy_unit_of_work.py
+++ b/tests/modules/media/integration/persistence/test_sqlalchemy_unit_of_work.py
@@ -26,6 +26,8 @@ from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import
     SqlAlchemyMediaUnitOfWorkFactory,
 )
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 @pytest.fixture
 async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
@@ -48,6 +50,7 @@ async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], 
 
 def _movie(title: str = "Inception") -> Movie:
     return Movie(
+        library_id=_LIBRARY_ID,
         id=MovieId.generate(),
         title=Title(title),
         year=Year(2010),

--- a/tests/modules/media/unit/application/use_cases/test_add_file_variant.py
+++ b/tests/modules/media/unit/application/use_cases/test_add_file_variant.py
@@ -8,6 +8,8 @@ from src.modules.media.application.use_cases import AddFileVariantUseCase
 from src.modules.media.domain.entities import Movie
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 @pytest.mark.unit
 class TestAddFileVariantUseCase:
@@ -18,6 +20,7 @@ class TestAddFileVariantUseCase:
         mocks = make_media_uow_mock()
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -21,9 +21,12 @@ from src.modules.media.domain.value_objects import ContentRating, TmdbId
 from src.modules.media.domain.value_objects.cast_member import CastMember
 from tests.modules.media.unit.conftest import MediaUoWMocks, make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_movie() -> Movie:
     return Movie.create(
+        library_id=_LIBRARY_ID,
         title="Inception",
         year=2010,
         duration=0,
@@ -174,6 +177,7 @@ class TestEnrichMovieMetadata:
     @pytest.mark.asyncio
     async def test_should_retry_with_cleaned_title(self) -> None:
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception 1080p BluRay x264",
             year=2010,
             duration=0,

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -32,9 +32,11 @@ from src.modules.media.domain.value_objects import (
 )
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_series(**kwargs: object) -> Series:
-    series = Series.create(title="Breaking Bad", start_year=2008, **kwargs)
+    series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008, **kwargs)
     assert series.id is not None
     season = Season(series_id=series.id, season_number=1)
     episode = Episode(
@@ -378,7 +380,9 @@ class TestEnrichSeriesByTmdbId:
 
     @pytest.mark.asyncio
     async def test_should_retry_with_cleaned_title(self) -> None:
-        series = Series.create(title="Breaking Bad 1080p BluRay", start_year=2008)
+        series = Series.create(
+            library_id=_LIBRARY_ID, title="Breaking Bad 1080p BluRay", start_year=2008
+        )
         mocks = make_media_uow_mock()
         mocks.series.find_by_id.return_value = series
         mocks.series.save.side_effect = lambda s: s

--- a/tests/modules/media/unit/application/use_cases/test_get_collection_by_tmdb_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_collection_by_tmdb_id.py
@@ -22,9 +22,12 @@ from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import TmdbId
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _movie_with_tmdb(*, title: str, tmdb_id: int, year: int = 2010) -> Movie:
     movie = Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=year,
         duration=8880,

--- a/tests/modules/media/unit/application/use_cases/test_get_featured_media.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_featured_media.py
@@ -13,9 +13,12 @@ from src.modules.media.domain.entities import Movie, Series
 from src.modules.media.domain.value_objects import ImageUrl
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_movie(title: str = "Inception") -> Movie:
     movie = Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=2010,
         duration=8880,
@@ -29,7 +32,7 @@ def _make_movie(title: str = "Inception") -> Movie:
 
 
 def _make_series(title: str = "Breaking Bad") -> Series:
-    series = Series.create(title=title, start_year=2008)
+    series = Series.create(library_id=_LIBRARY_ID, title=title, start_year=2008)
     return series.with_updates(
         backdrop_path=ImageUrl("https://image.tmdb.org/series_backdrop.jpg"),
     )

--- a/tests/modules/media/unit/application/use_cases/test_get_file_variants.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_file_variants.py
@@ -10,6 +10,8 @@ from src.modules.media.domain.value_objects import MediaFile, Resolution
 from src.shared_kernel.value_objects.file_path import FilePath
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 @pytest.mark.unit
 class TestGetFileVariantsUseCase:
@@ -19,6 +21,7 @@ class TestGetFileVariantsUseCase:
     async def test_should_return_all_variants(self):
         mocks = make_media_uow_mock()
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,

--- a/tests/modules/media/unit/application/use_cases/test_get_movie_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_movie_by_id.py
@@ -9,6 +9,8 @@ from src.modules.media.application.use_cases import GetMovieByIdUseCase
 from src.modules.media.domain.entities import Movie
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 class TestGetMovieByIdUseCase:
     """Tests for GetMovieByIdUseCase."""
@@ -17,6 +19,7 @@ class TestGetMovieByIdUseCase:
     async def test_should_return_movie_when_found(self):
         mocks = make_media_uow_mock()
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -39,6 +42,7 @@ class TestGetMovieByIdUseCase:
     async def test_should_return_formatted_duration(self):
         mocks = make_media_uow_mock()
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Test Movie",
             year=2020,
             duration=7200,
@@ -57,6 +61,7 @@ class TestGetMovieByIdUseCase:
     async def test_should_return_genres_as_strings(self):
         mocks = make_media_uow_mock()
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Test Movie",
             year=2020,
             duration=7200,
@@ -77,6 +82,7 @@ class TestGetMovieByIdUseCase:
     async def test_should_handle_optional_fields_as_none(self):
         mocks = make_media_uow_mock()
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Test Movie",
             year=2020,
             duration=7200,
@@ -112,6 +118,7 @@ class TestGetMovieByIdUseCase:
     async def test_should_call_repository_with_movie_id(self):
         mocks = make_media_uow_mock()
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Test Movie",
             year=2020,
             duration=7200,

--- a/tests/modules/media/unit/application/use_cases/test_get_related_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_related_movies.py
@@ -13,9 +13,12 @@ from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import MovieId, TmdbId
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _movie(*, title: str, tmdb_id: int | None) -> Movie:
     movie = Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=2010,
         duration=8880,

--- a/tests/modules/media/unit/application/use_cases/test_get_related_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_related_series.py
@@ -13,9 +13,11 @@ from src.modules.media.domain.entities import Series
 from src.modules.media.domain.value_objects import SeriesId, TmdbId
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _series(*, title: str, tmdb_id: int | None) -> Series:
-    series = Series.create(title=title, start_year=2010)
+    series = Series.create(library_id=_LIBRARY_ID, title=title, start_year=2010)
     return series.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id is not None else series
 
 

--- a/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
@@ -21,6 +21,8 @@ from src.modules.media.domain.value_objects import (
 )
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 @pytest.fixture()
 def mock_progress_lookup() -> AsyncMock:
@@ -39,7 +41,9 @@ class TestGetSeriesByIdUseCase:
         carries name, profile_path, role and tmdb_id so the detail UI
         can render the same actor cards across both media types."""
         mocks = make_media_uow_mock()
-        series = Series.create(title="Breaking Bad", start_year=2008).with_updates(
+        series = Series.create(
+            library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008
+        ).with_updates(
             cast=[
                 CastMember(
                     name="Bryan Cranston",
@@ -71,6 +75,7 @@ class TestGetSeriesByIdUseCase:
     async def test_should_return_series_when_found(self, mock_progress_lookup):
         mocks = make_media_uow_mock()
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="Breaking Bad",
             start_year=2008,
         )
@@ -91,6 +96,7 @@ class TestGetSeriesByIdUseCase:
     async def test_should_return_series_with_seasons(self, mock_progress_lookup):
         mocks = make_media_uow_mock()
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="Breaking Bad",
             start_year=2008,
             end_year=2013,
@@ -117,6 +123,7 @@ class TestGetSeriesByIdUseCase:
     async def test_should_return_series_with_episodes(self, mock_progress_lookup):
         mocks = make_media_uow_mock()
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="Breaking Bad",
             start_year=2008,
         )
@@ -162,6 +169,7 @@ class TestGetSeriesByIdUseCase:
     async def test_should_return_ongoing_status(self, mock_progress_lookup):
         mocks = make_media_uow_mock()
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="Ongoing Show",
             start_year=2020,
         )
@@ -180,6 +188,7 @@ class TestGetSeriesByIdUseCase:
     async def test_should_return_completed_status(self, mock_progress_lookup):
         mocks = make_media_uow_mock()
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="Completed Show",
             start_year=2010,
             end_year=2015,
@@ -214,6 +223,7 @@ class TestGetSeriesByIdUseCase:
     async def test_should_handle_series_with_no_seasons(self, mock_progress_lookup):
         mocks = make_media_uow_mock()
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="New Show",
             start_year=2024,
         )
@@ -233,6 +243,7 @@ class TestGetSeriesByIdUseCase:
     async def test_should_return_genres_as_strings(self, mock_progress_lookup):
         mocks = make_media_uow_mock()
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="Drama Show",
             start_year=2020,
             genres=["Drama", "Thriller"],

--- a/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
@@ -17,9 +17,12 @@ from src.modules.media.application.use_cases.list_by_genre import ListByGenreUse
 from src.modules.media.domain.entities import Movie, Series
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _movie(title: str) -> Movie:
     return Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=2020,
         duration=7200,
@@ -30,7 +33,7 @@ def _movie(title: str) -> Movie:
 
 
 def _series(title: str) -> Series:
-    return Series.create(title=title, start_year=2020)
+    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=2020)
 
 
 def _movies_page(

--- a/tests/modules/media/unit/application/use_cases/test_list_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies.py
@@ -8,9 +8,12 @@ from src.modules.media.application.use_cases import ListMoviesUseCase
 from src.modules.media.domain.entities import Movie
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_movie(title: str = "Test Movie", year: int = 2020) -> Movie:
     return Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=year,
         duration=7200,

--- a/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
@@ -12,6 +12,8 @@ from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects.cast_member import CastMember
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_movie(
     title: str = "Test Movie",
@@ -19,6 +21,7 @@ def _make_movie(
     cast: list[CastMember] | None = None,
 ) -> Movie:
     movie = Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=year,
         duration=7200,

--- a/tests/modules/media/unit/application/use_cases/test_list_recently_added_catalog.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_recently_added_catalog.py
@@ -13,10 +13,13 @@ from src.modules.media.application.use_cases import ListRecentlyAddedCatalogUseC
 from src.modules.media.domain.entities import Movie, Series
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _movie_at(title: str, when: datetime) -> Movie:
     """Build a movie pinned to a specific ``created_at`` for the merge test."""
     return Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=2020,
         duration=7200,
@@ -28,7 +31,9 @@ def _movie_at(title: str, when: datetime) -> Movie:
 
 def _series_at(title: str, when: datetime) -> Series:
     """Build a series pinned to a specific ``created_at`` for the merge test."""
-    return Series.create(title=title, start_year=2020).with_updates(created_at=when)
+    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=2020).with_updates(
+        created_at=when
+    )
 
 
 class TestListRecentlyAddedCatalogUseCase:

--- a/tests/modules/media/unit/application/use_cases/test_list_recently_added_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_recently_added_movies.py
@@ -11,9 +11,12 @@ from src.modules.media.application.use_cases import ListRecentlyAddedMoviesUseCa
 from src.modules.media.domain.entities import Movie
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_movie(title: str = "Test Movie", year: int = 2020) -> Movie:
     return Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=year,
         duration=7200,

--- a/tests/modules/media/unit/application/use_cases/test_list_recently_added_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_recently_added_series.py
@@ -11,9 +11,11 @@ from src.modules.media.application.use_cases import ListRecentlyAddedSeriesUseCa
 from src.modules.media.domain.entities import Series
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _make_series(title: str = "Test Series", year: int = 2020) -> Series:
-    return Series.create(title=title, start_year=year)
+    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=year)
 
 
 class TestListRecentlyAddedSeriesUseCase:

--- a/tests/modules/media/unit/application/use_cases/test_list_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series.py
@@ -13,6 +13,8 @@ from src.modules.media.application.use_cases import ListSeriesUseCase
 from src.modules.media.domain.entities import Series
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _page(
     series_list: list[Series],
@@ -36,8 +38,8 @@ class TestListSeriesUseCase:
         mocks = make_media_uow_mock()
         mocks.series.list_paginated.return_value = _page(
             [
-                Series.create(title="Show 1", start_year=2020),
-                Series.create(title="Show 2", start_year=2021),
+                Series.create(library_id=_LIBRARY_ID, title="Show 1", start_year=2020),
+                Series.create(library_id=_LIBRARY_ID, title="Show 2", start_year=2021),
             ]
         )
         use_case = ListSeriesUseCase(uow_factory=mocks.factory)
@@ -59,6 +61,7 @@ class TestListSeriesUseCase:
     async def test_should_convert_series_to_summaries(self) -> None:
         mocks = make_media_uow_mock()
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="Breaking Bad",
             start_year=2008,
             end_year=2013,
@@ -95,7 +98,7 @@ class TestListSeriesUseCase:
     async def test_should_propagate_next_cursor_and_has_more(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.list_paginated.return_value = _page(
-            [Series.create(title="Show 1", start_year=2020)],
+            [Series.create(library_id=_LIBRARY_ID, title="Show 1", start_year=2020)],
             next_cursor="next-token",
             has_more=True,
         )
@@ -121,7 +124,7 @@ class TestListSeriesUseCase:
     @pytest.mark.asyncio
     async def test_should_indicate_ongoing_series(self) -> None:
         mocks = make_media_uow_mock()
-        series = Series.create(title="Ongoing Show", start_year=2020)
+        series = Series.create(library_id=_LIBRARY_ID, title="Ongoing Show", start_year=2020)
         mocks.series.list_paginated.return_value = _page([series])
         use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
@@ -133,7 +136,7 @@ class TestListSeriesUseCase:
     @pytest.mark.asyncio
     async def test_should_include_season_and_episode_counts(self) -> None:
         mocks = make_media_uow_mock()
-        series = Series.create(title="Test Show", start_year=2020)
+        series = Series.create(library_id=_LIBRARY_ID, title="Test Show", start_year=2020)
         mocks.series.list_paginated.return_value = _page([series])
         use_case = ListSeriesUseCase(uow_factory=mocks.factory)
 
@@ -146,7 +149,7 @@ class TestListSeriesUseCase:
     async def test_should_request_total_when_include_total_is_true(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.list_paginated.return_value = _page(
-            [Series.create(title="Show 1", start_year=2020)],
+            [Series.create(library_id=_LIBRARY_ID, title="Show 1", start_year=2020)],
             total_count=10,
         )
         use_case = ListSeriesUseCase(uow_factory=mocks.factory)

--- a/tests/modules/media/unit/application/use_cases/test_remove_file_variant.py
+++ b/tests/modules/media/unit/application/use_cases/test_remove_file_variant.py
@@ -19,10 +19,13 @@ from src.modules.media.domain.value_objects import (
 from src.shared_kernel.value_objects.file_path import FilePath
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _create_movie_with_variants() -> Movie:
     """Create a movie with multiple file variants."""
     movie = Movie.create(
+        library_id=_LIBRARY_ID,
         title="Inception",
         year=2010,
         duration=8880,
@@ -88,6 +91,7 @@ class TestRemoveFileVariantUseCase:
     async def test_should_raise_when_removing_last_file(self) -> None:
         mocks = make_media_uow_mock()
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -171,7 +175,7 @@ class TestRemoveFileVariantUseCase:
 
 def _create_series_with_episode_variants() -> Series:
     """Create a series with one episode that has two file variants."""
-    series = Series.create(title="Breaking Bad", start_year=2008)
+    series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
     assert series.id is not None
     episode = Episode(
         id=EpisodeId.generate(),

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -29,6 +29,8 @@ from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 from tests.modules.media.unit.conftest import MediaUoWMocks, make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _audio_track(lang: str, *, index: int = 0) -> AudioTrack:
     return AudioTrack(
@@ -123,7 +125,7 @@ class TestScanMovies:
         files = [_movie_file("/movies/Inception.2010.1080p.mkv", "Inception", 2010)]
         use_case, _ = _make_use_case(scanner_results=files)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert isinstance(result, ScanMediaOutput)
         assert result.movies_created == 1
@@ -137,7 +139,7 @@ class TestScanMovies:
         ]
         use_case, _ = _make_use_case(scanner_results=files)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_created == 1
         assert result.movies_updated == 0
@@ -150,13 +152,14 @@ class TestScanMovies:
         ]
         use_case, _ = _make_use_case(scanner_results=files)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_created == 2
 
     @pytest.mark.asyncio
     async def test_should_update_existing_movie_with_new_variant(self) -> None:
         existing = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -177,7 +180,7 @@ class TestScanMovies:
         ]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_updated == 1
         assert result.movies_created == 0
@@ -186,7 +189,7 @@ class TestScanMovies:
     async def test_should_return_empty_when_no_files(self) -> None:
         use_case, _ = _make_use_case(scanner_results=[])
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_created == 0
         assert result.episodes_created == 0
@@ -203,7 +206,7 @@ class TestScanEpisodes:
         ]
         use_case, _ = _make_use_case(scanner_results=files)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.episodes_created == 1
 
@@ -216,7 +219,7 @@ class TestScanEpisodes:
         ]
         use_case, _ = _make_use_case(scanner_results=files)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.episodes_created == 3
 
@@ -228,7 +231,7 @@ class TestScanEpisodes:
         ]
         use_case, _ = _make_use_case(scanner_results=files)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.episodes_created == 2
 
@@ -240,7 +243,7 @@ class TestScanEpisodes:
         ]
         use_case, _ = _make_use_case(scanner_results=files)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_created == 1
         assert result.episodes_created == 1
@@ -253,6 +256,7 @@ class TestRescanResolutionUpgrade:
     @pytest.mark.asyncio
     async def test_should_upgrade_movie_unknown_resolution(self) -> None:
         existing = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -270,7 +274,7 @@ class TestRescanResolutionUpgrade:
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_updated == 1
         assert saved[0].files[0].resolution == Resolution("1080p")
@@ -278,6 +282,7 @@ class TestRescanResolutionUpgrade:
     @pytest.mark.asyncio
     async def test_should_not_overwrite_known_movie_resolution(self) -> None:
         existing = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -295,7 +300,7 @@ class TestRescanResolutionUpgrade:
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_updated == 0
         mocks.movies.save.assert_not_called()
@@ -303,6 +308,7 @@ class TestRescanResolutionUpgrade:
     @pytest.mark.asyncio
     async def test_should_skip_when_rescan_also_returns_no_resolution(self) -> None:
         existing = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -319,7 +325,7 @@ class TestRescanResolutionUpgrade:
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_updated == 0
         mocks.movies.save.assert_not_called()
@@ -333,7 +339,7 @@ class TestRescanResolutionUpgrade:
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
         use_case, _ = _make_use_case(scanner_results=files, probe_service=probe)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_created == 1
         probe.probe.assert_called_once_with("/movies/inception.mkv")
@@ -341,6 +347,7 @@ class TestRescanResolutionUpgrade:
     @pytest.mark.asyncio
     async def test_should_probe_when_existing_resolution_is_unknown(self) -> None:
         existing = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -365,7 +372,7 @@ class TestRescanResolutionUpgrade:
             probe_service=probe,
         )
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_updated == 1
         probe.probe.assert_called_once_with("/movies/inception.mkv")
@@ -376,6 +383,7 @@ class TestRescanResolutionUpgrade:
         self,
     ) -> None:
         existing = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -407,7 +415,7 @@ class TestRescanResolutionUpgrade:
             probe_service=probe,
         )
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_updated == 0
         probe.probe.assert_not_called()
@@ -425,14 +433,14 @@ class TestRescanResolutionUpgrade:
         files = [_movie_file("/movies/inception.1080p.mkv", "Inception", 2010, "1080p")]
         use_case, _ = _make_use_case(scanner_results=files, probe_service=probe)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_created == 1
         probe.probe.assert_called_once_with("/movies/inception.1080p.mkv")
 
     @pytest.mark.asyncio
     async def test_should_upgrade_episode_unknown_resolution(self) -> None:
-        series = Series.create(title="Show", start_year=2024)
+        series = Series.create(library_id=_LIBRARY_ID, title="Show", start_year=2024)
         assert series.id is not None
         episode = Episode(
             series_id=series.id,
@@ -472,7 +480,7 @@ class TestRescanResolutionUpgrade:
         ]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.episodes_updated == 1
         saved_episode = saved[0].seasons[0].episodes[0]
@@ -499,7 +507,7 @@ class TestTrackDetection:
         files = [_movie_file("/movies/Inception.mkv", "Inception", 2010, "1080p")]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_created == 1
         media_file = saved[0].files[0]
@@ -524,7 +532,7 @@ class TestTrackDetection:
         files = [_episode_file("/series/Anime/S01/Anime.S01E01.mkv")]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.episodes_created == 1
         ep_file = saved[0].seasons[0].episodes[0].files[0]
@@ -536,6 +544,7 @@ class TestTrackDetection:
     @pytest.mark.asyncio
     async def test_should_backfill_empty_tracks_on_rescan(self) -> None:
         existing = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -559,7 +568,7 @@ class TestTrackDetection:
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_updated == 1
         media_file = saved[0].files[0]
@@ -570,6 +579,7 @@ class TestTrackDetection:
     @pytest.mark.asyncio
     async def test_should_not_overwrite_existing_tracks_on_rescan(self) -> None:
         existing = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -596,7 +606,7 @@ class TestTrackDetection:
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_updated == 0
         probe.probe.assert_not_called()
@@ -625,7 +635,7 @@ class TestTrackDetection:
         files = [_movie_file("/movies/inception.mkv", "Inception", 2010, "1080p")]
         use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
 
-        result = await use_case.execute(ScanMediaInput())
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
 
         assert result.movies_created == 1
         media_file = saved[0].files[0]
@@ -640,3 +650,63 @@ class TestTrackDetection:
         assert external[0].language == LanguageCode("pt")
         assert external[0].index == 1
         assert external[0].file_path == FilePath("/movies/inception.pt.srt")
+
+
+@pytest.mark.unit
+class TestScanLibraryIdPropagation:
+    """The scan input's ``library_id`` must reach every saved entity.
+
+    The catalog is filtered per-profile downstream by ``library_id``,
+    so a regression that drops the value during scan would un-scope
+    the entire newly-created catalog.
+    """
+
+    @pytest.mark.asyncio
+    async def test_movie_save_carries_input_library_id(self) -> None:
+        saved: list[Movie] = []
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
+        mocks.series.find_by_title.return_value = None
+
+        files = [_movie_file("/movies/Inception.2010.1080p.mkv", "Inception", 2010)]
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
+
+        await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert len(saved) == 1
+        assert saved[0].library_id == _LIBRARY_ID
+
+    @pytest.mark.asyncio
+    async def test_series_save_carries_input_library_id(self) -> None:
+        saved: list[Series] = []
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.series.find_by_title.return_value = None
+        mocks.series.save.side_effect = lambda s: saved.append(s) or s
+
+        files = [_episode_file("/series/Show/S01/Show.S01E01.mkv")]
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
+
+        await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert len(saved) == 1
+        assert saved[0].library_id == _LIBRARY_ID
+
+    @pytest.mark.asyncio
+    async def test_distinct_library_id_propagates_to_movie(self) -> None:
+        """Passing a non-default library_id reaches the saved Movie."""
+        saved: list[Movie] = []
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
+        mocks.series.find_by_title.return_value = None
+
+        files = [_movie_file("/movies/Inception.2010.1080p.mkv", "Inception", 2010)]
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
+
+        other_library = "lib_otherlibrary"
+        await use_case.execute(ScanMediaInput(library_id=other_library))
+
+        assert len(saved) == 1
+        assert saved[0].library_id == other_library

--- a/tests/modules/media/unit/application/use_cases/test_search_catalog.py
+++ b/tests/modules/media/unit/application/use_cases/test_search_catalog.py
@@ -12,9 +12,12 @@ from src.modules.media.application.use_cases.search_catalog import SearchCatalog
 from src.modules.media.domain.entities import Movie, Series
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _movie(title: str) -> Movie:
     return Movie.create(
+        library_id=_LIBRARY_ID,
         title=title,
         year=2020,
         duration=7200,
@@ -25,7 +28,7 @@ def _movie(title: str) -> Movie:
 
 
 def _series(title: str) -> Series:
-    return Series.create(title=title, start_year=2020)
+    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=2020)
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/application/use_cases/test_set_primary_file.py
+++ b/tests/modules/media/unit/application/use_cases/test_set_primary_file.py
@@ -16,10 +16,13 @@ from src.modules.media.domain.value_objects import (
 from src.shared_kernel.value_objects.file_path import FilePath
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _create_movie_with_variants() -> Movie:
     """Create a movie with multiple file variants."""
     movie = Movie.create(
+        library_id=_LIBRARY_ID,
         title="Inception",
         year=2010,
         duration=8880,
@@ -38,7 +41,7 @@ def _create_movie_with_variants() -> Movie:
 
 def _create_series_with_episode_variants() -> Series:
     """Create a series with one episode that has multiple file variants."""
-    series = Series.create(title="Breaking Bad", start_year=2008)
+    series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
     assert series.id is not None
     episode_id = EpisodeId.generate()
     episode = Episode(

--- a/tests/modules/media/unit/domain/entities/test_movie.py
+++ b/tests/modules/media/unit/domain/entities/test_movie.py
@@ -4,6 +4,8 @@ import pytest
 
 from src.building_blocks.domain.errors import DomainValidationException
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 class TestMovieCreation:
     """Tests for Movie instantiation."""
@@ -20,6 +22,7 @@ class TestMovieCreation:
         )
 
         movie = Movie(
+            library_id=_LIBRARY_ID,
             title=Title("Inception"),
             year=Year(2010),
             duration=Duration(8880),
@@ -42,6 +45,7 @@ class TestMovieCreation:
         from src.modules.media.domain.value_objects import MovieId
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -58,6 +62,7 @@ class TestMovieCreation:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -81,6 +86,7 @@ class TestMovieCreation:
         )
 
         movie = Movie(
+            library_id=_LIBRARY_ID,
             id="mov_abc123abc123",
             title=Title("Inception"),
             year=Year(2010),
@@ -109,6 +115,7 @@ class TestMovieOptionalFields:
         )
 
         movie = Movie(
+            library_id=_LIBRARY_ID,
             title=Title("Inception"),
             original_title=Title("Inception"),
             year=Year(2010),
@@ -144,6 +151,7 @@ class TestMovieGenreManagement:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -162,6 +170,7 @@ class TestMovieGenreManagement:
         from src.modules.media.domain.value_objects import Genre
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -178,6 +187,7 @@ class TestMovieGenreManagement:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -199,6 +209,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -216,6 +227,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.value_objects import Duration, Title, Year
 
         movie = Movie(
+            library_id=_LIBRARY_ID,
             title=Title("Test"),
             year=Year(2024),
             duration=Duration(7200),
@@ -228,6 +240,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -252,6 +265,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -275,6 +289,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -297,6 +312,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -319,6 +335,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -343,6 +360,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -359,6 +377,7 @@ class TestMovieFileManagement:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -386,6 +405,7 @@ class TestMovieEquality:
         movie_id = MovieId.generate()
 
         movie1 = Movie(
+            library_id=_LIBRARY_ID,
             id=movie_id,
             title=Title("Inception"),
             year=Year(2010),
@@ -393,6 +413,7 @@ class TestMovieEquality:
         )
 
         movie2 = Movie(
+            library_id=_LIBRARY_ID,
             id=movie_id,
             title=Title("Different"),
             year=Year(2010),
@@ -410,6 +431,7 @@ class TestMovieEvents:
         from src.modules.media.domain.events import MediaCreatedEvent
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -432,6 +454,7 @@ class TestMovieEvents:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -462,6 +485,7 @@ class TestMovieEvents:
         from src.modules.media.domain.value_objects import Year
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -486,6 +510,7 @@ class TestMovieImmutability:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -501,6 +526,7 @@ class TestMovieImmutability:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -519,6 +545,7 @@ class TestMovieImmutability:
         from src.modules.media.domain.entities import Movie
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -537,6 +564,7 @@ class TestMovieImmutability:
         from src.modules.media.domain.value_objects import Genre
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -555,6 +583,7 @@ class TestMovieImmutability:
         from src.modules.media.domain.value_objects import FilePath, MediaFile, Resolution
 
         movie = Movie.create(
+            library_id=_LIBRARY_ID,
             title="Inception",
             year=2010,
             duration=8880,
@@ -598,7 +627,7 @@ class TestMovieLogoLocalization:
             },
         }
         defaults.update(kwargs)
-        return Movie(**defaults)
+        return Movie(library_id=_LIBRARY_ID, **defaults)
 
     def test_returns_localized_logo_when_lang_has_one(self):
         movie = self._movie()

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -7,6 +7,8 @@ from src.building_blocks.domain.errors import (
     DomainValidationException,
 )
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 class TestSeriesCreation:
     """Tests for Series instantiation."""
@@ -16,6 +18,7 @@ class TestSeriesCreation:
         from src.modules.media.domain.value_objects import Title, Year
 
         series = Series(
+            library_id=_LIBRARY_ID,
             title=Title("Breaking Bad"),
             start_year=Year(2008),
         )
@@ -31,6 +34,7 @@ class TestSeriesCreation:
         from src.modules.media.domain.value_objects import SeriesId
 
         series = Series.create(
+            library_id=_LIBRARY_ID,
             title="Breaking Bad",
             start_year=2008,
         )
@@ -44,6 +48,7 @@ class TestSeriesCreation:
         from src.modules.media.domain.value_objects import Title, Year
 
         series = Series(
+            library_id=_LIBRARY_ID,
             title=Title("Breaking Bad"),
             start_year=Year(2008),
             end_year=Year(2013),
@@ -59,6 +64,7 @@ class TestSeriesCreation:
 
         with pytest.raises(DomainValidationException, match="end_year"):
             Series(
+                library_id=_LIBRARY_ID,
                 title=Title("Breaking Bad"),
                 start_year=Year(2013),
                 end_year=Year(2008),
@@ -71,14 +77,14 @@ class TestSeriesSeasonManagement:
     def test_season_count_should_return_zero_when_empty(self):
         from src.modules.media.domain.entities import Series
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         assert series.season_count == 0
 
     def test_total_episodes_should_return_zero_when_empty(self):
         from src.modules.media.domain.entities import Series
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         assert series.total_episodes == 0
 
@@ -86,7 +92,7 @@ class TestSeriesSeasonManagement:
         from src.modules.media.domain.entities import Season, Series
         from src.modules.media.domain.value_objects import SeasonId
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         season = Season(
             id=SeasonId.generate(),
@@ -102,7 +108,7 @@ class TestSeriesSeasonManagement:
         from src.modules.media.domain.entities import Season, Series
         from src.modules.media.domain.value_objects import SeasonId, SeriesId
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         season = Season(
             id=SeasonId.generate(),
@@ -117,7 +123,7 @@ class TestSeriesSeasonManagement:
         from src.modules.media.domain.entities import Season, Series
         from src.modules.media.domain.value_objects import SeasonId
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         season = Season(
             id=SeasonId.generate(),
@@ -133,7 +139,7 @@ class TestSeriesSeasonManagement:
     def test_should_return_none_when_season_not_found(self):
         from src.modules.media.domain.entities import Series
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         found = series.get_season(99)
         assert found is None
@@ -149,12 +155,14 @@ class TestSeriesEquality:
         series_id = SeriesId.generate()
 
         series1 = Series(
+            library_id=_LIBRARY_ID,
             id=series_id,
             title=Title("Breaking Bad"),
             start_year=Year(2008),
         )
 
         series2 = Series(
+            library_id=_LIBRARY_ID,
             id=series_id,
             title=Title("Different"),
             start_year=Year(2010),
@@ -170,7 +178,7 @@ class TestSeriesEvents:
         from src.modules.media.domain.entities import Series
         from src.modules.media.domain.events import MediaCreatedEvent
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         assert series.has_pending_events is True
 
@@ -185,7 +193,7 @@ class TestSeriesEvents:
     def test_should_add_and_pull_events(self):
         from src.modules.media.domain.entities import Series
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         from dataclasses import dataclass
 
@@ -210,7 +218,7 @@ class TestSeriesImmutability:
     def test_should_reject_direct_attribute_assignment(self):
         from src.modules.media.domain.entities import Series
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
 
         with pytest.raises(DomainValidationException):
             series.start_year = 2020  # type: ignore[assignment, misc]
@@ -219,7 +227,7 @@ class TestSeriesImmutability:
         from src.modules.media.domain.entities import Season, Series
         from src.modules.media.domain.value_objects import SeasonId
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
         season = Season(
             id=SeasonId.generate(),
             series_id=series.id,
@@ -236,7 +244,7 @@ class TestSeriesImmutability:
         from src.modules.media.domain.entities import Season, Series
         from src.modules.media.domain.value_objects import SeasonId
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
         season = Season(
             id=SeasonId.generate(),
             series_id=series.id,
@@ -251,7 +259,7 @@ class TestSeriesImmutability:
         from src.modules.media.domain.entities import Season, Series
         from src.modules.media.domain.value_objects import SeasonId
 
-        series = Series.create(title="Breaking Bad", start_year=2008)
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
         season = Season(
             id=SeasonId.generate(),
             series_id=series.id,
@@ -283,7 +291,7 @@ class TestSeriesLogoLocalization:
             },
         }
         defaults.update(kwargs)
-        return Series(**defaults)
+        return Series(library_id=_LIBRARY_ID, **defaults)
 
     def test_returns_localized_logo_when_lang_has_one(self):
         series = self._series()

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
@@ -17,10 +17,13 @@ from src.modules.media.domain.value_objects import (
 from src.modules.media.infrastructure.persistence.mappers import MovieMapper
 from src.modules.media.infrastructure.persistence.models import MovieModel
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _create_movie(movie_id: MovieId | None = None) -> Movie:
     """Create a Movie entity for testing."""
     return Movie(
+        library_id=_LIBRARY_ID,
         id=movie_id,
         title=Title("Test Movie"),
         year=Year(2024),
@@ -72,6 +75,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -98,6 +102,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -125,6 +130,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -151,6 +157,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -182,6 +189,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -205,6 +213,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -233,6 +242,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -256,6 +266,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -279,6 +290,7 @@ class TestMovieMapper:
         movie_id = MovieId.generate()
         now = datetime.now(UTC)
         model = MovieModel(
+            library_id=_LIBRARY_ID,
             external_id=str(movie_id),
             title="Test Movie",
             year=2024,
@@ -297,3 +309,66 @@ class TestMovieMapper:
 
         assert len(entity.cast) == 1
         assert entity.cast[0].name == "Leonardo DiCaprio"
+
+    def test_to_model_persists_library_id_from_entity(self) -> None:
+        """``to_model`` carries the entity's ``library_id`` onto the row.
+
+        Pinned because the catalog is filtered per-profile downstream
+        through ``library_id``; a regression that drops the column
+        copy would silently un-scope every newly inserted movie.
+        """
+        movie_id = MovieId.generate()
+        movie = _create_movie(movie_id=movie_id)
+
+        model = MovieMapper.to_model(movie)
+
+        assert model.library_id == _LIBRARY_ID
+
+    def test_round_trip_preserves_library_id(self) -> None:
+        """Entity → model → entity round-trip keeps ``library_id`` intact."""
+        movie_id = MovieId.generate()
+        movie = _create_movie(movie_id=movie_id)
+
+        model = MovieMapper.to_model(movie)
+        now = datetime.now(UTC)
+        model.created_at = now
+        model.updated_at = now
+
+        rebuilt = MovieMapper.to_entity(model, include_files=False)
+
+        assert rebuilt.library_id == _LIBRARY_ID
+
+    def test_update_model_preserves_existing_library_id(self) -> None:
+        """``update_model`` deliberately leaves ``library_id`` alone.
+
+        ``library_id`` is the immutable owning-library reference set at
+        scan time; subsequent enrichment / update flows should never
+        rewrite it. The model's existing value wins even if the entity
+        somehow carries a different one.
+        """
+        movie_id = MovieId.generate()
+        existing_model = MovieMapper.to_model(_create_movie(movie_id=movie_id))
+        # Sanity-check baseline before update.
+        assert existing_model.library_id == _LIBRARY_ID
+
+        # Construct a refreshed entity that claims a *different* library_id
+        # to prove update_model does not propagate it onto the model.
+        refreshed = Movie(
+            library_id="lib_otherlibrary",
+            id=movie_id,
+            title=Title("Refreshed"),
+            year=Year(2025),
+            duration=Duration(7200),
+            files=[
+                MediaFile(
+                    file_path=FilePath("/movies/test.mkv"),
+                    file_size=1_000_000_000,
+                    resolution=Resolution("1080p"),
+                    is_primary=True,
+                )
+            ],
+        )
+
+        MovieMapper.update_model(existing_model, refreshed)
+
+        assert existing_model.library_id == _LIBRARY_ID

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
@@ -31,6 +31,8 @@ from src.modules.media.infrastructure.persistence.models import (
     SeriesModel,
 )
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _create_episode(
     episode_id: EpisodeId | None = None,
@@ -71,6 +73,7 @@ def _create_season(
 def _create_series(series_id: SeriesId | None = None) -> Series:
     """Create a Series entity for testing."""
     return Series(
+        library_id=_LIBRARY_ID,
         id=series_id,
         title=Title("Test Series"),
         start_year=Year(2020),
@@ -280,6 +283,7 @@ class TestSeriesMapper:
         series_id = SeriesId.generate()
         now = datetime.now(UTC)
         model = SeriesModel(
+            library_id=_LIBRARY_ID,
             external_id=str(series_id),
             title="Shallow Series",
             start_year=2020,
@@ -347,3 +351,53 @@ class TestSeriesMapper:
         SeriesMapper.update_model(existing, refreshed)
         assert "New Actor" in (existing.cast or "")
         assert "Old Actor" not in (existing.cast or "")
+
+    def test_to_model_persists_library_id_from_entity(self) -> None:
+        """``to_model`` carries the entity's ``library_id`` onto the row.
+
+        Pinned because the catalog is filtered per-profile downstream
+        through ``library_id``; a regression that drops the column copy
+        would silently un-scope every newly inserted series.
+        """
+        series_id = SeriesId.generate()
+        series = _create_series(series_id=series_id)
+
+        model = SeriesMapper.to_model(series)
+
+        assert model.library_id == _LIBRARY_ID
+
+    def test_round_trip_preserves_library_id(self) -> None:
+        """Entity → model → entity round-trip keeps ``library_id`` intact."""
+        series_id = SeriesId.generate()
+        series = _create_series(series_id=series_id)
+
+        model = SeriesMapper.to_model(series)
+        now = datetime.now(UTC)
+        model.created_at = now
+        model.updated_at = now
+
+        rebuilt = SeriesMapper.to_entity(model, include_seasons=False)
+
+        assert rebuilt.library_id == _LIBRARY_ID
+
+    def test_update_model_preserves_existing_library_id(self) -> None:
+        """``update_model`` deliberately leaves ``library_id`` alone.
+
+        ``library_id`` is set once at scan time and must not be
+        overwritten by enrichment / update flows. The model's existing
+        value wins even if the entity carries a different one.
+        """
+        series_id = SeriesId.generate()
+        existing_model = SeriesMapper.to_model(_create_series(series_id=series_id))
+        assert existing_model.library_id == _LIBRARY_ID
+
+        refreshed = Series(
+            library_id="lib_otherlibrary",
+            id=series_id,
+            title=Title("Refreshed"),
+            start_year=Year(2024),
+        )
+
+        SeriesMapper.update_model(existing_model, refreshed)
+
+        assert existing_model.library_id == _LIBRARY_ID

--- a/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
+++ b/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
@@ -26,6 +26,8 @@ from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import
 )
 from src.modules.watch_progress.infrastructure.acl import MediaLookupAdapter
 
+_LIBRARY_ID = "lib_test12345678"
+
 
 def _movie(
     movie_id: MovieId,
@@ -34,6 +36,7 @@ def _movie(
     backdrop: str | None = "/b/m.jpg",
 ) -> Movie:
     return Movie(
+        library_id=_LIBRARY_ID,
         id=movie_id,
         title=Title(title),
         year=Year(2024),
@@ -58,6 +61,7 @@ def _series_with_episodes(
 ) -> Series:
     """Create a series with given (season, episode, title) triples."""
     series = Series(
+        library_id=_LIBRARY_ID,
         id=series_id,
         title=Title(title),
         start_year=Year(2024),


### PR DESCRIPTION
## Summary

- Adds ``library_id: str`` (the ``lib_xxx`` external id of the owning Library) to the ``Movie`` and ``Series`` aggregates and the corresponding ORM models. The relationship was previously implicit — the scanner happened to write paths under directories that matched a configured library, but nothing recorded which library actually owned each catalog row.
- Held as ``str`` (not a typed VO) because Library lives in another bounded context and ADR-008 forbids the cross-BC import. Same pattern as ``WatchProgress.media_id``. Episode is unchanged because episodes inherit scoping through their parent Series.
- Scanner threading: ``ScanMediaInput`` requires ``library_id``; the scheduler passes the per-library id it already knows; the manual scan route now takes ``{""library_id"": ""lib_xxx""}`` and loads the library to get both the paths and the id from a single source of truth.
- Migration ``b09c1d2e3f4a`` follows the standard 3-step pattern (NULLABLE add → Python-side backfill → ALTER NOT NULL + index). Backfill matches each row's ``file_path`` (or for series, the earliest-recorded episode's ``file_path``) against every active library's ``paths`` JSON. Orphans abort with a clear error listing the offending rows.

## Why split from PR 6

The original master plan PR 6 was ""Profile ACL via allowed_library_ids + filter catalog reads."" Survey turned up a blocker: there was no ``library_id`` column to filter on. This PR materialises the data dependency so PR 6b (the actual ACL + filter) is a clean per-profile filtering change.

## Out of scope (flagged in commit body)

- ``movies.file_path UNIQUE`` is still global; with multi-library it should likely become ``UNIQUE(library_id, file_path)``. No incident yet — punted.
- Catalog read filter by library — lands in PR 6b along with ``Profile.allowed_library_ids`` and the new ``ProfileLibraryAccessPort``.
- The ""scan ``settings.media_directories`` fallback"" path on the manual route is removed. The scheduler is the production path; the manual route exists for ops/debug. If somebody actually depended on the env-driven mode, raise it on the PR — happy to add a body-less ""scan all configured libraries"" mode.

## Test plan

- [x] ``poetry run pytest tests/modules/media -q`` → 1179 passed (was 332 failed before the sweep).
- [x] ``poetry run pytest -q`` → 2175 passed, 5 skipped — no regressions in other BCs.
- [x] ``ruff check`` and ``ruff format --check`` clean across the diff.
- [x] Migration smoke against fresh SQLite: ``alembic upgrade head`` lands ``library_id VARCHAR(50) NOT NULL`` + ``ix_movies_library_id`` / ``ix_series_library_id``.
- [x] Backfill smoke: downgrade one revision, seed a library + a movie under its path + a series with one episode under another of its paths, upgrade — both rows pick up the seeded library_id.
- [x] Cross-library coexistence: integration tests for both repos prove rows from two libraries coexist and don't leak when filtered by ``library_id``.
- [ ] Manual end-to-end (will exercise after merge by triggering a scheduler scan and confirming new rows persist their library_id).

## Summary by Sourcery

Add explicit library scoping to the media catalog and wire it through scanning, persistence, and APIs for future per-profile filtering.

New Features:
- Introduce a required library_id field on Movie and Series aggregates and their ORM models to represent the owning library.
- Require library_id on scan inputs and propagate it through the scan pipeline so newly discovered movies and series are scoped to a specific library.
- Update the manual scan API to accept a library_id, load the library’s configured paths, and run scans against those paths.

Enhancements:
- Adjust media mappers and repositories so library_id is persisted, round-tripped, and treated as an immutable owning-library reference.
- Add cross-library coexistence and isolation tests to ensure queries filtered by library_id do not leak movies or series between libraries.
- Extend existing media domain, application, and scheduling tests to account for library_id in creation, listing, enrichment, and background jobs.
- Add a migration that backfills library_id for existing movies and series by matching file paths against active libraries and then enforces non-nullability with supporting indexes.

Tests:
- Add unit and integration tests to verify library_id propagation from scan inputs to saved entities and through mapper round-trips.
- Add repository-level tests to confirm multiple libraries’ movies and series coexist and remain isolated when filtered by library_id.