### PR TITLE
refactor(identity): centralize resolve_profile_id factory

### DIFF
--- a/src/modules/collections/presentation/dependencies.py
+++ b/src/modules/collections/presentation/dependencies.py
@@ -1,43 +1,18 @@
 """FastAPI dependency that resolves the caller's ``profile_id`` for collections.
 
-Same per-profile rollout pattern documented in
-``watch_progress/presentation/dependencies.py``: try the
-authenticated path first, fall back to
-``settings.collections_default_profile_id`` when no cookie is
-present, raise 401 otherwise. Once strict mode is acceptable
-project-wide, this dep can be replaced by a direct re-export of
-``identity.presentation.dependencies.get_current_profile``.
+Thin wrapper around the centralised
+``identity.presentation.dependencies.make_resolve_profile_id``
+factory, parameterised with the collections-specific transitional
+setting and 401 message. See the factory's docstring for resolution
+semantics.
 """
 
-from fastapi import Request
+from src.modules.identity.presentation.dependencies import make_resolve_profile_id
 
-from src.config.settings import get_settings
-from src.modules.identity.domain.errors import NoActiveSessionError
-
-
-async def resolve_profile_id(request: Request) -> str:
-    """Return the caller's profile_id (prefixed external ID).
-
-    Errors raised by the identity UoW (container not wired, DB
-    unreachable, etc.) propagate as 500 by design — silently falling
-    back to anonymous on real misconfigurations would mask bugs and
-    serve authenticated requests as anonymous.
-    """
-    settings = get_settings()
-
-    token = request.cookies.get(settings.session_cookie_name)
-    if token is not None:
-        container = request.app.state.container
-        factory = container.identity.identity_unit_of_work_factory()
-        async with factory() as uow:
-            snap = await uow.access_tokens.get_by_token(token)
-        if snap is not None and snap.current_profile_id is not None:
-            return str(snap.current_profile_id)
-
-    if settings.collections_default_profile_id:
-        return settings.collections_default_profile_id
-
-    raise NoActiveSessionError(message="Authentication required to access collections")
+resolve_profile_id = make_resolve_profile_id(
+    setting_attr="collections_default_profile_id",
+    missing_message="Authentication required to access collections",
+)
 
 
 __all__ = ["resolve_profile_id"]

--- a/src/modules/identity/presentation/dependencies.py
+++ b/src/modules/identity/presentation/dependencies.py
@@ -1,22 +1,29 @@
 """FastAPI dependencies that resolve the caller's identity context.
 
-The single entry point is ``get_current_profile``: it combines the
-authenticated ``UserModel`` from FastAPI Users with the active
-``profile_id`` carried by the session row, returning a
-``ProfileContext`` with both as prefixed external IDs (UUIDs never
-cross into the domain).
+Two layers:
 
-Shipped in PR 1 deliberately unused — the consumer BCs
-(``watch_progress``, ``collections``, ``preferences``) pick this up
-in subsequent PRs to enforce per-profile isolation. Adding it now
-means PR 2 can import the dependency on day one without waiting on
-any further wiring.
+1. ``get_current_profile`` — the strict-mode dep. Combines the
+   authenticated ``UserModel`` from FastAPI Users with the active
+   ``profile_id`` carried by the session row, returning a
+   ``ProfileContext`` with both as prefixed external IDs (UUIDs
+   never cross into the domain).
+2. ``make_resolve_profile_id`` — the transitional factory. Returns
+   a per-BC dep that tries the cookie path first and falls back to
+   a configured ``*_default_profile_id`` setting when the request
+   has no session yet. Each consumer BC (``watch_progress``,
+   ``collections``, ``preferences``, ``media``) wires its own
+   bound dep at module level, parameterising the setting attribute
+   and the missing-session error message. Once every consumer
+   ships login support and the env vars are unset, the helpers
+   collapse into a direct re-export of ``get_current_profile``.
 """
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from fastapi import Depends, Request
 
+from src.config.settings import get_settings
 from src.modules.identity.domain.errors import (
     NoActiveProfileSelectedError,
     NoActiveSessionError,
@@ -88,4 +95,64 @@ async def get_current_profile(
     )
 
 
-__all__ = ["ProfileContext", "get_current_profile"]
+def make_resolve_profile_id(
+    *,
+    setting_attr: str,
+    missing_message: str,
+) -> Callable[[Request], Awaitable[str]]:
+    """Build a per-BC ``resolve_profile_id`` dep with a transitional fallback.
+
+    Resolution order at request time:
+
+    1. Session cookie present → look up the matching ``access_tokens``
+       row in the identity BC's UoW. If a ``current_profile_id``
+       exists, return it.
+    2. No usable cookie or unknown token + the configured
+       ``settings.<setting_attr>`` is set → return that fallback
+       (transition mode).
+    3. Otherwise → raise :class:`NoActiveSessionError` (HTTP 401)
+       with ``missing_message``.
+
+    Errors raised by the identity UoW (container not wired, DB
+    unreachable, etc.) propagate as 500 by design — silently falling
+    back to anonymous on real misconfigurations would mask bugs and
+    serve authenticated requests as anonymous.
+
+    Args:
+        setting_attr: Name of the field on ``Settings`` that holds
+            the per-BC fallback (e.g. ``"watch_progress_default_profile_id"``).
+            ``getattr`` is read every request so changes to the
+            setting (when sourced from a re-loaded ``.env``) take
+            effect without restarting.
+        missing_message: User-facing 401 message when neither path
+            resolves a profile.
+
+    Returns:
+        An ``async`` FastAPI dep returning the prefixed profile_id
+        as a plain ``str`` — kept primitive because every consumer
+        passes it straight into a use case input that already
+        validates the prefix.
+    """
+
+    async def resolve_profile_id(request: Request) -> str:
+        settings = get_settings()
+
+        token = request.cookies.get(settings.session_cookie_name)
+        if token is not None:
+            container = request.app.state.container
+            factory = container.identity.identity_unit_of_work_factory()
+            async with factory() as uow:
+                snap = await uow.access_tokens.get_by_token(token)
+            if snap is not None and snap.current_profile_id is not None:
+                return str(snap.current_profile_id)
+
+        fallback = getattr(settings, setting_attr)
+        if fallback:
+            return str(fallback)
+
+        raise NoActiveSessionError(message=missing_message)
+
+    return resolve_profile_id
+
+
+__all__ = ["ProfileContext", "get_current_profile", "make_resolve_profile_id"]

--- a/src/modules/preferences/presentation/dependencies.py
+++ b/src/modules/preferences/presentation/dependencies.py
@@ -1,44 +1,18 @@
 """FastAPI dependency that resolves the caller's ``profile_id`` for preferences.
 
-Same per-profile rollout pattern documented in
-``watch_progress/presentation/dependencies.py`` and
-``collections/presentation/dependencies.py``: try the authenticated
-path first, fall back to ``settings.preferences_default_profile_id``
-when no cookie is present, raise 401 otherwise. Once strict mode is
-acceptable project-wide this dep, along with its siblings, can be
-collapsed into a direct re-export of
-``identity.presentation.dependencies.get_current_profile``.
+Thin wrapper around the centralised
+``identity.presentation.dependencies.make_resolve_profile_id``
+factory, parameterised with the preferences-specific transitional
+setting and 401 message. See the factory's docstring for resolution
+semantics.
 """
 
-from fastapi import Request
+from src.modules.identity.presentation.dependencies import make_resolve_profile_id
 
-from src.config.settings import get_settings
-from src.modules.identity.domain.errors import NoActiveSessionError
-
-
-async def resolve_profile_id(request: Request) -> str:
-    """Return the caller's profile_id (prefixed external ID).
-
-    Errors raised by the identity UoW (container not wired, DB
-    unreachable, etc.) propagate as 500 by design — silently falling
-    back to anonymous on real misconfigurations would mask bugs and
-    serve authenticated requests as anonymous.
-    """
-    settings = get_settings()
-
-    token = request.cookies.get(settings.session_cookie_name)
-    if token is not None:
-        container = request.app.state.container
-        factory = container.identity.identity_unit_of_work_factory()
-        async with factory() as uow:
-            snap = await uow.access_tokens.get_by_token(token)
-        if snap is not None and snap.current_profile_id is not None:
-            return str(snap.current_profile_id)
-
-    if settings.preferences_default_profile_id:
-        return settings.preferences_default_profile_id
-
-    raise NoActiveSessionError(message="Authentication required to access preferences")
+resolve_profile_id = make_resolve_profile_id(
+    setting_attr="preferences_default_profile_id",
+    missing_message="Authentication required to access preferences",
+)
 
 
 __all__ = ["resolve_profile_id"]

--- a/src/modules/watch_progress/presentation/dependencies.py
+++ b/src/modules/watch_progress/presentation/dependencies.py
@@ -1,57 +1,18 @@
-"""FastAPI dependencies that resolve the caller's ``profile_id``.
+"""FastAPI dependency that resolves the caller's ``profile_id``.
 
-During the per-profile rollout (see ADR-010), watch_progress routes
-need a way to scope data by profile *before* every consumer is sending
-the session cookie. ``resolve_profile_id`` implements the transition
-strategy: try the authenticated path first, fall back to the
-configured ``watch_progress_default_profile_id`` setting when no
-cookie is present, and finally raise ``NoActiveSessionError`` (HTTP
-401) if neither works.
-
-Once every consumer ships login support, unset the
-``WATCH_PROGRESS_DEFAULT_PROFILE_ID`` env var so the dependency runs
-strictly — at that point we can also collapse this dep into a direct
-re-export of ``identity.presentation.dependencies.get_current_profile``.
+Thin wrapper around the centralised
+``identity.presentation.dependencies.make_resolve_profile_id``
+factory, parameterised with the watch-progress-specific transitional
+setting and 401 message. See the factory's docstring for resolution
+semantics.
 """
 
-from fastapi import Request
+from src.modules.identity.presentation.dependencies import make_resolve_profile_id
 
-from src.config.settings import get_settings
-from src.modules.identity.domain.errors import NoActiveSessionError
-
-
-async def resolve_profile_id(request: Request) -> str:
-    """Return the caller's profile_id (prefixed external ID).
-
-    Resolution order:
-
-    1. Session cookie present → look up the matching access_tokens row
-       in the identity BC's UoW. If a ``current_profile_id`` exists,
-       return it.
-    2. No usable cookie or unknown token + ``watch_progress_default_profile_id``
-       setting configured → return that fallback (transition mode).
-    3. Otherwise → raise :class:`NoActiveSessionError` (HTTP 401).
-
-    Errors raised by the identity UoW (container not wired, DB
-    unreachable, etc.) propagate as 500 by design — silently falling
-    back to anonymous on real misconfigurations would mask bugs and
-    let authenticated requests be served as anonymous data.
-    """
-    settings = get_settings()
-
-    token = request.cookies.get(settings.session_cookie_name)
-    if token is not None:
-        container = request.app.state.container
-        factory = container.identity.identity_unit_of_work_factory()
-        async with factory() as uow:
-            snap = await uow.access_tokens.get_by_token(token)
-        if snap is not None and snap.current_profile_id is not None:
-            return str(snap.current_profile_id)
-
-    if settings.watch_progress_default_profile_id:
-        return settings.watch_progress_default_profile_id
-
-    raise NoActiveSessionError(message="Authentication required to access watch progress")
+resolve_profile_id = make_resolve_profile_id(
+    setting_attr="watch_progress_default_profile_id",
+    missing_message="Authentication required to access watch progress",
+)
 
 
 __all__ = ["resolve_profile_id"]


### PR DESCRIPTION
## Summary

- Lifts the per-BC ``resolve_profile_id`` duplication (3 identical implementations across watch_progress / collections / preferences) into ``identity/presentation/dependencies.py`` as a parameterised ``make_resolve_profile_id`` factory.
- Each consumer BC's ``dependencies.py`` is now a 5-line wrapper binding the module-level dep with its setting attribute and missing-session message. Route imports unchanged (``from src.modules.X.presentation.dependencies import resolve_profile_id``).
- Pre-PR-6c housekeeping: the upcoming media dep will land as a 4th wrapper consuming the same helper instead of creating yet another copy.

## Why now

Sourcery flagged the duplication on PR #173 with the note "consider centralising this logic so cookie handling / fallback behaviour doesn't drift between modules over time." The deferral was right at the time (3 copies, scope discipline), but with PR 6c about to add a 4th copy, the abstraction is now genuinely earned.

## Behavior change

None. Identical resolution semantics:

1. Cookie present → identity UoW lookup → return ``current_profile_id`` if set
2. No cookie / unknown token + per-BC ``*_default_profile_id`` setting non-empty → return fallback
3. Otherwise → 401 with per-BC message

The factory reads ``getattr(settings, setting_attr)`` per request so a reloaded .env still takes effect without restart, matching the prior per-BC behavior.

## Test plan

- [x] ``poetry run pytest -q`` → 2190 passed, 5 skipped — no regressions across the existing e2e tests for watch_progress / collections / preferences which already exercise all three resolution branches.
- [x] ``ruff check`` and ``ruff format --check`` clean across the diff.
- [ ] Quick manual smoke after merge: hit one of the per-profile routes with and without the cookie + with and without the fallback env var to confirm the strict / transition matrix still behaves identically.

## Summary by Sourcery

Centralize profile ID resolution logic into the identity module and update bounded contexts to reuse a shared dependency factory.

Enhancements:
- Introduce a reusable make_resolve_profile_id factory in the identity presentation layer for cookie- and fallback-based profile resolution.
- Refactor watch_progress, preferences, and collections dependencies to thin wrappers around the shared profile resolution factory, keeping behavior unchanged.