### PR TITLE
feat(identity): add allowed_library_ids ACL list to Profile (PR 6b)

### DIFF
--- a/migrations/versions/2026_05_04_add_allowed_library_ids_to_profiles.py
+++ b/migrations/versions/2026_05_04_add_allowed_library_ids_to_profiles.py
@@ -1,0 +1,86 @@
+"""Add allowed_library_ids ACL list to profiles.
+
+Per ADR-010, every profile carries the set of libraries it may
+see in the catalog (the ACL the upcoming PR 6c filter will
+consume). Stored as a JSON-encoded TEXT list — reads are always
+"the whole list per profile" and library cardinality is small,
+so a join table would buy nothing.
+
+Backfill semantics: pre-existing profiles inherit the snapshot of
+every active library at migration time. That preserves their
+current "see everything" experience without silently auto-granting
+access to libraries that get added later — once the ACL exists,
+new libraries become explicit-grant-only.
+
+Sequence:
+
+1. ADD COLUMN allowed_library_ids TEXT NULLABLE.
+2. UPDATE all rows with a JSON list of every active library
+   external_id (or ``[]`` when no libraries exist yet).
+3. ALTER COLUMN allowed_library_ids NOT NULL with server_default
+   ``"[]"`` so future rows default-deny.
+
+Revision ID: c1d2e3f4a5b6
+Revises: b09c1d2e3f4a
+Create Date: 2026-05-04 11:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: str | Sequence[str] | None = "b09c1d2e3f4a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the column, backfill from current libraries, then tighten."""
+    bind = op.get_bind()
+
+    # Step 1: add the column nullable so existing rows survive.
+    with op.batch_alter_table("profiles") as batch_op:
+        batch_op.add_column(sa.Column("allowed_library_ids", sa.Text(), nullable=True))
+
+    # Step 2: backfill. Every existing profile inherits the snapshot
+    # of currently-active library external_ids; downstream the catalog
+    # filter will read this column verbatim, so the snapshot preserves
+    # the pre-ACL "see everything" behavior. New libraries added after
+    # this migration require an explicit grant via the profile API.
+    libraries = bind.execute(
+        sa.text("SELECT external_id FROM libraries WHERE deleted_at IS NULL")
+    ).fetchall()
+    snapshot = json.dumps([row[0] for row in libraries])
+    bind.execute(
+        sa.text(
+            "UPDATE profiles SET allowed_library_ids = :snapshot "
+            "WHERE allowed_library_ids IS NULL"
+        ),
+        {"snapshot": snapshot},
+    )
+
+    # Step 3: tighten. server_default ``"[]"`` so any future INSERT
+    # that forgets to populate the column lands on the safe (deny-all)
+    # value rather than NULL.
+    with op.batch_alter_table("profiles") as batch_op:
+        batch_op.alter_column(
+            "allowed_library_ids",
+            existing_type=sa.Text(),
+            nullable=False,
+            server_default="[]",
+        )
+
+
+def downgrade() -> None:
+    """Drop the column. Loses ACL configuration — dev only."""
+    with op.batch_alter_table("profiles") as batch_op:
+        batch_op.drop_column("allowed_library_ids")

--- a/src/modules/identity/application/dtos/identity_dtos.py
+++ b/src/modules/identity/application/dtos/identity_dtos.py
@@ -21,6 +21,7 @@ class ProfileOutput:
     name: str
     avatar_url: str | None
     is_kids: bool
+    allowed_library_ids: list[str]
     created_at: str
     updated_at: str
 
@@ -31,12 +32,18 @@ class CreateProfileInput:
 
     ``user_id`` is the caller's prefixed external ID; the use case
     creates a profile owned by that user.
+
+    ``allowed_library_ids`` defaults to ``None`` meaning "use the
+    aggregate's default" (an empty list — the ACL is default-deny).
+    Pass an explicit list at creation time to grant access right
+    away.
     """
 
     user_id: str
     name: str
     is_kids: bool = False
     avatar_url: str | None = None
+    allowed_library_ids: list[str] | None = None
 
 
 @dataclass(frozen=True)
@@ -55,6 +62,10 @@ class UpdateProfileInput:
     ``avatar_url=None`` is **not** treated as "clear the avatar"; use
     a sentinel-typed payload at the route layer if explicit clearing
     is needed.
+
+    ``allowed_library_ids=None`` follows the same omitted-vs-cleared
+    convention: ``None`` means "don't touch the ACL"; an explicit
+    empty list ``[]`` means "revoke access to every library".
     """
 
     user_id: str
@@ -62,6 +73,7 @@ class UpdateProfileInput:
     name: str | None = None
     is_kids: bool | None = None
     avatar_url: str | None = None
+    allowed_library_ids: list[str] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/identity/application/use_cases/_to_output.py
+++ b/src/modules/identity/application/use_cases/_to_output.py
@@ -25,6 +25,7 @@ def profile_to_output(profile: Profile) -> ProfileOutput:
         name=profile.name.value,
         avatar_url=profile.avatar_url,
         is_kids=profile.is_kids,
+        allowed_library_ids=list(profile.allowed_library_ids),
         created_at=profile.created_at.isoformat(),
         updated_at=profile.updated_at.isoformat(),
     )

--- a/src/modules/identity/application/use_cases/create_profile.py
+++ b/src/modules/identity/application/use_cases/create_profile.py
@@ -31,6 +31,7 @@ class CreateProfileUseCase:
             name=ProfileName(input_dto.name),
             is_kids=input_dto.is_kids,
             avatar_url=input_dto.avatar_url,
+            allowed_library_ids=input_dto.allowed_library_ids,
         )
         async with self._uow_factory() as uow:
             saved = await uow.profiles.save(profile)

--- a/src/modules/identity/application/use_cases/update_profile.py
+++ b/src/modules/identity/application/use_cases/update_profile.py
@@ -52,6 +52,8 @@ class UpdateProfileUseCase:
                 updated = updated.with_kids_flag(is_kids=input_dto.is_kids)
             if input_dto.avatar_url is not None:
                 updated = updated.with_avatar(input_dto.avatar_url)
+            if input_dto.allowed_library_ids is not None:
+                updated = updated.with_allowed_library_ids(input_dto.allowed_library_ids)
 
             saved = await uow.profiles.save(updated)
 

--- a/src/modules/identity/domain/entities/profile.py
+++ b/src/modules/identity/domain/entities/profile.py
@@ -34,13 +34,21 @@ class Profile(AggregateRoot[ProfileId]):
             supported operation).
         name: Display name shown in the profile picker.
         avatar_url: Optional URL to an avatar image.
-        is_kids: Marks the profile as kids-mode (used by the future
-            library ACL — see ADR-010 PR 6).
+        is_kids: Marks the profile as kids-mode. Independent of the
+            ACL list — the kids flag is a UX hint; the ACL is the
+            actual authorization gate.
+        allowed_library_ids: Library external ids (``lib_xxx``) this
+            profile is allowed to see in the catalog. Default-deny:
+            an empty list means the profile sees nothing. The catalog
+            filter (see PR 6c) is a no-op when this list is empty
+            beyond returning empty pages — the field is the source
+            of truth, not a hint.
 
     Example:
         >>> profile = Profile.create(
         ...     user_id=UserId("usr_2xK9mPqR7nL4"),
         ...     name=ProfileName("Lucas"),
+        ...     allowed_library_ids=["lib_movies12345"],
         ... )
         >>> renamed = profile.with_name(ProfileName("Luc"))
         >>> renamed.name.value
@@ -52,6 +60,7 @@ class Profile(AggregateRoot[ProfileId]):
     name: ProfileName
     avatar_url: str | None = None
     is_kids: bool = False
+    allowed_library_ids: list[str] = Field(default_factory=list)
 
     @classmethod
     def create(
@@ -61,6 +70,7 @@ class Profile(AggregateRoot[ProfileId]):
         *,
         is_kids: bool = False,
         avatar_url: str | None = None,
+        allowed_library_ids: list[str] | None = None,
     ) -> Profile:
         """Build a fresh ``Profile`` (id assigned at persistence time)."""
         return cls(
@@ -68,6 +78,7 @@ class Profile(AggregateRoot[ProfileId]):
             name=name,
             is_kids=is_kids,
             avatar_url=avatar_url,
+            allowed_library_ids=list(allowed_library_ids) if allowed_library_ids else [],
         )
 
     def with_name(self, name: ProfileName) -> Self:
@@ -81,6 +92,16 @@ class Profile(AggregateRoot[ProfileId]):
     def with_avatar(self, avatar_url: str | None) -> Self:
         """Return a copy with the given avatar URL (or ``None`` to clear)."""
         return self.with_updates(avatar_url=avatar_url)
+
+    def with_allowed_library_ids(self, library_ids: list[str]) -> Self:
+        """Return a copy whose ACL is replaced by ``library_ids``.
+
+        Replaces the list entirely — there is no partial-add or
+        partial-remove operation. Callers that want to grant access
+        compute the new list themselves and pass the full set, which
+        keeps the aggregate's invariants explicit at one update site.
+        """
+        return self.with_updates(allowed_library_ids=list(library_ids))
 
 
 __all__ = ["Profile"]

--- a/src/modules/identity/infrastructure/persistence/mappers/profile_mapper.py
+++ b/src/modules/identity/infrastructure/persistence/mappers/profile_mapper.py
@@ -12,6 +12,7 @@ import json
 import uuid
 from datetime import UTC, datetime
 
+from src.config.logging import get_logger
 from src.modules.identity.domain.entities.profile import Profile
 from src.modules.identity.domain.value_objects.profile_name import ProfileName
 from src.modules.identity.infrastructure.persistence.models.profile_model import (
@@ -19,6 +20,8 @@ from src.modules.identity.infrastructure.persistence.models.profile_model import
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId
+
+_logger = get_logger()
 
 
 def _ensure_utc(value: datetime | None) -> datetime | None:
@@ -28,20 +31,35 @@ def _ensure_utc(value: datetime | None) -> datetime | None:
     return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
 
 
-def _decode_allowed_libraries(raw: str | None) -> list[str]:
+def _decode_allowed_libraries(profile_external_id: str, raw: str | None) -> list[str]:
     """Decode the JSON-encoded allowed_library_ids column.
 
-    A null or unparsable value is treated as an empty list so a
-    bad row can never silently grant access — explicit JSON or
-    empty-list, no third interpretation.
+    A null or unparsable value is coerced to an empty list so a bad
+    row can never silently grant access — but the coercion is logged
+    at WARNING so corrupted ACLs are observable in dashboards rather
+    than disappearing into a silent default-deny.
     """
-    if not raw:
+    if raw is None:
+        return []
+    if raw == "":
         return []
     try:
         decoded = json.loads(raw)
     except (TypeError, ValueError):
+        _logger.warning(
+            "[identity] Malformed allowed_library_ids JSON; coercing to empty list",
+            profile_external_id=profile_external_id,
+            raw=raw,
+        )
         return []
-    return [str(item) for item in decoded] if isinstance(decoded, list) else []
+    if not isinstance(decoded, list):
+        _logger.warning(
+            "[identity] allowed_library_ids decoded to non-list; coercing to empty list",
+            profile_external_id=profile_external_id,
+            decoded_type=type(decoded).__name__,
+        )
+        return []
+    return [str(item) for item in decoded]
 
 
 class ProfileMapper:
@@ -95,7 +113,9 @@ class ProfileMapper:
             name=ProfileName(model.name),
             avatar_url=model.avatar_url,
             is_kids=model.is_kids,
-            allowed_library_ids=_decode_allowed_libraries(model.allowed_library_ids),
+            allowed_library_ids=_decode_allowed_libraries(
+                model.external_id, model.allowed_library_ids
+            ),
             created_at=_ensure_utc(model.created_at) or datetime.now(UTC),
             updated_at=_ensure_utc(model.updated_at) or datetime.now(UTC),
         )

--- a/src/modules/identity/infrastructure/persistence/mappers/profile_mapper.py
+++ b/src/modules/identity/infrastructure/persistence/mappers/profile_mapper.py
@@ -8,6 +8,7 @@ responsible for resolving the user's UUID before calling
 lookup, keeping it dependency-free and synchronous.
 """
 
+import json
 import uuid
 from datetime import UTC, datetime
 
@@ -25,6 +26,22 @@ def _ensure_utc(value: datetime | None) -> datetime | None:
     if value is None:
         return None
     return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def _decode_allowed_libraries(raw: str | None) -> list[str]:
+    """Decode the JSON-encoded allowed_library_ids column.
+
+    A null or unparsable value is treated as an empty list so a
+    bad row can never silently grant access — explicit JSON or
+    empty-list, no third interpretation.
+    """
+    if not raw:
+        return []
+    try:
+        decoded = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    return [str(item) for item in decoded] if isinstance(decoded, list) else []
 
 
 class ProfileMapper:
@@ -55,6 +72,7 @@ class ProfileMapper:
             name=entity.name.value,
             avatar_url=entity.avatar_url,
             is_kids=entity.is_kids,
+            allowed_library_ids=json.dumps(entity.allowed_library_ids),
         )
 
     @staticmethod
@@ -77,6 +95,7 @@ class ProfileMapper:
             name=ProfileName(model.name),
             avatar_url=model.avatar_url,
             is_kids=model.is_kids,
+            allowed_library_ids=_decode_allowed_libraries(model.allowed_library_ids),
             created_at=_ensure_utc(model.created_at) or datetime.now(UTC),
             updated_at=_ensure_utc(model.updated_at) or datetime.now(UTC),
         )
@@ -100,6 +119,7 @@ class ProfileMapper:
         model.name = entity.name.value
         model.avatar_url = entity.avatar_url
         model.is_kids = entity.is_kids
+        model.allowed_library_ids = json.dumps(entity.allowed_library_ids)
         return model
 
 

--- a/src/modules/identity/infrastructure/persistence/models/profile_model.py
+++ b/src/modules/identity/infrastructure/persistence/models/profile_model.py
@@ -3,7 +3,7 @@
 import uuid
 
 from fastapi_users_db_sqlalchemy.generics import GUID
-from sqlalchemy import Boolean, ForeignKey, String
+from sqlalchemy import Boolean, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.infrastructure.persistence.base import BaseWithUUID
@@ -23,8 +23,14 @@ class ProfileModel(BaseWithUUID):
             so deleting an account also removes its profiles.
         name: Display name shown in the profile picker (1..50 chars).
         avatar_url: Optional URL to an avatar image.
-        is_kids: Marks the profile as kids-mode (used by future library
-            ACL — see ADR-010 PR 6).
+        is_kids: Marks the profile as kids-mode (UX hint independent
+            of the ACL).
+        allowed_library_ids: JSON-encoded list of library external_ids
+            (``lib_xxx``) this profile may see in the catalog. Stored
+            as TEXT/JSON rather than a join table because reads are
+            "the whole list per profile" and the cardinality is small
+            (libraries are operator-managed, not user-generated).
+            Default-deny: empty list means no access.
     """
 
     __tablename__ = "profiles"
@@ -42,6 +48,12 @@ class ProfileModel(BaseWithUUID):
         Boolean,
         nullable=False,
         default=False,
+    )
+    allowed_library_ids: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="[]",
+        server_default="[]",
     )
 
 

--- a/src/modules/identity/presentation/routes/profile_routes.py
+++ b/src/modules/identity/presentation/routes/profile_routes.py
@@ -74,6 +74,7 @@ async def create_profile(
             name=body.name,
             is_kids=body.is_kids,
             avatar_url=body.avatar_url,
+            allowed_library_ids=body.allowed_library_ids,
         ),
     )
     return api_single("profile", asdict(result))
@@ -102,6 +103,7 @@ async def update_profile(
             name=body.name,
             is_kids=body.is_kids,
             avatar_url=body.avatar_url,
+            allowed_library_ids=body.allowed_library_ids,
         ),
     )
     return api_single("profile", asdict(result))

--- a/src/modules/identity/presentation/schemas/profile_schemas.py
+++ b/src/modules/identity/presentation/schemas/profile_schemas.py
@@ -4,11 +4,18 @@ from pydantic import BaseModel, Field
 
 
 class CreateProfileRequest(BaseModel):
-    """``POST /api/v1/profiles`` body."""
+    """``POST /api/v1/profiles`` body.
+
+    ``allowed_library_ids`` is omitted by default — the new profile
+    starts with no library access (the ACL is default-deny). The
+    admin / profile owner grants access via this field at creation
+    time, or later via ``PUT /api/v1/profiles/{id}``.
+    """
 
     name: str = Field(min_length=1, max_length=50)
     is_kids: bool = False
     avatar_url: str | None = Field(default=None, max_length=500)
+    allowed_library_ids: list[str] | None = Field(default=None)
 
 
 class UpdateProfileRequest(BaseModel):
@@ -16,12 +23,15 @@ class UpdateProfileRequest(BaseModel):
 
     All fields optional: only supplied fields are mutated. ``None``
     is treated as "field omitted", not "clear the value", to keep
-    PATCH-style semantics inside a PUT route.
+    PATCH-style semantics inside a PUT route. To revoke every
+    library, send ``allowed_library_ids: []`` explicitly — the empty
+    list is meaningful, ``null`` is not.
     """
 
     name: str | None = Field(default=None, min_length=1, max_length=50)
     is_kids: bool | None = None
     avatar_url: str | None = Field(default=None, max_length=500)
+    allowed_library_ids: list[str] | None = Field(default=None)
 
 
 __all__ = ["CreateProfileRequest", "UpdateProfileRequest"]

--- a/tests/modules/identity/e2e/test_profile_routes.py
+++ b/tests/modules/identity/e2e/test_profile_routes.py
@@ -120,6 +120,41 @@ class TestCreateProfile:
         # Pydantic schema rejects empty name (min_length=1) -> 422.
         assert response.status_code == 422
 
+    async def test_should_default_allowed_library_ids_to_empty_when_omitted(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        # Default-deny: a fresh profile that does not name any
+        # libraries explicitly comes back with an empty ACL.
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        response = await client.post(PROFILES_PATH, json={"name": "Anon"})
+
+        assert response.status_code == 201
+        assert response.json()["data"]["allowed_library_ids"] == []
+
+    async def test_should_persist_allowed_library_ids_when_supplied(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        response = await client.post(
+            PROFILES_PATH,
+            json={
+                "name": "Lucas",
+                "allowed_library_ids": ["lib_movies123456", "lib_series123456"],
+            },
+        )
+
+        assert response.status_code == 201
+        created = response.json()["data"]
+        assert created["allowed_library_ids"] == ["lib_movies123456", "lib_series123456"]
+
 
 class TestUpdateProfile:
     async def test_should_apply_partial_update(
@@ -158,6 +193,68 @@ class TestUpdateProfile:
             json={"name": "Whatever"},
         )
         assert response.status_code == 404
+
+    async def test_should_replace_allowed_library_ids_when_supplied(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        response = await client.put(
+            f"{PROFILES_PATH}/{user.profile_external_id}",
+            json={"allowed_library_ids": ["lib_grant1235678"]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["data"]["allowed_library_ids"] == ["lib_grant1235678"]
+
+    async def test_should_revoke_all_libraries_with_explicit_empty_list(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        # Empty list is meaningful: revoke every library. Distinct
+        # from "field omitted" (None), which leaves the ACL alone.
+        user = await seed_user_with_profile()
+        await _login(client, user)
+        await client.put(
+            f"{PROFILES_PATH}/{user.profile_external_id}",
+            json={"allowed_library_ids": ["lib_grant1235678"]},
+        )
+
+        response = await client.put(
+            f"{PROFILES_PATH}/{user.profile_external_id}",
+            json={"allowed_library_ids": []},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["data"]["allowed_library_ids"] == []
+
+    async def test_should_leave_allowed_library_ids_alone_when_omitted(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        # PATCH-style semantics: omitted field never touches the
+        # underlying value, even when other fields are updated.
+        user = await seed_user_with_profile()
+        await _login(client, user)
+        await client.put(
+            f"{PROFILES_PATH}/{user.profile_external_id}",
+            json={"allowed_library_ids": ["lib_keepvalue12"]},
+        )
+
+        response = await client.put(
+            f"{PROFILES_PATH}/{user.profile_external_id}",
+            json={"name": "Renamed"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()["data"]
+        assert body["name"] == "Renamed"
+        assert body["allowed_library_ids"] == ["lib_keepvalue12"]
 
 
 class TestDeleteProfile:

--- a/tests/modules/identity/integration/persistence/test_sqlalchemy_profile_repository.py
+++ b/tests/modules/identity/integration/persistence/test_sqlalchemy_profile_repository.py
@@ -1,12 +1,17 @@
 """Integration tests for SqlAlchemyProfileRepository."""
 
 import pytest
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.modules.identity.domain.entities.profile import Profile
 from src.modules.identity.domain.entities.user import User
 from src.modules.identity.domain.value_objects.email import Email
 from src.modules.identity.domain.value_objects.profile_name import ProfileName
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId
 
@@ -140,6 +145,44 @@ class TestSqlAlchemyProfileRepositorySave:
 
         assert found is not None
         assert found.allowed_library_ids == []
+
+    async def test_should_coerce_corrupted_allowed_library_ids_to_empty(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        db_session: AsyncSession,
+    ) -> None:
+        # A corrupted JSON payload (e.g. an old deploy that wrote a
+        # scalar) must never be interpreted as "grant something" — the
+        # mapper coerces to an empty list and logs a warning so the
+        # corruption is observable in dashboards rather than silently
+        # turning a deny-all ACL into anything else.
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            saved = await uow.profiles.save(
+                Profile.create(
+                    user_id=owner.id,
+                    name=ProfileName("L"),
+                    allowed_library_ids=["lib_originaltttt"],
+                )
+            )
+
+        # Force a corrupted payload directly into the row (simulates
+        # an older release writing a non-list value).
+        assert saved.id is not None
+        await db_session.execute(
+            update(ProfileModel)
+            .where(ProfileModel.external_id == saved.id.value)
+            .values(allowed_library_ids='{"not": "a list"}')
+        )
+        await db_session.commit()
+
+        async with uow_factory() as uow:
+            after = await uow.profiles.find_by_id(saved.id)
+
+        assert after is not None
+        assert after.allowed_library_ids == []
 
     async def test_save_should_replace_allowed_library_ids_on_update(
         self, uow_factory: IdentityUnitOfWorkFactory

--- a/tests/modules/identity/integration/persistence/test_sqlalchemy_profile_repository.py
+++ b/tests/modules/identity/integration/persistence/test_sqlalchemy_profile_repository.py
@@ -97,6 +97,80 @@ class TestSqlAlchemyProfileRepositorySave:
                     Profile.create(user_id=ghost_user_id, name=ProfileName("Ghost"))
                 )
 
+    async def test_should_round_trip_allowed_library_ids(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        granted = ["lib_movies123456", "lib_series123456"]
+        async with uow_factory() as uow:
+            saved = await uow.profiles.save(
+                Profile.create(
+                    user_id=owner.id,
+                    name=ProfileName("Lucas"),
+                    allowed_library_ids=granted,
+                )
+            )
+
+        assert saved.id is not None
+        async with uow_factory() as uow:
+            found = await uow.profiles.find_by_id(saved.id)
+
+        assert found is not None
+        assert found.allowed_library_ids == granted
+
+    async def test_should_default_allowed_library_ids_to_empty_when_unset(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        # Default-deny: a freshly persisted profile with no explicit
+        # ACL must round-trip as an empty list, not as null or any
+        # legacy "see everything" sentinel.
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            saved = await uow.profiles.save(
+                Profile.create(user_id=owner.id, name=ProfileName("Anon"))
+            )
+
+        async with uow_factory() as uow:
+            assert saved.id is not None
+            found = await uow.profiles.find_by_id(saved.id)
+
+        assert found is not None
+        assert found.allowed_library_ids == []
+
+    async def test_save_should_replace_allowed_library_ids_on_update(
+        self, uow_factory: IdentityUnitOfWorkFactory
+    ):
+        # The aggregate's with_allowed_library_ids replaces the list
+        # entirely; persistence must mirror that semantics so a
+        # subsequent revoke (passing []) is durable.
+        owner = await _seed_user(uow_factory)
+        assert owner.id is not None
+
+        async with uow_factory() as uow:
+            original = await uow.profiles.save(
+                Profile.create(
+                    user_id=owner.id,
+                    name=ProfileName("L"),
+                    allowed_library_ids=["lib_a", "lib_b"],
+                )
+            )
+
+        revoked = original.with_allowed_library_ids([])
+
+        async with uow_factory() as uow:
+            await uow.profiles.save(revoked)
+
+        async with uow_factory() as uow:
+            assert original.id is not None
+            after = await uow.profiles.find_by_id(original.id)
+
+        assert after is not None
+        assert after.allowed_library_ids == []
+
 
 class TestSqlAlchemyProfileRepositoryReads:
     async def test_find_by_id_should_return_none_for_unknown_profile(

--- a/tests/modules/identity/unit/domain/entities/test_profile.py
+++ b/tests/modules/identity/unit/domain/entities/test_profile.py
@@ -84,3 +84,60 @@ class TestProfileEquality:
         b = Profile(id=pid, user_id=_user_id(), name=ProfileName("Other"))
 
         assert a == b
+
+
+class TestProfileAllowedLibraryIds:
+    def test_should_default_to_empty_list_when_unset(self):
+        profile = Profile.create(user_id=_user_id(), name=ProfileName("L"))
+
+        # Default-deny — the ACL is empty, not "everything".
+        assert profile.allowed_library_ids == []
+
+    def test_should_default_to_empty_when_factory_sees_none(self):
+        profile = Profile.create(
+            user_id=_user_id(), name=ProfileName("L"), allowed_library_ids=None
+        )
+
+        assert profile.allowed_library_ids == []
+
+    def test_should_accept_explicit_list_at_creation(self):
+        profile = Profile.create(
+            user_id=_user_id(),
+            name=ProfileName("L"),
+            allowed_library_ids=["lib_movies123456", "lib_series123456"],
+        )
+
+        assert profile.allowed_library_ids == ["lib_movies123456", "lib_series123456"]
+
+    def test_factory_should_copy_input_list(self):
+        # The aggregate must not alias caller-owned lists; otherwise
+        # an outside mutation would leak past the with_* boundary.
+        ids = ["lib_a"]
+        profile = Profile.create(user_id=_user_id(), name=ProfileName("L"), allowed_library_ids=ids)
+        ids.append("lib_b")
+
+        assert profile.allowed_library_ids == ["lib_a"]
+
+    def test_with_allowed_library_ids_should_replace_entirely(self):
+        original = Profile.create(
+            user_id=_user_id(),
+            name=ProfileName("L"),
+            allowed_library_ids=["lib_old"],
+        )
+
+        updated = original.with_allowed_library_ids(["lib_new1", "lib_new2"])
+
+        assert original.allowed_library_ids == ["lib_old"]
+        assert updated.allowed_library_ids == ["lib_new1", "lib_new2"]
+        assert updated is not original
+
+    def test_with_allowed_library_ids_should_accept_empty_list_to_revoke(self):
+        original = Profile.create(
+            user_id=_user_id(),
+            name=ProfileName("L"),
+            allowed_library_ids=["lib_a", "lib_b"],
+        )
+
+        revoked = original.with_allowed_library_ids([])
+
+        assert revoked.allowed_library_ids == []


### PR DESCRIPTION
## Summary

- Adds ``allowed_library_ids: list[str]`` to the Profile aggregate as the source of truth for which catalog libraries each profile may see. Default-deny — empty list means no access.
- Stored as JSON-encoded TEXT on ``profiles.allowed_library_ids`` (NOT NULL, ``server_default='[]'``). Reads are always ""the whole list per profile"" and library cardinality is small, so a join table would buy nothing.
- Migration ``c1d2e3f4a5b6`` follows the standard 3-step pattern. Backfill takes a snapshot of every active library external_id at migration time so existing profiles preserve their pre-ACL ""see everything"" experience without auto-granting access to libraries added later.
- DTOs and routes follow the existing PATCH-style convention: ``allowed_library_ids: None`` means ""omitted"" (don't touch the ACL); explicit ``[]`` means ""revoke every library""; an explicit list replaces the ACL entirely.

## Why split from PR 6 (and even from PR 6b)

PR 6 of the master plan was ""Profile ACL via allowed_library_ids + filter catalog reads"". After PR 6a (``library_id`` FK on Movie/Series, prerequisite), the remaining work is ~70 files when bundled. Splitting again:

- **PR 6b (this one)**: schema + API surface only. ~13 files. Frontend can already build the admin UI for granting / revoking libraries against this contract.
- **PR 6c (next)**: ProfileLibraryAccessPort + filter catalog reads — the riskier behavioral change with FF rollout, isolated for review.

## Test plan

- [x] ``poetry run pytest tests/modules/identity -q`` → 160 passed (was 146 — +14 new).
- [x] ``poetry run pytest -q`` → 2189 passed, 5 skipped — no regressions in other BCs.
- [x] ``ruff check`` and ``ruff format --check`` clean across the diff.
- [x] Migration smoke against fresh SQLite: ``alembic upgrade head`` lands ``allowed_library_ids TEXT NOT NULL DEFAULT '[]'`` on ``profiles``.
- [x] Backfill smoke: downgrade one revision, seed a user + profile + two libraries, upgrade — the legacy profile picks up the snapshot ``[""lib_x"", ""lib_y""]`` so today's behavior is preserved.
- [x] Mapper round-trip integration test (set / read / replace / revoke).
- [x] e2e tests for the create + update routes covering default-deny, explicit grant, explicit revoke, and PATCH-omit semantics.

## Summary by Sourcery

Add profile-level allowed_library_ids ACL list and wire it through domain, persistence, and API layers with default-deny semantics.

New Features:
- Introduce allowed_library_ids ACL list on profiles to control which libraries each profile can access.
- Expose allowed_library_ids on profile create/update requests and profile responses with PATCH-style semantics.

Enhancements:
- Persist allowed_library_ids as a JSON-encoded TEXT column on profiles with a migration that backfills existing profiles to their current library set.
- Update profile domain entity and mapper to treat allowed_library_ids as default-empty, fully replacing the list on updates, and to safely decode malformed data.

Tests:
- Add unit, integration, and e2e tests covering default-deny behavior, ACL round-tripping, replacement, revocation, and omission semantics.