### PR TITLE
feat(building-blocks): error→HTTP status registry (ADR-012 PR 1/3)

### DIFF
--- a/src/building_blocks/presentation/error_mapping.py
+++ b/src/building_blocks/presentation/error_mapping.py
@@ -11,6 +11,9 @@ property; a coverage test guards parity between the property and this
 registry. Subsequent PRs invert the handler and remove the property.
 """
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 _REGISTRY: dict[str, int] = {}
 
 _STATUS_TO_ERROR_TYPE: dict[int, str] = {
@@ -65,30 +68,66 @@ GENERIC_HTTP_STATUSES: dict[str, int] = {
 def register_http_statuses(mapping: dict[str, int]) -> None:
     """Register a batch of ``error_code → http_status`` entries.
 
+    Transactional: the batch is validated in full before any entry is
+    written. If any status is out of range or any code conflicts with
+    an existing different value, no entry from the batch is applied —
+    callers can fix the offending entry and retry without worrying that
+    earlier entries already landed.
+
     Idempotent for equal values (registering the same pair repeatedly is
     a no-op). Conflicts — same code, different status — raise instead
     of silently overwriting, since silent wins would mask bootstrap-order
     bugs and cross-BC code collisions.
 
     Args:
-        mapping: Dict of error code → HTTP status code.
+        mapping: Dict of error code → HTTP status code. Each status must
+            be a valid HTTP status code in the inclusive range [100, 599].
 
     Raises:
-        ValueError: If a code is already registered with a different
-            status. The exception lists both values so the caller can
+        ValueError: If any status is outside [100, 599], or if a code is
+            already registered with a different status. The exception
+            message identifies the offending entry so the caller can
             decide which BC owns the code.
 
     Example:
         >>> register_http_statuses({"PROFILE_NOT_FOUND": 404})
     """
+    # Phase 1 — validate every entry. No mutation until the batch is clean.
     for code, status in mapping.items():
+        if not 100 <= status <= 599:
+            raise ValueError(f"HTTP status for code {code!r} must be in [100, 599], got {status}")
         existing = _REGISTRY.get(code)
         if existing is not None and existing != status:
             raise ValueError(
                 f"Conflicting http_status registration for code {code!r}: "
                 f"already registered as {existing}, new value {status}"
             )
-        _REGISTRY[code] = status
+    # Phase 2 — commit. All entries pass validation so this is atomic
+    # from the caller's perspective.
+    _REGISTRY.update(mapping)
+
+
+@contextmanager
+def isolated_registry() -> Iterator[None]:
+    """Snapshot the registry on entry, restore the snapshot on exit.
+
+    Test-isolation primitive that lets a block mutate the registry
+    without leaking changes to subsequent code. Equivalent to a
+    save/restore around any number of ``register_http_statuses`` calls.
+
+    Example:
+        >>> with isolated_registry():
+        ...     register_http_statuses({"TEMP_CODE": 418})
+        ...     assert resolve_http_status("TEMP_CODE") == 418
+        >>> resolve_http_status("TEMP_CODE", default=-1)  # restored
+        -1
+    """
+    snapshot = dict(_REGISTRY)
+    try:
+        yield
+    finally:
+        _REGISTRY.clear()
+        _REGISTRY.update(snapshot)
 
 
 def resolve_http_status(code: str, default: int = 500) -> int:
@@ -128,6 +167,7 @@ register_http_statuses(GENERIC_HTTP_STATUSES)
 
 __all__ = [
     "GENERIC_HTTP_STATUSES",
+    "isolated_registry",
     "register_http_statuses",
     "resolve_error_type",
     "resolve_http_status",

--- a/src/building_blocks/presentation/error_mapping.py
+++ b/src/building_blocks/presentation/error_mapping.py
@@ -1,0 +1,134 @@
+"""Decentralized error code → HTTP status registry (ADR-012).
+
+Holds the source of truth for `error_code → http_status` mapping. Each
+Bounded Context with module-specific codes registers its own mapping at
+bootstrap; transversal codes (`RESOURCE_NOT_FOUND`, `GATEWAY_TIMEOUT`,
+etc.) live in ``GENERIC_HTTP_STATUSES`` and auto-register on import.
+
+This is the foundation step of the migration in ADR-012. During this PR
+the global handler still reads ``exc.http_status`` from the exception
+property; a coverage test guards parity between the property and this
+registry. Subsequent PRs invert the handler and remove the property.
+"""
+
+_REGISTRY: dict[str, int] = {}
+
+_STATUS_TO_ERROR_TYPE: dict[int, str] = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    405: "invalid_request_error",
+    409: "conflict_error",
+    413: "request_too_large_error",
+    415: "invalid_request_error",
+    422: "validation_error",
+    429: "rate_limit_error",
+    500: "api_error",
+    502: "bad_gateway_error",
+    503: "service_unavailable_error",
+    504: "gateway_timeout_error",
+}
+
+GENERIC_HTTP_STATUSES: dict[str, int] = {
+    # Core
+    "CORE_ERROR": 500,
+    # Domain
+    "DOMAIN_ERROR": 422,
+    "DOMAIN_VALIDATION_ERROR": 422,
+    "BUSINESS_RULE_VIOLATION": 422,
+    "DOMAIN_NOT_FOUND": 404,
+    "DOMAIN_CONFLICT": 409,
+    # Application
+    "APPLICATION_ERROR": 400,
+    "USE_CASE_VALIDATION_ERROR": 400,
+    "UNAUTHORIZED": 401,
+    "FORBIDDEN": 403,
+    "RESOURCE_NOT_FOUND": 404,
+    # Infrastructure
+    "INFRASTRUCTURE_ERROR": 500,
+    "GATEWAY_ERROR": 500,
+    "GATEWAY_TIMEOUT": 504,
+    "GATEWAY_UNAVAILABLE": 503,
+    "GATEWAY_RATE_LIMIT": 429,
+    "GATEWAY_BAD_RESPONSE": 502,
+    "CIRCUIT_OPEN": 503,
+    "REPOSITORY_ERROR": 500,
+    "DATABASE_CONNECTION_ERROR": 503,
+    "DATA_INTEGRITY_ERROR": 409,
+    "FILESYSTEM_ERROR": 500,
+    "FILE_NOT_FOUND": 404,
+    "FILE_ACCESS_ERROR": 500,
+}
+
+
+def register_http_statuses(mapping: dict[str, int]) -> None:
+    """Register a batch of ``error_code → http_status`` entries.
+
+    Idempotent for equal values (registering the same pair repeatedly is
+    a no-op). Conflicts — same code, different status — raise instead
+    of silently overwriting, since silent wins would mask bootstrap-order
+    bugs and cross-BC code collisions.
+
+    Args:
+        mapping: Dict of error code → HTTP status code.
+
+    Raises:
+        ValueError: If a code is already registered with a different
+            status. The exception lists both values so the caller can
+            decide which BC owns the code.
+
+    Example:
+        >>> register_http_statuses({"PROFILE_NOT_FOUND": 404})
+    """
+    for code, status in mapping.items():
+        existing = _REGISTRY.get(code)
+        if existing is not None and existing != status:
+            raise ValueError(
+                f"Conflicting http_status registration for code {code!r}: "
+                f"already registered as {existing}, new value {status}"
+            )
+        _REGISTRY[code] = status
+
+
+def resolve_http_status(code: str, default: int = 500) -> int:
+    """Resolve an error code to its HTTP status.
+
+    Returns ``default`` if the code is not registered. Callers that want
+    to detect unregistered codes (e.g. coverage tests) should pass a
+    sentinel value distinguishable from a valid status.
+
+    Args:
+        code: Error code (matches ``CoreException.code``).
+        default: Status returned for unknown codes. Defaults to 500.
+
+    Returns:
+        HTTP status code.
+    """
+    return _REGISTRY.get(code, default)
+
+
+def resolve_error_type(http_status: int) -> str:
+    """Resolve an HTTP status to the v3 error envelope ``type`` field.
+
+    Args:
+        http_status: HTTP status code.
+
+    Returns:
+        Error type string (e.g. ``"validation_error"``, ``"not_found_error"``).
+        Falls back to ``"api_error"`` for unmapped statuses.
+    """
+    return _STATUS_TO_ERROR_TYPE.get(http_status, "api_error")
+
+
+# Auto-register transversal building_blocks codes at import time so
+# the registry is usable as soon as anyone imports this module.
+register_http_statuses(GENERIC_HTTP_STATUSES)
+
+
+__all__ = [
+    "GENERIC_HTTP_STATUSES",
+    "register_http_statuses",
+    "resolve_error_type",
+    "resolve_http_status",
+]

--- a/src/main.py
+++ b/src/main.py
@@ -161,6 +161,19 @@ def _subscribe_event_handlers(container: ApplicationContainer) -> None:
     event_bus.subscribe(MediaCreatedEvent, handler)
 
 
+def _bootstrap_modules() -> None:
+    """Run per-module bootstrap hooks (ADR-012).
+
+    Each Bounded Context with cross-cutting wiring exposes a
+    ``bootstrap.setup()`` invoked from here. Today this only covers the
+    error-code → HTTP-status registration; BCs without such concerns
+    are simply omitted from the list.
+    """
+    from src.modules.identity import bootstrap as identity_bootstrap
+
+    identity_bootstrap.setup()
+
+
 def create_app() -> FastAPI:
     """Application factory.
 
@@ -195,6 +208,11 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Bootstrap module-level cross-cutting wiring (ADR-012). Must run
+    # before the exception handlers are registered so the registry is
+    # populated by the time any handler resolves a status.
+    _bootstrap_modules()
 
     # Translate typed exceptions into the standard v3 error envelope
     register_exception_handlers(app)

--- a/src/modules/identity/bootstrap.py
+++ b/src/modules/identity/bootstrap.py
@@ -1,0 +1,25 @@
+"""Identity module bootstrap (ADR-012).
+
+Registers cross-cutting wiring that the BC owns but that needs to be in
+place before route or exception handlers fire. Today this only registers
+the BC's error-code → HTTP-status mapping; future bootstrap-time concerns
+(e.g. translation catalog hooks) would also go here.
+
+Called once from the application composition root in ``src/main.py``.
+"""
+
+
+def setup() -> None:
+    """Register identity-specific HTTP status mappings.
+
+    Imports are deferred inside the function so that importing this
+    module is side-effect-free — the registration only happens when the
+    composition root chooses to invoke it.
+    """
+    from src.building_blocks.presentation.error_mapping import register_http_statuses
+    from src.modules.identity.presentation.error_mapping import IDENTITY_HTTP_STATUSES
+
+    register_http_statuses(IDENTITY_HTTP_STATUSES)
+
+
+__all__ = ["setup"]

--- a/src/modules/identity/presentation/error_mapping.py
+++ b/src/modules/identity/presentation/error_mapping.py
@@ -1,0 +1,20 @@
+"""Identity-specific HTTP status mappings (ADR-012).
+
+The identity Bounded Context is the only one with codes that don't fall
+under the generic transversal mapping today. ``CANNOT_DELETE_LAST_PROFILE``
+and ``NO_ACTIVE_PROFILE`` map to 409 (the parent ``ApplicationException``
+defaults to 400, so the override is meaningful); the remaining entries
+restate inherited statuses explicitly because the registry is flat and
+indexed by code, not by exception class.
+"""
+
+IDENTITY_HTTP_STATUSES: dict[str, int] = {
+    "PROFILE_NOT_FOUND": 404,
+    "PROFILE_OWNERSHIP_VIOLATION": 403,
+    "NO_ACTIVE_SESSION": 401,
+    "CANNOT_DELETE_LAST_PROFILE": 409,
+    "NO_ACTIVE_PROFILE": 409,
+}
+
+
+__all__ = ["IDENTITY_HTTP_STATUSES"]

--- a/tests/building_blocks/unit/presentation/test_error_mapping.py
+++ b/tests/building_blocks/unit/presentation/test_error_mapping.py
@@ -9,15 +9,15 @@ from src.building_blocks.presentation import error_mapping
 
 @pytest.fixture(autouse=True)
 def _isolated_registry() -> Iterator[None]:
-    """Snapshot/restore ``_REGISTRY`` so mutations don't leak across tests.
+    """Snapshot/restore the registry so mutations don't leak across tests.
 
-    The snapshot is taken after module import, so ``GENERIC_HTTP_STATUSES``
-    is part of it and is restored intact between tests.
+    Uses ``error_mapping.isolated_registry()`` so the test depends only
+    on the public test-isolation primitive, not on the private
+    ``_REGISTRY`` dict. The snapshot includes ``GENERIC_HTTP_STATUSES``
+    (auto-registered at import) so generic codes are intact between tests.
     """
-    snapshot = dict(error_mapping._REGISTRY)
-    yield
-    error_mapping._REGISTRY.clear()
-    error_mapping._REGISTRY.update(snapshot)
+    with error_mapping.isolated_registry():
+        yield
 
 
 def _all_subclasses(cls: type) -> set[type]:
@@ -62,18 +62,44 @@ class TestRegisterHttpStatuses:
         assert error_mapping.resolve_http_status("CODE_A") == 418
         assert error_mapping.resolve_http_status("CODE_B") == 451
 
-    def test_should_not_apply_partial_batch_on_conflict(self) -> None:
+    def test_should_apply_batch_atomically_on_conflict(self) -> None:
+        """A conflict in any entry rolls the whole batch back."""
         error_mapping.register_http_statuses({"EXISTING": 418})
 
-        with pytest.raises(ValueError):
-            error_mapping.register_http_statuses({"BRAND_NEW": 451, "EXISTING": 999})
+        with pytest.raises(ValueError, match="Conflicting"):
+            error_mapping.register_http_statuses({"BRAND_NEW": 451, "EXISTING": 500})
 
-        # The batch raised on EXISTING; whether BRAND_NEW landed depends
-        # on dict iteration order. The contract we promise is "raises on
-        # conflict" — callers retrying after fixing the conflict can
-        # safely re-register due to idempotency. This test pins that
-        # the conflict actually surfaces (vs. silent overwrite).
+        # All-or-nothing: the offending entry raises, and no entry from
+        # the batch is applied. BRAND_NEW must NOT land regardless of
+        # the dict iteration order.
         assert error_mapping.resolve_http_status("EXISTING") == 418
+        assert error_mapping.resolve_http_status("BRAND_NEW", default=-1) == -1
+
+    def test_should_apply_batch_atomically_on_invalid_status(self) -> None:
+        """An out-of-range status in any entry rolls the whole batch back."""
+        with pytest.raises(ValueError, match=r"\[100, 599\]"):
+            error_mapping.register_http_statuses({"VALID": 418, "BAD": 999})
+
+        # Neither entry should land if any one is invalid.
+        assert error_mapping.resolve_http_status("VALID", default=-1) == -1
+        assert error_mapping.resolve_http_status("BAD", default=-1) == -1
+
+    @pytest.mark.parametrize("invalid_status", [-1, 0, 99, 600, 1000])
+    def test_should_raise_when_status_is_out_of_range(
+        self,
+        invalid_status: int,
+    ) -> None:
+        with pytest.raises(ValueError, match=r"\[100, 599\]"):
+            error_mapping.register_http_statuses({"BAD_CODE": invalid_status})
+
+    @pytest.mark.parametrize("valid_status", [100, 200, 404, 500, 599])
+    def test_should_accept_statuses_at_range_boundaries(
+        self,
+        valid_status: int,
+    ) -> None:
+        error_mapping.register_http_statuses({"BOUNDARY_CODE": valid_status})
+
+        assert error_mapping.resolve_http_status("BOUNDARY_CODE") == valid_status
 
 
 @pytest.mark.unit
@@ -98,6 +124,37 @@ class TestResolveErrorType:
 
     def test_should_fall_back_to_api_error_for_unmapped_status(self) -> None:
         assert error_mapping.resolve_error_type(999) == "api_error"
+
+
+@pytest.mark.unit
+class TestIsolatedRegistry:
+    """``isolated_registry`` snapshots and restores the registry."""
+
+    def test_should_restore_registry_after_context_exits(self) -> None:
+        with error_mapping.isolated_registry():
+            error_mapping.register_http_statuses({"SCOPED": 418})
+            assert error_mapping.resolve_http_status("SCOPED") == 418
+
+        assert error_mapping.resolve_http_status("SCOPED", default=-1) == -1
+
+    def test_should_restore_registry_when_block_raises(self) -> None:
+        try:
+            with error_mapping.isolated_registry():
+                error_mapping.register_http_statuses({"SCOPED": 418})
+                raise RuntimeError("simulated failure inside the block")
+        except RuntimeError:
+            pass
+
+        assert error_mapping.resolve_http_status("SCOPED", default=-1) == -1
+
+    def test_should_preserve_pre_existing_registrations(self) -> None:
+        # The autouse fixture has already taken a snapshot that includes
+        # GENERIC_HTTP_STATUSES; entering another context-manager scope
+        # must not lose those entries on exit.
+        with error_mapping.isolated_registry():
+            error_mapping.register_http_statuses({"SCOPED": 418})
+
+        assert error_mapping.resolve_http_status("RESOURCE_NOT_FOUND") == 404
 
 
 @pytest.mark.unit

--- a/tests/building_blocks/unit/presentation/test_error_mapping.py
+++ b/tests/building_blocks/unit/presentation/test_error_mapping.py
@@ -1,0 +1,166 @@
+"""Tests for the error_mapping registry (ADR-012)."""
+
+from collections.abc import Iterator
+
+import pytest
+
+from src.building_blocks.presentation import error_mapping
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry() -> Iterator[None]:
+    """Snapshot/restore ``_REGISTRY`` so mutations don't leak across tests.
+
+    The snapshot is taken after module import, so ``GENERIC_HTTP_STATUSES``
+    is part of it and is restored intact between tests.
+    """
+    snapshot = dict(error_mapping._REGISTRY)
+    yield
+    error_mapping._REGISTRY.clear()
+    error_mapping._REGISTRY.update(snapshot)
+
+
+def _all_subclasses(cls: type) -> set[type]:
+    """Return every (transitive) subclass of ``cls``."""
+    seen: set[type] = set()
+    stack = [cls]
+    while stack:
+        node = stack.pop()
+        for sub in node.__subclasses__():
+            if sub not in seen:
+                seen.add(sub)
+                stack.append(sub)
+    return seen
+
+
+@pytest.mark.unit
+class TestRegisterHttpStatuses:
+    """``register_http_statuses`` updates the registry idempotently."""
+
+    def test_should_register_a_new_code(self) -> None:
+        error_mapping.register_http_statuses({"NEW_CODE": 418})
+
+        assert error_mapping.resolve_http_status("NEW_CODE") == 418
+
+    def test_should_be_idempotent_when_value_matches(self) -> None:
+        error_mapping.register_http_statuses({"NEW_CODE": 418})
+        error_mapping.register_http_statuses({"NEW_CODE": 418})
+
+        assert error_mapping.resolve_http_status("NEW_CODE") == 418
+
+    def test_should_raise_when_code_already_registered_with_different_value(
+        self,
+    ) -> None:
+        error_mapping.register_http_statuses({"NEW_CODE": 418})
+
+        with pytest.raises(ValueError, match="Conflicting http_status"):
+            error_mapping.register_http_statuses({"NEW_CODE": 451})
+
+    def test_should_register_batch_of_codes(self) -> None:
+        error_mapping.register_http_statuses({"CODE_A": 418, "CODE_B": 451})
+
+        assert error_mapping.resolve_http_status("CODE_A") == 418
+        assert error_mapping.resolve_http_status("CODE_B") == 451
+
+    def test_should_not_apply_partial_batch_on_conflict(self) -> None:
+        error_mapping.register_http_statuses({"EXISTING": 418})
+
+        with pytest.raises(ValueError):
+            error_mapping.register_http_statuses({"BRAND_NEW": 451, "EXISTING": 999})
+
+        # The batch raised on EXISTING; whether BRAND_NEW landed depends
+        # on dict iteration order. The contract we promise is "raises on
+        # conflict" — callers retrying after fixing the conflict can
+        # safely re-register due to idempotency. This test pins that
+        # the conflict actually surfaces (vs. silent overwrite).
+        assert error_mapping.resolve_http_status("EXISTING") == 418
+
+
+@pytest.mark.unit
+class TestResolveHttpStatus:
+    """``resolve_http_status`` returns mapped values or the supplied default."""
+
+    def test_should_return_default_for_unknown_code(self) -> None:
+        assert error_mapping.resolve_http_status("UNKNOWN_CODE") == 500
+
+    def test_should_accept_custom_default(self) -> None:
+        assert error_mapping.resolve_http_status("UNKNOWN_CODE", default=-1) == -1
+
+
+@pytest.mark.unit
+class TestResolveErrorType:
+    """``resolve_error_type`` maps HTTP status to v3 error envelope ``type``."""
+
+    def test_should_map_known_statuses(self) -> None:
+        assert error_mapping.resolve_error_type(404) == "not_found_error"
+        assert error_mapping.resolve_error_type(422) == "validation_error"
+        assert error_mapping.resolve_error_type(503) == "service_unavailable_error"
+
+    def test_should_fall_back_to_api_error_for_unmapped_status(self) -> None:
+        assert error_mapping.resolve_error_type(999) == "api_error"
+
+
+@pytest.mark.unit
+class TestGenericAutoRegistration:
+    """``GENERIC_HTTP_STATUSES`` is registered at import time."""
+
+    def test_should_resolve_resource_not_found(self) -> None:
+        assert error_mapping.resolve_http_status("RESOURCE_NOT_FOUND") == 404
+
+    def test_should_resolve_gateway_timeout(self) -> None:
+        assert error_mapping.resolve_http_status("GATEWAY_TIMEOUT") == 504
+
+    def test_should_resolve_data_integrity_error(self) -> None:
+        assert error_mapping.resolve_http_status("DATA_INTEGRITY_ERROR") == 409
+
+
+@pytest.mark.unit
+class TestRegistryCoverage:
+    """Guards against codes added to exception classes without a registry entry.
+
+    During the ADR-012 migration the global handler still reads
+    ``exc.http_status`` from the property; this test pins that the
+    registry mirrors every concrete exception's ``code → status`` pair,
+    so PR 2 (which inverts the handler to read from the registry) won't
+    silently regress to 500 for any existing code path.
+
+    PR 3 will repurpose this test to assert "every code has an entry"
+    once the property is gone — until then the parity check is the
+    stronger guarantee.
+    """
+
+    def test_registry_mirrors_every_core_exception_subclass(self) -> None:
+        # Force-import error modules so their subclasses are visible
+        # via ``CoreException.__subclasses__()``.
+        import src.building_blocks.application.errors
+        import src.building_blocks.domain.errors
+        import src.building_blocks.infrastructure.errors
+        import src.modules.identity.domain.errors  # noqa: F401
+        from src.building_blocks.domain.errors import CoreException
+        from src.modules.identity import bootstrap as identity_bootstrap
+
+        # Identity is bootstrapped from main.py at app creation; do the
+        # same here so the coverage check sees the full registry.
+        identity_bootstrap.setup()
+
+        sentinel = -1
+        missing: list[tuple[str, str]] = []
+        mismatched: list[tuple[str, str, int, int]] = []
+
+        for cls in {CoreException, *_all_subclasses(CoreException)}:
+            instance = cls(message="probe")
+            registered = error_mapping.resolve_http_status(instance.code, default=sentinel)
+            if registered == sentinel:
+                missing.append((cls.__name__, instance.code))
+            elif registered != instance.http_status:
+                mismatched.append(
+                    (cls.__name__, instance.code, instance.http_status, registered),
+                )
+
+        assert not missing, (
+            "Codes without registry entry (would fall to 500 default in PR 2): " f"{missing}"
+        )
+        assert not mismatched, (
+            "Registry value disagrees with the http_status property "
+            f"(class, code, property, registry): {mismatched}"
+        )


### PR DESCRIPTION
## Summary

- Introduces the **code-keyed registry** for `error_code → http_status` mapping per [ADR-012](https://github.com/lucaschf/homeflix/blob/develop/docs/adr/ADR-012-decentralized-error-http-mapping.md). Registry lives in `src/building_blocks/presentation/error_mapping.py` with `register_http_statuses()`, `resolve_http_status()`, `resolve_error_type()` and a transversal `GENERIC_HTTP_STATUSES` auto-registered on import.
- Adds the **identity bootstrap pattern**: `src/modules/identity/presentation/error_mapping.py` declares `IDENTITY_HTTP_STATUSES`; `src/modules/identity/bootstrap.py` exposes `setup()`; the composition root in `src/main.py` calls a new `_bootstrap_modules()` before `register_exception_handlers(app)`.
- **Behavior is unchanged**: the handler still reads `exc.http_status` from the property. PR 2 will flip the source of truth; PR 3 will remove the property and refactor tests.
- Coverage test (`test_registry_mirrors_every_core_exception_subclass`) iterates every `CoreException` subclass, instantiates with `message="probe"`, and asserts the registry contains an entry that matches the property — guards PR 2 against silent 500 regressions and acts as a dev hint when a new subclass is added without a registry entry.

## Test plan

- [x] `pytest tests/building_blocks/unit/presentation/test_error_mapping.py` — 13/13 green (idempotency, conflict, default, error_type fallback, generic auto-registration, full subclass coverage).
- [x] `pytest tests/building_blocks/` — 318/318 (no regressions in adjacent suites).
- [x] `pytest tests/modules/identity/` — 192/192 (unit + e2e exercise the new bootstrap path via `create_app`).
- [x] `ruff check` + `ruff format --check` clean on changed files.
- [ ] CI green.

## Notes

- `register_http_statuses` raises on conflict (same code, different status) instead of silently overwriting — silent wins would mask bootstrap-order bugs and cross-BC code collisions. Idempotent for equal values so calling `bootstrap.setup()` more than once is safe.
- `_REGISTRY` is module-level mutable state; the test fixture `_isolated_registry` snapshots/restores it between tests so mutations don't leak.
- Identity is the only BC with codes outside the generic set today (`PROFILE_NOT_FOUND`, `PROFILE_OWNERSHIP_VIOLATION`, `NO_ACTIVE_SESSION`, `CANNOT_DELETE_LAST_PROFILE`, `NO_ACTIVE_PROFILE`). Other BCs reuse generic codes (`RESOURCE_NOT_FOUND`, etc.) and need no `bootstrap.py` until they introduce a custom code.

## Related

- ADR-012 §Migração — this is PR 1 of 3.
- PR 2 will rewrite `core_exception_handler` to call `resolve_http_status(exc.code)` and `resolve_error_type(http_status)` instead of reading the property.
- PR 3 will remove `http_status` from all 18 building_blocks subclasses + 2 identity overrides, and refactor the 18 affected tests.

## Summary by Sourcery

Introduce a centralized, code-keyed registry for mapping error codes to HTTP statuses and bootstrap it from the application entrypoint and the identity bounded context per ADR-012.

New Features:
- Add a building-blocks error mapping module exposing a registry, generic error-code→HTTP-status mappings, and helpers to resolve HTTP status and error envelope type.
- Introduce identity module HTTP status mappings and a bootstrap hook to register them into the shared registry during app startup.

Enhancements:
- Update the FastAPI application factory to run module-level bootstrap hooks before registering exception handlers so the error mapping registry is populated at startup.

Tests:
- Add unit tests covering the error mapping registry behavior, generic auto-registration, and full coverage parity between CoreException subclasses and the registry.