### PR TITLE
fix(identity): await async-Resource providers in cookie-auth chain

### DIFF
--- a/scripts/identity_create_admin.py
+++ b/scripts/identity_create_admin.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import asyncio
 import getpass
+import inspect
 import sys
 
 from pwdlib import PasswordHash
@@ -79,7 +80,16 @@ async def _bootstrap_admin() -> None:
     await container.infrastructure.init_resources()
 
     try:
+        # ``identity_unit_of_work_factory`` and ``create_profile`` are
+        # ``providers.Singleton`` / ``providers.Factory`` that
+        # transitively depend on ``infrastructure.session_factory``
+        # (a ``providers.Resource``). Invocation returns a Future
+        # under that wiring; ``isawaitable`` keeps the path tolerant
+        # of test wiring that overrides the resource as a synchronous
+        # ``providers.Object``.
         uow_factory = container.identity.identity_unit_of_work_factory()
+        if inspect.isawaitable(uow_factory):
+            uow_factory = await uow_factory
         async with uow_factory() as uow:
             existing = await uow.users.find_by_email(email)
             if existing is not None:
@@ -100,6 +110,8 @@ async def _bootstrap_admin() -> None:
             raise RuntimeError("user id was not assigned during save")
 
         create_profile = container.identity.create_profile()
+        if inspect.isawaitable(create_profile):
+            create_profile = await create_profile
         profile = await create_profile.execute(
             CreateProfileInput(user_id=saved.id.value, name=profile_name),
         )

--- a/src/modules/identity/infrastructure/auth/dependencies.py
+++ b/src/modules/identity/infrastructure/auth/dependencies.py
@@ -14,6 +14,7 @@ This is FastAPI-native (not registered in the dependency-injector
 container) because FastAPI Users assumes its own dependency style.
 """
 
+import inspect
 import uuid
 from collections.abc import AsyncGenerator
 
@@ -54,8 +55,18 @@ async def get_async_session(request: Request) -> AsyncGenerator[AsyncSession, No
     Reads the session factory from ``app.state.container`` so it
     picks up the same engine the dependency-injector resolved for
     every other repository in the app.
+
+    ``infrastructure.session_factory`` is a ``providers.Resource``
+    in production: invoking the provider returns a Future rather
+    than the cached factory. Tests override it as
+    ``providers.Object``, which returns the value synchronously.
+    The ``isawaitable`` branch covers both shapes so a single call
+    site works under prod and test wiring without forcing the test
+    conftest to mirror the async-Resource shape.
     """
     session_factory = request.app.state.container.infrastructure.session_factory()
+    if inspect.isawaitable(session_factory):
+        session_factory = await session_factory
     async with session_factory() as session:
         yield session
 

--- a/src/modules/identity/presentation/dependencies.py
+++ b/src/modules/identity/presentation/dependencies.py
@@ -18,6 +18,7 @@ Two layers:
    collapse into a direct re-export of ``get_current_profile``.
 """
 
+import inspect
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
@@ -76,7 +77,14 @@ async def get_current_profile(
        distinguish "logged in, pick a profile" from "not logged in".
     """
     container = request.app.state.container
+    # Provider invocation returns a Future in production because it
+    # transitively depends on the ``infrastructure.session_factory``
+    # ``providers.Resource``. Tests override that resource with
+    # ``providers.Object``, which returns synchronously. The
+    # ``isawaitable`` branch handles both shapes.
     factory = container.identity.identity_unit_of_work_factory()
+    if inspect.isawaitable(factory):
+        factory = await factory
     async with factory() as uow:
         snapshot = await uow.access_tokens.get_by_token(token)
 
@@ -140,7 +148,12 @@ def make_resolve_profile_id(
         token = request.cookies.get(settings.session_cookie_name)
         if token is not None:
             container = request.app.state.container
+            # Same async-Resource gotcha as ``get_current_profile``;
+            # the ``isawaitable`` branch tolerates both production
+            # (Future) and test (``providers.Object``) shapes.
             factory = container.identity.identity_unit_of_work_factory()
+            if inspect.isawaitable(factory):
+                factory = await factory
             async with factory() as uow:
                 snap = await uow.access_tokens.get_by_token(token)
             if snap is not None and snap.current_profile_id is not None:


### PR DESCRIPTION
## Summary

Fixes a latent ``TypeError: '_asyncio.Future' object is not callable`` that surfaced on the first real HTTP login attempt in dev. Since PR #167 (FastAPI Users wiring) merged, three production call sites have been invoking dependency-injector providers that transitively depend on ``infrastructure.session_factory`` — a ``providers.Resource``. After ``init_resources()`` runs at lifespan startup, invoking such a provider returns a ``Future`` that wraps the cached value, not the value itself. The sites tried to use that Future as if it were the factory and crashed at the first ``async with`` boundary.

The reason the existing e2e suite did not catch this: every identity-test conftest overrides ``infrastructure.session_factory`` with ``providers.Object`` (which returns the value synchronously), so the production async-Resource path was never exercised end-to-end.

## Fix

Tolerant: the call sites now check ``inspect.isawaitable`` and ``await`` only when needed. Existing test overrides keep working unchanged; production goes through the async path. Three sites updated:

- ``identity/infrastructure/auth/dependencies.py`` — ``get_async_session`` (the FastAPI Users dep that ``current_active_user`` and the cookie-login route ultimately depend on).
- ``identity/presentation/dependencies.py`` — ``get_current_profile`` (used by ``/profiles/{id}/switch``) and the inner ``resolve_profile_id`` returned by ``make_resolve_profile_id`` (used by every per-BC catalog read route in PRs #172/#173/#174/#178).

Same pattern applied to ``scripts/identity_create_admin.py`` so the bootstrap CLI works against the real container without overrides.

## Out of scope (follow-up)

Replacing the test override pattern with a production-shaped ``providers.Resource`` that exercises the async path end-to-end. A separate PR should add a test that runs the real lifespan against a temporary SQLite so a future regression in the same shape gets caught before another PR ships. The tolerant ``isawaitable`` branch is safe to keep when that follow-up lands — it does not re-introduce the bug if the test wiring is upgraded.

## Test plan

- [x] ``poetry run pytest -q`` → 2230 passed, 5 skipped (no regressions).
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [x] Manual end-to-end verified by the user: bootstrap CLI created the admin, frontend login → cookie roundtrip → ``/users/me`` resolved → profile picker auto-skipped to home, all without the crash.

## Summary by Sourcery

Handle async Resource-backed providers correctly in identity session and profile resolution paths so they work under both production and test container wiring.

Bug Fixes:
- Prevent runtime failures when invoking identity session and unit-of-work providers that return Futures from async Resource dependencies by awaiting them when necessary.

Enhancements:
- Make the identity admin bootstrap script tolerant of async Resource-backed providers while remaining compatible with existing test-time overrides.