### PR TITLE
docs: refresh roadmap and README to reflect Phases 1-4 shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,12 @@ HomeFlix is a self-hosted media server that allows you to:
 
 - 📁 Scan and organize your local video library
 - 🎯 Auto-fetch metadata from TMDB/OMDb
-- ▶️ Stream videos in your browser with subtitle support
-- 📊 Track watch progress across devices
-- 📋 Create watchlists and custom collections
+- ▶️ Stream videos in your browser with multi-audio / multi-subtitle support
+- 📊 Track watch progress per profile across devices
+- 👪 Share the household with multiple profiles (kids flag, library ACLs, custom avatars)
+- 📋 Create watchlists and custom collections per profile
+- ⏭️ Skip intros automatically (Chromaprint fingerprinting) and scrub with thumbnail trickplay
+- 🔍 Full-text search across the catalog
 
 ## Tech Stack
 
@@ -34,34 +37,23 @@ src/
 ├── building_blocks/      # Domain-agnostic base (Entity, ValueObject, errors, event bus)
 ├── shared_kernel/        # Cross-module value objects (FilePath, LanguageCode, AudioTrack)
 ├── modules/
-│   ├── media/            # Bounded Context: Media Catalog
-│   │   ├── domain/       #   entities, value_objects, repositories (ABCs), services
-│   │   ├── application/  #   use_cases, dtos, event_handlers
-│   │   ├── infrastructure/ # persistence, file_system, external APIs
-│   │   └── presentation/ #   routes (movies, series, scan, enrichment, streaming)
-│   ├── collections/      # Bounded Context: Watchlists & Custom Lists
-│   │   ├── domain/
-│   │   ├── application/
-│   │   ├── infrastructure/
-│   │   └── presentation/
-│   ├── watch_progress/   # Bounded Context: Watch Progress
-│   │   ├── domain/
-│   │   ├── application/
-│   │   ├── infrastructure/
-│   │   └── presentation/
-│   ├── library/          # Bounded Context: Library Configuration
-│   │   ├── domain/
-│   │   ├── application/
-│   │   ├── infrastructure/
-│   │   └── presentation/
-│   └── preferences/      # Bounded Context: Playback Preferences
-│       ├── application/
-│       ├── infrastructure/
-│       └── presentation/
-├── infrastructure/       # Shared infra (database, Base model)
+│   ├── media/             # Bounded Context: Media Catalog
+│   ├── library/           # Bounded Context: Library Configuration
+│   ├── watch_progress/    # Bounded Context: Watch Progress
+│   ├── collections/       # Bounded Context: Watchlists & Custom Lists
+│   ├── preferences/       # Bounded Context: Playback Preferences
+│   ├── identity/          # Bounded Context: Users, Profiles, Sessions, ACL
+│   └── catalog_requests/  # Bounded Context: Missing-title requests
+├── infrastructure/       # Shared infra (database, scheduler, Base model)
 ├── config/               # Settings, DI containers
 └── main.py
 ```
+
+Each module follows the same internal layout — `domain/` (entities,
+value objects, repository interfaces, domain services), `application/`
+(use cases, DTOs, event handlers, ports), `infrastructure/`
+(persistence, external integrations) and `presentation/` (FastAPI
+routes + Pydantic schemas).
 
 ### Dependency Rule
 
@@ -184,37 +176,41 @@ Commit messages follow [Conventional Commits](https://www.conventionalcommits.or
 
 ## Project Status
 
-**Phase 1: Foundation** — Complete
+**Phases 1–4 shipped.** HomeFlix is a working multi-user household
+streaming server with profile ACLs, automatic intro detection,
+trickplay scrub thumbnails, and a scheduled scan/enrichment pipeline.
 
-- 52 REST API endpoints across 5 bounded contexts
-- 1 450+ tests
-- Responsive React frontend with HLS player
+- 77 REST API endpoints across 7 bounded contexts
+- 2 200+ tests
+- Responsive React frontend with HLS player and per-profile UI
 
 ### Modules
 
 | Module | Scope | Highlights |
 |--------|-------|------------|
-| **Media Catalog** | Movies, Series, Seasons, Episodes | File variants (ADR-006), HLS streaming, multi-audio/subtitle, FTS5 search, TMDB enrichment, filesystem scanner |
+| **Media Catalog** | Movies, Series, Seasons, Episodes | File variants (ADR-006), HLS streaming, multi-audio/subtitle, FTS5 search, TMDB enrichment, filesystem scanner, intro markers, trickplay sprites |
 | **Library** | Media source configuration | CRUD, metadata providers, scan settings, TrackSelector service (ADR-005) |
-| **Watch Progress** | Playback tracking | Save/resume, continue watching, auto-complete at 90% |
-| **Collections** | Watchlist & Custom Lists | Toggle watchlist, up to 10 custom lists with ordering |
-| **Preferences** | Playback settings | Audio/subtitle language, subtitle mode, quality, speed |
+| **Watch Progress** | Playback tracking, scoped per profile | Save/resume, continue watching, auto-complete at 90% |
+| **Collections** | Watchlist & Custom Lists, scoped per profile | Toggle watchlist, up to 10 custom lists with ordering |
+| **Preferences** | Playback settings, scoped per profile | Audio/subtitle language, subtitle mode, quality, speed |
+| **Identity** | Users, Profiles, Sessions, ACL | FastAPI Users + cookie auth (ADR-011), prefixed external IDs (ADR-002), Profile aggregate with `allowed_library_ids`, avatar upload (Pillow → WebP), bootstrap admin CLI |
+| **Catalog Requests** | Missing-title tracking | Mark titles seen on TMDB but absent locally; auto-fulfilled when scanner picks them up |
 
 ### Frontend ([homeflix-web](https://github.com/lucaschf/homeflix-web))
 
+- Login, profile picker, profile management (HBO/Netflix-inspired), avatar upload, account menu chip
 - Hero carousel, genre browsing, full-text search with recent history
-- HLS player: multi-audio, multi-subtitle with smart modes, quality selector, playback speed, keyboard shortcuts, auto-advance
+- HLS player: multi-audio, multi-subtitle with smart modes, quality selector, playback speed, keyboard shortcuts, auto-advance, skip-intro button, scrub thumbnails
 - Continue watching, watchlist, custom lists, settings
 - i18n (pt-BR + en), responsive mobile-first design
 
 ### What's Next
 
-See [docs/roadmap.md](docs/roadmap.md) for the full roadmap. Up next:
+See [docs/roadmap.md](docs/roadmap.md) for the full roadmap. Open work:
 
-- **Phase 2**: Docker, primitive obsession cleanup, scheduled scan, subtitle appearance fix
-- **Phase 3**: Trickplay thumbnails, hardware transcoding, skip intro detection
-- **Phase 4**: Multi-user authentication and permissions
-- **Phase 5**: Webhooks and observability
+- **Phase 2**: Docker & Compose, primitive obsession cleanup, subtitle appearance fix
+- **Phase 3**: Hardware transcoding (VAAPI / NVENC) — depends on Docker
+- **Phase 5**: Webhooks / outbox pattern, Prometheus metrics
 
 ## License
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # HomeFlix — Roadmap
 
-> Last updated: 2026-04-13
+> Last updated: 2026-05-05
 
 This roadmap captures **what comes next** after the Phase 1 foundation.
 Items are ordered so each tier builds on the previous one — both in
@@ -15,9 +15,9 @@ patterns are explicitly excluded.
 
 ---
 
-## Current state (Phase 1 — Foundation)
+## Shipped (Phases 1–4)
 
-Completed:
+### Phase 1 — Foundation
 
 - Media catalog (Movie, Series, Season, Episode) with Clean Architecture
 - Library CRUD with metadata provider config and scan settings
@@ -29,42 +29,59 @@ Completed:
 - Genre browsing with cursor pagination
 - TMDB metadata enrichment (single + bulk)
 - Media file variants (multiple resolutions per media)
+- Catalog requests (mark missing titles for arrival)
 - Responsive React frontend with MUI, TanStack Query, hls.js player
 - i18n (pt-BR + en)
-- 52 REST API endpoints, 1 450+ tests
+
+### Phase 2 — Hardening (partial)
+
+- **2.3 Scheduled Scan / Background Jobs** — APScheduler-based
+  scheduler with library scan, thumbnail backfill, intro detection
+  pipeline.
+
+### Phase 3 — Player & Streaming (partial)
+
+- **3.1 Trickplay (Thumbnail Scrub)** — sprite-sheet generator +
+  WebVTT thumbnail track served alongside the HLS playlist; player
+  shows thumbnails on seek-bar hover.
+- **3.3 Skip Intro Detection** — Chromaprint-based fingerprinting,
+  cross-episode matching, per-episode intro markers, "Skip Intro"
+  button + manual override editor (`/admin/intros`).
+
+### Phase 4 — Multi-User & Access Control
+
+- **4.1 Authentication** — Identity bounded context (ADR-010, ADR-011)
+  with FastAPI Users, cookie sessions, prefixed external IDs, bootstrap
+  admin CLI.
+- **4.2 User Profiles & Permissions** — Profile aggregate with kids
+  flag, per-profile watch progress / collections / preferences,
+  `allowed_library_ids` ACL filtering catalog reads, profile picker
+  + management UI, profile avatar upload (Pillow centre-crop to WebP).
+- 77 REST API endpoints across 7 bounded contexts, 2 200+ tests.
 
 ---
 
-## Phase 2 — Hardening & Infrastructure
+## Open work
 
-Focus: solidify what exists, build shared infrastructure that later
-features depend on.
+### Phase 2 — Hardening & Infrastructure (remaining)
 
-### 2.1 Docker & Compose
+#### 2.1 Docker & Compose
 
 | | |
 |---|---|
 | **Teaches** | Multi-stage builds, containerization, infra as code |
-| **Unlocks** | Reproducible dev env, CI pipeline, easy deployment |
-| **Scope** | Dockerfile (backend), docker-compose with SQLite volume, optional PostgreSQL profile |
+| **Unlocks** | Reproducible dev env, CI pipeline, easy deployment, GPU passthrough for 3.2 |
+| **Scope** | Dockerfile (backend), docker-compose with SQLite volume, optional PostgreSQL profile, optional GPU runtime profile |
 
-### 2.2 Primitive Obsession Cleanup
+#### 2.2 Primitive Obsession Cleanup
 
 | | |
 |---|---|
 | **Teaches** | Value Object design, domain modeling discipline |
 | **Unlocks** | Stronger type safety, self-documenting domain |
-| **Scope** | Audit codebase for raw `str`, `int`, `float` that carry domain meaning; extract to Value Objects in `shared_kernel` or module-level `value_objects` |
+| **Scope** | Audit codebase for raw `str`, `int`, `float` that carry domain meaning; extract to Value Objects in `shared_kernel` or module-level `value_objects`. Can be scope-bound to one BC at a time |
 
-### 2.3 Scheduled Scan (Background Jobs)
-
-| | |
-|---|---|
-| **Teaches** | Task scheduling, background workers, async job lifecycle |
-| **Unlocks** | Foundation for trickplay generation, auto-enrichment, any future async pipeline |
-| **Scope** | Cron-like scheduler (APScheduler or similar), library scan on configurable interval, job status endpoint |
-
-### 2.4 Subtitle Appearance (fix)
+#### 2.4 Subtitle Appearance (fix)
 
 | | |
 |---|---|
@@ -72,22 +89,9 @@ features depend on.
 | **Unlocks** | Readable subtitles with user-chosen colors/size |
 | **Scope** | Investigate why `::cue` and custom overlay both failed; likely requires understanding HLS.js text track lifecycle in depth |
 
----
+### Phase 3 — Player & Streaming Evolution (remaining)
 
-## Phase 3 — Player & Streaming Evolution
-
-Focus: bring the playback experience closer to commercial quality.
-
-### 3.1 Trickplay (Thumbnail Scrub)
-
-| | |
-|---|---|
-| **Teaches** | Heavy async processing pipeline, sprite sheet generation, FFmpeg image extraction, BIF/WebVTT-thumbnails spec |
-| **Unlocks** | Visual seek — the single biggest UX gap in the player |
-| **Scope** | Background job generates thumbnail grid per media file; player shows thumbnails on hover over seek bar |
-| **Depends on** | 2.3 (background jobs) |
-
-### 3.2 Hardware Transcoding (VAAPI / NVENC)
+#### 3.2 Hardware Transcoding (VAAPI / NVENC)
 
 | | |
 |---|---|
@@ -96,44 +100,9 @@ Focus: bring the playback experience closer to commercial quality.
 | **Scope** | Detect available HW encoders at startup, prefer HW pipeline in HLS generation, graceful fallback to software |
 | **Depends on** | 2.1 (Docker — GPU passthrough config) |
 
-### 3.3 Skip Intro Detection
+### Phase 5 — Observability & Resilience
 
-| | |
-|---|---|
-| **Teaches** | Audio fingerprinting (Chromaprint), cross-episode matching algorithms |
-| **Unlocks** | "Skip Intro" button during playback |
-| **Scope** | Analyze first 5 min of each episode in a season, find common audio segment, store start/end timestamps, player shows skip button |
-| **Depends on** | 2.3 (background jobs) |
-
----
-
-## Phase 4 — Multi-User & Access Control
-
-Focus: make HomeFlix usable by more than one person on the network.
-
-### 4.1 Authentication (JWT)
-
-| | |
-|---|---|
-| **Teaches** | JWT lifecycle, refresh tokens, middleware auth, secure password storage |
-| **Unlocks** | Per-user state isolation |
-| **Scope** | Register/login endpoints, JWT access + refresh tokens, auth middleware, per-user preferences and progress |
-
-### 4.2 User Profiles & Permissions
-
-| | |
-|---|---|
-| **Teaches** | Row-level filtering, RBAC, multi-tenant patterns |
-| **Unlocks** | Parental controls, library-level access |
-| **Scope** | Admin vs. regular user roles, library visibility per user, content rating restrictions |
-
----
-
-## Phase 5 — Observability & Resilience
-
-Focus: production-grade operational visibility.
-
-### 5.1 Webhooks & Notifications
+#### 5.1 Webhooks & Notifications
 
 | | |
 |---|---|
@@ -141,13 +110,13 @@ Focus: production-grade operational visibility.
 | **Unlocks** | "Scan complete" notifications, integration with Telegram/Discord bots |
 | **Scope** | Domain events → outbox table → webhook dispatcher; configurable endpoints per event type |
 
-### 5.2 Structured Logging & Metrics
+#### 5.2 Structured Logging & Metrics
 
 | | |
 |---|---|
 | **Teaches** | Correlation IDs, structured JSON logs, Prometheus metrics |
 | **Unlocks** | Debugging production issues, performance monitoring |
-| **Scope** | Request-scoped correlation ID, structured log format, basic Prometheus endpoint (request count, latency, transcoding queue) |
+| **Scope** | Request-scoped correlation ID, structured log format, basic Prometheus endpoint (request count, latency, transcoding queue). Note: structlog with request_id middleware is already in place — this item is about exporting metrics, not the logging primitives. |
 
 ---
 


### PR DESCRIPTION
## Summary

The roadmap was last touched on 2026-04-13 and still listed Phase 4 (auth + profiles) plus several Phase 2/3 items as future work, even though all of that has shipped. The README likewise advertised 5 bounded contexts and Phase 1 as the latest milestone.

This PR resyncs both documents with what's actually in `develop`:

- Roadmap gets a new **Shipped (Phases 1–4)** section that gathers everything that's done, including:
  - **2.3 Scheduled Scan** — APScheduler + library scan + thumbnail backfill + intro detection.
  - **3.1 Trickplay** — sprite generator + WebVTT thumbnail track + seek-bar hover.
  - **3.3 Skip Intro Detection** — Chromaprint-based pipeline + manual editor at `/admin/intros`.
  - **4.1 Authentication** — Identity BC, FastAPI Users + cookie sessions, ADR-010/011, bootstrap admin CLI.
  - **4.2 Profiles & Permissions** — `Profile` aggregate, per-profile WP/collections/preferences, `allowed_library_ids` ACL, profile picker + management UI, avatar upload.
- "Open work" section keeps only what's actually unstarted: 2.1 Docker, 2.2 Primitive Obsession, 2.4 Subtitle Appearance, 3.2 HW Transcoding, 5.1 Webhooks, 5.2 Metrics. Notes that structlog with request_id is already in place under 5.2.
- README modules table now lists 7 BCs (adds `identity` and `catalog_requests`) and notes per-profile scoping on WP / collections / preferences. Endpoint count goes 52 → 77, test count 1 450 → 2 200+.
- README "What's Next" rewritten to point only at remaining work.

## Test plan

- [x] Markdown renders cleanly.
- [x] Endpoint count cross-checked against `grep '@router\.' src/modules` (77).
- [x] Test count cross-checked against `find tests -name 'test_*.py' | xargs grep 'def test_'` (2 221).
- [x] BC list matches `ls src/modules` (7).