### PR TITLE
fix(media): variant detector eats Windows path separators

### DIFF
--- a/src/modules/media/infrastructure/file_system/variant_detector.py
+++ b/src/modules/media/infrastructure/file_system/variant_detector.py
@@ -105,7 +105,9 @@ class VariantDetector(VariantDetectorPort):
         Returns:
             Base content name with quality indicators removed.
         """
-        name = PurePosixPath(file_path).stem
+        # Normalize Windows separators so the stem isolates the filename
+        # even when this code runs on POSIX against a path like ``D:\foo\bar.mkv``.
+        name = PurePosixPath(file_path.replace("\\", "/")).stem
 
         # Strip quality-related tags
         result = _COMBINED_PATTERN.sub("", name)

--- a/tests/modules/media/unit/infrastructure/file_system/test_variant_detector.py
+++ b/tests/modules/media/unit/infrastructure/file_system/test_variant_detector.py
@@ -52,6 +52,21 @@ class TestExtractBaseName:
     def test_preserves_name_without_tags(self, detector: VariantDetector) -> None:
         assert detector.extract_base_name("my_video.mkv") == "my_video"
 
+    def test_windows_path_does_not_eat_parent_folder(self, detector: VariantDetector) -> None:
+        # Sibling movie folders with "(YYYY)" must produce distinct base names.
+        # Regression: ``\(.*?\)`` previously backtracked across path separators
+        # because PurePosixPath treats Windows ``\`` as a literal character,
+        # collapsing both files below to ``D:\homeflix\Movies\Predator``.
+        predator = detector.extract_base_name(
+            r"D:\homeflix\Movies\Predator (1987)\Predator (1987).mkv",
+        )
+        mib = detector.extract_base_name(
+            r"D:\homeflix\Movies\Predator (2002)\Men in Black II (2002).mkv",
+        )
+        assert predator == "Predator"
+        assert mib == "Men in Black II"
+        assert predator != mib
+
 
 @pytest.mark.unit
 class TestAreVariants:

--- a/tests/modules/media/unit/infrastructure/file_system/test_variant_detector.py
+++ b/tests/modules/media/unit/infrastructure/file_system/test_variant_detector.py
@@ -67,6 +67,18 @@ class TestExtractBaseName:
         assert mib == "Men in Black II"
         assert predator != mib
 
+    def test_handles_mixed_and_unc_windows_paths(self, detector: VariantDetector) -> None:
+        # Mixed separators happen when paths get concatenated from different
+        # sources; UNC paths show up when libraries point at network shares.
+        mixed = detector.extract_base_name(
+            r"D:/homeflix\Movies\Predator (1987)\Predator (1987).mkv",
+        )
+        unc = detector.extract_base_name(
+            r"\\server\share\Movies\Predator (1987)\Predator (1987).mkv",
+        )
+        assert mixed == "Predator"
+        assert unc == "Predator"
+
 
 @pytest.mark.unit
 class TestAreVariants:


### PR DESCRIPTION
## Summary
- `VariantDetector.extract_base_name` used `PurePosixPath`, which treats `\` as a literal character. The strip pattern `\(.*?\)` could then backtrack across path separators and collapse sibling movie folders to the same base name (e.g. `D:\Movies\Predator (1987)\Predator (1987).mkv` and `D:\Movies\Predator (2002)\Men in Black II (2002).mkv` both reduced to `D:\Movies\Predator`).
- Effect on real scans: unrelated movies in sibling `(YYYY)` folders were merged as file variants of a single movie, so the second movie never got its own entry.
- Fix normalizes `\` → `/` before `PurePosixPath.stem`, so the regex only sees the filename portion regardless of host OS.

## Test plan
- [x] `pytest tests/modules/media/unit/infrastructure/file_system/ -v` (25 passed, including new regression `test_windows_path_does_not_eat_parent_folder`)
- [x] `ruff check` + `ruff format --check` on changed files
- [ ] Re-scan a library that previously exhibited the merge to confirm each movie now lands on its own entry

## Summary by Sourcery

Fix variant detection to correctly derive base names from Windows-style file paths so sibling movies are not merged as variants.

Bug Fixes:
- Prevent Windows paths with backslashes from causing different movies in sibling year folders to be merged into a single variant group.

Tests:
- Add a regression test ensuring Windows-style paths in sibling year folders produce distinct base names and are not treated as variants.