### PR TITLE
feat(media): filter catalog reads by Profile.allowed_library_ids (PR 6c)

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -22,7 +22,13 @@ from src.infrastructure.scheduling import (
     LibraryScanScheduler,
     ThumbnailBackfillJob,
 )
-from src.modules.media.infrastructure.acl import ProgressLookupAdapter
+from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyIdentityUnitOfWorkFactory,
+)
+from src.modules.media.infrastructure.acl import (
+    ProfileLibraryAccessAdapter,
+    ProgressLookupAdapter,
+)
 from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyWatchProgressUnitOfWorkFactory,
 )
@@ -82,6 +88,19 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         default_profile_id=config.provided.watch_progress_default_profile_id,
     )
 
+    # Same pattern for the per-profile library ACL: built at the
+    # composition root with its own identity UoW factory so the
+    # Media container stays free of an Identity import.
+    _identity_uow_factory_for_profile_library_access = providers.Singleton(
+        SqlAlchemyIdentityUnitOfWorkFactory,
+        session_factory=infrastructure.session_factory,
+    )
+
+    _profile_library_access_adapter = providers.Factory(
+        ProfileLibraryAccessAdapter,
+        identity_uow_factory=_identity_uow_factory_for_profile_library_access,
+    )
+
     # Catalog Requests is built before Media so its ACL adapter can be
     # plumbed into the Media container as the ``CatalogRequestLookupPort``
     # implementation. Catalog Requests itself takes no Media dependency,
@@ -96,6 +115,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         session_factory=infrastructure.session_factory,
         event_bus=infrastructure.event_bus,
         progress_lookup=_progress_lookup_adapter,
+        profile_library_access=_profile_library_access_adapter,
         catalog_request_lookup=catalog_requests.catalog_request_lookup,
         tmdb_api_key=config.provided.tmdb_api_key,
         hls_cache_directory=config.provided.hls_cache_directory,

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -103,6 +103,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # ``CatalogRequestLookupPort``.
     catalog_request_lookup = providers.Dependency()
 
+    # Wired at the composition root — the adapter reads
+    # ``Profile.allowed_library_ids`` via the Identity UoW so this
+    # BC only ever sees ``ProfileLibraryAccessPort``.
+    profile_library_access = providers.Dependency()
+
     # Must be wired from parent container (Settings.hls_cache_directory / hls_cache_max_size_mb)
     hls_cache_directory = providers.Dependency(default="./hls_cache")
     hls_cache_max_size_mb = providers.Dependency(default=5120)
@@ -135,21 +140,25 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     get_featured_media = providers.Factory(
         GetFeaturedMediaUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     get_movie_by_id = providers.Factory(
         GetMovieByIdUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     list_movies = providers.Factory(
         ListMoviesUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     list_recently_added_movies = providers.Factory(
         ListRecentlyAddedMoviesUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     delete_movie = providers.Factory(
@@ -161,16 +170,19 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         GetSeriesByIdUseCase,
         uow_factory=media_unit_of_work_factory,
         progress_lookup=progress_lookup,
+        profile_library_access=profile_library_access,
     )
 
     list_series = providers.Factory(
         ListSeriesUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     list_recently_added_series = providers.Factory(
         ListRecentlyAddedSeriesUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     # =========================================================================
@@ -180,26 +192,31 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     list_genres = providers.Factory(
         ListGenresUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     list_by_genre = providers.Factory(
         ListByGenreUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     list_movies_by_actor = providers.Factory(
         ListMoviesByActorUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     list_recently_added_catalog = providers.Factory(
         ListRecentlyAddedCatalogUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     search_catalog = providers.Factory(
         SearchCatalogUseCase,
         uow_factory=media_unit_of_work_factory,
+        profile_library_access=profile_library_access,
     )
 
     # =========================================================================
@@ -356,6 +373,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         GetRelatedMoviesUseCase,
         uow_factory=media_unit_of_work_factory,
         metadata_provider=tmdb_client,
+        profile_library_access=profile_library_access,
     )
 
     get_collection_by_tmdb_id = providers.Factory(
@@ -363,6 +381,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         uow_factory=media_unit_of_work_factory,
         metadata_provider=tmdb_client,
         catalog_request_lookup=catalog_request_lookup,
+        profile_library_access=profile_library_access,
     )
 
     get_person_bio = providers.Factory(
@@ -380,6 +399,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         GetRelatedSeriesUseCase,
         uow_factory=media_unit_of_work_factory,
         metadata_provider=tmdb_client,
+        profile_library_access=profile_library_access,
     )
 
     bulk_enrich_metadata = providers.Factory(

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -288,6 +288,16 @@ class Settings(BaseSettings):  # type: ignore[misc]
         "together while the frontend is being migrated, then removes "
         "them to enter strict mode.",
     )
+    media_default_profile_id: str | None = Field(
+        default=None,
+        description="Optional fallback ``profile_id`` (``prf_xxx``) "
+        "used by media routes (catalog list/search/get/stream) when "
+        "the request has no session cookie. Lets the backend keep "
+        "serving consumers that have not shipped login yet during "
+        "the per-profile rollout. Unset = strict mode (no cookie -> "
+        "401). Remove the env var once every consumer is sending "
+        "the session cookie.",
+    )
     collections_default_profile_id: str | None = Field(
         default=None,
         description="Optional fallback ``profile_id`` for the collections "

--- a/src/modules/media/application/dtos/catalog_dtos.py
+++ b/src/modules/media/application/dtos/catalog_dtos.py
@@ -40,6 +40,10 @@ class ListGenresInput:
     """Input for ``ListGenresUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts the
+            aggregation to libraries the profile may see; a deny-all
+            profile yields an empty genre list without opening a UoW.
         lang: Language code used to resolve the localized display
             name for each canonical genre.
         media_type: Optional filter — when set to ``"movie"`` or
@@ -48,6 +52,7 @@ class ListGenresInput:
             that media type alone. ``None`` (default) aggregates both.
     """
 
+    profile_id: str
     lang: str = "en"
     media_type: MediaTypeFilter | None = None
 
@@ -100,6 +105,10 @@ class ListByGenreInput:
     """Input for ``ListByGenreUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts both
+            streams to libraries the profile may see; a deny-all
+            profile yields an empty page without opening a UoW.
         genre: Canonical English genre id — same value the frontend
             received from ``ListGenresOutput.genres[*].id``.
         cursor: Opaque dual-stream cursor from the previous page, or
@@ -111,6 +120,7 @@ class ListByGenreInput:
             (default) merges both streams as usual.
     """
 
+    profile_id: str
     genre: str
     cursor: str | None = None
     limit: int = DEFAULT_PAGE_SIZE
@@ -140,12 +150,17 @@ class ListRecentlyAddedCatalogInput:
     """Input for ``ListRecentlyAddedCatalogUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts both
+            streams to libraries the profile may see; a deny-all
+            profile yields an empty list without opening a UoW.
         limit: Maximum number of mixed items to return. Routes clamp
             this to a sane upper bound before constructing the input.
         lang: Language code for localized titles, synopses, and genre
             names returned in each item.
     """
 
+    profile_id: str
     limit: int = 20
     lang: str = "en"
 

--- a/src/modules/media/application/dtos/collection_dtos.py
+++ b/src/modules/media/application/dtos/collection_dtos.py
@@ -10,6 +10,13 @@ class GetCollectionByTmdbIdInput:
     """Input for ``GetCollectionByTmdbIdUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts the
+            local-catalog overlay (which titles are marked
+            ``in_catalog``) to libraries the profile may see. The
+            TMDB call itself is unaffected — the page still lists
+            every TMDB part. A deny-all profile sees every part as
+            missing, without opening a UoW.
         tmdb_id: TMDB collection id (e.g. ``8091`` for Alien
             Collection).
         lang: BCP-47 tag for localized titles, overview, and the
@@ -17,6 +24,7 @@ class GetCollectionByTmdbIdInput:
             the rest of the read-side use cases.
     """
 
+    profile_id: str
     tmdb_id: int
     lang: str = "en"
 

--- a/src/modules/media/application/dtos/featured_dtos.py
+++ b/src/modules/media/application/dtos/featured_dtos.py
@@ -10,11 +10,16 @@ class GetFeaturedInput:
     """Input for GetFeaturedMediaUseCase.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts the
+            random pool to libraries the profile may see; a deny-all
+            profile yields an empty list without opening a UoW.
         media_type: Filter by type — "all", "movie", or "series".
         limit: Maximum number of items to return.
         lang: Language code for localized metadata.
     """
 
+    profile_id: str
     media_type: str = "all"
     limit: int = 6
     lang: str = "en"

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -16,10 +16,16 @@ class GetMovieByIdInput:
     """Input for GetMovieByIdUseCase.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case looks
+            up the per-profile library ACL through
+            ``ProfileLibraryAccessPort`` and restricts the lookup to
+            those libraries — a row outside the ACL surfaces as
+            ``ResourceNotFoundException`` (404).
         movie_id: External ID of the movie (mov_xxx format).
         lang: Language code for localized metadata (e.g., "en", "pt-BR").
     """
 
+    profile_id: str
     movie_id: str
     lang: str = "en"
 
@@ -172,6 +178,10 @@ class ListMoviesInput:
     """Input for ListMoviesUseCase.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts the
+            page to libraries the profile may see; a deny-all profile
+            yields an empty page without opening a UoW.
         cursor: Opaque pagination cursor from the previous page's
             ``next_cursor``. ``None`` (or any invalid token) starts at
             the first page.
@@ -185,6 +195,7 @@ class ListMoviesInput:
         lang: Language code for localized metadata.
     """
 
+    profile_id: str
     cursor: str | None = None
     limit: int = DEFAULT_PAGE_SIZE
     include_total: bool = False
@@ -218,11 +229,16 @@ class ListRecentlyAddedMoviesInput:
     """Input for ``ListRecentlyAddedMoviesUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts the
+            top-N to libraries the profile may see; a deny-all
+            profile yields an empty list without opening a UoW.
         limit: Maximum number of movies to return. Routes clamp this
             to a sane upper bound before constructing the input.
         lang: Language code for localized metadata.
     """
 
+    profile_id: str
     limit: int = 20
     lang: str = "en"
 

--- a/src/modules/media/application/dtos/search_dtos.py
+++ b/src/modules/media/application/dtos/search_dtos.py
@@ -13,6 +13,11 @@ class SearchInput:
     """Input for ``SearchCatalogUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts both
+            repositories' searches to libraries the profile may see;
+            a deny-all profile yields an empty result without opening
+            a UoW.
         query: Full-text search string. Supports prefix matching
             (e.g. ``"incep"`` matches ``"Inception"``).
         media_type: Optional filter — restrict to ``"movie"`` or
@@ -24,6 +29,7 @@ class SearchInput:
         limit: Max results to return.
     """
 
+    profile_id: str
     query: str
     media_type: Literal["movie", "series"] | None = None
     genre: str | None = None

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -168,10 +168,16 @@ class GetSeriesByIdInput:
     """Input for GetSeriesByIdUseCase.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case looks
+            up the per-profile library ACL through
+            ``ProfileLibraryAccessPort`` and restricts the lookup to
+            those libraries — a row outside the ACL surfaces as
+            ``ResourceNotFoundException`` (404).
         series_id: External ID of the series (ser_xxx format).
         lang: Language code for localized metadata.
     """
 
+    profile_id: str
     series_id: str
     lang: str = "en"
 
@@ -181,6 +187,10 @@ class ListSeriesInput:
     """Input for ListSeriesUseCase.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts the
+            page to libraries the profile may see; a deny-all profile
+            yields an empty page without opening a UoW.
         cursor: Opaque pagination cursor from the previous page's
             ``next_cursor``. ``None`` (or any invalid token) starts at
             the first page.
@@ -192,6 +202,7 @@ class ListSeriesInput:
         lang: Language code for localized metadata.
     """
 
+    profile_id: str
     cursor: str | None = None
     limit: int = DEFAULT_PAGE_SIZE
     include_total: bool = False
@@ -224,11 +235,16 @@ class ListRecentlyAddedSeriesInput:
     """Input for ``ListRecentlyAddedSeriesUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts the
+            top-N to libraries the profile may see; a deny-all
+            profile yields an empty list without opening a UoW.
         limit: Maximum number of series to return. Routes clamp this
             to a sane upper bound before constructing the input.
         lang: Language code for localized metadata.
     """
 
+    profile_id: str
     limit: int = 20
     lang: str = "en"
 

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -32,6 +32,9 @@ from src.modules.media.application.ports.metadata_provider_port import (
     PersonMetadata,
     SeasonMetadata,
 )
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.ports.progress_lookup_port import (
     ProgressLookupPort,
     ProgressSummary,
@@ -61,6 +64,7 @@ __all__ = [
     "MetadataProvider",
     "PersonMetadata",
     "ProbeResult",
+    "ProfileLibraryAccessPort",
     "ProgressLookupPort",
     "ProgressSummary",
     "ScannedFile",

--- a/src/modules/media/application/ports/profile_library_access_port.py
+++ b/src/modules/media/application/ports/profile_library_access_port.py
@@ -1,0 +1,40 @@
+"""Port for resolving the libraries a profile is allowed to read.
+
+Per ADR-010, every catalog list endpoint filters by the caller's
+``Profile.allowed_library_ids``. Media doesn't own the profile data —
+this port is the only surface through which it reaches into the
+identity BC. The adapter lives in ``media.infrastructure.acl``.
+
+The port returns a plain ``list[str]`` rather than a frozen DTO
+because the only datum it carries is the list itself; wrapping
+adds zero invariants. The "no domain types" rule from ADR-009
+still holds — strings are primitive.
+
+See ADR-009 for the cross-BC read port pattern.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class ProfileLibraryAccessPort(ABC):
+    """Lookup the library ACL for a single profile."""
+
+    @abstractmethod
+    async def find_for_profile(self, profile_id: str) -> list[str]:
+        """Return the prefixed library_ids ``profile_id`` may see.
+
+        Args:
+            profile_id: Prefixed external id (``prf_xxx``).
+
+        Returns:
+            The profile's ``allowed_library_ids``. An empty list
+            means deny-all (the profile may see nothing). A missing
+            profile also returns an empty list — the safer default
+            than raising, because the caller's intent is "what can
+            this profile see?" and the answer is "nothing" if it
+            doesn't exist.
+        """
+        ...
+
+
+__all__ = ["ProfileLibraryAccessPort"]

--- a/src/modules/media/application/use_cases/get_collection_by_tmdb_id.py
+++ b/src/modules/media/application/use_cases/get_collection_by_tmdb_id.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
         CollectionPartMetadata,
         MetadataProvider,
     )
+    from src.modules.media.application.ports.profile_library_access_port import (
+        ProfileLibraryAccessPort,
+    )
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
     from src.modules.media.domain.entities.movie import Movie
 
@@ -63,6 +66,7 @@ class GetCollectionByTmdbIdUseCase:
         uow_factory: MediaUnitOfWorkFactory,
         metadata_provider: MetadataProvider,
         catalog_request_lookup: CatalogRequestLookupPort,
+        profile_library_access: ProfileLibraryAccessPort,
     ) -> None:
         """Initialize the use case.
 
@@ -71,16 +75,26 @@ class GetCollectionByTmdbIdUseCase:
             metadata_provider: TMDB (or compatible) metadata client.
             catalog_request_lookup: Cross-BC port for resolving
                 per-title request/notification status.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids. The TMDB call itself is unaffected
+                — only the local-catalog overlay (which titles render
+                with ``in_catalog=True``) is restricted.
         """
         self._uow_factory = uow_factory
         self._metadata = metadata_provider
         self._catalog_request_lookup = catalog_request_lookup
+        self._profile_library_access = profile_library_access
 
     async def execute(
         self,
         input_dto: GetCollectionByTmdbIdInput,
     ) -> CollectionDetailOutput:
-        """Run the lookup."""
+        """Run the lookup.
+
+        A deny-all profile still hits TMDB (the page is informational
+        about the franchise as a whole) but skips the local-catalog
+        overlay so every part renders as missing.
+        """
         collection = await self._metadata.get_collection(
             input_dto.tmdb_id,
             language=_to_bcp47(input_dto.lang),
@@ -91,11 +105,17 @@ class GetCollectionByTmdbIdUseCase:
                 str(input_dto.tmdb_id),
             )
 
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+
         # Cross-reference local catalog by TMDB id so we can stitch
         # the local mov_xxx + duration + artwork onto each TMDB part.
         part_tmdb_ids = [p.tmdb_id for p in collection.parts]
-        async with self._uow_factory() as uow:
-            local_movies = await uow.movies.find_by_tmdb_ids(part_tmdb_ids)
+        local_movies: dict[int, Movie] = {}
+        if allowed:
+            async with self._uow_factory() as uow:
+                local_movies = await uow.movies.find_by_tmdb_ids(
+                    part_tmdb_ids, allowed_library_ids=allowed
+                )
 
         # Per-title catalog-request status. Missing keys mean "no
         # request / no subscription" — the merge step defaults to

--- a/src/modules/media/application/use_cases/get_featured_media.py
+++ b/src/modules/media/application/use_cases/get_featured_media.py
@@ -6,6 +6,9 @@ from src.modules.media.application.dtos.featured_dtos import (
     FeaturedItemOutput,
     GetFeaturedInput,
 )
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
 
@@ -16,38 +19,64 @@ class GetFeaturedMediaUseCase:
     Fetches items with backdrop images from the database using
     random ordering, then maps to a flat output list.
 
+    Per ADR-010, the random pool is restricted to the caller's
+    ``Profile.allowed_library_ids`` via ``ProfileLibraryAccessPort``. A
+    deny-all profile short-circuits to an empty list without opening
+    the UoW.
+
     Example:
-        >>> use_case = GetFeaturedMediaUseCase(uow_factory)
-        >>> items = await use_case.execute(GetFeaturedInput(media_type="all", limit=6))
+        >>> use_case = GetFeaturedMediaUseCase(uow_factory, profile_library_access)
+        >>> items = await use_case.execute(
+        ...     GetFeaturedInput(profile_id="prf_abc", media_type="all", limit=6)
+        ... )
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: GetFeaturedInput) -> list[FeaturedItemOutput]:
         """Execute the use case.
 
         Args:
-            input_dto: Contains media_type, limit, and lang.
+            input_dto: Contains profile_id, media_type, limit, and lang.
 
         Returns:
             List of FeaturedItemOutput for the hero banner.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return []
+
         results: list[FeaturedItemOutput] = []
         lang = input_dto.lang
 
         async with self._uow_factory() as uow:
             if input_dto.media_type in ("all", "movie"):
-                movies = await uow.movies.find_random(input_dto.limit, with_backdrop=True)
+                movies = await uow.movies.find_random(
+                    input_dto.limit,
+                    with_backdrop=True,
+                    allowed_library_ids=allowed,
+                )
                 results.extend(self._movie_to_output(m, lang) for m in movies)
 
             if input_dto.media_type in ("all", "series"):
-                series_list = await uow.series.find_random(input_dto.limit, with_backdrop=True)
+                series_list = await uow.series.find_random(
+                    input_dto.limit,
+                    with_backdrop=True,
+                    allowed_library_ids=allowed,
+                )
                 results.extend(self._series_to_output(s, lang) for s in series_list)
 
         if input_dto.media_type == "all":

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -7,6 +7,9 @@ from src.modules.media.application.dtos.movie_dtos import (
     GetMovieByIdInput,
     MovieOutput,
 )
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._media_file_helpers import (
     to_media_file_output,
@@ -21,36 +24,57 @@ class GetMovieByIdUseCase:
     This use case fetches a movie from the repository and returns
     it in a format suitable for API consumption.
 
+    Per ADR-010, the lookup is restricted to the caller's
+    ``Profile.allowed_library_ids`` via ``ProfileLibraryAccessPort``. A
+    movie that exists outside the ACL surfaces as
+    ``ResourceNotFoundException`` (HTTP 404), preventing the catalog
+    ACL from being bypassed by id-poking. A deny-all profile
+    short-circuits to a 404 without opening the UoW.
+
     Example:
-        >>> use_case = GetMovieByIdUseCase(uow_factory)
-        >>> result = await use_case.execute(GetMovieByIdInput("mov_abc123"))
+        >>> use_case = GetMovieByIdUseCase(uow_factory, profile_library_access)
+        >>> result = await use_case.execute(
+        ...     GetMovieByIdInput(profile_id="prf_abc", movie_id="mov_abc123")
+        ... )
         >>> result.title
         'Inception'
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: GetMovieByIdInput) -> MovieOutput:
         """Execute the use case.
 
         Args:
-            input_dto: Contains the movie_id to fetch.
+            input_dto: Contains the profile_id and movie_id to fetch.
 
         Returns:
             MovieOutput with all movie details.
 
         Raises:
-            ResourceNotFoundException: If movie with given ID doesn't exist.
+            ResourceNotFoundException: If the movie does not exist or
+                lives in a library outside the caller's ACL.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)
+
         movie_id = MovieId(input_dto.movie_id)
         async with self._uow_factory() as uow:
-            movie = await uow.movies.find_by_id(movie_id)
+            movie = await uow.movies.find_by_id(movie_id, allowed_library_ids=allowed)
 
         if movie is None:
             raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)

--- a/src/modules/media/application/use_cases/get_related_movies.py
+++ b/src/modules/media/application/use_cases/get_related_movies.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 
 from src.modules.media.application.dtos.movie_dtos import MovieSummaryOutput
 from src.modules.media.application.ports import MetadataProvider
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._movie_summary_helpers import to_movie_summary
 from src.modules.media.domain.value_objects import MovieId
@@ -14,11 +17,17 @@ class GetRelatedMoviesInput:
     """Input for ``GetRelatedMoviesUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts both
+            the source lookup and the related-movie intersection to
+            libraries the profile may see; a deny-all profile yields
+            an empty list without opening a UoW.
         movie_id: External id of the movie to look up recommendations for.
         lang: Language for localized fields on the response.
         limit: Maximum number of related movies to return.
     """
 
+    profile_id: str
     movie_id: str
     lang: str = "en"
     limit: int = 12
@@ -48,14 +57,29 @@ class GetRelatedMoviesUseCase:
         self,
         uow_factory: MediaUnitOfWorkFactory,
         metadata_provider: MetadataProvider,
+        profile_library_access: ProfileLibraryAccessPort,
     ) -> None:
         self._uow_factory = uow_factory
         self._metadata = metadata_provider
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: GetRelatedMoviesInput) -> list[MovieSummaryOutput]:
-        """Run the lookup."""
+        """Run the lookup.
+
+        A deny-all profile yields an empty list without opening a UoW.
+        When the source movie itself is outside the caller's ACL the
+        method also returns an empty list — best-effort polish, no
+        404 raised here (the parent endpoint may still surface the
+        movie's 404 from ``GetMovieByIdUseCase``).
+        """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return []
+
         async with self._uow_factory() as uow:
-            source = await uow.movies.find_by_id(MovieId(input_dto.movie_id))
+            source = await uow.movies.find_by_id(
+                MovieId(input_dto.movie_id), allowed_library_ids=allowed
+            )
             if source is None or source.tmdb_id is None:
                 return []
 
@@ -68,7 +92,7 @@ class GetRelatedMoviesUseCase:
             # Slight over-fetch (2x) so a few catalog gaps don't leave
             # the carousel sparse.
             candidate_ids = tmdb_ids[: input_dto.limit * 2]
-            local = await uow.movies.find_by_tmdb_ids(candidate_ids)
+            local = await uow.movies.find_by_tmdb_ids(candidate_ids, allowed_library_ids=allowed)
 
         # Preserve TMDB's relevance ordering by iterating the request
         # list rather than the dict's insertion order.

--- a/src/modules/media/application/use_cases/get_related_series.py
+++ b/src/modules/media/application/use_cases/get_related_series.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 
 from src.modules.media.application.dtos.series_dtos import SeriesSummaryOutput
 from src.modules.media.application.ports import MetadataProvider
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._series_summary_helpers import to_series_summary
 from src.modules.media.domain.value_objects import SeriesId
@@ -14,11 +17,17 @@ class GetRelatedSeriesInput:
     """Input for ``GetRelatedSeriesUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts both
+            the source lookup and the related-series intersection to
+            libraries the profile may see; a deny-all profile yields
+            an empty list without opening a UoW.
         series_id: External id of the series to look up recommendations for.
         lang: Language for localized fields on the response.
         limit: Maximum number of related series to return.
     """
 
+    profile_id: str
     series_id: str
     lang: str = "en"
     limit: int = 12
@@ -48,14 +57,28 @@ class GetRelatedSeriesUseCase:
         self,
         uow_factory: MediaUnitOfWorkFactory,
         metadata_provider: MetadataProvider,
+        profile_library_access: ProfileLibraryAccessPort,
     ) -> None:
         self._uow_factory = uow_factory
         self._metadata = metadata_provider
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: GetRelatedSeriesInput) -> list[SeriesSummaryOutput]:
-        """Run the lookup."""
+        """Run the lookup.
+
+        A deny-all profile yields an empty list without opening a UoW.
+        When the source series itself is outside the caller's ACL the
+        method also returns an empty list — best-effort polish, no
+        404 raised here.
+        """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return []
+
         async with self._uow_factory() as uow:
-            source = await uow.series.find_by_id(SeriesId(input_dto.series_id))
+            source = await uow.series.find_by_id(
+                SeriesId(input_dto.series_id), allowed_library_ids=allowed
+            )
             if source is None or source.tmdb_id is None:
                 return []
 
@@ -68,7 +91,7 @@ class GetRelatedSeriesUseCase:
             # Slight over-fetch (2x) so a few catalog gaps don't leave
             # the carousel sparse.
             candidate_ids = tmdb_ids[: input_dto.limit * 2]
-            local = await uow.series.find_by_tmdb_ids(candidate_ids)
+            local = await uow.series.find_by_tmdb_ids(candidate_ids, allowed_library_ids=allowed)
 
         # Preserve TMDB's relevance ordering by iterating the request
         # list rather than the dict's insertion order.

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -9,6 +9,9 @@ from src.modules.media.application.dtos.series_dtos import (
     SeriesOutput,
 )
 from src.modules.media.application.ports import ProgressLookupPort, ProgressSummary
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._intro_marker_helpers import (
     to_intro_marker_output,
@@ -42,31 +45,40 @@ class GetSeriesByIdUseCase:
         self,
         uow_factory: MediaUnitOfWorkFactory,
         progress_lookup: ProgressLookupPort,
+        profile_library_access: ProfileLibraryAccessPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
             progress_lookup: Port for resolving watch progress snapshots.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
         self._progress_lookup = progress_lookup
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: GetSeriesByIdInput) -> SeriesOutput:
         """Execute the use case.
 
         Args:
-            input_dto: Contains the series_id to fetch.
+            input_dto: Contains the profile_id and series_id to fetch.
 
         Returns:
             SeriesOutput with complete hierarchy.
 
         Raises:
-            ResourceNotFoundException: If series doesn't exist.
+            ResourceNotFoundException: If the series does not exist
+                or lives in a library outside the caller's ACL.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
+
         series_id = SeriesId(input_dto.series_id)
         async with self._uow_factory() as uow:
-            series = await uow.series.find_by_id(series_id)
+            series = await uow.series.find_by_id(series_id, allowed_library_ids=allowed)
 
         if series is None:
             raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)

--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -1,6 +1,7 @@
 """ListByGenreUseCase - paginated mixed (movies + series) listing per genre."""
 
 import asyncio
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, TypeVar
 
@@ -15,6 +16,9 @@ from src.modules.media.application.dtos.catalog_dtos import (
     CatalogItemOutput,
     ListByGenreInput,
     ListByGenreOutput,
+)
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
@@ -85,20 +89,31 @@ class ListByGenreUseCase:
     free.
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: ListByGenreInput) -> ListByGenreOutput:
         """Execute the use case.
 
         Args:
-            input_dto: ``genre`` (canonical id), ``cursor`` (opaque
-                dual-stream token), ``limit``, and ``lang``.
+            input_dto: ``profile_id``, ``genre`` (canonical id),
+                ``cursor`` (opaque dual-stream token), ``limit``, and
+                ``lang``.
 
         Returns:
             ``ListByGenreOutput`` carrying the merged page of catalog
-            items + the dual cursor for the next page.
+            items + the dual cursor for the next page. A deny-all
+            profile yields an empty page without opening a UoW.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return ListByGenreOutput(items=[], next_cursor=None, has_more=False)
+
         decoded = decode_dual_cursor(input_dto.cursor)
         genre = Genre(input_dto.genre)
 
@@ -111,6 +126,7 @@ class ListByGenreUseCase:
             decoded=decoded,
             limit=input_dto.limit,
             media_type=input_dto.media_type,
+            allowed_library_ids=allowed,
         )
 
         # Tag each entity with its source stream and its source-page
@@ -172,6 +188,7 @@ class ListByGenreUseCase:
         decoded: DualCursorValue,
         limit: int,
         media_type: Literal["movie", "series"] | None,
+        allowed_library_ids: Sequence[str],
     ) -> tuple[PaginatedResult[Movie], PaginatedResult[Series]]:
         """Fetch the movie and series pages, honoring the media-type filter.
 
@@ -191,6 +208,7 @@ class ListByGenreUseCase:
                     genre=genre,
                     cursor=decoded.movies,
                     limit=limit,
+                    allowed_library_ids=allowed_library_ids,
                 )
             return movies_page, _empty_page(Series)
         if media_type == "series":
@@ -199,11 +217,22 @@ class ListByGenreUseCase:
                     genre=genre,
                     cursor=decoded.series,
                     limit=limit,
+                    allowed_library_ids=allowed_library_ids,
                 )
             return _empty_page(Movie), series_page
         return await asyncio.gather(
-            self._fetch_movies_page(genre=genre, cursor=decoded.movies, limit=limit),
-            self._fetch_series_page(genre=genre, cursor=decoded.series, limit=limit),
+            self._fetch_movies_page(
+                genre=genre,
+                cursor=decoded.movies,
+                limit=limit,
+                allowed_library_ids=allowed_library_ids,
+            ),
+            self._fetch_series_page(
+                genre=genre,
+                cursor=decoded.series,
+                limit=limit,
+                allowed_library_ids=allowed_library_ids,
+            ),
         )
 
     async def _fetch_movies_page(
@@ -212,12 +241,14 @@ class ListByGenreUseCase:
         genre: Genre,
         cursor: str | None,
         limit: int,
+        allowed_library_ids: Sequence[str],
     ) -> PaginatedResult[Movie]:
         async with self._uow_factory() as uow:
             return await uow.movies.list_paginated_by_genre(
                 genre=genre,
                 cursor=cursor,
                 limit=limit,
+                allowed_library_ids=allowed_library_ids,
             )
 
     async def _fetch_series_page(
@@ -226,12 +257,14 @@ class ListByGenreUseCase:
         genre: Genre,
         cursor: str | None,
         limit: int,
+        allowed_library_ids: Sequence[str],
     ) -> PaginatedResult[Series]:
         async with self._uow_factory() as uow:
             return await uow.series.list_paginated_by_genre(
                 genre=genre,
                 cursor=cursor,
                 limit=limit,
+                allowed_library_ids=allowed_library_ids,
             )
 
     @staticmethod

--- a/src/modules/media/application/use_cases/list_genres.py
+++ b/src/modules/media/application/use_cases/list_genres.py
@@ -5,6 +5,9 @@ from src.modules.media.application.dtos.catalog_dtos import (
     ListGenresInput,
     ListGenresOutput,
 )
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.repositories.movie_repository import GenreRow
 
@@ -35,26 +38,41 @@ class ListGenresUseCase:
         GenreOutput(id="Action", name="Ação", count=42)
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: ListGenresInput) -> ListGenresOutput:
         """Execute the use case.
 
         Args:
-            input_dto: Carries the requested ``lang`` and optional
-                ``media_type`` filter.
+            input_dto: Carries the caller's ``profile_id``, the
+                requested ``lang``, and an optional ``media_type``
+                filter.
 
         Returns:
             ``ListGenresOutput`` with one ``GenreOutput`` per unique
             canonical genre present in the library (restricted to the
-            selected media type when ``media_type`` is set).
+            selected media type when ``media_type`` is set, and
+            further restricted to the caller's
+            ``Profile.allowed_library_ids``). A deny-all profile
+            yields an empty list without opening a UoW.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return ListGenresOutput(genres=[])
+
         # Skip the repo call for the excluded media type when a
         # filter is active. The Movies and Series tabs on the frontend
         # use this to get counts scoped to just their half of the
@@ -62,12 +80,18 @@ class ListGenresUseCase:
         # appear on the Movies tab.
         async with self._uow_factory() as uow:
             movie_rows = (
-                await uow.movies.list_genre_rows(input_dto.lang)
+                await uow.movies.list_genre_rows(
+                    input_dto.lang,
+                    allowed_library_ids=allowed,
+                )
                 if input_dto.media_type != "series"
                 else []
             )
             series_rows = (
-                await uow.series.list_genre_rows(input_dto.lang)
+                await uow.series.list_genre_rows(
+                    input_dto.lang,
+                    allowed_library_ids=allowed,
+                )
                 if input_dto.media_type != "movie"
                 else []
             )

--- a/src/modules/media/application/use_cases/list_movies.py
+++ b/src/modules/media/application/use_cases/list_movies.py
@@ -5,6 +5,9 @@ from src.modules.media.application.dtos.movie_dtos import (
     ListMoviesOutput,
     MovieSummaryOutput,
 )
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._movie_summary_helpers import to_movie_summary
 from src.modules.media.domain.entities import Movie
@@ -18,40 +21,65 @@ class ListMoviesUseCase:
     DTOs. The cursor is passed through opaquely — the use case never
     decodes or encodes it, the repository owns that contract.
 
+    Per ADR-010, the page is restricted to the caller's
+    ``Profile.allowed_library_ids`` via ``ProfileLibraryAccessPort``. A
+    deny-all profile short-circuits to an empty page without opening
+    the UoW — that avoids dialect-specific ``WHERE library_id IN ()``
+    issues and saves a round-trip.
+
     Example:
-        >>> use_case = ListMoviesUseCase(uow_factory)
-        >>> result = await use_case.execute(ListMoviesInput(limit=20))
+        >>> use_case = ListMoviesUseCase(uow_factory, profile_library_access)
+        >>> result = await use_case.execute(
+        ...     ListMoviesInput(profile_id="prf_abc", limit=20)
+        ... )
         >>> len(result.movies)
         20
         >>> result.has_more
         True
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: ListMoviesInput) -> ListMoviesOutput:
         """Execute the use case.
 
         Args:
-            input_dto: ``cursor`` (opaque), ``limit``, ``include_total``,
-                and ``lang``.
+            input_dto: ``profile_id``, ``cursor`` (opaque), ``limit``,
+                ``include_total``, and ``lang``.
 
         Returns:
             ``ListMoviesOutput`` with the page items, the next cursor,
             ``has_more``, and an optional ``total_count`` (only when
             ``include_total=True``).
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return ListMoviesOutput(
+                movies=[],
+                next_cursor=None,
+                has_more=False,
+                total_count=0 if input_dto.include_total else None,
+            )
+
         async with self._uow_factory() as uow:
             page = await uow.movies.list_paginated(
                 cursor=input_dto.cursor,
                 limit=input_dto.limit,
                 include_total=input_dto.include_total,
+                allowed_library_ids=allowed,
             )
 
         return ListMoviesOutput(

--- a/src/modules/media/application/use_cases/list_movies_by_actor.py
+++ b/src/modules/media/application/use_cases/list_movies_by_actor.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
 from src.modules.media.application.dtos.movie_dtos import MovieSummaryOutput
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._movie_summary_helpers import to_movie_summary
 
@@ -13,6 +16,10 @@ class ListMoviesByActorInput:
     """Input for ``ListMoviesByActorUseCase``.
 
     Attributes:
+        profile_id: Caller's prefixed profile id. The use case
+            consults ``ProfileLibraryAccessPort`` and restricts the
+            page to libraries the profile may see; a deny-all profile
+            yields an empty page without opening a UoW.
         actor_name: Exact display name of the cast member. Match is
             by literal equality against the stored ``cast[].name``
             values; collisions between two real people who share a
@@ -26,6 +33,7 @@ class ListMoviesByActorInput:
             on the returned summaries.
     """
 
+    profile_id: str
     actor_name: str
     cursor: str | None = None
     limit: int = DEFAULT_PAGE_SIZE
@@ -61,25 +69,36 @@ class ListMoviesByActorUseCase:
     ``ListByGenreUseCase`` without breaking the API contract.
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: ListMoviesByActorInput) -> ListMoviesByActorOutput:
         """Execute the use case.
 
         Args:
-            input_dto: ``actor_name`` (exact display name), ``cursor``,
-                ``limit``, ``lang``.
+            input_dto: ``profile_id``, ``actor_name`` (exact display
+                name), ``cursor``, ``limit``, ``lang``.
 
         Returns:
             ``ListMoviesByActorOutput`` carrying the page of summaries
-            plus the next cursor.
+            plus the next cursor. A deny-all profile yields an empty
+            page without opening a UoW.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return ListMoviesByActorOutput(movies=[], next_cursor=None, has_more=False)
+
         async with self._uow_factory() as uow:
             page = await uow.movies.list_paginated_by_cast_member(
                 actor_name=input_dto.actor_name,
                 cursor=input_dto.cursor,
                 limit=input_dto.limit,
+                allowed_library_ids=allowed,
             )
 
         return ListMoviesByActorOutput(

--- a/src/modules/media/application/use_cases/list_recently_added_catalog.py
+++ b/src/modules/media/application/use_cases/list_recently_added_catalog.py
@@ -1,11 +1,15 @@
 """ListRecentlyAddedCatalogUseCase - mixed (movies + series) recents."""
 
 import asyncio
+from collections.abc import Sequence
 
 from src.modules.media.application.dtos.catalog_dtos import (
     CatalogItemOutput,
     ListRecentlyAddedCatalogInput,
     ListRecentlyAddedCatalogOutput,
+)
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
@@ -37,13 +41,20 @@ class ListRecentlyAddedCatalogUseCase:
         20
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(
         self, input_dto: ListRecentlyAddedCatalogInput
@@ -51,19 +62,24 @@ class ListRecentlyAddedCatalogUseCase:
         """Execute the use case.
 
         Args:
-            input_dto: ``limit`` (max items in the merged result) and
-                ``lang``.
+            input_dto: ``profile_id``, ``limit`` (max items in the
+                merged result) and ``lang``.
 
         Returns:
             ``ListRecentlyAddedCatalogOutput`` with the merged page,
-            newest first.
+            newest first. Empty when the caller's profile has no
+            ``allowed_library_ids`` — short-circuits the UoW.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return ListRecentlyAddedCatalogOutput(items=[])
+
         # Each branch opens its own UoW because SQLAlchemy AsyncSession
         # forbids concurrent execution on the same session — same
         # pattern as ``ListByGenreUseCase``.
         movies, series_list = await asyncio.gather(
-            self._fetch_recent_movies(input_dto.limit),
-            self._fetch_recent_series(input_dto.limit),
+            self._fetch_recent_movies(input_dto.limit, allowed),
+            self._fetch_recent_series(input_dto.limit, allowed),
         )
 
         merged: list[Movie | Series] = sorted(
@@ -76,13 +92,27 @@ class ListRecentlyAddedCatalogUseCase:
             items=[self._to_output(item, input_dto.lang) for item in merged],
         )
 
-    async def _fetch_recent_movies(self, limit: int) -> list[Movie]:
+    async def _fetch_recent_movies(
+        self, limit: int, allowed_library_ids: Sequence[str]
+    ) -> list[Movie]:
         async with self._uow_factory() as uow:
-            return list(await uow.movies.list_recently_added(limit))
+            return list(
+                await uow.movies.list_recently_added(
+                    limit,
+                    allowed_library_ids=allowed_library_ids,
+                )
+            )
 
-    async def _fetch_recent_series(self, limit: int) -> list[Series]:
+    async def _fetch_recent_series(
+        self, limit: int, allowed_library_ids: Sequence[str]
+    ) -> list[Series]:
         async with self._uow_factory() as uow:
-            return list(await uow.series.list_recently_added(limit))
+            return list(
+                await uow.series.list_recently_added(
+                    limit,
+                    allowed_library_ids=allowed_library_ids,
+                )
+            )
 
     @staticmethod
     def _to_output(item: Movie | Series, lang: str) -> CatalogItemOutput:

--- a/src/modules/media/application/use_cases/list_recently_added_movies.py
+++ b/src/modules/media/application/use_cases/list_recently_added_movies.py
@@ -4,6 +4,9 @@ from src.modules.media.application.dtos.movie_dtos import (
     ListRecentlyAddedMoviesInput,
     ListRecentlyAddedMoviesOutput,
 )
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._movie_summary_helpers import to_movie_summary
 
@@ -15,20 +18,36 @@ class ListRecentlyAddedMoviesUseCase:
     The home-page carousel renders the full slice and the user goes
     to the catalog page if they want to keep browsing.
 
+    Per ADR-010, results are restricted to the caller's
+    ``Profile.allowed_library_ids`` via ``ProfileLibraryAccessPort``. A
+    deny-all profile short-circuits to an empty list without opening
+    the UoW.
+
     Example:
-        >>> use_case = ListRecentlyAddedMoviesUseCase(uow_factory)
-        >>> result = await use_case.execute(ListRecentlyAddedMoviesInput(limit=20))
+        >>> use_case = ListRecentlyAddedMoviesUseCase(
+        ...     uow_factory, profile_library_access
+        ... )
+        >>> result = await use_case.execute(
+        ...     ListRecentlyAddedMoviesInput(profile_id="prf_abc", limit=20)
+        ... )
         >>> len(result.movies)
         20
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(
         self, input_dto: ListRecentlyAddedMoviesInput
@@ -36,14 +55,21 @@ class ListRecentlyAddedMoviesUseCase:
         """Execute the use case.
 
         Args:
-            input_dto: ``limit`` (max items) and ``lang``.
+            input_dto: ``profile_id``, ``limit`` (max items) and ``lang``.
 
         Returns:
             ``ListRecentlyAddedMoviesOutput`` with newest-first
             movie summaries.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return ListRecentlyAddedMoviesOutput(movies=[])
+
         async with self._uow_factory() as uow:
-            movies = await uow.movies.list_recently_added(input_dto.limit)
+            movies = await uow.movies.list_recently_added(
+                input_dto.limit,
+                allowed_library_ids=allowed,
+            )
 
         return ListRecentlyAddedMoviesOutput(
             movies=[to_movie_summary(movie, input_dto.lang) for movie in movies],

--- a/src/modules/media/application/use_cases/list_recently_added_series.py
+++ b/src/modules/media/application/use_cases/list_recently_added_series.py
@@ -4,6 +4,9 @@ from src.modules.media.application.dtos.series_dtos import (
     ListRecentlyAddedSeriesInput,
     ListRecentlyAddedSeriesOutput,
 )
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._series_summary_helpers import to_series_summary
 
@@ -14,20 +17,36 @@ class ListRecentlyAddedSeriesUseCase:
     Bounded "top N" projection — mirror of
     ``ListRecentlyAddedMoviesUseCase`` for the series side.
 
+    Per ADR-010, results are restricted to the caller's
+    ``Profile.allowed_library_ids`` via ``ProfileLibraryAccessPort``. A
+    deny-all profile short-circuits to an empty list without opening
+    the UoW.
+
     Example:
-        >>> use_case = ListRecentlyAddedSeriesUseCase(uow_factory)
-        >>> result = await use_case.execute(ListRecentlyAddedSeriesInput(limit=20))
+        >>> use_case = ListRecentlyAddedSeriesUseCase(
+        ...     uow_factory, profile_library_access
+        ... )
+        >>> result = await use_case.execute(
+        ...     ListRecentlyAddedSeriesInput(profile_id="prf_abc", limit=20)
+        ... )
         >>> len(result.series)
         20
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(
         self, input_dto: ListRecentlyAddedSeriesInput
@@ -35,14 +54,21 @@ class ListRecentlyAddedSeriesUseCase:
         """Execute the use case.
 
         Args:
-            input_dto: ``limit`` (max items) and ``lang``.
+            input_dto: ``profile_id``, ``limit`` (max items) and ``lang``.
 
         Returns:
             ``ListRecentlyAddedSeriesOutput`` with newest-first
             series summaries.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return ListRecentlyAddedSeriesOutput(series=[])
+
         async with self._uow_factory() as uow:
-            series_list = await uow.series.list_recently_added(input_dto.limit)
+            series_list = await uow.series.list_recently_added(
+                input_dto.limit,
+                allowed_library_ids=allowed,
+            )
 
         return ListRecentlyAddedSeriesOutput(
             series=[to_series_summary(s, input_dto.lang) for s in series_list],

--- a/src/modules/media/application/use_cases/list_series.py
+++ b/src/modules/media/application/use_cases/list_series.py
@@ -4,6 +4,9 @@ from src.modules.media.application.dtos.series_dtos import (
     ListSeriesInput,
     ListSeriesOutput,
 )
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._series_summary_helpers import to_series_summary
 
@@ -16,40 +19,62 @@ class ListSeriesUseCase:
     ``SeriesSummaryOutput`` DTOs. The cursor is passed through
     opaquely.
 
+    Per ADR-010, the page is restricted to the caller's
+    ``Profile.allowed_library_ids`` via ``ProfileLibraryAccessPort``. A
+    deny-all profile short-circuits to an empty page without opening
+    the UoW.
+
     Example:
-        >>> use_case = ListSeriesUseCase(uow_factory)
-        >>> result = await use_case.execute(ListSeriesInput())
+        >>> use_case = ListSeriesUseCase(uow_factory, profile_library_access)
+        >>> result = await use_case.execute(ListSeriesInput(profile_id="prf_abc"))
         >>> len(result.series)
         20
         >>> result.has_more
         True
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh media Unit of Work.
+            profile_library_access: Port that resolves the caller's
+                allowed library_ids.
         """
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: ListSeriesInput) -> ListSeriesOutput:
         """Execute the use case.
 
         Args:
-            input_dto: ``cursor`` (opaque), ``limit``, ``include_total``,
-                and ``lang``.
+            input_dto: ``profile_id``, ``cursor`` (opaque), ``limit``,
+                ``include_total``, and ``lang``.
 
         Returns:
             ``ListSeriesOutput`` with the page items, the next cursor,
             ``has_more``, and an optional ``total_count`` (only when
             ``include_total=True``).
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return ListSeriesOutput(
+                series=[],
+                next_cursor=None,
+                has_more=False,
+                total_count=0 if input_dto.include_total else None,
+            )
+
         async with self._uow_factory() as uow:
             page = await uow.series.list_paginated(
                 cursor=input_dto.cursor,
                 limit=input_dto.limit,
                 include_total=input_dto.include_total,
+                allowed_library_ids=allowed,
             )
 
         return ListSeriesOutput(

--- a/src/modules/media/application/use_cases/search_catalog.py
+++ b/src/modules/media/application/use_cases/search_catalog.py
@@ -1,11 +1,15 @@
 """SearchCatalogUseCase - full-text search across movies and series."""
 
 import asyncio
+from collections.abc import Sequence
 
 from src.modules.media.application.dtos.search_dtos import (
     SearchInput,
     SearchItemOutput,
     SearchOutput,
+)
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
@@ -27,19 +31,30 @@ class SearchCatalogUseCase:
     tables produces comparable scores for practical purposes.
     """
 
-    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        profile_library_access: ProfileLibraryAccessPort,
+    ) -> None:
         self._uow_factory = uow_factory
+        self._profile_library_access = profile_library_access
 
     async def execute(self, input_dto: SearchInput) -> SearchOutput:
         """Execute the search.
 
         Args:
-            input_dto: Search query, optional filters, lang, limit.
+            input_dto: ``profile_id``, search query, optional filters,
+                lang, limit.
 
         Returns:
             ``SearchOutput`` with items sorted by relevance and a
-            total count.
+            total count. A deny-all profile yields an empty result
+            without opening a UoW.
         """
+        allowed = await self._profile_library_access.find_for_profile(input_dto.profile_id)
+        if not allowed:
+            return SearchOutput(items=[], total=0)
+
         # Fetch from both repos in parallel, skipping the excluded
         # type when a filter is active. Each branch opens its own
         # UoW so parallel queries run on independent sessions
@@ -48,13 +63,13 @@ class SearchCatalogUseCase:
         series_hits: list[tuple[Series, float]] = []
 
         if input_dto.media_type == "movie":
-            movie_hits = await self._search_movies(input_dto)
+            movie_hits = await self._search_movies(input_dto, allowed)
         elif input_dto.media_type == "series":
-            series_hits = await self._search_series(input_dto)
+            series_hits = await self._search_series(input_dto, allowed)
         else:
             movie_hits, series_hits = await asyncio.gather(
-                self._search_movies(input_dto),
-                self._search_series(input_dto),
+                self._search_movies(input_dto, allowed),
+                self._search_series(input_dto, allowed),
             )
 
         # Pool and sort by rank (ascending = most relevant first)
@@ -69,7 +84,9 @@ class SearchCatalogUseCase:
 
         return SearchOutput(items=items, total=len(combined))
 
-    async def _search_movies(self, input_dto: SearchInput) -> list[tuple[Movie, float]]:
+    async def _search_movies(
+        self, input_dto: SearchInput, allowed_library_ids: Sequence[str]
+    ) -> list[tuple[Movie, float]]:
         async with self._uow_factory() as uow:
             return await uow.movies.search(
                 input_dto.query,
@@ -77,9 +94,12 @@ class SearchCatalogUseCase:
                 year_min=input_dto.year_min,
                 year_max=input_dto.year_max,
                 limit=input_dto.limit,
+                allowed_library_ids=allowed_library_ids,
             )
 
-    async def _search_series(self, input_dto: SearchInput) -> list[tuple[Series, float]]:
+    async def _search_series(
+        self, input_dto: SearchInput, allowed_library_ids: Sequence[str]
+    ) -> list[tuple[Series, float]]:
         async with self._uow_factory() as uow:
             return await uow.series.search(
                 input_dto.query,
@@ -87,6 +107,7 @@ class SearchCatalogUseCase:
                 year_min=input_dto.year_min,
                 year_max=input_dto.year_max,
                 limit=input_dto.limit,
+                allowed_library_ids=allowed_library_ids,
             )
 
     @staticmethod

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -33,11 +33,23 @@ class MovieRepository(ABC):
     """
 
     @abstractmethod
-    async def find_by_id(self, movie_id: MovieId) -> Movie | None:
+    async def find_by_id(
+        self,
+        movie_id: MovieId,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Movie | None:
         """Find a movie by its ID.
 
         Args:
             movie_id: The movie's external ID.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, the lookup also requires the row's
+                ``library_id`` to be in the supplied set; otherwise the
+                method returns ``None`` even when a row with the id
+                exists. ``None`` (default) applies no library filter —
+                used by internal callers (scanner, cross-BC ACL
+                adapters) that operate outside the per-profile catalog.
 
         Returns:
             The Movie if found, None otherwise.
@@ -84,6 +96,7 @@ class MovieRepository(ABC):
         limit: int,
         *,
         include_total: bool = False,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies in a single page using cursor-based pagination.
 
@@ -109,6 +122,11 @@ class MovieRepository(ABC):
                 ``PaginatedResult.total_count``. Defaults to ``False``
                 because the count is the most expensive part of the
                 query and is rarely needed by infinite-scroll consumers.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, both the page query and the optional
+                ``COUNT(*)`` are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             ``PaginatedResult`` containing the page items, the
@@ -118,7 +136,12 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
-    async def list_recently_added(self, limit: int) -> Sequence[Movie]:
+    async def list_recently_added(
+        self,
+        limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Movie]:
         """List the most recently added movies.
 
         Sorted by ``id DESC`` — internal autoincrement id is monotonic
@@ -131,6 +154,10 @@ class MovieRepository(ABC):
 
         Args:
             limit: Maximum number of movies to return.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             Sequence of recently added movies (excluding soft-deleted),
@@ -139,7 +166,12 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
-    async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
+    async def list_genre_rows(
+        self,
+        lang: str,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[GenreRow]:
         """Project the genre columns of every non-deleted row.
 
         This is the cheap input to cross-aggregate listings (e.g.
@@ -151,6 +183,10 @@ class MovieRepository(ABC):
             lang: Language code used to extract the localized genre
                 names from the per-row ``localized`` JSON. Falls back
                 to canonical English when no translation is present.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, the projection is restricted to rows
+                whose ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             One ``GenreRow`` per non-deleted movie. Order is not
@@ -164,6 +200,8 @@ class MovieRepository(ABC):
         genre: Genre,
         cursor: str | None,
         limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies belonging to a specific genre, paginated.
 
@@ -187,6 +225,10 @@ class MovieRepository(ABC):
                 fall back to the first page.
             limit: Page size. The repository fetches ``limit + 1``
                 rows and trims the sentinel to detect ``has_more``.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             ``PaginatedResult`` with the page items and pagination
@@ -203,6 +245,8 @@ class MovieRepository(ABC):
         actor_name: str,
         cursor: str | None,
         limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies whose cast includes a member named ``actor_name``.
 
@@ -226,6 +270,10 @@ class MovieRepository(ABC):
                 fall back to the first page.
             limit: Page size. Implementations fetch ``limit + 1`` rows
                 to detect ``has_more`` cheaply.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             ``PaginatedResult`` with the page items and pagination
@@ -242,6 +290,7 @@ class MovieRepository(ABC):
         year_min: int | None = None,
         year_max: int | None = None,
         limit: int = 20,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> list[tuple[Movie, float]]:
         """Full-text search over title, synopsis, cast, and genres.
 
@@ -257,6 +306,10 @@ class MovieRepository(ABC):
             year_min: Optional inclusive lower bound on release year.
             year_max: Optional inclusive upper bound on release year.
             limit: Maximum items to return.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, hits are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             List of (Movie, rank) tuples, ordered by relevance.
@@ -264,12 +317,22 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:
+    async def find_random(
+        self,
+        limit: int,
+        *,
+        with_backdrop: bool = False,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Movie]:
         """Return random movies, optionally filtering to those with backdrop.
 
         Args:
             limit: Maximum number of movies to return.
             with_backdrop: If True, only return movies with a backdrop_path.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             Sequence of randomly selected movies.
@@ -277,11 +340,20 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_by_ids(self, movie_ids: Sequence[MovieId]) -> dict[str, Movie]:
+    async def find_by_ids(
+        self,
+        movie_ids: Sequence[MovieId],
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> dict[str, Movie]:
         """Find multiple movies by their IDs in a single query.
 
         Args:
             movie_ids: Sequence of movie external IDs.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             Dict mapping external ID string to Movie entity.
@@ -289,7 +361,12 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_by_tmdb_ids(self, tmdb_ids: Sequence[int]) -> dict[int, Movie]:
+    async def find_by_tmdb_ids(
+        self,
+        tmdb_ids: Sequence[int],
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> dict[int, Movie]:
         """Find movies whose ``tmdb_id`` is in ``tmdb_ids``.
 
         Used by the "you might also like" path: ``GetRelatedMovies``
@@ -301,6 +378,13 @@ class MovieRepository(ABC):
         up in the dict.
 
         Soft-deleted rows are excluded.
+
+        Args:
+            tmdb_ids: TMDB movie ids to look up.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             Dict mapping ``tmdb_id`` int to ``Movie`` entity. Keys

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -29,11 +29,23 @@ class SeriesRepository(ABC):
     """
 
     @abstractmethod
-    async def find_by_id(self, series_id: SeriesId) -> Series | None:
+    async def find_by_id(
+        self,
+        series_id: SeriesId,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Series | None:
         """Find a series by its ID (includes seasons and episodes).
 
         Args:
             series_id: The series' external ID.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, the lookup also requires the row's
+                ``library_id`` to be in the supplied set; otherwise the
+                method returns ``None`` even when a row with the id
+                exists. ``None`` (default) applies no library filter —
+                used by internal callers (scanner, cross-BC ACL
+                adapters) that operate outside the per-profile catalog.
 
         Returns:
             The Series if found, None otherwise.
@@ -80,6 +92,7 @@ class SeriesRepository(ABC):
         limit: int,
         *,
         include_total: bool = False,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Series]:
         """List series in a single page using cursor-based pagination.
 
@@ -102,6 +115,11 @@ class SeriesRepository(ABC):
             include_total: When ``True`` the implementation runs an
                 extra ``COUNT(*)`` to populate
                 ``PaginatedResult.total_count``. Defaults to ``False``.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, both the page query and the optional
+                ``COUNT(*)`` are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             ``PaginatedResult`` containing the page items, the
@@ -111,7 +129,12 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def list_recently_added(self, limit: int) -> Sequence[Series]:
+    async def list_recently_added(
+        self,
+        limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Series]:
         """List the most recently added series.
 
         Sorted by ``id DESC`` — same justification as
@@ -121,6 +144,10 @@ class SeriesRepository(ABC):
 
         Args:
             limit: Maximum number of series to return.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             Sequence of recently added series (excluding soft-deleted),
@@ -129,7 +156,12 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
+    async def list_genre_rows(
+        self,
+        lang: str,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[GenreRow]:
         """Project the genre columns of every non-deleted series row.
 
         Same contract as ``MovieRepository.list_genre_rows`` — see
@@ -145,6 +177,8 @@ class SeriesRepository(ABC):
         genre: Genre,
         cursor: str | None,
         limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Series]:
         """List series belonging to a specific genre, paginated.
 
@@ -165,6 +199,7 @@ class SeriesRepository(ABC):
         year_min: int | None = None,
         year_max: int | None = None,
         limit: int = 20,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> list[tuple[Series, float]]:
         """Full-text search over title, synopsis, and genres.
 
@@ -174,12 +209,22 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Series]:
+    async def find_random(
+        self,
+        limit: int,
+        *,
+        with_backdrop: bool = False,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Series]:
         """Return random series, optionally filtering to those with backdrop.
 
         Args:
             limit: Maximum number of series to return.
             with_backdrop: If True, only return series with a backdrop_path.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             Sequence of randomly selected series.
@@ -187,11 +232,20 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_by_ids(self, series_ids: Sequence[SeriesId]) -> dict[str, Series]:
+    async def find_by_ids(
+        self,
+        series_ids: Sequence[SeriesId],
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> dict[str, Series]:
         """Find multiple series by their IDs in a single query.
 
         Args:
             series_ids: Sequence of series external IDs.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             Dict mapping external ID string to Series entity.
@@ -199,7 +253,12 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_by_tmdb_ids(self, tmdb_ids: Sequence[int]) -> dict[int, Series]:
+    async def find_by_tmdb_ids(
+        self,
+        tmdb_ids: Sequence[int],
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> dict[int, Series]:
         """Find series whose ``tmdb_id`` matches any of ``tmdb_ids``.
 
         Used by ``GetRelatedSeries`` to resolve the subset of TMDB's
@@ -209,6 +268,10 @@ class SeriesRepository(ABC):
 
         Args:
             tmdb_ids: TMDB tv ids to look up.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, results are restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             Dict mapping ``tmdb_id`` to the matching ``Series``. Empty
@@ -217,11 +280,20 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_by_episode_id(self, episode_id: EpisodeId) -> Series | None:
+    async def find_by_episode_id(
+        self,
+        episode_id: EpisodeId,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Series | None:
         """Find a series containing an episode with this ID.
 
         Args:
             episode_id: The episode's external ID.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, the lookup is restricted to series rows
+                whose ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             The Series if found, None otherwise.
@@ -229,11 +301,20 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_by_title(self, title: Title) -> Series | None:
+    async def find_by_title(
+        self,
+        title: Title,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Series | None:
         """Find a series by its title (case-insensitive).
 
         Args:
             title: The series title to search for.
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, the lookup is restricted to rows whose
+                ``library_id`` is in the supplied set. ``None``
+                (default) applies no library filter.
 
         Returns:
             The Series if found, None otherwise.

--- a/src/modules/media/infrastructure/acl/__init__.py
+++ b/src/modules/media/infrastructure/acl/__init__.py
@@ -1,7 +1,10 @@
 """Anti-corruption layer: adapters translating external BCs to local ports."""
 
+from src.modules.media.infrastructure.acl.profile_library_access_adapter import (
+    ProfileLibraryAccessAdapter,
+)
 from src.modules.media.infrastructure.acl.progress_lookup_adapter import (
     ProgressLookupAdapter,
 )
 
-__all__ = ["ProgressLookupAdapter"]
+__all__ = ["ProfileLibraryAccessAdapter", "ProgressLookupAdapter"]

--- a/src/modules/media/infrastructure/acl/profile_library_access_adapter.py
+++ b/src/modules/media/infrastructure/acl/profile_library_access_adapter.py
@@ -1,0 +1,40 @@
+"""Adapter implementing ``ProfileLibraryAccessPort`` via the identity UoW.
+
+This is the only file in the Media BC that imports from the Identity
+BC. Above the adapter, the use cases only see the abstract port —
+the cross-BC boundary stays explicit, per ADR-009.
+"""
+
+from src.modules.identity.application.unit_of_work import (
+    IdentityUnitOfWorkFactory,
+)
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+
+class ProfileLibraryAccessAdapter(ProfileLibraryAccessPort):
+    """Resolve a profile's library ACL via the Identity Unit of Work."""
+
+    def __init__(self, identity_uow_factory: IdentityUnitOfWorkFactory) -> None:
+        self._identity_uow_factory = identity_uow_factory
+
+    async def find_for_profile(self, profile_id: str) -> list[str]:
+        """Return the prefixed library_ids the profile may see.
+
+        A missing profile returns an empty list — deny-all is the
+        safer default than raising. The use cases short-circuit on
+        an empty list and skip the catalog UoW altogether, so this
+        also keeps cost down for unauthenticated requests served
+        through the transitional fallback when the configured
+        default profile no longer exists.
+        """
+        async with self._identity_uow_factory() as uow:
+            profile = await uow.profiles.find_by_id(ProfileId(profile_id))
+        if profile is None:
+            return []
+        return list(profile.allowed_library_ids)
+
+
+__all__ = ["ProfileLibraryAccessAdapter"]

--- a/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
@@ -81,6 +81,8 @@ async def fetch_genre_rows(
     session: AsyncSession,
     model: Any,
     lang: str,
+    *,
+    allowed_library_ids: Sequence[str] | None = None,
 ) -> list[GenreRow]:
     """Project the lightweight genre data of every non-deleted row.
 
@@ -89,11 +91,18 @@ async def fetch_genre_rows(
     Each returned ``GenreRow`` pairs the canonical genre list with
     the localized translation for the requested language (or an
     empty list when no translation is present).
+
+    When ``allowed_library_ids`` is non-``None``, the projection is
+    restricted to rows whose ``library_id`` is in the supplied set —
+    used by the per-profile catalog ACL. ``None`` (default) preserves
+    the unfiltered behavior for internal callers.
     """
     stmt = select(model.genres, model.localized).where(
         model.deleted_at.is_(None),
         model.genres.is_not(None),
     )
+    if allowed_library_ids is not None:
+        stmt = stmt.where(model.library_id.in_(allowed_library_ids))
     result = await session.execute(stmt)
     return [
         GenreRow(
@@ -113,6 +122,7 @@ async def fetch_genre_paginated_page(
     genre: Genre,
     cursor: str | None,
     limit: int,
+    allowed_library_ids: Sequence[str] | None = None,
 ) -> PaginatedResult[TEntity]:
     """Run one page of the title-sorted by-genre listing for ``model``.
 
@@ -140,6 +150,10 @@ async def fetch_genre_paginated_page(
             fall back to the first page.
         limit: Page size. The query fetches ``limit + 1`` rows and
             trims the sentinel.
+        allowed_library_ids: Optional per-profile ACL filter. When
+            non-``None``, rows are restricted to those whose
+            ``library_id`` is in the supplied set. ``None`` (default)
+            applies no library filter.
 
     Returns:
         ``PaginatedResult`` with mapped entities, pagination
@@ -162,6 +176,9 @@ async def fetch_genre_paginated_page(
         )
         .options(*options)
     )
+
+    if allowed_library_ids is not None:
+        stmt = stmt.where(model.library_id.in_(allowed_library_ids))
 
     if decoded is not None:
         # Composite ascending: anything strictly after the cursor

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -48,11 +48,17 @@ class SQLAlchemyMovieRepository(MovieRepository):
         """
         self._session = session
 
-    async def find_by_id(self, movie_id: MovieId) -> Movie | None:
+    async def find_by_id(
+        self,
+        movie_id: MovieId,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Movie | None:
         """Find a movie by its ID.
 
         Args:
             movie_id: The movie's external ID.
+            allowed_library_ids: Optional per-profile ACL filter.
 
         Returns:
             The Movie if found, None otherwise.
@@ -65,6 +71,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
             )
             .options(selectinload(MovieModel.file_variants))
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
         result = await self._session.execute(stmt)
         model = result.scalar_one_or_none()
 
@@ -159,6 +167,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
         limit: int,
         *,
         include_total: bool = False,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies in a single cursor-paginated page.
 
@@ -181,6 +190,9 @@ class SQLAlchemyMovieRepository(MovieRepository):
             .options(selectinload(MovieModel.file_variants))
         )
 
+        if allowed_library_ids is not None:
+            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
+
         if decoded is not None:
             stmt = stmt.where(MovieModel.id < decoded.id)
 
@@ -202,6 +214,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
             count_stmt = (
                 select(func.count()).select_from(MovieModel).where(MovieModel.deleted_at.is_(None))
             )
+            if allowed_library_ids is not None:
+                count_stmt = count_stmt.where(MovieModel.library_id.in_(allowed_library_ids))
             total_count = (await self._session.execute(count_stmt)).scalar_one()
 
         return PaginatedResult(
@@ -210,7 +224,12 @@ class SQLAlchemyMovieRepository(MovieRepository):
             total_count=total_count,
         )
 
-    async def list_recently_added(self, limit: int) -> Sequence[Movie]:
+    async def list_recently_added(
+        self,
+        limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Movie]:
         """Return the top ``limit`` non-deleted movies, newest first.
 
         Same ``id DESC`` ordering as ``list_paginated`` — autoincrement
@@ -223,21 +242,34 @@ class SQLAlchemyMovieRepository(MovieRepository):
             select(MovieModel)
             .where(MovieModel.deleted_at.is_(None))
             .options(selectinload(MovieModel.file_variants))
-            .order_by(MovieModel.id.desc())
-            .limit(limit)
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
+        stmt = stmt.order_by(MovieModel.id.desc()).limit(limit)
         result = await self._session.execute(stmt)
         return [MovieMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
+    async def list_genre_rows(
+        self,
+        lang: str,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[GenreRow]:
         """Project the genre columns of every non-deleted movie row."""
-        return await fetch_genre_rows(self._session, MovieModel, lang)
+        return await fetch_genre_rows(
+            self._session,
+            MovieModel,
+            lang,
+            allowed_library_ids=allowed_library_ids,
+        )
 
     async def list_paginated_by_genre(
         self,
         genre: Genre,
         cursor: str | None,
         limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies for a single genre, paginated and sorted by title.
 
@@ -255,6 +287,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
             genre=genre,
             cursor=cursor,
             limit=limit,
+            allowed_library_ids=allowed_library_ids,
         )
 
     async def list_paginated_by_cast_member(
@@ -262,6 +295,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
         actor_name: str,
         cursor: str | None,
         limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies whose ``cast`` JSON contains an entry for ``actor_name``.
 
@@ -308,6 +343,9 @@ class SQLAlchemyMovieRepository(MovieRepository):
             .options(selectinload(MovieModel.file_variants))
         )
 
+        if allowed_library_ids is not None:
+            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
+
         if decoded is not None:
             stmt = stmt.where(
                 or_(
@@ -335,7 +373,13 @@ class SQLAlchemyMovieRepository(MovieRepository):
             total_count=None,
         )
 
-    async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Movie]:
+    async def find_random(
+        self,
+        limit: int,
+        *,
+        with_backdrop: bool = False,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Movie]:
         """Return random movies."""
         from sqlalchemy.sql.expression import func
 
@@ -349,11 +393,18 @@ class SQLAlchemyMovieRepository(MovieRepository):
                 MovieModel.backdrop_path.is_not(None),
                 MovieModel.backdrop_path != "",
             )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
         stmt = stmt.order_by(func.random()).limit(limit)
         result = await self._session.execute(stmt)
         return [MovieMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def find_by_ids(self, movie_ids: Sequence[MovieId]) -> dict[str, Movie]:
+    async def find_by_ids(
+        self,
+        movie_ids: Sequence[MovieId],
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> dict[str, Movie]:
         """Find multiple movies by their IDs in a single query."""
         if not movie_ids:
             return {}
@@ -367,10 +418,17 @@ class SQLAlchemyMovieRepository(MovieRepository):
             )
             .options(selectinload(MovieModel.file_variants))
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
         result = await self._session.execute(stmt)
         return {model.external_id: MovieMapper.to_entity(model) for model in result.scalars().all()}
 
-    async def find_by_tmdb_ids(self, tmdb_ids: Sequence[int]) -> dict[int, Movie]:
+    async def find_by_tmdb_ids(
+        self,
+        tmdb_ids: Sequence[int],
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> dict[int, Movie]:
         """Find movies whose ``tmdb_id`` matches any of ``tmdb_ids``.
 
         Used by ``GetRelatedMovies`` to resolve the subset of TMDB's
@@ -388,6 +446,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
             )
             .options(selectinload(MovieModel.file_variants))
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
         result = await self._session.execute(stmt)
         return {
             model.tmdb_id: MovieMapper.to_entity(model)
@@ -487,6 +547,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
         year_min: int | None = None,
         year_max: int | None = None,
         limit: int = 20,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> list[tuple[Movie, float]]:
         """Full-text search using FTS5.
 
@@ -540,6 +601,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
             stmt = stmt.where(MovieModel.year >= year_min)
         if year_max is not None:
             stmt = stmt.where(MovieModel.year <= year_max)
+        if allowed_library_ids is not None:
+            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
 
         result = await self._session.execute(stmt)
         models = result.scalars().all()

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -75,11 +75,17 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             .selectinload(EpisodeModel.file_variants),
         ]
 
-    async def find_by_id(self, series_id: SeriesId) -> Series | None:
+    async def find_by_id(
+        self,
+        series_id: SeriesId,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Series | None:
         """Find a series by its ID (includes seasons and episodes).
 
         Args:
             series_id: The series' external ID.
+            allowed_library_ids: Optional per-profile ACL filter.
 
         Returns:
             The Series if found, None otherwise.
@@ -93,6 +99,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             .options(*self._series_load_options())
             .execution_options(populate_existing=True)
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
         result = await self._session.execute(stmt)
         model = result.scalar_one_or_none()
 
@@ -191,6 +199,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         limit: int,
         *,
         include_total: bool = False,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Series]:
         """List series in a single cursor-paginated page.
 
@@ -210,6 +219,9 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             .where(SeriesModel.deleted_at.is_(None))
             .options(*self._series_load_options())
         )
+
+        if allowed_library_ids is not None:
+            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
 
         if decoded is not None:
             stmt = stmt.where(SeriesModel.id < decoded.id)
@@ -234,6 +246,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 .select_from(SeriesModel)
                 .where(SeriesModel.deleted_at.is_(None))
             )
+            if allowed_library_ids is not None:
+                count_stmt = count_stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
             total_count = (await self._session.execute(count_stmt)).scalar_one()
 
         return PaginatedResult(
@@ -242,7 +256,12 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             total_count=total_count,
         )
 
-    async def list_recently_added(self, limit: int) -> Sequence[Series]:
+    async def list_recently_added(
+        self,
+        limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Series]:
         """Return the top ``limit`` non-deleted series, newest first.
 
         Same ``id DESC`` ordering as ``list_paginated`` — see the
@@ -255,21 +274,34 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             select(SeriesModel)
             .where(SeriesModel.deleted_at.is_(None))
             .options(*self._series_load_options())
-            .order_by(SeriesModel.id.desc())
-            .limit(limit)
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
+        stmt = stmt.order_by(SeriesModel.id.desc()).limit(limit)
         result = await self._session.execute(stmt)
         return [SeriesMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def list_genre_rows(self, lang: str) -> Sequence[GenreRow]:
+    async def list_genre_rows(
+        self,
+        lang: str,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[GenreRow]:
         """Project the genre columns of every non-deleted series row."""
-        return await fetch_genre_rows(self._session, SeriesModel, lang)
+        return await fetch_genre_rows(
+            self._session,
+            SeriesModel,
+            lang,
+            allowed_library_ids=allowed_library_ids,
+        )
 
     async def list_paginated_by_genre(
         self,
         genre: Genre,
         cursor: str | None,
         limit: int,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> PaginatedResult[Series]:
         """List series for a single genre, paginated and sorted by title.
 
@@ -288,9 +320,16 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             genre=genre,
             cursor=cursor,
             limit=limit,
+            allowed_library_ids=allowed_library_ids,
         )
 
-    async def find_random(self, limit: int, *, with_backdrop: bool = False) -> Sequence[Series]:
+    async def find_random(
+        self,
+        limit: int,
+        *,
+        with_backdrop: bool = False,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Series]:
         """Return random series."""
         from sqlalchemy.sql.expression import func
 
@@ -304,15 +343,23 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 SeriesModel.backdrop_path.is_not(None),
                 SeriesModel.backdrop_path != "",
             )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
         stmt = stmt.order_by(func.random()).limit(limit)
         result = await self._session.execute(stmt)
         return [SeriesMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def find_by_title(self, title: Title) -> Series | None:
+    async def find_by_title(
+        self,
+        title: Title,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Series | None:
         """Find a series by its title (case-insensitive).
 
         Args:
             title: The series title to search for.
+            allowed_library_ids: Optional per-profile ACL filter.
 
         Returns:
             The Series if found, None otherwise.
@@ -326,12 +373,19 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             .options(*self._series_load_options())
             .execution_options(populate_existing=True)
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
         result = await self._session.execute(stmt)
         model = result.scalar_one_or_none()
 
         return None if model is None else SeriesMapper.to_entity(model)
 
-    async def find_by_ids(self, series_ids: Sequence[SeriesId]) -> dict[str, Series]:
+    async def find_by_ids(
+        self,
+        series_ids: Sequence[SeriesId],
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> dict[str, Series]:
         """Find multiple series by their IDs in a single query."""
         if not series_ids:
             return {}
@@ -346,12 +400,19 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             .options(*self._series_load_options())
             .execution_options(populate_existing=True)
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
         result = await self._session.execute(stmt)
         return {
             model.external_id: SeriesMapper.to_entity(model) for model in result.scalars().all()
         }
 
-    async def find_by_tmdb_ids(self, tmdb_ids: Sequence[int]) -> dict[int, Series]:
+    async def find_by_tmdb_ids(
+        self,
+        tmdb_ids: Sequence[int],
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> dict[int, Series]:
         """Find series whose ``tmdb_id`` matches any of ``tmdb_ids``.
 
         Used by ``GetRelatedSeries`` to resolve the subset of TMDB's
@@ -370,6 +431,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             .options(*self._series_load_options())
             .execution_options(populate_existing=True)
         )
+        if allowed_library_ids is not None:
+            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
         result = await self._session.execute(stmt)
         return {
             model.tmdb_id: SeriesMapper.to_entity(model)
@@ -377,11 +440,18 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             if model.tmdb_id is not None
         }
 
-    async def find_by_episode_id(self, episode_id: EpisodeId) -> Series | None:
+    async def find_by_episode_id(
+        self,
+        episode_id: EpisodeId,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Series | None:
         """Find a series containing an episode with this ID.
 
         Args:
             episode_id: The episode's external ID.
+            allowed_library_ids: Optional per-profile ACL filter
+                forwarded to the inner ``find_by_id`` lookup.
 
         Returns:
             The Series if found, None otherwise.
@@ -396,7 +466,10 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         if episode_model is None:
             return None
 
-        return await self.find_by_id(SeriesId(episode_model.series_external_id))
+        return await self.find_by_id(
+            SeriesId(episode_model.series_external_id),
+            allowed_library_ids=allowed_library_ids,
+        )
 
     async def find_by_file_path(self, file_path: FilePath) -> Series | None:
         """Find a series containing an episode with this file path.
@@ -770,6 +843,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         year_min: int | None = None,
         year_max: int | None = None,
         limit: int = 20,
+        allowed_library_ids: Sequence[str] | None = None,
     ) -> list[tuple[Series, float]]:
         """Full-text search using FTS5.
 
@@ -820,6 +894,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             stmt = stmt.where(SeriesModel.start_year >= year_min)
         if year_max is not None:
             stmt = stmt.where(SeriesModel.start_year <= year_max)
+        if allowed_library_ids is not None:
+            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
 
         result = await self._session.execute(stmt)
         models = result.scalars().unique().all()

--- a/src/modules/media/presentation/dependencies.py
+++ b/src/modules/media/presentation/dependencies.py
@@ -1,0 +1,18 @@
+"""FastAPI dependency that resolves the caller's ``profile_id`` for the catalog.
+
+Thin wrapper around the centralised
+``identity.presentation.dependencies.make_resolve_profile_id``
+factory, parameterised with the media-specific transitional setting
+and 401 message. See the factory's docstring for resolution
+semantics.
+"""
+
+from src.modules.identity.presentation.dependencies import make_resolve_profile_id
+
+resolve_profile_id = make_resolve_profile_id(
+    setting_attr="media_default_profile_id",
+    missing_message="Authentication required to access the catalog",
+)
+
+
+__all__ = ["resolve_profile_id"]

--- a/src/modules/media/presentation/routes/catalog_routes.py
+++ b/src/modules/media/presentation/routes/catalog_routes.py
@@ -24,6 +24,7 @@ from src.modules.media.application.use_cases.list_movies_by_actor import (
 from src.modules.media.application.use_cases.list_recently_added_catalog import (
     ListRecentlyAddedCatalogUseCase,
 )
+from src.modules.media.presentation.dependencies import resolve_profile_id
 
 router = APIRouter(prefix="/api/v1/catalog", tags=["Catalog"])
 
@@ -44,6 +45,7 @@ _MEDIA_TYPE_QUERY: MediaTypeFilter | None = Query(
 async def list_genres(
     lang: str = "en",
     type: Literal["movie", "series"] | None = _MEDIA_TYPE_QUERY,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListGenresUseCase = Depends(
         Provide[ApplicationContainer.media.list_genres],
     ),
@@ -66,7 +68,9 @@ async def list_genres(
             and Series tabs can skip genres that exist only on the
             other side.
     """
-    result = await use_case.execute(ListGenresInput(lang=lang, media_type=type))
+    result = await use_case.execute(
+        ListGenresInput(profile_id=profile_id, lang=lang, media_type=type)
+    )
     return api_list([asdict(g) for g in result.genres])
 
 
@@ -78,6 +82,7 @@ async def list_by_genre(
     limit: int = DEFAULT_PAGE_SIZE,
     lang: str = "en",
     type: Literal["movie", "series"] | None = _MEDIA_TYPE_QUERY,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListByGenreUseCase = Depends(
         Provide[ApplicationContainer.media.list_by_genre],
     ),
@@ -105,6 +110,7 @@ async def list_by_genre(
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
         ListByGenreInput(
+            profile_id=profile_id,
             genre=genre,
             cursor=cursor,
             limit=clamped_limit,
@@ -123,6 +129,7 @@ async def list_by_genre(
 async def list_recently_added_catalog(
     limit: int = 20,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListRecentlyAddedCatalogUseCase = Depends(
         Provide[ApplicationContainer.media.list_recently_added_catalog],
     ),
@@ -142,7 +149,7 @@ async def list_recently_added_catalog(
     """
     clamped_limit = max(1, min(limit, 50))
     result = await use_case.execute(
-        ListRecentlyAddedCatalogInput(limit=clamped_limit, lang=lang),
+        ListRecentlyAddedCatalogInput(profile_id=profile_id, limit=clamped_limit, lang=lang),
     )
     return api_list([asdict(item) for item in result.items])
 
@@ -154,6 +161,7 @@ async def list_by_actor(
     cursor: str | None = None,
     limit: int = DEFAULT_PAGE_SIZE,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListMoviesByActorUseCase = Depends(
         Provide[ApplicationContainer.media.list_movies_by_actor],
     ),
@@ -187,6 +195,7 @@ async def list_by_actor(
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
         ListMoviesByActorInput(
+            profile_id=profile_id,
             actor_name=name,
             cursor=cursor,
             limit=clamped_limit,

--- a/src/modules/media/presentation/routes/collection_routes.py
+++ b/src/modules/media/presentation/routes/collection_routes.py
@@ -14,6 +14,7 @@ from src.modules.media.application.dtos.collection_dtos import (
 from src.modules.media.application.use_cases.get_collection_by_tmdb_id import (
     GetCollectionByTmdbIdUseCase,
 )
+from src.modules.media.presentation.dependencies import resolve_profile_id
 
 router = APIRouter(prefix="/api/v1/collections", tags=["Collections"])
 
@@ -23,6 +24,7 @@ router = APIRouter(prefix="/api/v1/collections", tags=["Collections"])
 async def get_collection(
     tmdb_id: int = Path(..., ge=1, description="TMDB collection id."),
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetCollectionByTmdbIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_collection_by_tmdb_id],
     ),
@@ -37,7 +39,7 @@ async def get_collection(
     upstream call fails — see ``GetCollectionByTmdbIdUseCase``.
     """
     result = await use_case.execute(
-        GetCollectionByTmdbIdInput(tmdb_id=tmdb_id, lang=lang),
+        GetCollectionByTmdbIdInput(profile_id=profile_id, tmdb_id=tmdb_id, lang=lang),
     )
     return api_single("collection", asdict(result))
 

--- a/src/modules/media/presentation/routes/featured_routes.py
+++ b/src/modules/media/presentation/routes/featured_routes.py
@@ -10,6 +10,7 @@ from src.building_blocks.presentation import api_list
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.featured_dtos import GetFeaturedInput
 from src.modules.media.application.use_cases.get_featured_media import GetFeaturedMediaUseCase
+from src.modules.media.presentation.dependencies import resolve_profile_id
 
 router = APIRouter(prefix="/api/v1/featured", tags=["Featured"])
 
@@ -20,12 +21,15 @@ async def get_featured(
     type: str = Query("all", pattern="^(all|movie|series)$"),
     limit: int = Query(6, ge=1, le=20),
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetFeaturedMediaUseCase = Depends(
         Provide[ApplicationContainer.media.get_featured_media],
     ),
 ) -> dict[str, Any]:
     """Get random featured media for the hero banner."""
-    items = await use_case.execute(GetFeaturedInput(media_type=type, limit=limit, lang=lang))
+    items = await use_case.execute(
+        GetFeaturedInput(profile_id=profile_id, media_type=type, limit=limit, lang=lang)
+    )
     return api_list([asdict(item) for item in items])
 
 

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -34,6 +34,7 @@ from src.modules.media.application.use_cases.list_recently_added_movies import (
 )
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
+from src.modules.media.presentation.dependencies import resolve_profile_id
 from src.modules.media.presentation.schemas import (
     AddFileVariantRequest,
     RemoveFileVariantRequest,
@@ -53,6 +54,7 @@ async def list_movies(
     limit: int = DEFAULT_PAGE_SIZE,
     include_count: bool = False,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListMoviesUseCase = Depends(
         Provide[ApplicationContainer.media.list_movies],
     ),
@@ -75,6 +77,7 @@ async def list_movies(
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
         ListMoviesInput(
+            profile_id=profile_id,
             cursor=cursor,
             limit=clamped_limit,
             include_total=include_count,
@@ -98,6 +101,7 @@ async def list_movies(
 async def list_recently_added_movies(
     limit: int = 20,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListRecentlyAddedMoviesUseCase = Depends(
         Provide[ApplicationContainer.media.list_recently_added_movies],
     ),
@@ -111,7 +115,7 @@ async def list_recently_added_movies(
     """
     clamped_limit = max(1, min(limit, 50))
     result = await use_case.execute(
-        ListRecentlyAddedMoviesInput(limit=clamped_limit, lang=lang),
+        ListRecentlyAddedMoviesInput(profile_id=profile_id, limit=clamped_limit, lang=lang),
     )
     return api_list([_dataclass_to_dict(m) for m in result.movies])
 
@@ -121,12 +125,15 @@ async def list_recently_added_movies(
 async def get_movie(
     movie_id: str,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
 ) -> dict[str, Any]:
     """Get a movie by ID."""
-    result = await use_case.execute(GetMovieByIdInput(movie_id=movie_id, lang=lang))
+    result = await use_case.execute(
+        GetMovieByIdInput(profile_id=profile_id, movie_id=movie_id, lang=lang)
+    )
     return api_single("movie", _dataclass_to_dict(result))
 
 
@@ -136,6 +143,7 @@ async def get_related_movies(
     movie_id: str,
     lang: str = "en",
     limit: int = 12,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetRelatedMoviesUseCase = Depends(
         Provide[ApplicationContainer.media.get_related_movies],
     ),
@@ -148,7 +156,12 @@ async def get_related_movies(
     local catalog. The route never raises.
     """
     items = await use_case.execute(
-        GetRelatedMoviesInput(movie_id=movie_id, lang=lang, limit=max(1, min(limit, 30))),
+        GetRelatedMoviesInput(
+            profile_id=profile_id,
+            movie_id=movie_id,
+            lang=lang,
+            limit=max(1, min(limit, 30)),
+        ),
     )
     return api_list([_dataclass_to_dict(item) for item in items])
 

--- a/src/modules/media/presentation/routes/search_routes.py
+++ b/src/modules/media/presentation/routes/search_routes.py
@@ -11,6 +11,7 @@ from src.building_blocks.presentation import api_list
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.search_dtos import SearchInput
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
+from src.modules.media.presentation.dependencies import resolve_profile_id
 
 router = APIRouter(prefix="/api/v1", tags=["Search"])
 
@@ -28,6 +29,7 @@ async def search(
     year_max: int | None = Query(default=None, description="Inclusive upper bound on year"),
     limit: int = Query(default=20, ge=1, le=MAX_PAGE_SIZE, description="Max results"),
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: SearchCatalogUseCase = Depends(
         Provide[ApplicationContainer.media.search_catalog],
     ),
@@ -49,6 +51,7 @@ async def search(
     """
     result = await use_case.execute(
         SearchInput(
+            profile_id=profile_id,
             query=q,
             media_type=type,
             genre=genre,

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -38,6 +38,7 @@ from src.modules.media.application.use_cases.list_series import ListSeriesUseCas
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
 from src.modules.media.application.use_cases.set_episode_intro import SetEpisodeIntroUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
+from src.modules.media.presentation.dependencies import resolve_profile_id
 from src.modules.media.presentation.schemas import (
     AddFileVariantRequest,
     RemoveFileVariantRequest,
@@ -58,6 +59,7 @@ async def list_series(
     limit: int = DEFAULT_PAGE_SIZE,
     include_count: bool = False,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.list_series],
     ),
@@ -71,6 +73,7 @@ async def list_series(
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
         ListSeriesInput(
+            profile_id=profile_id,
             cursor=cursor,
             limit=clamped_limit,
             include_total=include_count,
@@ -94,6 +97,7 @@ async def list_series(
 async def list_recently_added_series(
     limit: int = 20,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: ListRecentlyAddedSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.list_recently_added_series],
     ),
@@ -106,7 +110,7 @@ async def list_recently_added_series(
     """
     clamped_limit = max(1, min(limit, 50))
     result = await use_case.execute(
-        ListRecentlyAddedSeriesInput(limit=clamped_limit, lang=lang),
+        ListRecentlyAddedSeriesInput(profile_id=profile_id, limit=clamped_limit, lang=lang),
     )
     return api_list([_dataclass_to_dict(s) for s in result.series])
 
@@ -116,12 +120,15 @@ async def list_recently_added_series(
 async def get_series(
     series_id: str,
     lang: str = "en",
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
 ) -> dict[str, Any]:
     """Get a series by ID (includes full season/episode hierarchy)."""
-    result = await use_case.execute(GetSeriesByIdInput(series_id=series_id, lang=lang))
+    result = await use_case.execute(
+        GetSeriesByIdInput(profile_id=profile_id, series_id=series_id, lang=lang)
+    )
     return api_single("series", _dataclass_to_dict(result))
 
 
@@ -131,6 +138,7 @@ async def get_related_series(
     series_id: str,
     lang: str = "en",
     limit: int = 12,
+    profile_id: str = Depends(resolve_profile_id),
     use_case: GetRelatedSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.get_related_series],
     ),
@@ -143,7 +151,12 @@ async def get_related_series(
     local catalog. The route never raises.
     """
     items = await use_case.execute(
-        GetRelatedSeriesInput(series_id=series_id, lang=lang, limit=max(1, min(limit, 30))),
+        GetRelatedSeriesInput(
+            profile_id=profile_id,
+            series_id=series_id,
+            lang=lang,
+            limit=max(1, min(limit, 30)),
+        ),
     )
     return api_list([_dataclass_to_dict(item) for item in items])
 

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -46,6 +46,7 @@ from src.modules.media.application.use_cases.stream_file_range import (
     StreamFileRangeInput,
     StreamFileRangeUseCase,
 )
+from src.modules.media.presentation.dependencies import resolve_profile_id
 
 router = APIRouter(prefix="/api/v1/stream", tags=["Streaming"])
 
@@ -131,6 +132,7 @@ async def hls_file(
 @inject  # type: ignore[misc]
 async def movie_hls_playlist(
     movie_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
@@ -147,7 +149,7 @@ async def movie_hls_playlist(
     in the background so a freshly-imported file gets thumbnails
     without waiting for the next periodic tick.
     """
-    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    movie = await movie_uc.execute(GetMovieByIdInput(profile_id=profile_id, movie_id=movie_id))
     file_path = _require_file(movie.file_path)
     if movie.scrub_preview_path is None:
         _fire_eager_movie(backfill_job, movie_id)
@@ -160,6 +162,7 @@ async def episode_hls_playlist(
     series_id: str,
     season_number: int,
     episode_number: int,
+    profile_id: str = Depends(resolve_profile_id),
     series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
@@ -171,7 +174,7 @@ async def episode_hls_playlist(
     ),
 ) -> Response:
     """Generate and serve HLS master playlist for an episode."""
-    episode = await _find_episode(series_uc, series_id, season_number, episode_number)
+    episode = await _find_episode(series_uc, profile_id, series_id, season_number, episode_number)
     if episode is None:
         raise HTTPException(status_code=404, detail="Episode not found")
     file_path = _require_file(episode.file_path)
@@ -187,6 +190,7 @@ async def episode_hls_playlist(
 @inject  # type: ignore[misc]
 async def movie_tracks(
     movie_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
@@ -195,7 +199,7 @@ async def movie_tracks(
     ),
 ) -> dict[str, Any]:
     """Get available audio and subtitle tracks for a movie."""
-    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    movie = await movie_uc.execute(GetMovieByIdInput(profile_id=profile_id, movie_id=movie_id))
     file_path = _require_file(movie.file_path)
     tracks = await tracks_uc.execute(GetFileTracksInput(file_path=file_path))
     return asdict(tracks)
@@ -207,6 +211,7 @@ async def episode_tracks(
     series_id: str,
     season_number: int,
     episode_number: int,
+    profile_id: str = Depends(resolve_profile_id),
     series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
@@ -215,7 +220,9 @@ async def episode_tracks(
     ),
 ) -> dict[str, Any]:
     """Get available audio and subtitle tracks for an episode."""
-    file_path = await _find_episode_file(series_uc, series_id, season_number, episode_number)
+    file_path = await _find_episode_file(
+        series_uc, profile_id, series_id, season_number, episode_number
+    )
     file_path = _require_file(file_path)
     tracks = await tracks_uc.execute(GetFileTracksInput(file_path=file_path))
     return asdict(tracks)
@@ -256,12 +263,13 @@ def _scrub_preview_files(scrub_preview_path: str | None) -> tuple[Path, Path]:
 @inject  # type: ignore[misc]
 async def movie_scrub_preview_vtt(
     movie_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
 ) -> FileResponse:
     """Serve the persisted scrub-preview WebVTT for a movie."""
-    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    movie = await movie_uc.execute(GetMovieByIdInput(profile_id=profile_id, movie_id=movie_id))
     vtt_path, _ = _scrub_preview_files(movie.scrub_preview_path)
     return FileResponse(str(vtt_path), media_type="text/vtt")
 
@@ -270,12 +278,13 @@ async def movie_scrub_preview_vtt(
 @inject  # type: ignore[misc]
 async def movie_scrub_preview_sprite(
     movie_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
 ) -> FileResponse:
     """Serve the persisted scrub-preview sprite JPEG for a movie."""
-    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    movie = await movie_uc.execute(GetMovieByIdInput(profile_id=profile_id, movie_id=movie_id))
     _, sprite_path = _scrub_preview_files(movie.scrub_preview_path)
     return FileResponse(str(sprite_path), media_type="image/jpeg")
 
@@ -286,12 +295,13 @@ async def episode_scrub_preview_vtt(
     series_id: str,
     season_number: int,
     episode_number: int,
+    profile_id: str = Depends(resolve_profile_id),
     series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
 ) -> FileResponse:
     """Serve the persisted scrub-preview WebVTT for an episode."""
-    episode = await _find_episode(series_uc, series_id, season_number, episode_number)
+    episode = await _find_episode(series_uc, profile_id, series_id, season_number, episode_number)
     if episode is None:
         raise HTTPException(status_code=404, detail="Episode not found")
     vtt_path, _ = _scrub_preview_files(episode.scrub_preview_path)
@@ -304,12 +314,13 @@ async def episode_scrub_preview_sprite(
     series_id: str,
     season_number: int,
     episode_number: int,
+    profile_id: str = Depends(resolve_profile_id),
     series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
 ) -> FileResponse:
     """Serve the persisted scrub-preview sprite JPEG for an episode."""
-    episode = await _find_episode(series_uc, series_id, season_number, episode_number)
+    episode = await _find_episode(series_uc, profile_id, series_id, season_number, episode_number)
     if episode is None:
         raise HTTPException(status_code=404, detail="Episode not found")
     _, sprite_path = _scrub_preview_files(episode.scrub_preview_path)
@@ -323,6 +334,7 @@ async def episode_scrub_preview_sprite(
 @inject  # type: ignore[misc]
 async def clear_movie_hls_cache(
     movie_id: str,
+    profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
@@ -331,7 +343,7 @@ async def clear_movie_hls_cache(
     ),
 ) -> Response:
     """Clear cached HLS segments for a movie, forcing regeneration."""
-    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    movie = await movie_uc.execute(GetMovieByIdInput(profile_id=profile_id, movie_id=movie_id))
     await clear_uc.execute(ClearHlsCacheInput(file_path=movie.file_path))
     return Response(status_code=204)
 
@@ -344,6 +356,7 @@ async def clear_movie_hls_cache(
 async def stream_movie(
     movie_id: str,
     request: Request,
+    profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
     ),
@@ -352,7 +365,7 @@ async def stream_movie(
     ),
 ) -> StreamingResponse:
     """Direct stream a movie file with Range support (MP4/WebM only)."""
-    movie = await movie_uc.execute(GetMovieByIdInput(movie_id=movie_id))
+    movie = await movie_uc.execute(GetMovieByIdInput(profile_id=profile_id, movie_id=movie_id))
     file_path = _require_file(movie.file_path)
     return await _stream_range(stream_uc, file_path, request.headers.get("range"))
 
@@ -364,6 +377,7 @@ async def stream_episode(
     season_number: int,
     episode_number: int,
     request: Request,
+    profile_id: str = Depends(resolve_profile_id),
     series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
     ),
@@ -372,7 +386,9 @@ async def stream_episode(
     ),
 ) -> StreamingResponse:
     """Direct stream an episode file with Range support."""
-    file_path = await _find_episode_file(series_uc, series_id, season_number, episode_number)
+    file_path = await _find_episode_file(
+        series_uc, profile_id, series_id, season_number, episode_number
+    )
     file_path = _require_file(file_path)
     return await _stream_range(stream_uc, file_path, request.headers.get("range"))
 
@@ -417,23 +433,25 @@ async def _stream_range(
 
 async def _find_episode_file(
     use_case: GetSeriesByIdUseCase,
+    profile_id: str,
     series_id: str,
     season_number: int,
     episode_number: int,
 ) -> str | None:
     """Find episode file path from series hierarchy."""
-    episode = await _find_episode(use_case, series_id, season_number, episode_number)
+    episode = await _find_episode(use_case, profile_id, series_id, season_number, episode_number)
     return episode.file_path if episode else None
 
 
 async def _find_episode(
     use_case: GetSeriesByIdUseCase,
+    profile_id: str,
     series_id: str,
     season_number: int,
     episode_number: int,
 ) -> EpisodeOutput | None:
     """Resolve a single ``EpisodeOutput`` from the series aggregate."""
-    series = await use_case.execute(GetSeriesByIdInput(series_id=series_id))
+    series = await use_case.execute(GetSeriesByIdInput(profile_id=profile_id, series_id=series_id))
     for season in series.seasons:
         if season.season_number == season_number:
             for episode in season.episodes:

--- a/tests/modules/media/integration/acl/test_profile_library_access_adapter.py
+++ b/tests/modules/media/integration/acl/test_profile_library_access_adapter.py
@@ -1,0 +1,117 @@
+"""Integration tests for the Media ProfileLibraryAccessAdapter."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+# Importing the identity models ensures Base.metadata.create_all
+# (called by the integration conftest) discovers ``users`` /
+# ``profiles`` / ``access_tokens``.
+import src.modules.identity.infrastructure.persistence.models  # noqa: F401
+from src.modules.identity.domain.entities.profile import Profile
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.profile_name import ProfileName
+from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyIdentityUnitOfWorkFactory,
+)
+from src.modules.media.infrastructure.acl import ProfileLibraryAccessAdapter
+
+
+async def _seed_profile(
+    factory: SqlAlchemyIdentityUnitOfWorkFactory,
+    *,
+    email: str,
+    profile_name: str,
+    allowed_library_ids: list[str],
+) -> Profile:
+    """Create + persist a user and a single profile, returning the profile."""
+    async with factory() as uow:
+        user = await uow.users.save(User.create(email=Email(email), hashed_password="hp"))
+        assert user.id is not None
+        return await uow.profiles.save(
+            Profile.create(
+                user_id=user.id,
+                name=ProfileName(profile_name),
+                allowed_library_ids=allowed_library_ids,
+            )
+        )
+
+
+def _make_adapter(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> ProfileLibraryAccessAdapter:
+    return ProfileLibraryAccessAdapter(SqlAlchemyIdentityUnitOfWorkFactory(session_factory))
+
+
+@pytest.mark.integration
+class TestProfileLibraryAccessAdapter:
+    async def test_should_return_allowed_library_ids_for_known_profile(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        factory = SqlAlchemyIdentityUnitOfWorkFactory(session_factory)
+        granted = ["lib_movies123456", "lib_series123456"]
+        profile = await _seed_profile(
+            factory,
+            email="lucas@homeflix.local",
+            profile_name="Lucas",
+            allowed_library_ids=granted,
+        )
+
+        adapter = _make_adapter(session_factory)
+
+        assert profile.id is not None
+        assert await adapter.find_for_profile(profile.id.value) == granted
+
+    async def test_should_return_empty_list_for_default_deny_profile(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        factory = SqlAlchemyIdentityUnitOfWorkFactory(session_factory)
+        profile = await _seed_profile(
+            factory,
+            email="anon@homeflix.local",
+            profile_name="Anon",
+            allowed_library_ids=[],
+        )
+
+        adapter = _make_adapter(session_factory)
+
+        assert profile.id is not None
+        assert await adapter.find_for_profile(profile.id.value) == []
+
+    async def test_should_return_empty_list_for_unknown_profile_id(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Deny-all is the safer default than raising — the adapter
+        # is the only thing standing between an absent profile and
+        # the catalog reads downstream.
+        adapter = _make_adapter(session_factory)
+
+        assert await adapter.find_for_profile("prf_doesnotexist") == []
+
+    async def test_should_isolate_acls_across_profiles(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        factory = SqlAlchemyIdentityUnitOfWorkFactory(session_factory)
+        a = await _seed_profile(
+            factory,
+            email="a@homeflix.local",
+            profile_name="A",
+            allowed_library_ids=["lib_a"],
+        )
+        b = await _seed_profile(
+            factory,
+            email="b@homeflix.local",
+            profile_name="B",
+            allowed_library_ids=["lib_b1", "lib_b2"],
+        )
+
+        adapter = _make_adapter(session_factory)
+
+        assert a.id is not None
+        assert b.id is not None
+        assert await adapter.find_for_profile(a.id.value) == ["lib_a"]
+        assert await adapter.find_for_profile(b.id.value) == ["lib_b1", "lib_b2"]

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -1101,3 +1101,114 @@ class TestSQLAlchemyMovieRepositoryLibraryIsolation:
 
         assert found is not None
         assert found.library_id == _LIBRARY_ID
+
+
+def _movie_in_library(*, library_id: str, title: str, file_path: str) -> Movie:
+    """Build a Movie with an explicit ``library_id`` for ACL tests."""
+    return Movie(
+        library_id=library_id,
+        id=MovieId.generate(),
+        title=Title(title),
+        year=Year(2024),
+        duration=Duration(7200),
+        files=[
+            MediaFile(
+                file_path=FilePath(file_path),
+                file_size=1_000_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            )
+        ],
+    )
+
+
+@pytest.mark.integration
+class TestAllowedLibraryIdsFilter:
+    """``allowed_library_ids`` kwarg restricts reads to a set of libraries.
+
+    The use cases pass the caller's profile ACL as this kwarg; these
+    tests pin the SQL filter at the repository boundary. Two
+    representative methods are covered: ``list_paginated`` (the page
+    query that backs the catalog grid) and ``find_by_id`` (the lookup
+    that backs the detail page and the stream routes).
+    """
+
+    async def test_list_paginated_includes_only_allowed_libraries(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(
+            _movie_in_library(library_id=_LIBRARY_ID, title="Visible", file_path="/libA/v.mkv")
+        )
+        await repo.save(
+            _movie_in_library(
+                library_id=_LIBRARY_ID_OTHER,
+                title="Hidden",
+                file_path="/libB/h.mkv",
+            )
+        )
+
+        page = await repo.list_paginated(
+            cursor=None,
+            limit=10,
+            allowed_library_ids=[_LIBRARY_ID],
+        )
+
+        titles = {m.title.value for m in page.items}
+        assert titles == {"Visible"}
+        assert "Hidden" not in titles
+
+    async def test_list_paginated_excludes_libraries_outside_allowed_set(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(
+            _movie_in_library(library_id=_LIBRARY_ID, title="In A", file_path="/libA/in.mkv")
+        )
+        await repo.save(
+            _movie_in_library(
+                library_id=_LIBRARY_ID_OTHER,
+                title="In B",
+                file_path="/libB/in.mkv",
+            )
+        )
+
+        # Allowed = library B only.
+        page = await repo.list_paginated(
+            cursor=None,
+            limit=10,
+            allowed_library_ids=[_LIBRARY_ID_OTHER],
+        )
+
+        titles = {m.title.value for m in page.items}
+        assert titles == {"In B"}
+
+    async def test_find_by_id_returns_none_for_row_outside_acl(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _movie_in_library(
+            library_id=_LIBRARY_ID_OTHER,
+            title="Forbidden",
+            file_path="/libB/forbidden.mkv",
+        )
+        await repo.save(movie)
+        assert movie.id is not None
+
+        # Caller is restricted to library A — must NOT see the row.
+        found = await repo.find_by_id(movie.id, allowed_library_ids=[_LIBRARY_ID])
+
+        assert found is None
+
+    async def test_find_by_id_returns_row_when_inside_acl(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _movie_in_library(
+            library_id=_LIBRARY_ID, title="Allowed", file_path="/libA/allowed.mkv"
+        )
+        await repo.save(movie)
+        assert movie.id is not None
+
+        found = await repo.find_by_id(movie.id, allowed_library_ids=[_LIBRARY_ID])
+
+        assert found is not None
+        assert found.title.value == "Allowed"

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -1554,3 +1554,81 @@ class TestSQLAlchemySeriesRepositoryLibraryIsolation:
 
         assert found is not None
         assert found.library_id == _LIBRARY_ID
+
+
+def _series_in_library(*, library_id: str, title: str) -> Series:
+    """Build a Series with an explicit ``library_id`` for ACL tests."""
+    return Series(
+        library_id=library_id,
+        id=SeriesId.generate(),
+        title=Title(title),
+        start_year=Year(2024),
+    )
+
+
+@pytest.mark.integration
+class TestAllowedLibraryIdsFilter:
+    """``allowed_library_ids`` kwarg restricts reads to a set of libraries.
+
+    Mirror of the movies-side coverage: pin ``list_paginated`` and
+    ``find_by_id`` at the repo boundary so the use cases can rely on
+    the kwarg's semantics without re-asserting in every unit test.
+    """
+
+    async def test_list_paginated_includes_only_allowed_libraries(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_series_in_library(library_id=_LIBRARY_ID, title="Visible"))
+        await repo.save(_series_in_library(library_id=_LIBRARY_ID_OTHER, title="Hidden"))
+
+        page = await repo.list_paginated(
+            cursor=None,
+            limit=10,
+            allowed_library_ids=[_LIBRARY_ID],
+        )
+
+        titles = {s.title.value for s in page.items}
+        assert titles == {"Visible"}
+        assert "Hidden" not in titles
+
+    async def test_list_paginated_excludes_libraries_outside_allowed_set(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_series_in_library(library_id=_LIBRARY_ID, title="In A"))
+        await repo.save(_series_in_library(library_id=_LIBRARY_ID_OTHER, title="In B"))
+
+        # Allowed = library B only.
+        page = await repo.list_paginated(
+            cursor=None,
+            limit=10,
+            allowed_library_ids=[_LIBRARY_ID_OTHER],
+        )
+
+        titles = {s.title.value for s in page.items}
+        assert titles == {"In B"}
+
+    async def test_find_by_id_returns_none_for_row_outside_acl(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _series_in_library(library_id=_LIBRARY_ID_OTHER, title="Forbidden")
+        await repo.save(series)
+        assert series.id is not None
+
+        # Caller is restricted to library A — must NOT see the row.
+        found = await repo.find_by_id(series.id, allowed_library_ids=[_LIBRARY_ID])
+
+        assert found is None
+
+    async def test_find_by_id_returns_row_when_inside_acl(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _series_in_library(library_id=_LIBRARY_ID, title="Allowed")
+        await repo.save(series)
+        assert series.id is not None
+
+        found = await repo.find_by_id(series.id, allowed_library_ids=[_LIBRARY_ID])
+
+        assert found is not None
+        assert found.title.value == "Allowed"

--- a/tests/modules/media/unit/application/use_cases/test_get_collection_by_tmdb_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_collection_by_tmdb_id.py
@@ -20,9 +20,13 @@ from src.modules.media.application.use_cases.get_collection_by_tmdb_id import (
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import TmdbId
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_PROFILE_ID = "prf_test12345678"
 
 
 def _movie_with_tmdb(*, title: str, tmdb_id: int, year: int = 2010) -> Movie:
@@ -61,6 +65,19 @@ def _make_lookup_adapter(
     return lookup
 
 
+def _make_use_case(
+    mocks, provider, lookup, *, allowed: list[str] | None = None
+) -> GetCollectionByTmdbIdUseCase:
+    if allowed is None:
+        allowed = [_LIBRARY_ID]
+    return GetCollectionByTmdbIdUseCase(
+        mocks.factory,
+        provider,
+        lookup,
+        FakeProfileLibraryAccessPort({_PROFILE_ID: allowed}),
+    )
+
+
 class TestGetCollectionByTmdbIdUseCase:
     @pytest.mark.asyncio
     async def test_raises_when_collection_missing(self) -> None:
@@ -69,10 +86,10 @@ class TestGetCollectionByTmdbIdUseCase:
         provider.get_collection.return_value = None
         lookup = _make_lookup_adapter()
 
-        use_case = GetCollectionByTmdbIdUseCase(mocks.factory, provider, lookup)
+        use_case = _make_use_case(mocks, provider, lookup)
 
         with pytest.raises(ResourceNotFoundException):
-            await use_case.execute(GetCollectionByTmdbIdInput(tmdb_id=8091))
+            await use_case.execute(GetCollectionByTmdbIdInput(profile_id=_PROFILE_ID, tmdb_id=8091))
 
     @pytest.mark.asyncio
     async def test_marks_local_parts_as_in_catalog(self) -> None:
@@ -97,9 +114,9 @@ class TestGetCollectionByTmdbIdUseCase:
         provider = _make_metadata_provider(parts)
         lookup = _make_lookup_adapter()
 
-        use_case = GetCollectionByTmdbIdUseCase(mocks.factory, provider, lookup)
+        use_case = _make_use_case(mocks, provider, lookup)
         result = await use_case.execute(
-            GetCollectionByTmdbIdInput(tmdb_id=8091),
+            GetCollectionByTmdbIdInput(profile_id=_PROFILE_ID, tmdb_id=8091),
         )
 
         assert result.total_parts == 2
@@ -111,6 +128,9 @@ class TestGetCollectionByTmdbIdUseCase:
         assert result.parts[0].movie_id is not None
         assert result.parts[1].in_catalog is False
         assert result.parts[1].movie_id is None
+        # The catalog overlay must be ACL-scoped.
+        find_by_tmdb_ids_kwargs = mocks.movies.find_by_tmdb_ids.await_args.kwargs
+        assert list(find_by_tmdb_ids_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
 
     @pytest.mark.asyncio
     async def test_surfaces_request_status_for_missing_parts_only(self) -> None:
@@ -141,8 +161,10 @@ class TestGetCollectionByTmdbIdUseCase:
             },
         )
 
-        use_case = GetCollectionByTmdbIdUseCase(mocks.factory, provider, lookup)
-        result = await use_case.execute(GetCollectionByTmdbIdInput(tmdb_id=8091))
+        use_case = _make_use_case(mocks, provider, lookup)
+        result = await use_case.execute(
+            GetCollectionByTmdbIdInput(profile_id=_PROFILE_ID, tmdb_id=8091)
+        )
 
         in_catalog_part = next(p for p in result.parts if p.in_catalog)
         missing_part = next(p for p in result.parts if not p.in_catalog)
@@ -163,7 +185,34 @@ class TestGetCollectionByTmdbIdUseCase:
         provider = _make_metadata_provider(parts)
         lookup = _make_lookup_adapter()
 
-        use_case = GetCollectionByTmdbIdUseCase(mocks.factory, provider, lookup)
-        result = await use_case.execute(GetCollectionByTmdbIdInput(tmdb_id=8091))
+        use_case = _make_use_case(mocks, provider, lookup)
+        result = await use_case.execute(
+            GetCollectionByTmdbIdInput(profile_id=_PROFILE_ID, tmdb_id=8091)
+        )
 
         assert [p.tmdb_id for p in result.parts] == [2, 3, 1]
+
+    @pytest.mark.asyncio
+    async def test_skips_local_overlay_for_deny_all_profile(self) -> None:
+        # The TMDB call still happens (the page is informational about
+        # the franchise as a whole) but the local-catalog overlay is
+        # skipped — every part renders as missing for a profile that
+        # cannot see anything in the local library.
+        parts = [
+            CollectionPartMetadata(tmdb_id=348, title="Alien", year=1979),
+        ]
+        mocks = make_media_uow_mock()
+        provider = _make_metadata_provider(parts)
+        lookup = _make_lookup_adapter()
+
+        use_case = _make_use_case(mocks, provider, lookup, allowed=[])
+        result = await use_case.execute(
+            GetCollectionByTmdbIdInput(profile_id=_PROFILE_ID, tmdb_id=8091)
+        )
+
+        assert result.total_parts == 1
+        assert result.available_parts == 0
+        assert result.parts[0].in_catalog is False
+        # No UoW opened, no repo call.
+        mocks.factory.assert_not_called()
+        mocks.movies.find_by_tmdb_ids.assert_not_called()

--- a/tests/modules/media/unit/application/use_cases/test_get_featured_media.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_featured_media.py
@@ -11,14 +11,20 @@ from src.modules.media.application.use_cases.get_featured_media import (
 )
 from src.modules.media.domain.entities import Movie, Series
 from src.modules.media.domain.value_objects import ImageUrl
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
-def _make_movie(title: str = "Inception") -> Movie:
+def _make_movie(title: str = "Inception", *, library_id: str = _LIBRARY_ID) -> Movie:
     movie = Movie.create(
-        library_id=_LIBRARY_ID,
+        library_id=library_id,
         title=title,
         year=2010,
         duration=8880,
@@ -31,8 +37,8 @@ def _make_movie(title: str = "Inception") -> Movie:
     )
 
 
-def _make_series(title: str = "Breaking Bad") -> Series:
-    series = Series.create(library_id=_LIBRARY_ID, title=title, start_year=2008)
+def _make_series(title: str = "Breaking Bad", *, library_id: str = _LIBRARY_ID) -> Series:
+    series = Series.create(library_id=library_id, title=title, start_year=2008)
     return series.with_updates(
         backdrop_path=ImageUrl("https://image.tmdb.org/series_backdrop.jpg"),
     )
@@ -46,9 +52,14 @@ class TestGetFeaturedMediaUseCase:
     async def test_should_return_movies_only(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.find_random.return_value = [_make_movie("Inception")]
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=10))
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="movie", limit=10)
+        )
 
         assert len(result) == 1
         assert isinstance(result[0], FeaturedItemOutput)
@@ -60,9 +71,14 @@ class TestGetFeaturedMediaUseCase:
     async def test_should_return_series_only(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.find_random.return_value = [_make_series("Breaking Bad")]
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetFeaturedInput(media_type="series", limit=10))
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="series", limit=10)
+        )
 
         assert len(result) == 1
         assert result[0].type == "series"
@@ -74,9 +90,14 @@ class TestGetFeaturedMediaUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.find_random.return_value = [_make_movie("Inception")]
         mocks.series.find_random.return_value = [_make_series("Breaking Bad")]
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetFeaturedInput(media_type="all", limit=10))
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="all", limit=10)
+        )
 
         assert len(result) == 2
         types = {item.type for item in result}
@@ -87,9 +108,14 @@ class TestGetFeaturedMediaUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.find_random.return_value = [_make_movie(f"Movie{i}") for i in range(5)]
         mocks.series.find_random.return_value = [_make_series(f"Series{i}") for i in range(5)]
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetFeaturedInput(media_type="all", limit=4))
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="all", limit=4)
+        )
 
         assert len(result) == 4
 
@@ -98,9 +124,14 @@ class TestGetFeaturedMediaUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.find_random.return_value = []
         mocks.series.find_random.return_value = []
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetFeaturedInput(media_type="all", limit=10))
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="all", limit=10)
+        )
 
         assert result == []
 
@@ -108,11 +139,18 @@ class TestGetFeaturedMediaUseCase:
     async def test_should_filter_with_backdrop(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.find_random.return_value = []
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(GetFeaturedInput(media_type="movie", limit=5))
+        await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="movie", limit=5)
+        )
 
-        mocks.movies.find_random.assert_called_once_with(5, with_backdrop=True)
+        mocks.movies.find_random.assert_called_once_with(
+            5, with_backdrop=True, allowed_library_ids=[_LIBRARY_ID]
+        )
 
     @pytest.mark.asyncio
     async def test_should_pass_language_to_movie_outputs(self) -> None:
@@ -122,9 +160,14 @@ class TestGetFeaturedMediaUseCase:
         )
         mocks = make_media_uow_mock()
         mocks.movies.find_random.return_value = [movie]
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=1, lang="pt-BR"))
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="movie", limit=1, lang="pt-BR")
+        )
 
         assert result[0].title == "A Origem"
 
@@ -133,9 +176,14 @@ class TestGetFeaturedMediaUseCase:
         movie = _make_movie("Inception")
         mocks = make_media_uow_mock()
         mocks.movies.find_random.return_value = [movie]
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetFeaturedInput(media_type="movie", limit=1))
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="movie", limit=1)
+        )
 
         assert result[0].backdrop_path == "https://image.tmdb.org/backdrop.jpg"
         assert result[0].year == 2010
@@ -146,9 +194,54 @@ class TestGetFeaturedMediaUseCase:
         series = _make_series("Breaking Bad")
         mocks = make_media_uow_mock()
         mocks.series.find_random.return_value = [series]
-        use_case = GetFeaturedMediaUseCase(uow_factory=mocks.factory)
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetFeaturedInput(media_type="series", limit=1))
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="series", limit=1)
+        )
 
         assert result[0].duration_formatted is None
         assert result[0].year == 2008
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="all", limit=10)
+        )
+
+        assert result == []
+        mocks.factory.assert_not_called()
+        mocks.movies.find_random.assert_not_called()
+        mocks.series.find_random.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_random.return_value = [_make_movie("Visible")]
+        mocks.series.find_random.return_value = []
+        use_case = GetFeaturedMediaUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        result = await use_case.execute(
+            GetFeaturedInput(profile_id=_PROFILE_ID, media_type="all", limit=5)
+        )
+
+        assert [item.title for item in result] == ["Visible"]
+        movie_kwargs = mocks.movies.find_random.call_args.kwargs
+        series_kwargs = mocks.series.find_random.call_args.kwargs
+        assert list(movie_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert list(series_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(movie_kwargs["allowed_library_ids"])

--- a/tests/modules/media/unit/application/use_cases/test_get_movie_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_movie_by_id.py
@@ -7,9 +7,14 @@ from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos import GetMovieByIdInput, MovieOutput
 from src.modules.media.application.use_cases import GetMovieByIdUseCase
 from src.modules.media.domain.entities import Movie
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_PROFILE_ID = "prf_test12345678"
 
 
 class TestGetMovieByIdUseCase:
@@ -28,9 +33,14 @@ class TestGetMovieByIdUseCase:
             resolution="1080p",
         )
         mocks.movies.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
+        use_case = GetMovieByIdUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
+        result = await use_case.execute(
+            GetMovieByIdInput(profile_id=_PROFILE_ID, movie_id=str(movie.id))
+        )
 
         assert isinstance(result, MovieOutput)
         assert result.title == "Inception"
@@ -51,9 +61,14 @@ class TestGetMovieByIdUseCase:
             resolution="1080p",
         )
         mocks.movies.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
+        use_case = GetMovieByIdUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
+        result = await use_case.execute(
+            GetMovieByIdInput(profile_id=_PROFILE_ID, movie_id=str(movie.id))
+        )
 
         assert result.duration_formatted == "02:00:00"
 
@@ -72,9 +87,14 @@ class TestGetMovieByIdUseCase:
         movie = movie.with_genre("Action")
         movie = movie.with_genre("Sci-Fi")
         mocks.movies.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
+        use_case = GetMovieByIdUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
+        result = await use_case.execute(
+            GetMovieByIdInput(profile_id=_PROFILE_ID, movie_id=str(movie.id))
+        )
 
         assert result.genres == ["Action", "Sci-Fi"]
 
@@ -91,9 +111,14 @@ class TestGetMovieByIdUseCase:
             resolution="1080p",
         )
         mocks.movies.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
+        use_case = GetMovieByIdUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
+        result = await use_case.execute(
+            GetMovieByIdInput(profile_id=_PROFILE_ID, movie_id=str(movie.id))
+        )
 
         assert result.original_title is None
         assert result.synopsis is None
@@ -106,16 +131,21 @@ class TestGetMovieByIdUseCase:
     async def test_should_raise_not_found_when_movie_missing(self):
         mocks = make_media_uow_mock()
         mocks.movies.find_by_id.return_value = None
-        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
+        use_case = GetMovieByIdUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
-            await use_case.execute(GetMovieByIdInput(movie_id="mov_nonexistent1"))
+            await use_case.execute(
+                GetMovieByIdInput(profile_id=_PROFILE_ID, movie_id="mov_nonexistent1")
+            )
 
         assert exc_info.value.resource_type == "Movie"
         assert exc_info.value.resource_id == "mov_nonexistent1"
 
     @pytest.mark.asyncio
-    async def test_should_call_repository_with_movie_id(self):
+    async def test_should_call_repository_with_movie_id_and_allowed_libraries(self):
         mocks = make_media_uow_mock()
         movie = Movie.create(
             library_id=_LIBRARY_ID,
@@ -127,10 +157,33 @@ class TestGetMovieByIdUseCase:
             resolution="1080p",
         )
         mocks.movies.find_by_id.return_value = movie
-        use_case = GetMovieByIdUseCase(uow_factory=mocks.factory)
+        use_case = GetMovieByIdUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(GetMovieByIdInput(movie_id=str(movie.id)))
+        await use_case.execute(GetMovieByIdInput(profile_id=_PROFILE_ID, movie_id=str(movie.id)))
 
-        mocks.movies.find_by_id.assert_called_once()
-        call_arg = mocks.movies.find_by_id.call_args[0][0]
-        assert str(call_arg) == str(movie.id)
+        mocks.movies.find_by_id.assert_awaited_once()
+        call_args = mocks.movies.find_by_id.await_args
+        assert str(call_args.args[0]) == str(movie.id)
+        assert list(call_args.kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+
+    @pytest.mark.asyncio
+    async def test_should_raise_404_for_deny_all_profile(self):
+        # Deny-all profile must surface as 404 (matching the behavior
+        # for a movie that lives outside the ACL — id-poking should
+        # not leak the row's existence). Load-bearing security
+        # assertion.
+        mocks = make_media_uow_mock()
+        use_case = GetMovieByIdUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                GetMovieByIdInput(profile_id=_PROFILE_ID, movie_id="mov_anything12345")
+            )
+        mocks.factory.assert_not_called()
+        mocks.movies.find_by_id.assert_not_awaited()

--- a/tests/modules/media/unit/application/use_cases/test_get_related_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_related_movies.py
@@ -11,9 +11,13 @@ from src.modules.media.application.use_cases.get_related_movies import (
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import MovieId, TmdbId
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_PROFILE_ID = "prf_test12345678"
 
 
 def _movie(*, title: str, tmdb_id: int | None) -> Movie:
@@ -29,6 +33,16 @@ def _movie(*, title: str, tmdb_id: int | None) -> Movie:
     return movie.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id is not None else movie
 
 
+def _make_use_case(mocks, provider, *, allowed: list[str] | None = None) -> GetRelatedMoviesUseCase:
+    if allowed is None:
+        allowed = [_LIBRARY_ID]
+    return GetRelatedMoviesUseCase(
+        mocks.factory,
+        provider,
+        FakeProfileLibraryAccessPort({_PROFILE_ID: allowed}),
+    )
+
+
 class TestGetRelatedMoviesUseCase:
     @pytest.mark.asyncio
     async def test_returns_empty_when_source_movie_missing(self) -> None:
@@ -36,9 +50,9 @@ class TestGetRelatedMoviesUseCase:
         mocks.movies.find_by_id.return_value = None
         provider = AsyncMock(spec=MetadataProvider)
 
-        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedMoviesInput(movie_id=str(MovieId.generate())),
+            GetRelatedMoviesInput(profile_id=_PROFILE_ID, movie_id=str(MovieId.generate())),
         )
 
         assert result == []
@@ -52,9 +66,9 @@ class TestGetRelatedMoviesUseCase:
         mocks.movies.find_by_id.return_value = _movie(title="Manual", tmdb_id=None)
         provider = AsyncMock(spec=MetadataProvider)
 
-        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedMoviesInput(movie_id=str(MovieId.generate())),
+            GetRelatedMoviesInput(profile_id=_PROFILE_ID, movie_id=str(MovieId.generate())),
         )
 
         assert result == []
@@ -80,12 +94,21 @@ class TestGetRelatedMoviesUseCase:
             888888,
         ]
 
-        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedMoviesInput(movie_id=str(MovieId.generate()), limit=10),
+            GetRelatedMoviesInput(
+                profile_id=_PROFILE_ID,
+                movie_id=str(MovieId.generate()),
+                limit=10,
+            ),
         )
 
         assert [m.title for m in result] == ["The Departed", "Inception"]
+        # Both repo calls must carry the ACL.
+        find_by_id_kwargs = mocks.movies.find_by_id.await_args.kwargs
+        find_by_tmdb_ids_kwargs = mocks.movies.find_by_tmdb_ids.await_args.kwargs
+        assert list(find_by_id_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert list(find_by_tmdb_ids_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
 
     @pytest.mark.asyncio
     async def test_truncates_to_limit(self) -> None:
@@ -97,9 +120,13 @@ class TestGetRelatedMoviesUseCase:
         provider = AsyncMock(spec=MetadataProvider)
         provider.get_movie_recommendations.return_value = [10, 11, 12, 13, 14]
 
-        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedMoviesInput(movie_id=str(MovieId.generate()), limit=3),
+            GetRelatedMoviesInput(
+                profile_id=_PROFILE_ID,
+                movie_id=str(MovieId.generate()),
+                limit=3,
+            ),
         )
 
         assert len(result) == 3
@@ -113,9 +140,49 @@ class TestGetRelatedMoviesUseCase:
         provider = AsyncMock(spec=MetadataProvider)
         provider.get_movie_recommendations.return_value = [99, 100, 101]
 
-        use_case = GetRelatedMoviesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedMoviesInput(movie_id=str(MovieId.generate())),
+            GetRelatedMoviesInput(profile_id=_PROFILE_ID, movie_id=str(MovieId.generate())),
         )
 
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_deny_all_profile(self) -> None:
+        # Deny-all profile must short-circuit before hitting the
+        # provider — no leak of recommendations to a profile that
+        # cannot see anything in the catalog.
+        mocks = make_media_uow_mock()
+        provider = AsyncMock(spec=MetadataProvider)
+
+        use_case = _make_use_case(mocks, provider, allowed=[])
+        result = await use_case.execute(
+            GetRelatedMoviesInput(profile_id=_PROFILE_ID, movie_id=str(MovieId.generate())),
+        )
+
+        assert result == []
+        mocks.factory.assert_not_called()
+        provider.get_movie_recommendations.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_passes_allowed_library_ids_to_both_repo_calls(self) -> None:
+        mocks = make_media_uow_mock()
+        # Make sure we hit both find_by_id and find_by_tmdb_ids.
+        mocks.movies.find_by_id.return_value = _movie(title="Source", tmdb_id=1)
+        mocks.movies.find_by_tmdb_ids.return_value = {10: _movie(title="Visible", tmdb_id=10)}
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_movie_recommendations.return_value = [10]
+
+        use_case = GetRelatedMoviesUseCase(
+            mocks.factory,
+            provider,
+            FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+        await use_case.execute(
+            GetRelatedMoviesInput(profile_id=_PROFILE_ID, movie_id=str(MovieId.generate()))
+        )
+
+        find_by_id_kwargs = mocks.movies.find_by_id.await_args.kwargs
+        find_by_tmdb_ids_kwargs = mocks.movies.find_by_tmdb_ids.await_args.kwargs
+        assert list(find_by_id_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert list(find_by_tmdb_ids_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]

--- a/tests/modules/media/unit/application/use_cases/test_get_related_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_related_series.py
@@ -11,14 +11,28 @@ from src.modules.media.application.use_cases.get_related_series import (
 )
 from src.modules.media.domain.entities import Series
 from src.modules.media.domain.value_objects import SeriesId, TmdbId
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_PROFILE_ID = "prf_test12345678"
 
 
 def _series(*, title: str, tmdb_id: int | None) -> Series:
     series = Series.create(library_id=_LIBRARY_ID, title=title, start_year=2010)
     return series.with_updates(tmdb_id=TmdbId(tmdb_id)) if tmdb_id is not None else series
+
+
+def _make_use_case(mocks, provider, *, allowed: list[str] | None = None) -> GetRelatedSeriesUseCase:
+    if allowed is None:
+        allowed = [_LIBRARY_ID]
+    return GetRelatedSeriesUseCase(
+        mocks.factory,
+        provider,
+        FakeProfileLibraryAccessPort({_PROFILE_ID: allowed}),
+    )
 
 
 class TestGetRelatedSeriesUseCase:
@@ -28,9 +42,9 @@ class TestGetRelatedSeriesUseCase:
         mocks.series.find_by_id.return_value = None
         provider = AsyncMock(spec=MetadataProvider)
 
-        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedSeriesInput(series_id=str(SeriesId.generate())),
+            GetRelatedSeriesInput(profile_id=_PROFILE_ID, series_id=str(SeriesId.generate())),
         )
 
         assert result == []
@@ -44,9 +58,9 @@ class TestGetRelatedSeriesUseCase:
         mocks.series.find_by_id.return_value = _series(title="Manual", tmdb_id=None)
         provider = AsyncMock(spec=MetadataProvider)
 
-        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedSeriesInput(series_id=str(SeriesId.generate())),
+            GetRelatedSeriesInput(profile_id=_PROFILE_ID, series_id=str(SeriesId.generate())),
         )
 
         assert result == []
@@ -72,12 +86,20 @@ class TestGetRelatedSeriesUseCase:
             888888,
         ]
 
-        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedSeriesInput(series_id=str(SeriesId.generate()), limit=10),
+            GetRelatedSeriesInput(
+                profile_id=_PROFILE_ID,
+                series_id=str(SeriesId.generate()),
+                limit=10,
+            ),
         )
 
         assert [s.title for s in result] == ["Breaking Bad", "Rick and Morty"]
+        find_by_id_kwargs = mocks.series.find_by_id.await_args.kwargs
+        find_by_tmdb_ids_kwargs = mocks.series.find_by_tmdb_ids.await_args.kwargs
+        assert list(find_by_id_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert list(find_by_tmdb_ids_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
 
     @pytest.mark.asyncio
     async def test_truncates_to_limit(self) -> None:
@@ -89,9 +111,13 @@ class TestGetRelatedSeriesUseCase:
         provider = AsyncMock(spec=MetadataProvider)
         provider.get_series_recommendations.return_value = [10, 11, 12, 13, 14]
 
-        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedSeriesInput(series_id=str(SeriesId.generate()), limit=3),
+            GetRelatedSeriesInput(
+                profile_id=_PROFILE_ID,
+                series_id=str(SeriesId.generate()),
+                limit=3,
+            ),
         )
 
         assert len(result) == 3
@@ -105,9 +131,9 @@ class TestGetRelatedSeriesUseCase:
         provider = AsyncMock(spec=MetadataProvider)
         provider.get_series_recommendations.return_value = [99, 100, 101]
 
-        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedSeriesInput(series_id=str(SeriesId.generate())),
+            GetRelatedSeriesInput(profile_id=_PROFILE_ID, series_id=str(SeriesId.generate())),
         )
 
         assert result == []
@@ -119,11 +145,25 @@ class TestGetRelatedSeriesUseCase:
         provider = AsyncMock(spec=MetadataProvider)
         provider.get_series_recommendations.return_value = []
 
-        use_case = GetRelatedSeriesUseCase(mocks.factory, provider)
+        use_case = _make_use_case(mocks, provider)
         result = await use_case.execute(
-            GetRelatedSeriesInput(series_id=str(SeriesId.generate())),
+            GetRelatedSeriesInput(profile_id=_PROFILE_ID, series_id=str(SeriesId.generate())),
         )
 
         assert result == []
         # Should not even hit the repo on an empty TMDB result.
         mocks.series.find_by_tmdb_ids.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        provider = AsyncMock(spec=MetadataProvider)
+
+        use_case = _make_use_case(mocks, provider, allowed=[])
+        result = await use_case.execute(
+            GetRelatedSeriesInput(profile_id=_PROFILE_ID, series_id=str(SeriesId.generate())),
+        )
+
+        assert result == []
+        mocks.factory.assert_not_called()
+        provider.get_series_recommendations.assert_not_called()

--- a/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
@@ -19,9 +19,13 @@ from src.modules.media.domain.value_objects import (
     SeasonId,
     Title,
 )
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_PROFILE_ID = "prf_test12345678"
 
 
 @pytest.fixture()
@@ -30,6 +34,16 @@ def mock_progress_lookup() -> AsyncMock:
     lookup = AsyncMock(spec=ProgressLookupPort)
     lookup.find_for_media_ids.return_value = {}
     return lookup
+
+
+def _make_use_case(mocks, lookup, *, allowed: list[str] | None = None):
+    if allowed is None:
+        allowed = [_LIBRARY_ID]
+    return GetSeriesByIdUseCase(
+        uow_factory=mocks.factory,
+        progress_lookup=lookup,
+        profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: allowed}),
+    )
 
 
 class TestGetSeriesByIdUseCase:
@@ -55,12 +69,11 @@ class TestGetSeriesByIdUseCase:
             ],
         )
         mocks.series.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
-        )
+        use_case = _make_use_case(mocks, mock_progress_lookup)
 
-        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
+        )
 
         assert len(result.cast) == 2
         assert result.cast[0].name == "Bryan Cranston"
@@ -80,12 +93,11 @@ class TestGetSeriesByIdUseCase:
             start_year=2008,
         )
         mocks.series.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
-        )
+        use_case = _make_use_case(mocks, mock_progress_lookup)
 
-        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
+        )
 
         assert isinstance(result, SeriesOutput)
         assert result.title == "Breaking Bad"
@@ -108,12 +120,11 @@ class TestGetSeriesByIdUseCase:
         )
         series = series.with_season(season)
         mocks.series.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
-        )
+        use_case = _make_use_case(mocks, mock_progress_lookup)
 
-        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
+        )
 
         assert result.season_count == 1
         assert len(result.seasons) == 1
@@ -151,12 +162,11 @@ class TestGetSeriesByIdUseCase:
         season = season.with_episode(episode)
         series = series.with_season(season)
         mocks.series.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
-        )
+        use_case = _make_use_case(mocks, mock_progress_lookup)
 
-        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
+        )
 
         assert result.total_episodes == 1
         assert len(result.seasons[0].episodes) == 1
@@ -174,12 +184,11 @@ class TestGetSeriesByIdUseCase:
             start_year=2020,
         )
         mocks.series.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
-        )
+        use_case = _make_use_case(mocks, mock_progress_lookup)
 
-        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
+        )
 
         assert result.is_ongoing is True
         assert result.end_year is None
@@ -194,12 +203,11 @@ class TestGetSeriesByIdUseCase:
             end_year=2015,
         )
         mocks.series.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
-        )
+        use_case = _make_use_case(mocks, mock_progress_lookup)
 
-        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
+        )
 
         assert result.is_ongoing is False
         assert result.end_year == 2015
@@ -208,13 +216,12 @@ class TestGetSeriesByIdUseCase:
     async def test_should_raise_not_found_when_series_missing(self, mock_progress_lookup):
         mocks = make_media_uow_mock()
         mocks.series.find_by_id.return_value = None
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
-        )
+        use_case = _make_use_case(mocks, mock_progress_lookup)
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
-            await use_case.execute(GetSeriesByIdInput(series_id="ser_nonexistent1"))
+            await use_case.execute(
+                GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id="ser_nonexistent1")
+            )
 
         assert exc_info.value.resource_type == "Series"
         assert exc_info.value.resource_id == "ser_nonexistent1"
@@ -228,12 +235,11 @@ class TestGetSeriesByIdUseCase:
             start_year=2024,
         )
         mocks.series.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
-        )
+        use_case = _make_use_case(mocks, mock_progress_lookup)
 
-        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
+        )
 
         assert result.season_count == 0
         assert result.total_episodes == 0
@@ -249,11 +255,36 @@ class TestGetSeriesByIdUseCase:
             genres=["Drama", "Thriller"],
         )
         mocks.series.find_by_id.return_value = series
-        use_case = GetSeriesByIdUseCase(
-            uow_factory=mocks.factory,
-            progress_lookup=mock_progress_lookup,
+        use_case = _make_use_case(mocks, mock_progress_lookup)
+
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
         )
 
-        result = await use_case.execute(GetSeriesByIdInput(series_id=str(series.id)))
-
         assert result.genres == ["Drama", "Thriller"]
+
+    @pytest.mark.asyncio
+    async def test_should_pass_allowed_libraries_to_repo(self, mock_progress_lookup):
+        mocks = make_media_uow_mock()
+        series = Series.create(library_id=_LIBRARY_ID, title="Show", start_year=2020)
+        mocks.series.find_by_id.return_value = series
+        use_case = _make_use_case(mocks, mock_progress_lookup)
+
+        await use_case.execute(GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id)))
+
+        call_args = mocks.series.find_by_id.await_args
+        assert list(call_args.kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+
+    @pytest.mark.asyncio
+    async def test_should_raise_404_for_deny_all_profile(self, mock_progress_lookup):
+        # Deny-all profile must surface as 404 — same security
+        # justification as for movies.
+        mocks = make_media_uow_mock()
+        use_case = _make_use_case(mocks, mock_progress_lookup, allowed=[])
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id="ser_anything123456")
+            )
+        mocks.factory.assert_not_called()
+        mocks.series.find_by_id.assert_not_awaited()

--- a/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
@@ -15,14 +15,19 @@ from src.modules.media.application.dtos.catalog_dtos import (
 )
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.domain.entities import Movie, Series
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
-def _movie(title: str) -> Movie:
+def _movie(title: str, *, library_id: str = _LIBRARY_ID) -> Movie:
     return Movie.create(
-        library_id=_LIBRARY_ID,
+        library_id=library_id,
         title=title,
         year=2020,
         duration=7200,
@@ -32,8 +37,8 @@ def _movie(title: str) -> Movie:
     )
 
 
-def _series(title: str) -> Series:
-    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=2020)
+def _series(title: str, *, library_id: str = _LIBRARY_ID) -> Series:
+    return Series.create(library_id=library_id, title=title, start_year=2020)
 
 
 def _movies_page(
@@ -64,6 +69,15 @@ def _series_page(
     )
 
 
+def _make_use_case(mocks, *, allowed: list[str] | None = None) -> ListByGenreUseCase:
+    if allowed is None:
+        allowed = [_LIBRARY_ID]
+    return ListByGenreUseCase(
+        uow_factory=mocks.factory,
+        profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: allowed}),
+    )
+
+
 @pytest.mark.unit
 class TestListByGenreUseCase:
     """Merge + dual-cursor behavior of ListByGenreUseCase."""
@@ -75,9 +89,9 @@ class TestListByGenreUseCase:
             [_movie("Avatar"), _movie("Cyrano")]
         )
         mocks.series.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
-        result = await use_case.execute(ListByGenreInput(genre="Action"))
+        result = await use_case.execute(ListByGenreInput(profile_id=_PROFILE_ID, genre="Action"))
 
         assert isinstance(result, ListByGenreOutput)
         titles = [item.title for item in result.items]
@@ -89,9 +103,9 @@ class TestListByGenreUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_paginated_by_genre.return_value = _movies_page([_movie("Avatar")])
         mocks.series.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
-        result = await use_case.execute(ListByGenreInput(genre="Action"))
+        result = await use_case.execute(ListByGenreInput(profile_id=_PROFILE_ID, genre="Action"))
 
         types = {(item.title, item.type) for item in result.items}
         assert types == {("Avatar", "movie"), ("Breaking Bad", "series")}
@@ -101,18 +115,22 @@ class TestListByGenreUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_paginated_by_genre.return_value = _movies_page([])
         mocks.series.list_paginated_by_genre.return_value = _series_page([])
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
         # Build a real dual cursor so the use case decodes it
         from src.building_blocks.application.pagination import encode_dual_cursor
 
         cursor = encode_dual_cursor("movies-token", "series-token")
-        await use_case.execute(ListByGenreInput(genre="Action", cursor=cursor))
+        await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", cursor=cursor)
+        )
 
         movie_call_kwargs = mocks.movies.list_paginated_by_genre.await_args.kwargs
         series_call_kwargs = mocks.series.list_paginated_by_genre.await_args.kwargs
         assert movie_call_kwargs["cursor"] == "movies-token"
         assert series_call_kwargs["cursor"] == "series-token"
+        assert list(movie_call_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert list(series_call_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
 
     @pytest.mark.asyncio
     async def test_should_advance_cursor_only_for_consumed_streams(self) -> None:
@@ -131,13 +149,18 @@ class TestListByGenreUseCase:
             [_series("Zebra")],
             has_more=False,
         )
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
         from src.building_blocks.application.pagination import encode_dual_cursor
 
         previous_cursor = encode_dual_cursor(None, "previous-series-cursor")
         result = await use_case.execute(
-            ListByGenreInput(genre="Action", cursor=previous_cursor, limit=2)
+            ListByGenreInput(
+                profile_id=_PROFILE_ID,
+                genre="Action",
+                cursor=previous_cursor,
+                limit=2,
+            )
         )
 
         assert result.has_more is True
@@ -165,9 +188,11 @@ class TestListByGenreUseCase:
             [_series("Banana"), _series("Date"), _series("Fig")],
             has_more=False,
         )
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
-        result = await use_case.execute(ListByGenreInput(genre="Action", limit=2))
+        result = await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", limit=2)
+        )
 
         assert len(result.items) == 2
         assert [item.title for item in result.items] == ["Apple", "Banana"]
@@ -182,9 +207,11 @@ class TestListByGenreUseCase:
         mocks.series.list_paginated_by_genre.return_value = _series_page(
             [_series("Breaking Bad")], has_more=False
         )
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
-        result = await use_case.execute(ListByGenreInput(genre="Action", limit=10))
+        result = await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", limit=10)
+        )
 
         assert len(result.items) == 2
         assert result.has_more is False
@@ -195,9 +222,11 @@ class TestListByGenreUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_paginated_by_genre.return_value = _movies_page([])
         mocks.series.list_paginated_by_genre.return_value = _series_page([])
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
-        result = await use_case.execute(ListByGenreInput(genre="NoSuchGenre"))
+        result = await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="NoSuchGenre")
+        )
 
         assert result.items == []
         assert result.has_more is False
@@ -212,9 +241,11 @@ class TestListByGenreUseCase:
         mocks.movies.list_paginated_by_genre.return_value = _movies_page(
             [_movie("Avatar"), _movie("Cyrano")]
         )
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
-        result = await use_case.execute(ListByGenreInput(genre="Action", media_type="movie"))
+        result = await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", media_type="movie")
+        )
 
         mocks.movies.list_paginated_by_genre.assert_awaited_once()
         mocks.series.list_paginated_by_genre.assert_not_awaited()
@@ -227,9 +258,11 @@ class TestListByGenreUseCase:
         mocks.series.list_paginated_by_genre.return_value = _series_page(
             [_series("Breaking Bad"), _series("Dark")]
         )
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
-        result = await use_case.execute(ListByGenreInput(genre="Action", media_type="series"))
+        result = await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", media_type="series")
+        )
 
         mocks.series.list_paginated_by_genre.assert_awaited_once()
         mocks.movies.list_paginated_by_genre.assert_not_awaited()
@@ -249,13 +282,14 @@ class TestListByGenreUseCase:
             [_movie("Apple"), _movie("Banana")],
             has_more=True,
         )
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
         from src.building_blocks.application.pagination import encode_dual_cursor
 
         previous_cursor = encode_dual_cursor(None, "untouched-series-cursor")
         result = await use_case.execute(
             ListByGenreInput(
+                profile_id=_PROFILE_ID,
                 genre="Action",
                 cursor=previous_cursor,
                 limit=2,
@@ -273,12 +307,47 @@ class TestListByGenreUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_paginated_by_genre.return_value = _movies_page([_movie("Test")])
         mocks.series.list_paginated_by_genre.return_value = _series_page([])
-        use_case = ListByGenreUseCase(uow_factory=mocks.factory)
+        use_case = _make_use_case(mocks)
 
-        result = await use_case.execute(ListByGenreInput(genre="Action"))
+        result = await use_case.execute(ListByGenreInput(profile_id=_PROFILE_ID, genre="Action"))
 
         item = result.items[0]
         assert isinstance(item, CatalogItemOutput)
         assert item.title == "Test"
         assert item.type == "movie"
         assert item.year == 2020
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListByGenreUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(ListByGenreInput(profile_id=_PROFILE_ID, genre="Action"))
+
+        assert result.items == []
+        assert result.has_more is False
+        assert result.next_cursor is None
+        mocks.factory.assert_not_called()
+        mocks.movies.list_paginated_by_genre.assert_not_awaited()
+        mocks.series.list_paginated_by_genre.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page([_movie("Visible")])
+        mocks.series.list_paginated_by_genre.return_value = _series_page([])
+        use_case = _make_use_case(mocks)
+
+        result = await use_case.execute(ListByGenreInput(profile_id=_PROFILE_ID, genre="Action"))
+
+        assert [item.title for item in result.items] == ["Visible"]
+        movie_kwargs = mocks.movies.list_paginated_by_genre.await_args.kwargs
+        series_kwargs = mocks.series.list_paginated_by_genre.await_args.kwargs
+        assert list(movie_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert list(series_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(movie_kwargs["allowed_library_ids"])

--- a/tests/modules/media/unit/application/use_cases/test_list_genres.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_genres.py
@@ -10,7 +10,15 @@ from src.modules.media.application.dtos.catalog_dtos import (
 )
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
 from src.modules.media.domain.repositories.movie_repository import GenreRow
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
+
+_LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
 def _row(canonical: list[str], localized: list[str] | None = None) -> GenreRow:
@@ -32,9 +40,12 @@ class TestListGenresUseCase:
             _row(["Comedy"]),
             _row(["Drama"]),
         ]
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListGenresInput())
+        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID))
 
         assert isinstance(result, ListGenresOutput)
         counts = {g.id: g.count for g in result.genres}
@@ -53,9 +64,12 @@ class TestListGenresUseCase:
             _row(["Action"]),
         ]
         mocks.series.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListGenresInput())
+        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID))
 
         # Drama (3) → Action, Comedy (tied at 2, alphabetical)
         assert [g.id for g in result.genres] == ["Drama", "Action", "Comedy"]
@@ -68,9 +82,12 @@ class TestListGenresUseCase:
             _row(["Action"], ["A Wrong Translation"]),  # ignored — first wins
         ]
         mocks.series.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListGenresInput(lang="pt-BR"))
+        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID, lang="pt-BR"))
 
         assert result.genres[0] == GenreOutput(id="Action", name="Ação", count=2)
 
@@ -80,9 +97,12 @@ class TestListGenresUseCase:
         # No localized genres available — repo returns empty list for that field
         mocks.movies.list_genre_rows.return_value = [_row(["Action"])]
         mocks.series.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListGenresInput(lang="pt-BR"))
+        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID, lang="pt-BR"))
 
         # Falls back to the canonical English name
         assert result.genres[0].name == "Action"
@@ -97,9 +117,12 @@ class TestListGenresUseCase:
             _row(["Action"], ["Ação"]),
         ]
         mocks.series.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListGenresInput(lang="pt-BR"))
+        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID, lang="pt-BR"))
 
         assert result.genres[0].name == "Ação"
 
@@ -108,9 +131,12 @@ class TestListGenresUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_genre_rows.return_value = []
         mocks.series.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListGenresInput())
+        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID))
 
         assert result.genres == []
 
@@ -119,12 +145,19 @@ class TestListGenresUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_genre_rows.return_value = []
         mocks.series.list_genre_rows.return_value = []
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(ListGenresInput(lang="pt-BR"))
+        await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID, lang="pt-BR"))
 
-        mocks.movies.list_genre_rows.assert_awaited_once_with("pt-BR")
-        mocks.series.list_genre_rows.assert_awaited_once_with("pt-BR")
+        mocks.movies.list_genre_rows.assert_awaited_once_with(
+            "pt-BR", allowed_library_ids=[_LIBRARY_ID]
+        )
+        mocks.series.list_genre_rows.assert_awaited_once_with(
+            "pt-BR", allowed_library_ids=[_LIBRARY_ID]
+        )
 
     @pytest.mark.asyncio
     async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
@@ -135,9 +168,12 @@ class TestListGenresUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_genre_rows.return_value = [_row(["Action"]), _row(["Comedy"])]
         mocks.series.list_genre_rows.return_value = [_row(["Drama"])]
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListGenresInput(media_type="movie"))
+        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID, media_type="movie"))
 
         mocks.movies.list_genre_rows.assert_awaited_once()
         mocks.series.list_genre_rows.assert_not_awaited()
@@ -150,10 +186,50 @@ class TestListGenresUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_genre_rows.return_value = [_row(["Action"])]
         mocks.series.list_genre_rows.return_value = [_row(["Drama"]), _row(["Thriller"])]
-        use_case = ListGenresUseCase(uow_factory=mocks.factory)
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListGenresInput(media_type="series"))
+        result = await use_case.execute(
+            ListGenresInput(profile_id=_PROFILE_ID, media_type="series")
+        )
 
         mocks.series.list_genre_rows.assert_awaited_once()
         mocks.movies.list_genre_rows.assert_not_awaited()
         assert {g.id for g in result.genres} == {"Drama", "Thriller"}
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID))
+
+        assert result.genres == []
+        mocks.factory.assert_not_called()
+        mocks.movies.list_genre_rows.assert_not_awaited()
+        mocks.series.list_genre_rows.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_genre_rows.return_value = [_row(["Action"])]
+        mocks.series.list_genre_rows.return_value = []
+        use_case = ListGenresUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID))
+
+        passed_movies = mocks.movies.list_genre_rows.await_args.kwargs["allowed_library_ids"]
+        passed_series = mocks.series.list_genre_rows.await_args.kwargs["allowed_library_ids"]
+        assert list(passed_movies) == [_LIBRARY_ID]
+        assert list(passed_series) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(passed_movies)

--- a/tests/modules/media/unit/application/use_cases/test_list_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies.py
@@ -6,14 +6,25 @@ from src.building_blocks.application.pagination import PaginatedResult, Paginati
 from src.modules.media.application.dtos import ListMoviesInput, ListMoviesOutput, MovieSummaryOutput
 from src.modules.media.application.use_cases import ListMoviesUseCase
 from src.modules.media.domain.entities import Movie
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
-def _make_movie(title: str = "Test Movie", year: int = 2020) -> Movie:
+def _make_movie(
+    title: str = "Test Movie",
+    year: int = 2020,
+    *,
+    library_id: str = _LIBRARY_ID,
+) -> Movie:
     return Movie.create(
-        library_id=_LIBRARY_ID,
+        library_id=library_id,
         title=title,
         year=year,
         duration=7200,
@@ -47,9 +58,12 @@ class TestListMoviesUseCase:
             [_make_movie("Movie 1"), _make_movie("Movie 2")],
             has_more=False,
         )
-        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListMoviesInput())
+        result = await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID))
 
         assert isinstance(result, ListMoviesOutput)
         assert len(result.movies) == 2
@@ -61,6 +75,7 @@ class TestListMoviesUseCase:
             cursor=None,
             limit=20,
             include_total=False,
+            allowed_library_ids=[_LIBRARY_ID],
         )
 
     @pytest.mark.asyncio
@@ -68,9 +83,12 @@ class TestListMoviesUseCase:
         mocks = make_media_uow_mock()
         movie = _make_movie("Test Movie", 2020).with_genre("Action")
         mocks.movies.list_paginated.return_value = _page([movie])
-        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListMoviesInput())
+        result = await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID))
 
         summary = result.movies[0]
         assert isinstance(summary, MovieSummaryOutput)
@@ -84,14 +102,18 @@ class TestListMoviesUseCase:
     async def test_should_pass_cursor_and_limit_to_repository(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.list_paginated.return_value = _page([])
-        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(ListMoviesInput(cursor="abc123", limit=15))
+        await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID, cursor="abc123", limit=15))
 
         mocks.movies.list_paginated.assert_awaited_once_with(
             cursor="abc123",
             limit=15,
             include_total=False,
+            allowed_library_ids=[_LIBRARY_ID],
         )
 
     @pytest.mark.asyncio
@@ -102,9 +124,12 @@ class TestListMoviesUseCase:
             next_cursor="next-token",
             has_more=True,
         )
-        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListMoviesInput())
+        result = await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID))
 
         assert result.next_cursor == "next-token"
         assert result.has_more is True
@@ -113,9 +138,12 @@ class TestListMoviesUseCase:
     async def test_should_return_empty_page_when_no_movies(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.list_paginated.return_value = _page([])
-        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListMoviesInput())
+        result = await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID))
 
         assert result.movies == []
         assert result.has_more is False
@@ -128,13 +156,75 @@ class TestListMoviesUseCase:
             [_make_movie("Movie 1")],
             total_count=42,
         )
-        use_case = ListMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListMoviesInput(include_total=True))
+        result = await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID, include_total=True))
 
         assert result.total_count == 42
         mocks.movies.list_paginated.assert_awaited_once_with(
             cursor=None,
             limit=20,
             include_total=True,
+            allowed_library_ids=[_LIBRARY_ID],
         )
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        # Deny-all profile (empty allowed list) → empty result + no UoW.
+        # Load-bearing security assertion: an unauthorized profile must
+        # NEVER reach the catalog repository.
+        mocks = make_media_uow_mock()
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID))
+
+        assert result.movies == []
+        assert result.has_more is False
+        assert result.next_cursor is None
+        # The UoW factory must not be called.
+        mocks.factory.assert_not_called()
+        mocks.movies.list_paginated.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_zero_total_count_for_deny_all_when_requested(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID, include_total=True))
+
+        assert result.total_count == 0
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        # Two libraries' worth of items exist on the repo side; the
+        # fake port restricts the profile to library A, so only the
+        # library-A items must come back. We assert the kwarg the
+        # use case passes — the repo is mocked, so the actual filter
+        # is exercised in the integration tests; here we pin the
+        # contract between use case and repo.
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated.return_value = _page(
+            [_make_movie("Visible", library_id=_LIBRARY_ID)]
+        )
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        result = await use_case.execute(ListMoviesInput(profile_id=_PROFILE_ID))
+
+        assert [m.title for m in result.movies] == ["Visible"]
+        passed = mocks.movies.list_paginated.await_args.kwargs["allowed_library_ids"]
+        assert list(passed) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(passed)

--- a/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
@@ -10,18 +10,26 @@ from src.modules.media.application.use_cases.list_movies_by_actor import (
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects.cast_member import CastMember
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
 def _make_movie(
     title: str = "Test Movie",
     year: int = 2020,
     cast: list[CastMember] | None = None,
+    *,
+    library_id: str = _LIBRARY_ID,
 ) -> Movie:
     movie = Movie.create(
-        library_id=_LIBRARY_ID,
+        library_id=library_id,
         title=title,
         year=year,
         duration=7200,
@@ -60,9 +68,14 @@ class TestListMoviesByActorUseCase:
                 _make_movie("Aliens", 1986, cast=cast),
             ]
         )
-        use_case = ListMoviesByActorUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesByActorUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListMoviesByActorInput(actor_name="Sigourney Weaver"))
+        result = await use_case.execute(
+            ListMoviesByActorInput(profile_id=_PROFILE_ID, actor_name="Sigourney Weaver")
+        )
 
         assert isinstance(result, ListMoviesByActorOutput)
         assert [m.title for m in result.movies] == ["Alien", "Aliens"]
@@ -70,16 +83,21 @@ class TestListMoviesByActorUseCase:
             actor_name="Sigourney Weaver",
             cursor=None,
             limit=20,
+            allowed_library_ids=[_LIBRARY_ID],
         )
 
     @pytest.mark.asyncio
     async def test_should_pass_cursor_and_limit_to_repository(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.list_paginated_by_cast_member.return_value = _page([])
-        use_case = ListMoviesByActorUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesByActorUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
         await use_case.execute(
             ListMoviesByActorInput(
+                profile_id=_PROFILE_ID,
                 actor_name="Sigourney Weaver",
                 cursor="abc123",
                 limit=15,
@@ -90,6 +108,7 @@ class TestListMoviesByActorUseCase:
             actor_name="Sigourney Weaver",
             cursor="abc123",
             limit=15,
+            allowed_library_ids=[_LIBRARY_ID],
         )
 
     @pytest.mark.asyncio
@@ -100,9 +119,14 @@ class TestListMoviesByActorUseCase:
             next_cursor="next-token",
             has_more=True,
         )
-        use_case = ListMoviesByActorUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesByActorUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListMoviesByActorInput(actor_name="Sigourney Weaver"))
+        result = await use_case.execute(
+            ListMoviesByActorInput(profile_id=_PROFILE_ID, actor_name="Sigourney Weaver")
+        )
 
         assert result.next_cursor == "next-token"
         assert result.has_more is True
@@ -111,10 +135,56 @@ class TestListMoviesByActorUseCase:
     async def test_should_return_empty_page_when_no_matches(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.list_paginated_by_cast_member.return_value = _page([])
-        use_case = ListMoviesByActorUseCase(uow_factory=mocks.factory)
+        use_case = ListMoviesByActorUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListMoviesByActorInput(actor_name="Nobody Famous"))
+        result = await use_case.execute(
+            ListMoviesByActorInput(profile_id=_PROFILE_ID, actor_name="Nobody Famous")
+        )
 
         assert result.movies == []
         assert result.has_more is False
         assert result.next_cursor is None
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListMoviesByActorUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(
+            ListMoviesByActorInput(profile_id=_PROFILE_ID, actor_name="Sigourney Weaver")
+        )
+
+        assert result.movies == []
+        assert result.has_more is False
+        assert result.next_cursor is None
+        mocks.factory.assert_not_called()
+        mocks.movies.list_paginated_by_cast_member.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        mocks = make_media_uow_mock()
+        cast = [CastMember(name="Sigourney Weaver")]
+        mocks.movies.list_paginated_by_cast_member.return_value = _page(
+            [_make_movie("Visible", cast=cast, library_id=_LIBRARY_ID)]
+        )
+        use_case = ListMoviesByActorUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        result = await use_case.execute(
+            ListMoviesByActorInput(profile_id=_PROFILE_ID, actor_name="Sigourney Weaver")
+        )
+
+        assert [m.title for m in result.movies] == ["Visible"]
+        passed = mocks.movies.list_paginated_by_cast_member.await_args.kwargs["allowed_library_ids"]
+        assert list(passed) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(passed)

--- a/tests/modules/media/unit/application/use_cases/test_list_recently_added_catalog.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_recently_added_catalog.py
@@ -11,15 +11,21 @@ from src.modules.media.application.dtos.catalog_dtos import (
 )
 from src.modules.media.application.use_cases import ListRecentlyAddedCatalogUseCase
 from src.modules.media.domain.entities import Movie, Series
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
-def _movie_at(title: str, when: datetime) -> Movie:
+def _movie_at(title: str, when: datetime, *, library_id: str = _LIBRARY_ID) -> Movie:
     """Build a movie pinned to a specific ``created_at`` for the merge test."""
     return Movie.create(
-        library_id=_LIBRARY_ID,
+        library_id=library_id,
         title=title,
         year=2020,
         duration=7200,
@@ -29,9 +35,9 @@ def _movie_at(title: str, when: datetime) -> Movie:
     ).with_updates(created_at=when)
 
 
-def _series_at(title: str, when: datetime) -> Series:
+def _series_at(title: str, when: datetime, *, library_id: str = _LIBRARY_ID) -> Series:
     """Build a series pinned to a specific ``created_at`` for the merge test."""
-    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=2020).with_updates(
+    return Series.create(library_id=library_id, title=title, start_year=2020).with_updates(
         created_at=when
     )
 
@@ -50,9 +56,14 @@ class TestListRecentlyAddedCatalogUseCase:
         mocks.series.list_recently_added.return_value = [
             _series_at("Series mid", base - timedelta(hours=2)),
         ]
-        use_case = ListRecentlyAddedCatalogUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedCatalogInput(limit=10))
+        result = await use_case.execute(
+            ListRecentlyAddedCatalogInput(profile_id=_PROFILE_ID, limit=10)
+        )
 
         assert isinstance(result, ListRecentlyAddedCatalogOutput)
         assert [(it.type, it.title) for it in result.items] == [
@@ -73,9 +84,14 @@ class TestListRecentlyAddedCatalogUseCase:
             _series_at("S1", base - timedelta(hours=1)),
             _series_at("S2", base - timedelta(hours=3)),
         ]
-        use_case = ListRecentlyAddedCatalogUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedCatalogInput(limit=2))
+        result = await use_case.execute(
+            ListRecentlyAddedCatalogInput(profile_id=_PROFILE_ID, limit=2)
+        )
 
         # The two newest across both streams; the third and fourth
         # are dropped by the limit clamp regardless of their type.
@@ -89,12 +105,19 @@ class TestListRecentlyAddedCatalogUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_recently_added.return_value = []
         mocks.series.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedCatalogUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(ListRecentlyAddedCatalogInput(limit=15))
+        await use_case.execute(ListRecentlyAddedCatalogInput(profile_id=_PROFILE_ID, limit=15))
 
-        mocks.movies.list_recently_added.assert_awaited_once_with(15)
-        mocks.series.list_recently_added.assert_awaited_once_with(15)
+        mocks.movies.list_recently_added.assert_awaited_once_with(
+            15, allowed_library_ids=[_LIBRARY_ID]
+        )
+        mocks.series.list_recently_added.assert_awaited_once_with(
+            15, allowed_library_ids=[_LIBRARY_ID]
+        )
 
     @pytest.mark.asyncio
     async def test_should_return_only_movies_when_no_series(self) -> None:
@@ -102,9 +125,12 @@ class TestListRecentlyAddedCatalogUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_recently_added.return_value = [_movie_at("Solo", base)]
         mocks.series.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedCatalogUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedCatalogInput())
+        result = await use_case.execute(ListRecentlyAddedCatalogInput(profile_id=_PROFILE_ID))
 
         assert len(result.items) == 1
         assert result.items[0].type == "movie"
@@ -115,9 +141,12 @@ class TestListRecentlyAddedCatalogUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.list_recently_added.return_value = []
         mocks.series.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedCatalogUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedCatalogInput())
+        result = await use_case.execute(ListRecentlyAddedCatalogInput(profile_id=_PROFILE_ID))
 
         assert result.items == []
 
@@ -129,9 +158,51 @@ class TestListRecentlyAddedCatalogUseCase:
         mocks.series.list_recently_added.return_value = [
             _series_at("Series", base - timedelta(hours=1))
         ]
-        use_case = ListRecentlyAddedCatalogUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedCatalogInput())
+        result = await use_case.execute(ListRecentlyAddedCatalogInput(profile_id=_PROFILE_ID))
 
         assert all(isinstance(item, CatalogItemOutput) for item in result.items)
         assert {it.type for it in result.items} == {"movie", "series"}
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListRecentlyAddedCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(ListRecentlyAddedCatalogInput(profile_id=_PROFILE_ID))
+
+        assert result.items == []
+        mocks.factory.assert_not_called()
+        mocks.movies.list_recently_added.assert_not_awaited()
+        mocks.series.list_recently_added.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        base = datetime(2026, 5, 1, tzinfo=UTC)
+        mocks = make_media_uow_mock()
+        mocks.movies.list_recently_added.return_value = [
+            _movie_at("Visible", base, library_id=_LIBRARY_ID),
+        ]
+        mocks.series.list_recently_added.return_value = []
+        use_case = ListRecentlyAddedCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        result = await use_case.execute(ListRecentlyAddedCatalogInput(profile_id=_PROFILE_ID))
+
+        assert [it.title for it in result.items] == ["Visible"]
+        movie_kwargs = mocks.movies.list_recently_added.await_args.kwargs
+        series_kwargs = mocks.series.list_recently_added.await_args.kwargs
+        assert list(movie_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert list(series_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(movie_kwargs["allowed_library_ids"])

--- a/tests/modules/media/unit/application/use_cases/test_list_recently_added_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_recently_added_movies.py
@@ -9,14 +9,25 @@ from src.modules.media.application.dtos import (
 )
 from src.modules.media.application.use_cases import ListRecentlyAddedMoviesUseCase
 from src.modules.media.domain.entities import Movie
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
-def _make_movie(title: str = "Test Movie", year: int = 2020) -> Movie:
+def _make_movie(
+    title: str = "Test Movie",
+    year: int = 2020,
+    *,
+    library_id: str = _LIBRARY_ID,
+) -> Movie:
     return Movie.create(
-        library_id=_LIBRARY_ID,
+        library_id=library_id,
         title=title,
         year=year,
         duration=7200,
@@ -36,9 +47,14 @@ class TestListRecentlyAddedMoviesUseCase:
             _make_movie("Newest"),
             _make_movie("Older"),
         ]
-        use_case = ListRecentlyAddedMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedMoviesInput(limit=10))
+        result = await use_case.execute(
+            ListRecentlyAddedMoviesInput(profile_id=_PROFILE_ID, limit=10)
+        )
 
         assert isinstance(result, ListRecentlyAddedMoviesOutput)
         assert [m.title for m in result.movies] == ["Newest", "Older"]
@@ -48,29 +64,42 @@ class TestListRecentlyAddedMoviesUseCase:
     async def test_should_pass_limit_to_repository(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(ListRecentlyAddedMoviesInput(limit=15))
+        await use_case.execute(ListRecentlyAddedMoviesInput(profile_id=_PROFILE_ID, limit=15))
 
-        mocks.movies.list_recently_added.assert_awaited_once_with(15)
+        mocks.movies.list_recently_added.assert_awaited_once_with(
+            15, allowed_library_ids=[_LIBRARY_ID]
+        )
 
     @pytest.mark.asyncio
     async def test_should_default_limit_to_twenty(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(ListRecentlyAddedMoviesInput())
+        await use_case.execute(ListRecentlyAddedMoviesInput(profile_id=_PROFILE_ID))
 
-        mocks.movies.list_recently_added.assert_awaited_once_with(20)
+        mocks.movies.list_recently_added.assert_awaited_once_with(
+            20, allowed_library_ids=[_LIBRARY_ID]
+        )
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_repository_empty(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedMoviesInput())
+        result = await use_case.execute(ListRecentlyAddedMoviesInput(profile_id=_PROFILE_ID))
 
         assert result.movies == []
 
@@ -78,9 +107,48 @@ class TestListRecentlyAddedMoviesUseCase:
     async def test_should_localize_summaries_with_input_lang(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.list_recently_added.return_value = [_make_movie("A Movie", 2024)]
-        use_case = ListRecentlyAddedMoviesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedMoviesInput(lang="pt-BR"))
+        result = await use_case.execute(
+            ListRecentlyAddedMoviesInput(profile_id=_PROFILE_ID, lang="pt-BR")
+        )
 
         assert len(result.movies) == 1
         assert result.movies[0].title == "A Movie"
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListRecentlyAddedMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(ListRecentlyAddedMoviesInput(profile_id=_PROFILE_ID))
+
+        assert result.movies == []
+        mocks.factory.assert_not_called()
+        mocks.movies.list_recently_added.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_recently_added.return_value = [
+            _make_movie("Visible", library_id=_LIBRARY_ID)
+        ]
+        use_case = ListRecentlyAddedMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        result = await use_case.execute(ListRecentlyAddedMoviesInput(profile_id=_PROFILE_ID))
+
+        assert [m.title for m in result.movies] == ["Visible"]
+        passed = mocks.movies.list_recently_added.await_args.kwargs["allowed_library_ids"]
+        assert list(passed) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(passed)

--- a/tests/modules/media/unit/application/use_cases/test_list_recently_added_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_recently_added_series.py
@@ -9,13 +9,21 @@ from src.modules.media.application.dtos import (
 )
 from src.modules.media.application.use_cases import ListRecentlyAddedSeriesUseCase
 from src.modules.media.domain.entities import Series
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
-def _make_series(title: str = "Test Series", year: int = 2020) -> Series:
-    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=year)
+def _make_series(
+    title: str = "Test Series", year: int = 2020, *, library_id: str = _LIBRARY_ID
+) -> Series:
+    return Series.create(library_id=library_id, title=title, start_year=year)
 
 
 class TestListRecentlyAddedSeriesUseCase:
@@ -28,9 +36,14 @@ class TestListRecentlyAddedSeriesUseCase:
             _make_series("Newest"),
             _make_series("Older"),
         ]
-        use_case = ListRecentlyAddedSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedSeriesInput(limit=10))
+        result = await use_case.execute(
+            ListRecentlyAddedSeriesInput(profile_id=_PROFILE_ID, limit=10)
+        )
 
         assert isinstance(result, ListRecentlyAddedSeriesOutput)
         assert [s.title for s in result.series] == ["Newest", "Older"]
@@ -40,28 +53,75 @@ class TestListRecentlyAddedSeriesUseCase:
     async def test_should_pass_limit_to_repository(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(ListRecentlyAddedSeriesInput(limit=15))
+        await use_case.execute(ListRecentlyAddedSeriesInput(profile_id=_PROFILE_ID, limit=15))
 
-        mocks.series.list_recently_added.assert_awaited_once_with(15)
+        mocks.series.list_recently_added.assert_awaited_once_with(
+            15, allowed_library_ids=[_LIBRARY_ID]
+        )
 
     @pytest.mark.asyncio
     async def test_should_default_limit_to_twenty(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(ListRecentlyAddedSeriesInput())
+        await use_case.execute(ListRecentlyAddedSeriesInput(profile_id=_PROFILE_ID))
 
-        mocks.series.list_recently_added.assert_awaited_once_with(20)
+        mocks.series.list_recently_added.assert_awaited_once_with(
+            20, allowed_library_ids=[_LIBRARY_ID]
+        )
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_repository_empty(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.list_recently_added.return_value = []
-        use_case = ListRecentlyAddedSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListRecentlyAddedSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListRecentlyAddedSeriesInput())
+        result = await use_case.execute(ListRecentlyAddedSeriesInput(profile_id=_PROFILE_ID))
 
         assert result.series == []
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListRecentlyAddedSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(ListRecentlyAddedSeriesInput(profile_id=_PROFILE_ID))
+
+        assert result.series == []
+        mocks.factory.assert_not_called()
+        mocks.series.list_recently_added.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.list_recently_added.return_value = [
+            _make_series("Visible", library_id=_LIBRARY_ID)
+        ]
+        use_case = ListRecentlyAddedSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        result = await use_case.execute(ListRecentlyAddedSeriesInput(profile_id=_PROFILE_ID))
+
+        assert [s.title for s in result.series] == ["Visible"]
+        passed = mocks.series.list_recently_added.await_args.kwargs["allowed_library_ids"]
+        assert list(passed) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(passed)

--- a/tests/modules/media/unit/application/use_cases/test_list_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series.py
@@ -11,9 +11,15 @@ from src.modules.media.application.dtos import (
 )
 from src.modules.media.application.use_cases import ListSeriesUseCase
 from src.modules.media.domain.entities import Series
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
 def _page(
@@ -42,9 +48,12 @@ class TestListSeriesUseCase:
                 Series.create(library_id=_LIBRARY_ID, title="Show 2", start_year=2021),
             ]
         )
-        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListSeriesInput())
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID))
 
         assert isinstance(result, ListSeriesOutput)
         assert len(result.series) == 2
@@ -55,6 +64,7 @@ class TestListSeriesUseCase:
             cursor=None,
             limit=20,
             include_total=False,
+            allowed_library_ids=[_LIBRARY_ID],
         )
 
     @pytest.mark.asyncio
@@ -68,9 +78,12 @@ class TestListSeriesUseCase:
             genres=["Drama", "Crime"],
         )
         mocks.series.list_paginated.return_value = _page([series])
-        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListSeriesInput())
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID))
 
         summary = result.series[0]
         assert isinstance(summary, SeriesSummaryOutput)
@@ -84,14 +97,18 @@ class TestListSeriesUseCase:
     async def test_should_pass_cursor_and_limit_to_repository(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.list_paginated.return_value = _page([])
-        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        await use_case.execute(ListSeriesInput(cursor="abc123", limit=15))
+        await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID, cursor="abc123", limit=15))
 
         mocks.series.list_paginated.assert_awaited_once_with(
             cursor="abc123",
             limit=15,
             include_total=False,
+            allowed_library_ids=[_LIBRARY_ID],
         )
 
     @pytest.mark.asyncio
@@ -102,9 +119,12 @@ class TestListSeriesUseCase:
             next_cursor="next-token",
             has_more=True,
         )
-        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListSeriesInput())
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID))
 
         assert result.next_cursor == "next-token"
         assert result.has_more is True
@@ -113,9 +133,12 @@ class TestListSeriesUseCase:
     async def test_should_return_empty_page_when_no_series(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.list_paginated.return_value = _page([])
-        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListSeriesInput())
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID))
 
         assert result.series == []
         assert result.has_more is False
@@ -126,9 +149,12 @@ class TestListSeriesUseCase:
         mocks = make_media_uow_mock()
         series = Series.create(library_id=_LIBRARY_ID, title="Ongoing Show", start_year=2020)
         mocks.series.list_paginated.return_value = _page([series])
-        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListSeriesInput())
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID))
 
         assert result.series[0].is_ongoing is True
         assert result.series[0].end_year is None
@@ -138,9 +164,12 @@ class TestListSeriesUseCase:
         mocks = make_media_uow_mock()
         series = Series.create(library_id=_LIBRARY_ID, title="Test Show", start_year=2020)
         mocks.series.list_paginated.return_value = _page([series])
-        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListSeriesInput())
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID))
 
         assert result.series[0].season_count == 0
         assert result.series[0].total_episodes == 0
@@ -152,13 +181,53 @@ class TestListSeriesUseCase:
             [Series.create(library_id=_LIBRARY_ID, title="Show 1", start_year=2020)],
             total_count=10,
         )
-        use_case = ListSeriesUseCase(uow_factory=mocks.factory)
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(ListSeriesInput(include_total=True))
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID, include_total=True))
 
         assert result.total_count == 10
         mocks.series.list_paginated.assert_awaited_once_with(
             cursor=None,
             limit=20,
             include_total=True,
+            allowed_library_ids=[_LIBRARY_ID],
         )
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID))
+
+        assert result.series == []
+        assert result.has_more is False
+        assert result.next_cursor is None
+        mocks.factory.assert_not_called()
+        mocks.series.list_paginated.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.list_paginated.return_value = _page(
+            [Series.create(library_id=_LIBRARY_ID, title="Visible", start_year=2020)]
+        )
+        use_case = ListSeriesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        result = await use_case.execute(ListSeriesInput(profile_id=_PROFILE_ID))
+
+        assert [s.title for s in result.series] == ["Visible"]
+        passed = mocks.series.list_paginated.await_args.kwargs["allowed_library_ids"]
+        assert list(passed) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(passed)

--- a/tests/modules/media/unit/application/use_cases/test_search_catalog.py
+++ b/tests/modules/media/unit/application/use_cases/test_search_catalog.py
@@ -10,14 +10,20 @@ from src.modules.media.application.dtos.search_dtos import (
 )
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
 from src.modules.media.domain.entities import Movie, Series
-from tests.modules.media.unit.conftest import make_media_uow_mock
+from tests.modules.media.unit.conftest import (
+    FakeProfileLibraryAccessPort,
+    make_media_uow_mock,
+    make_profile_library_access,
+)
 
 _LIBRARY_ID = "lib_test12345678"
+_LIBRARY_ID_OTHER = "lib_otherlibrary"
+_PROFILE_ID = "prf_test12345678"
 
 
-def _movie(title: str) -> Movie:
+def _movie(title: str, *, library_id: str = _LIBRARY_ID) -> Movie:
     return Movie.create(
-        library_id=_LIBRARY_ID,
+        library_id=library_id,
         title=title,
         year=2020,
         duration=7200,
@@ -27,8 +33,8 @@ def _movie(title: str) -> Movie:
     )
 
 
-def _series(title: str) -> Series:
-    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=2020)
+def _series(title: str, *, library_id: str = _LIBRARY_ID) -> Series:
+    return Series.create(library_id=library_id, title=title, start_year=2020)
 
 
 @pytest.mark.unit
@@ -41,9 +47,12 @@ class TestSearchCatalogUseCase:
         # Movie rank -5 (better) + series rank -2 (worse)
         mocks.movies.search.return_value = [(_movie("Inception"), -5.0)]
         mocks.series.search.return_value = [(_series("Breaking Bad"), -2.0)]
-        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(SearchInput(query="test"))
+        result = await use_case.execute(SearchInput(profile_id=_PROFILE_ID, query="test"))
 
         assert isinstance(result, SearchOutput)
         # Movie has better rank (-5 < -2), so it comes first
@@ -54,9 +63,14 @@ class TestSearchCatalogUseCase:
     async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.search.return_value = [(_movie("Avatar"), -3.0)]
-        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(SearchInput(query="avatar", media_type="movie"))
+        result = await use_case.execute(
+            SearchInput(profile_id=_PROFILE_ID, query="avatar", media_type="movie")
+        )
 
         mocks.movies.search.assert_awaited_once()
         mocks.series.search.assert_not_awaited()
@@ -67,9 +81,14 @@ class TestSearchCatalogUseCase:
     async def test_should_skip_movie_repo_when_filtered_to_series(self) -> None:
         mocks = make_media_uow_mock()
         mocks.series.search.return_value = [(_series("Dark"), -4.0)]
-        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(SearchInput(query="dark", media_type="series"))
+        result = await use_case.execute(
+            SearchInput(profile_id=_PROFILE_ID, query="dark", media_type="series")
+        )
 
         mocks.series.search.assert_awaited_once()
         mocks.movies.search.assert_not_awaited()
@@ -88,9 +107,12 @@ class TestSearchCatalogUseCase:
             (_series("D"), -2.0),
             (_series("E"), -1.0),
         ]
-        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(SearchInput(query="test", limit=3))
+        result = await use_case.execute(SearchInput(profile_id=_PROFILE_ID, query="test", limit=3))
 
         assert len(result.items) == 3
         assert result.total == 5  # Total before trimming
@@ -100,9 +122,12 @@ class TestSearchCatalogUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.search.return_value = []
         mocks.series.search.return_value = []
-        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(SearchInput(query="nonexistent"))
+        result = await use_case.execute(SearchInput(profile_id=_PROFILE_ID, query="nonexistent"))
 
         assert result.items == []
         assert result.total == 0
@@ -112,10 +137,14 @@ class TestSearchCatalogUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.search.return_value = []
         mocks.series.search.return_value = []
-        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
         await use_case.execute(
             SearchInput(
+                profile_id=_PROFILE_ID,
                 query="test",
                 genre="Action",
                 year_min=2000,
@@ -129,15 +158,19 @@ class TestSearchCatalogUseCase:
         assert call_kwargs.kwargs["year_min"] == 2000
         assert call_kwargs.kwargs["year_max"] == 2020
         assert call_kwargs.kwargs["limit"] == 10
+        assert list(call_kwargs.kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
 
     @pytest.mark.asyncio
     async def test_search_item_output_carries_required_fields(self) -> None:
         mocks = make_media_uow_mock()
         mocks.movies.search.return_value = [(_movie("Test Movie"), -5.0)]
         mocks.series.search.return_value = [(_series("Test Series"), -3.0)]
-        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(SearchInput(query="test"))
+        result = await use_case.execute(SearchInput(profile_id=_PROFILE_ID, query="test"))
 
         for item in result.items:
             assert isinstance(item, SearchItemOutput)
@@ -151,9 +184,49 @@ class TestSearchCatalogUseCase:
         mocks = make_media_uow_mock()
         mocks.movies.search.return_value = [(_movie("Avatar"), -5.0)]
         mocks.series.search.return_value = [(_series("Dark"), -3.0)]
-        use_case = SearchCatalogUseCase(uow_factory=mocks.factory)
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
 
-        result = await use_case.execute(SearchInput(query="test"))
+        result = await use_case.execute(SearchInput(profile_id=_PROFILE_ID, query="test"))
 
         types = {(item.title, item.type) for item in result.items}
         assert types == {("Avatar", "movie"), ("Dark", "series")}
+
+    @pytest.mark.asyncio
+    async def test_should_short_circuit_for_deny_all_profile(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: []}),
+        )
+
+        result = await use_case.execute(SearchInput(profile_id=_PROFILE_ID, query="anything"))
+
+        assert result.items == []
+        assert result.total == 0
+        mocks.factory.assert_not_called()
+        mocks.movies.search.assert_not_awaited()
+        mocks.series.search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_forward_only_allowed_libraries_for_inclusion_path(
+        self,
+    ) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.search.return_value = [(_movie("Visible"), -5.0)]
+        mocks.series.search.return_value = []
+        use_case = SearchCatalogUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=FakeProfileLibraryAccessPort({_PROFILE_ID: [_LIBRARY_ID]}),
+        )
+
+        result = await use_case.execute(SearchInput(profile_id=_PROFILE_ID, query="visible"))
+
+        assert [item.title for item in result.items] == ["Visible"]
+        movie_kwargs = mocks.movies.search.await_args.kwargs
+        series_kwargs = mocks.series.search.await_args.kwargs
+        assert list(movie_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert list(series_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
+        assert _LIBRARY_ID_OTHER not in list(movie_kwargs["allowed_library_ids"])

--- a/tests/modules/media/unit/conftest.py
+++ b/tests/modules/media/unit/conftest.py
@@ -8,6 +8,9 @@ unit test reaches for — chiefly a factory that builds a mock
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
+from src.modules.media.application.ports.profile_library_access_port import (
+    ProfileLibraryAccessPort,
+)
 from src.modules.media.application.unit_of_work import (
     MediaUnitOfWork,
     MediaUnitOfWorkFactory,
@@ -52,3 +55,42 @@ def make_media_uow_mock() -> MediaUoWMocks:
 
     factory = MagicMock(return_value=uow)
     return MediaUoWMocks(factory=factory, uow=uow, movies=movies, series=series)
+
+
+class FakeProfileLibraryAccessPort(ProfileLibraryAccessPort):
+    """In-memory implementation of ``ProfileLibraryAccessPort`` for tests.
+
+    Stores a ``profile_id -> list[library_id]`` mapping and resolves
+    ``find_for_profile`` against it. Unmapped profile ids resolve to
+    an empty list — matching the production adapter's deny-all-on-miss
+    semantics. Tests that want the inclusion path map the configured
+    test profile to ``[_LIBRARY_ID]`` (``"lib_test12345678"``); tests
+    that want the deny-all path map it to ``[]`` (or omit it
+    entirely).
+    """
+
+    def __init__(self, mapping: dict[str, list[str]] | None = None) -> None:
+        self._mapping: dict[str, list[str]] = dict(mapping) if mapping else {}
+
+    def set(self, profile_id: str, library_ids: list[str]) -> None:
+        """Set the allowed libraries for ``profile_id``."""
+        self._mapping[profile_id] = list(library_ids)
+
+    async def find_for_profile(self, profile_id: str) -> list[str]:
+        return list(self._mapping.get(profile_id, []))
+
+
+def make_profile_library_access(
+    *,
+    profile_id: str = "prf_test12345678",
+    library_ids: list[str] | None = None,
+) -> FakeProfileLibraryAccessPort:
+    """Build a fake port bound to a single test profile.
+
+    By default maps ``prf_test12345678`` to ``["lib_test12345678"]``,
+    matching the constants used by the existing media unit tests.
+    Passing ``library_ids=[]`` exercises the deny-all path.
+    """
+    if library_ids is None:
+        library_ids = ["lib_test12345678"]
+    return FakeProfileLibraryAccessPort({profile_id: list(library_ids)})


### PR DESCRIPTION
## Summary

Closes the per-profile rollout master plan: every user-facing catalog read is now gated by the caller's ``Profile.allowed_library_ids`` ACL. A profile with an empty list sees nothing; a profile with a restricted list sees only its libraries' content; legacy profiles backfilled in PR #176 keep seeing every existing library.

- ``ProfileLibraryAccessPort`` + ``ProfileLibraryAccessAdapter`` (ADR-009 cross-BC read port). Adapter is the only Media file that imports from Identity.
- ``media_default_profile_id`` transitional setting + ``media/presentation/dependencies.py`` consuming the centralized ``make_resolve_profile_id`` factory (PR #177). Same FF semantics as the other three BCs.
- Repository read methods on Movie / Series gained ``allowed_library_ids: Sequence[str] | None = None`` (defaulted, so internal callers — scanner, intro detection, scrub-preview backfill, ``count_under_paths``, ``list_all`` — are unaffected).
- 14 catalog-read use cases now resolve the ACL via the port and short-circuit an empty result for deny-all profiles **without opening the UoW**, avoiding ``WHERE library_id IN ()`` dialect issues and giving a load-bearing test point.
- Every read-side route + every stream / HLS / scrub-preview route now ``Depends(resolve_profile_id)``. The stream-side wiring is deliberate: without it, a user could bypass the ACL by hitting ``/api/v1/stream/movie/{id}/...`` with a known id.

## Test plan

- [x] ``poetry run pytest -q`` → 2230 passed, 5 skipped (was 2190 before this PR — +40 new tests).
- [x] ``ruff check`` and ``ruff format --check`` clean across the diff.
- [x] Adapter integration test (``test_profile_library_access_adapter.py``): known profile, default-deny, unknown profile, cross-profile isolation.
- [x] Per use case: deny-all short-circuit assertion that pins ""no UoW opened"" (~13 tests).
- [x] Per list-style use case: inclusion + exclusion forwarding (~10 tests).
- [x] ``get_movie_by_id`` / ``get_series_by_id``: 404 when the row's library is outside the ACL (no info leak — looks identical to a missing id).
- [x] Repo integration: ``TestAllowedLibraryIdsFilter`` on both Movie and Series repos covering ``list_paginated`` (include/exclude) + ``find_by_id`` (inside/outside) — 8 tests.
- [ ] Manual end-to-end after merge: set ``MEDIA_DEFAULT_PROFILE_ID`` to a profile with one library, hit the catalog endpoints, confirm only that library's content shows up.

## Out of scope

- Caching the profile → libraries lookup (single indexed PK read per request; defer until profiling proves it matters).
- The ``is_kids`` UX flag and any content-rating filter (separate concern).
- Frontend changes (separate repo).
- Operator / admin write paths (``save``, ``delete``, scan, enrich) which bypass the ACL by design.