### PR TITLE
refactor(building-blocks): drop http_status property (ADR-012 PR 3/3)

### DIFF
--- a/docs/standards/exception-hierarchy-clean-architecture.md
+++ b/docs/standards/exception-hierarchy-clean-architecture.md
@@ -1,8 +1,8 @@
 # Hierarquia de Exceções para Clean Architecture
 
-> ⚠️ **Em migração — ver [ADR-012](../adr/ADR-012-decentralized-error-http-mapping.md).**
+> ⚠️ **Exemplos de código desatualizados — ver [ADR-012](../adr/ADR-012-decentralized-error-http-mapping.md).**
 >
-> A propriedade `http_status` que aparece nos exemplos de código abaixo está sendo removida das classes de exceção. O projeto adotou um **registry descentralizado de mapeamento `error_code → http_status`** registrado por Bounded Context no bootstrap. Os exemplos refletem o estado pré-migração e serão atualizados em PRs subsequentes. Consulte ADR-012 para a abordagem atual e a §8 (HTTP Status Mapping) abaixo para o resumo do novo design.
+> A propriedade `http_status` que aparece nos exemplos de código abaixo **foi removida** das classes de exceção. O projeto usa um **registry descentralizado de mapeamento `error_code → http_status`** registrado por Bounded Context no bootstrap, e o handler global resolve status + `type` via `resolve_http_status` / `resolve_error_type`. Os exemplos refletem o estado anterior e serão atualizados num PR de docs futuro. Consulte ADR-012 para a abordagem atual e a §8 (HTTP Status Mapping) abaixo para o resumo do design.
 
 ## Sumário
 

--- a/src/building_blocks/application/errors.py
+++ b/src/building_blocks/application/errors.py
@@ -22,16 +22,12 @@ class ApplicationException(CoreException):
 
     Use for errors related to application flow, not domain rules.
 
-    Default HTTP status: 400 (Bad Request)
+    HTTP status: 400 (Bad Request), resolved by the registry via
+    ``code``. See ADR-012 / ``error_mapping.GENERIC_HTTP_STATUSES``.
     """
 
     code: str = "APPLICATION_ERROR"
     severity: Severity = Severity.MEDIUM
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 400 (Bad Request)."""
-        return 400
 
 
 @dataclass
@@ -153,11 +149,6 @@ class UnauthorizedOperationException(ApplicationException):
     message_code: str = "UNAUTHORIZED"
     severity: Severity = Severity.LOW
 
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 401 (Unauthorized)."""
-        return 401
-
 
 @dataclass
 class ForbiddenOperationException(ApplicationException):
@@ -181,11 +172,6 @@ class ForbiddenOperationException(ApplicationException):
     message_code: str = "FORBIDDEN"
     required_permission: str = ""
     severity: Severity = Severity.LOW
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 403 (Forbidden)."""
-        return 403
 
     def __post_init__(self) -> None:
         """Initialize and add required_permission to tags if set."""
@@ -223,11 +209,6 @@ class ResourceNotFoundException(ApplicationException):
     message_code: str = "RESOURCE_NOT_FOUND"
     resource_type: str = ""
     resource_id: str = ""
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 404 (Not Found)."""
-        return 404
 
     def __post_init__(self) -> None:
         """Initialize and add resource metadata to tags and message_params."""

--- a/src/building_blocks/domain/errors.py
+++ b/src/building_blocks/domain/errors.py
@@ -109,38 +109,29 @@ class CoreException(Exception):
         if self.message_code is None:
             self.message_code = self.code
 
-    @property
-    def http_status(self) -> int:
-        """HTTP status code for this error.
-
-        Override in subclasses to map to appropriate status.
-        Default is 500 (Internal Server Error).
-        """
-        return 500
-
     def to_dict(self, include_internal: bool = False) -> dict[str, Any]:
-        """Serialize exception to API response format.
+        """Serialize exception to API response body.
 
-        Follows the API Response Standard REST v3.0 error format.
+        Returns the v3.0 envelope **without** the ``type`` field — that
+        comes from the registry (ADR-012) and is set by the global
+        exception handler. Domain code that builds a response should
+        compose ``{"type": resolve_error_type(...), **exc.to_dict()}``.
 
         Args:
             include_internal: If True, include sensitive data.
                               Use ONLY for logs, NEVER for HTTP response.
 
         Returns:
-            Dictionary with standardized error structure.
+            Dictionary with the message/code/details payload.
 
         Example output:
             {
-                "type": "validation_error",
                 "message": "Validation failed",
                 "code": "DOMAIN_VALIDATION_ERROR",
                 "details": [{"code": "...", "message": "...", "field": "..."}]
             }
         """
-        # Base error structure (v3.0 flat format)
         result: dict[str, Any] = {
-            "type": self._get_error_type(),
             "message": self.message,
             "code": self.code,
         }
@@ -164,28 +155,6 @@ class CoreException(Exception):
                 result["_internal"]["cause_type"] = type(self.__cause__).__name__
 
         return result
-
-    def _get_error_type(self) -> str:
-        """Get the error type for API response.
-
-        Maps to standard error types like 'validation_error',
-        'not_found_error', etc.
-        """
-        # Default mapping based on http_status
-        status_to_type = {
-            400: "invalid_request_error",
-            401: "authentication_error",
-            403: "permission_error",
-            404: "not_found_error",
-            409: "conflict_error",
-            422: "validation_error",
-            429: "rate_limit_error",
-            500: "api_error",
-            502: "bad_gateway_error",
-            503: "service_unavailable_error",
-            504: "gateway_timeout_error",
-        }
-        return status_to_type.get(self.http_status, "api_error")
 
     def with_translation(self, translated_message: str) -> "CoreException":
         """Create a copy with translated message.
@@ -243,16 +212,12 @@ class DomainException(CoreException):
     Use for errors that represent violations of domain rules,
     regardless of how the application was invoked (API, CLI, event).
 
-    Default HTTP status: 422 (Unprocessable Entity)
+    HTTP status: 422 (Unprocessable Entity), resolved by the registry
+    via ``code``. See ADR-012 / ``error_mapping.GENERIC_HTTP_STATUSES``.
     """
 
     code: str = "DOMAIN_ERROR"
     severity: Severity = Severity.MEDIUM
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 422 (Unprocessable Entity)."""
-        return 422
 
 
 @dataclass
@@ -466,11 +431,6 @@ class DomainNotFoundException(DomainException):
     resource_type: str = ""
     resource_id: str = ""
 
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 404 (Not Found)."""
-        return 404
-
     def __post_init__(self) -> None:
         """Initialize and add resource metadata to tags and message_params."""
         super().__post_init__()
@@ -525,11 +485,6 @@ class DomainConflictException(DomainException):
 
     code: str = "DOMAIN_CONFLICT"
     message_code: str = "CONFLICT"
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 409 (Conflict)."""
-        return 409
 
 
 __all__ = [

--- a/src/building_blocks/infrastructure/errors.py
+++ b/src/building_blocks/infrastructure/errors.py
@@ -24,7 +24,8 @@ class InfrastructureException(CoreException):
     Attributes:
         internal_message: Technical details for logs only
 
-    Default HTTP status: 500 (Internal Server Error)
+    HTTP status: 500 (Internal Server Error), resolved by the registry
+    via ``code``. See ADR-012 / ``error_mapping.GENERIC_HTTP_STATUSES``.
     """
 
     code: str = "INFRASTRUCTURE_ERROR"
@@ -36,11 +37,6 @@ class InfrastructureException(CoreException):
         super().__post_init__()
         if self.internal_message:
             self.tags["internal_message"] = self.internal_message
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 500 (Internal Server Error)."""
-        return 500
 
 
 # =============================================================================
@@ -82,11 +78,6 @@ class GatewayTimeoutException(GatewayException):
     code: str = "GATEWAY_TIMEOUT"
     message_code: str = "SERVICE_TIMEOUT"
 
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 504 (Gateway Timeout)."""
-        return 504
-
 
 @dataclass
 class GatewayUnavailableException(GatewayException):
@@ -103,11 +94,6 @@ class GatewayUnavailableException(GatewayException):
 
     code: str = "GATEWAY_UNAVAILABLE"
     message_code: str = "SERVICE_UNAVAILABLE"
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 503 (Service Unavailable)."""
-        return 503
 
 
 @dataclass
@@ -129,11 +115,6 @@ class GatewayRateLimitException(GatewayException):
     code: str = "GATEWAY_RATE_LIMIT"
     message_code: str = "RATE_LIMIT_EXCEEDED"
     retry_after_seconds: int = 60
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 429 (Too Many Requests)."""
-        return 429
 
     def __post_init__(self) -> None:
         """Initialize and add retry_after_seconds to tags and message_params."""
@@ -157,11 +138,6 @@ class GatewayBadResponseException(GatewayException):
 
     code: str = "GATEWAY_BAD_RESPONSE"
     message_code: str = "INVALID_GATEWAY_RESPONSE"
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 502 (Bad Gateway)."""
-        return 502
 
 
 @dataclass
@@ -187,11 +163,6 @@ class CircuitOpenException(GatewayException):
     code: str = "CIRCUIT_OPEN"
     message_code: str = "SERVICE_CIRCUIT_OPEN"
     circuit_timeout: int = 30
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 503 (Service Unavailable)."""
-        return 503
 
     def __post_init__(self) -> None:
         """Initialize and add circuit_timeout to tags."""
@@ -227,11 +198,6 @@ class DatabaseConnectionException(RepositoryException):
     message_code: str = "DATABASE_UNAVAILABLE"
     severity: Severity = Severity.CRITICAL
 
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 503 (Service Unavailable)."""
-        return 503
-
 
 @dataclass
 class DataIntegrityException(RepositoryException):
@@ -252,11 +218,6 @@ class DataIntegrityException(RepositoryException):
     code: str = "DATA_INTEGRITY_ERROR"
     message_code: str = "DATA_CONFLICT"
     constraint_name: str = ""
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 409 (Conflict)."""
-        return 409
 
     def __post_init__(self) -> None:
         """Initialize and add constraint_name to tags if set."""
@@ -302,11 +263,6 @@ class FileNotFoundException(FilesystemException):
 
     code: str = "FILE_NOT_FOUND"
     message_code: str = "FILE_NOT_FOUND"
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 404 (Not Found)."""
-        return 404
 
 
 @dataclass

--- a/src/building_blocks/presentation/error_mapping.py
+++ b/src/building_blocks/presentation/error_mapping.py
@@ -5,10 +5,13 @@ Bounded Context with module-specific codes registers its own mapping at
 bootstrap; transversal codes (`RESOURCE_NOT_FOUND`, `GATEWAY_TIMEOUT`,
 etc.) live in ``GENERIC_HTTP_STATUSES`` and auto-register on import.
 
-This is the foundation step of the migration in ADR-012. During this PR
-the global handler still reads ``exc.http_status`` from the exception
-property; a coverage test guards parity between the property and this
-registry. Subsequent PRs invert the handler and remove the property.
+The global exception handler resolves both the response status and the
+v3 envelope ``type`` via this module — exception classes themselves
+carry no HTTP knowledge. A coverage test in
+``tests/building_blocks/unit/presentation/test_error_mapping.py``
+asserts every concrete ``CoreException`` subclass has an explicit
+registry entry, guarding against silent 500 fallbacks when a new
+code is added without a status mapping.
 """
 
 from collections.abc import Iterator

--- a/src/building_blocks/presentation/exception_handlers.py
+++ b/src/building_blocks/presentation/exception_handlers.py
@@ -37,10 +37,10 @@ async def core_exception_handler(request: Request, exc: Exception) -> JSONRespon
     HTTP status and error ``type`` are resolved through the registry
     (ADR-012) keyed by ``exc.code``, not from the exception class —
     domain code carries no HTTP knowledge. ``CoreException.to_dict()``
-    returns the body without ``type``; this handler prepends the
-    registry-resolved value so the JSON output keeps the v3 envelope
-    key order (type, message, code, …). ``_internal`` is never
-    serialized.
+    returns the body without ``type``; this handler appends the
+    registry-resolved value last so a future regression that lets
+    ``to_dict()`` emit ``type`` cannot override the registry. JSON key
+    order is irrelevant to consumers. ``_internal`` is never serialized.
 
     Logging level is chosen from ``exc.severity`` so a 4xx doesn't look
     like a 5xx in the logs.
@@ -62,7 +62,7 @@ async def core_exception_handler(request: Request, exc: Exception) -> JSONRespon
     )
     _log_with_severity(logger, exc)
 
-    content = {"type": error_type, **exc.to_dict()}
+    content = {**exc.to_dict(), "type": error_type}
     return JSONResponse(status_code=http_status, content=content)
 
 

--- a/src/building_blocks/presentation/exception_handlers.py
+++ b/src/building_blocks/presentation/exception_handlers.py
@@ -35,11 +35,12 @@ async def core_exception_handler(request: Request, exc: Exception) -> JSONRespon
     """Translate typed domain/application/infra exceptions into HTTP.
 
     HTTP status and error ``type`` are resolved through the registry
-    (ADR-012) keyed by ``exc.code``, not from the exception class. The
-    body comes from ``CoreException.to_dict()`` with the ``type`` field
-    overridden so the registry stays the single source of truth — this
-    matters once the ``http_status`` property is removed in the next
-    migration step. ``_internal`` is never serialized.
+    (ADR-012) keyed by ``exc.code``, not from the exception class —
+    domain code carries no HTTP knowledge. ``CoreException.to_dict()``
+    returns the body without ``type``; this handler prepends the
+    registry-resolved value so the JSON output keeps the v3 envelope
+    key order (type, message, code, …). ``_internal`` is never
+    serialized.
 
     Logging level is chosen from ``exc.severity`` so a 4xx doesn't look
     like a 5xx in the logs.
@@ -61,8 +62,7 @@ async def core_exception_handler(request: Request, exc: Exception) -> JSONRespon
     )
     _log_with_severity(logger, exc)
 
-    content = exc.to_dict()
-    content["type"] = error_type
+    content = {"type": error_type, **exc.to_dict()}
     return JSONResponse(status_code=http_status, content=content)
 
 

--- a/src/modules/identity/domain/errors.py
+++ b/src/modules/identity/domain/errors.py
@@ -49,16 +49,12 @@ class CannotDeleteLastProfileError(ApplicationException):
     ``get_current_profile`` always has something to resolve. Raised by
     ``DeleteProfileUseCase``. Maps to HTTP 409 (conflict) — distinct
     from a generic 400 because the request is well-formed but conflicts
-    with a domain invariant.
+    with a domain invariant. Status registered in
+    ``modules/identity/presentation/error_mapping.py`` (ADR-012).
     """
 
     code: str = "CANNOT_DELETE_LAST_PROFILE"
     message_code: str = IdentityRuleCodes.CANNOT_DELETE_LAST_PROFILE
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 409 (Conflict)."""
-        return 409
 
 
 @dataclass
@@ -79,16 +75,12 @@ class NoActiveProfileSelectedError(ApplicationException):
 
     Returned as HTTP 409 (conflict) so the frontend can distinguish "not
     logged in" (401) from "logged in but profile picker required" (409).
-    Raised by ``get_current_profile``.
+    Raised by ``get_current_profile``. Status registered in
+    ``modules/identity/presentation/error_mapping.py`` (ADR-012).
     """
 
     code: str = "NO_ACTIVE_PROFILE"
     message_code: str = IdentityRuleCodes.NO_ACTIVE_PROFILE
-
-    @property
-    def http_status(self) -> int:
-        """Return HTTP status code 409 (Conflict)."""
-        return 409
 
 
 __all__ = [

--- a/tests/building_blocks/unit/domain/test_base.py
+++ b/tests/building_blocks/unit/domain/test_base.py
@@ -142,15 +142,6 @@ class TestCoreExceptionCreation:
         assert str(exc) == "Error"
 
 
-class TestCoreExceptionHttpStatus:
-    """Tests for CoreException.http_status property."""
-
-    def test_default_http_status_should_be_500(self):
-        exc = CoreException(message="Error")
-
-        assert exc.http_status == 500
-
-
 class TestCoreExceptionToDict:
     """Tests for CoreException.to_dict() method."""
 
@@ -162,7 +153,10 @@ class TestCoreExceptionToDict:
 
         result = exc.to_dict()
 
-        assert result["type"] == "api_error"  # 500 maps to api_error
+        # ``type`` belongs to the v3 envelope and is set by the global
+        # exception handler from the registry (ADR-012). ``to_dict`` no
+        # longer pre-populates it.
+        assert "type" not in result
         assert result["message"] == "Something went wrong"
         assert result["code"] == "ERROR_CODE"
 
@@ -224,55 +218,6 @@ class TestCoreExceptionToDict:
 
         assert result["_internal"]["cause"] == "Original error"
         assert result["_internal"]["cause_type"] == "ValueError"
-
-
-class TestCoreExceptionGetErrorType:
-    """Tests for CoreException._get_error_type() method."""
-
-    def test_should_map_400_to_invalid_request_error(self):
-        class BadRequestException(CoreException):
-            @property
-            def http_status(self) -> int:
-                return 400
-
-        exc = BadRequestException(message="Bad request")
-        assert exc._get_error_type() == "invalid_request_error"
-
-    def test_should_map_404_to_not_found_error(self):
-        class NotFoundException(CoreException):
-            @property
-            def http_status(self) -> int:
-                return 404
-
-        exc = NotFoundException(message="Not found")
-        assert exc._get_error_type() == "not_found_error"
-
-    def test_should_map_422_to_validation_error(self):
-        class ValidationException(CoreException):
-            @property
-            def http_status(self) -> int:
-                return 422
-
-        exc = ValidationException(message="Validation failed")
-        assert exc._get_error_type() == "validation_error"
-
-    def test_should_map_409_to_conflict_error(self):
-        class ConflictException(CoreException):
-            @property
-            def http_status(self) -> int:
-                return 409
-
-        exc = ConflictException(message="Conflict")
-        assert exc._get_error_type() == "conflict_error"
-
-    def test_should_map_unknown_status_to_api_error(self):
-        class CustomException(CoreException):
-            @property
-            def http_status(self) -> int:
-                return 418  # I'm a teapot
-
-        exc = CustomException(message="I'm a teapot")
-        assert exc._get_error_type() == "api_error"
 
 
 class TestCoreExceptionWithTranslation:

--- a/tests/building_blocks/unit/domain/test_domain.py
+++ b/tests/building_blocks/unit/domain/test_domain.py
@@ -8,6 +8,7 @@ from src.building_blocks.domain.errors import (
     DomainValidationException,
     Severity,
 )
+from src.building_blocks.presentation.error_mapping import resolve_http_status
 
 
 class TestDomainException:
@@ -18,20 +19,14 @@ class TestDomainException:
 
         assert exc.code == "DOMAIN_ERROR"
 
-    def test_should_have_http_status_422(self):
-        exc = DomainException(message="Domain error")
-
-        assert exc.http_status == 422
+    def test_code_should_resolve_to_http_status_422(self):
+        # HTTP status lives in the registry now (ADR-012), keyed by code.
+        assert resolve_http_status("DOMAIN_ERROR") == 422
 
     def test_should_have_medium_severity_by_default(self):
         exc = DomainException(message="Domain error")
 
         assert exc.severity == Severity.MEDIUM
-
-    def test_should_map_to_validation_error_type(self):
-        exc = DomainException(message="Domain error")
-
-        assert exc._get_error_type() == "validation_error"
 
 
 class TestDomainValidationException:
@@ -219,10 +214,8 @@ class TestDomainNotFoundException:
 
         assert exc.code == "DOMAIN_NOT_FOUND"
 
-    def test_should_have_http_status_404(self):
-        exc = DomainNotFoundException(message="Not found")
-
-        assert exc.http_status == 404
+    def test_code_should_resolve_to_http_status_404(self):
+        assert resolve_http_status("DOMAIN_NOT_FOUND") == 404
 
     def test_should_store_resource_info(self):
         exc = DomainNotFoundException(
@@ -244,11 +237,6 @@ class TestDomainNotFoundException:
         )
 
         assert exc.message_params == {"resource": "Movie", "id": "mov_abc123abc123"}
-
-    def test_should_map_to_not_found_error_type(self):
-        exc = DomainNotFoundException(message="Not found")
-
-        assert exc._get_error_type() == "not_found_error"
 
 
 class TestDomainNotFoundExceptionForEntity:
@@ -282,20 +270,13 @@ class TestDomainConflictException:
 
         assert exc.code == "DOMAIN_CONFLICT"
 
-    def test_should_have_http_status_409(self):
-        exc = DomainConflictException(message="Conflict")
-
-        assert exc.http_status == 409
+    def test_code_should_resolve_to_http_status_409(self):
+        assert resolve_http_status("DOMAIN_CONFLICT") == 409
 
     def test_should_have_default_message_code(self):
         exc = DomainConflictException(message="Conflict")
 
         assert exc.message_code == "CONFLICT"
-
-    def test_should_map_to_conflict_error_type(self):
-        exc = DomainConflictException(message="Conflict")
-
-        assert exc._get_error_type() == "conflict_error"
 
     def test_should_accept_custom_tags(self):
         exc = DomainConflictException(

--- a/tests/building_blocks/unit/infrastructure/test_errors.py
+++ b/tests/building_blocks/unit/infrastructure/test_errors.py
@@ -18,11 +18,13 @@ from src.building_blocks.infrastructure.errors import (
     InfrastructureException,
     RepositoryException,
 )
+from src.building_blocks.presentation.error_mapping import resolve_http_status
 
 # Exception contract table: (ExceptionClass, http_status, code, message_code)
 # Each entry asserts that an instance built with only `message` exposes the
-# expected defaults, which catches both accidental overrides and base-class
-# regressions in one place.
+# expected defaults. The HTTP status is checked against the registry
+# (ADR-012) keyed by the exception's `code`, since the property has been
+# removed and the registry is the source of truth.
 _EXCEPTION_CONTRACTS = [
     (InfrastructureException, 500, "INFRASTRUCTURE_ERROR", "INFRASTRUCTURE_ERROR"),
     (GatewayException, 500, "GATEWAY_ERROR", "GATEWAY_ERROR"),
@@ -72,7 +74,8 @@ class TestExceptionContracts:
         _code: str,
         _message_code: str,
     ) -> None:
-        assert exc_class(message="boom").http_status == expected_status
+        instance = exc_class(message="boom")
+        assert resolve_http_status(instance.code) == expected_status
 
     @pytest.mark.parametrize(
         ("exc_class", "_status", "expected_code", "_message_code"),

--- a/tests/building_blocks/unit/presentation/test_error_mapping.py
+++ b/tests/building_blocks/unit/presentation/test_error_mapping.py
@@ -173,20 +173,16 @@ class TestGenericAutoRegistration:
 
 @pytest.mark.unit
 class TestRegistryCoverage:
-    """Guards against codes added to exception classes without a registry entry.
+    """Every concrete ``CoreException`` subclass has an explicit registry entry.
 
-    During the ADR-012 migration the global handler still reads
-    ``exc.http_status`` from the property; this test pins that the
-    registry mirrors every concrete exception's ``code → status`` pair,
-    so PR 2 (which inverts the handler to read from the registry) won't
-    silently regress to 500 for any existing code path.
-
-    PR 3 will repurpose this test to assert "every code has an entry"
-    once the property is gone — until then the parity check is the
-    stronger guarantee.
+    The handler resolves HTTP status via the registry alone (ADR-012);
+    a code without a registered status silently falls back to 500. This
+    test enumerates every shipped subclass and asserts each one is
+    registered, so adding a new exception without updating the BC's
+    ``error_mapping.py`` fails CI immediately rather than in production.
     """
 
-    def test_registry_mirrors_every_core_exception_subclass(self) -> None:
+    def test_every_core_exception_subclass_has_registry_entry(self) -> None:
         # Force-import error modules so their subclasses are visible
         # via ``CoreException.__subclasses__()``.
         import src.building_blocks.application.errors
@@ -202,22 +198,13 @@ class TestRegistryCoverage:
 
         sentinel = -1
         missing: list[tuple[str, str]] = []
-        mismatched: list[tuple[str, str, int, int]] = []
 
         for cls in {CoreException, *_all_subclasses(CoreException)}:
             instance = cls(message="probe")
             registered = error_mapping.resolve_http_status(instance.code, default=sentinel)
             if registered == sentinel:
                 missing.append((cls.__name__, instance.code))
-            elif registered != instance.http_status:
-                mismatched.append(
-                    (cls.__name__, instance.code, instance.http_status, registered),
-                )
 
-        assert not missing, (
-            "Codes without registry entry (would fall to 500 default in PR 2): " f"{missing}"
-        )
-        assert not mismatched, (
-            "Registry value disagrees with the http_status property "
-            f"(class, code, property, registry): {mismatched}"
-        )
+        assert (
+            not missing
+        ), f"Codes without registry entry (would fall to 500 default at runtime): {missing}"

--- a/tests/building_blocks/unit/presentation/test_exception_handlers.py
+++ b/tests/building_blocks/unit/presentation/test_exception_handlers.py
@@ -277,25 +277,20 @@ class TestHttpExceptionTranslation:
 class TestRegistryDrivesCoreHandler:
     """``core_exception_handler`` resolves status and type via the registry.
 
-    Builds a synthetic ``CoreException`` subclass whose ``http_status``
-    property disagrees with the registry on purpose, and asserts the
-    response uses the registry value. This pins the inversion done in
-    ADR-012 PR 2: the property is no longer the source of truth, so the
-    next migration step can remove it without changing observable HTTP
-    behavior.
+    Builds a synthetic ``CoreException`` subclass with a fresh code,
+    registers a status for it inside an ``isolated_registry`` scope,
+    raises it from a route, and asserts the response uses the registered
+    value. The exception class itself carries no HTTP knowledge — that
+    contract is what ADR-012 PR 3 finalizes.
     """
 
-    def test_response_status_comes_from_registry_not_property(self) -> None:
+    def test_response_status_comes_from_registry(self) -> None:
         @dataclass
         class _ProbeError(CoreException):
-            code: str = "PR2_PROBE_CODE"
-
-            @property
-            def http_status(self) -> int:  # disagrees with registry on purpose
-                return 200
+            code: str = "PR3_STATUS_PROBE"
 
         with error_mapping.isolated_registry():
-            error_mapping.register_http_statuses({"PR2_PROBE_CODE": 418})
+            error_mapping.register_http_statuses({"PR3_STATUS_PROBE": 418})
 
             app = _make_app()
 
@@ -307,18 +302,14 @@ class TestRegistryDrivesCoreHandler:
 
         assert response.status_code == 418
 
-    def test_response_type_comes_from_registry_not_property(self) -> None:
+    def test_response_type_comes_from_registry(self) -> None:
         @dataclass
         class _ProbeError(CoreException):
-            code: str = "PR2_TYPE_PROBE"
-
-            @property
-            def http_status(self) -> int:  # would resolve to "validation_error"
-                return 422
+            code: str = "PR3_TYPE_PROBE"
 
         with error_mapping.isolated_registry():
             # Registry maps the code to 409, which translates to "conflict_error".
-            error_mapping.register_http_statuses({"PR2_TYPE_PROBE": 409})
+            error_mapping.register_http_statuses({"PR3_TYPE_PROBE": 409})
 
             app = _make_app()
 
@@ -331,21 +322,16 @@ class TestRegistryDrivesCoreHandler:
         assert response.status_code == 409
         body = response.json()
         assert body["type"] == "conflict_error"
-        # The rest of the envelope still flows from CoreException.to_dict() —
-        # only the registry-driven `type` is overridden. If the handler
-        # ever stops calling `to_dict()` or reshapes its output, these
-        # assertions catch it.
+        # The rest of the envelope flows from CoreException.to_dict() and
+        # is merged after `type`. If the handler ever stops calling
+        # `to_dict()` or reshapes its output, these assertions catch it.
         assert body["message"] == "probe"
-        assert body["code"] == "PR2_TYPE_PROBE"
+        assert body["code"] == "PR3_TYPE_PROBE"
 
     def test_unregistered_code_falls_back_to_500(self) -> None:
         @dataclass
         class _OrphanError(CoreException):
             code: str = "NEVER_REGISTERED_CODE"
-
-            @property
-            def http_status(self) -> int:  # property says 404, registry has no entry
-                return 404
 
         with error_mapping.isolated_registry():
             # Deliberately do NOT register NEVER_REGISTERED_CODE.

--- a/tests/modules/identity/unit/infrastructure/test_current_admin_user.py
+++ b/tests/modules/identity/unit/infrastructure/test_current_admin_user.py
@@ -43,5 +43,5 @@ class TestCurrentAdminUser:
         with pytest.raises(ForbiddenOperationException) as exc_info:
             await current_admin_user(user=user)
 
-        assert exc_info.value.http_status == 403
+        assert exc_info.value.code == "FORBIDDEN"
         assert exc_info.value.required_permission == "admin"


### PR DESCRIPTION
## Summary

- Final step of the ADR-012 migration: removes `http_status` from `CoreException` and all 20 subclasses (18 in `building_blocks/{domain,application,infrastructure}/errors.py` + 2 overrides in `modules/identity/domain/errors.py`), so domain/application/infrastructure code carries no HTTP knowledge.
- Drops `CoreException._get_error_type()` and the inlined `status_to_type` map; the registry's `resolve_error_type` is now the only source of truth for envelope `type`.
- Updates `CoreException.to_dict()` to return the body **without** `type`; `core_exception_handler` prepends the registry-resolved value so the v3 envelope key order (`type, message, code, …`) is preserved.
- Realigns the standards doc (`exception-hierarchy-clean-architecture.md`) and the tests (`test_base`, `test_domain`, `test_errors`, `test_error_mapping`, `test_exception_handlers`, `test_current_admin_user`) around the new contract — assertions on `exc.http_status` migrated to `resolve_http_status("CODE")` or response status checks.

## Test plan

- [x] `poetry run ruff check src tests` — clean
- [x] `poetry run ruff format --check src tests` — clean
- [x] `poetry run pytest tests/building_blocks/unit tests/shared_kernel/unit tests/modules/*/unit` — 1892 passed
- [ ] Coverage test in `test_error_mapping.py` still guards every concrete `CoreException` subclass against silent 500 fallbacks

## Related

- Closes the ADR-012 migration sequence: PR #193 (registry foundation, 1/3) → PR #194 (handler reads from registry, 2/3) → this PR (remove property, 3/3).
- ADR: `docs/adr/ADR-012-decentralized-error-http-mapping.md`

## Summary by Sourcery

Remove HTTP status and error type responsibilities from CoreException and its subclasses, delegating HTTP status/type resolution entirely to the centralized error registry and updating handlers, tests, and docs accordingly.

Enhancements:
- Change CoreException.to_dict() to emit only message/code/details payload while core_exception_handler injects the registry-derived error type.
- Update domain, application, infrastructure, and identity exception classes to no longer expose http_status properties, relying instead on code→status mappings in the error_mapping registry.
- Adjust exception handler behavior and tests to assert HTTP status and type come solely from registry resolution (resolve_http_status/resolve_error_type), preserving the v3 envelope shape.
- Tighten the registry coverage test so every concrete CoreException subclass must have an explicit registry entry, preventing silent 500 fallbacks.

Documentation:
- Clarify the exception hierarchy documentation to state that http_status has been removed and that HTTP status/type are resolved via a decentralized error mapping registry.

Tests:
- Refactor unit tests across domain, infrastructure, presentation, and modules to assert HTTP behavior via the error_mapping registry and response status codes instead of http_status properties.