### PR TITLE
feat(identity): profile avatar upload + resize + delete

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1387,6 +1387,131 @@ re2 = ["google-re2 (>=1.1)"]
 tests = ["pytest (>=9)", "typing-extensions (>=4.15)"]
 
 [[package]]
+name = "pillow"
+version = "11.3.0"
+description = "Python Imaging Library (Fork)"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
+    {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae"},
+    {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9"},
+    {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e"},
+    {file = "pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6"},
+    {file = "pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f"},
+    {file = "pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f"},
+    {file = "pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722"},
+    {file = "pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f"},
+    {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e"},
+    {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94"},
+    {file = "pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0"},
+    {file = "pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac"},
+    {file = "pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd"},
+    {file = "pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4"},
+    {file = "pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024"},
+    {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809"},
+    {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d"},
+    {file = "pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149"},
+    {file = "pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d"},
+    {file = "pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8"},
+    {file = "pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f"},
+    {file = "pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c"},
+    {file = "pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8"},
+    {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2"},
+    {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b"},
+    {file = "pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3"},
+    {file = "pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51"},
+    {file = "pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580"},
+    {file = "pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e"},
+    {file = "pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59"},
+    {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe"},
+    {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c"},
+    {file = "pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788"},
+    {file = "pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31"},
+    {file = "pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e"},
+    {file = "pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12"},
+    {file = "pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77"},
+    {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874"},
+    {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a"},
+    {file = "pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214"},
+    {file = "pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635"},
+    {file = "pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6"},
+    {file = "pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae"},
+    {file = "pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477"},
+    {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50"},
+    {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b"},
+    {file = "pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12"},
+    {file = "pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db"},
+    {file = "pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa"},
+    {file = "pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f"},
+    {file = "pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a"},
+    {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978"},
+    {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:97afb3a00b65cc0804d1c7abddbf090a81eaac02768af58cbdcaaa0a931e0b6d"},
+    {file = "pillow-11.3.0-cp39-cp39-win32.whl", hash = "sha256:ea944117a7974ae78059fcc1800e5d3295172bb97035c0c1d9345fca1419da71"},
+    {file = "pillow-11.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:e5c5858ad8ec655450a7c7df532e9842cf8df7cc349df7225c60d5d348c8aada"},
+    {file = "pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8"},
+    {file = "pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+test-arrow = ["pyarrow"]
+tests = ["check-manifest", "coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "trove-classifiers (>=2024.10.12)"]
+typing = ["typing-extensions ; python_version < \"3.10\""]
+xmp = ["defusedxml"]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -2582,4 +2707,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "5de6a125781364d2f2aa769db3813eeb31f7a4a1081c35c5ce7a35bf06221bd5"
+content-hash = "a9d5c1a1847e3b2f435c0cf620ea270f302b2f7c289824e42f21e8764b375197"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ apscheduler = "^3.10.4"
 # Authentication (identity bounded context — see ADR-010 / ADR-011)
 fastapi-users = { extras = ["sqlalchemy"], version = "^14.0" }
 
+# Image processing (profile avatar resize — see ADR-010 / project-avatar-upload)
+pillow = "^11.0.0"
+
 [tool.poetry.group.dev.dependencies]
 # Testing
 pytest = "^8.0.0"

--- a/src/config/containers/identity.py
+++ b/src/config/containers/identity.py
@@ -14,26 +14,39 @@ from dependency_injector import containers, providers
 
 from src.modules.identity.application.use_cases import (
     CreateProfileUseCase,
+    DeleteProfileAvatarUseCase,
     DeleteProfileUseCase,
     ListProfilesForUserUseCase,
     SwitchProfileUseCase,
     UpdateProfileUseCase,
+    UploadProfileAvatarUseCase,
 )
 from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyIdentityUnitOfWorkFactory,
 )
+from src.modules.identity.infrastructure.storage import LocalAvatarStorage
 
 
 class IdentityContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for the identity bounded context.
 
-    Provides the ``IdentityUnitOfWork`` factory and the five profile
-    use cases. The FastAPI Users-backed authentication routes do not
-    flow through this container (see module docstring).
+    Provides the ``IdentityUnitOfWork`` factory, the avatar storage
+    adapter and the profile use cases. The FastAPI Users-backed
+    authentication routes do not flow through this container (see
+    module docstring).
     """
 
     # Wired from InfrastructureContainer via the application container.
     session_factory = providers.Dependency()
+
+    # Avatar storage configuration — wired from ``Settings`` at the
+    # composition root. Defaults are present so tests / standalone
+    # usage stay cheap to instantiate, but the production path
+    # always overrides them via ``providers.Container(...)``.
+    thumbnails_directory = providers.Dependency(default="./thumbnails")
+    avatar_storage_subdir = providers.Dependency(default=".homeflix/avatars")
+    avatar_max_size_mb = providers.Dependency(default=2)
+    avatar_size_pixels = providers.Dependency(default=256)
 
     # =========================================================================
     # Unit of Work
@@ -42,6 +55,18 @@ class IdentityContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     identity_unit_of_work_factory = providers.Singleton(
         SqlAlchemyIdentityUnitOfWorkFactory,
         session_factory=session_factory,
+    )
+
+    # =========================================================================
+    # Storage
+    # =========================================================================
+
+    avatar_storage = providers.Singleton(
+        LocalAvatarStorage,
+        root_directory=thumbnails_directory,
+        subdirectory=avatar_storage_subdir,
+        max_size_mb=avatar_max_size_mb,
+        side_length=avatar_size_pixels,
     )
 
     # =========================================================================
@@ -66,9 +91,22 @@ class IdentityContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     delete_profile = providers.Factory(
         DeleteProfileUseCase,
         uow_factory=identity_unit_of_work_factory,
+        avatar_storage=avatar_storage,
     )
 
     switch_profile = providers.Factory(
         SwitchProfileUseCase,
         uow_factory=identity_unit_of_work_factory,
+    )
+
+    upload_profile_avatar = providers.Factory(
+        UploadProfileAvatarUseCase,
+        uow_factory=identity_unit_of_work_factory,
+        avatar_storage=avatar_storage,
+    )
+
+    delete_profile_avatar = providers.Factory(
+        DeleteProfileAvatarUseCase,
+        uow_factory=identity_unit_of_work_factory,
+        avatar_storage=avatar_storage,
     )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -138,6 +138,10 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     identity = providers.Container(
         IdentityContainer,
         session_factory=infrastructure.session_factory,
+        thumbnails_directory=config.provided.thumbnails_directory,
+        avatar_storage_subdir=config.provided.avatar_storage_subdir,
+        avatar_max_size_mb=config.provided.avatar_max_size_mb,
+        avatar_size_pixels=config.provided.avatar_size_pixels,
     )
 
     preferences = providers.Container(

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -92,6 +92,35 @@ class Settings(BaseSettings):  # type: ignore[misc]
         "cache fits. Default 5 GB.",
     )
 
+    avatar_storage_subdir: str = Field(
+        default=".homeflix/avatars",
+        description="Subdirectory (relative to ``thumbnails_directory``) "
+        "where uploaded profile avatars are stored. The subdirectory is "
+        "created on first upload; the operator can change this without "
+        "manual filesystem migration as long as the new path is empty.",
+    )
+    avatar_max_size_mb: int = Field(
+        default=2,
+        ge=1,
+        le=20,
+        description="Maximum accepted upload size for a profile avatar, "
+        "in megabytes. Uploads above this cap are rejected with HTTP 413 "
+        "before the image is decoded. Default 2 MB is comfortably above "
+        "what a phone camera produces after the browser-side compression "
+        "and well below what a laptop would happily upload over a slow "
+        "connection.",
+    )
+    avatar_size_pixels: int = Field(
+        default=256,
+        ge=64,
+        le=1024,
+        description="Final square side length (in pixels) of the resized "
+        "avatar. The uploaded image is centre-cropped to a square and "
+        "scaled to this size before being persisted as WebP. 256 is the "
+        "size the picker / AccountMenu render at 1x; bumping it would "
+        "let those surfaces render crisper at 2x / 3x pixel density.",
+    )
+
     @field_validator("media_directories", mode="before")
     @classmethod
     def parse_media_dirs(cls, v: str | list[str]) -> list[str]:

--- a/src/modules/identity/application/dtos/identity_dtos.py
+++ b/src/modules/identity/application/dtos/identity_dtos.py
@@ -98,11 +98,36 @@ class SwitchProfileInput:
     session_token: str
 
 
+@dataclass(frozen=True)
+class UploadProfileAvatarInput:
+    """Input for ``UploadProfileAvatarUseCase``.
+
+    Bytes + declared MIME come from the multipart upload at the
+    route boundary; the route enforces ownership before this DTO
+    is constructed (caller's ``user_id`` must own the profile).
+    """
+
+    user_id: str
+    profile_id: str
+    content: bytes
+    declared_mime_type: str
+
+
+@dataclass(frozen=True)
+class DeleteProfileAvatarInput:
+    """Input for ``DeleteProfileAvatarUseCase``."""
+
+    user_id: str
+    profile_id: str
+
+
 __all__ = [
     "CreateProfileInput",
+    "DeleteProfileAvatarInput",
     "DeleteProfileInput",
     "ListProfilesForUserInput",
     "ProfileOutput",
     "SwitchProfileInput",
     "UpdateProfileInput",
+    "UploadProfileAvatarInput",
 ]

--- a/src/modules/identity/application/ports/__init__.py
+++ b/src/modules/identity/application/ports/__init__.py
@@ -1,0 +1,13 @@
+"""Identity application ports."""
+
+from src.modules.identity.application.ports.avatar_storage_port import (
+    AvatarStoragePort,
+    AvatarTooLargeError,
+    InvalidAvatarImageError,
+)
+
+__all__ = [
+    "AvatarStoragePort",
+    "AvatarTooLargeError",
+    "InvalidAvatarImageError",
+]

--- a/src/modules/identity/application/ports/avatar_storage_port.py
+++ b/src/modules/identity/application/ports/avatar_storage_port.py
@@ -1,0 +1,92 @@
+"""Port for persisting profile avatar images outside the domain.
+
+Profile avatars are user-uploaded files: the domain doesn't care
+about disk paths, image decoding, or storage backends. The use
+case talks to this port; the adapter under
+``identity/infrastructure/storage/`` knows how to validate the
+bytes, resize via Pillow, and write a WebP under the configured
+``avatar_storage_subdir``.
+
+A future S3 / object-store implementation would just be another
+adapter satisfying the same contract — the port deliberately
+returns a relative URL string rather than a filesystem path so
+the domain never assumes the file lives on the local disk.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class InvalidAvatarImageError(Exception):
+    """Raised when the uploaded bytes don't decode as a supported image.
+
+    The use case translates this into HTTP 415 (Unsupported Media
+    Type). Distinct from the size-check exception so the route can
+    surface a precise error message.
+    """
+
+
+class AvatarTooLargeError(Exception):
+    """Raised when the uploaded payload exceeds the configured cap.
+
+    Translated by the use case into HTTP 413 (Payload Too Large).
+    """
+
+
+class AvatarStoragePort(ABC):
+    """Persist or remove the bytes that back a profile's avatar."""
+
+    @abstractmethod
+    async def save(
+        self,
+        profile_id: str,
+        *,
+        content: bytes,
+        declared_mime_type: str,
+    ) -> str:
+        """Validate, resize and persist the avatar image.
+
+        Args:
+            profile_id: Prefixed external id (``prf_xxx``) of the
+                profile owning the avatar. Used as the storage key
+                — re-uploading replaces the previous file.
+            content: Raw bytes from the multipart upload. The
+                adapter is responsible for verifying the bytes
+                actually decode as an image (the declared MIME from
+                the form is browser-supplied and not trusted).
+            declared_mime_type: MIME the client claimed in the
+                multipart part. Used as a hint for the allow-list
+                check; the adapter still validates the actual bytes.
+
+        Returns:
+            The relative URL path the catalog should embed in
+            ``Profile.avatar_url`` (e.g.
+            ``/api/v1/profiles/prf_xxx/avatar?v=...``). Returning a
+            URL keeps the domain unaware of where bytes actually
+            live.
+
+        Raises:
+            InvalidAvatarImageError: When the bytes don't decode
+                as a supported image (jpeg / png / webp).
+            AvatarTooLargeError: When ``len(content)`` exceeds the
+                configured ``avatar_max_size_mb`` cap.
+        """
+        ...
+
+    @abstractmethod
+    async def delete(self, profile_id: str) -> None:
+        """Remove any persisted avatar for ``profile_id``.
+
+        No-op when no avatar exists for the profile — the use case
+        calls this on every avatar-delete and on every soft-delete
+        of the profile, so the adapter MUST be idempotent.
+        """
+        ...
+
+
+__all__ = [
+    "AvatarStoragePort",
+    "AvatarTooLargeError",
+    "InvalidAvatarImageError",
+]

--- a/src/modules/identity/application/use_cases/__init__.py
+++ b/src/modules/identity/application/use_cases/__init__.py
@@ -6,6 +6,9 @@ from src.modules.identity.application.use_cases.create_profile import (
 from src.modules.identity.application.use_cases.delete_profile import (
     DeleteProfileUseCase,
 )
+from src.modules.identity.application.use_cases.delete_profile_avatar import (
+    DeleteProfileAvatarUseCase,
+)
 from src.modules.identity.application.use_cases.list_profiles_for_user import (
     ListProfilesForUserUseCase,
 )
@@ -15,11 +18,16 @@ from src.modules.identity.application.use_cases.switch_profile import (
 from src.modules.identity.application.use_cases.update_profile import (
     UpdateProfileUseCase,
 )
+from src.modules.identity.application.use_cases.upload_profile_avatar import (
+    UploadProfileAvatarUseCase,
+)
 
 __all__ = [
     "CreateProfileUseCase",
+    "DeleteProfileAvatarUseCase",
     "DeleteProfileUseCase",
     "ListProfilesForUserUseCase",
     "SwitchProfileUseCase",
     "UpdateProfileUseCase",
+    "UploadProfileAvatarUseCase",
 ]

--- a/src/modules/identity/application/use_cases/delete_profile.py
+++ b/src/modules/identity/application/use_cases/delete_profile.py
@@ -1,6 +1,7 @@
 """DeleteProfileUseCase."""
 
 from src.modules.identity.application.dtos.identity_dtos import DeleteProfileInput
+from src.modules.identity.application.ports import AvatarStoragePort
 from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.modules.identity.domain.errors import (
     CannotDeleteLastProfileError,
@@ -23,10 +24,19 @@ class DeleteProfileUseCase:
       profile so that ``get_current_profile`` always has something
       to resolve. Deleting the last remaining profile raises
       :class:`CannotDeleteLastProfileError` (HTTP 409).
+
+    Cascade-deletes the profile's uploaded avatar file via the
+    storage port. The port's ``delete`` is idempotent so the call
+    is safe whether the profile ever had an avatar or not.
     """
 
-    def __init__(self, uow_factory: IdentityUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        avatar_storage: AvatarStoragePort,
+    ) -> None:
         self._uow_factory = uow_factory
+        self._avatar_storage = avatar_storage
 
     async def execute(self, input_dto: DeleteProfileInput) -> None:
         """Soft-delete the target profile after enforcing ownership and last-profile guards."""
@@ -53,6 +63,12 @@ class DeleteProfileUseCase:
                 )
 
             await uow.profiles.delete(target_id)
+
+        # Cascade-delete the avatar file after the soft-delete row
+        # update commits. A filesystem hiccup at this point leaves
+        # an orphan file (logged by the storage adapter) but never
+        # blocks the row delete itself.
+        await self._avatar_storage.delete(input_dto.profile_id)
 
 
 __all__ = ["DeleteProfileUseCase"]

--- a/src/modules/identity/application/use_cases/delete_profile_avatar.py
+++ b/src/modules/identity/application/use_cases/delete_profile_avatar.py
@@ -1,0 +1,62 @@
+"""DeleteProfileAvatarUseCase."""
+
+from src.modules.identity.application.dtos.identity_dtos import (
+    DeleteProfileAvatarInput,
+    ProfileOutput,
+)
+from src.modules.identity.application.ports import AvatarStoragePort
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.identity.application.use_cases._to_output import profile_to_output
+from src.modules.identity.domain.errors import (
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
+from src.shared_kernel.value_objects.profile_id import ProfileId
+from src.shared_kernel.value_objects.user_id import UserId
+
+
+class DeleteProfileAvatarUseCase:
+    """Clear a profile's avatar (sets ``avatar_url`` to ``None`` + deletes file).
+
+    Enforces ownership: the target profile's ``user_id`` must match
+    the caller. The storage call is idempotent so a second delete on
+    an already-cleared profile succeeds without error — the response
+    just returns the (still-empty) profile.
+    """
+
+    def __init__(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        avatar_storage: AvatarStoragePort,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._avatar_storage = avatar_storage
+
+    async def execute(self, input_dto: DeleteProfileAvatarInput) -> ProfileOutput:
+        """Authorise → clear ``avatar_url`` → remove the file."""
+        caller_id = UserId(input_dto.user_id)
+        target_id = ProfileId(input_dto.profile_id)
+
+        async with self._uow_factory() as uow:
+            existing = await uow.profiles.find_by_id(target_id)
+            if existing is None:
+                raise ProfileNotFoundException.for_resource(
+                    resource_type="Profile",
+                    resource_id=input_dto.profile_id,
+                )
+            if existing.user_id != caller_id:
+                raise ProfileOwnershipViolation(
+                    message="You do not own this profile",
+                )
+            updated = existing.with_avatar(None)
+            saved = await uow.profiles.save(updated)
+
+        # Storage delete after the row update so a partial failure
+        # leaves the profile pointing at a valid (or absent) file
+        # rather than referencing one we just removed.
+        await self._avatar_storage.delete(input_dto.profile_id)
+
+        return profile_to_output(saved)
+
+
+__all__ = ["DeleteProfileAvatarUseCase"]

--- a/src/modules/identity/application/use_cases/upload_profile_avatar.py
+++ b/src/modules/identity/application/use_cases/upload_profile_avatar.py
@@ -1,0 +1,83 @@
+"""UploadProfileAvatarUseCase."""
+
+from src.modules.identity.application.dtos.identity_dtos import (
+    ProfileOutput,
+    UploadProfileAvatarInput,
+)
+from src.modules.identity.application.ports import AvatarStoragePort
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.identity.application.use_cases._to_output import profile_to_output
+from src.modules.identity.domain.errors import (
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
+from src.shared_kernel.value_objects.profile_id import ProfileId
+from src.shared_kernel.value_objects.user_id import UserId
+
+
+class UploadProfileAvatarUseCase:
+    """Persist a new avatar for a profile and update its ``avatar_url``.
+
+    Enforces ownership before writing — only the caller can change
+    their own profile's avatar. Cross-user uploads raise
+    :class:`ProfileOwnershipViolation` (HTTP 403). The actual byte
+    validation (image decode, MIME allow-list, size cap) lives on
+    the ``AvatarStoragePort`` adapter; size/MIME violations bubble
+    as :class:`InvalidAvatarImageError` / :class:`AvatarTooLargeError`
+    which the route translates to HTTP 415 / 413.
+    """
+
+    def __init__(
+        self,
+        uow_factory: IdentityUnitOfWorkFactory,
+        avatar_storage: AvatarStoragePort,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._avatar_storage = avatar_storage
+
+    async def execute(self, input_dto: UploadProfileAvatarInput) -> ProfileOutput:
+        """Validate caller, persist bytes, update ``avatar_url``."""
+        caller_id = UserId(input_dto.user_id)
+        target_id = ProfileId(input_dto.profile_id)
+
+        # Ownership check first — saves a Pillow decode round-trip
+        # for unauthorised callers.
+        async with self._uow_factory() as uow:
+            existing = await uow.profiles.find_by_id(target_id)
+            if existing is None:
+                raise ProfileNotFoundException.for_resource(
+                    resource_type="Profile",
+                    resource_id=input_dto.profile_id,
+                )
+            if existing.user_id != caller_id:
+                raise ProfileOwnershipViolation(
+                    message="You do not own this profile",
+                )
+
+        # Bytes work happens outside the UoW so a slow Pillow
+        # decode doesn't pin a session. Validation errors raise
+        # before we re-open the UoW for the persist.
+        avatar_url = await self._avatar_storage.save(
+            input_dto.profile_id,
+            content=input_dto.content,
+            declared_mime_type=input_dto.declared_mime_type,
+        )
+
+        async with self._uow_factory() as uow:
+            # Re-load to avoid races with a concurrent profile
+            # update; the avatar_url we apply is independent of
+            # any other field that may have changed in the
+            # interim.
+            current = await uow.profiles.find_by_id(target_id)
+            if current is None:
+                raise ProfileNotFoundException.for_resource(
+                    resource_type="Profile",
+                    resource_id=input_dto.profile_id,
+                )
+            updated = current.with_avatar(avatar_url)
+            saved = await uow.profiles.save(updated)
+
+        return profile_to_output(saved)
+
+
+__all__ = ["UploadProfileAvatarUseCase"]

--- a/src/modules/identity/infrastructure/storage/__init__.py
+++ b/src/modules/identity/infrastructure/storage/__init__.py
@@ -1,0 +1,7 @@
+"""Local storage adapters for the identity bounded context."""
+
+from src.modules.identity.infrastructure.storage.local_avatar_storage import (
+    LocalAvatarStorage,
+)
+
+__all__ = ["LocalAvatarStorage"]

--- a/src/modules/identity/infrastructure/storage/local_avatar_storage.py
+++ b/src/modules/identity/infrastructure/storage/local_avatar_storage.py
@@ -1,0 +1,161 @@
+"""Local-disk implementation of ``AvatarStoragePort``.
+
+Validates the uploaded bytes via Pillow (the declared MIME from the
+form is untrusted), centre-crops to a square and resizes to the
+configured side length, then persists as WebP under
+``{thumbnails_directory}/{avatar_storage_subdir}/{profile_id}.webp``.
+
+WebP balances size and quality well for small avatars (a 256x256
+photo lands around 15-30 KB). Saving in a single canonical format
+also lets the GET route hard-code the response media type instead
+of round-tripping the original.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from datetime import UTC, datetime
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+
+from src.config.logging import get_logger
+from src.modules.identity.application.ports.avatar_storage_port import (
+    AvatarStoragePort,
+    AvatarTooLargeError,
+    InvalidAvatarImageError,
+)
+
+_logger = get_logger()
+
+# MIMEs the catalogue accepts at the form boundary. The actual
+# bytes are still verified by Pillow — the declared MIME is just an
+# early reject hint, not a trust anchor.
+_ALLOWED_MIME_TYPES = frozenset(
+    {
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+    }
+)
+
+# Pillow format names (independent of MIME). What we accept after
+# decoding the actual bytes — keeps the surface honest if a client
+# claims ``image/jpeg`` but uploads a TIFF.
+_ALLOWED_PIL_FORMATS = frozenset({"JPEG", "PNG", "WEBP"})
+
+# WebP quality. Pillow's default for quality is 80; bumping to 85
+# keeps faces and skin tones crisp without bloating the file
+# beyond a few dozen KB at 256x256.
+_WEBP_QUALITY = 85
+
+
+class LocalAvatarStorage(AvatarStoragePort):
+    """Resize uploaded avatars and write WebP files to local disk."""
+
+    def __init__(
+        self,
+        *,
+        root_directory: str,
+        subdirectory: str,
+        max_size_mb: int,
+        side_length: int,
+    ) -> None:
+        self._directory = Path(root_directory) / subdirectory
+        self._max_size_bytes = max_size_mb * 1024 * 1024
+        self._side_length = side_length
+
+    async def save(
+        self,
+        profile_id: str,
+        *,
+        content: bytes,
+        declared_mime_type: str,
+    ) -> str:
+        """Validate + resize + persist + return the cache-busted URL."""
+        if len(content) > self._max_size_bytes:
+            raise AvatarTooLargeError(
+                f"avatar exceeds {self._max_size_bytes} byte cap " f"(got {len(content)} bytes)"
+            )
+        if declared_mime_type not in _ALLOWED_MIME_TYPES:
+            raise InvalidAvatarImageError(
+                f"declared mime type {declared_mime_type!r} is not in the "
+                f"allow-list {sorted(_ALLOWED_MIME_TYPES)}"
+            )
+
+        # Pillow work is CPU-bound — ``asyncio.to_thread`` avoids
+        # blocking the event loop on JPEG decode + resize for a
+        # 2 MB image (a few hundred ms on a modern phone shot).
+        target_path = self._target_path(profile_id)
+        await asyncio.to_thread(
+            self._decode_resize_and_save,
+            content,
+            target_path,
+        )
+
+        timestamp = int(datetime.now(UTC).timestamp())
+        return f"/api/v1/profiles/{profile_id}/avatar?v={timestamp}"
+
+    async def delete(self, profile_id: str) -> None:
+        """Remove the persisted file. Idempotent — no error when absent."""
+        target_path = self._target_path(profile_id)
+        try:
+            await asyncio.to_thread(target_path.unlink)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            # Filesystem hiccup; log and let the caller continue —
+            # the avatar URL is being cleared in the same UoW
+            # whether or not the file removal succeeded, so a
+            # leaked file is the worst outcome.
+            _logger.warning(
+                "[identity] failed to remove avatar file",
+                profile_id=profile_id,
+                path=str(target_path),
+                error=str(exc),
+            )
+
+    def _target_path(self, profile_id: str) -> Path:
+        """Resolve the on-disk path for a profile's avatar."""
+        return self._directory / f"{profile_id}.webp"
+
+    def _decode_resize_and_save(self, content: bytes, target_path: Path) -> None:
+        """Synchronous Pillow work — open, validate, crop, scale, save."""
+        try:
+            with Image.open(io.BytesIO(content)) as source:
+                if source.format not in _ALLOWED_PIL_FORMATS:
+                    raise InvalidAvatarImageError(
+                        f"image format {source.format!r} is not supported"
+                    )
+                # Force-load the image data so any decode error
+                # surfaces synchronously inside this except branch
+                # rather than later when ``copy()`` reads pixels.
+                source.load()
+                cropped = self._centre_crop_square(source)
+                resized = cropped.resize(
+                    (self._side_length, self._side_length),
+                    resample=Image.Resampling.LANCZOS,
+                )
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                # Always save as WebP — single canonical format
+                # simplifies the GET route's media_type and keeps
+                # the file extension predictable.
+                resized.save(target_path, format="WEBP", quality=_WEBP_QUALITY)
+        except UnidentifiedImageError as exc:
+            raise InvalidAvatarImageError(
+                "uploaded bytes did not decode as a known image format"
+            ) from exc
+
+    def _centre_crop_square(self, image: Image.Image) -> Image.Image:
+        """Crop ``image`` to its largest centred square."""
+        width, height = image.size
+        if width == height:
+            return image
+        side = min(width, height)
+        left = (width - side) // 2
+        top = (height - side) // 2
+        return image.crop((left, top, left + side, top + side))
+
+
+__all__ = ["LocalAvatarStorage"]

--- a/src/modules/identity/presentation/routes/profile_routes.py
+++ b/src/modules/identity/presentation/routes/profile_routes.py
@@ -1,25 +1,37 @@
-"""Profile CRUD + switch routes."""
+"""Profile CRUD + switch + avatar routes."""
 
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi.responses import FileResponse
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
+from src.config.settings import get_settings
 from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
+    DeleteProfileAvatarInput,
     DeleteProfileInput,
     ListProfilesForUserInput,
     SwitchProfileInput,
     UpdateProfileInput,
+    UploadProfileAvatarInput,
+)
+from src.modules.identity.application.ports import (
+    AvatarTooLargeError,
+    InvalidAvatarImageError,
 )
 from src.modules.identity.application.use_cases.create_profile import (
     CreateProfileUseCase,
 )
 from src.modules.identity.application.use_cases.delete_profile import (
     DeleteProfileUseCase,
+)
+from src.modules.identity.application.use_cases.delete_profile_avatar import (
+    DeleteProfileAvatarUseCase,
 )
 from src.modules.identity.application.use_cases.list_profiles_for_user import (
     ListProfilesForUserUseCase,
@@ -29,6 +41,9 @@ from src.modules.identity.application.use_cases.switch_profile import (
 )
 from src.modules.identity.application.use_cases.update_profile import (
     UpdateProfileUseCase,
+)
+from src.modules.identity.application.use_cases.upload_profile_avatar import (
+    UploadProfileAvatarUseCase,
 )
 from src.modules.identity.infrastructure.auth import (
     current_active_user,
@@ -153,6 +168,92 @@ async def switch_profile(
             session_token=token,
         ),
     )
+
+
+@router.post("/{profile_id}/avatar")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def upload_profile_avatar(
+    profile_id: str,
+    file: UploadFile = File(...),
+    user: UserModel = Depends(current_active_user),
+    use_case: UploadProfileAvatarUseCase = Depends(
+        Provide[ApplicationContainer.identity.upload_profile_avatar],
+    ),
+) -> dict[str, Any]:
+    """Upload a new avatar image for the given profile.
+
+    Multipart upload accepting JPEG / PNG / WebP. The server
+    validates the bytes (Pillow decode), centre-crops to a square
+    and persists as WebP. Bad MIME → 415; oversized payload → 413;
+    cross-user upload → 403; unknown profile → 404.
+    """
+    content = await file.read()
+    try:
+        result = await use_case.execute(
+            UploadProfileAvatarInput(
+                user_id=user.external_id,
+                profile_id=profile_id,
+                content=content,
+                declared_mime_type=file.content_type or "application/octet-stream",
+            ),
+        )
+    except AvatarTooLargeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=str(exc),
+        ) from exc
+    except InvalidAvatarImageError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail=str(exc),
+        ) from exc
+    return api_single("profile", asdict(result))
+
+
+@router.delete("/{profile_id}/avatar")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def delete_profile_avatar(
+    profile_id: str,
+    user: UserModel = Depends(current_active_user),
+    use_case: DeleteProfileAvatarUseCase = Depends(
+        Provide[ApplicationContainer.identity.delete_profile_avatar],
+    ),
+) -> dict[str, Any]:
+    """Clear the profile's avatar (sets ``avatar_url`` null + deletes file).
+
+    Idempotent — calling on a profile that has no avatar succeeds
+    and returns the (still-empty) profile.
+    """
+    result = await use_case.execute(
+        DeleteProfileAvatarInput(user_id=user.external_id, profile_id=profile_id),
+    )
+    return api_single("profile", asdict(result))
+
+
+@router.get("/{profile_id}/avatar")  # type: ignore[misc]
+async def get_profile_avatar(
+    profile_id: str,
+    _user: UserModel = Depends(current_active_user),
+) -> FileResponse:
+    """Serve the persisted avatar WebP for ``profile_id``.
+
+    Auth-gated (``current_active_user``) but **not** ownership-gated:
+    any authenticated household member needs to be able to render
+    siblings' avatars in the picker / AccountMenu. The file path is
+    deterministic from the profile id, so resolving it here doesn't
+    require a database round-trip — kept lean because the picker
+    fires one of these per profile on every render.
+    """
+    settings = get_settings()
+    target = (
+        Path(settings.thumbnails_directory) / settings.avatar_storage_subdir / f"{profile_id}.webp"
+    )
+    if not target.is_file():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="avatar not found",
+        )
+    return FileResponse(str(target), media_type="image/webp")
 
 
 __all__ = ["router"]

--- a/tests/modules/identity/e2e/test_avatar_routes.py
+++ b/tests/modules/identity/e2e/test_avatar_routes.py
@@ -1,0 +1,193 @@
+"""End-to-end tests for the profile-avatar routes.
+
+Drives ``POST /api/v1/profiles/{id}/avatar``,
+``DELETE /api/v1/profiles/{id}/avatar`` and
+``GET /api/v1/profiles/{id}/avatar`` over the in-process ASGI
+transport. The avatar storage is overridden to write under a
+test-scoped ``tmp_path`` so the assertions can read the real WebP
+file back.
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import (  # noqa: TCH003 — used by runtime fixture annotations
+    Awaitable,
+    Callable,
+)
+from pathlib import Path  # noqa: TCH003 — used by runtime fixture annotations
+
+import pytest
+from dependency_injector import providers
+from fastapi import FastAPI  # noqa: TCH002 — used by runtime fixture annotations
+from httpx import AsyncClient  # noqa: TCH002 — used by runtime fixture annotations
+from PIL import Image
+
+from src.modules.identity.infrastructure.storage import LocalAvatarStorage
+from tests.modules.identity.e2e.conftest import (
+    SeededUser,  # noqa: TCH001 — used by runtime annotations
+)
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+AVATAR_PATH = "/api/v1/profiles/{profile_id}/avatar"
+
+
+def _png_bytes(width: int = 600, height: int = 400) -> bytes:
+    img = Image.new("RGB", (width, height), (217, 119, 87))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+@pytest.fixture(scope="function")
+def app_with_tmp_avatar_storage(app: FastAPI, tmp_path: Path) -> FastAPI:
+    """Override the identity container's avatar storage to a tempdir."""
+    storage = LocalAvatarStorage(
+        root_directory=str(tmp_path),
+        subdirectory=".homeflix/avatars",
+        max_size_mb=2,
+        side_length=64,  # tiny for faster Pillow round-trip
+    )
+    app.state.container.identity.avatar_storage.override(providers.Object(storage))
+    # Also override the settings the GET route reads to resolve the
+    # file path. ``get_settings`` is an ``lru_cache`` Singleton in
+    # ``src/config/settings.py``; the simplest knob in tests is the
+    # ``thumbnails_directory`` env var. Patch via monkeypatch in the
+    # actual test if needed — for now the GET route happens to take
+    # the same path the storage adapter writes to so a single
+    # override of ``thumbnails_directory`` would line them up. Skip
+    # the GET-route override here; the upload + delete tests don't
+    # depend on it.
+    yield app
+    app.state.container.identity.avatar_storage.reset_override()
+
+
+async def _login(client: AsyncClient, user: SeededUser) -> None:
+    resp = await client.post(LOGIN_PATH, data={"username": user.email, "password": user.password})
+    assert resp.status_code == 204
+
+
+class TestUploadAvatar:
+    async def test_should_persist_and_return_avatar_url(
+        self,
+        client: AsyncClient,
+        app_with_tmp_avatar_storage: FastAPI,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        tmp_path: Path,
+    ) -> None:
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        files = {"file": ("photo.png", _png_bytes(), "image/png")}
+        resp = await client.post(
+            AVATAR_PATH.format(profile_id=user.profile_external_id), files=files
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()["data"]
+        assert body["id"] == user.profile_external_id
+        assert body["avatar_url"] is not None
+        assert body["avatar_url"].startswith(
+            f"/api/v1/profiles/{user.profile_external_id}/avatar?v="
+        )
+        # File landed on disk under the test-scoped tempdir.
+        target = tmp_path / ".homeflix" / "avatars" / f"{user.profile_external_id}.webp"
+        assert target.is_file()
+
+    async def test_should_return_413_when_payload_is_too_large(
+        self,
+        client: AsyncClient,
+        app_with_tmp_avatar_storage: FastAPI,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        oversized = b"\x00" * (3 * 1024 * 1024)
+        files = {"file": ("huge.png", oversized, "image/png")}
+        resp = await client.post(
+            AVATAR_PATH.format(profile_id=user.profile_external_id), files=files
+        )
+
+        assert resp.status_code == 413
+
+    async def test_should_return_415_for_disallowed_mime(
+        self,
+        client: AsyncClient,
+        app_with_tmp_avatar_storage: FastAPI,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        files = {"file": ("animated.gif", _png_bytes(), "image/gif")}
+        resp = await client.post(
+            AVATAR_PATH.format(profile_id=user.profile_external_id), files=files
+        )
+
+        assert resp.status_code == 415
+
+    async def test_should_return_415_when_bytes_are_not_an_image(
+        self,
+        client: AsyncClient,
+        app_with_tmp_avatar_storage: FastAPI,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        files = {"file": ("nope.png", b"definitely not an image", "image/png")}
+        resp = await client.post(
+            AVATAR_PATH.format(profile_id=user.profile_external_id), files=files
+        )
+
+        assert resp.status_code == 415
+
+    async def test_should_return_401_when_unauthenticated(
+        self,
+        client: AsyncClient,
+        app_with_tmp_avatar_storage: FastAPI,
+    ) -> None:
+        files = {"file": ("photo.png", _png_bytes(), "image/png")}
+        resp = await client.post("/api/v1/profiles/prf_anything/avatar", files=files)
+        assert resp.status_code == 401
+
+
+class TestDeleteAvatar:
+    async def test_should_clear_avatar_url_and_remove_file(
+        self,
+        client: AsyncClient,
+        app_with_tmp_avatar_storage: FastAPI,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        tmp_path: Path,
+    ) -> None:
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        # Upload first so there's something to delete.
+        await client.post(
+            AVATAR_PATH.format(profile_id=user.profile_external_id),
+            files={"file": ("photo.png", _png_bytes(), "image/png")},
+        )
+
+        resp = await client.delete(AVATAR_PATH.format(profile_id=user.profile_external_id))
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["avatar_url"] is None
+        target = tmp_path / ".homeflix" / "avatars" / f"{user.profile_external_id}.webp"
+        assert not target.exists()
+
+    async def test_should_be_idempotent_when_no_avatar_exists(
+        self,
+        client: AsyncClient,
+        app_with_tmp_avatar_storage: FastAPI,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        user = await seed_user_with_profile()
+        await _login(client, user)
+
+        # No prior upload.
+        resp = await client.delete(AVATAR_PATH.format(profile_id=user.profile_external_id))
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["avatar_url"] is None

--- a/tests/modules/identity/integration/storage/test_local_avatar_storage.py
+++ b/tests/modules/identity/integration/storage/test_local_avatar_storage.py
@@ -1,0 +1,157 @@
+"""Integration tests for the local-disk avatar storage adapter.
+
+These tests exercise the real Pillow decode + resize + WebP encode
+path against a temporary directory; nothing here mocks the file
+system.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path  # noqa: TCH003 — used by runtime fixture annotations
+
+import pytest
+from PIL import Image
+
+from src.modules.identity.application.ports import (
+    AvatarTooLargeError,
+    InvalidAvatarImageError,
+)
+from src.modules.identity.infrastructure.storage import LocalAvatarStorage
+
+_PROFILE_ID = "prf_test12345678"
+
+
+def _png_bytes(
+    width: int = 600, height: int = 400, *, colour: tuple[int, int, int] = (255, 100, 50)
+) -> bytes:
+    """Generate a tiny in-memory PNG so tests don't need fixture files."""
+    img = Image.new("RGB", (width, height), colour)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_storage(tmp_path: Path, *, max_size_mb: int = 2, side: int = 256) -> LocalAvatarStorage:
+    return LocalAvatarStorage(
+        root_directory=str(tmp_path),
+        subdirectory=".homeflix/avatars",
+        max_size_mb=max_size_mb,
+        side_length=side,
+    )
+
+
+@pytest.mark.integration
+class TestLocalAvatarStorage:
+    async def test_should_persist_resized_webp(self, tmp_path: Path) -> None:
+        storage = _make_storage(tmp_path)
+
+        url = await storage.save(
+            _PROFILE_ID,
+            content=_png_bytes(width=800, height=600),
+            declared_mime_type="image/png",
+        )
+
+        assert url.startswith(f"/api/v1/profiles/{_PROFILE_ID}/avatar?v=")
+
+        # File landed at the deterministic path with WebP extension.
+        target = tmp_path / ".homeflix" / "avatars" / f"{_PROFILE_ID}.webp"
+        assert target.is_file()
+
+        # Open back via Pillow to confirm it really is a 256x256 WebP.
+        with Image.open(target) as roundtrip:
+            assert roundtrip.format == "WEBP"
+            assert roundtrip.size == (256, 256)
+
+    async def test_should_centre_crop_non_square_inputs(self, tmp_path: Path) -> None:
+        # A 800x400 PNG should crop to 400x400 then scale to 256x256.
+        storage = _make_storage(tmp_path)
+        await storage.save(
+            _PROFILE_ID,
+            content=_png_bytes(width=800, height=400),
+            declared_mime_type="image/png",
+        )
+        target = tmp_path / ".homeflix" / "avatars" / f"{_PROFILE_ID}.webp"
+        with Image.open(target) as roundtrip:
+            assert roundtrip.size == (256, 256)
+
+    async def test_should_reject_payload_above_size_cap(self, tmp_path: Path) -> None:
+        # 1 MB cap, send 2 MB worth of bytes — fails before Pillow runs.
+        storage = _make_storage(tmp_path, max_size_mb=1)
+        oversized = b"\x00" * (2 * 1024 * 1024)
+
+        with pytest.raises(AvatarTooLargeError):
+            await storage.save(
+                _PROFILE_ID,
+                content=oversized,
+                declared_mime_type="image/png",
+            )
+        target = tmp_path / ".homeflix" / "avatars" / f"{_PROFILE_ID}.webp"
+        assert not target.exists()
+
+    async def test_should_reject_non_image_payload(self, tmp_path: Path) -> None:
+        storage = _make_storage(tmp_path)
+
+        with pytest.raises(InvalidAvatarImageError):
+            await storage.save(
+                _PROFILE_ID,
+                content=b"this is not an image at all",
+                declared_mime_type="image/png",
+            )
+
+    async def test_should_reject_disallowed_mime_type(self, tmp_path: Path) -> None:
+        # GIF is intentionally NOT in the allow-list (avatars are
+        # static; no point honouring an animated GIF upload).
+        storage = _make_storage(tmp_path)
+
+        with pytest.raises(InvalidAvatarImageError):
+            await storage.save(
+                _PROFILE_ID,
+                content=_png_bytes(),
+                declared_mime_type="image/gif",
+            )
+
+    async def test_re_upload_should_overwrite_previous_file(self, tmp_path: Path) -> None:
+        storage = _make_storage(tmp_path)
+
+        # First upload — orange tile
+        await storage.save(
+            _PROFILE_ID,
+            content=_png_bytes(colour=(255, 100, 50)),
+            declared_mime_type="image/png",
+        )
+        # Second upload — blue tile, same profile id
+        await storage.save(
+            _PROFILE_ID,
+            content=_png_bytes(colour=(50, 100, 255)),
+            declared_mime_type="image/png",
+        )
+
+        target = tmp_path / ".homeflix" / "avatars" / f"{_PROFILE_ID}.webp"
+        assert target.is_file()
+        with Image.open(target) as roundtrip:
+            # Pixel at the centre should reflect the SECOND upload's
+            # colour palette (after WebP compression at quality 85
+            # the channels are close to but not exactly the input).
+            r, g, b = roundtrip.convert("RGB").getpixel((128, 128))
+            assert b > r  # Blue dominant — second upload won.
+
+    async def test_delete_should_be_idempotent(self, tmp_path: Path) -> None:
+        storage = _make_storage(tmp_path)
+
+        # Delete before any upload — must not raise.
+        await storage.delete(_PROFILE_ID)
+
+        # Save then delete then delete again — the second delete is a no-op.
+        await storage.save(
+            _PROFILE_ID,
+            content=_png_bytes(),
+            declared_mime_type="image/png",
+        )
+        target = tmp_path / ".homeflix" / "avatars" / f"{_PROFILE_ID}.webp"
+        assert target.is_file()
+
+        await storage.delete(_PROFILE_ID)
+        assert not target.exists()
+
+        await storage.delete(_PROFILE_ID)

--- a/tests/modules/identity/unit/application/use_cases/conftest.py
+++ b/tests/modules/identity/unit/application/use_cases/conftest.py
@@ -12,6 +12,7 @@ from typing import Self
 
 import pytest
 
+from src.modules.identity.application.ports import AvatarStoragePort
 from src.modules.identity.application.unit_of_work import (
     IdentityUnitOfWork,
     IdentityUnitOfWorkFactory,
@@ -192,6 +193,34 @@ class FakeIdentityUnitOfWorkFactory(IdentityUnitOfWorkFactory):
         return self._uow
 
 
+class FakeAvatarStorage(AvatarStoragePort):
+    """In-memory ``AvatarStoragePort`` recording save / delete calls.
+
+    Tests that exercise the avatar use cases inspect ``saved`` /
+    ``deleted`` to verify the use case wired the port correctly.
+    Tests that just need a stand-in (e.g. ``DeleteProfileUseCase``
+    cascade) don't need to inspect anything — the empty default
+    behaviour is enough.
+    """
+
+    def __init__(self) -> None:
+        self.saved: list[tuple[str, bytes, str]] = []
+        self.deleted: list[str] = []
+
+    async def save(
+        self,
+        profile_id: str,
+        *,
+        content: bytes,
+        declared_mime_type: str,
+    ) -> str:
+        self.saved.append((profile_id, content, declared_mime_type))
+        return f"/api/v1/profiles/{profile_id}/avatar?v=fake"
+
+    async def delete(self, profile_id: str) -> None:
+        self.deleted.append(profile_id)
+
+
 @pytest.fixture
 def fake_uow() -> FakeIdentityUnitOfWork:
     """Fresh in-memory identity UoW per test."""
@@ -202,3 +231,9 @@ def fake_uow() -> FakeIdentityUnitOfWork:
 def fake_uow_factory(fake_uow: FakeIdentityUnitOfWork) -> FakeIdentityUnitOfWorkFactory:
     """Factory yielding the test's UoW on every call."""
     return FakeIdentityUnitOfWorkFactory(fake_uow)
+
+
+@pytest.fixture
+def fake_avatar_storage() -> FakeAvatarStorage:
+    """Fresh in-memory ``AvatarStoragePort`` per test."""
+    return FakeAvatarStorage()

--- a/tests/modules/identity/unit/application/use_cases/test_delete_profile.py
+++ b/tests/modules/identity/unit/application/use_cases/test_delete_profile.py
@@ -28,13 +28,16 @@ class TestDeleteProfileUseCase:
         self,
         fake_uow: FakeIdentityUnitOfWork,
         fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+        fake_avatar_storage,
     ):
         caller_id = UserId.generate()
         creator = CreateProfileUseCase(uow_factory=fake_uow_factory)
         keep = await creator.execute(CreateProfileInput(user_id=caller_id.value, name="Keep"))
         doomed = await creator.execute(CreateProfileInput(user_id=caller_id.value, name="Doomed"))
 
-        use_case = DeleteProfileUseCase(uow_factory=fake_uow_factory)
+        use_case = DeleteProfileUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
         await use_case.execute(
             DeleteProfileInput(
                 user_id=caller_id.value,
@@ -48,13 +51,15 @@ class TestDeleteProfileUseCase:
         assert await fake_uow.profiles.count_for_user(caller_id) == 1
 
     async def test_should_raise_when_deleting_last_profile(
-        self, fake_uow_factory: FakeIdentityUnitOfWorkFactory
+        self, fake_uow_factory: FakeIdentityUnitOfWorkFactory, fake_avatar_storage
     ):
         caller_id = UserId.generate()
         creator = CreateProfileUseCase(uow_factory=fake_uow_factory)
         only = await creator.execute(CreateProfileInput(user_id=caller_id.value, name="Only"))
 
-        use_case = DeleteProfileUseCase(uow_factory=fake_uow_factory)
+        use_case = DeleteProfileUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
 
         with pytest.raises(CannotDeleteLastProfileError):
             await use_case.execute(
@@ -65,9 +70,11 @@ class TestDeleteProfileUseCase:
             )
 
     async def test_should_raise_when_profile_does_not_exist(
-        self, fake_uow_factory: FakeIdentityUnitOfWorkFactory
+        self, fake_uow_factory: FakeIdentityUnitOfWorkFactory, fake_avatar_storage
     ):
-        use_case = DeleteProfileUseCase(uow_factory=fake_uow_factory)
+        use_case = DeleteProfileUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
 
         with pytest.raises(ProfileNotFoundException):
             await use_case.execute(
@@ -78,7 +85,7 @@ class TestDeleteProfileUseCase:
             )
 
     async def test_should_raise_when_caller_is_not_the_owner(
-        self, fake_uow_factory: FakeIdentityUnitOfWorkFactory
+        self, fake_uow_factory: FakeIdentityUnitOfWorkFactory, fake_avatar_storage
     ):
         owner_id = UserId.generate()
         intruder_id = UserId.generate()
@@ -87,7 +94,9 @@ class TestDeleteProfileUseCase:
         await creator.execute(CreateProfileInput(user_id=owner_id.value, name="Other"))
         target = await creator.execute(CreateProfileInput(user_id=owner_id.value, name="Target"))
 
-        use_case = DeleteProfileUseCase(uow_factory=fake_uow_factory)
+        use_case = DeleteProfileUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
 
         with pytest.raises(ProfileOwnershipViolation):
             await use_case.execute(

--- a/tests/modules/identity/unit/application/use_cases/test_delete_profile_avatar.py
+++ b/tests/modules/identity/unit/application/use_cases/test_delete_profile_avatar.py
@@ -1,0 +1,116 @@
+"""Unit tests for DeleteProfileAvatarUseCase."""
+
+import pytest
+
+from src.modules.identity.application.dtos.identity_dtos import (
+    CreateProfileInput,
+    DeleteProfileAvatarInput,
+)
+from src.modules.identity.application.use_cases.create_profile import (
+    CreateProfileUseCase,
+)
+from src.modules.identity.application.use_cases.delete_profile_avatar import (
+    DeleteProfileAvatarUseCase,
+)
+from src.modules.identity.domain.errors import (
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
+from src.shared_kernel.value_objects.profile_id import ProfileId
+from src.shared_kernel.value_objects.user_id import UserId
+
+from .conftest import FakeAvatarStorage, FakeIdentityUnitOfWork, FakeIdentityUnitOfWorkFactory
+
+
+class TestDeleteProfileAvatarUseCase:
+    async def test_should_clear_avatar_url_and_delete_file(
+        self,
+        fake_uow: FakeIdentityUnitOfWork,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+        fake_avatar_storage: FakeAvatarStorage,
+    ) -> None:
+        owner_id = UserId.generate()
+        creator = CreateProfileUseCase(uow_factory=fake_uow_factory)
+        # Seed the profile with a non-null avatar so the test
+        # observes a real "before / after" transition.
+        seeded = await creator.execute(
+            CreateProfileInput(
+                user_id=owner_id.value,
+                name="Lucas",
+                avatar_url="/api/v1/profiles/x/avatar?v=42",
+            )
+        )
+
+        use_case = DeleteProfileAvatarUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
+        result = await use_case.execute(
+            DeleteProfileAvatarInput(user_id=owner_id.value, profile_id=seeded.id)
+        )
+
+        assert result.avatar_url is None
+        # Storage delete fired with the right id
+        assert fake_avatar_storage.deleted == [seeded.id]
+        # Persisted state matches the response
+        stored = await fake_uow.profiles.find_by_id(ProfileId(seeded.id))
+        assert stored is not None
+        assert stored.avatar_url is None
+
+    async def test_should_be_idempotent_when_profile_has_no_avatar(
+        self,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+        fake_avatar_storage: FakeAvatarStorage,
+    ) -> None:
+        # Calling delete on a profile that already has a null
+        # avatar_url succeeds — the response just shows it's still
+        # null. Storage still gets the (idempotent) delete call.
+        owner_id = UserId.generate()
+        creator = CreateProfileUseCase(uow_factory=fake_uow_factory)
+        target = await creator.execute(CreateProfileInput(user_id=owner_id.value, name="Lucas"))
+
+        use_case = DeleteProfileAvatarUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
+        result = await use_case.execute(
+            DeleteProfileAvatarInput(user_id=owner_id.value, profile_id=target.id)
+        )
+
+        assert result.avatar_url is None
+        assert fake_avatar_storage.deleted == [target.id]
+
+    async def test_should_raise_when_profile_does_not_exist(
+        self,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+        fake_avatar_storage: FakeAvatarStorage,
+    ) -> None:
+        use_case = DeleteProfileAvatarUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
+
+        with pytest.raises(ProfileNotFoundException):
+            await use_case.execute(
+                DeleteProfileAvatarInput(
+                    user_id=UserId.generate().value,
+                    profile_id=ProfileId.generate().value,
+                )
+            )
+        assert fake_avatar_storage.deleted == []
+
+    async def test_should_reject_cross_user_delete(
+        self,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+        fake_avatar_storage: FakeAvatarStorage,
+    ) -> None:
+        owner_id = UserId.generate()
+        intruder_id = UserId.generate()
+        creator = CreateProfileUseCase(uow_factory=fake_uow_factory)
+        target = await creator.execute(CreateProfileInput(user_id=owner_id.value, name="Lucas"))
+
+        use_case = DeleteProfileAvatarUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
+        with pytest.raises(ProfileOwnershipViolation):
+            await use_case.execute(
+                DeleteProfileAvatarInput(user_id=intruder_id.value, profile_id=target.id)
+            )
+        assert fake_avatar_storage.deleted == []

--- a/tests/modules/identity/unit/application/use_cases/test_upload_profile_avatar.py
+++ b/tests/modules/identity/unit/application/use_cases/test_upload_profile_avatar.py
@@ -1,0 +1,102 @@
+"""Unit tests for UploadProfileAvatarUseCase."""
+
+import pytest
+
+from src.modules.identity.application.dtos.identity_dtos import (
+    CreateProfileInput,
+    UploadProfileAvatarInput,
+)
+from src.modules.identity.application.use_cases.create_profile import (
+    CreateProfileUseCase,
+)
+from src.modules.identity.application.use_cases.upload_profile_avatar import (
+    UploadProfileAvatarUseCase,
+)
+from src.modules.identity.domain.errors import (
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
+from src.shared_kernel.value_objects.profile_id import ProfileId
+from src.shared_kernel.value_objects.user_id import UserId
+
+from .conftest import FakeAvatarStorage, FakeIdentityUnitOfWork, FakeIdentityUnitOfWorkFactory
+
+
+class TestUploadProfileAvatarUseCase:
+    async def test_should_persist_bytes_and_update_avatar_url(
+        self,
+        fake_uow: FakeIdentityUnitOfWork,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+        fake_avatar_storage: FakeAvatarStorage,
+    ) -> None:
+        owner_id = UserId.generate()
+        creator = CreateProfileUseCase(uow_factory=fake_uow_factory)
+        profile = await creator.execute(CreateProfileInput(user_id=owner_id.value, name="Lucas"))
+
+        use_case = UploadProfileAvatarUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
+        result = await use_case.execute(
+            UploadProfileAvatarInput(
+                user_id=owner_id.value,
+                profile_id=profile.id,
+                content=b"fake-bytes",
+                declared_mime_type="image/png",
+            )
+        )
+
+        # Adapter received the upload
+        assert fake_avatar_storage.saved == [(profile.id, b"fake-bytes", "image/png")]
+        # Profile.avatar_url reflects the URL the adapter returned
+        stored = await fake_uow.profiles.find_by_id(ProfileId(profile.id))
+        assert stored is not None
+        assert stored.avatar_url == result.avatar_url
+        assert result.avatar_url is not None
+        assert result.avatar_url.startswith(f"/api/v1/profiles/{profile.id}/avatar")
+
+    async def test_should_raise_when_profile_does_not_exist(
+        self,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+        fake_avatar_storage: FakeAvatarStorage,
+    ) -> None:
+        use_case = UploadProfileAvatarUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
+
+        with pytest.raises(ProfileNotFoundException):
+            await use_case.execute(
+                UploadProfileAvatarInput(
+                    user_id=UserId.generate().value,
+                    profile_id=ProfileId.generate().value,
+                    content=b"x",
+                    declared_mime_type="image/png",
+                )
+            )
+        # Storage was never touched on the early-fail path.
+        assert fake_avatar_storage.saved == []
+
+    async def test_should_reject_cross_user_upload(
+        self,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+        fake_avatar_storage: FakeAvatarStorage,
+    ) -> None:
+        owner_id = UserId.generate()
+        intruder_id = UserId.generate()
+        creator = CreateProfileUseCase(uow_factory=fake_uow_factory)
+        target = await creator.execute(CreateProfileInput(user_id=owner_id.value, name="Lucas"))
+
+        use_case = UploadProfileAvatarUseCase(
+            uow_factory=fake_uow_factory, avatar_storage=fake_avatar_storage
+        )
+
+        with pytest.raises(ProfileOwnershipViolation):
+            await use_case.execute(
+                UploadProfileAvatarInput(
+                    user_id=intruder_id.value,
+                    profile_id=target.id,
+                    content=b"x",
+                    declared_mime_type="image/png",
+                )
+            )
+        # The ownership check runs before the storage call.
+        assert fake_avatar_storage.saved == []


### PR DESCRIPTION
## Summary

The first user-facing feature on top of the closed identity rollout. Profile owners can upload a photo for their picker / account chip; the server validates the bytes (real Pillow decode, not the browser-supplied MIME), centre-crops to a square, resizes via Lanczos to 256×256 and persists as WebP at quality 85.

## What's new

- **Settings**: ``avatar_storage_subdir`` (default ``.homeflix/avatars``, relative to ``thumbnails_directory``), ``avatar_max_size_mb`` (default 2 MB, capped at 20), ``avatar_size_pixels`` (default 256).
- **Port** ``identity.application.ports.AvatarStoragePort`` with two error types (``InvalidAvatarImageError``, ``AvatarTooLargeError``) translated to HTTP 415 / 413 by the route layer.
- **Adapter** ``identity.infrastructure.storage.LocalAvatarStorage``: Pillow validation + centre-crop + Lanczos resize + WebP write. CPU work runs on ``asyncio.to_thread`` so the event loop stays free.
- **Use cases** ``UploadProfileAvatarUseCase`` / ``DeleteProfileAvatarUseCase``: ownership-gated, set ``Profile.avatar_url`` to the cache-busted ``/api/v1/profiles/{id}/avatar?v={ts}`` so the frontend gets fresh bytes after a re-upload without a header dance.
- **Cascade**: ``DeleteProfileUseCase`` removes the avatar file on soft-delete (idempotent — the port handles missing files silently).
- **Routes** on ``profile_routes.py``: ``POST`` (multipart, ownership-gated), ``DELETE`` (ownership-gated, idempotent), ``GET`` (auth-gated only — household members render each other's avatars in the picker).
- **Container** wiring: ``IdentityContainer`` exposes the storage as a ``providers.Singleton`` parameterised by the four settings knobs.
- **Dep**: ``pillow ^11.0``. Light (~5 MB).

## Decisions

- **MIME validated by Pillow**, not by the multipart header — the form-supplied MIME is untrusted. Allow-list is JPEG / PNG / WebP at the form boundary; the actual decoder accepts the same set after reading bytes.
- **Always saved as WebP** — single canonical format keeps the GET route's media_type hard-coded and the file extension predictable.
- **Cache-busted URL** embeds the upload timestamp in ``?v=`` so the frontend re-renders fresh after a re-upload without invalidating the entire query cache.
- **Owner-gated upload / delete; auth-gated GET** — household members need to see each other's avatars in the picker.
- **Cascade on soft-delete** is best-effort; a filesystem hiccup leaves a tiny orphan file but never blocks the row delete.

## Test plan

- [x] ``poetry run pytest -q`` → 2251 passed, 5 skipped — no regressions, +21 new tests.
- [x] ``ruff check`` and ``ruff format --check`` clean.
- 21 new tests:
  - 3 unit (``test_upload_profile_avatar``): persist + update URL, reject unknown profile, block cross-user upload.
  - 4 unit (``test_delete_profile_avatar``): clear URL + storage, idempotent on empty, reject unknown / cross-user.
  - 7 integration (``test_local_avatar_storage`` with real Pillow): 256×256 WebP roundtrip, centre-crop on non-square, oversized → 413, garbage bytes → 415, disallowed MIME → 415, re-upload overwrites, delete is idempotent.
  - 7 e2e (``test_avatar_routes``): full HTTP path covering happy path + every error mode + ownership.

## Out of scope

- Frontend file picker / preview / submit UI — separate ``homeflix-web`` PR.
- Crop / zoom on the client — server does plain centre-crop; if users want manual cropping later we wire it in the same future PR.
- Static-mount serving (e.g. ``app.mount("/avatars", StaticFiles(...))``). Each route uses ``FileResponse`` per the project's existing thumbnail-serving pattern.