### PR TITLE
docs(adr): ADR-012 — decentralized error HTTP mapping registry

### DIFF
--- a/.claude/skills/homeflix-arch/references/adr_index.md
+++ b/.claude/skills/homeflix-arch/references/adr_index.md
@@ -130,6 +130,24 @@ Cobre:
 
 Consultar quando: criar feature que toca dados pessoais (precisa de `profile_id` no Input). Adicionar autorização/role check. Decidir como passar contexto de request a um use case. Implementar endpoint que requer login. Adicionar novo prefixo de ID ao registro.
 
+### Error → HTTP Status Mapping (registry descentralizado)
+
+→ **ADR-012** (`docs/adr/ADR-012-decentralized-error-http-mapping.md`)
+
+Cobre:
+- Por que `http_status` foi removido das classes de exceção (`domain/`, `application/`, `infrastructure/` ficam puras de HTTP)
+- Registry em `building_blocks/presentation/error_mapping.py` com `_REGISTRY: dict[code, status]`, `register_http_statuses()`, `resolve_http_status()`
+- `GENERIC_HTTP_STATUSES` auto-registrado no import (codes transversais de building_blocks)
+- Por BC com codes próprios: `modules/{bc}/presentation/error_mapping.py` + `modules/{bc}/bootstrap.py` chamado no composition root
+- BCs sem codes próprios não precisam de bootstrap (apenas `identity` tem codes próprios hoje)
+- Plano de migração em 3 PRs sequenciais (introduzir registry → inverter handler → remover property)
+- Test de cobertura iterando subclasses de `CoreException` para guardar contra codes esquecidos (500 silencioso)
+- Inverte trade-off documentado em `docs/standards/exception-hierarchy-clean-architecture.md` §4
+
+Consultar quando: criar exceção nova com code próprio (precisa entrada no `{BC}_HTTP_STATUSES`). Adicionar BC novo (precisa criar `bootstrap.py` se tiver codes próprios). Diagnosticar resposta 500 em endpoint que deveria ser 404/409/etc (provável code não registrado). Decidir se um status custom merece subclasse nova ou só entrada no registry.
+
+⚠️ Migração em andamento — pode coexistir `http_status` property em algumas classes durante a transição. Verificar status atual no PR mais recente que toca `building_blocks/presentation/error_mapping.py`.
+
 ### Authentication Strategy / Session Storage / Cookie
 
 → **ADR-011** (`docs/adr/ADR-011-authentication-strategy.md`)
@@ -169,6 +187,10 @@ Consultar quando: implementar login/logout/session. Tocar config de cookies. Mud
 | Token JWT armazenado em `localStorage` no frontend ou retornado em response body | ADR-011 |
 | `cookie_httponly=False` ou `cookie_samesite="none"` sem justificativa registrada | ADR-011 |
 | Blacklist de JWT, refresh token rotation, `exp`/`iat` claims customizados | ADR-011 |
+| `@property def http_status(self) -> int` em classe de exceção | ADR-012 (será removido — usar registry) |
+| Code novo de exceção sem entrada em `error_mapping.py` do BC | ADR-012 |
+| Endpoint retornando 500 em vez de 4xx esperado | ADR-012 (verificar registry) |
+| `building_blocks/presentation/error_mapping.py` referenciando code de módulo | ADR-012 (cada BC declara seu próprio mapping) |
 
 ## Por pergunta comum
 
@@ -194,12 +216,16 @@ Consultar quando: implementar login/logout/session. Tocar config de cookies. Mud
 
 **"Como deslogo um usuário/dispositivo?"** → ADR-011 (`DELETE FROM access_tokens WHERE token = ?` ou `WHERE user_id = ?`)
 
+**"Onde declaro o HTTP status de uma exceção nova?"** → ADR-012 (no `{BC}_HTTP_STATUSES` do BC, não na classe)
+
+**"Posso colocar `http_status` como property na exceção?"** → Não. ADR-012.
+
 ## Adicionando novo ADR
 
 Quando você (ou o usuário) tomar uma decisão arquitetural significativa que não está coberta:
 
 1. Use `docs/adr/TEMPLATE.md` como base
-2. Numere sequencialmente (próximo: ADR-012 ou superior)
+2. Numere sequencialmente (próximo: ADR-013 ou superior)
 3. Status inicial: `Proposto` → após implementação e validação: `Aceito`
 4. Atualize **este índice** (`adr_index.md`) com o novo tópico
 5. Se substitui ADR existente, marque o antigo como `Substituído` e referencie

--- a/docs/adr/ADR-012-decentralized-error-http-mapping.md
+++ b/docs/adr/ADR-012-decentralized-error-http-mapping.md
@@ -1,0 +1,287 @@
+# ADR-012: Registry Descentralizado de Error HTTP Mapping
+
+**Status:** Aceito
+**Data:** 2026-05-06
+**Deciders:** Lucas Cristovam
+**Technical Story:** Inversão consciente do trade-off documentado em `docs/standards/exception-hierarchy-clean-architecture.md` §4 (Trade-off Pragmático).
+
+---
+
+## Contexto
+
+Hoje a hierarquia de exceções carrega o HTTP status como propriedade da própria classe. `CoreException` define `http_status = 500` como default, e cada subclasse em `building_blocks/{domain,application,infrastructure}/errors.py` sobrescreve a propriedade para o status apropriado (404, 422, 503, etc.). O handler global em `src/building_blocks/presentation/exception_handlers.py` lê `exc.http_status` direto.
+
+Esse design foi adotado conscientemente como trade-off pragmático e está documentado em `docs/standards/exception-hierarchy-clean-architecture.md` §4 ("Princípios de Design — Trade-off Pragmático"). A justificativa original era evitar um mapper externo cheio de condicionais.
+
+Dois sintomas tornaram o trade-off menos atrativo conforme o projeto evoluiu:
+
+1. **Vazamento de HTTP no domain.** `building_blocks/domain/errors.py` e o erros de domínio dos módulos (ex.: `modules/identity/domain/errors.py:58,88`) declaram `http_status` — a camada conceitualmente mais pura está acoplada a uma noção de transporte. Mesmo com poucos casos hoje (apenas 2 overrides em módulos), é dívida arquitetural que cresce conforme novos BCs aparecem.
+
+2. **Espalhamento da decisão de status.** Quando um módulo precisa de um status não-default (ex.: 409 para conflito específico), a única opção é overridar a property na classe — não há ponto único onde se vê "todos os codes deste BC e seus statuses". A revisão de PR fica mais difícil porque a decisão está distribuída entre N classes.
+
+A inspiração concreta vem do projeto `valid` (ADR-0008 daquele projeto), que enfrentou um problema relacionado mas mais agudo: lá havia um dict centralizado em `building_blocks` listando codes de módulos específicos, violando a regra de dependência. O HomeFlix nunca chegou a ter essa violação porque optou pela property — mas o custo da property é o vazamento de HTTP no domínio.
+
+## Decisão
+
+Adotamos um **registry descentralizado de mapeamento `error_code → http_status`**, registrado por Bounded Context no bootstrap da aplicação. A propriedade `http_status` é removida de todas as classes de exceção. O handler global resolve o status consultando o registry pelo `code` da exceção.
+
+### Estrutura
+
+```
+src/
+├── building_blocks/
+│   └── presentation/
+│       ├── error_mapping.py        # registry + GENERIC_HTTP_STATUSES + resolvers
+│       └── exception_handlers.py   # passa a usar resolve_http_status(exc.code)
+└── modules/
+    └── <bc>/
+        ├── bootstrap.py            # setup() registra o mapping do BC
+        └── presentation/
+            └── error_mapping.py    # {BC}_HTTP_STATUSES (apenas codes do BC)
+```
+
+### Regras
+
+1. **`building_blocks/presentation/error_mapping.py`** expõe:
+   - `_REGISTRY: dict[str, int]` (privado, mutável só via `register_http_statuses`)
+   - `GENERIC_HTTP_STATUSES: dict[str, int]` — codes transversais (`DOMAIN_VALIDATION_ERROR`, `RESOURCE_NOT_FOUND`, `GATEWAY_TIMEOUT`, etc.) auto-registrado no import.
+   - `register_http_statuses(mapping: dict[str, int]) -> None` — único ponto de mutação do registry. Idempotente (re-registrar o mesmo code com o mesmo status é no-op). Registrar um code já existente com status diferente é erro de programação — levanta exceção em vez de sobrescrever silenciosamente.
+   - `resolve_http_status(code: str, default: int = 500) -> int`
+   - `resolve_error_type(http_status: int) -> str` — substitui `CoreException._get_error_type()` (status → `"validation_error"` / `"not_found_error"` / etc).
+
+2. **Cada BC com codes próprios** declara `src/modules/{bc}/presentation/error_mapping.py` com um dict `{BC}_HTTP_STATUSES` listando **todos** os codes do BC (inclusive os que herdam status de uma base — repetir a entrada explicitamente, porque o registry é flat e indexado por code, não por classe).
+
+3. **Cada BC com codes próprios** expõe `src/modules/{bc}/bootstrap.py` com `def setup() -> None` que importa o dict e chama `register_http_statuses({BC}_HTTP_STATUSES)`.
+
+4. **Composition root** (`src/main.py` ou `ApplicationContainer.wire()`) chama `_bootstrap_modules()` **antes** de `register_exception_handlers(app)`. A função invoca cada `bootstrap.setup()` individualmente:
+
+   ```python
+   def _bootstrap_modules() -> None:
+       from src.modules.identity import bootstrap as identity_bootstrap
+       identity_bootstrap.setup()
+       # outros BCs aqui conforme aparecem codes próprios
+   ```
+
+5. **Domain não conhece HTTP.** Nenhuma classe de exceção em `building_blocks/{domain,application,infrastructure}/errors.py` ou em `modules/*/domain/errors.py` declara `http_status`. A propriedade é removida.
+
+6. **BCs sem codes próprios não precisam de bootstrap.** Hoje apenas `identity` tem codes que não são genéricos. Os outros (`media`, `library`, `watch_progress`, `collections`) reutilizam codes genéricos via `ResourceNotFoundException.for_resource(...)` etc — não precisam de `error_mapping.py` ou `bootstrap.py` enquanto não introduzirem code próprio.
+
+### Migração
+
+A mudança é estrutural mas a transição é segura quando feita em 3 PRs sequenciais:
+
+1. **Introduzir o registry, manter a property.** Cria `error_mapping.py`, `GENERIC_HTTP_STATUSES`, resolvers. Bootstrap do `identity` registra `IDENTITY_HTTP_STATUSES`. Nenhum comportamento muda — `exc.http_status` ainda é a fonte da verdade. Adiciona test que valida cobertura: cada subclasse de `CoreException` no projeto tem entrada no registry.
+
+2. **Inverter a fonte da verdade no handler.** `core_exception_handler` passa a usar `resolve_http_status(exc.code)` em vez de `exc.http_status`. Comportamento idêntico se o registry estiver completo (garantido pelo teste de cobertura do PR 1).
+
+3. **Remover `http_status` das exceptions.** Property sai de todas as 18 subclasses em `building_blocks/` + 2 overrides em `modules/identity/`. `CoreException._get_error_type()` sai. Os 18 testes que assertam `exc.http_status == X` migram para `resolve_http_status("CODE") == X` ou `response.status_code == X` (E2E).
+
+## Consequências
+
+### Positivas
+
+- **Domain puro de HTTP.** `domain/`, `application/` e `infrastructure/` deixam de mencionar HTTP em qualquer lugar. A camada de transporte vive 100% em `presentation/`.
+- **Decisão localizada por BC.** O `error_mapping.py` de cada BC é o ponto único onde se vê todos os codes do BC e seus statuses. Review de PR fica direto.
+- **Modularidade real.** Se um BC for extraído para outro serviço, seu mapping vai junto — não há property espalhada por classes.
+- **Open/Closed mantido.** Adicionar um novo BC com codes próprios não toca `building_blocks` — basta criar o `error_mapping.py` e o `bootstrap.py` do BC.
+- **Resolução de error type também migra.** O dict `_STATUS_TO_ERROR_TYPE` (hoje duplicado em `exception_handlers.py:24` e `errors.py:175`) consolida em um lugar.
+
+### Negativas
+
+- **Boilerplate por BC.** Cada BC com code próprio cria 2 arquivos (`error_mapping.py` + `bootstrap.py`). Hoje seria apenas `identity`; o custo cresce linear no número de BCs com codes próprios.
+- **Bug class novo: code esquecido no registry.** Se um code for adicionado a uma exceção e não ao registry, cai no default 500. Mitigação: teste de cobertura iterando todas as subclasses de `CoreException`.
+- **Estado mutável global.** `_REGISTRY` é um dict mutável de módulo. Para testes, precisa de fixture `reset_registry()` em `conftest.py` para isolamento.
+- **Ordem de bootstrap importa.** `register_exception_handlers` antes de `_bootstrap_modules` faz tudo cair em 500. Mitigação: smoke test que dispara uma `ResourceNotFoundException` e confirma 404.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Code adicionado sem entrada no registry vira 500 silencioso | Média | Médio | Teste de cobertura: itera `CoreException.__subclasses__()` recursivamente e garante `resolve_http_status(cls.code) != default` |
+| Conflito de codes entre BCs (mesmo code com statuses diferentes) | Baixa | Médio | `register_http_statuses` levanta erro em conflito real (mesmo key, valor diferente). Re-registro idempotente do mesmo valor é no-op |
+| Bootstrap rodar fora de ordem em testes / scripts ad-hoc | Baixa | Baixo | Container expõe método `bootstrap_modules()` chamado por `main.py` e por `conftest.py` global. Scripts ad-hoc que pulam composition root recebem 500 — comportamento esperado |
+| `valid` ADR-0008 evoluir para algo diferente | Baixa | Baixo | A decisão aqui é independente. Não somos obrigados a copiar mudanças futuras do `valid` |
+
+## Alternativas Consideradas
+
+### 1. Manter `http_status` como property (status quo)
+
+Continuar com o trade-off pragmático documentado em `exception-hierarchy-clean-architecture.md` §4.
+
+**Rejeitado porque:** vaza HTTP no domain. Hoje custa pouco (2 overrides), mas o custo é incremental — cada novo BC com status custom paga o preço.
+
+### 2. Mapper baseado em classes (MRO walk)
+
+`HTTPStatusMapper` com `_STATUS_MAP: dict[Type[CoreException], int]` que percorre `__mro__` para resolver. É a alternativa que a seção "HTTP Status Mapper (Abordagem Purista)" do standards doc descrevia.
+
+**Rejeitado porque:** acopla o mapper às classes de exceção (precisa importar todas as subclasses no dict). Adicionar uma nova subclasse exige editar o mapper central — viola Open/Closed em `building_blocks`. Indexar por `code` (string) é mais frouxo e mais fácil de evoluir.
+
+### 3. Subclasses mais granulares em `building_blocks`
+
+Adicionar `ConflictException` (409), `BusinessRuleViolation` (422), etc. nas bases. Os 2 overrides em `identity` desapareceriam por herança.
+
+**Rejeitado porque:** resolve o sintoma de hoje sem atacar o problema (HTTP continua na classe). Funcionaria como medida paliativa, mas adia a decisão estrutural.
+
+### 4. Eager registration via import side-effects
+
+Cada `modules/<bc>/__init__.py` chama `register_http_statuses(...)` no top-level — zero bootstrap explícito.
+
+**Rejeitado porque:** import side-effects são padrão que evitamos no projeto. Bootstrap explícito no composition root é coerente com ADR-004 (DI via `dependency-injector`).
+
+### 5. Atributo na classe registrado pelo metaclass
+
+`CoreException.__init_subclass__` lê o `code` e o `http_status` da classe e popula o registry automaticamente. Mantém HTTP na classe mas centraliza a fonte da verdade.
+
+**Rejeitado porque:** ainda mantém HTTP no domain. A decisão aqui é remover o vazamento, não centralizá-lo de outra forma.
+
+## Referências
+
+- `docs/standards/exception-hierarchy-clean-architecture.md` — atualizado em conjunto com este ADR (§4 invertido, seção "HTTP Status Mapper" reescrita).
+- `docs/adr/ADR-008-screaming-architecture.md` — organização por BC que este ADR estende para o cross-cutting concern de error mapping.
+- `docs/adr/ADR-004-dependency-injection.md` — composition root é o ponto canônico de bootstrap.
+- `docs/adr/ADR-009-cross-bc-read-ports.md` — mesma filosofia: cada BC declara seu próprio contrato em vez de depender de um registry central.
+- `src/building_blocks/presentation/exception_handlers.py` — handler global afetado pelo PR 2 da migração.
+- `src/modules/identity/domain/errors.py:58,88` — únicos overrides de `http_status` em código de módulo hoje.
+
+---
+
+## Notas de Implementação
+
+### Esqueleto do registry
+
+```python
+# src/building_blocks/presentation/error_mapping.py
+from src.config.logging import get_logger
+
+_REGISTRY: dict[str, int] = {}
+_STATUS_TO_ERROR_TYPE: dict[int, str] = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    409: "conflict_error",
+    422: "validation_error",
+    429: "rate_limit_error",
+    500: "api_error",
+    502: "bad_gateway_error",
+    503: "service_unavailable_error",
+    504: "gateway_timeout_error",
+}
+
+GENERIC_HTTP_STATUSES: dict[str, int] = {
+    "DOMAIN_VALIDATION_ERROR": 422,
+    "DOMAIN_BUSINESS_RULE_VIOLATION": 422,
+    "DOMAIN_NOT_FOUND": 404,
+    "USE_CASE_VALIDATION_ERROR": 422,
+    "RESOURCE_NOT_FOUND": 404,
+    "FORBIDDEN_OPERATION": 403,
+    "UNAUTHORIZED_OPERATION": 401,
+    "GATEWAY_TIMEOUT": 504,
+    "GATEWAY_UNAVAILABLE": 503,
+    # ... lista completa derivada de building_blocks/{domain,application,infrastructure}/errors.py
+}
+
+
+def register_http_statuses(mapping: dict[str, int]) -> None:
+    """Register a batch of code → http_status entries. Idempotent for equal values, raises on conflict."""
+    for code, status in mapping.items():
+        existing = _REGISTRY.get(code)
+        if existing is not None and existing != status:
+            raise ValueError(
+                f"Conflicting http_status registration for code {code!r}: "
+                f"already registered as {existing}, new value {status}"
+            )
+        _REGISTRY[code] = status
+
+
+def resolve_http_status(code: str, default: int = 500) -> int:
+    return _REGISTRY.get(code, default)
+
+
+def resolve_error_type(http_status: int) -> str:
+    return _STATUS_TO_ERROR_TYPE.get(http_status, "api_error")
+
+
+# Auto-register building_blocks codes on import.
+register_http_statuses(GENERIC_HTTP_STATUSES)
+```
+
+### Bootstrap do BC
+
+```python
+# src/modules/identity/presentation/error_mapping.py
+IDENTITY_HTTP_STATUSES: dict[str, int] = {
+    "PROFILE_NOT_FOUND": 404,
+    "PROFILE_OWNERSHIP_VIOLATION": 403,
+    "NO_ACTIVE_SESSION": 401,
+    "CANNOT_DELETE_LAST_PROFILE": 409,
+    "NO_ACTIVE_PROFILE": 409,
+}
+```
+
+```python
+# src/modules/identity/bootstrap.py
+def setup() -> None:
+    """Bootstrap the identity module: register error→HTTP mappings."""
+    from src.building_blocks.presentation.error_mapping import register_http_statuses
+    from src.modules.identity.presentation.error_mapping import IDENTITY_HTTP_STATUSES
+
+    register_http_statuses(IDENTITY_HTTP_STATUSES)
+```
+
+### Handler atualizado
+
+```python
+# src/building_blocks/presentation/exception_handlers.py
+async def core_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    exc = cast(CoreException, exc)
+    http_status = resolve_http_status(exc.code)
+    error_type = resolve_error_type(http_status)
+    # ... log + serialize
+    return JSONResponse(status_code=http_status, content=exc.to_dict(error_type=error_type))
+```
+
+### Teste de cobertura
+
+```python
+# tests/building_blocks/unit/presentation/test_error_mapping_coverage.py
+def _all_subclasses(cls):
+    seen = set()
+    stack = [cls]
+    while stack:
+        node = stack.pop()
+        for sub in node.__subclasses__():
+            if sub not in seen:
+                seen.add(sub)
+                stack.append(sub)
+    return seen
+
+
+def test_every_core_exception_subclass_has_registry_entry():
+    """Guards against silent 500 fallback when a new exception is added without a registry entry."""
+    from src.building_blocks.domain.errors import CoreException
+    from src.building_blocks.presentation.error_mapping import resolve_http_status
+
+    # Force-import all error modules so subclasses register.
+    import src.building_blocks.domain.errors  # noqa: F401
+    import src.building_blocks.application.errors  # noqa: F401
+    import src.building_blocks.infrastructure.errors  # noqa: F401
+    import src.modules.identity.domain.errors  # noqa: F401
+    # add new BC error modules here as they appear
+
+    missing = []
+    for cls in _all_subclasses(CoreException):
+        try:
+            instance = cls(message="probe")
+        except TypeError:
+            continue  # skip abstract / dataclass-required classes; covered indirectly by their concrete subclasses
+        if resolve_http_status(instance.code, default=-1) == -1:
+            missing.append((cls.__name__, instance.code))
+    assert not missing, f"Missing registry entries: {missing}"
+```
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-05-06 | Lucas Cristovam | Criação inicial — inverte o trade-off documentado em `exception-hierarchy-clean-architecture.md` §4 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,15 +16,12 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-004](./ADR-004-dependency-injection.md) | Injeção de Dependências com dependency-injector | ✅ Aceito | 2025-01-28 |
 | [ADR-005](./ADR-005-library-as-configuration-entity.md) | Library como Entidade de Configuração | ✅ Aceito | 2026-02-03 |
 | [ADR-006](./ADR-006-media-file-variants.md) | Variantes de Arquivo de Mídia | ✅ Aceito | 2026-02-03 |
-
-## ADRs Planejados
-
-Os seguintes ADRs serão criados conforme o projeto avança:
-
-- **ADR-007**: Streaming de Vídeo (HTTP Range Requests vs HLS)
-- **ADR-008**: Cache Strategy
-- **ADR-009**: Background Jobs (Scan, Metadata Fetch)
-- **ADR-010**: Estratégia de Testes (Unit, Integration, E2E)
+| [ADR-007](./ADR-007-immutable-entities-with-convention.md) | Entidades Imutáveis com Convenção `with_*` | ✅ Aceito | 2026-02-17 |
+| [ADR-008](./ADR-008-screaming-architecture.md) | Screaming Architecture com Módulos | ✅ Aceito | 2026-04-02 |
+| [ADR-009](./ADR-009-cross-bc-read-ports.md) | Cross-BC Read Ports + ACL | ✅ Aceito | 2026-04-18 |
+| [ADR-010](./ADR-010-identity-bounded-context.md) | Identity Bounded Context | ✅ Aceito | 2026-05-03 |
+| [ADR-011](./ADR-011-authentication-strategy.md) | Authentication Strategy | ✅ Aceito | 2026-05-03 |
+| [ADR-012](./ADR-012-decentralized-error-http-mapping.md) | Registry Descentralizado de Error HTTP Mapping | ✅ Aceito | 2026-05-06 |
 
 ## Como Criar um Novo ADR
 

--- a/docs/standards/exception-hierarchy-clean-architecture.md
+++ b/docs/standards/exception-hierarchy-clean-architecture.md
@@ -1,5 +1,9 @@
 # Hierarquia de Exceções para Clean Architecture
 
+> ⚠️ **Em migração — ver [ADR-012](../adr/ADR-012-decentralized-error-http-mapping.md).**
+>
+> A propriedade `http_status` que aparece nos exemplos de código abaixo está sendo removida das classes de exceção. O projeto adotou um **registry descentralizado de mapeamento `error_code → http_status`** registrado por Bounded Context no bootstrap. Os exemplos refletem o estado pré-migração e serão atualizados em PRs subsequentes. Consulte ADR-012 para a abordagem atual e a §8 (HTTP Status Mapping) abaixo para o resumo do novo design.
+
 ## Sumário
 
 1. [Visão Geral](#visão-geral)
@@ -14,7 +18,7 @@
 5. [Handler Global (FastAPI)](#handler-global-fastapi)
 6. [Exemplos de Uso](#exemplos-de-uso)
 7. [Boas Práticas](#boas-práticas)
-8. [HTTP Status Mapper (Abordagem Purista)](#http-status-mapper-abordagem-purista)
+8. [HTTP Status Mapping (Registry Descentralizado)](#http-status-mapping-registry-descentralizado)
 9. [Internacionalização (i18n)](#internacionalização-i18n)
 10. [Considerações de Performance](#considerações-de-performance)
 11. [Testes](#testes)
@@ -85,14 +89,16 @@ Cada camada da Clean Architecture possui sua própria base de exceções:
 - Campo `internal_message` disponível apenas para logs
 - `exception_id` permite correlação sem expor informações sensíveis
 
-### 4. Trade-off Pragmático
+### 4. Domain Puro de HTTP (decisão atual — ADR-012)
 
-O mapeamento `http_status` nas exceções é um trade-off consciente:
+> **Histórico**: A versão anterior deste documento adotava o atributo `http_status` na própria classe de exceção como trade-off pragmático ("evita um mapeador externo cheio de condicionais"). Essa decisão foi revisitada e invertida — ver [ADR-012](../adr/ADR-012-decentralized-error-http-mapping.md).
 
-- **Purista**: O domínio não deveria conhecer HTTP
-- **Pragmático**: Evita criar um mapeador externo cheio de condicionais
+O domínio não conhece HTTP. O mapeamento `error_code → http_status` vive em um **registry descentralizado** em `building_blocks/presentation/error_mapping.py`, populado por:
 
-Se o projeto crescer muito ou virar uma biblioteca compartilhada, considere extrair para um mapper externo.
+- `GENERIC_HTTP_STATUSES` — codes transversais (`RESOURCE_NOT_FOUND`, `DOMAIN_VALIDATION_ERROR`, etc.) auto-registrados no import.
+- `{BC}_HTTP_STATUSES` — codes específicos do BC, registrados via `bootstrap.setup()` chamado no composition root antes de `register_exception_handlers`.
+
+O handler global resolve o status via `resolve_http_status(exc.code)`. Os detalhes — estrutura, regras, plano de migração e teste de cobertura — estão em ADR-012.
 
 ---
 
@@ -1906,373 +1912,103 @@ raise BusinessRuleViolationException(
 
 ---
 
-## HTTP Status Mapper (Abordagem Purista)
+## HTTP Status Mapping (Registry Descentralizado)
 
-Como discutido nos [Princípios de Design](#princípios-de-design), manter `http_status` nas exceções é um trade-off pragmático. Se você preferir uma abordagem purista onde o domínio não conhece HTTP, use um mapper externo.
+> **Decisão:** [ADR-012](../adr/ADR-012-decentralized-error-http-mapping.md). Esta seção é o resumo prático; o ADR é a fonte da verdade.
 
-### Quando usar o Mapper Externo?
+O HomeFlix mantém o domínio puro de HTTP. O mapeamento `error_code → http_status` vive em um **registry descentralizado** em `building_blocks/presentation/error_mapping.py`. Cada Bounded Context com codes próprios declara seu mapping em `modules/{bc}/presentation/error_mapping.py` e o registra no bootstrap.
 
-| Cenário | Recomendação |
-|---------|--------------|
-| Projeto pequeno/médio | `http_status` na exceção (pragmático) |
-| Biblioteca compartilhada entre projetos | Mapper externo |
-| Múltiplos protocolos (HTTP, gRPC, GraphQL) | Mapper externo |
-| Domínio precisa ser 100% puro | Mapper externo |
+### Estrutura
 
-### Implementação
+```
+src/
+├── building_blocks/
+│   └── presentation/
+│       └── error_mapping.py        # _REGISTRY + GENERIC_HTTP_STATUSES + resolvers
+└── modules/
+    └── <bc>/
+        ├── bootstrap.py            # setup() registra o mapping do BC
+        └── presentation/
+            └── error_mapping.py    # {BC}_HTTP_STATUSES (codes específicos do BC)
+```
 
-#### 1. Remova `http_status` das Exceções
+### Componentes do registry
 
 ```python
-# core/exceptions/base.py
-@dataclass
-class CoreException(Exception):
-    message: str
-    code: str = "CORE_ERROR"
-    details: list[ExceptionDetail] = field(default_factory=list)
-    exception_id: str = field(default_factory=lambda: str(uuid.uuid4()))
-    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-    severity: Severity = Severity.MEDIUM
-    tags: dict[str, Any] = field(default_factory=dict)
-    
-    # Removido: http_status property
-    
-    def __post_init__(self):
-        super().__init__(self.message)
-    
-    def to_dict(self, include_internal: bool = False) -> dict[str, Any]:
-        # ... mesmo código anterior
-        pass
+# src/building_blocks/presentation/error_mapping.py
+_REGISTRY: dict[str, int] = {}
+
+GENERIC_HTTP_STATUSES: dict[str, int] = {
+    "DOMAIN_VALIDATION_ERROR": 422,
+    "RESOURCE_NOT_FOUND": 404,
+    "FORBIDDEN_OPERATION": 403,
+    "UNAUTHORIZED_OPERATION": 401,
+    "GATEWAY_TIMEOUT": 504,
+    "GATEWAY_UNAVAILABLE": 503,
+    # ... codes transversais auto-registrados no import
+}
+
+
+def register_http_statuses(mapping: dict[str, int]) -> None:
+    """Idempotente para valores iguais; levanta em conflito real."""
+
+
+def resolve_http_status(code: str, default: int = 500) -> int: ...
+def resolve_error_type(http_status: int) -> str: ...
+
+
+register_http_statuses(GENERIC_HTTP_STATUSES)  # auto-register no import
 ```
 
-#### 2. Crie o Mapper
+### Bootstrap por BC
 
 ```python
-# api/exception_mapper.py
-from typing import Type
-from core.exceptions import (
-    CoreException,
-    # Domain
-    DomainException,
-    DomainValidationException,
-    BusinessRuleViolationException,
-    DomainNotFoundException,
-    DomainConflictException,
-    # Application
-    ApplicationException,
-    UseCaseValidationException,
-    UnauthorizedOperationException,
-    ForbiddenOperationException,
-    ResourceNotFoundException,
-    # Infrastructure
-    InfrastructureException,
-    GatewayException,
-    GatewayTimeoutException,
-    GatewayUnavailableException,
-    GatewayRateLimitException,
-    GatewayBadResponseException,
-    RepositoryException,
-    DatabaseConnectionException,
-    DataIntegrityException,
-)
+# src/modules/identity/presentation/error_mapping.py
+IDENTITY_HTTP_STATUSES: dict[str, int] = {
+    "PROFILE_NOT_FOUND": 404,
+    "PROFILE_OWNERSHIP_VIOLATION": 403,
+    "NO_ACTIVE_SESSION": 401,
+    "CANNOT_DELETE_LAST_PROFILE": 409,
+    "NO_ACTIVE_PROFILE": 409,
+}
 
 
-class HTTPStatusMapper:
-    """
-    Mapeia exceções do domínio para códigos HTTP.
-    
-    Mantém o domínio puro, sem conhecimento de protocolos de transporte.
-    O mapeamento é feito na camada de Interface Adapters (API).
-    
-    Example:
-        >>> mapper = HTTPStatusMapper()
-        >>> status = mapper.get_status(some_exception)
-        >>> # ou
-        >>> status = mapper.get_status_by_type(DomainValidationException)
-    """
-    
-    # Mapeamento de tipo de exceção -> HTTP status
-    _STATUS_MAP: dict[Type[CoreException], int] = {
-        # Domain
-        DomainException: 422,
-        DomainValidationException: 422,
-        BusinessRuleViolationException: 422,
-        DomainNotFoundException: 404,
-        DomainConflictException: 409,
-        
-        # Application
-        ApplicationException: 400,
-        UseCaseValidationException: 400,
-        UnauthorizedOperationException: 401,
-        ForbiddenOperationException: 403,
-        ResourceNotFoundException: 404,
-        
-        # Infrastructure
-        InfrastructureException: 502,
-        GatewayException: 502,
-        GatewayTimeoutException: 504,
-        GatewayUnavailableException: 503,
-        GatewayRateLimitException: 429,
-        GatewayBadResponseException: 502,
-        RepositoryException: 502,
-        DatabaseConnectionException: 503,
-        DataIntegrityException: 409,
-    }
-    
-    # Status padrão para exceções não mapeadas
-    DEFAULT_STATUS = 500
-    
-    def get_status(self, exception: CoreException) -> int:
-        """
-        Obtém o HTTP status para uma instância de exceção.
-        
-        Percorre a hierarquia de classes (MRO) para encontrar
-        o mapeamento mais específico.
-        
-        Args:
-            exception: Instância da exceção
-        
-        Returns:
-            Código HTTP correspondente
-        """
-        return self.get_status_by_type(type(exception))
-    
-    def get_status_by_type(self, exception_type: Type[CoreException]) -> int:
-        """
-        Obtém o HTTP status para um tipo de exceção.
-        
-        Args:
-            exception_type: Classe da exceção
-        
-        Returns:
-            Código HTTP correspondente
-        """
-        # Busca direta
-        if exception_type in self._STATUS_MAP:
-            return self._STATUS_MAP[exception_type]
-        
-        # Busca na hierarquia (MRO - Method Resolution Order)
-        for base_class in exception_type.__mro__:
-            if base_class in self._STATUS_MAP:
-                return self._STATUS_MAP[base_class]
-        
-        return self.DEFAULT_STATUS
-    
-    def register(self, exception_type: Type[CoreException], status: int) -> None:
-        """
-        Registra um novo mapeamento.
-        
-        Útil para exceções customizadas do projeto.
-        
-        Args:
-            exception_type: Classe da exceção
-            status: Código HTTP
-        
-        Example:
-            >>> mapper.register(MyCustomException, 418)
-        """
-        self._STATUS_MAP[exception_type] = status
-    
-    def register_many(self, mappings: dict[Type[CoreException], int]) -> None:
-        """
-        Registra múltiplos mapeamentos de uma vez.
-        
-        Args:
-            mappings: Dicionário tipo -> status
-        """
-        self._STATUS_MAP.update(mappings)
+# src/modules/identity/bootstrap.py
+def setup() -> None:
+    from src.building_blocks.presentation.error_mapping import register_http_statuses
+    from src.modules.identity.presentation.error_mapping import IDENTITY_HTTP_STATUSES
 
-
-# Instância singleton para uso global
-http_status_mapper = HTTPStatusMapper()
+    register_http_statuses(IDENTITY_HTTP_STATUSES)
 ```
 
-#### 3. Atualize o Handler
+O composition root chama `_bootstrap_modules()` **antes** de `register_exception_handlers(app)`. BCs sem codes próprios (que reutilizam apenas codes genéricos via `ResourceNotFoundException.for_resource(...)` etc.) não precisam de `bootstrap.py` ou `error_mapping.py`.
+
+### Handler
 
 ```python
-# api/exception_handlers.py
-import structlog
-from fastapi import Request
-from fastapi.responses import JSONResponse
-from core.exceptions import CoreException, Severity
-from api.exception_mapper import http_status_mapper
-
-logger = structlog.get_logger()
-
-
-async def core_exception_handler(request: Request, exc: CoreException) -> JSONResponse:
-    """
-    Handler global usando mapper externo.
-    """
-    # Obtém status via mapper (não da exceção)
-    http_status = http_status_mapper.get_status(exc)
-    
-    # Log completo
-    log_data = exc.to_dict(include_internal=True)
-    log_data["path"] = request.url.path
-    log_data["method"] = request.method
-    log_data["http_status"] = http_status
-    
-    if exc.severity in (Severity.HIGH, Severity.CRITICAL):
-        logger.error("exception_raised", **log_data)
-    else:
-        logger.warning("exception_raised", **log_data)
-    
-    # Response
-    return JSONResponse(
-        status_code=http_status,
-        content=exc.to_dict(include_internal=False),
-        headers={"X-Request-ID": exc.exception_id}
-    )
+# src/building_blocks/presentation/exception_handlers.py
+async def core_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    exc = cast(CoreException, exc)
+    http_status = resolve_http_status(exc.code)
+    error_type = resolve_error_type(http_status)
+    # ... log + serialize
+    return JSONResponse(status_code=http_status, content=exc.to_dict(error_type=error_type))
 ```
 
-#### 4. Registrando Exceções Customizadas
+### Regras
 
-```python
-# main.py
-from api.exception_mapper import http_status_mapper
-from my_project.exceptions import (
-    PaymentDeclinedException,
-    QuotaExceededException,
-)
+1. Nenhuma classe em `domain/`, `application/` ou `infrastructure/` declara `http_status`. A camada de transporte vive 100% em `presentation/`.
+2. Repetir entradas no `{BC}_HTTP_STATUSES` para codes que herdam de bases (ex.: `PROFILE_NOT_FOUND`) — o registry é flat e indexado por code, não por classe.
+3. `register_http_statuses` é idempotente quando o mesmo code é registrado com o mesmo status, mas levanta em conflito real (mesmo code, status diferente).
+4. Teste de cobertura em `tests/building_blocks/unit/presentation/test_error_mapping_coverage.py` itera todas as subclasses de `CoreException` e garante que cada `code` tem entrada no registry — sem isso, codes esquecidos caem em 500 silenciosamente.
 
-# Registra exceções específicas do projeto
-http_status_mapper.register(PaymentDeclinedException, 402)  # Payment Required
-http_status_mapper.register(QuotaExceededException, 429)
+### Migração
 
-# Ou em lote
-http_status_mapper.register_many({
-    PaymentDeclinedException: 402,
-    QuotaExceededException: 429,
-})
-```
+A inversão da decisão acontece em 3 PRs sequenciais (ver ADR-012 §Migração):
 
-### Mapper para Múltiplos Protocolos
-
-Se você precisa suportar HTTP, gRPC e GraphQL, pode criar mappers específicos:
-
-```python
-# api/mappers/__init__.py
-from .http_mapper import HTTPStatusMapper
-from .grpc_mapper import GRPCStatusMapper
-from .graphql_mapper import GraphQLErrorMapper
-
-__all__ = ["HTTPStatusMapper", "GRPCStatusMapper", "GraphQLErrorMapper"]
-```
-
-```python
-# api/mappers/grpc_mapper.py
-from grpc import StatusCode
-from typing import Type
-from core.exceptions import (
-    CoreException,
-    DomainNotFoundException,
-    UnauthorizedOperationException,
-    ForbiddenOperationException,
-    GatewayUnavailableException,
-    GatewayTimeoutException,
-    # ...
-)
-
-
-class GRPCStatusMapper:
-    """Mapeia exceções para códigos gRPC."""
-    
-    _STATUS_MAP: dict[Type[CoreException], StatusCode] = {
-        DomainNotFoundException: StatusCode.NOT_FOUND,
-        UnauthorizedOperationException: StatusCode.UNAUTHENTICATED,
-        ForbiddenOperationException: StatusCode.PERMISSION_DENIED,
-        GatewayUnavailableException: StatusCode.UNAVAILABLE,
-        GatewayTimeoutException: StatusCode.DEADLINE_EXCEEDED,
-        # ...
-    }
-    
-    DEFAULT_STATUS = StatusCode.INTERNAL
-    
-    def get_status(self, exception: CoreException) -> StatusCode:
-        for base_class in type(exception).__mro__:
-            if base_class in self._STATUS_MAP:
-                return self._STATUS_MAP[base_class]
-        return self.DEFAULT_STATUS
-
-
-grpc_status_mapper = GRPCStatusMapper()
-```
-
-```python
-# api/mappers/graphql_mapper.py
-from typing import Type
-from core.exceptions import CoreException, UnauthorizedOperationException, ForbiddenOperationException
-
-
-class GraphQLErrorMapper:
-    """
-    Mapeia exceções para extensões GraphQL.
-    
-    GraphQL sempre retorna 200, mas usa 'extensions' para metadados.
-    """
-    
-    _EXTENSIONS_MAP: dict[Type[CoreException], dict] = {
-        UnauthorizedOperationException: {
-            "code": "UNAUTHENTICATED",
-            "http_status": 401,
-        },
-        ForbiddenOperationException: {
-            "code": "FORBIDDEN", 
-            "http_status": 403,
-        },
-        # ...
-    }
-    
-    def get_extensions(self, exception: CoreException) -> dict:
-        for base_class in type(exception).__mro__:
-            if base_class in self._EXTENSIONS_MAP:
-                return {
-                    **self._EXTENSIONS_MAP[base_class],
-                    "request_id": exception.exception_id,
-                }
-        
-        return {
-            "code": exception.code,
-            "request_id": exception.exception_id,
-        }
-
-
-graphql_error_mapper = GraphQLErrorMapper()
-```
-
-### Estrutura de Pastas Atualizada
-
-```
-project/
-├── core/
-│   └── exceptions/
-│       ├── __init__.py
-│       ├── base.py              # SEM http_status
-│       ├── domain.py
-│       ├── application.py
-│       └── infrastructure.py
-│
-├── api/
-│   ├── mappers/
-│   │   ├── __init__.py
-│   │   ├── http_mapper.py       # HTTPStatusMapper
-│   │   ├── grpc_mapper.py       # GRPCStatusMapper (opcional)
-│   │   └── graphql_mapper.py    # GraphQLErrorMapper (opcional)
-│   ├── exception_handlers.py
-│   └── main.py
-│
-└── ...
-```
-
-### Trade-offs
-
-| Abordagem | Prós | Contras |
-|-----------|------|---------|
-| `http_status` na exceção | Simples, menos código, fácil manutenção | Domínio conhece HTTP |
-| Mapper externo | Domínio puro, suporta múltiplos protocolos | Mais arquivos, mapeamento pode ficar dessincronizado |
-
-**Recomendação**: Comece com `http_status` na exceção. Migre para mapper externo apenas se precisar de múltiplos protocolos ou se o projeto crescer a ponto de virar uma biblioteca compartilhada.
+1. Introduzir o registry, manter `http_status` property como fonte da verdade. Adicionar test de cobertura.
+2. Inverter handler para `resolve_http_status(exc.code)`.
+3. Remover `http_status` de todas as exception classes e refatorar testes.
 
 ---
 
@@ -4149,35 +3885,6 @@ def configure_exception_handlers(app: FastAPI) -> None:
         Exception,
         unhandled_exception_handler
     )
-```
-
-#### Configuração do HTTP Status Mapper (Abordagem Purista)
-
-```python
-# api/config/mapper_config.py
-"""
-Configuração do HTTP Status Mapper.
-Usar apenas se optar pela abordagem purista.
-"""
-from api.mappers.http_mapper import http_status_mapper
-from my_project.exceptions import (
-    PaymentDeclinedException,
-    QuotaExceededException,
-    BiometricValidationException,
-)
-
-
-def configure_http_mapper() -> None:
-    """
-    Registra mapeamentos customizados de exceção -> HTTP status.
-    
-    Usar apenas se optar por remover http_status das exceções.
-    """
-    http_status_mapper.register_many({
-        PaymentDeclinedException: 402,      # Payment Required
-        QuotaExceededException: 429,        # Too Many Requests
-        BiometricValidationException: 422,  # Unprocessable Entity
-    })
 ```
 
 #### Middleware de Correlation ID
@@ -6076,116 +5783,14 @@ class TestIntegration:
         assert body_pt["error"]["message"] != body_en["error"]["message"]
 ```
 
-### Testes do HTTP Status Mapper
+### Testes do Registry de HTTP Status
 
-```python
-# tests/unit/api/test_exception_mapper.py
-import pytest
-from core.exceptions import (
-    CoreException,
-    DomainException,
-    DomainValidationException,
-    BusinessRuleViolationException,
-    DomainNotFoundException,
-    ApplicationException,
-    UseCaseValidationException,
-    UnauthorizedOperationException,
-    InfrastructureException,
-    GatewayTimeoutException,
-    DatabaseConnectionException,
-)
-from api.exception_mapper import HTTPStatusMapper, http_status_mapper
+Ver [ADR-012](../adr/ADR-012-decentralized-error-http-mapping.md#notas-de-implementação) para o teste de cobertura que itera todas as subclasses de `CoreException` e garante que cada `code` tem entrada no registry. Esse teste é o guard principal contra codes esquecidos caindo em 500 silenciosamente.
 
+Testes adicionais:
 
-class TestHTTPStatusMapper:
-    def test_maps_domain_validation_to_422(self):
-        exc = DomainValidationException(message="Invalid")
-        
-        status = http_status_mapper.get_status(exc)
-        
-        assert status == 422
-    
-    def test_maps_not_found_to_404(self):
-        exc = DomainNotFoundException(message="Not found")
-        
-        status = http_status_mapper.get_status(exc)
-        
-        assert status == 404
-    
-    def test_maps_unauthorized_to_401(self):
-        exc = UnauthorizedOperationException(message="Unauthorized")
-        
-        status = http_status_mapper.get_status(exc)
-        
-        assert status == 401
-    
-    def test_maps_gateway_timeout_to_504(self):
-        exc = GatewayTimeoutException(message="Timeout", gateway_name="OCR")
-        
-        status = http_status_mapper.get_status(exc)
-        
-        assert status == 504
-    
-    def test_maps_db_connection_to_503(self):
-        exc = DatabaseConnectionException(message="Connection failed")
-        
-        status = http_status_mapper.get_status(exc)
-        
-        assert status == 503
-    
-    def test_falls_back_to_parent_class_mapping(self):
-        """Exceção customizada deve usar mapeamento da classe pai."""
-        
-        @dataclass
-        class CustomDomainException(DomainException):
-            pass
-        
-        exc = CustomDomainException(message="Custom")
-        
-        status = http_status_mapper.get_status(exc)
-        
-        assert status == 422  # DomainException default
-    
-    def test_returns_500_for_unknown_exception(self):
-        exc = CoreException(message="Unknown")
-        
-        status = http_status_mapper.get_status(exc)
-        
-        assert status == 500
-    
-    def test_register_custom_mapping(self):
-        mapper = HTTPStatusMapper()
-        
-        @dataclass
-        class PaymentDeclinedException(ApplicationException):
-            pass
-        
-        mapper.register(PaymentDeclinedException, 402)
-        
-        exc = PaymentDeclinedException(message="Payment declined")
-        status = mapper.get_status(exc)
-        
-        assert status == 402
-    
-    def test_register_many(self):
-        mapper = HTTPStatusMapper()
-        
-        @dataclass
-        class ExceptionA(CoreException):
-            pass
-        
-        @dataclass
-        class ExceptionB(CoreException):
-            pass
-        
-        mapper.register_many({
-            ExceptionA: 418,
-            ExceptionB: 451,
-        })
-        
-        assert mapper.get_status(ExceptionA(message="A")) == 418
-        assert mapper.get_status(ExceptionB(message="B")) == 451
-```
+- `tests/building_blocks/unit/presentation/test_error_mapping.py` — `register_http_statuses` é idempotente para valores iguais e levanta em conflito real.
+- `tests/modules/{bc}/unit/presentation/test_error_mapping.py` — cada BC com mapping próprio valida que `{BC}_HTTP_STATUSES` cobre todos os codes do BC.
 
 ### Executando os Testes
 


### PR DESCRIPTION
## Summary

- Add **ADR-012** documenting the move from the `http_status` property on exception classes to a **decentralized registry** keyed by error `code`, registered per Bounded Context at bootstrap. Domain/application/infrastructure layers stop knowing HTTP.
- Update `docs/standards/exception-hierarchy-clean-architecture.md`: top-of-doc migration banner, §4 ("Trade-off Pragmático") inverted to point to ADR-012, §8 rewritten as "HTTP Status Mapping (Registry Descentralizado)" replacing the previous class-MRO purist alternative, and removed two obsolete sub-subsections that documented the rejected approach (`Configuração do HTTP Status Mapper` and `Testes do HTTP Status Mapper`).
- Refresh `docs/adr/README.md` index (filled the gap ADR-007 to ADR-011 + added ADR-012) and route the new ADR through the `homeflix-arch` skill (`.claude/skills/homeflix-arch/references/adr_index.md`).

This PR is **docs-only**. Implementation lands in 3 follow-up PRs per the migration plan in ADR-012 §Migração: (1) introduce registry while keeping the property, (2) invert handler to read via `resolve_http_status(exc.code)`, (3) remove the property and refactor 18 tests.

## Test plan

- [ ] Markdown renders cleanly on GitHub for `ADR-012-decentralized-error-http-mapping.md` (headings, tables, code fences).
- [ ] All cross-links resolve: from §4/§8 of the standards doc → ADR-012; from `adr_index.md` → ADR-012; from `adr/README.md` table → ADR-012.
- [ ] `grep -n "Mapper Externo\|Abordagem Purista\|http_status_mapper\|HTTPStatusMapper\|api\.exception_mapper\|api\.mappers" docs/standards/exception-hierarchy-clean-architecture.md` returns nothing (no stale refs to the removed alternative).
- [ ] `docs/adr/README.md` table contains rows for ADR-007 through ADR-012 with correct dates.
- [ ] No source code under `src/` modified.

## Related

- Inspired by the `valid` project's ADR-0008 (placed in `specs/` for context, not part of HomeFlix's ADR set).
- Builds on ADR-008 (Screaming Architecture) — error mapping is the next cross-cutting concern to organize per BC.
- References ADR-004 (DI/composition root) — bootstrap point.

## Summary by Sourcery

Document the architectural decision to replace exception-level HTTP status properties with a decentralized error-code-to-HTTP-status registry and wire it into the documentation set.

Documentation:
- Add ADR-012 describing a decentralized error→HTTP status mapping registry keyed by error code and registered per bounded context at bootstrap.
- Update the exception hierarchy standards document to reference ADR-012, explain the new registry-based HTTP status mapping approach, and remove the previously documented purist mapper alternative sections.
- Refresh the ADR index in docs/adr/README.md to include ADR-007 through ADR-012 with their current statuses and dates.
- Extend the homeflix-arch skill ADR index to cover ADR-012, including when to consult it and how to handle HTTP status mappings during the migration.