### PR TITLE
refactor(identity): drop transitional default_profile_id FF

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -85,7 +85,6 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     _progress_lookup_adapter = providers.Factory(
         ProgressLookupAdapter,
         watch_progress_uow_factory=_watch_progress_uow_factory_for_progress_lookup,
-        default_profile_id=config.provided.watch_progress_default_profile_id,
     )
 
     # Same pattern for the per-profile library ACL: built at the

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -270,43 +270,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     )
     session_cookie_name: str = Field(default="homeflix_session")
 
-    watch_progress_default_profile_id: str | None = Field(
-        default=None,
-        description="Optional fallback ``profile_id`` (``prf_xxx``) used "
-        "by watch-progress/media routes when the request has no session "
-        "cookie. Lets the backend keep serving consumers that have not "
-        "shipped login yet during the per-profile rollout. Unset = strict "
-        "mode (no cookie -> 401). Remove the env var once every consumer "
-        "is sending the session cookie.",
-    )
-    preferences_default_profile_id: str | None = Field(
-        default=None,
-        description="Optional fallback ``profile_id`` for the playback "
-        "preferences routes during the per-profile rollout. Same "
-        "semantics as ``watch_progress_default_profile_id`` — the "
-        "operator typically sets all *_default_profile_id env vars "
-        "together while the frontend is being migrated, then removes "
-        "them to enter strict mode.",
-    )
-    media_default_profile_id: str | None = Field(
-        default=None,
-        description="Optional fallback ``profile_id`` (``prf_xxx``) "
-        "used by media routes (catalog list/search/get/stream) when "
-        "the request has no session cookie. Lets the backend keep "
-        "serving consumers that have not shipped login yet during "
-        "the per-profile rollout. Unset = strict mode (no cookie -> "
-        "401). Remove the env var once every consumer is sending "
-        "the session cookie.",
-    )
-    collections_default_profile_id: str | None = Field(
-        default=None,
-        description="Optional fallback ``profile_id`` for the collections "
-        "routes (``/custom-lists``, ``/watchlist``) during the per-profile "
-        "rollout. Same semantics as ``watch_progress_default_profile_id`` — "
-        "in practice the operator sets both together while the frontend "
-        "is being migrated, then removes both to enter strict mode.",
-    )
-
     # =========================================================================
     # Internationalization
     # =========================================================================

--- a/src/modules/collections/presentation/dependencies.py
+++ b/src/modules/collections/presentation/dependencies.py
@@ -1,18 +1,12 @@
 """FastAPI dependency that resolves the caller's ``profile_id`` for collections.
 
-Thin wrapper around the centralised
-``identity.presentation.dependencies.make_resolve_profile_id``
-factory, parameterised with the collections-specific transitional
-setting and 401 message. See the factory's docstring for resolution
-semantics.
+Re-exports the canonical strict-mode helper from the identity BC.
+The per-BC wrapper file still exists so route imports stay local
+(``from .dependencies import resolve_profile_id``) — if a future
+feature needs a collections-specific override (e.g. shared lists)
+it can wrap here without touching every route file.
 """
 
-from src.modules.identity.presentation.dependencies import make_resolve_profile_id
-
-resolve_profile_id = make_resolve_profile_id(
-    setting_attr="collections_default_profile_id",
-    missing_message="Authentication required to access collections",
-)
-
+from src.modules.identity.presentation.dependencies import resolve_profile_id
 
 __all__ = ["resolve_profile_id"]

--- a/src/modules/identity/presentation/dependencies.py
+++ b/src/modules/identity/presentation/dependencies.py
@@ -1,25 +1,29 @@
 """FastAPI dependencies that resolve the caller's identity context.
 
-Two layers:
+Two layers, both strict (no transitional fallback):
 
-1. ``get_current_profile`` — the strict-mode dep. Combines the
-   authenticated ``UserModel`` from FastAPI Users with the active
-   ``profile_id`` carried by the session row, returning a
-   ``ProfileContext`` with both as prefixed external IDs (UUIDs
-   never cross into the domain).
-2. ``make_resolve_profile_id`` — the transitional factory. Returns
-   a per-BC dep that tries the cookie path first and falls back to
-   a configured ``*_default_profile_id`` setting when the request
-   has no session yet. Each consumer BC (``watch_progress``,
-   ``collections``, ``preferences``, ``media``) wires its own
-   bound dep at module level, parameterising the setting attribute
-   and the missing-session error message. Once every consumer
-   ships login support and the env vars are unset, the helpers
-   collapse into a direct re-export of ``get_current_profile``.
+1. ``get_current_profile`` — combines the authenticated ``UserModel``
+   from FastAPI Users with the active ``profile_id`` carried by the
+   session row, returning a ``ProfileContext`` with both as
+   prefixed external IDs (UUIDs never cross into the domain).
+2. ``resolve_profile_id`` — the lighter dep used by the per-BC
+   catalog reads (watch_progress, collections, preferences, media).
+   Reads the session cookie, looks up the matching ``access_tokens``
+   row and returns ``current_profile_id``. Raises 401 when the
+   cookie is missing or the row has no profile selected.
+
+The earlier ``make_resolve_profile_id`` factory threaded a per-BC
+``*_default_profile_id`` env-var fallback through this path so the
+old frontend (pre-login) could keep serving anonymous catalog
+requests during the rollout (PRs #163-180). With the route guards
+in ``homeflix-web`` (#107-#112) anonymous requests never reach the
+catalog, so the fallback was dead code in practice. Removed in this
+cleanup so the entry point is a single function with one
+behaviour — easier to reason about and to migrate when the next
+auth feature lands.
 """
 
 import inspect
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from fastapi import Depends, Request
@@ -54,6 +58,21 @@ class ProfileContext:
     session_token: str
 
 
+async def _resolve_uow_factory(request: Request):  # type: ignore[no-untyped-def]
+    """Resolve the identity UoW factory from ``app.state.container``.
+
+    ``infrastructure.session_factory`` is a ``providers.Resource`` in
+    production: invoking the wrapping ``identity_unit_of_work_factory``
+    provider returns a Future. Tests override the session factory with
+    ``providers.Object``, which returns synchronously. The
+    ``isawaitable`` branch covers both shapes.
+    """
+    factory = request.app.state.container.identity.identity_unit_of_work_factory()
+    if inspect.isawaitable(factory):
+        factory = await factory
+    return factory
+
+
 async def get_current_profile(
     request: Request,
     user: UserModel = Depends(current_active_user),
@@ -76,15 +95,7 @@ async def get_current_profile(
        user has not yet selected a profile, so the frontend can
        distinguish "logged in, pick a profile" from "not logged in".
     """
-    container = request.app.state.container
-    # Provider invocation returns a Future in production because it
-    # transitively depends on the ``infrastructure.session_factory``
-    # ``providers.Resource``. Tests override that resource with
-    # ``providers.Object``, which returns synchronously. The
-    # ``isawaitable`` branch handles both shapes.
-    factory = container.identity.identity_unit_of_work_factory()
-    if inspect.isawaitable(factory):
-        factory = await factory
+    factory = await _resolve_uow_factory(request)
     async with factory() as uow:
         snapshot = await uow.access_tokens.get_by_token(token)
 
@@ -103,69 +114,36 @@ async def get_current_profile(
     )
 
 
-def make_resolve_profile_id(
-    *,
-    setting_attr: str,
-    missing_message: str,
-) -> Callable[[Request], Awaitable[str]]:
-    """Build a per-BC ``resolve_profile_id`` dep with a transitional fallback.
+async def resolve_profile_id(request: Request) -> str:
+    """Return the caller's prefixed ``profile_id`` (``prf_xxx``).
 
-    Resolution order at request time:
+    Resolution:
 
-    1. Session cookie present → look up the matching ``access_tokens``
-       row in the identity BC's UoW. If a ``current_profile_id``
-       exists, return it.
-    2. No usable cookie or unknown token + the configured
-       ``settings.<setting_attr>`` is set → return that fallback
-       (transition mode).
-    3. Otherwise → raise :class:`NoActiveSessionError` (HTTP 401)
-       with ``missing_message``.
+    1. Session cookie missing → :class:`NoActiveSessionError` (HTTP 401).
+    2. Cookie present but the matching ``access_tokens`` row has no
+       ``current_profile_id`` (logged in, picker not visited yet) →
+       same 401.
+    3. Otherwise → return the ``current_profile_id`` as a plain
+       string.
 
     Errors raised by the identity UoW (container not wired, DB
-    unreachable, etc.) propagate as 500 by design — silently falling
-    back to anonymous on real misconfigurations would mask bugs and
-    serve authenticated requests as anonymous.
-
-    Args:
-        setting_attr: Name of the field on ``Settings`` that holds
-            the per-BC fallback (e.g. ``"watch_progress_default_profile_id"``).
-            ``getattr`` is read every request so changes to the
-            setting (when sourced from a re-loaded ``.env``) take
-            effect without restarting.
-        missing_message: User-facing 401 message when neither path
-            resolves a profile.
-
-    Returns:
-        An ``async`` FastAPI dep returning the prefixed profile_id
-        as a plain ``str`` — kept primitive because every consumer
-        passes it straight into a use case input that already
-        validates the prefix.
+    unreachable, etc.) propagate as 500 by design — silently
+    degrading to anonymous on real misconfigurations would mask
+    bugs and serve authenticated requests as anonymous data.
     """
+    settings = get_settings()
+    token = request.cookies.get(settings.session_cookie_name)
+    if token is None:
+        raise NoActiveSessionError(message="Authentication required")
 
-    async def resolve_profile_id(request: Request) -> str:
-        settings = get_settings()
+    factory = await _resolve_uow_factory(request)
+    async with factory() as uow:
+        snap = await uow.access_tokens.get_by_token(token)
 
-        token = request.cookies.get(settings.session_cookie_name)
-        if token is not None:
-            container = request.app.state.container
-            # Same async-Resource gotcha as ``get_current_profile``;
-            # the ``isawaitable`` branch tolerates both production
-            # (Future) and test (``providers.Object``) shapes.
-            factory = container.identity.identity_unit_of_work_factory()
-            if inspect.isawaitable(factory):
-                factory = await factory
-            async with factory() as uow:
-                snap = await uow.access_tokens.get_by_token(token)
-            if snap is not None and snap.current_profile_id is not None:
-                return str(snap.current_profile_id)
+    if snap is None or snap.current_profile_id is None:
+        raise NoActiveSessionError(message="Authentication required")
 
-        fallback = getattr(settings, setting_attr)
-        if fallback:
-            return str(fallback)
-
-        raise NoActiveSessionError(message=missing_message)
-
-    return resolve_profile_id
+    return str(snap.current_profile_id)
 
 
-__all__ = ["ProfileContext", "get_current_profile", "make_resolve_profile_id"]
+__all__ = ["ProfileContext", "get_current_profile", "resolve_profile_id"]

--- a/src/modules/media/application/ports/progress_lookup_port.py
+++ b/src/modules/media/application/ports/progress_lookup_port.py
@@ -38,21 +38,26 @@ class ProgressSummary:
 
 
 class ProgressLookupPort(ABC):
-    """Batch lookup of progress records by media id."""
+    """Batch lookup of progress records by media id, scoped to a profile."""
 
     @abstractmethod
     async def find_for_media_ids(
         self,
         media_ids: Sequence[str],
+        *,
+        profile_id: str,
     ) -> dict[str, ProgressSummary]:
         """Return progress summaries for the given media ids.
 
         Args:
             media_ids: Composite or standalone media ids to look up.
+            profile_id: Prefixed external id (``prf_xxx``) of the
+                profile whose progress to read. Per-profile rollout
+                (PR #172) scopes every progress row to a profile.
 
         Returns:
             Map keyed by ``media_id``. Ids without a matching progress
-            row are simply absent from the map.
+            row for the given profile are simply absent from the map.
         """
         ...
 

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -91,7 +91,10 @@ class GetSeriesByIdUseCase:
             for s in series.seasons
             for ep in s.episodes
         ]
-        progress_map = await self._progress_lookup.find_for_media_ids(composite_ids)
+        progress_map = await self._progress_lookup.find_for_media_ids(
+            composite_ids,
+            profile_id=input_dto.profile_id,
+        )
 
         return self._to_output(series, input_dto.lang, progress_map)
 

--- a/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
+++ b/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
@@ -3,19 +3,6 @@
 This is the only file in the Media BC that imports from the Watch
 Progress BC. Above the adapter, the use cases only see
 ``ProgressSummary``.
-
-Per ADR-010, watch_progress is now scoped per profile. The
-``ProgressLookupPort`` interface still doesn't carry a profile
-parameter (Media routes have not been refactored to thread
-``profile_id`` through their use cases yet), so the adapter applies
-``settings.watch_progress_default_profile_id`` to every query during
-the transition. When the setting is unset, the adapter degrades
-gracefully — every call returns an empty map so Media routes simply
-do not enrich responses with progress information.
-
-Once Media's use cases gain ``profile_id`` in their inputs (a follow-up
-PR), the port and this adapter will gain a ``profile_id`` parameter
-and the default fallback will be removed.
 """
 
 from collections.abc import Sequence
@@ -33,29 +20,21 @@ from src.shared_kernel.value_objects.profile_id import ProfileId
 class ProgressLookupAdapter(ProgressLookupPort):
     """Resolve progress snapshots via the Watch Progress Unit of Work."""
 
-    def __init__(
-        self,
-        watch_progress_uow_factory: WatchProgressUnitOfWorkFactory,
-        default_profile_id: str | None,
-    ) -> None:
+    def __init__(self, watch_progress_uow_factory: WatchProgressUnitOfWorkFactory) -> None:
         self._watch_progress_uow_factory = watch_progress_uow_factory
-        self._default_profile_id = default_profile_id
 
     async def find_for_media_ids(
         self,
         media_ids: Sequence[str],
+        *,
+        profile_id: str,
     ) -> dict[str, ProgressSummary]:
-        """Fetch progress rows scoped to the configured default profile.
-
-        Returns an empty map when the default profile is unset so the
-        consumer can still serve responses without progress
-        enrichment during strict-mode rollout.
-        """
-        if not media_ids or self._default_profile_id is None:
+        """Fetch progress rows scoped to the caller's profile."""
+        if not media_ids:
             return {}
-        profile_id = ProfileId(self._default_profile_id)
+        profile = ProfileId(profile_id)
         async with self._watch_progress_uow_factory() as uow:
-            progress_map = await uow.progress.find_by_media_ids(list(media_ids), profile_id)
+            progress_map = await uow.progress.find_by_media_ids(list(media_ids), profile)
         return {
             media_id: ProgressSummary(
                 media_id=media_id,

--- a/src/modules/media/presentation/dependencies.py
+++ b/src/modules/media/presentation/dependencies.py
@@ -1,18 +1,12 @@
 """FastAPI dependency that resolves the caller's ``profile_id`` for the catalog.
 
-Thin wrapper around the centralised
-``identity.presentation.dependencies.make_resolve_profile_id``
-factory, parameterised with the media-specific transitional setting
-and 401 message. See the factory's docstring for resolution
-semantics.
+Re-exports the canonical strict-mode helper from the identity BC.
+The per-BC wrapper file still exists so route imports stay local
+(``from .dependencies import resolve_profile_id``) — future
+catalog-specific overrides (e.g. parental controls, kids-mode
+filtering) plug in here without touching every route file.
 """
 
-from src.modules.identity.presentation.dependencies import make_resolve_profile_id
-
-resolve_profile_id = make_resolve_profile_id(
-    setting_attr="media_default_profile_id",
-    missing_message="Authentication required to access the catalog",
-)
-
+from src.modules.identity.presentation.dependencies import resolve_profile_id
 
 __all__ = ["resolve_profile_id"]

--- a/src/modules/preferences/presentation/dependencies.py
+++ b/src/modules/preferences/presentation/dependencies.py
@@ -1,18 +1,12 @@
 """FastAPI dependency that resolves the caller's ``profile_id`` for preferences.
 
-Thin wrapper around the centralised
-``identity.presentation.dependencies.make_resolve_profile_id``
-factory, parameterised with the preferences-specific transitional
-setting and 401 message. See the factory's docstring for resolution
-semantics.
+Re-exports the canonical strict-mode helper from the identity BC.
+The per-BC wrapper file still exists so route imports stay local
+(``from .dependencies import resolve_profile_id``) — future
+preference-specific overrides plug in here without touching every
+route file.
 """
 
-from src.modules.identity.presentation.dependencies import make_resolve_profile_id
-
-resolve_profile_id = make_resolve_profile_id(
-    setting_attr="preferences_default_profile_id",
-    missing_message="Authentication required to access preferences",
-)
-
+from src.modules.identity.presentation.dependencies import resolve_profile_id
 
 __all__ = ["resolve_profile_id"]

--- a/src/modules/watch_progress/presentation/dependencies.py
+++ b/src/modules/watch_progress/presentation/dependencies.py
@@ -1,18 +1,13 @@
 """FastAPI dependency that resolves the caller's ``profile_id``.
 
-Thin wrapper around the centralised
-``identity.presentation.dependencies.make_resolve_profile_id``
-factory, parameterised with the watch-progress-specific transitional
-setting and 401 message. See the factory's docstring for resolution
-semantics.
+Re-exports the canonical strict-mode helper from the identity BC.
+The per-BC wrapper file still exists so route imports stay
+local (``from .dependencies import resolve_profile_id``) — if a
+future feature needs a watch-progress-specific override (rate
+limit, kids-mode gating, etc.) it can wrap here without touching
+every route file.
 """
 
-from src.modules.identity.presentation.dependencies import make_resolve_profile_id
-
-resolve_profile_id = make_resolve_profile_id(
-    setting_attr="watch_progress_default_profile_id",
-    missing_message="Authentication required to access watch progress",
-)
-
+from src.modules.identity.presentation.dependencies import resolve_profile_id
 
 __all__ = ["resolve_profile_id"]

--- a/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
+++ b/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
@@ -15,6 +15,7 @@ from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_wo
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
+_OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
 
 
 def _progress(
@@ -22,9 +23,11 @@ def _progress(
     position: int = 1800,
     duration: int = 3600,
     media_type: WatchableMediaType = WatchableMediaType.EPISODE,
+    *,
+    profile_id: ProfileId = _PROFILE_ID,
 ) -> WatchProgress:
     return WatchProgress.create(
-        profile_id=_PROFILE_ID,
+        profile_id=profile_id,
         media_id=media_id,
         media_type=media_type,
         position_seconds=position,
@@ -34,12 +37,9 @@ def _progress(
 
 def _make_adapter(
     session_factory: async_sessionmaker[AsyncSession],
-    *,
-    default_profile_id: str | None = _PROFILE_ID.value,
 ) -> ProgressLookupAdapter:
     return ProgressLookupAdapter(
         SqlAlchemyWatchProgressUnitOfWorkFactory(session_factory),
-        default_profile_id=default_profile_id,
     )
 
 
@@ -47,7 +47,7 @@ def _make_adapter(
 class TestProgressLookupAdapter:
     """The adapter exposes ProgressSummary without leaking domain types."""
 
-    async def test_find_for_media_ids_returns_summaries(
+    async def test_find_for_media_ids_returns_summaries_for_caller_profile(
         self,
         db_session: AsyncSession,
         session_factory: async_sessionmaker[AsyncSession],
@@ -61,6 +61,7 @@ class TestProgressLookupAdapter:
 
         result = await adapter.find_for_media_ids(
             ["epi_ser_ABC_1_1", "epi_ser_ABC_1_2", "epi_ser_ABC_1_3"],
+            profile_id=_PROFILE_ID.value,
         )
 
         assert set(result.keys()) == {"epi_ser_ABC_1_1", "epi_ser_ABC_1_2"}
@@ -74,22 +75,36 @@ class TestProgressLookupAdapter:
     ) -> None:
         adapter = _make_adapter(session_factory)
 
-        assert await adapter.find_for_media_ids([]) == {}
+        assert await adapter.find_for_media_ids([], profile_id=_PROFILE_ID.value) == {}
 
-    async def test_find_for_media_ids_returns_empty_when_no_default_profile(
+    async def test_find_for_media_ids_isolates_across_profiles(
         self,
         db_session: AsyncSession,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        # Strict transition mode: no default_profile_id -> graceful
-        # degradation, even when matching rows exist.
+        # Per-profile rollout asserts that one profile's progress is
+        # never visible to another. Same media_id, two profiles, only
+        # the caller's row comes back.
         progress_repo = SQLAlchemyWatchProgressRepository(db_session)
-        await progress_repo.save(_progress("epi_ser_ABC_1_1"))
+        await progress_repo.save(_progress("epi_ser_ABC_1_1", position=900))
+        await progress_repo.save(
+            _progress("epi_ser_ABC_1_1", position=3300, profile_id=_OTHER_PROFILE_ID),
+        )
         await db_session.commit()
 
-        adapter = _make_adapter(session_factory, default_profile_id=None)
+        adapter = _make_adapter(session_factory)
 
-        assert await adapter.find_for_media_ids(["epi_ser_ABC_1_1"]) == {}
+        mine = await adapter.find_for_media_ids(
+            ["epi_ser_ABC_1_1"],
+            profile_id=_PROFILE_ID.value,
+        )
+        theirs = await adapter.find_for_media_ids(
+            ["epi_ser_ABC_1_1"],
+            profile_id=_OTHER_PROFILE_ID.value,
+        )
+
+        assert mine["epi_ser_ABC_1_1"].position_seconds == 900
+        assert theirs["epi_ser_ABC_1_1"].position_seconds == 3300
 
     async def test_progress_summary_includes_last_watched_at(
         self,
@@ -101,7 +116,10 @@ class TestProgressLookupAdapter:
         await db_session.commit()
 
         adapter = _make_adapter(session_factory)
-        result = await adapter.find_for_media_ids(["epi_ser_ABC_1_1"])
+        result = await adapter.find_for_media_ids(
+            ["epi_ser_ABC_1_1"],
+            profile_id=_PROFILE_ID.value,
+        )
 
         summary = result["epi_ser_ABC_1_1"]
         assert summary.last_watched_at is not None


### PR DESCRIPTION
## Summary

The four ``*_default_profile_id`` settings (``watch_progress_``, ``collections_``, ``preferences_``, ``media_``) were the transitional fallback that kept anonymous catalog reads working while the frontend was being migrated to login + picker. With ``RequireAuth`` shipping in homeflix-web (#107-#112), every catalog request now carries a session cookie + an active profile — the operator's ``.env`` never set those vars and the fallback path was dead code in practice.

This cleanup removes the FF surface so the strict-mode behaviour is the only behaviour.

## What changes

- ``Settings`` loses the four fields. Stray references in any operator ``.env`` are silently ignored via ``extra=""ignore""`` on ``SettingsConfigDict``.
- ``identity.presentation.dependencies.make_resolve_profile_id`` factory → single ``resolve_profile_id`` async function. Same cookie → ``access_tokens`` → ``current_profile_id`` resolution; missing or unselected → ``NoActiveSessionError`` (HTTP 401).
- Four BC wrapper files collapse to 3-line re-exports of the canonical helper. Kept (not deleted) so a future per-BC override has somewhere to live without touching every route file.
- ``ProgressLookupPort.find_for_media_ids`` + ``ProgressLookupAdapter`` gain a required ``profile_id`` kwarg. ``GetSeriesByIdUseCase`` already has the caller's ``profile_id`` from PR #178 and forwards it through. The ``default_profile_id`` adapter ctor arg is gone; composition root drops the corresponding wiring.
- Adapter integration test: replaces the ``returns_empty_when_no_default_profile`` case with a cross-profile isolation test that proves the same ``media_id`` never leaks across profiles. Better aligned with the strict-mode contract.

## Out of scope

Deleting the four wrapper files entirely. They cost ~5 lines each, preserve route-import locality (``from .dependencies import resolve_profile_id``), and give the next per-BC auth tweak somewhere to live. Defer until that need materialises.

## Test plan

- [x] ``poetry run pytest -q`` → 2230 passed, 5 skipped — no regressions.
- [x] ``ruff check`` and ``ruff format --check`` clean.
- [x] Backwards-compat note: any leftover ``MEDIA_DEFAULT_PROFILE_ID`` (etc) entries in an operator ``.env`` are silently ignored thanks to Pydantic's ``extra=""ignore""``. No upgrade step required.