### PR TITLE
feat(identity): expose active_profile_id on /api/v1/users/me

### DIFF
--- a/src/config/containers/identity.py
+++ b/src/config/containers/identity.py
@@ -16,6 +16,7 @@ from src.modules.identity.application.use_cases import (
     CreateProfileUseCase,
     DeleteProfileAvatarUseCase,
     DeleteProfileUseCase,
+    GetActiveProfileForSessionUseCase,
     ListProfilesForUserUseCase,
     SwitchProfileUseCase,
     UpdateProfileUseCase,
@@ -80,6 +81,11 @@ class IdentityContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     list_profiles_for_user = providers.Factory(
         ListProfilesForUserUseCase,
+        uow_factory=identity_unit_of_work_factory,
+    )
+
+    get_active_profile_for_session = providers.Factory(
+        GetActiveProfileForSessionUseCase,
         uow_factory=identity_unit_of_work_factory,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -63,6 +63,7 @@ WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.library.presentation.routes.library_routes",
     "src.modules.preferences.presentation.routes.preferences_routes",
     "src.modules.identity.presentation.routes.profile_routes",
+    "src.modules.identity.presentation.routes.users_routes",
 )
 
 

--- a/src/modules/identity/application/use_cases/__init__.py
+++ b/src/modules/identity/application/use_cases/__init__.py
@@ -9,6 +9,9 @@ from src.modules.identity.application.use_cases.delete_profile import (
 from src.modules.identity.application.use_cases.delete_profile_avatar import (
     DeleteProfileAvatarUseCase,
 )
+from src.modules.identity.application.use_cases.get_active_profile_for_session import (
+    GetActiveProfileForSessionUseCase,
+)
 from src.modules.identity.application.use_cases.list_profiles_for_user import (
     ListProfilesForUserUseCase,
 )
@@ -26,6 +29,7 @@ __all__ = [
     "CreateProfileUseCase",
     "DeleteProfileAvatarUseCase",
     "DeleteProfileUseCase",
+    "GetActiveProfileForSessionUseCase",
     "ListProfilesForUserUseCase",
     "SwitchProfileUseCase",
     "UpdateProfileUseCase",

--- a/src/modules/identity/application/use_cases/get_active_profile_for_session.py
+++ b/src/modules/identity/application/use_cases/get_active_profile_for_session.py
@@ -1,0 +1,42 @@
+"""GetActiveProfileForSessionUseCase."""
+
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+
+
+class GetActiveProfileForSessionUseCase:
+    """Resolve a session token to its currently-active profile id.
+
+    Read-only projection over ``access_tokens.current_profile_id``,
+    consumed by ``GET /api/v1/users/me`` so the frontend learns
+    which profile the session is scoped to without keeping its own
+    mirror. Returns the prefixed external id (``prf_xxx``) — the
+    repository's snapshot already translates the on-disk UUID, so
+    the use case is just a thin pass-through.
+
+    Returns ``None`` when:
+
+    - the token is unknown (cookie was forged or already revoked), or
+    - the token exists but no profile has been selected yet
+      (post-login, pre-picker — every user with a fresh login lands
+      here until they hit ``POST /profiles/{id}/switch``).
+
+    Both branches collapse to ``None`` on purpose: the route caller
+    does not need to distinguish "session gone" from "profile not
+    chosen" — the only consumer is a UI hint, and a missing token
+    in a request that already passed ``current_active_user`` is a
+    self-inconsistent state we don't want to model as a hard error.
+    """
+
+    def __init__(self, uow_factory: IdentityUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(self, session_token: str) -> str | None:
+        """Return the active profile's prefixed id, or ``None``."""
+        async with self._uow_factory() as uow:
+            snapshot = await uow.access_tokens.get_by_token(session_token)
+        if snapshot is None or snapshot.current_profile_id is None:
+            return None
+        return str(snapshot.current_profile_id)
+
+
+__all__ = ["GetActiveProfileForSessionUseCase"]

--- a/src/modules/identity/presentation/routes/users_routes.py
+++ b/src/modules/identity/presentation/routes/users_routes.py
@@ -8,10 +8,18 @@ prefixed ``external_id`` returned as ``id``.
 
 from typing import Any
 
+from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
-from src.modules.identity.infrastructure.auth import current_active_user
+from src.config.containers import ApplicationContainer
+from src.modules.identity.application.use_cases.get_active_profile_for_session import (
+    GetActiveProfileForSessionUseCase,
+)
+from src.modules.identity.infrastructure.auth import (
+    current_active_user,
+    get_session_token,
+)
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.identity.presentation.schemas.user_schemas import UserRead
 
@@ -19,11 +27,26 @@ router = APIRouter(prefix="/api/v1/users", tags=["Users"])
 
 
 @router.get("/me")  # type: ignore[misc]
+@inject  # type: ignore[misc]
 async def get_me(
     user: UserModel = Depends(current_active_user),
+    session_token: str = Depends(get_session_token),
+    get_active_profile: GetActiveProfileForSessionUseCase = Depends(
+        Provide[ApplicationContainer.identity.get_active_profile_for_session],
+    ),
 ) -> dict[str, Any]:
-    """Return the authenticated user with prefixed external IDs."""
-    return api_single("user", UserRead.from_model(user).model_dump())
+    """Return the authenticated user plus the session's active profile.
+
+    ``active_profile_id`` is the prefixed external id (``prf_xxx``)
+    of the profile currently bound to this session, sourced from
+    ``access_tokens.current_profile_id``. ``None`` until the user
+    selects a profile via ``POST /profiles/{id}/switch``.
+    """
+    active_profile_id = await get_active_profile.execute(session_token)
+    return api_single(
+        "user",
+        UserRead.from_model(user, active_profile_id=active_profile_id).model_dump(),
+    )
 
 
 __all__ = ["router"]

--- a/src/modules/identity/presentation/schemas/user_schemas.py
+++ b/src/modules/identity/presentation/schemas/user_schemas.py
@@ -15,20 +15,32 @@ from src.modules.identity.infrastructure.persistence.models.user_model import Us
 
 
 class UserRead(BaseModel):
-    """Public read shape for the authenticated user (``GET /users/me``)."""
+    """Public read shape for the authenticated user (``GET /users/me``).
+
+    ``active_profile_id`` mirrors ``access_tokens.current_profile_id``
+    for the caller's session so the frontend can render
+    profile-scoped UI (the navbar avatar chip, the active-profile
+    badge) without keeping a localStorage shadow of the value. It is
+    ``None`` while the session has not yet selected a profile
+    (post-login, pre-picker), and switches to a prefixed ``prf_xxx``
+    once the user hits ``POST /profiles/{id}/switch``.
+    """
 
     id: str
     email: str
     role: str
     is_active: bool
     is_verified: bool
+    active_profile_id: str | None = None
 
     @classmethod
-    def from_model(cls, user: UserModel) -> Self:
+    def from_model(cls, user: UserModel, active_profile_id: str | None = None) -> Self:
         """Project a ``UserModel`` into the API response shape.
 
         Only the prefixed ``external_id`` is exposed as ``id`` — the
-        database UUID never leaves infrastructure.
+        database UUID never leaves infrastructure. ``active_profile_id``
+        is supplied by the route after a session-token lookup; the
+        schema itself stays decoupled from access-token storage.
         """
         return cls(
             id=user.external_id,
@@ -36,6 +48,7 @@ class UserRead(BaseModel):
             role=user.role,
             is_active=user.is_active,
             is_verified=user.is_verified,
+            active_profile_id=active_profile_id,
         )
 
 

--- a/tests/modules/identity/e2e/test_auth_routes.py
+++ b/tests/modules/identity/e2e/test_auth_routes.py
@@ -182,6 +182,45 @@ class TestProtectedRoute:
         assert payload["id"].startswith("usr_")
         assert payload["email"] == "lucas@homeflix.local"
 
+    async def test_should_return_null_active_profile_id_after_fresh_login(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        # Post-login, pre-picker — the access token row exists but no
+        # profile has been bound to it yet.
+        user = await seed_user_with_profile()
+        await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+
+        response = await client.get(ME_PATH)
+
+        assert response.status_code == 200
+        assert response.json()["data"]["active_profile_id"] is None
+
+    async def test_should_reflect_active_profile_id_after_switch(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ):
+        # Full picker flow: login → switch → /me carries the prefixed
+        # prf_xxx so the frontend can render profile-scoped UI without
+        # keeping its own mirror of the active profile.
+        user = await seed_user_with_profile()
+        await client.post(
+            LOGIN_PATH,
+            data={"username": user.email, "password": user.password},
+        )
+        switch = await client.post(f"/api/v1/profiles/{user.profile_external_id}/switch")
+        assert switch.status_code == 204
+
+        response = await client.get(ME_PATH)
+
+        assert response.status_code == 200
+        assert response.json()["data"]["active_profile_id"] == user.profile_external_id
+
     async def test_should_return_401_on_users_me_after_logout(
         self,
         client: AsyncClient,

--- a/tests/modules/identity/unit/application/use_cases/test_get_active_profile_for_session.py
+++ b/tests/modules/identity/unit/application/use_cases/test_get_active_profile_for_session.py
@@ -1,0 +1,52 @@
+"""Unit tests for GetActiveProfileForSessionUseCase."""
+
+from src.modules.identity.application.use_cases.get_active_profile_for_session import (
+    GetActiveProfileForSessionUseCase,
+)
+from src.shared_kernel.value_objects.profile_id import ProfileId
+from src.shared_kernel.value_objects.user_id import UserId
+
+from .conftest import FakeIdentityUnitOfWork, FakeIdentityUnitOfWorkFactory
+
+
+class TestGetActiveProfileForSessionUseCase:
+    async def test_should_return_none_when_token_is_unknown(
+        self,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+    ) -> None:
+        use_case = GetActiveProfileForSessionUseCase(uow_factory=fake_uow_factory)
+
+        result = await use_case.execute("ghost-token")
+
+        assert result is None
+
+    async def test_should_return_none_when_session_has_no_active_profile(
+        self,
+        fake_uow: FakeIdentityUnitOfWork,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+    ) -> None:
+        token = "session-abc"
+        fake_uow.access_tokens.seed(token=token, user_id=UserId.generate())
+        use_case = GetActiveProfileForSessionUseCase(uow_factory=fake_uow_factory)
+
+        result = await use_case.execute(token)
+
+        assert result is None
+
+    async def test_should_return_external_profile_id_when_one_is_set(
+        self,
+        fake_uow: FakeIdentityUnitOfWork,
+        fake_uow_factory: FakeIdentityUnitOfWorkFactory,
+    ) -> None:
+        token = "session-abc"
+        active = ProfileId.generate()
+        fake_uow.access_tokens.seed(
+            token=token,
+            user_id=UserId.generate(),
+            current_profile_id=active,
+        )
+        use_case = GetActiveProfileForSessionUseCase(uow_factory=fake_uow_factory)
+
+        result = await use_case.execute(token)
+
+        assert result == active.value


### PR DESCRIPTION
## Summary

- Adds `active_profile_id: str | None` to the `/api/v1/users/me` payload, sourced from `access_tokens.current_profile_id` for the caller's session. Resolved via a new `GetActiveProfileForSessionUseCase` — a thin read-side projection over the existing `AccessTokenSnapshot` (the repo already translates the on-disk UUID to `prf_xxx`).
- Registers the use case in `IdentityContainer`, wires `users_routes` for `@inject` (added to `WIRED_ROUTE_MODULES`), and extends `UserRead` with the new optional field.
- Returns `null` post-login / pre-picker; flips to the prefixed `prf_xxx` after `POST /profiles/{id}/switch`.
- Unblocks the homeflix-web cleanup that drops the `localStorage` mirror behind `getActiveProfileId()`.

## Test plan

- [x] Unit: 3 cases for `GetActiveProfileForSessionUseCase` (unknown token / token without selected profile / token with selected profile).
- [x] E2E: `/me` returns `active_profile_id == null` after fresh login; flips to `prf_xxx` after switch.
- [x] Full identity suite (187 tests) green.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] Smoke after restart: `curl -b cookies.txt /api/v1/users/me` shows `null` before switch and the prefixed id after.