### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # HomeFlix — Roadmap
 
-> Last updated: 2026-05-05
+> Last updated: 2026-05-06
 
 This roadmap captures **what comes next** after the Phase 1 foundation.
 Items are ordered so each tier builds on the previous one — both in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "homeflix"
-version = "0.1.0"
+version = "0.2.0"
 description = "Personal streaming platform for local media"
 authors = ["Lucas"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` version from `0.1.0` (initial scaffold) to `0.2.0`. Marks the line of work between the project skeleton and the first stable feature plateau (Phases 1–4 shipped).
- Refresh roadmap stamp to `2026-05-06`.

## Test plan

- [x] `poetry run pytest` — 2261 passed, 5 skipped (1m05s)
- [x] `poetry run ruff check .` clean
- [x] `poetry run ruff format --check .` — 763 files already formatted

## Next steps (post-merge)

1. PR `develop` → `main` (267-commit catch-up; first promotion since project setup)
2. Tag `v0.2.0` on the merge commit

## Summary by Sourcery

Bump the project version to 0.2.0 and refresh the roadmap metadata date.

Build:
- Update the package version in pyproject.toml from 0.1.0 to 0.2.0.

Documentation:
- Update the roadmap document’s last-updated date to 2026-05-06.