### PR TITLE
feat(identity): bootstrap admin grants all current libraries

### DIFF
--- a/scripts/identity_create_admin.py
+++ b/scripts/identity_create_admin.py
@@ -15,8 +15,15 @@ the default profile's display name, then:
    ``is_superuser=True``, ``is_verified=True`` and persists it via
    ``UserRepository``.
 4. Creates a default ``Profile`` for the new admin via the
-   ``CreateProfileUseCase`` so ``get_current_profile`` resolves on
-   the first login.
+   ``CreateProfileUseCase`` and grants it access to every library
+   currently registered, so the operator can use the catalog
+   immediately. The domain default for ``allowed_library_ids`` is
+   the empty list (deny-all) — that's the right default for new
+   household members added via the UI later, but the bootstrap
+   account is the operator's admin and would otherwise see an
+   empty catalog after first login. The grant snapshots the
+   current libraries; libraries added afterward need an explicit
+   grant via ``PUT /api/v1/profiles/{id}``.
 
 Bootstrap path lives in ``scripts/`` rather than as a public route
 because PR 1 deliberately does not expose ``/auth/register`` —
@@ -38,6 +45,7 @@ from src.modules.identity.application.dtos.identity_dtos import CreateProfileInp
 from src.modules.identity.domain.entities.user import User
 from src.modules.identity.domain.value_objects.email import Email
 from src.modules.identity.domain.value_objects.user_role import UserRole
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory  # noqa: TCH001
 
 _password_hash = PasswordHash.recommended()
 
@@ -71,6 +79,27 @@ def _read_profile_name() -> str:
     return raw or "Admin"
 
 
+async def _resolve_uow_factory(provider):  # type: ignore[no-untyped-def]
+    """Resolve a dependency-injector provider to its concrete factory.
+
+    Provider invocation returns a ``Future`` in production (because
+    of the ``providers.Resource`` session_factory dependency); in
+    tests it returns synchronously when overridden as
+    ``providers.Object``. ``isawaitable`` covers both shapes.
+    """
+    result = provider()
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
+async def _snapshot_library_ids(library_uow_factory: LibraryUnitOfWorkFactory) -> list[str]:
+    """Return the prefixed external_ids of every active library."""
+    async with library_uow_factory() as uow:
+        libraries = await uow.libraries.find_all()
+    return [str(library.id) for library in libraries if library.id is not None]
+
+
 async def _bootstrap_admin() -> None:
     email = _read_email()
     password = _read_password()
@@ -80,17 +109,10 @@ async def _bootstrap_admin() -> None:
     await container.infrastructure.init_resources()
 
     try:
-        # ``identity_unit_of_work_factory`` and ``create_profile`` are
-        # ``providers.Singleton`` / ``providers.Factory`` that
-        # transitively depend on ``infrastructure.session_factory``
-        # (a ``providers.Resource``). Invocation returns a Future
-        # under that wiring; ``isawaitable`` keeps the path tolerant
-        # of test wiring that overrides the resource as a synchronous
-        # ``providers.Object``.
-        uow_factory = container.identity.identity_unit_of_work_factory()
-        if inspect.isawaitable(uow_factory):
-            uow_factory = await uow_factory
-        async with uow_factory() as uow:
+        identity_uow_factory = await _resolve_uow_factory(
+            container.identity.identity_unit_of_work_factory,
+        )
+        async with identity_uow_factory() as uow:
             existing = await uow.users.find_by_email(email)
             if existing is not None:
                 print(f"  refusing to overwrite existing user {existing.id}")
@@ -109,15 +131,34 @@ async def _bootstrap_admin() -> None:
         if saved.id is None:
             raise RuntimeError("user id was not assigned during save")
 
+        # Snapshot every currently-registered library and grant the
+        # new admin access to all of them. Otherwise the domain's
+        # default-deny on ``allowed_library_ids`` would leave the
+        # operator with an empty catalog on first login.
+        library_uow_factory = await _resolve_uow_factory(
+            container.library.library_unit_of_work_factory,
+        )
+        library_ids = await _snapshot_library_ids(library_uow_factory)
+
         create_profile = container.identity.create_profile()
         if inspect.isawaitable(create_profile):
             create_profile = await create_profile
         profile = await create_profile.execute(
-            CreateProfileInput(user_id=saved.id.value, name=profile_name),
+            CreateProfileInput(
+                user_id=saved.id.value,
+                name=profile_name,
+                allowed_library_ids=library_ids,
+            ),
         )
 
         print(f"created admin {saved.id}")
         print(f"created default profile {profile.id} ({profile.name!r})")
+        if library_ids:
+            print(f"  granted access to {len(library_ids)} libraries: {', '.join(library_ids)}")
+        else:
+            print("  no libraries registered yet — admin will see an empty catalog")
+            print("  until libraries are created. Re-run identity_grant_all_libraries.py")
+            print("  after creating libraries, or grant via PUT /api/v1/profiles/{id}.")
     finally:
         await container.infrastructure.shutdown_resources()
 

--- a/scripts/identity_grant_all_libraries.py
+++ b/scripts/identity_grant_all_libraries.py
@@ -1,0 +1,120 @@
+"""Grant a profile access to every currently-registered library.
+
+Useful when an existing profile was created before this PR's
+default-grant behaviour shipped (or before any libraries were
+registered): its ``allowed_library_ids`` is empty and the catalog
+returns nothing under the per-profile ACL filter (PR #178). Run
+this script to refresh the snapshot — same semantics as
+``PUT /api/v1/profiles/{id}`` with an explicit list, including the
+revoke-anything-not-in-the-snapshot side effect (intentional:
+this is the "sync to current state" tool, not "additive grant").
+
+Run from the project root with the virtualenv active::
+
+    poetry run python scripts/identity_grant_all_libraries.py
+    poetry run python scripts/identity_grant_all_libraries.py --profile-id prf_xxxxxxxxxxxx
+
+A bulk ``--all`` mode is intentionally out of scope until the
+profile repository exposes a list-all method — operator-only
+maintenance and per-profile invocations cover the immediate need.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import inspect
+import sys
+
+from src.config.containers import ApplicationContainer
+from src.modules.identity.application.dtos.identity_dtos import UpdateProfileInput
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory  # noqa: TCH001
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+
+async def _resolve(provider):  # type: ignore[no-untyped-def]
+    """Resolve a provider to its concrete value, awaiting if needed."""
+    result = provider()
+    if inspect.isawaitable(result):
+        result = await result
+    return result
+
+
+async def _snapshot_library_ids(library_uow_factory: LibraryUnitOfWorkFactory) -> list[str]:
+    """Return prefixed external_ids of every active library."""
+    async with library_uow_factory() as uow:
+        libraries = await uow.libraries.find_all()
+    return [str(library.id) for library in libraries if library.id is not None]
+
+
+async def _grant_one(
+    container: ApplicationContainer,
+    profile_id: str,
+    library_ids: list[str],
+) -> None:
+    """Grant ``library_ids`` to a single profile via the update use case."""
+    # The update use case enforces ownership: ``user_id`` must match
+    # the profile's owner. Resolve it via the identity UoW so this
+    # script can operate on any profile regardless of caller.
+    identity_uow_factory = await _resolve(container.identity.identity_unit_of_work_factory)
+    async with identity_uow_factory() as uow:
+        target = await uow.profiles.find_by_id(ProfileId(profile_id))
+    if target is None:
+        print(f"  profile {profile_id} not found")
+        sys.exit(1)
+
+    update_profile = container.identity.update_profile()
+    if inspect.isawaitable(update_profile):
+        update_profile = await update_profile
+
+    await update_profile.execute(
+        UpdateProfileInput(
+            user_id=target.user_id.value,
+            profile_id=profile_id,
+            allowed_library_ids=library_ids,
+        ),
+    )
+    print(f"  granted {len(library_ids)} libraries to {profile_id}")
+
+
+async def _run(profile_id: str | None) -> None:
+    container = ApplicationContainer()
+    await container.infrastructure.init_resources()
+
+    try:
+        library_uow_factory = await _resolve(container.library.library_unit_of_work_factory)
+        library_ids = await _snapshot_library_ids(library_uow_factory)
+        if not library_ids:
+            print("no libraries registered yet — nothing to grant")
+            return
+
+        print(f"current libraries: {', '.join(library_ids)}")
+
+        target = profile_id or input("Profile ID (prf_xxxxxxxxxxxx): ").strip()
+        if not target:
+            print("no profile id supplied; aborting")
+            sys.exit(1)
+        await _grant_one(container, target, library_ids)
+    finally:
+        await container.infrastructure.shutdown_resources()
+
+
+def main() -> None:
+    """Synchronous CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile-id",
+        help="Prefixed external id (prf_xxxxxxxxxxxx) of the target profile. "
+        "Prompts interactively when omitted.",
+    )
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(_run(args.profile_id))
+    except KeyboardInterrupt:
+        print("\nAborted.")
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Default-deny on ``Profile.allowed_library_ids`` (PR #176) is the right invariant for new household members added through the UI, but the bootstrap admin is the operator's setup account — leaving its ACL empty meant that after the per-profile catalog filter landed (PR #178), the very first login showed an empty catalog because the admin had been created via this script with no library grants.

Two changes, both scoped to the bootstrap CLI:

1. ``scripts/identity_create_admin.py`` snapshots every active library at create-time and seeds ``CreateProfileInput.allowed_library_ids`` with the result. The new admin sees the catalog they own as soon as they log in. Libraries added later still need an explicit grant — the snapshot is intentionally point-in-time so future household members don't auto-inherit content the operator may want to gate.

2. ``scripts/identity_grant_all_libraries.py`` (new) rebuilds the snapshot for an existing profile, replacing its ``allowed_library_ids`` with the current set. Same semantics as ``PUT /api/v1/profiles/{id}`` with an explicit list — the "sync to current state" tool, not "additive grant". Useful for admins created before this PR (the operator's immediate need) and for resyncing after registering new libraries.

## Out of scope

A ``--all`` mode that walks every active profile. The profile repository doesn't expose a list-all method today and the per-profile invocation covers the immediate operator need; defer until that becomes a recurring pain.

## Immediate unblock

The user's existing admin can be unblocked right now (without merging this) by hitting the existing ``PUT /api/v1/profiles/{id}`` route from the browser console while logged in:

```js
await fetch('/api/v1/libraries', {credentials: 'include'}).then(r => r.json())
// note the lib_xxx ids, then:
await fetch('/api/v1/profiles/PROFILE_ID', {
  method: 'PUT', credentials: 'include',
  headers: {'Content-Type': 'application/json'},
  body: JSON.stringify({allowed_library_ids: ['lib_xxx', 'lib_yyy']}),
}).then(r => r.json())
```

After merging, the same outcome via ``poetry run python scripts/identity_grant_all_libraries.py --profile-id prf_xxx``.

## Test plan

- [x] ``poetry run pytest -q`` → 2230 passed, 5 skipped — no regressions (the change touches script-only code, not the domain or use cases).
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [ ] Manual: rerun the bootstrap CLI on a fresh DB → admin's first login shows the catalog (not empty).