### PR TITLE
feat(identity): gate household-write endpoints behind admin role

### DIFF
--- a/src/modules/identity/infrastructure/auth/__init__.py
+++ b/src/modules/identity/infrastructure/auth/__init__.py
@@ -11,12 +11,14 @@ from src.modules.identity.infrastructure.auth.backend import auth_backend
 from src.modules.identity.infrastructure.auth.dependencies import get_session_token
 from src.modules.identity.infrastructure.auth.fastapi_users import (
     current_active_user,
+    current_admin_user,
     fastapi_users,
 )
 
 __all__ = [
     "auth_backend",
     "current_active_user",
+    "current_admin_user",
     "fastapi_users",
     "get_session_token",
 ]

--- a/src/modules/identity/infrastructure/auth/fastapi_users.py
+++ b/src/modules/identity/infrastructure/auth/fastapi_users.py
@@ -1,15 +1,23 @@
-"""``FastAPIUsers`` singleton and the ``current_active_user`` dependency.
+"""``FastAPIUsers`` singleton plus the auth dependencies.
 
-Routes import ``current_active_user`` from this module (or from the
-package ``src.modules.identity.infrastructure.auth``) and use it as
-``Depends(current_active_user)`` to require an authenticated, active
-user on a route.
+Routes import ``current_active_user`` (or ``current_admin_user``) from
+this module (or from the package
+``src.modules.identity.infrastructure.auth``) and use it as
+``Depends(...)`` to gate a route. ``current_admin_user`` layers a role
+check on top of ``current_active_user`` so write-side endpoints
+(library CRUD, scan, enrichment, intro markers, file management) stay
+restricted to operators of the household, while regular members can
+still hit read endpoints, watch progress, collections and profile
+management.
 """
 
 import uuid
 
+from fastapi import Depends
 from fastapi_users import FastAPIUsers
 
+from src.building_blocks.application.errors import ForbiddenOperationException
+from src.modules.identity.domain.value_objects.user_role import UserRole
 from src.modules.identity.infrastructure.auth.backend import auth_backend
 from src.modules.identity.infrastructure.auth.dependencies import get_user_manager
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
@@ -21,4 +29,31 @@ fastapi_users: FastAPIUsers[UserModel, uuid.UUID] = FastAPIUsers[UserModel, uuid
 
 current_active_user = fastapi_users.current_user(active=True)
 
-__all__ = ["current_active_user", "fastapi_users"]
+
+async def current_admin_user(
+    user: UserModel = Depends(current_active_user),
+) -> UserModel:
+    """Require the authenticated user to carry the ``admin`` role.
+
+    Composes on top of ``current_active_user`` — the underlying chain
+    still validates the cookie + active flag — and adds a role check
+    so write-side household-management endpoints (library CRUD, scan,
+    enrichment, intro markers, file management, HLS cache flush) are
+    only reachable by the household operator.
+
+    Raises:
+        ForbiddenOperationException: When the authenticated user's
+            role is not ``admin``. The application exception handler
+            translates this into HTTP 403 with the standard error
+            envelope.
+    """
+    if user.role != UserRole.ADMIN.value:
+        raise ForbiddenOperationException(
+            message="Admin role required",
+            message_code="ADMIN_REQUIRED",
+            required_permission="admin",
+        )
+    return user
+
+
+__all__ = ["current_active_user", "current_admin_user", "fastapi_users"]

--- a/src/modules/library/presentation/routes/library_routes.py
+++ b/src/modules/library/presentation/routes/library_routes.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.library.application.dtos.library_dtos import (
     CreateLibraryInput,
     DeleteLibraryInput,
@@ -31,6 +33,7 @@ router = APIRouter(prefix="/api/v1/libraries", tags=["Libraries"])
 @inject  # type: ignore[misc]
 async def create_library(
     body: CreateLibraryRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: CreateLibraryUseCase = Depends(
         Provide[ApplicationContainer.library.create_library],
     ),
@@ -80,6 +83,7 @@ async def get_library(
 async def update_library(
     library_id: str,
     body: UpdateLibraryRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: UpdateLibraryUseCase = Depends(
         Provide[ApplicationContainer.library.update_library],
     ),
@@ -108,6 +112,7 @@ async def update_library(
 @inject  # type: ignore[misc]
 async def delete_library(
     library_id: str,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: DeleteLibraryUseCase = Depends(
         Provide[ApplicationContainer.library.delete_library],
     ),

--- a/src/modules/media/presentation/routes/enrichment_routes.py
+++ b/src/modules/media/presentation/routes/enrichment_routes.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.enrichment_dtos import (
     BulkEnrichInput,
     EnrichMediaInput,
@@ -31,6 +33,7 @@ router = APIRouter(prefix="/api/v1", tags=["Metadata Enrichment"])
 async def enrich_movie(
     movie_id: str,
     body: EnrichRequest | None = None,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: EnrichMovieMetadataUseCase = Depends(
         Provide[ApplicationContainer.media.enrich_movie_metadata],
     ),
@@ -46,6 +49,7 @@ async def enrich_movie(
 async def enrich_series(
     series_id: str,
     body: EnrichRequest | None = None,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: EnrichSeriesMetadataUseCase = Depends(
         Provide[ApplicationContainer.media.enrich_series_metadata],
     ),
@@ -60,6 +64,7 @@ async def enrich_series(
 @inject  # type: ignore[misc]
 async def bulk_enrich(
     body: EnrichRequest | None = None,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: BulkEnrichMetadataUseCase = Depends(
         Provide[ApplicationContainer.media.bulk_enrich_metadata],
     ),

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, Depends
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.building_blocks.presentation import Pagination, api_list, api_single
 from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
     GetFileVariantsInput,
@@ -170,6 +172,7 @@ async def get_related_movies(
 @inject  # type: ignore[misc]
 async def delete_movie(
     movie_id: str,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: DeleteMovieUseCase = Depends(
         Provide[ApplicationContainer.media.delete_movie],
     ),
@@ -203,6 +206,7 @@ async def get_file_variants(
 async def add_file_variant(
     movie_id: str,
     body: AddFileVariantRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: AddFileVariantUseCase = Depends(
         Provide[ApplicationContainer.media.add_file_variant],
     ),
@@ -228,6 +232,7 @@ async def add_file_variant(
 async def remove_file_variant(
     movie_id: str,
     body: RemoveFileVariantRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: RemoveFileVariantUseCase = Depends(
         Provide[ApplicationContainer.media.remove_file_variant],
     ),
@@ -243,6 +248,7 @@ async def remove_file_variant(
 async def set_primary_file(
     movie_id: str,
     body: SetPrimaryFileRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: SetPrimaryFileUseCase = Depends(
         Provide[ApplicationContainer.media.set_primary_file],
     ),

--- a/src/modules/media/presentation/routes/scan_routes.py
+++ b/src/modules/media/presentation/routes/scan_routes.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.library.domain.value_objects.library_id import LibraryId
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
@@ -23,6 +25,7 @@ router = APIRouter(prefix="/api/v1/scan", tags=["Scan"])
 @inject  # type: ignore[misc]
 async def scan_media(
     body: ScanMediaRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: ScanMediaDirectoriesUseCase = Depends(
         Provide[ApplicationContainer.media.scan_media_directories],
     ),

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -8,6 +8,8 @@ from fastapi import APIRouter, Depends
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.building_blocks.presentation import Pagination, api_list, api_single
 from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.intro_dtos import (
     ClearEpisodeIntroInput,
     SetEpisodeIntroInput,
@@ -182,6 +184,7 @@ async def get_episode_file_variants(
 async def add_episode_file_variant(
     episode_id: str,
     body: AddFileVariantRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: AddFileVariantUseCase = Depends(
         Provide[ApplicationContainer.media.add_file_variant],
     ),
@@ -207,6 +210,7 @@ async def add_episode_file_variant(
 async def remove_episode_file_variant(
     episode_id: str,
     body: RemoveFileVariantRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: RemoveFileVariantUseCase = Depends(
         Provide[ApplicationContainer.media.remove_file_variant],
     ),
@@ -222,6 +226,7 @@ async def remove_episode_file_variant(
 async def set_episode_primary_file(
     episode_id: str,
     body: SetPrimaryFileRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: SetPrimaryFileUseCase = Depends(
         Provide[ApplicationContainer.media.set_primary_file],
     ),
@@ -238,6 +243,7 @@ async def set_episode_primary_file(
 async def set_episode_intro(
     episode_id: str,
     body: SetIntroRequest,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: SetEpisodeIntroUseCase = Depends(
         Provide[ApplicationContainer.media.set_episode_intro],
     ),
@@ -261,6 +267,7 @@ async def set_episode_intro(
 @inject  # type: ignore[misc]
 async def clear_episode_intro(
     episode_id: str,
+    _admin: UserModel = Depends(current_admin_user),
     use_case: ClearEpisodeIntroUseCase = Depends(
         Provide[ApplicationContainer.media.clear_episode_intro],
     ),

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -22,6 +22,8 @@ from fastapi.responses import FileResponse, Response, StreamingResponse
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.config.containers import ApplicationContainer
 from src.infrastructure.scheduling import ThumbnailBackfillJob
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
 from src.modules.media.application.dtos.series_dtos import EpisodeOutput, GetSeriesByIdInput
 from src.modules.media.application.use_cases.clear_hls_cache import (
@@ -334,6 +336,7 @@ async def episode_scrub_preview_sprite(
 @inject  # type: ignore[misc]
 async def clear_movie_hls_cache(
     movie_id: str,
+    _admin: UserModel = Depends(current_admin_user),
     profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],

--- a/tests/modules/identity/e2e/test_admin_role_gating.py
+++ b/tests/modules/identity/e2e/test_admin_role_gating.py
@@ -1,0 +1,86 @@
+"""End-to-end tests for the admin role gate.
+
+Drives ``POST /api/v1/libraries`` (a representative gated endpoint)
+as both an admin user and a regular member to confirm
+``current_admin_user`` is wired through and returns the standard
+403 envelope for members. Other gated endpoints (scan, enrichment,
+intro markers, file management, HLS cache flush) reuse the same dep,
+so a single representative check is enough — duplicating the matrix
+across every route would test FastAPI's dependency mechanics, not
+our code.
+"""
+
+from collections.abc import Awaitable, Callable
+
+from httpx import AsyncClient
+
+from tests.modules.identity.e2e.conftest import SeededUser
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+LIBRARIES_PATH = "/api/v1/libraries"
+
+_VALID_LIBRARY_BODY = {
+    "name": "Movies",
+    "library_type": "movies",
+    "paths": ["/tmp/movies"],
+    "language": "en",
+    "metadata_providers": [{"provider": "tmdb", "priority": 1, "enabled": True}],
+    "scan_schedule": None,
+    "settings": {
+        "preferred_audio_language": "en",
+        "preferred_subtitle_language": "en",
+        "subtitle_mode": "none",
+        "generate_thumbnails": True,
+        "detect_intros": True,
+        "auto_refresh_metadata": True,
+    },
+}
+
+
+async def _login(client: AsyncClient, user: SeededUser) -> None:
+    resp = await client.post(
+        LOGIN_PATH,
+        data={"username": user.email, "password": user.password},
+    )
+    assert resp.status_code == 204
+
+
+class TestAdminRoleGating:
+    async def test_should_return_403_when_member_calls_admin_endpoint(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile(email="member@example.com", is_admin=False)
+        await _login(client, member)
+
+        response = await client.post(LIBRARIES_PATH, json=_VALID_LIBRARY_BODY)
+
+        assert response.status_code == 403
+
+    async def test_should_allow_admin_to_call_admin_endpoint(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await seed_user_with_profile(email="admin@example.com", is_admin=True)
+        await _login(client, admin)
+
+        response = await client.post(LIBRARIES_PATH, json=_VALID_LIBRARY_BODY)
+
+        # Library creation succeeds — proves the gate let the admin
+        # through; deeper library semantics live in the library e2e
+        # suite. (Library POST returns 200 with the body, not 201;
+        # both signal success here.)
+        assert response.status_code in (200, 201)
+
+    async def test_should_return_401_when_unauthenticated(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        response = await client.post(LIBRARIES_PATH, json=_VALID_LIBRARY_BODY)
+
+        # ``current_admin_user`` composes on top of
+        # ``current_active_user`` so the unauthenticated path stays
+        # 401, not 403 — the cookie check fires first.
+        assert response.status_code == 401

--- a/tests/modules/identity/unit/infrastructure/test_current_admin_user.py
+++ b/tests/modules/identity/unit/infrastructure/test_current_admin_user.py
@@ -1,0 +1,47 @@
+"""Unit tests for the ``current_admin_user`` FastAPI dependency."""
+
+import uuid
+
+import pytest
+
+from src.building_blocks.application.errors import ForbiddenOperationException
+from src.modules.identity.domain.value_objects.user_role import UserRole
+from src.modules.identity.infrastructure.auth.fastapi_users import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+
+def _make_user(role: str) -> UserModel:
+    """Build a minimal ``UserModel`` for the dep call.
+
+    Only attributes the dep actually inspects are set — the rest of
+    the SQLAlchemy machinery (PK, hashed password, timestamps) is
+    irrelevant here; ``current_admin_user`` only reads ``role``.
+    """
+    user = UserModel()
+    user.id = uuid.uuid4()
+    user.external_id = "usr_test"
+    user.email = "user@example.com"
+    user.hashed_password = "x"
+    user.is_active = True
+    user.is_superuser = role == UserRole.ADMIN.value
+    user.is_verified = True
+    user.role = role
+    return user
+
+
+class TestCurrentAdminUser:
+    async def test_should_return_user_when_role_is_admin(self) -> None:
+        user = _make_user(UserRole.ADMIN.value)
+
+        result = await current_admin_user(user=user)
+
+        assert result is user
+
+    async def test_should_raise_forbidden_when_role_is_member(self) -> None:
+        user = _make_user(UserRole.MEMBER.value)
+
+        with pytest.raises(ForbiddenOperationException) as exc_info:
+            await current_admin_user(user=user)
+
+        assert exc_info.value.http_status == 403
+        assert exc_info.value.required_permission == "admin"


### PR DESCRIPTION
## Summary

Adds a `current_admin_user` FastAPI dependency layered on top of `current_active_user` that returns 403 (`ForbiddenOperationException`) when the caller's role is not `admin`. Applied to the household-operator surface so a regular `member` can browse, watch, manage their profile and lists, but cannot configure libraries, trigger scans / enrichment, edit intro markers or manage media files.

Gated endpoints (17):

- `POST/PUT/DELETE /api/v1/libraries[/{id}]`
- `POST /api/v1/scan`
- `POST /api/v1/movies/{id}/enrich`, `POST /api/v1/series/{id}/enrich`, `POST /api/v1/enrich`
- `DELETE /api/v1/movies/{id}` (catalog soft-delete)
- `POST/DELETE/PUT /api/v1/movies/{id}/files[*]`
- `POST/DELETE/PUT /api/v1/series/episodes/{id}/files[*]`
- `PUT/DELETE /api/v1/series/episodes/{id}/intro`
- `DELETE /api/v1/stream/movie/{id}/hls/cache`

Untouched (members keep access): catalog reads (already filtered by profile ACL), watch progress, collections, preferences, profile management, the user-facing `POST /catalog-requests` (it's a wishlist action, not triage).

## Test plan

- [x] Unit: `tests/modules/identity/unit/infrastructure/test_current_admin_user.py` — admin returns the user, member raises `ForbiddenOperationException` with `http_status=403`.
- [x] E2E: `tests/modules/identity/e2e/test_admin_role_gating.py` — POST `/libraries` returns 401 unauthenticated, 403 as a member, 200 as admin. One representative is enough because the dep is shared.
- [x] Full identity + library + media suites green (1 520 passed).
- [ ] Smoke after restart: non-admin member sees admin endpoints reject with 403; admin still hits them.

## Follow-ups

- Frontend `RequireAdmin` route guard + hide admin-only nav for non-admins (separate PR on homeflix-web).
- Settings panel admin-only sections gated on the frontend the same way.