### PR TITLE
fix(media): match TMDB entries by year and type

### DIFF
--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -68,10 +68,11 @@ class EnrichMovieMetadataUseCase:
 
             metadata, provider_name = await self._fetch_metadata(movie)
             if not metadata:
+                error_msg = await self._build_no_metadata_error(movie, input_dto.media_id)
                 return EnrichMediaOutput(
                     media_id=input_dto.media_id,
                     enriched=False,
-                    error="No metadata found from any provider",
+                    error=error_msg,
                 )
 
             # Re-fetch with localization if TMDB provider supports it
@@ -89,8 +90,13 @@ class EnrichMovieMetadataUseCase:
     async def _fetch_metadata(self, movie: Movie) -> tuple[MediaMetadata | None, str | None]:
         """Try primary provider, then fallback.
 
-        Searches with original title first, then retries with a
-        cleaned title (quality tags removed) and without year.
+        Always year-strict: every search retains the ``year`` hint so a
+        popular off-year title (e.g. ``Salem's Lot`` 2024 outranking the
+        1979 entry that doesn't exist as a movie on TMDB at all) cannot
+        win as a silent title-only fallback. When no year-correct match
+        is found, ``_build_no_metadata_error`` runs a cross-type check
+        against ``/search/tv`` so the user gets an actionable hint
+        instead of a wrong enrichment.
         """
         if movie.tmdb_id:
             metadata = await self._primary.get_movie_by_id(movie.tmdb_id.value)
@@ -100,30 +106,70 @@ class EnrichMovieMetadataUseCase:
         title = movie.title.value
         year = movie.year.value
 
-        # Try with original title + year
         metadata = await self._primary.search_movie(title, year)
         if metadata:
             return metadata, "tmdb"
 
-        # Retry with cleaned title (remove quality tags) and no year
+        # Retry with quality tags stripped — keep the year hint so we
+        # don't open the door to off-year matches the strict search
+        # already rejected.
         clean = _clean_title(title)
         if clean != title:
-            metadata = await self._primary.search_movie(clean)
+            metadata = await self._primary.search_movie(clean, year)
             if metadata:
                 return metadata, "tmdb"
 
-        # Retry with just the title, no year
-        metadata = await self._primary.search_movie(title)
-        if metadata:
-            return metadata, "tmdb"
-
         if self._fallback:
-            metadata = await self._fallback.search_movie(clean or title)
+            metadata = await self._fallback.search_movie(clean or title, year)
             if metadata:
                 return metadata, "omdb"
 
-        _logger.warning("No metadata found for movie %r", title)
+        _logger.warning("No metadata found for movie %r (year=%s)", title, year)
         return None, None
+
+    async def _detect_cross_type_series(self, title: str, year: int | None) -> int | None:
+        """Look for a TV series match when a movie search came back empty.
+
+        Why: the scanner classifies any file without an ``SxxExx`` pattern
+        as a Movie (see ``scanner.py:_detect_episode``), but some titles
+        only exist on TMDB as TV miniseries — e.g. ``Salem's Lot (1979)``
+        lives at ``tmdb/tv/16118``, not under ``/search/movie`` at all.
+        When the movie path can't find a match, we re-query ``/search/tv``
+        so we can surface an actionable hint instead of silently leaving
+        the item un-enriched. Returns the TMDB series ID on match, or
+        ``None`` if the title isn't on the TV side either.
+        """
+        metadata = await self._primary.search_series(title, year)
+        if metadata is None and year is not None:
+            metadata = await self._primary.search_series(title)
+        return metadata.tmdb_id if metadata else None
+
+    async def _build_no_metadata_error(self, movie: Movie, media_id: str) -> str:
+        """Produce the ``error`` payload for a failed enrichment.
+
+        Defaults to a generic "no provider matched" message. When the
+        title resolves on the TV side instead, the message embeds the
+        suggested TMDB series ID so the user can re-classify the file
+        (move into a series library or rename with ``SxxExx``).
+        """
+        cross_type_tmdb_id = await self._detect_cross_type_series(
+            movie.title.value, movie.year.value
+        )
+        if cross_type_tmdb_id is None:
+            return "No metadata found from any provider"
+
+        _logger.warning(
+            "Cross-type match for movie %r (id=%s): TMDB series tv/%s",
+            movie.title.value,
+            media_id,
+            cross_type_tmdb_id,
+        )
+        return (
+            f"Cross-type match: this title appears to be a TV series on TMDB "
+            f"(tmdb/tv/{cross_type_tmdb_id}). Move the file into a series "
+            f"library or rename with an SxxExx pattern so the scanner "
+            f"classifies it as a series."
+        )
 
 
 def _clean_title(title: str) -> str:

--- a/src/modules/media/infrastructure/file_system/scanner.py
+++ b/src/modules/media/infrastructure/file_system/scanner.py
@@ -45,7 +45,14 @@ def _extract_year(filename: str) -> int | None:
 
 
 def _extract_title(filename: str, year: int | None) -> str:
-    """Extract title from filename by removing year and quality tags."""
+    """Extract title from filename by removing year and quality tags.
+
+    When the year is wrapped in brackets (``Title (1979).mkv``,
+    ``Title [1979].mkv``), slicing at the year digit leaves the opening
+    bracket behind. Those characters are included in the final strip so
+    downstream TMDB matching sees ``Salem's Lot`` rather than
+    ``Salem's Lot (``.
+    """
     stem = PurePath(filename).stem
 
     # Remove everything from year onwards (if present)
@@ -57,7 +64,7 @@ def _extract_title(filename: str, year: int | None) -> str:
     # Replace dots, underscores with spaces and strip
     title = re.sub(r"[\._]", " ", stem).strip()
     title = re.sub(r"\s+", " ", title)
-    return title.strip(" -")
+    return title.strip(" -([{")
 
 
 def _detect_episode(file_path: str) -> tuple[str, int, int] | None:

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -109,7 +109,16 @@ class TmdbClient(MetadataProvider):
         return self._image_url(best.get("file_path"))
 
     async def search_movie(self, title: str, year: int | None = None) -> MediaMetadata | None:
-        """Search TMDB for a movie and return metadata for the best match."""
+        """Search TMDB for a movie and return metadata for the best match.
+
+        When ``year`` is provided, results are filtered to entries whose
+        ``release_date`` falls in that exact year — TMDB's ``year`` query
+        param is a soft ranking signal, not a hard filter, so without
+        this post-filter a popular off-year title (e.g. ``Salem's Lot``
+        2024) can outrank the year-correct entry. Returns ``None`` when
+        no result matches the requested year; the caller's retry layer
+        will re-search without the year hint.
+        """
         resp = await self._client.get(
             f"{self._base_url}/search/movie",
             params=self._params(query=title, year=year),
@@ -117,14 +126,23 @@ class TmdbClient(MetadataProvider):
         resp.raise_for_status()
         results = resp.json().get("results", [])
 
-        if not results:
+        best = self._pick_year_match(results, year, "release_date")
+        if best is None:
             return None
 
-        tmdb_id = results[0]["id"]
-        return await self._fetch_movie_details(tmdb_id)
+        return await self._fetch_movie_details(best["id"])
 
     async def search_series(self, title: str, year: int | None = None) -> MediaMetadata | None:
-        """Search TMDB for a TV series and return metadata for the best match."""
+        """Search TMDB for a TV series and return metadata for the best match.
+
+        When ``year`` is provided, results are filtered to entries whose
+        ``first_air_date`` falls in that exact year. See ``search_movie``
+        for the rationale: ``first_air_date_year`` boosts ranking but does
+        not strictly filter, so the more-popular off-year entry can come
+        back first (e.g. ``American Gothic`` 1995 outranking the 2016
+        revival). Returns ``None`` when no result matches the requested
+        year.
+        """
         resp = await self._client.get(
             f"{self._base_url}/search/tv",
             params=self._params(query=title, first_air_date_year=year),
@@ -132,11 +150,36 @@ class TmdbClient(MetadataProvider):
         resp.raise_for_status()
         results = resp.json().get("results", [])
 
-        if not results:
+        best = self._pick_year_match(results, year, "first_air_date")
+        if best is None:
             return None
 
-        tmdb_id = results[0]["id"]
-        return await self._fetch_series_details(tmdb_id)
+        return await self._fetch_series_details(best["id"])
+
+    @staticmethod
+    def _pick_year_match(
+        results: list[dict[str, object]],
+        year: int | None,
+        date_field: str,
+    ) -> dict[str, object] | None:
+        """Pick the first result whose ``date_field`` starts with ``year``.
+
+        Without a ``year`` hint, falls back to the first result (TMDB's
+        own popularity ranking). With a ``year`` hint, returns ``None``
+        if no result matches — strict year semantics, to avoid silently
+        returning a popular off-year entry.
+        """
+        if not results:
+            return None
+        if year is None:
+            return results[0]
+
+        prefix = f"{year}"
+        for result in results:
+            date = result.get(date_field)
+            if isinstance(date, str) and date.startswith(prefix):
+                return result
+        return None
 
     async def get_movie_by_id(self, tmdb_id: int) -> MediaMetadata | None:
         """Fetch movie details by TMDB ID."""

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -127,12 +127,56 @@ class TestEnrichMovieMetadata:
         movie = _make_movie()
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_movie.return_value = None
+        provider.search_series.return_value = None
+
+        use_case, _ = _set_up_enrichment(movie, provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is False
+        assert result.error == "No metadata found from any provider"
+
+    @pytest.mark.asyncio
+    async def test_should_surface_cross_type_hint_when_title_is_a_tv_series(self) -> None:
+        """Salem's Lot 1979 case: movie search finds nothing for the year,
+        but ``/search/tv`` matches a miniseries. The use case must surface
+        the suggested TMDB series id so the user can re-classify."""
+        movie = _make_movie()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = None
+        provider.search_series.return_value = MediaMetadata(
+            title="Salem's Lot",
+            tmdb_id=16118,
+            year=1979,
+        )
 
         use_case, _ = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is False
         assert result.error is not None
+        assert "tmdb/tv/16118" in result.error
+        assert "series" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_should_retry_cross_type_without_year_when_year_search_misses(self) -> None:
+        """If the TV-side search misses with the year hint, retry without
+        it — same fallback chain as the movie path, since the folder year
+        may be off-by-one for a miniseries premiere."""
+        movie = _make_movie()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = None
+        provider.search_series.side_effect = [
+            None,
+            MediaMetadata(title="Salem's Lot", tmdb_id=16118, year=1979),
+        ]
+
+        use_case, _ = _set_up_enrichment(movie, provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        assert result.enriched is False
+        assert result.error is not None
+        assert "tmdb/tv/16118" in result.error
+        assert provider.search_series.await_count == 2
 
     @pytest.mark.asyncio
     async def test_should_raise_when_movie_not_found(self) -> None:
@@ -175,7 +219,9 @@ class TestEnrichMovieMetadata:
         assert "pt-BR" in saved.localized
 
     @pytest.mark.asyncio
-    async def test_should_retry_with_cleaned_title(self) -> None:
+    async def test_should_retry_with_cleaned_title_preserving_year(self) -> None:
+        """Quality-tag cleanup still passes the year hint — dropping the
+        year on retry was the original Salem's Lot regression."""
         movie = Movie.create(
             library_id=_LIBRARY_ID,
             title="Inception 1080p BluRay x264",
@@ -187,23 +233,37 @@ class TestEnrichMovieMetadata:
         )
         provider = AsyncMock(spec=MetadataProvider)
         provider.search_movie.side_effect = [None, _make_metadata()]
+        provider.search_series.return_value = None
 
         use_case, _ = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         assert result.enriched is True
         assert provider.search_movie.await_count == 2
+        first_call, second_call = provider.search_movie.await_args_list
+        assert first_call.args == ("Inception 1080p BluRay x264", 2010)
+        assert second_call.args == ("Inception", 2010)
 
     @pytest.mark.asyncio
-    async def test_should_retry_with_title_only_when_year_search_fails(self) -> None:
+    async def test_should_not_retry_title_only_when_year_search_fails(self) -> None:
+        """Year-strict contract: when the year-correct match is missing,
+        do NOT silently promote a popular off-year result. Falls through
+        to cross-type detection (or generic "not found") instead. This
+        is what got Salem's Lot 1979 wrongly enriched as the 2024 movie
+        before — the no-year retry overrode the year filter."""
         movie = _make_movie()
         provider = AsyncMock(spec=MetadataProvider)
-        provider.search_movie.side_effect = [None, _make_metadata()]
+        provider.search_movie.return_value = None
+        provider.search_series.return_value = None
 
         use_case, _ = _set_up_enrichment(movie, provider)
         result = await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
-        assert result.enriched is True
+        assert result.enriched is False
+        # One movie call with year, plus the cross-type series lookup.
+        # No title-only retry should have been made.
+        assert provider.search_movie.await_count == 1
+        assert provider.search_movie.await_args.args == ("Inception", 2010)
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/infrastructure/file_system/test_scanner.py
+++ b/tests/modules/media/unit/infrastructure/file_system/test_scanner.py
@@ -94,6 +94,19 @@ class TestScanDirectories:
         assert results[0].title == "Inception"
         assert results[0].year == 2010
 
+    def test_should_strip_trailing_bracket_when_year_is_wrapped(
+        self, scanner: LocalFileSystemScanner, media_dir: Path
+    ) -> None:
+        """Folders like ``Title (year)`` left a dangling ``(`` in the
+        extracted title — broke fuzzy matching against TMDB."""
+        _create_file(media_dir, "Salem's Lot (1979).mkv")
+        _create_file(media_dir, "Other Movie [1985].mkv")
+
+        results = scanner.scan_directories([FilePath(str(media_dir))])
+        titles = {r.title for r in results}
+
+        assert titles == {"Salem's Lot", "Other Movie"}
+
     def test_should_extract_resolution(
         self, scanner: LocalFileSystemScanner, media_dir: Path
     ) -> None:

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -433,7 +433,9 @@ class TestSearchMovie:
     async def test_should_return_metadata_for_match(self) -> None:
         client = _make_client(
             get_responses=[
-                _build_response(json_data={"results": [{"id": 27205}]}),
+                _build_response(
+                    json_data={"results": [{"id": 27205, "release_date": "2010-07-16"}]}
+                ),
                 _build_response(json_data=_movie_details()),
             ]
         )
@@ -454,7 +456,7 @@ class TestSearchMovie:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_should_use_first_result_when_multiple(self) -> None:
+    async def test_should_use_first_result_when_no_year_hint(self) -> None:
         client = _make_client(
             get_responses=[
                 _build_response(json_data={"results": [{"id": 100}, {"id": 200}]}),
@@ -467,6 +469,71 @@ class TestSearchMovie:
         assert result is not None
         assert result.tmdb_id == 100
 
+    @pytest.mark.asyncio
+    async def test_should_prefer_year_match_over_first_result(self) -> None:
+        """American Gothic-style case for movies: year-correct entry is not
+        ranked first by TMDB and must be selected by the year post-filter."""
+        client = _make_client(
+            get_responses=[
+                _build_response(
+                    json_data={
+                        "results": [
+                            {"id": 748230, "release_date": "2024-10-03"},
+                            {"id": 555, "release_date": "2016-05-12"},
+                        ]
+                    }
+                ),
+                _build_response(json_data=_movie_details(tmdb_id=555)),
+            ]
+        )
+
+        result = await client.search_movie("Salem's Lot", 2016)
+
+        assert result is not None
+        assert result.tmdb_id == 555
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_when_no_result_matches_year(self) -> None:
+        """Salem's Lot 1979 case: the 1979 entry isn't a movie on TMDB, so
+        no movie result matches year=1979. Returns None so the caller can
+        retry without the year hint instead of silently picking 2024."""
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "results": [
+                        {"id": 748230, "release_date": "2024-10-03"},
+                        {"id": 999, "release_date": "2004-06-04"},
+                    ]
+                }
+            )
+        )
+
+        result = await client.search_movie("Salem's Lot", 1979)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_skip_results_with_missing_release_date(self) -> None:
+        client = _make_client(
+            get_responses=[
+                _build_response(
+                    json_data={
+                        "results": [
+                            {"id": 100},
+                            {"id": 200, "release_date": ""},
+                            {"id": 300, "release_date": "2010-07-16"},
+                        ]
+                    }
+                ),
+                _build_response(json_data=_movie_details(tmdb_id=300)),
+            ]
+        )
+
+        result = await client.search_movie("Inception", 2010)
+
+        assert result is not None
+        assert result.tmdb_id == 300
+
 
 @pytest.mark.unit
 class TestSearchSeries:
@@ -476,7 +543,9 @@ class TestSearchSeries:
     async def test_should_return_metadata_for_match(self) -> None:
         client = _make_client(
             get_responses=[
-                _build_response(json_data={"results": [{"id": 1396}]}),
+                _build_response(
+                    json_data={"results": [{"id": 1396, "first_air_date": "2008-01-20"}]}
+                ),
                 _build_response(json_data=_series_details()),
                 _build_response(json_data=_season_details()),
             ]
@@ -494,6 +563,50 @@ class TestSearchSeries:
         client = _make_client(get_responses=_build_response(json_data={"results": []}))
 
         result = await client.search_series("Nonexistent")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_prefer_year_match_over_first_result(self) -> None:
+        """American Gothic 2016 case: TMDB ranks the more-popular 1995
+        series first even when ``first_air_date_year=2016`` is set. The
+        post-filter must pick the 2016 entry."""
+        client = _make_client(
+            get_responses=[
+                _build_response(
+                    json_data={
+                        "results": [
+                            {"id": 11366, "first_air_date": "1995-09-22"},
+                            {"id": 66718, "first_air_date": "2016-06-22"},
+                        ]
+                    }
+                ),
+                _build_response(
+                    json_data={**_series_details(), "id": 66718, "name": "American Gothic"}
+                ),
+                _build_response(json_data=_season_details()),
+            ]
+        )
+
+        result = await client.search_series("American Gothic", 2016)
+
+        assert result is not None
+        assert result.tmdb_id == 66718
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_when_no_result_matches_year(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "results": [
+                        {"id": 11366, "first_air_date": "1995-09-22"},
+                        {"id": 9999, "first_air_date": "2004-06-04"},
+                    ]
+                }
+            )
+        )
+
+        result = await client.search_series("American Gothic", 2016)
 
         assert result is None
 


### PR DESCRIPTION
## Summary

- TMDB client (`search_movie`/`search_series`) post-filters results by `release_date`/`first_air_date` so the soft year hint becomes strict — fixes American Gothic 2016 picking up the 1995 series.
- Movie enrichment retry chain keeps the year on every search (clean-title retry, OMDb fallback); drops the title-only no-year retry that previously promoted a popular off-year title. When all year-strict searches miss, runs `/search/tv` and surfaces `tmdb/tv/<id>` on the error — Salem's Lot (1979) returns a cross-type warning pointing at `tv/16118` instead of being enriched as `movie/748230` (the 2024 film).
- Scanner `_extract_title` strips dangling `(` / `[` left over when the year is wrapped (`Title (1979).mkv` → `Title`, not `Title (`).

## Test plan

- [x] `pytest tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py` (96 tests, including the new year-match / no-year-match cases for movies and series)
- [x] `pytest tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py` (25 tests, including `test_should_surface_cross_type_hint_when_title_is_a_tv_series` and `test_should_not_retry_title_only_when_year_search_fails`)
- [x] `pytest tests/modules/media/unit/infrastructure/file_system/test_scanner.py` (13 tests, including the new `test_should_strip_trailing_bracket_when_year_is_wrapped`)
- [x] `pytest tests/modules/media/` (1265 passing, 5 skipped)
- [x] `ruff check` + `ruff format --check` on all touched files
- [x] Live repro: re-scanned `F:\homeflix\Movies\Salem's Lot (1979)` after the fix — Movie row stays unenriched, log shows `Cross-type match for movie "Salem's Lot" (id=...): TMDB series tv/16118`, and the enrich response's `error` field carries the same hint.

## Notes

- Two follow-ups intentionally left out of this PR:
  - Admin-facing UI for relinking flagged movies to the suggested TMDB ID (will be a separate piece of work; today the hint is only visible in logs / API responses).
  - `PRAGMA foreign_keys = ON` on the SQLAlchemy SQLite engine so `ON DELETE CASCADE` from `media_files.movie_id` actually fires — without it, manually deleting a movie row leaves orphan `media_files` rows that block re-scans because of the `UNIQUE` constraint on `file_path`.

## Summary by Sourcery

Tighten TMDB movie and series matching to enforce year-accurate results and surface cross-type TV hints when movie enrichment fails, while improving scanner title extraction for year-wrapped filenames.

Bug Fixes:
- Ensure TMDB movie and TV searches prefer entries whose release or first-air year matches the requested year and return no result when none match, avoiding incorrect off-year matches.
- Fix movie enrichment so it no longer retries title-only searches without a year, preventing popular off-year titles from overriding year-strict lookups.
- Correct scanner title extraction so titles with years in brackets (e.g. "Title (1979)") no longer retain dangling bracket characters.

Enhancements:
- Return more informative enrichment error messages that can include a suggested TMDB TV series ID when a movie actually corresponds to a series.
- Add cross-type detection in movie enrichment to check TMDB TV search when no movie match is found, providing actionable guidance for reclassifying items.
- Refine TMDB client result selection logic with a reusable year-matching helper that skips entries missing or mismatching the requested year.

Tests:
- Extend TMDB client tests to cover year-based movie and series selection, missing-year handling, and no-year fallback behavior.
- Expand movie enrichment tests to validate year-preserving retries, absence of title-only fallbacks, and cross-type TV hint behavior.
- Add scanner tests to confirm correct title extraction when the year is wrapped in brackets.