### PR TITLE
feat(media): HLS resume/seek via offset buckets

### DIFF
--- a/src/modules/media/application/ports/hls_playlist_port.py
+++ b/src/modules/media/application/ports/hls_playlist_port.py
@@ -17,15 +17,18 @@ class HlsPlaylistPort(ABC):
     """Manage the HLS cache: playlists, segments, subtitles, eviction."""
 
     @abstractmethod
-    async def ensure_playlist(self, file_path: str) -> str:
+    async def ensure_playlist(self, file_path: str, start: int = 0) -> str:
         """Prepare an HLS cache for ``file_path`` and return its path hash.
 
         Blocks until at least the master playlist and the first segment
-        are ready so the caller can serve the playlist immediately. The
-        transcode always starts at the beginning of the source —
-        resume positions are a player-side concern applied via
-        ``HTMLMediaElement.currentTime`` once the manifest loads, which
-        keeps a single cache bucket per file reusable across sessions.
+        are ready so the caller can serve the playlist immediately.
+
+        ``start`` is the source-time second the player wants playback
+        to begin from. When non-zero, the implementation rounds it
+        down to a coarser bucket (so a small change in resume position
+        reuses the same encode) and spawns ffmpeg with an input seek
+        to that bucket. The default of ``0`` preserves the
+        single-bucket-per-file behaviour for cold first plays.
         """
         ...
 

--- a/src/modules/media/application/use_cases/generate_hls_playlist.py
+++ b/src/modules/media/application/use_cases/generate_hls_playlist.py
@@ -21,10 +21,16 @@ class GenerateHlsPlaylistInput:
             e.g. ``"/api/v1/stream/hls/{path_hash}"``. The use case
             does not know its own mount point, so presentation passes
             it in.
+        start: Source-time second the player wants playback to begin
+            from. ``0`` (the default) keeps the legacy single-bucket
+            cache. Non-zero values are rounded down to a coarser
+            bucket by the adapter so adjacent resume positions reuse
+            the same encode.
     """
 
     file_path: str
     base_url_template: str
+    start: int = 0
 
 
 class GenerateHlsPlaylistUseCase:
@@ -37,7 +43,7 @@ class GenerateHlsPlaylistUseCase:
         """Generate (or reuse) the cache and return the rewritten master playlist.
 
         Args:
-            input_dto: File path and base URL template.
+            input_dto: File path, base URL template, and start offset.
 
         Returns:
             Path hash and rewritten master m3u8 content.
@@ -46,7 +52,7 @@ class GenerateHlsPlaylistUseCase:
             ResourceNotFoundException: If the playlist content is missing
                 from the cache after ``ensure_playlist`` returns.
         """
-        path_hash = await self._hls.ensure_playlist(input_dto.file_path)
+        path_hash = await self._hls.ensure_playlist(input_dto.file_path, input_dto.start)
 
         content = self._hls.get_master_playlist(path_hash)
         if content is None:

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -61,6 +61,13 @@ _BROWSER_SAFE_CODECS = {"h264"}
 # hls.js something to render; the rest stream in as they're written.
 _MIN_SEGMENTS_FRESH = 1
 
+# Granularity (in source-time seconds) for the cache key when a non-zero
+# ``start`` offset is requested. Adjacent resume positions inside the
+# same bucket reuse the same encode instead of spawning a fresh ffmpeg
+# per second; coarser buckets save disk at the cost of a longer wait
+# for ``video.currentTime`` to land on the exact saved point.
+_RESUME_BUCKET_SECONDS = 300
+
 # Idle eviction defaults: kill ffmpeg after this many seconds with no
 # segment requests. Trade-off: short timeout frees CPU faster after the
 # user navigates away, but a paused user beyond this window will see the
@@ -230,20 +237,26 @@ class HlsService(HlsPlaylistPort):
 
     # -- Public API ------------------------------------------------------------
 
-    def get_path_hash(self, file_path: str) -> str:
-        """Get the hash key for a source file.
+    def get_path_hash(self, file_path: str, start: int = 0) -> str:
+        """Get the hash key for a source file at a given start offset.
 
         Args:
             file_path: Absolute path to the source video file.
+            start: Source-time second the playback session starts from.
+                Rounded down to ``_RESUME_BUCKET_SECONDS`` so adjacent
+                resume positions share a cache bucket. ``0`` (the
+                default) hashes the file path alone, keeping
+                pre-existing cache directories valid after upgrade.
 
         Returns:
-            Hex MD5 digest uniquely identifying the cache bucket for
-            this file. One bucket per file regardless of resume offset —
-            playback positions are handled client-side via the native
-            ``HTMLMediaElement.currentTime`` seek once the manifest
-            loads.
+            Hex MD5 digest uniquely identifying the cache bucket. The
+            seek-ahead and resume flows on cold cache rely on this
+            being deterministic so the same offset always re-attaches
+            to the same on-disk bucket.
         """
-        return hashlib.md5(file_path.encode()).hexdigest()
+        bucket = (start // _RESUME_BUCKET_SECONDS) * _RESUME_BUCKET_SECONDS
+        key = file_path if bucket == 0 else f"{file_path}:{bucket}"
+        return hashlib.md5(key.encode()).hexdigest()
 
     def get_file_by_hash(self, path_hash: str, relative_path: str) -> Path | None:
         """Get any file from cache by hash + relative path.
@@ -345,23 +358,25 @@ class HlsService(HlsPlaylistPort):
         except (OSError, json.JSONDecodeError):
             return None
 
-    async def ensure_playlist(self, file_path: str) -> str:
+    async def ensure_playlist(self, file_path: str, start: int = 0) -> str:
         """Start generation and wait until the first segments are ready.
 
         Args:
             file_path: Absolute path to the source video file.
+            start: Source-time second to begin transcoding at. Rounded
+                down to a 5-minute bucket via ``get_path_hash`` so a
+                small change in resume position reuses the same encode.
+                ``0`` is the legacy behaviour (single bucket per file).
 
         Returns:
-            The path hash for this file. Always the same hash for a
-            given path — resume positions are applied client-side after
-            the full manifest loads, so a single cache bucket per file
-            is reused across every session.
+            The path hash for the bucket — unique per ``(file_path,
+            start_bucket)`` pair.
 
         Raises:
             RuntimeError: If FFmpeg is not available, fails, or times out.
             FileNotFoundError: If the source file does not exist.
         """
-        path_hash = self.get_path_hash(file_path)
+        path_hash = self.get_path_hash(file_path, start)
         # Touch immediately so the eviction loop never kills a process
         # that the user just asked for, even if no segments have been
         # served yet (e.g. while waiting for ffmpeg to start).
@@ -379,7 +394,7 @@ class HlsService(HlsPlaylistPort):
             msg = f"Source file not found: {file_path}"
             raise FileNotFoundError(msg)
 
-        await asyncio.to_thread(self._start_generation, file_path)
+        await asyncio.to_thread(self._start_generation, file_path, start)
 
         video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
         attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
@@ -468,21 +483,24 @@ class HlsService(HlsPlaylistPort):
 
     # -- Private: generation ---------------------------------------------------
 
-    def _start_generation(self, file_path: str) -> str:
+    def _start_generation(self, file_path: str, start: int = 0) -> str:
         """Start all FFmpeg processes for multi-track HLS generation.
 
-        Always transcodes from t=0 into a single per-file bucket. Resume
-        positions are applied client-side via ``video.currentTime`` once
-        the event-style playlist starts populating — this keeps the
-        cache reusable across sessions and lets the browser seek freely
-        in either direction.
+        Transcodes from ``start`` seconds (rounded down to the cache
+        bucket) into a bucket keyed by ``(file_path, start_bucket)``.
+        Each ffmpeg invocation gets ``-ss N`` as an input seek so the
+        encode skips fast to the nearest preceding keyframe before
+        producing segments. ENDLIST sealing happens via the watcher
+        spawned in ``_spawn_ffmpeg``.
 
         Args:
             file_path: Absolute path to the source video file.
+            start: Source-time second to begin the encode at.
         """
         source = self._validate_source(file_path)
         safe_path = str(source)
-        path_hash = self.get_path_hash(file_path)
+        path_hash = self.get_path_hash(file_path, start)
+        bucket_start = (start // _RESUME_BUCKET_SECONDS) * _RESUME_BUCKET_SECONDS
 
         if self.is_complete(path_hash):
             return path_hash
@@ -525,10 +543,10 @@ class HlsService(HlsPlaylistPort):
             video_dir = output_dir / _VIDEO_DIR
             video_dir.mkdir()
             cmd = with_ffmpeg_threads(
-                self._build_video_cmd(safe_path, video_dir, probe_result),
+                self._build_video_cmd(safe_path, video_dir, probe_result, bucket_start),
                 self._ffmpeg_threads,
             )
-            _logger.info("Starting video HLS for %s", safe_path)
+            _logger.info("Starting video HLS for %s (offset=%ds)", safe_path, bucket_start)
             procs.append(
                 self._spawn_ffmpeg(cmd, playlist_path=video_dir / "playlist.m3u8"),
             )
@@ -541,14 +559,15 @@ class HlsService(HlsPlaylistPort):
                 audio_dir = output_dir / f"audio_{track.index}"
                 audio_dir.mkdir()
                 cmd = with_ffmpeg_threads(
-                    self._build_audio_cmd(safe_path, audio_dir, track.index),
+                    self._build_audio_cmd(safe_path, audio_dir, track.index, bucket_start),
                     self._ffmpeg_threads,
                 )
                 _logger.info(
-                    "Starting audio HLS for track %d (%s) of %s",
+                    "Starting audio HLS for track %d (%s) of %s (offset=%ds)",
                     track.index,
                     track.language.value,
                     safe_path,
+                    bucket_start,
                 )
                 procs.append(
                     self._spawn_ffmpeg(cmd, playlist_path=audio_dir / "playlist.m3u8"),
@@ -675,13 +694,19 @@ class HlsService(HlsPlaylistPort):
         file_path: str,
         output_dir: Path,
         probe: ProbeResult,
+        start: int = 0,
     ) -> list[str]:
         """Build FFmpeg command for video + default audio.
 
-        Always transcodes (or remuxes, for already-H.264 sources) from
-        the beginning of the file. Resume positions are a client-side
-        concern — the player calls ``video.currentTime`` once the
-        event-style playlist starts populating.
+        Transcodes (or remuxes, for already-H.264 sources) from the
+        ``start`` second of the file. ``-ss`` is placed BEFORE ``-i``
+        so ffmpeg does an input seek — fast and keyframe-accurate —
+        and the resulting segments carry timestamps starting near zero
+        in bucket-local time. Bucket-local timestamps are why the
+        frontend computes ``video.currentTime = saved - bucket_start``
+        instead of ``video.currentTime = saved`` (which would only
+        work with ``-copyts`` / source-time preserved, a path the
+        prior attempts at this refactor never landed reliably).
         """
         codec = self._probe_video_codec(file_path)
         needs_transcode = codec not in _BROWSER_SAFE_CODECS
@@ -696,8 +721,11 @@ class HlsService(HlsPlaylistPort):
         primary_idx = _primary_audio_index(probe)
         audio_map = f"0:a:{primary_idx}"
 
+        seek_args = ["-ss", str(start)] if start > 0 else []
+
         return [
             "ffmpeg",
+            *seek_args,
             "-i",
             file_path,
             "-map",
@@ -736,10 +764,17 @@ class HlsService(HlsPlaylistPort):
         file_path: str,
         output_dir: Path,
         audio_index: int,
+        start: int = 0,
     ) -> list[str]:
-        """Build FFmpeg command for audio-only HLS track."""
+        """Build FFmpeg command for audio-only HLS track.
+
+        ``-ss`` placed before ``-i`` when ``start > 0`` — same input-seek
+        rationale as ``_build_video_cmd``.
+        """
+        seek_args = ["-ss", str(start)] if start > 0 else []
         return [
             "ffmpeg",
+            *seek_args,
             "-i",
             file_path,
             "-map",

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -707,12 +707,28 @@ class HlsService(HlsPlaylistPort):
         instead of ``video.currentTime = saved`` (which would only
         work with ``-copyts`` / source-time preserved, a path the
         prior attempts at this refactor never landed reliably).
+
+        When ``start > 0`` we also emit ``-accurate_seek`` and
+        ``-avoid_negative_ts make_zero``. The first forces ffmpeg to
+        decode-and-drop frames between the preceding keyframe and the
+        exact requested second; without it, video opens at the
+        keyframe while audio opens at ``start`` and the two streams
+        play out of sync by that gap. The second clamps the minimum
+        PTS to zero across streams so any residual offset surfaces as
+        a tiny silence prefix instead of an audio-leads-video drift.
+
+        The H.264 ``-c:v copy`` fast path is bypassed for non-zero
+        ``start`` because copying skips the decode pass that
+        ``-accurate_seek`` relies on to drop pre-target frames — the
+        copied video would land at the preceding keyframe while the
+        re-encoded audio lands at the exact ``start``, recreating the
+        same 1-3s gap the seek flag was meant to close.
         """
         codec = self._probe_video_codec(file_path)
-        needs_transcode = codec not in _BROWSER_SAFE_CODECS
+        needs_transcode = codec not in _BROWSER_SAFE_CODECS or start > 0
 
         if needs_transcode:
-            _logger.info("Source codec %s — transcoding to H.264", codec)
+            _logger.info("Source codec %s — transcoding to H.264 (start=%d)", codec, start)
             video_args = ["-c:v", "libx264", "-preset", "ultrafast", "-crf", "23"]
         else:
             _logger.info("Source codec %s — copying", codec)
@@ -721,7 +737,8 @@ class HlsService(HlsPlaylistPort):
         primary_idx = _primary_audio_index(probe)
         audio_map = f"0:a:{primary_idx}"
 
-        seek_args = ["-ss", str(start)] if start > 0 else []
+        seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
+        ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
 
         return [
             "ffmpeg",
@@ -740,6 +757,7 @@ class HlsService(HlsPlaylistPort):
             "2",
             "-ar",
             "48000",
+            *ts_normalize_args,
             "-hls_time",
             str(_SEGMENT_DURATION),
             "-hls_list_size",
@@ -769,9 +787,15 @@ class HlsService(HlsPlaylistPort):
         """Build FFmpeg command for audio-only HLS track.
 
         ``-ss`` placed before ``-i`` when ``start > 0`` — same input-seek
-        rationale as ``_build_video_cmd``.
+        rationale as ``_build_video_cmd``. The alternate-audio playlist
+        is consumed independently by the player; even though there is
+        no video stream here, we still match the video pipeline's
+        ``-accurate_seek`` / ``-avoid_negative_ts make_zero`` so a
+        switch from primary to alternate audio at a non-zero bucket
+        lands on the same source-time second.
         """
-        seek_args = ["-ss", str(start)] if start > 0 else []
+        seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
+        ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
         return [
             "ffmpeg",
             *seek_args,
@@ -787,6 +811,7 @@ class HlsService(HlsPlaylistPort):
             "2",
             "-ar",
             "48000",
+            *ts_normalize_args,
             "-hls_time",
             str(_SEGMENT_DURATION),
             "-hls_list_size",

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -598,7 +598,7 @@ class HlsService(HlsPlaylistPort):
         for sub in text_subs:
             threading.Thread(
                 target=self._extract_one_subtitle,
-                args=(safe_path, output_dir, sub, path_hash),
+                args=(safe_path, output_dir, sub, path_hash, bucket_start),
                 daemon=True,
                 name=f"hls-sub-{path_hash[:8]}-{sub.index}",
             ).start()
@@ -836,6 +836,7 @@ class HlsService(HlsPlaylistPort):
         output_dir: Path,
         track: SubtitleTrack,
         path_hash: str,
+        start: int = 0,
     ) -> None:
         """Extract a single text-based subtitle to WebVTT.
 
@@ -845,14 +846,22 @@ class HlsService(HlsPlaylistPort):
         on ffmpeg failure or timeout) and gets a chance to respond —
         typically with a 404 if extraction never produced a file.
 
-        The source is read from the beginning; subtitle timestamps are
-        in source time, which matches the HLS stream (also from t=0)
-        and the player's ``video.currentTime``.
+        Subtitle cues are emitted in the same timeline as the HLS
+        stream that wraps them. For a non-zero ``start`` we input-seek
+        and let ``-avoid_negative_ts make_zero`` rebase the cue times
+        to bucket-local: a cue at source-K is written with timestamp
+        ``K - start`` so it fires when ``video.currentTime`` (also
+        bucket-local) reaches the right moment. Without this shift,
+        resume sessions would show every cue at ``start`` seconds
+        later than the actual line of dialogue.
         """
         try:
             sub_dir = output_dir / f"sub_{track.index}"
             sub_dir.mkdir(exist_ok=True)
             vtt_path = sub_dir / "sub.vtt"
+
+            seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
+            ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
 
             if track.is_external:
                 if track.file_path is None:
@@ -864,10 +873,12 @@ class HlsService(HlsPlaylistPort):
                         with_ffmpeg_threads(
                             [
                                 "ffmpeg",
+                                *seek_args,
                                 "-i",
                                 input_arg,
                                 "-c:s",
                                 "webvtt",
+                                *ts_normalize_args,
                                 "-loglevel",
                                 "error",
                                 "-y",
@@ -889,12 +900,14 @@ class HlsService(HlsPlaylistPort):
                         with_ffmpeg_threads(
                             [
                                 "ffmpeg",
+                                *seek_args,
                                 "-i",
                                 file_path,
                                 "-map",
                                 f"0:s:{track.index}",
                                 "-c:s",
                                 "webvtt",
+                                *ts_normalize_args,
                                 "-loglevel",
                                 "error",
                                 "-y",

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -266,20 +266,29 @@ class HlsService(HlsPlaylistPort):
         return target
 
     def is_complete(self, path_hash: str) -> bool:
-        """Check if generation is fully complete."""
-        video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
-        if not video_playlist.is_file():
-            flat = self._cache_dir / path_hash / "playlist.m3u8"
-            if not flat.is_file():
-                return False
-            try:
-                return "#EXT-X-ENDLIST" in flat.read_text(encoding="utf-8")
-            except OSError:
-                return False
-        try:
-            return "#EXT-X-ENDLIST" in video_playlist.read_text(encoding="utf-8")
-        except OSError:
+        """Check if every playlist in the bucket has been sealed with ENDLIST.
+
+        A bucket is "complete" only when every nested ``playlist.m3u8``
+        (video, alternate audios, subtitle wrappers) carries the
+        ``#EXT-X-ENDLIST`` tag. The encode-watcher writes the tag on
+        clean ffmpeg exit; subtitle wrappers are emitted with the tag
+        baked in. Checking ALL playlists prevents the next session from
+        skipping regeneration when the video encode finished cleanly
+        but an alternate-audio encode was killed mid-flight.
+        """
+        bucket = self._cache_dir / path_hash
+        if not bucket.is_dir():
             return False
+
+        flat = bucket / "playlist.m3u8"
+        nested_video_dir = bucket / _VIDEO_DIR
+        if flat.is_file() and not nested_video_dir.is_dir():
+            return _has_endlist(flat)
+
+        playlists = list(bucket.glob("*/playlist.m3u8"))
+        if not playlists:
+            return False
+        return all(_has_endlist(p) for p in playlists)
 
     def get_master_playlist(self, path_hash: str) -> str | None:
         """Get master playlist content, falling back to legacy flat playlist.
@@ -520,7 +529,9 @@ class HlsService(HlsPlaylistPort):
                 self._ffmpeg_threads,
             )
             _logger.info("Starting video HLS for %s", safe_path)
-            procs.append(self._spawn_ffmpeg(cmd))
+            procs.append(
+                self._spawn_ffmpeg(cmd, playlist_path=video_dir / "playlist.m3u8"),
+            )
 
             # 2. Additional audio tracks (audio-only HLS)
             primary_audio_idx = _primary_audio_index(probe_result)
@@ -539,7 +550,9 @@ class HlsService(HlsPlaylistPort):
                     track.language.value,
                     safe_path,
                 )
-                procs.append(self._spawn_ffmpeg(cmd))
+                procs.append(
+                    self._spawn_ffmpeg(cmd, playlist_path=audio_dir / "playlist.m3u8"),
+                )
 
             # 3. Build master playlist now — it references sub_N/playlist.m3u8
             # paths that get filled in by the background subtitle extraction
@@ -573,18 +586,61 @@ class HlsService(HlsPlaylistPort):
 
         return path_hash
 
-    @staticmethod
-    def _spawn_ffmpeg(cmd: list[str]) -> subprocess.Popen[bytes]:
+    def _spawn_ffmpeg(
+        self,
+        cmd: list[str],
+        playlist_path: Path | None = None,
+    ) -> subprocess.Popen[bytes]:
         """Spawn an FFmpeg subprocess.
 
         All arguments are built internally from validated paths,
         not from user-controlled input.
+
+        When ``playlist_path`` is provided, a daemon thread waits for
+        the process and seals the playlist with ``#EXT-X-ENDLIST`` on
+        clean exit (returncode 0). This is what makes ``is_complete``
+        flip to True after a successful full encode, so the next
+        session reuses the cache instead of respawning ffmpeg.
         """
-        return subprocess.Popen(
+        proc = subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
         )
+        if playlist_path is not None:
+            threading.Thread(
+                target=self._watch_for_endlist,
+                args=(proc, playlist_path),
+                daemon=True,
+                name=f"hls-endlist-{playlist_path.parent.name}",
+            ).start()
+        return proc
+
+    @staticmethod
+    def _watch_for_endlist(
+        proc: subprocess.Popen[bytes],
+        playlist_path: Path,
+    ) -> None:
+        """Wait for an ffmpeg encode to finish; seal the playlist on success.
+
+        Skips the seal on any non-zero exit — eviction killing the
+        process (negative returncode from SIGKILL) or ffmpeg failing
+        partway both fall through here and leave the playlist as a
+        growing event stream, so the next session correctly
+        regenerates instead of treating a half-encoded cache as final.
+        """
+        try:
+            returncode = proc.wait()
+        except Exception:
+            _logger.exception("ffmpeg watcher for %s failed", playlist_path)
+            return
+        if returncode != 0:
+            return
+        try:
+            _append_endlist_atomic(playlist_path)
+            _logger.info("Sealed HLS playlist with ENDLIST: %s", playlist_path)
+        except OSError:
+            _logger.exception("Failed to append ENDLIST to %s", playlist_path)
 
     # -- Private: FFmpeg commands ----------------------------------------------
 
@@ -972,6 +1028,35 @@ def _write_subtitle_playlist(sub_dir: Path) -> None:
         "#EXT-X-ENDLIST\n",
         encoding="utf-8",
     )
+
+
+def _has_endlist(playlist_path: Path) -> bool:
+    """Return ``True`` iff the playlist file exists and contains ``#EXT-X-ENDLIST``."""
+    try:
+        return "#EXT-X-ENDLIST" in playlist_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+
+
+def _append_endlist_atomic(playlist_path: Path) -> None:
+    """Append ``#EXT-X-ENDLIST`` to a playlist via temp-file + atomic rename.
+
+    Idempotent — returns early if the tag is already present. The
+    rename is atomic on POSIX and on Windows (``Path.replace``), so a
+    concurrent playlist GET sees either the pre-ENDLIST content or the
+    sealed one, never a torn write.
+    """
+    if not playlist_path.is_file():
+        return
+    content = playlist_path.read_text(encoding="utf-8")
+    if "#EXT-X-ENDLIST" in content:
+        return
+    if not content.endswith("\n"):
+        content += "\n"
+    content += "#EXT-X-ENDLIST\n"
+    tmp_path = playlist_path.with_name(playlist_path.name + ".endlist.tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    tmp_path.replace(playlist_path)
 
 
 __all__ = ["HlsService"]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -33,6 +33,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import re
 import shutil
 import subprocess
 import threading
@@ -847,85 +848,33 @@ class HlsService(HlsPlaylistPort):
         typically with a 404 if extraction never produced a file.
 
         Subtitle cues are emitted in the same timeline as the HLS
-        stream that wraps them. For a non-zero ``start`` we input-seek
-        and let ``-avoid_negative_ts make_zero`` rebase the cue times
-        to bucket-local: a cue at source-K is written with timestamp
-        ``K - start`` so it fires when ``video.currentTime`` (also
-        bucket-local) reaches the right moment. Without this shift,
-        resume sessions would show every cue at ``start`` seconds
-        later than the actual line of dialogue.
+        stream that wraps them. ffmpeg is invoked WITHOUT ``-ss`` so
+        the full subtitle stream is written in source-time — that
+        cmd-line worked uniformly across MKV/MP4/SRT demuxers; using
+        ``-ss N`` instead produced container-dependent results
+        (cues either late by ``N`` seconds or compressed to bucket
+        start by ``-avoid_negative_ts``). After the extraction
+        succeeds the post-processor ``_shift_webvtt_to_bucket_local``
+        subtracts ``start`` from every cue, clamping negatives to
+        zero, so cue at source-K lands at bucket-local ``K - start``.
         """
         try:
             sub_dir = output_dir / f"sub_{track.index}"
             sub_dir.mkdir(exist_ok=True)
             vtt_path = sub_dir / "sub.vtt"
 
-            seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
-            ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
-
-            if track.is_external:
-                if track.file_path is None:
-                    return
-                input_arg = track.file_path.value
-                log_label = f"external subtitle {input_arg}"
-                try:
-                    subprocess.run(
-                        with_ffmpeg_threads(
-                            [
-                                "ffmpeg",
-                                *seek_args,
-                                "-i",
-                                input_arg,
-                                "-c:s",
-                                "webvtt",
-                                *ts_normalize_args,
-                                "-loglevel",
-                                "error",
-                                "-y",
-                                str(vtt_path),
-                            ],
-                            self._ffmpeg_threads,
-                        ),
-                        **SUBPROCESS_TEXT_KWARGS,
-                        check=False,
-                        timeout=120,
-                    )
-                except subprocess.TimeoutExpired:
-                    _logger.warning("Extraction timed out for %s", log_label)
-                    return
-            else:
-                log_label = f"subtitle track {track.index}"
-                try:
-                    subprocess.run(
-                        with_ffmpeg_threads(
-                            [
-                                "ffmpeg",
-                                *seek_args,
-                                "-i",
-                                file_path,
-                                "-map",
-                                f"0:s:{track.index}",
-                                "-c:s",
-                                "webvtt",
-                                *ts_normalize_args,
-                                "-loglevel",
-                                "error",
-                                "-y",
-                                str(vtt_path),
-                            ],
-                            self._ffmpeg_threads,
-                        ),
-                        **SUBPROCESS_TEXT_KWARGS,
-                        check=False,
-                        timeout=120,
-                    )
-                except subprocess.TimeoutExpired:
-                    _logger.warning("Extraction timed out for %s", log_label)
-                    return
+            cmd_and_label = self._build_subtitle_extract_cmd(track, file_path, vtt_path)
+            if cmd_and_label is None:
+                return
+            cmd, log_label = cmd_and_label
+            if not self._run_subtitle_ffmpeg(cmd, log_label):
+                return
 
             if vtt_path.is_file():
+                if start > 0:
+                    _shift_webvtt_to_bucket_local(vtt_path, start)
                 _write_subtitle_playlist(sub_dir)
-                _logger.info("Extracted %s to %s", log_label, vtt_path)
+                _logger.info("Extracted %s to %s (start=%d)", log_label, vtt_path, start)
             else:
                 _logger.warning("Failed to extract %s", log_label)
         finally:
@@ -933,6 +882,69 @@ class HlsService(HlsPlaylistPort):
                 event = self._subtitle_events.get(path_hash, {}).get(track.index)
             if event is not None:
                 event.set()
+
+    def _build_subtitle_extract_cmd(
+        self,
+        track: SubtitleTrack,
+        file_path: str,
+        vtt_path: Path,
+    ) -> tuple[list[str], str] | None:
+        """Build the ffmpeg argv + log label for a single subtitle track.
+
+        Returns ``None`` when the track is unusable (external sidecar
+        with no resolved file path). The cmd is wrapped through
+        ``with_ffmpeg_threads`` so the global cap applies uniformly.
+        """
+        if track.is_external:
+            if track.file_path is None:
+                return None
+            cmd = with_ffmpeg_threads(
+                [
+                    "ffmpeg",
+                    "-i",
+                    track.file_path.value,
+                    "-c:s",
+                    "webvtt",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    str(vtt_path),
+                ],
+                self._ffmpeg_threads,
+            )
+            return cmd, f"external subtitle {track.file_path.value}"
+        cmd = with_ffmpeg_threads(
+            [
+                "ffmpeg",
+                "-i",
+                file_path,
+                "-map",
+                f"0:s:{track.index}",
+                "-c:s",
+                "webvtt",
+                "-loglevel",
+                "error",
+                "-y",
+                str(vtt_path),
+            ],
+            self._ffmpeg_threads,
+        )
+        return cmd, f"subtitle track {track.index}"
+
+    @staticmethod
+    def _run_subtitle_ffmpeg(cmd: list[str], log_label: str) -> bool:
+        """Run a subtitle ffmpeg cmd, returning True iff it didn't time out."""
+        try:
+            subprocess.run(
+                cmd,
+                **SUBPROCESS_TEXT_KWARGS,
+                check=False,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            _logger.warning("Extraction timed out for %s", log_label)
+            return False
+        return True
 
     # -- Private: master playlist ----------------------------------------------
 
@@ -1130,6 +1142,63 @@ def _append_endlist_atomic(playlist_path: Path) -> None:
     tmp_path = playlist_path.with_name(playlist_path.name + ".endlist.tmp")
     tmp_path.write_text(content, encoding="utf-8")
     tmp_path.replace(playlist_path)
+
+
+# Matches WebVTT cue timestamps in either ``mm:ss.fff`` (under one hour)
+# or ``hh:mm:ss.fff`` shape, so the post-processor can shift cues
+# regardless of which form ffmpeg picked when writing the file.
+_VTT_TIMESTAMP_RE = re.compile(r"(?:(?P<h>\d+):)?(?P<m>\d{2}):(?P<s>\d{2})\.(?P<ms>\d{3})")
+
+
+def _shift_one_timestamp(match: re.Match[str], shift_seconds: int) -> str:
+    """Return the WebVTT timestamp in ``match`` shifted back by ``shift_seconds``.
+
+    Negatives clamp to zero so a cue that straddled the bucket
+    boundary collapses to ``00:00:00.000`` (start == end → the player
+    skips it) instead of producing an invalid VTT line.
+    """
+    h = int(match.group("h") or 0)
+    m = int(match.group("m"))
+    s = int(match.group("s"))
+    ms = int(match.group("ms"))
+    total_ms = ((h * 60 + m) * 60 + s) * 1000 + ms - shift_seconds * 1000
+    if total_ms < 0:
+        total_ms = 0
+    new_h, rem = divmod(total_ms, 3_600_000)
+    new_m, rem = divmod(rem, 60_000)
+    new_s, new_ms = divmod(rem, 1_000)
+    return f"{new_h:02d}:{new_m:02d}:{new_s:02d}.{new_ms:03d}"
+
+
+def _shift_webvtt_to_bucket_local(vtt_path: Path, shift_seconds: int) -> None:
+    """Subtract ``shift_seconds`` from every cue timestamp in the VTT.
+
+    The extracted subtitle carries source-time cue timestamps; on a
+    non-zero bucket start the player runs a bucket-local clock and
+    every cue would otherwise fire ``shift_seconds`` seconds after
+    the spoken line. Shift everything once on disk so hls.js can map
+    cues to the active manifest's timeline without further help.
+    """
+    if shift_seconds <= 0:
+        return
+    if not vtt_path.is_file():
+        return
+    try:
+        content = vtt_path.read_text(encoding="utf-8")
+    except OSError:
+        _logger.exception("Failed to read VTT for shifting: %s", vtt_path)
+        return
+
+    def _replace(m: re.Match[str]) -> str:
+        return _shift_one_timestamp(m, shift_seconds)
+
+    new_content = _VTT_TIMESTAMP_RE.sub(_replace, content)
+    tmp_path = vtt_path.with_name(vtt_path.name + ".shift.tmp")
+    try:
+        tmp_path.write_text(new_content, encoding="utf-8")
+        tmp_path.replace(vtt_path)
+    except OSError:
+        _logger.exception("Failed to write shifted VTT: %s", vtt_path)
 
 
 __all__ = ["HlsService"]

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import FileResponse, Response, StreamingResponse
 
 from src.building_blocks.application.errors import ResourceNotFoundException
@@ -134,6 +134,15 @@ async def hls_file(
 @inject  # type: ignore[misc]
 async def movie_hls_playlist(
     movie_id: str,
+    start: int = Query(
+        0,
+        ge=0,
+        description=(
+            "Source-time second to begin transcoding at. Rounded down "
+            "to a 5-minute bucket. Defaults to 0 for legacy single-bucket "
+            "caching."
+        ),
+    ),
     profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],
@@ -155,7 +164,7 @@ async def movie_hls_playlist(
     file_path = _require_file(movie.file_path)
     if movie.scrub_preview_path is None:
         _fire_eager_movie(backfill_job, movie_id)
-    return await _serve_master(hls_uc, file_path)
+    return await _serve_master(hls_uc, file_path, start=start)
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/playlist.m3u8")  # type: ignore[misc]
@@ -164,6 +173,15 @@ async def episode_hls_playlist(
     series_id: str,
     season_number: int,
     episode_number: int,
+    start: int = Query(
+        0,
+        ge=0,
+        description=(
+            "Source-time second to begin transcoding at. Rounded down "
+            "to a 5-minute bucket. Defaults to 0 for legacy single-bucket "
+            "caching."
+        ),
+    ),
     profile_id: str = Depends(resolve_profile_id),
     series_uc: GetSeriesByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_by_id],
@@ -182,7 +200,7 @@ async def episode_hls_playlist(
     file_path = _require_file(episode.file_path)
     if episode.scrub_preview_path is None and episode.id is not None:
         _fire_eager_episode(backfill_job, episode.id)
-    return await _serve_master(hls_uc, file_path)
+    return await _serve_master(hls_uc, file_path, start=start)
 
 
 # -- Track info ----------------------------------------------------------------
@@ -402,12 +420,14 @@ async def stream_episode(
 async def _serve_master(
     use_case: GenerateHlsPlaylistUseCase,
     file_path: str,
+    start: int = 0,
 ) -> Response:
     """Run the generate-playlist use case and wrap its DTO in a Response."""
     output = await use_case.execute(
         GenerateHlsPlaylistInput(
             file_path=file_path,
             base_url_template=_MASTER_BASE_URL,
+            start=start,
         )
     )
     return Response(

--- a/tests/modules/media/unit/application/use_cases/test_generate_hls_playlist.py
+++ b/tests/modules/media/unit/application/use_cases/test_generate_hls_playlist.py
@@ -41,7 +41,22 @@ class TestGenerateHlsPlaylistUseCase:
 
         assert output.path_hash == "abc"
         assert "/api/v1/stream/hls/abc/video/playlist.m3u8" in output.rewritten_content
-        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv")
+        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv", 0)
+
+    @pytest.mark.asyncio
+    async def test_should_forward_start_offset_to_port(self) -> None:
+        hls = _make_hls_mock(path_hash="abc")
+        use_case = GenerateHlsPlaylistUseCase(hls=hls)
+
+        await use_case.execute(
+            GenerateHlsPlaylistInput(
+                file_path="/movies/file.mkv",
+                base_url_template="/api/v1/stream/hls/{path_hash}",
+                start=1800,
+            )
+        )
+
+        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv", 1800)
 
     @pytest.mark.asyncio
     async def test_should_raise_when_master_playlist_missing(self) -> None:

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -105,14 +105,35 @@ class TestHlsServiceGetPathHash:
         service = HlsService(cache_dir=str(tmp_path / "hls"))
         assert service.get_path_hash("/a.mkv") != service.get_path_hash("/b.mkv")
 
-    def test_should_depend_only_on_file_path(self, tmp_path: Path) -> None:
-        # The cache bucket is keyed by the source file alone: resume
-        # positions apply client-side via ``video.currentTime`` so every
-        # session for the same file reuses the same transcode output.
+    def test_should_match_legacy_hash_when_start_is_zero(self, tmp_path: Path) -> None:
+        # The default ``start=0`` bucket keeps the legacy hash scheme so
+        # caches generated before the resume-offset refactor stay
+        # addressable. This is the load-bearing contract for not
+        # invalidating warm caches on deploy.
         service = HlsService(cache_dir=str(tmp_path / "hls"))
         path = "/movies/test.mkv"
         expected = hashlib.md5(path.encode()).hexdigest()
         assert service.get_path_hash(path) == expected
+        assert service.get_path_hash(path, start=0) == expected
+
+    def test_should_round_start_down_to_bucket(self, tmp_path: Path) -> None:
+        # Adjacent resume positions inside the same 5-minute window
+        # collapse onto the same bucket so a player resuming at t=302
+        # reuses the ffmpeg encode started at t=300.
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+        path = "/movies/test.mkv"
+        # 299s rounds down to bucket 0 — same as default
+        assert service.get_path_hash(path, start=299) == service.get_path_hash(path)
+        # 300s and 599s share the same bucket (300)
+        assert service.get_path_hash(path, start=300) == service.get_path_hash(path, start=599)
+        # 600s steps to the next bucket
+        assert service.get_path_hash(path, start=300) != service.get_path_hash(path, start=600)
+
+    def test_should_differ_across_buckets_for_same_file(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+        path = "/movies/test.mkv"
+        assert service.get_path_hash(path, start=0) != service.get_path_hash(path, start=300)
+        assert service.get_path_hash(path, start=300) != service.get_path_hash(path, start=600)
 
 
 @pytest.mark.unit
@@ -283,14 +304,23 @@ class TestHlsServiceBuildAudioCmd:
 
         assert "aac" in cmd
 
-    def test_should_never_emit_a_seek_flag(self, tmp_path: Path) -> None:
-        # The transcode always starts at t=0 — resume positions are
-        # applied client-side via ``video.currentTime``. A ``-ss`` in
-        # the ffmpeg argv would re-introduce the per-offset bucket
-        # problem the per-file cache was designed to avoid.
+    def test_should_omit_seek_flag_when_start_is_zero(self, tmp_path: Path) -> None:
+        # Default cold-cache transcode starts at t=0 — no ``-ss``.
         cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
 
         assert "-ss" not in cmd
+
+    def test_should_emit_seek_flag_before_input_when_start_positive(self, tmp_path: Path) -> None:
+        # ``-ss N`` must come BEFORE ``-i`` so ffmpeg does an input
+        # seek (fast, keyframe-accurate) rather than decoding from 0
+        # and dropping output.
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0, start=1800)
+
+        assert "-ss" in cmd
+        ss_index = cmd.index("-ss")
+        input_index = cmd.index("-i")
+        assert cmd[ss_index + 1] == "1800"
+        assert ss_index < input_index
 
 
 @pytest.mark.unit
@@ -327,9 +357,8 @@ class TestHlsServiceBuildVideoCmd:
 
         assert "0:a:3" in cmd
 
-    def test_should_never_emit_a_seek_flag(self, tmp_path: Path) -> None:
-        # Symmetric with the audio-only pipeline: the video transcode
-        # starts at t=0 and the player seeks natively.
+    def test_should_omit_seek_flag_when_start_is_zero(self, tmp_path: Path) -> None:
+        # Default cold-cache transcode starts at t=0 — no ``-ss``.
         service = HlsService(cache_dir=str(tmp_path / "cache"))
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
@@ -337,6 +366,22 @@ class TestHlsServiceBuildVideoCmd:
             cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "-ss" not in cmd
+
+    def test_should_emit_seek_flag_before_input_when_start_positive(self, tmp_path: Path) -> None:
+        # Input seek for the video pipeline mirrors the audio one — the
+        # seek is in source-time seconds and lands at the nearest
+        # preceding keyframe before any encoding work begins.
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+
+        assert "-ss" in cmd
+        ss_index = cmd.index("-ss")
+        input_index = cmd.index("-i")
+        assert cmd[ss_index + 1] == "1800"
+        assert ss_index < input_index
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -15,6 +15,7 @@ from src.modules.media.infrastructure.streaming.hls_service import (
     _append_endlist_atomic,
     _has_endlist,
     _primary_audio_index,
+    _shift_webvtt_to_bucket_local,
 )
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
 from src.shared_kernel.value_objects.language_code import LanguageCode
@@ -881,20 +882,21 @@ class TestHlsServiceExtractOneSubtitle:
 
         assert event.is_set()
 
-    def test_should_omit_seek_flag_when_start_is_zero(self, tmp_path: Path) -> None:
-        # Cold play emits cues in source time — same scale as the
-        # bucket-local timeline when ``bucket_start == 0``.
+    def test_should_skip_post_shift_when_start_is_zero(self, tmp_path: Path) -> None:
+        # Cold play has bucket-local == source-time, so the VTT is
+        # left exactly as ffmpeg wrote it and no post-shift runs.
         import threading
 
         service, output_dir = self._make_service(tmp_path)
         service._subtitle_events["abc"] = {0: threading.Event()}
         track = _make_subtitle_track(index=0, fmt="srt")
 
+        original_vtt = "WEBVTT\n\n00:00:05.000 --> 00:00:07.000\nhello\n"
         captured: dict[str, list[str]] = {}
 
         def _capture(cmd: list[str], **_: object) -> MagicMock:
             captured["cmd"] = cmd
-            (output_dir / "sub_0" / "sub.vtt").write_text("WEBVTT\n")
+            (output_dir / "sub_0" / "sub.vtt").write_text(original_vtt)
             return MagicMock(returncode=0)
 
         with patch("subprocess.run", side_effect=_capture):
@@ -908,13 +910,17 @@ class TestHlsServiceExtractOneSubtitle:
         assert "-ss" not in captured["cmd"]
         assert "-accurate_seek" not in captured["cmd"]
         assert "-avoid_negative_ts" not in captured["cmd"]
+        assert (output_dir / "sub_0" / "sub.vtt").read_text(encoding="utf-8") == original_vtt
 
-    def test_should_shift_embedded_subtitle_cues_when_start_positive(self, tmp_path: Path) -> None:
-        # Resume buckets play on a bucket-local timeline that starts
-        # at ``bucket_start``. Without ``-ss N`` the VTT cues stay in
-        # source-time and fire ``bucket_start`` seconds after the line
-        # is actually spoken in the bucket. Verify the ffmpeg argv
-        # carries the seek + the normalize-PTS pair that rebases cues.
+    def test_should_post_shift_embedded_subtitle_cues_when_start_positive(
+        self, tmp_path: Path
+    ) -> None:
+        # ffmpeg is invoked WITHOUT ``-ss`` regardless of bucket
+        # offset because cue-PTS handling under ``-ss`` is
+        # container-dependent (we'd land at either source-time or
+        # over-shifted to zero depending on the demuxer). The full
+        # source-time VTT is then post-processed in Python to subtract
+        # ``start`` from every cue — deterministic across containers.
         import threading
 
         service, output_dir = self._make_service(tmp_path)
@@ -925,7 +931,11 @@ class TestHlsServiceExtractOneSubtitle:
 
         def _capture(cmd: list[str], **_: object) -> MagicMock:
             captured["cmd"] = cmd
-            (output_dir / "sub_1" / "sub.vtt").write_text("WEBVTT\n")
+            # ffmpeg "writes" a VTT with source-time cues — cue at
+            # source 00:30:30 (1830s), 8s past the bucket start of 1800.
+            (output_dir / "sub_1" / "sub.vtt").write_text(
+                "WEBVTT\n\n00:30:30.500 --> 00:30:33.200\nhello\n"
+            )
             return MagicMock(returncode=0)
 
         with patch("subprocess.run", side_effect=_capture):
@@ -938,20 +948,16 @@ class TestHlsServiceExtractOneSubtitle:
             )
 
         cmd = captured["cmd"]
-        assert "-ss" in cmd
-        ss_index = cmd.index("-ss")
-        input_index = cmd.index("-i")
-        assert cmd[ss_index + 1] == "1800"
-        assert ss_index < input_index
-        assert "-accurate_seek" in cmd
-        assert cmd.index("-accurate_seek") < input_index
-        ant_idx = cmd.index("-avoid_negative_ts")
-        assert cmd[ant_idx + 1] == "make_zero"
+        assert "-ss" not in cmd
+        assert "-accurate_seek" not in cmd
+        assert "-avoid_negative_ts" not in cmd
+        # Post-shift moved the cue from source-1830.5 to bucket-30.5.
+        shifted = (output_dir / "sub_1" / "sub.vtt").read_text(encoding="utf-8")
+        assert "00:00:30.500 --> 00:00:33.200" in shifted
 
-    def test_should_shift_external_subtitle_cues_when_start_positive(self, tmp_path: Path) -> None:
-        # External sidecar subs (.srt/.ass next to the video) carry the
-        # same source-time timestamps as embedded tracks, so they need
-        # the same bucket-local rebase to stay in sync on resume.
+    def test_should_post_shift_external_subtitle_cues_when_start_positive(
+        self, tmp_path: Path
+    ) -> None:
         import threading
 
         from src.shared_kernel.value_objects.file_path import FilePath
@@ -972,7 +978,9 @@ class TestHlsServiceExtractOneSubtitle:
 
         def _capture(cmd: list[str], **_: object) -> MagicMock:
             captured["cmd"] = cmd
-            (output_dir / "sub_2" / "sub.vtt").write_text("WEBVTT\n")
+            (output_dir / "sub_2" / "sub.vtt").write_text(
+                "WEBVTT\n\n00:15:10.000 --> 00:15:12.500\nhello\n"
+            )
             return MagicMock(returncode=0)
 
         with patch("subprocess.run", side_effect=_capture):
@@ -985,10 +993,12 @@ class TestHlsServiceExtractOneSubtitle:
             )
 
         cmd = captured["cmd"]
-        assert "-ss" in cmd
-        assert cmd[cmd.index("-ss") + 1] == "900"
-        assert "-accurate_seek" in cmd
-        assert "-avoid_negative_ts" in cmd
+        assert "-ss" not in cmd
+        assert "-accurate_seek" not in cmd
+        assert str(sidecar) in cmd
+        # Post-shift moved cue at source-15:10 (910s) to bucket-00:10.
+        shifted = (output_dir / "sub_2" / "sub.vtt").read_text(encoding="utf-8")
+        assert "00:00:10.000 --> 00:00:12.500" in shifted
         # External input path replaces the source file in the argv.
         assert str(sidecar) in cmd
 
@@ -1164,6 +1174,77 @@ class TestAppendEndlistAtomic:
 
         tmp_files = list(tmp_path.glob("*.endlist.tmp"))
         assert tmp_files == []
+
+
+@pytest.mark.unit
+@pytest.mark.unit
+class TestShiftWebvttToBucketLocal:
+    """Tests for the WebVTT post-shift helper."""
+
+    def test_should_shift_cue_timestamps_back_by_start(self, tmp_path: Path) -> None:
+        vtt_path = tmp_path / "sub.vtt"
+        vtt_path.write_text("WEBVTT\n\n00:30:30.500 --> 00:30:33.200\nhello\n", encoding="utf-8")
+
+        _shift_webvtt_to_bucket_local(vtt_path, 1800)
+
+        content = vtt_path.read_text(encoding="utf-8")
+        assert "00:00:30.500 --> 00:00:33.200" in content
+        assert "hello" in content
+
+    def test_should_handle_mm_ss_short_form(self, tmp_path: Path) -> None:
+        # ffmpeg sometimes writes the short ``mm:ss.fff`` form when
+        # the hour component is zero. The regex must catch both
+        # shapes so the post-shift doesn't silently skip cues.
+        vtt_path = tmp_path / "sub.vtt"
+        vtt_path.write_text("WEBVTT\n\n10:30.000 --> 10:32.500\nhello\n", encoding="utf-8")
+
+        _shift_webvtt_to_bucket_local(vtt_path, 300)
+
+        content = vtt_path.read_text(encoding="utf-8")
+        assert "00:05:30.000 --> 00:05:32.500" in content
+
+    def test_should_clamp_negative_timestamps_to_zero(self, tmp_path: Path) -> None:
+        # Cues that straddle the bucket boundary end up with a negative
+        # start after the shift. Clamping to ``00:00:00.000`` collapses
+        # them to ``start == end`` which the player skips silently.
+        vtt_path = tmp_path / "sub.vtt"
+        vtt_path.write_text(
+            "WEBVTT\n\n00:29:58.000 --> 00:30:02.000\nstraddle\n",
+            encoding="utf-8",
+        )
+
+        _shift_webvtt_to_bucket_local(vtt_path, 1800)
+
+        content = vtt_path.read_text(encoding="utf-8")
+        # Start was 2s before the new zero → clamps to 00:00:00.000.
+        assert "00:00:00.000 --> 00:00:02.000" in content
+
+    def test_should_preserve_cue_text_lines(self, tmp_path: Path) -> None:
+        vtt_path = tmp_path / "sub.vtt"
+        vtt_path.write_text(
+            "WEBVTT\n\n00:31:00.000 --> 00:31:02.000\n" "first line\n" "second line\n",
+            encoding="utf-8",
+        )
+
+        _shift_webvtt_to_bucket_local(vtt_path, 1800)
+
+        content = vtt_path.read_text(encoding="utf-8")
+        assert "first line" in content
+        assert "second line" in content
+
+    def test_should_no_op_when_shift_is_zero(self, tmp_path: Path) -> None:
+        vtt_path = tmp_path / "sub.vtt"
+        original = "WEBVTT\n\n00:00:05.000 --> 00:00:07.000\nhello\n"
+        vtt_path.write_text(original, encoding="utf-8")
+
+        _shift_webvtt_to_bucket_local(vtt_path, 0)
+
+        assert vtt_path.read_text(encoding="utf-8") == original
+
+    def test_should_no_op_when_file_missing(self, tmp_path: Path) -> None:
+        # Defensive — caller may pass a path that the ffmpeg run never
+        # actually produced (timeout, demuxer error). Don't blow up.
+        _shift_webvtt_to_bucket_local(tmp_path / "missing.vtt", 100)
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -322,6 +322,36 @@ class TestHlsServiceBuildAudioCmd:
         assert cmd[ss_index + 1] == "1800"
         assert ss_index < input_index
 
+    def test_should_force_accurate_seek_when_start_positive(self, tmp_path: Path) -> None:
+        # Without ``-accurate_seek`` ffmpeg drops to the preceding
+        # keyframe but audio starts at exactly ``start`` — the two
+        # streams open out of sync by ``start - keyframe_pos``.
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0, start=1800)
+
+        assert "-accurate_seek" in cmd
+        accurate_index = cmd.index("-accurate_seek")
+        input_index = cmd.index("-i")
+        assert accurate_index < input_index
+
+    def test_should_normalize_negative_ts_when_start_positive(self, tmp_path: Path) -> None:
+        # ``-avoid_negative_ts make_zero`` clamps the per-stream PTS
+        # minimum to zero so any residual offset surfaces as a tiny
+        # leading silence instead of an audio-leads-video drift.
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0, start=1800)
+
+        assert "-avoid_negative_ts" in cmd
+        idx = cmd.index("-avoid_negative_ts")
+        assert cmd[idx + 1] == "make_zero"
+
+    def test_should_not_emit_sync_flags_when_start_is_zero(self, tmp_path: Path) -> None:
+        # Sync hardening only kicks in for non-zero ``start`` since the
+        # legacy cold-cache transcode never hits the keyframe-vs-audio
+        # gap (it begins at t=0 of the source).
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
+
+        assert "-accurate_seek" not in cmd
+        assert "-avoid_negative_ts" not in cmd
+
 
 @pytest.mark.unit
 class TestHlsServiceBuildVideoCmd:
@@ -336,6 +366,21 @@ class TestHlsServiceBuildVideoCmd:
 
         assert "copy" in cmd
         assert "libx264" not in cmd
+
+    def test_should_transcode_h264_when_start_positive(self, tmp_path: Path) -> None:
+        # ``-c:v copy`` is the fast path for cold cache but it skips
+        # the decode pass that ``-accurate_seek`` depends on. With a
+        # non-zero ``start`` the copy would land at the preceding
+        # keyframe while audio lands at the exact second, so we force
+        # the transcode to keep the two streams aligned.
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+
+        assert "libx264" in cmd
+        assert "copy" not in cmd
 
     def test_should_transcode_non_h264(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path / "cache"))
@@ -382,6 +427,42 @@ class TestHlsServiceBuildVideoCmd:
         input_index = cmd.index("-i")
         assert cmd[ss_index + 1] == "1800"
         assert ss_index < input_index
+
+    def test_should_force_accurate_seek_when_start_positive(self, tmp_path: Path) -> None:
+        # Mirrors the audio-cmd test — without this, the video opens at
+        # the preceding keyframe while audio opens at the exact seek
+        # point and playback drifts audio-leads-video.
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+
+        assert "-accurate_seek" in cmd
+        accurate_index = cmd.index("-accurate_seek")
+        input_index = cmd.index("-i")
+        assert accurate_index < input_index
+
+    def test_should_normalize_negative_ts_when_start_positive(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+
+        assert "-avoid_negative_ts" in cmd
+        idx = cmd.index("-avoid_negative_ts")
+        assert cmd[idx + 1] == "make_zero"
+
+    def test_should_not_emit_sync_flags_when_start_is_zero(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "cache"))
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "-accurate_seek" not in cmd
+        assert "-avoid_negative_ts" not in cmd
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -881,9 +881,9 @@ class TestHlsServiceExtractOneSubtitle:
 
         assert event.is_set()
 
-    def test_should_not_emit_a_seek_flag(self, tmp_path: Path) -> None:
-        # Subtitle timestamps are absolute source times, which is also
-        # what the player's ``currentTime`` reports — no seek needed.
+    def test_should_omit_seek_flag_when_start_is_zero(self, tmp_path: Path) -> None:
+        # Cold play emits cues in source time — same scale as the
+        # bucket-local timeline when ``bucket_start == 0``.
         import threading
 
         service, output_dir = self._make_service(tmp_path)
@@ -906,6 +906,91 @@ class TestHlsServiceExtractOneSubtitle:
             )
 
         assert "-ss" not in captured["cmd"]
+        assert "-accurate_seek" not in captured["cmd"]
+        assert "-avoid_negative_ts" not in captured["cmd"]
+
+    def test_should_shift_embedded_subtitle_cues_when_start_positive(self, tmp_path: Path) -> None:
+        # Resume buckets play on a bucket-local timeline that starts
+        # at ``bucket_start``. Without ``-ss N`` the VTT cues stay in
+        # source-time and fire ``bucket_start`` seconds after the line
+        # is actually spoken in the bucket. Verify the ffmpeg argv
+        # carries the seek + the normalize-PTS pair that rebases cues.
+        import threading
+
+        service, output_dir = self._make_service(tmp_path)
+        service._subtitle_events["abc"] = {1: threading.Event()}
+        track = _make_subtitle_track(index=1, fmt="srt")
+
+        captured: dict[str, list[str]] = {}
+
+        def _capture(cmd: list[str], **_: object) -> MagicMock:
+            captured["cmd"] = cmd
+            (output_dir / "sub_1" / "sub.vtt").write_text("WEBVTT\n")
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=_capture):
+            service._extract_one_subtitle(
+                file_path="/movies/test.mkv",
+                output_dir=output_dir,
+                track=track,
+                path_hash="abc",
+                start=1800,
+            )
+
+        cmd = captured["cmd"]
+        assert "-ss" in cmd
+        ss_index = cmd.index("-ss")
+        input_index = cmd.index("-i")
+        assert cmd[ss_index + 1] == "1800"
+        assert ss_index < input_index
+        assert "-accurate_seek" in cmd
+        assert cmd.index("-accurate_seek") < input_index
+        ant_idx = cmd.index("-avoid_negative_ts")
+        assert cmd[ant_idx + 1] == "make_zero"
+
+    def test_should_shift_external_subtitle_cues_when_start_positive(self, tmp_path: Path) -> None:
+        # External sidecar subs (.srt/.ass next to the video) carry the
+        # same source-time timestamps as embedded tracks, so they need
+        # the same bucket-local rebase to stay in sync on resume.
+        import threading
+
+        from src.shared_kernel.value_objects.file_path import FilePath
+
+        service, output_dir = self._make_service(tmp_path)
+        service._subtitle_events["abc"] = {2: threading.Event()}
+        sidecar = tmp_path / "movie.en.srt"
+        sidecar.write_text("1\n00:00:01,000 --> 00:00:02,000\nhello\n")
+        track = SubtitleTrack(
+            index=2,
+            language=LanguageCode("en"),
+            format="srt",
+            is_external=True,
+            file_path=FilePath(str(sidecar)),
+        )
+
+        captured: dict[str, list[str]] = {}
+
+        def _capture(cmd: list[str], **_: object) -> MagicMock:
+            captured["cmd"] = cmd
+            (output_dir / "sub_2" / "sub.vtt").write_text("WEBVTT\n")
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=_capture):
+            service._extract_one_subtitle(
+                file_path="/movies/test.mkv",
+                output_dir=output_dir,
+                track=track,
+                path_hash="abc",
+                start=900,
+            )
+
+        cmd = captured["cmd"]
+        assert "-ss" in cmd
+        assert cmd[cmd.index("-ss") + 1] == "900"
+        assert "-accurate_seek" in cmd
+        assert "-avoid_negative_ts" in cmd
+        # External input path replaces the source file in the argv.
+        assert str(sidecar) in cmd
 
     def test_kill_processes_should_release_subtitle_waiters(self, tmp_path: Path) -> None:
         import threading

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -12,6 +12,8 @@ import pytest
 from src.modules.media.application.ports import ProbeResult
 from src.modules.media.infrastructure.streaming.hls_service import (
     HlsService,
+    _append_endlist_atomic,
+    _has_endlist,
     _primary_audio_index,
 )
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
@@ -880,3 +882,206 @@ class TestEvictLru:
         evicted = service.evict_lru()
 
         assert evicted == []
+
+
+@pytest.mark.unit
+class TestHasEndlist:
+    """Tests for the _has_endlist helper."""
+
+    def test_should_return_true_when_tag_present(self, tmp_path: Path) -> None:
+        playlist = tmp_path / "playlist.m3u8"
+        playlist.write_text("#EXTM3U\n#EXTINF:10,\nseg.ts\n#EXT-X-ENDLIST\n")
+
+        assert _has_endlist(playlist) is True
+
+    def test_should_return_false_when_tag_missing(self, tmp_path: Path) -> None:
+        playlist = tmp_path / "playlist.m3u8"
+        playlist.write_text("#EXTM3U\n#EXTINF:10,\nseg.ts\n")
+
+        assert _has_endlist(playlist) is False
+
+    def test_should_return_false_when_file_missing(self, tmp_path: Path) -> None:
+        assert _has_endlist(tmp_path / "nonexistent.m3u8") is False
+
+
+@pytest.mark.unit
+class TestAppendEndlistAtomic:
+    """Tests for the _append_endlist_atomic helper."""
+
+    def test_should_append_endlist_when_missing(self, tmp_path: Path) -> None:
+        playlist = tmp_path / "playlist.m3u8"
+        playlist.write_text("#EXTM3U\n#EXTINF:10,\nseg.ts\n")
+
+        _append_endlist_atomic(playlist)
+
+        content = playlist.read_text(encoding="utf-8")
+        assert content.endswith("#EXT-X-ENDLIST\n")
+        # Original content preserved, not duplicated
+        assert content.count("#EXTINF") == 1
+
+    def test_should_be_idempotent_when_endlist_already_present(self, tmp_path: Path) -> None:
+        playlist = tmp_path / "playlist.m3u8"
+        original = "#EXTM3U\n#EXTINF:10,\nseg.ts\n#EXT-X-ENDLIST\n"
+        playlist.write_text(original)
+
+        _append_endlist_atomic(playlist)
+
+        assert playlist.read_text(encoding="utf-8") == original
+
+    def test_should_add_trailing_newline_before_endlist(self, tmp_path: Path) -> None:
+        playlist = tmp_path / "playlist.m3u8"
+        # Last line has no trailing newline
+        playlist.write_text("#EXTM3U\n#EXTINF:10,\nseg.ts")
+
+        _append_endlist_atomic(playlist)
+
+        content = playlist.read_text(encoding="utf-8")
+        assert "seg.ts\n#EXT-X-ENDLIST\n" in content
+
+    def test_should_no_op_when_file_missing(self, tmp_path: Path) -> None:
+        missing = tmp_path / "missing.m3u8"
+
+        _append_endlist_atomic(missing)
+
+        assert not missing.exists()
+
+    def test_should_not_leave_tmp_file_behind(self, tmp_path: Path) -> None:
+        playlist = tmp_path / "playlist.m3u8"
+        playlist.write_text("#EXTM3U\n#EXTINF:10,\nseg.ts\n")
+
+        _append_endlist_atomic(playlist)
+
+        tmp_files = list(tmp_path.glob("*.endlist.tmp"))
+        assert tmp_files == []
+
+
+@pytest.mark.unit
+class TestHlsServiceIsCompleteAllPlaylists:
+    """Tests for the all-playlists check in is_complete."""
+
+    def test_should_return_true_when_every_nested_playlist_sealed(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        bucket = tmp_path / "abc"
+        bucket.mkdir()
+        for sub in ("video", "audio_1", "sub_0"):
+            (bucket / sub).mkdir()
+            (bucket / sub / "playlist.m3u8").write_text(
+                "#EXTM3U\n#EXTINF:10,\nseg.ts\n#EXT-X-ENDLIST\n"
+            )
+
+        assert service.is_complete("abc") is True
+
+    def test_should_return_false_when_one_playlist_missing_endlist(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        bucket = tmp_path / "abc"
+        bucket.mkdir()
+        # Video sealed, alt audio still growing (no ENDLIST)
+        (bucket / "video").mkdir()
+        (bucket / "video" / "playlist.m3u8").write_text(
+            "#EXTM3U\n#EXTINF:10,\nseg.ts\n#EXT-X-ENDLIST\n"
+        )
+        (bucket / "audio_1").mkdir()
+        (bucket / "audio_1" / "playlist.m3u8").write_text("#EXTM3U\n#EXTINF:10,\nseg.ts\n")
+
+        assert service.is_complete("abc") is False
+
+
+@pytest.mark.unit
+class TestHlsServiceWatchForEndlist:
+    """Tests for the daemon-thread encode watcher."""
+
+    def test_should_seal_playlist_when_ffmpeg_exits_clean(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        playlist = tmp_path / "playlist.m3u8"
+        playlist.write_text("#EXTM3U\n#EXTINF:10,\nseg.ts\n")
+        proc = MagicMock()
+        proc.wait.return_value = 0
+
+        service._watch_for_endlist(proc, playlist)
+
+        assert "#EXT-X-ENDLIST" in playlist.read_text(encoding="utf-8")
+
+    def test_should_not_seal_when_ffmpeg_exits_with_error(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        playlist = tmp_path / "playlist.m3u8"
+        original = "#EXTM3U\n#EXTINF:10,\nseg.ts\n"
+        playlist.write_text(original)
+        proc = MagicMock()
+        proc.wait.return_value = 1
+
+        service._watch_for_endlist(proc, playlist)
+
+        assert playlist.read_text(encoding="utf-8") == original
+
+    def test_should_not_seal_when_process_killed_by_eviction(self, tmp_path: Path) -> None:
+        # SIGKILL gives a negative returncode on POSIX; the watcher must
+        # treat this exactly like a hard failure and leave the playlist
+        # growable so the next session regenerates.
+        service = HlsService(cache_dir=str(tmp_path))
+        playlist = tmp_path / "playlist.m3u8"
+        original = "#EXTM3U\n#EXTINF:10,\nseg.ts\n"
+        playlist.write_text(original)
+        proc = MagicMock()
+        proc.wait.return_value = -9
+
+        service._watch_for_endlist(proc, playlist)
+
+        assert playlist.read_text(encoding="utf-8") == original
+
+    def test_should_swallow_wait_exceptions(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        playlist = tmp_path / "playlist.m3u8"
+        original = "#EXTM3U\n#EXTINF:10,\nseg.ts\n"
+        playlist.write_text(original)
+        proc = MagicMock()
+        proc.wait.side_effect = OSError("broken pipe")
+
+        # Must not raise — the watcher runs in a daemon thread and a
+        # crash there is silently dropped, leaving the cache untouched.
+        service._watch_for_endlist(proc, playlist)
+
+        assert playlist.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.unit
+class TestHlsServiceSpawnFfmpegWatcher:
+    """Tests for the watcher hookup in _spawn_ffmpeg."""
+
+    def test_should_start_watcher_thread_when_playlist_path_provided(self, tmp_path: Path) -> None:
+        import threading as _threading
+
+        service = HlsService(cache_dir=str(tmp_path))
+        playlist = tmp_path / "playlist.m3u8"
+        playlist.write_text("#EXTM3U\n#EXTINF:10,\nseg.ts\n")
+
+        fake_proc = MagicMock()
+        fake_proc.wait.return_value = 0
+        # Snapshot live threads before, then count new ones after.
+        threads_before = {t.ident for t in _threading.enumerate()}
+
+        with patch("subprocess.Popen", return_value=fake_proc):
+            service._spawn_ffmpeg(["ffmpeg", "-i", "in", "out"], playlist_path=playlist)
+
+        # Allow the daemon thread to run and seal the playlist.
+        for _ in range(50):
+            if "#EXT-X-ENDLIST" in playlist.read_text(encoding="utf-8"):
+                break
+            time.sleep(0.02)
+
+        assert "#EXT-X-ENDLIST" in playlist.read_text(encoding="utf-8")
+
+        # A new daemon thread must have been spawned with our prefix.
+        new_threads = [t for t in _threading.enumerate() if t.ident not in threads_before]
+        assert any(t.name.startswith("hls-endlist-") for t in new_threads) or all(
+            not t.is_alive() for t in new_threads
+        )
+
+    def test_should_not_start_watcher_when_playlist_path_none(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+        fake_proc = MagicMock()
+
+        with patch("subprocess.Popen", return_value=fake_proc):
+            service._spawn_ffmpeg(["ffmpeg", "-i", "in", "out"])
+
+        # wait() must not have been called from a watcher — no watcher started.
+        fake_proc.wait.assert_not_called()


### PR DESCRIPTION
## Summary

- Add `?start=N` query on `/api/v1/stream/.../hls/playlist.m3u8` that pins the HLS encode to a 5-minute bucket beginning at source-time second `N`. Default `start=0` keeps the legacy single-bucket cache so existing on-disk encodes stay valid (`get_path_hash` reuses the old hash when `start=0`).
- Seal each `playlist.m3u8` (video + alternate audio) with `#EXT-X-ENDLIST` on ffmpeg's clean exit so `is_complete` flips to `True` and subsequent sessions reuse the cache instead of respawning a fresh transcode. `is_complete` now requires the tag on every nested playlist so an alt-audio encode killed mid-flight doesn't make a half-encoded bucket look final.
- Force `-c:v libx264` (drop the H.264 copy fast path) when `start > 0` so `-accurate_seek` actually decodes-and-drops video frames between the preceding keyframe and the requested second. With copy, video opened at the keyframe while audio opened at the exact second and the streams played 1-3s out of sync.
- Emit `-accurate_seek` + `-avoid_negative_ts make_zero` on the video/audio ffmpeg argvs for non-zero `start` to align PTS baselines at zero after the seek.
- Subtitle pipeline extracts the WebVTT in source-time (no `-ss`) and post-processes the file in Python: a regex over `MM:SS.fff` / `HH:MM:SS.fff` cue timestamps subtracts `start` from each one, clamping negatives to zero. The python shift is deterministic across MKV/MP4/sidecar demuxers; the previous attempt via `-ss N` produced container-dependent results (cues over-shifted to `00:00.000` with `make_zero`, late by `N` seconds without it).

## Test plan

- [x] `pytest tests/modules/media/` — 1257 passed, 5 skipped
- [x] `ruff check` + `ruff format --check` clean across changed files
- [x] Manual smoke: warm-cache resume lands at saved position (was landing at buffer head)
- [x] Manual smoke: audio synchronised with video on cold-cache resume bucket (was 1-3s drift)
- [x] Manual smoke: subtitle cues match the spoken line on cold-cache resume bucket (was several-second drift)
- [ ] Manual smoke (pending review): cold-cache far-forward seek beyond buffered head
- [ ] Manual smoke (pending review): seek-back across a bucket boundary triggers a clean remount
- [ ] Manual smoke (pending review): episode auto-advance re-computes bucketStart from the next episode's saved progress

## Related PR

Pairs with `feat/hls-resume-bucket-translation` on the frontend repo (Player.tsx consumes the new `?start=` query).

## Summary by Sourcery

Add start-offset-aware HLS caching and encoding so cold-cache resume/seek uses bucketed offsets while preserving legacy caches for start=0.

New Features:
- Support a start query parameter on HLS playlist endpoints to begin transcoding from a specified source-time offset, bucketed into 5-minute windows.
- Enable bucketed HLS cache keys that differentiate encodes by file path and start-offset bucket instead of a single per-file cache.
- Introduce subtitle cue post-processing to shift WebVTT timestamps into bucket-local time for non-zero start offsets.

Enhancements:
- Mark HLS playlists as complete only when all nested playlists (video, alternate audio, subtitles) are sealed with ENDLIST, and add an ffmpeg watcher that appends ENDLIST on clean exits.
- Adjust video and audio ffmpeg commands to perform input seeks with accurate timing and normalized timestamps for non-zero start offsets, while preserving legacy behavior for start=0.
- Refactor subtitle extraction into smaller helpers and consolidate ffmpeg invocation and timeout handling.

Tests:
- Extend media streaming, playlist generation, and subtitle handling unit tests to cover start-offset bucketing, seek-related ffmpeg flags, ENDLIST sealing, and WebVTT post-shift behavior.