### PR TITLE
feat(building-blocks): handler reads from registry (ADR-012 PR 2/3)

### DIFF
--- a/src/building_blocks/presentation/exception_handlers.py
+++ b/src/building_blocks/presentation/exception_handlers.py
@@ -19,24 +19,11 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request
 
 from src.building_blocks.domain.errors import CoreException, Severity
+from src.building_blocks.presentation.error_mapping import (
+    resolve_error_type,
+    resolve_http_status,
+)
 from src.config.logging import get_logger
-
-_STATUS_TO_ERROR_TYPE = {
-    400: "invalid_request_error",
-    401: "authentication_error",
-    403: "permission_error",
-    404: "not_found_error",
-    405: "invalid_request_error",
-    409: "conflict_error",
-    413: "request_too_large_error",
-    415: "invalid_request_error",
-    422: "validation_error",
-    429: "rate_limit_error",
-    500: "api_error",
-    502: "bad_gateway_error",
-    503: "service_unavailable_error",
-    504: "gateway_timeout_error",
-}
 
 # Keys a caller may supply via ``HTTPException(detail={...})`` — everything
 # else is dropped so an attacker-controlled or typo'd dict can't reshape
@@ -47,9 +34,15 @@ _ALLOWED_DETAIL_KEYS = frozenset({"message", "code", "param", "details"})
 async def core_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Translate typed domain/application/infra exceptions into HTTP.
 
+    HTTP status and error ``type`` are resolved through the registry
+    (ADR-012) keyed by ``exc.code``, not from the exception class. The
+    body comes from ``CoreException.to_dict()`` with the ``type`` field
+    overridden so the registry stays the single source of truth — this
+    matters once the ``http_status`` property is removed in the next
+    migration step. ``_internal`` is never serialized.
+
     Logging level is chosen from ``exc.severity`` so a 4xx doesn't look
-    like a 5xx in the logs. The payload uses ``CoreException.to_dict()``
-    — no sensitive ``_internal`` block is ever serialized.
+    like a 5xx in the logs.
 
     The ``Exception`` parameter type matches FastAPI's handler protocol;
     registration in ``register_exception_handlers`` guarantees this
@@ -57,15 +50,20 @@ async def core_exception_handler(request: Request, exc: Exception) -> JSONRespon
     ``cast`` instead of a runtime check.
     """
     exc = cast(CoreException, exc)
+    http_status = resolve_http_status(exc.code)
+    error_type = resolve_error_type(http_status)
+
     logger = get_logger().bind(
         exception_id=exc.exception_id,
         code=exc.code,
-        http_status=exc.http_status,
+        http_status=http_status,
         path=request.url.path,
     )
     _log_with_severity(logger, exc)
 
-    return JSONResponse(status_code=exc.http_status, content=exc.to_dict())
+    content = exc.to_dict()
+    content["type"] = error_type
+    return JSONResponse(status_code=http_status, content=content)
 
 
 async def request_validation_exception_handler(
@@ -106,7 +104,7 @@ async def http_exception_handler(request: Request, exc: Exception) -> JSONRespon
     see the same shape as typed exceptions.
     """
     exc = cast(StarletteHTTPException, exc)
-    error_type = _STATUS_TO_ERROR_TYPE.get(exc.status_code, "api_error")
+    error_type = resolve_error_type(exc.status_code)
 
     detail = exc.detail
     content: dict[str, Any] = {"type": error_type}

--- a/tests/building_blocks/unit/presentation/test_exception_handlers.py
+++ b/tests/building_blocks/unit/presentation/test_exception_handlers.py
@@ -234,6 +234,27 @@ class TestHttpExceptionTranslation:
         assert body["param"] == "email"
         assert body["details"] == {"expected": "string"}
 
+    def test_should_fall_back_to_api_error_type_for_unmapped_status(self) -> None:
+        """End-to-end fallback: an HTTP status with no entry in the registry's
+        ``_STATUS_TO_ERROR_TYPE`` table surfaces as ``"api_error"`` in the
+        envelope. Pins the contract that consolidating the local
+        ``_STATUS_TO_ERROR_TYPE`` into ``resolve_error_type`` preserved the
+        previous default behavior at the handler boundary, not just inside
+        the helper.
+        """
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise HTTPException(status_code=418, detail="i'm a teapot")
+
+        response = TestClient(app).get("/foo")
+
+        assert response.status_code == 418
+        body = response.json()
+        assert body["type"] == "api_error"
+        assert body["message"] == "i'm a teapot"
+
     def test_should_default_message_and_code_when_dict_detail_lacks_them(self) -> None:
         app = _make_app()
 
@@ -308,7 +329,14 @@ class TestRegistryDrivesCoreHandler:
             response = TestClient(app).get("/foo")
 
         assert response.status_code == 409
-        assert response.json()["type"] == "conflict_error"
+        body = response.json()
+        assert body["type"] == "conflict_error"
+        # The rest of the envelope still flows from CoreException.to_dict() —
+        # only the registry-driven `type` is overridden. If the handler
+        # ever stops calling `to_dict()` or reshapes its output, these
+        # assertions catch it.
+        assert body["message"] == "probe"
+        assert body["code"] == "PR2_TYPE_PROBE"
 
     def test_unregistered_code_falls_back_to_500(self) -> None:
         @dataclass

--- a/tests/building_blocks/unit/presentation/test_exception_handlers.py
+++ b/tests/building_blocks/unit/presentation/test_exception_handlers.py
@@ -5,6 +5,8 @@ translation path (status, body, handler selection) rather than calling
 the handlers directly with hand-rolled requests.
 """
 
+from dataclasses import dataclass
+
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -15,9 +17,11 @@ from src.building_blocks.application.errors import (
 )
 from src.building_blocks.domain.errors import (
     BusinessRuleViolationException,
+    CoreException,
     DomainValidationException,
 )
 from src.building_blocks.infrastructure.errors import GatewayTimeoutException
+from src.building_blocks.presentation import error_mapping
 from src.building_blocks.presentation.exception_handlers import (
     register_exception_handlers,
 )
@@ -246,6 +250,92 @@ class TestHttpExceptionTranslation:
             "message": "",
             "code": "CONFLICT_ERROR",
         }
+
+
+@pytest.mark.unit
+class TestRegistryDrivesCoreHandler:
+    """``core_exception_handler`` resolves status and type via the registry.
+
+    Builds a synthetic ``CoreException`` subclass whose ``http_status``
+    property disagrees with the registry on purpose, and asserts the
+    response uses the registry value. This pins the inversion done in
+    ADR-012 PR 2: the property is no longer the source of truth, so the
+    next migration step can remove it without changing observable HTTP
+    behavior.
+    """
+
+    def test_response_status_comes_from_registry_not_property(self) -> None:
+        @dataclass
+        class _ProbeError(CoreException):
+            code: str = "PR2_PROBE_CODE"
+
+            @property
+            def http_status(self) -> int:  # disagrees with registry on purpose
+                return 200
+
+        with error_mapping.isolated_registry():
+            error_mapping.register_http_statuses({"PR2_PROBE_CODE": 418})
+
+            app = _make_app()
+
+            @app.get("/foo")
+            async def _route() -> None:
+                raise _ProbeError(message="probe")
+
+            response = TestClient(app).get("/foo")
+
+        assert response.status_code == 418
+
+    def test_response_type_comes_from_registry_not_property(self) -> None:
+        @dataclass
+        class _ProbeError(CoreException):
+            code: str = "PR2_TYPE_PROBE"
+
+            @property
+            def http_status(self) -> int:  # would resolve to "validation_error"
+                return 422
+
+        with error_mapping.isolated_registry():
+            # Registry maps the code to 409, which translates to "conflict_error".
+            error_mapping.register_http_statuses({"PR2_TYPE_PROBE": 409})
+
+            app = _make_app()
+
+            @app.get("/foo")
+            async def _route() -> None:
+                raise _ProbeError(message="probe")
+
+            response = TestClient(app).get("/foo")
+
+        assert response.status_code == 409
+        assert response.json()["type"] == "conflict_error"
+
+    def test_unregistered_code_falls_back_to_500(self) -> None:
+        @dataclass
+        class _OrphanError(CoreException):
+            code: str = "NEVER_REGISTERED_CODE"
+
+            @property
+            def http_status(self) -> int:  # property says 404, registry has no entry
+                return 404
+
+        with error_mapping.isolated_registry():
+            # Deliberately do NOT register NEVER_REGISTERED_CODE.
+
+            app = _make_app()
+
+            @app.get("/foo")
+            async def _route() -> None:
+                raise _OrphanError(message="orphan")
+
+            response = TestClient(app).get("/foo")
+
+        # The registry default is 500 and the handler trusts it. The
+        # coverage test in test_error_mapping guards the codebase against
+        # ever shipping an unregistered code, so this fallback should
+        # never fire in production.
+        assert response.status_code == 500
+        assert response.json()["type"] == "api_error"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Inverts the source of truth in `core_exception_handler`: HTTP status and envelope `type` are now resolved via `resolve_http_status(exc.code)` and `resolve_error_type(http_status)` from the registry introduced in [PR #193](https://github.com/lucaschf/homeflix/pull/193). The body's `type` field is overridden after `to_dict()` so PR 3 can remove the `http_status` property without touching the handler again.
- Consolidates the duplicated `_STATUS_TO_ERROR_TYPE` dict — `http_exception_handler` also calls `resolve_error_type`, deleting the local copy.
- **No observable change in HTTP behavior**: existing handler tests pass unmodified because the PR 1 coverage test guarantees registry == property for every shipped exception code.

## Test plan

- [x] `pytest tests/building_blocks/unit/presentation/test_exception_handlers.py` — 16/16 (13 existing + 3 new).
  - New `TestRegistryDrivesCoreHandler` class: probe exceptions whose `http_status` property disagrees with the registry confirm the registry wins for both `status_code` (418 vs property's 200) and envelope `type` (`conflict_error` vs property's `validation_error`), plus a fallback-to-500 case for unregistered codes.
- [x] `pytest tests/building_blocks/ tests/modules/identity/` — 527/527, including identity e2e that exercises `create_app` + the live handler.
- [x] `ruff check` + `ruff format --check` clean on changed files.
- [ ] CI green.

## Notes

- The `_get_error_type()` method and `http_status` property still exist on `CoreException` — PR 3 removes them. The handler now ignores both.
- Probe-exception tests use `error_mapping.isolated_registry()` so registrations are scoped and don't leak to other tests.
- `test_unregistered_code_falls_back_to_500` documents the intentional default — the coverage test in `test_error_mapping.py::TestRegistryCoverage` is what prevents this fallback from firing in production.

## Related

- ADR-012 §Migração — this is PR 2 of 3.
- Builds on #193 (registry + identity bootstrap).
- PR 3 will remove `http_status` from all 18 building_blocks subclasses + 2 identity overrides, drop `_get_error_type`, and refactor the 18 affected unit tests.

## Summary by Sourcery

Tests:
- Add unit tests ensuring core_exception_handler uses registry-derived status and type, including fallback behavior for unregistered codes.