### PR TITLE
feat(media): admin TMDB relink for misclassified movies

### DIFF
--- a/migrations/versions/2026_05_17_add_needs_enrichment_review_to_movies.py
+++ b/migrations/versions/2026_05_17_add_needs_enrichment_review_to_movies.py
@@ -1,0 +1,57 @@
+"""Add needs_enrichment_review flag to movies.
+
+Used by the admin "needs review" listing to surface movies whose
+TMDB enrichment couldn't resolve a match (off-year title, cross-type
+miss, ambiguous folder). The flag is set by ``EnrichMovieMetadataUseCase``
+on failure and cleared on success.
+
+``op.add_column`` is used directly (no ``batch_alter_table``)
+because rewriting the ``movies`` table on SQLite would silently
+break the external-content FTS5 link — same rationale as the
+2026-04-14 catch-up migration that introduced this discipline.
+
+Revision ID: a6b7c8d9e0f1
+Revises: f4a5b6c7d8e9
+Create Date: 2026-05-17 09:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "a6b7c8d9e0f1"
+down_revision: str | Sequence[str] | None = "f4a5b6c7d8e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add needs_enrichment_review column + supporting index."""
+    op.add_column(
+        "movies",
+        sa.Column(
+            "needs_enrichment_review",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.create_index(
+        "ix_movies_needs_enrichment_review",
+        "movies",
+        ["needs_enrichment_review"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the flag column and its index."""
+    op.drop_index("ix_movies_needs_enrichment_review", table_name="movies")
+    op.drop_column("movies", "needs_enrichment_review")

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -29,6 +29,9 @@ from src.modules.media.application.use_cases.get_featured_media import GetFeatur
 from src.modules.media.application.use_cases.get_file_tracks import GetFileTracksUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
+from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
+    GetMovieTmdbSuggestionsUseCase,
+)
 from src.modules.media.application.use_cases.get_person_bio import GetPersonBioUseCase
 from src.modules.media.application.use_cases.get_related_movies import GetRelatedMoviesUseCase
 from src.modules.media.application.use_cases.get_related_series import GetRelatedSeriesUseCase
@@ -37,6 +40,9 @@ from src.modules.media.application.use_cases.list_by_genre import ListByGenreUse
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
 from src.modules.media.application.use_cases.list_movies import ListMoviesUseCase
 from src.modules.media.application.use_cases.list_movies_by_actor import ListMoviesByActorUseCase
+from src.modules.media.application.use_cases.list_movies_needing_review import (
+    ListMoviesNeedingReviewUseCase,
+)
 from src.modules.media.application.use_cases.list_recently_added_catalog import (
     ListRecentlyAddedCatalogUseCase,
 )
@@ -47,6 +53,7 @@ from src.modules.media.application.use_cases.list_recently_added_series import (
     ListRecentlyAddedSeriesUseCase,
 )
 from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
+from src.modules.media.application.use_cases.relink_movie import RelinkMovieUseCase
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
@@ -407,6 +414,27 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         enrich_movie=enrich_movie_metadata,
         enrich_series=enrich_series_metadata,
         uow_factory=media_unit_of_work_factory,
+    )
+
+    # =========================================================================
+    # Use Cases — Admin Relink
+    # =========================================================================
+
+    list_movies_needing_review = providers.Factory(
+        ListMoviesNeedingReviewUseCase,
+        uow_factory=media_unit_of_work_factory,
+    )
+
+    get_movie_tmdb_suggestions = providers.Factory(
+        GetMovieTmdbSuggestionsUseCase,
+        uow_factory=media_unit_of_work_factory,
+        metadata_provider=tmdb_client,
+    )
+
+    relink_movie = providers.Factory(
+        RelinkMovieUseCase,
+        uow_factory=media_unit_of_work_factory,
+        enrich_use_case=enrich_movie_metadata,
     )
 
     # =========================================================================

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ from src.modules.library.presentation.routes.library_routes import (
     router as library_router,
 )
 from src.modules.media.presentation.routes import (
+    admin_relink_router,
     catalog_router,
     collection_router,
     enrichment_router,
@@ -46,6 +47,7 @@ from src.modules.watch_progress.presentation.routes import progress_router
 #: tests can build a container with the same wiring without copying the
 #: list (drift between the two would mean tests miss DI-resolved deps).
 WIRED_ROUTE_MODULES: tuple[str, ...] = (
+    "src.modules.media.presentation.routes.admin_relink_routes",
     "src.modules.media.presentation.routes.catalog_routes",
     "src.modules.media.presentation.routes.collection_routes",
     "src.modules.media.presentation.routes.search_routes",
@@ -219,6 +221,7 @@ def create_app() -> FastAPI:
 
     # Register routes
     register_health_routes(app)
+    app.include_router(admin_relink_router)
     app.include_router(catalog_router)
     app.include_router(collection_router)
     app.include_router(search_router)

--- a/src/modules/media/application/dtos/admin_relink_dtos.py
+++ b/src/modules/media/application/dtos/admin_relink_dtos.py
@@ -1,0 +1,145 @@
+"""DTOs for the admin enrichment-review and TMDB relink endpoints.
+
+Shared by:
+    - ListMoviesNeedingReviewUseCase
+    - GetMovieTmdbSuggestionsUseCase
+    - RelinkMovieUseCase
+
+These shapes mirror what the admin UI consumes — slim per-row data
+for the listing, structured TMDB cards for the picker, and a single
+relink command payload.
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+MediaType = Literal["movie", "tv"]
+
+
+@dataclass(frozen=True)
+class NeedsReviewMovieOutput:
+    """One row on the admin "needs review" list.
+
+    Intentionally slim — the movie isn't enriched yet, so fields the
+    catalog card would normally show (poster, synopsis, genres) are
+    NULL. The admin needs just enough to identify the file and pick
+    a TMDB match.
+
+    Attributes:
+        id: External movie id (``mov_xxx``).
+        title: Title as the scanner extracted it from the folder.
+        year: Year as the scanner extracted it from the folder.
+        file_path: Primary file path on disk, or ``None`` if no
+            variant has been registered yet.
+    """
+
+    id: str
+    title: str
+    year: int
+    file_path: str | None
+
+
+@dataclass(frozen=True)
+class ListMoviesNeedingReviewOutput:
+    """Top-level response for the needs-review listing."""
+
+    movies: list[NeedsReviewMovieOutput] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TmdbSuggestionOutput:
+    """A single TMDB suggestion card shown in the relink picker.
+
+    Both movie and TV candidates share this shape — the
+    ``media_type`` field tells the front which TMDB endpoint
+    produced it and which relink ``media_type`` to send back.
+
+    Attributes:
+        tmdb_id: TMDB primary key for the entry.
+        media_type: ``"movie"`` (from ``/search/movie``) or ``"tv"``
+            (from ``/search/tv``).
+        title: Display title from TMDB.
+        year: Release / first-air year, or ``None`` if TMDB has no
+            usable date for this entry.
+        overview: Synopsis (may be empty for obscure entries).
+        poster_url: Absolute TMDB poster URL, or ``None`` when no
+            poster is on file.
+    """
+
+    tmdb_id: int
+    media_type: MediaType
+    title: str
+    year: int | None
+    overview: str | None
+    poster_url: str | None
+
+
+@dataclass(frozen=True)
+class GetMovieTmdbSuggestionsInput:
+    """Input for the suggestion picker.
+
+    Attributes:
+        movie_id: External movie id whose folder title + year are
+            the search seed.
+    """
+
+    movie_id: str
+
+
+@dataclass(frozen=True)
+class GetMovieTmdbSuggestionsOutput:
+    """Picker payload — movie and TV candidates rendered side by side."""
+
+    movie_id: str
+    movies: list[TmdbSuggestionOutput] = field(default_factory=list)
+    series: list[TmdbSuggestionOutput] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RelinkMovieInput:
+    """Admin's pick from the suggestion picker.
+
+    Attributes:
+        movie_id: External movie id to relink.
+        tmdb_id: TMDB id the admin selected.
+        media_type: ``"movie"`` triggers an enrichment refresh against
+            the picked id. ``"tv"`` is rejected by this PR with a
+            "use promote-to-series" error — the cross-BC conversion
+            lives in a follow-up.
+    """
+
+    movie_id: str
+    tmdb_id: int
+    media_type: MediaType
+
+
+@dataclass(frozen=True)
+class RelinkMovieOutput:
+    """Result of a relink command.
+
+    Attributes:
+        movie_id: External movie id (echoed).
+        enriched: ``True`` when the new TMDB metadata was written.
+        provider: Provider that resolved the new metadata
+            (``"tmdb"`` in practice).
+        error: Failure reason when ``enriched`` is ``False`` (e.g.
+            TMDB id couldn't be fetched, or media_type isn't
+            supported yet).
+    """
+
+    movie_id: str
+    enriched: bool
+    provider: str | None = None
+    error: str | None = None
+
+
+__all__ = [
+    "GetMovieTmdbSuggestionsInput",
+    "GetMovieTmdbSuggestionsOutput",
+    "ListMoviesNeedingReviewOutput",
+    "MediaType",
+    "NeedsReviewMovieOutput",
+    "RelinkMovieInput",
+    "RelinkMovieOutput",
+    "TmdbSuggestionOutput",
+]

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -30,6 +30,7 @@ from src.modules.media.application.ports.metadata_provider_port import (
     MediaMetadata,
     MetadataProvider,
     PersonMetadata,
+    SearchCandidate,
     SeasonMetadata,
 )
 from src.modules.media.application.ports.profile_library_access_port import (
@@ -68,6 +69,7 @@ __all__ = [
     "ProgressLookupPort",
     "ProgressSummary",
     "ScannedFile",
+    "SearchCandidate",
     "SeasonMetadata",
     "VariantDetectorPort",
 ]

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from typing import Literal
 
 
 @dataclass(frozen=True)
@@ -238,6 +239,36 @@ class MediaMetadata:
     localized: dict[str, LocalizedFields] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class SearchCandidate:
+    """A single raw search hit for the admin relink picker.
+
+    Distinct from ``MediaMetadata`` because the picker only needs the
+    card-level fields (title, year, poster, overview) and shouldn't
+    pay for the per-detail round-trip TMDB requires for full
+    ``MediaMetadata``. The admin clicks a card → relink flow then
+    triggers a real enrichment for the selected id.
+
+    Attributes:
+        tmdb_id: TMDB primary key.
+        media_type: ``"movie"`` for ``/search/movie`` hits, ``"tv"``
+            for ``/search/tv`` hits — tells the caller which TMDB
+            endpoint to refetch from.
+        title: Display title.
+        year: Release / first-air year, or ``None`` when the source
+            lacks a usable date.
+        overview: Synopsis (possibly empty).
+        poster_url: Absolute image URL, or ``None``.
+    """
+
+    tmdb_id: int
+    media_type: Literal["movie", "tv"]
+    title: str
+    year: int | None
+    overview: str | None
+    poster_url: str | None
+
+
 class MetadataProvider(ABC):
     """Port for fetching media metadata from external services."""
 
@@ -264,6 +295,47 @@ class MetadataProvider(ABC):
 
         Returns:
             Metadata for the best match, or None if not found.
+        """
+        ...
+
+    @abstractmethod
+    async def find_movie_candidates(
+        self,
+        title: str,
+        year: int | None = None,
+        limit: int = 5,
+    ) -> list["SearchCandidate"]:
+        """Return raw movie search hits for the admin relink picker.
+
+        Unlike ``search_movie`` (which year-strict-filters and returns
+        a single best match for auto-enrichment), this returns the
+        top ``limit`` raw results sorted by the provider's own
+        ranking — admins want to see candidates, including off-year
+        ones, to pick visually.
+
+        Args:
+            title: Movie title to search for.
+            year: Year hint passed to the provider as a soft ranking
+                signal (not strictly filtered).
+            limit: Maximum number of results to return.
+
+        Returns:
+            List of candidates (possibly empty).
+        """
+        ...
+
+    @abstractmethod
+    async def find_series_candidates(
+        self,
+        title: str,
+        year: int | None = None,
+        limit: int = 5,
+    ) -> list["SearchCandidate"]:
+        """Return raw TV search hits for the admin relink picker.
+
+        Same contract as ``find_movie_candidates`` but hits
+        ``/search/tv`` — used to surface the "this is actually a
+        miniseries" case (Salem's Lot 1979 → ``tv/16118``).
         """
         ...
 

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -69,6 +69,13 @@ class EnrichMovieMetadataUseCase:
             metadata, provider_name = await self._fetch_metadata(movie)
             if not metadata:
                 error_msg = await self._build_no_metadata_error(movie, input_dto.media_id)
+                # Flag the movie for admin review (cleared on the next
+                # successful enrichment). Persisting on the failure
+                # path turns "log-only cross-type hints" into a
+                # queryable inbox.
+                if not movie.needs_enrichment_review:
+                    movie = movie.with_updates(needs_enrichment_review=True)
+                    await uow.movies.save(movie)
                 return EnrichMediaOutput(
                     media_id=input_dto.media_id,
                     enriched=False,
@@ -83,6 +90,8 @@ class EnrichMovieMetadataUseCase:
                     metadata = localized_meta
 
             movie = _apply_movie_metadata(movie, metadata, force=input_dto.force)
+            if movie.needs_enrichment_review:
+                movie = movie.with_updates(needs_enrichment_review=False)
             await uow.movies.save(movie)
 
         return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)

--- a/src/modules/media/application/use_cases/get_movie_tmdb_suggestions.py
+++ b/src/modules/media/application/use_cases/get_movie_tmdb_suggestions.py
@@ -1,0 +1,102 @@
+"""Use case: live TMDB picker payload for the admin relink flow."""
+
+import asyncio
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    GetMovieTmdbSuggestionsInput,
+    GetMovieTmdbSuggestionsOutput,
+    TmdbSuggestionOutput,
+)
+from src.modules.media.application.ports import MetadataProvider, SearchCandidate
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.value_objects import MovieId
+
+
+class GetMovieTmdbSuggestionsUseCase:
+    """Return TMDB movie + TV candidates for an unenriched movie.
+
+    Loads the movie to seed the search with its scanner-extracted
+    title and year, then issues both ``/search/movie`` and
+    ``/search/tv`` in parallel. When the year-hinted query returns
+    nothing, retries without the year — the admin picker is meant
+    to show *something* so the operator can pick visually.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+        metadata_provider: TMDB-side metadata port. The admin
+            endpoint registers the primary provider (TMDB).
+        candidates_limit: Maximum number of suggestions per type.
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        metadata_provider: MetadataProvider,
+        candidates_limit: int = 5,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._provider = metadata_provider
+        self._limit = candidates_limit
+
+    async def execute(
+        self,
+        input_dto: GetMovieTmdbSuggestionsInput,
+    ) -> GetMovieTmdbSuggestionsOutput:
+        """Return TMDB movie + TV candidates for the picker UI."""
+        async with self._uow_factory() as uow:
+            movie = await uow.movies.find_by_id(MovieId(input_dto.movie_id))
+            if not movie:
+                raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)
+            title = movie.title.value
+            year = movie.year.value
+
+        movie_candidates, series_candidates = await asyncio.gather(
+            self._candidates_with_fallback(title, year, kind="movie"),
+            self._candidates_with_fallback(title, year, kind="series"),
+        )
+
+        return GetMovieTmdbSuggestionsOutput(
+            movie_id=input_dto.movie_id,
+            movies=[_to_output(c) for c in movie_candidates],
+            series=[_to_output(c) for c in series_candidates],
+        )
+
+    async def _candidates_with_fallback(
+        self,
+        title: str,
+        year: int | None,
+        *,
+        kind: str,
+    ) -> list[SearchCandidate]:
+        """Search with year first; if empty, drop the year hint.
+
+        TMDB's ``year`` / ``first_air_date_year`` is a soft ranking
+        signal — when it produces no hits, falling back to the
+        unfiltered query usually surfaces the title elsewhere on the
+        timeline (e.g. a remake series for a folder marked with the
+        original-film year).
+        """
+        fetch = (
+            self._provider.find_movie_candidates
+            if kind == "movie"
+            else self._provider.find_series_candidates
+        )
+        candidates = await fetch(title, year, self._limit)
+        if not candidates and year is not None:
+            candidates = await fetch(title, None, self._limit)
+        return candidates
+
+
+def _to_output(candidate: SearchCandidate) -> TmdbSuggestionOutput:
+    return TmdbSuggestionOutput(
+        tmdb_id=candidate.tmdb_id,
+        media_type=candidate.media_type,
+        title=candidate.title,
+        year=candidate.year,
+        overview=candidate.overview,
+        poster_url=candidate.poster_url,
+    )
+
+
+__all__ = ["GetMovieTmdbSuggestionsUseCase"]

--- a/src/modules/media/application/use_cases/list_movies_needing_review.py
+++ b/src/modules/media/application/use_cases/list_movies_needing_review.py
@@ -1,0 +1,47 @@
+"""Use case: list movies the admin needs to relink manually."""
+
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    ListMoviesNeedingReviewOutput,
+    NeedsReviewMovieOutput,
+)
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.entities import Movie
+
+
+class ListMoviesNeedingReviewUseCase:
+    """Return movies whose ``needs_enrichment_review`` flag is set.
+
+    Backs the admin "review queue" — small set in practice (a few
+    rows per few hundred movies), so no pagination. Newest-flagged
+    first comes from the repository's ``updated_at DESC`` order.
+
+    The admin endpoint is global (no per-profile filter): the user
+    triggering it is already gated by ``current_admin_user``.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+    """
+
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(self) -> ListMoviesNeedingReviewOutput:
+        """Return all movies pending enrichment review."""
+        async with self._uow_factory() as uow:
+            movies = await uow.movies.find_needs_enrichment_review()
+            return ListMoviesNeedingReviewOutput(
+                movies=[_to_output(m) for m in movies],
+            )
+
+
+def _to_output(movie: Movie) -> NeedsReviewMovieOutput:
+    primary = movie.primary_file
+    return NeedsReviewMovieOutput(
+        id=str(movie.id),
+        title=movie.title.value,
+        year=movie.year.value,
+        file_path=primary.file_path.value if primary else None,
+    )
+
+
+__all__ = ["ListMoviesNeedingReviewUseCase"]

--- a/src/modules/media/application/use_cases/relink_movie.py
+++ b/src/modules/media/application/use_cases/relink_movie.py
@@ -1,0 +1,81 @@
+"""Use case: admin re-points a movie at a specific TMDB id."""
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    RelinkMovieInput,
+    RelinkMovieOutput,
+)
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases.enrich_movie_metadata import (
+    EnrichMovieMetadataUseCase,
+)
+from src.modules.media.domain.value_objects import MovieId, TmdbId
+
+
+class RelinkMovieUseCase:
+    """Apply an admin-picked TMDB id to a movie and re-enrich.
+
+    Flow:
+        1. Validate ``media_type``. ``"tv"`` is rejected with a
+           ``UseCaseValidationException`` — the Movie→Series
+           conversion lives in a follow-up PR (the deferred
+           "Option C" promote-to-series flow).
+        2. Load the movie and stamp the picked ``tmdb_id``.
+        3. Force-enrich. ``EnrichMovieMetadataUseCase`` resolves
+           ``get_movie_by_id`` first when ``movie.tmdb_id`` is set,
+           so the admin's pick wins over the title-based search.
+        4. Surface the enrichment outcome to the caller.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+        enrich_use_case: ``EnrichMovieMetadataUseCase`` instance used
+            to refresh the entity after the new id is stamped.
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        enrich_use_case: EnrichMovieMetadataUseCase,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._enrich = enrich_use_case
+
+    async def execute(self, input_dto: RelinkMovieInput) -> RelinkMovieOutput:
+        """Execute the relink command."""
+        if input_dto.media_type == "tv":
+            raise UseCaseValidationException(
+                message=(
+                    "Cross-type relink (movie → series) is not yet "
+                    "supported. The TMDB candidate you picked is a TV "
+                    "series; a dedicated promote-to-series endpoint "
+                    "will handle that conversion in a follow-up."
+                ),
+                message_code="RELINK_CROSS_TYPE_NOT_SUPPORTED",
+            )
+
+        async with self._uow_factory() as uow:
+            movie = await uow.movies.find_by_id(MovieId(input_dto.movie_id))
+            if not movie:
+                raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)
+            # Stamp the picked id so the enrichment path resolves
+            # via ``get_movie_by_id`` instead of the title search.
+            # The flag is cleared by the enrich use case on success.
+            movie = movie.with_updates(tmdb_id=TmdbId(input_dto.tmdb_id))
+            await uow.movies.save(movie)
+
+        result = await self._enrich.execute(
+            EnrichMediaInput(media_id=input_dto.movie_id, force=True),
+        )
+        return RelinkMovieOutput(
+            movie_id=result.media_id,
+            enriched=result.enriched,
+            provider=result.provider,
+            error=result.error,
+        )
+
+
+__all__ = ["RelinkMovieUseCase"]

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -93,6 +93,12 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
     tmdb_id: TmdbId | None = None
     imdb_id: ImdbId | None = None
 
+    # Set true when an enrichment attempt could not resolve a TMDB
+    # match (off-year movie, cross-type miss, ambiguous title, …).
+    # Read by the admin "needs review" listing so the operator can
+    # relink manually. Cleared on successful enrichment.
+    needs_enrichment_review: bool = False
+
     # noinspection PyNestedDecorators
     @field_validator("id", mode="before")
     @classmethod

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -406,6 +406,30 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_needs_enrichment_review(
+        self,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Movie]:
+        """Return movies flagged for admin enrichment review.
+
+        Backs the ``GET /admin/movies/needs-review`` listing.
+        Soft-deleted rows are excluded. The set is expected to be
+        small (a few entries per few hundred movies) so no pagination
+        — caller orders by ``updated_at`` so newest-flagged float up.
+
+        Args:
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, restricts to rows owned by libraries in
+                the set; ``None`` means no library filter (current
+                admin endpoint passes ``None``).
+
+        Returns:
+            Sequence of flagged movies.
+        """
+        ...
+
+    @abstractmethod
     async def find_missing_scrub_preview(self, limit: int) -> Sequence[Movie]:
         """Return up to ``limit`` movies that have no scrub-preview thumbnails yet.
 

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -1,5 +1,6 @@
 """TMDB API client implementing MetadataProvider port."""
 
+from collections.abc import Callable
 from typing import Literal
 
 import httpx
@@ -14,6 +15,7 @@ from src.modules.media.application.ports import (
     MediaMetadata,
     MetadataProvider,
     PersonMetadata,
+    SearchCandidate,
     SeasonMetadata,
 )
 from src.modules.media.domain.value_objects import ContentRating
@@ -155,6 +157,41 @@ class TmdbClient(MetadataProvider):
             return None
 
         return await self._fetch_series_details(best["id"])
+
+    async def find_movie_candidates(
+        self,
+        title: str,
+        year: int | None = None,
+        limit: int = 5,
+    ) -> list[SearchCandidate]:
+        """Return the top ``limit`` raw movie search hits.
+
+        See ``find_movie_candidates`` on ``MetadataProvider`` for the
+        contract — picker-mode, no year post-filter, TMDB's own
+        popularity ranking preserved.
+        """
+        resp = await self._client.get(
+            f"{self._base_url}/search/movie",
+            params=self._params(query=title, year=year),
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
+        return [_to_movie_candidate(r, self._image_url) for r in results[:limit]]
+
+    async def find_series_candidates(
+        self,
+        title: str,
+        year: int | None = None,
+        limit: int = 5,
+    ) -> list[SearchCandidate]:
+        """Return the top ``limit`` raw TV search hits."""
+        resp = await self._client.get(
+            f"{self._base_url}/search/tv",
+            params=self._params(query=title, first_air_date_year=year),
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
+        return [_to_series_candidate(r, self._image_url) for r in results[:limit]]
 
     @staticmethod
     def _pick_year_match(
@@ -884,6 +921,58 @@ class TmdbClient(MetadataProvider):
             profile_url=self._image_url(profile_path),
             tmdb_id=int(str(data["id"])) if data.get("id") else None,
         )
+
+
+def _extract_year_prefix(value: object) -> int | None:
+    """Return the 4-digit year prefix of an ISO date string, or ``None``.
+
+    Both ``release_date`` (movies) and ``first_air_date`` (TV) come
+    in as ``"YYYY-MM-DD"`` — or empty/missing for poorly catalogued
+    entries. Defensive parsing here avoids ``ValueError`` polluting
+    the picker payload when TMDB returns ``""`` or no field at all.
+    """
+    if not isinstance(value, str) or len(value) < 4:
+        return None
+    try:
+        return int(value[:4])
+    except ValueError:
+        return None
+
+
+def _to_movie_candidate(
+    raw: dict[str, object],
+    image_url: Callable[[str | None], str | None],
+) -> SearchCandidate:
+    title = str(raw.get("title") or raw.get("original_title") or "")
+    overview_raw = raw.get("overview")
+    overview = str(overview_raw) if overview_raw else None
+    poster = raw.get("poster_path")
+    return SearchCandidate(
+        tmdb_id=int(str(raw["id"])),
+        media_type="movie",
+        title=title,
+        year=_extract_year_prefix(raw.get("release_date")),
+        overview=overview,
+        poster_url=image_url(str(poster)) if isinstance(poster, str) else None,
+    )
+
+
+def _to_series_candidate(
+    raw: dict[str, object],
+    image_url: Callable[[str | None], str | None],
+) -> SearchCandidate:
+    title = str(raw.get("name") or raw.get("original_name") or "")
+    overview_raw = raw.get("overview")
+    overview = str(overview_raw) if overview_raw else None
+    poster = raw.get("poster_path")
+    return SearchCandidate(
+        tmdb_id=int(str(raw["id"])),
+        media_type="tv",
+        title=title,
+        year=_extract_year_prefix(raw.get("first_air_date")),
+        overview=overview,
+        poster_url=image_url(str(poster)) if isinstance(poster, str) else None,
+    )
 
 
 __all__ = ["TmdbClient"]

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -93,6 +93,7 @@ class MovieMapper:
             resolution=primary.resolution.value if primary else None,
             tmdb_id=entity.tmdb_id.value if entity.tmdb_id else None,
             imdb_id=entity.imdb_id.value if entity.imdb_id else None,
+            needs_enrichment_review=entity.needs_enrichment_review,
         )
 
         for file in entity.files:
@@ -178,6 +179,10 @@ class MovieMapper:
             files=files,
             tmdb_id=TmdbId(model.tmdb_id) if model.tmdb_id else None,
             imdb_id=ImdbId(model.imdb_id) if model.imdb_id else None,
+            # ``Mapped[bool]`` only auto-fills the SQL default on INSERT;
+            # in-memory models built by tests can have ``None`` here.
+            # Domain default is ``False`` so coerce safely.
+            needs_enrichment_review=bool(model.needs_enrichment_review),
             created_at=model.created_at,
             updated_at=model.updated_at,
         )
@@ -231,6 +236,7 @@ class MovieMapper:
         model.resolution = primary.resolution.value if primary else None
         model.tmdb_id = entity.tmdb_id.value if entity.tmdb_id else None
         model.imdb_id = entity.imdb_id.value if entity.imdb_id else None
+        model.needs_enrichment_review = entity.needs_enrichment_review
 
         _sync_file_variants(model.file_variants, entity.files)
 

--- a/src/modules/media/infrastructure/persistence/models/movie.py
+++ b/src/modules/media/infrastructure/persistence/models/movie.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, Integer, String, Text
+from sqlalchemy import BigInteger, Boolean, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.infrastructure.persistence.base import Base
@@ -87,6 +87,17 @@ class MovieModel(Base):
     # External IDs for metadata enrichment
     tmdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
     imdb_id: Mapped[str | None] = mapped_column(String(20), nullable=True, index=True)
+
+    # Flag set when enrichment couldn't resolve a TMDB match.
+    # Indexed so the admin "needs review" listing scans cheaply even
+    # as the catalog grows past tens of thousands of rows.
+    needs_enrichment_review: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="0",
+        index=True,
+    )
 
     # Relationships
     file_variants: Mapped[list["MediaFileModel"]] = relationship(

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -494,6 +494,31 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         return None if model is None else MovieMapper.to_entity(model)
 
+    async def find_needs_enrichment_review(
+        self,
+        *,
+        allowed_library_ids: Sequence[str] | None = None,
+    ) -> Sequence[Movie]:
+        """Return movies with the review flag set, newest-first."""
+        conditions = [
+            MovieModel.deleted_at.is_(None),
+            MovieModel.needs_enrichment_review.is_(True),
+        ]
+        if allowed_library_ids is not None:
+            allowed = list(allowed_library_ids)
+            if not allowed:
+                return []
+            conditions.append(MovieModel.library_id.in_(allowed))
+
+        stmt = (
+            select(MovieModel)
+            .where(*conditions)
+            .options(selectinload(MovieModel.file_variants))
+            .order_by(MovieModel.updated_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return [MovieMapper.to_entity(model) for model in result.scalars().all()]
+
     async def find_missing_scrub_preview(self, limit: int) -> Sequence[Movie]:
         """Return up to ``limit`` movies whose ``scrub_preview_path`` is null.
 

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -1,5 +1,8 @@
 """Media API routes."""
 
+from src.modules.media.presentation.routes.admin_relink_routes import (
+    router as admin_relink_router,
+)
 from src.modules.media.presentation.routes.catalog_routes import router as catalog_router
 from src.modules.media.presentation.routes.collection_routes import router as collection_router
 from src.modules.media.presentation.routes.enrichment_routes import router as enrichment_router
@@ -12,6 +15,7 @@ from src.modules.media.presentation.routes.series_routes import router as series
 from src.modules.media.presentation.routes.stream_routes import router as stream_router
 
 __all__ = [
+    "admin_relink_router",
     "catalog_router",
     "collection_router",
     "enrichment_router",

--- a/src/modules/media/presentation/routes/admin_relink_routes.py
+++ b/src/modules/media/presentation/routes/admin_relink_routes.py
@@ -1,0 +1,88 @@
+"""Admin REST API routes for the TMDB relink workflow.
+
+Three endpoints, all gated by ``current_admin_user``:
+
+* ``GET  /admin/movies/needs-review`` — listing of movies whose
+  enrichment couldn't find a TMDB match.
+* ``GET  /admin/movies/{id}/tmdb-suggestions`` — live TMDB picker
+  payload (movie + TV candidates) seeded by the movie's title/year.
+* ``POST /admin/movies/{id}/relink`` — admin commits a pick. Movie
+  picks refresh the enrichment in place; TV picks 422 with a
+  pointer to the deferred promote-to-series flow.
+"""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.presentation import api_list, api_single
+from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    GetMovieTmdbSuggestionsInput,
+    RelinkMovieInput,
+)
+from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
+    GetMovieTmdbSuggestionsUseCase,
+)
+from src.modules.media.application.use_cases.list_movies_needing_review import (
+    ListMoviesNeedingReviewUseCase,
+)
+from src.modules.media.application.use_cases.relink_movie import RelinkMovieUseCase
+from src.modules.media.presentation.schemas import RelinkMovieRequest
+
+router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Movie Relink"])
+
+
+@router.get("/movies/needs-review")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_movies_needing_review(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: ListMoviesNeedingReviewUseCase = Depends(
+        Provide[ApplicationContainer.media.list_movies_needing_review],
+    ),
+) -> dict[str, Any]:
+    """List movies whose enrichment couldn't resolve a TMDB match."""
+    output = await use_case.execute()
+    return api_list([asdict(m) for m in output.movies])
+
+
+@router.get("/movies/{movie_id}/tmdb-suggestions")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_movie_tmdb_suggestions(
+    movie_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: GetMovieTmdbSuggestionsUseCase = Depends(
+        Provide[ApplicationContainer.media.get_movie_tmdb_suggestions],
+    ),
+) -> dict[str, Any]:
+    """Return TMDB movie + TV candidates seeded by the movie's title/year."""
+    output = await use_case.execute(GetMovieTmdbSuggestionsInput(movie_id=movie_id))
+    return api_single("tmdb_suggestions", asdict(output))
+
+
+@router.post("/movies/{movie_id}/relink")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def relink_movie(
+    movie_id: str,
+    body: RelinkMovieRequest,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: RelinkMovieUseCase = Depends(
+        Provide[ApplicationContainer.media.relink_movie],
+    ),
+) -> dict[str, Any]:
+    """Stamp the picked TMDB id on the movie and force-enrich."""
+    output = await use_case.execute(
+        RelinkMovieInput(
+            movie_id=movie_id,
+            tmdb_id=body.tmdb_id,
+            media_type=body.media_type,
+        ),
+    )
+    return api_single("relink", asdict(output))
+
+
+__all__ = ["router"]

--- a/src/modules/media/presentation/schemas/__init__.py
+++ b/src/modules/media/presentation/schemas/__init__.py
@@ -1,5 +1,6 @@
 """Media API request/response schemas."""
 
+from src.modules.media.presentation.schemas.admin_relink_schemas import RelinkMovieRequest
 from src.modules.media.presentation.schemas.enrichment_schemas import EnrichRequest
 from src.modules.media.presentation.schemas.file_variant_schemas import (
     AddFileVariantRequest,
@@ -12,6 +13,7 @@ from src.modules.media.presentation.schemas.scan_schemas import ScanMediaRequest
 __all__ = [
     "AddFileVariantRequest",
     "EnrichRequest",
+    "RelinkMovieRequest",
     "RemoveFileVariantRequest",
     "ScanMediaRequest",
     "SetIntroRequest",

--- a/src/modules/media/presentation/schemas/admin_relink_schemas.py
+++ b/src/modules/media/presentation/schemas/admin_relink_schemas.py
@@ -1,0 +1,30 @@
+"""Pydantic schemas for the admin TMDB relink endpoints."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class RelinkMovieRequest(BaseModel):
+    """Request body for ``POST /admin/movies/{id}/relink``.
+
+    The admin picked one of the cards returned by
+    ``GET /admin/movies/{id}/tmdb-suggestions`` and is committing
+    that choice. ``media_type`` mirrors which TMDB endpoint produced
+    the card so the server knows whether to refresh the movie
+    in-place (``movie``) or short-circuit to the not-yet-implemented
+    promote-to-series flow (``tv``).
+    """
+
+    tmdb_id: int = Field(..., ge=1, description="TMDB primary key of the picked entry.")
+    media_type: Literal["movie", "tv"] = Field(
+        ...,
+        description=(
+            "Which TMDB endpoint the picked card came from. 'movie' "
+            "triggers an enrichment refresh; 'tv' returns a 422 "
+            "asking to use the future promote-to-series endpoint."
+        ),
+    )
+
+
+__all__ = ["RelinkMovieRequest"]

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -1212,3 +1212,47 @@ class TestAllowedLibraryIdsFilter:
 
         assert found is not None
         assert found.title.value == "Allowed"
+
+
+class TestFindNeedsEnrichmentReview:
+    """Tests for ``find_needs_enrichment_review`` — admin review queue."""
+
+    async def test_should_return_only_flagged_movies(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        flagged = _create_movie(
+            title="Salem's Lot",
+            file_path="/movies/salem.mkv",
+            needs_enrichment_review=True,
+        )
+        clean = _create_movie(title="Inception", file_path="/movies/inception.mkv")
+        await repo.save(flagged)
+        await repo.save(clean)
+
+        result = await repo.find_needs_enrichment_review()
+
+        assert [m.title.value for m in result] == ["Salem's Lot"]
+
+    async def test_should_return_empty_when_none_flagged(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="Inception", file_path="/movies/inception.mkv"))
+
+        result = await repo.find_needs_enrichment_review()
+
+        assert result == []
+
+    async def test_should_exclude_soft_deleted_rows(self, db_session: AsyncSession) -> None:
+        """Admin queue shouldn't surface rows the operator already
+        soft-deleted — they're conceptually gone."""
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _create_movie(
+            title="Salem's Lot",
+            file_path="/movies/salem.mkv",
+            needs_enrichment_review=True,
+        )
+        await repo.save(movie)
+        assert movie.id is not None
+        await repo.delete(movie.id)
+
+        result = await repo.find_needs_enrichment_review()
+
+        assert result == []

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -158,6 +158,53 @@ class TestEnrichMovieMetadata:
         assert "series" in result.error.lower()
 
     @pytest.mark.asyncio
+    async def test_should_flag_movie_for_review_when_enrichment_fails(self) -> None:
+        """Failure path persists ``needs_enrichment_review=True`` so the
+        admin needs-review listing can pick it up — without this, the
+        cross-type warning would live only in the log."""
+        movie = _make_movie()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = None
+        provider.search_series.return_value = None
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        mocks.movies.save.assert_called_once()
+        saved_movie = mocks.movies.save.call_args.args[0]
+        assert saved_movie.needs_enrichment_review is True
+
+    @pytest.mark.asyncio
+    async def test_should_clear_review_flag_on_successful_enrichment(self) -> None:
+        """Re-enriching a previously-flagged movie clears the flag so it
+        falls off the admin queue without manual intervention."""
+        movie = _make_movie().with_updates(needs_enrichment_review=True)
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = _make_metadata()
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        mocks.movies.save.assert_called_once()
+        saved_movie = mocks.movies.save.call_args.args[0]
+        assert saved_movie.needs_enrichment_review is False
+
+    @pytest.mark.asyncio
+    async def test_should_not_double_save_when_flag_already_set(self) -> None:
+        """If the movie is already flagged, the failure path skips an
+        extra save — repeated failed enrichments shouldn't churn the
+        ``updated_at`` timestamp on the row."""
+        movie = _make_movie().with_updates(needs_enrichment_review=True)
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = None
+        provider.search_series.return_value = None
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        mocks.movies.save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_should_retry_cross_type_without_year_when_year_search_misses(self) -> None:
         """If the TV-side search misses with the year hint, retry without
         it — same fallback chain as the movie path, since the folder year

--- a/tests/modules/media/unit/application/use_cases/test_get_movie_tmdb_suggestions.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_movie_tmdb_suggestions.py
@@ -1,0 +1,127 @@
+"""Tests for GetMovieTmdbSuggestionsUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    GetMovieTmdbSuggestionsInput,
+)
+from src.modules.media.application.ports import MetadataProvider, SearchCandidate
+from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
+    GetMovieTmdbSuggestionsUseCase,
+)
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects import MovieId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_movie(title: str = "Salem's Lot", year: int = 1979) -> Movie:
+    return Movie.create(
+        library_id=_LIBRARY_ID,
+        title=title,
+        year=year,
+        duration=0,
+        file_path="/movies/file.mkv",
+        file_size=1,
+        resolution="1080p",
+    )
+
+
+def _movie_candidate(tmdb_id: int, title: str, year: int | None = None) -> SearchCandidate:
+    return SearchCandidate(
+        tmdb_id=tmdb_id,
+        media_type="movie",
+        title=title,
+        year=year,
+        overview=None,
+        poster_url=None,
+    )
+
+
+def _series_candidate(tmdb_id: int, title: str, year: int | None = None) -> SearchCandidate:
+    return SearchCandidate(
+        tmdb_id=tmdb_id,
+        media_type="tv",
+        title=title,
+        year=year,
+        overview=None,
+        poster_url=None,
+    )
+
+
+@pytest.mark.unit
+class TestGetMovieTmdbSuggestions:
+    @pytest.mark.asyncio
+    async def test_should_return_movie_and_series_candidates(self) -> None:
+        movie = _make_movie()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.find_movie_candidates.return_value = [
+            _movie_candidate(748230, "Salem's Lot", 2024),
+        ]
+        provider.find_series_candidates.return_value = [
+            _series_candidate(16118, "Salem's Lot", 1979),
+        ]
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+
+        use_case = GetMovieTmdbSuggestionsUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+        )
+        output = await use_case.execute(
+            GetMovieTmdbSuggestionsInput(movie_id=str(movie.id)),
+        )
+
+        assert [c.tmdb_id for c in output.movies] == [748230]
+        assert [c.tmdb_id for c in output.series] == [16118]
+        assert output.movie_id == str(movie.id)
+
+    @pytest.mark.asyncio
+    async def test_should_retry_without_year_when_year_search_misses(self) -> None:
+        """Picker mode prioritises showing *something* — when the
+        year-hinted TMDB query is empty, retry without the year so
+        the admin sees off-year candidates worth picking."""
+        movie = _make_movie()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.find_movie_candidates.side_effect = [
+            [],  # year=1979 returns nothing
+            [_movie_candidate(748230, "Salem's Lot", 2024)],
+        ]
+        provider.find_series_candidates.return_value = []
+
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+
+        use_case = GetMovieTmdbSuggestionsUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+        )
+        output = await use_case.execute(
+            GetMovieTmdbSuggestionsInput(movie_id=str(movie.id)),
+        )
+
+        assert [c.tmdb_id for c in output.movies] == [748230]
+        assert provider.find_movie_candidates.await_count == 2
+        first_call, second_call = provider.find_movie_candidates.await_args_list
+        assert first_call.args[1] == 1979
+        assert second_call.args[1] is None
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_movie_not_found(self) -> None:
+        provider = AsyncMock(spec=MetadataProvider)
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
+
+        use_case = GetMovieTmdbSuggestionsUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+        )
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                GetMovieTmdbSuggestionsInput(movie_id=str(MovieId.generate())),
+            )

--- a/tests/modules/media/unit/application/use_cases/test_list_movies_needing_review.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies_needing_review.py
@@ -1,0 +1,65 @@
+"""Tests for ListMoviesNeedingReviewUseCase."""
+
+import pytest
+
+from src.modules.media.application.use_cases.list_movies_needing_review import (
+    ListMoviesNeedingReviewUseCase,
+)
+from src.modules.media.domain.entities import Movie
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_movie(title: str, year: int, file_path: str | None = "/movies/file.mkv") -> Movie:
+    return Movie.create(
+        library_id=_LIBRARY_ID,
+        title=title,
+        year=year,
+        duration=0,
+        file_path=file_path or "/dev/null",
+        file_size=1,
+        resolution="1080p",
+    )
+
+
+@pytest.mark.unit
+class TestListMoviesNeedingReview:
+    @pytest.mark.asyncio
+    async def test_should_return_flagged_movies(self) -> None:
+        flagged = [
+            _make_movie("Salem's Lot", 1979),
+            _make_movie("American Gothic", 2016),
+        ]
+        mocks = make_media_uow_mock()
+        mocks.movies.find_needs_enrichment_review.return_value = flagged
+
+        use_case = ListMoviesNeedingReviewUseCase(uow_factory=mocks.factory)
+        output = await use_case.execute()
+
+        assert len(output.movies) == 2
+        assert {m.title for m in output.movies} == {"Salem's Lot", "American Gothic"}
+        assert all(m.id.startswith("mov_") for m in output.movies)
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_list_when_none_flagged(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_needs_enrichment_review.return_value = []
+
+        use_case = ListMoviesNeedingReviewUseCase(uow_factory=mocks.factory)
+        output = await use_case.execute()
+
+        assert output.movies == []
+
+    @pytest.mark.asyncio
+    async def test_should_surface_primary_file_path(self) -> None:
+        """File path is the most actionable hint for an admin scrolling
+        a list of un-enriched titles — make sure the projection keeps it."""
+        movie = _make_movie("Salem's Lot", 1979, file_path="/movies/Salem (1979).mkv")
+        mocks = make_media_uow_mock()
+        mocks.movies.find_needs_enrichment_review.return_value = [movie]
+
+        use_case = ListMoviesNeedingReviewUseCase(uow_factory=mocks.factory)
+        output = await use_case.execute()
+
+        assert output.movies[0].file_path == "/movies/Salem (1979).mkv"

--- a/tests/modules/media/unit/application/use_cases/test_relink_movie.py
+++ b/tests/modules/media/unit/application/use_cases/test_relink_movie.py
@@ -1,0 +1,111 @@
+"""Tests for RelinkMovieUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.modules.media.application.dtos.admin_relink_dtos import RelinkMovieInput
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaOutput
+from src.modules.media.application.use_cases.enrich_movie_metadata import (
+    EnrichMovieMetadataUseCase,
+)
+from src.modules.media.application.use_cases.relink_movie import RelinkMovieUseCase
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects import MovieId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_movie() -> Movie:
+    return Movie.create(
+        library_id=_LIBRARY_ID,
+        title="Salem's Lot",
+        year=1979,
+        duration=0,
+        file_path="/movies/file.mkv",
+        file_size=1,
+        resolution="1080p",
+    )
+
+
+@pytest.mark.unit
+class TestRelinkMovie:
+    @pytest.mark.asyncio
+    async def test_should_stamp_tmdb_id_and_force_enrich_on_movie_pick(self) -> None:
+        movie = _make_movie()
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
+
+        enrich = AsyncMock(spec=EnrichMovieMetadataUseCase)
+        enrich.execute.return_value = EnrichMediaOutput(
+            media_id=str(movie.id),
+            enriched=True,
+            provider="tmdb",
+        )
+
+        use_case = RelinkMovieUseCase(uow_factory=mocks.factory, enrich_use_case=enrich)
+        result = await use_case.execute(
+            RelinkMovieInput(movie_id=str(movie.id), tmdb_id=12345, media_type="movie"),
+        )
+
+        assert result.enriched is True
+        assert result.provider == "tmdb"
+
+        # The pre-enrich save stamped the picked TMDB id.
+        mocks.movies.save.assert_called_once()
+        saved = mocks.movies.save.call_args.args[0]
+        assert saved.tmdb_id is not None
+        assert saved.tmdb_id.value == 12345
+
+        # Enrich was triggered with force=True so the new id wins
+        # even though the row had no tmdb_id before.
+        enrich.execute.assert_awaited_once()
+        enrich_input = enrich.execute.await_args.args[0]
+        assert enrich_input.media_id == str(movie.id)
+        assert enrich_input.force is True
+
+    @pytest.mark.asyncio
+    async def test_should_reject_tv_media_type_with_validation_error(self) -> None:
+        """Cross-type relink (Movie → Series) is deferred to a future
+        promote-to-series flow; the endpoint must surface the limitation
+        instead of silently succeeding."""
+        mocks = make_media_uow_mock()
+        enrich = AsyncMock(spec=EnrichMovieMetadataUseCase)
+
+        use_case = RelinkMovieUseCase(uow_factory=mocks.factory, enrich_use_case=enrich)
+
+        with pytest.raises(UseCaseValidationException) as excinfo:
+            await use_case.execute(
+                RelinkMovieInput(
+                    movie_id=str(MovieId.generate()),
+                    tmdb_id=16118,
+                    media_type="tv",
+                ),
+            )
+
+        assert excinfo.value.message_code == "RELINK_CROSS_TYPE_NOT_SUPPORTED"
+        mocks.movies.find_by_id.assert_not_called()
+        enrich.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_movie_not_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
+        enrich = AsyncMock(spec=EnrichMovieMetadataUseCase)
+
+        use_case = RelinkMovieUseCase(uow_factory=mocks.factory, enrich_use_case=enrich)
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                RelinkMovieInput(
+                    movie_id=str(MovieId.generate()),
+                    tmdb_id=12345,
+                    media_type="movie",
+                ),
+            )

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -612,6 +612,106 @@ class TestSearchSeries:
 
 
 @pytest.mark.unit
+class TestFindMovieCandidates:
+    """Tests for ``find_movie_candidates`` — picker-mode raw search."""
+
+    @pytest.mark.asyncio
+    async def test_should_return_raw_candidates_without_detail_fetch(self) -> None:
+        """A single HTTP call (no per-id detail roundtrip) is the
+        whole point of the picker path."""
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "results": [
+                        {
+                            "id": 748230,
+                            "title": "Salem's Lot",
+                            "release_date": "2024-10-03",
+                            "overview": "Reboot",
+                            "poster_path": "/poster.jpg",
+                        },
+                    ],
+                },
+            ),
+        )
+
+        result = await client.find_movie_candidates("Salem's Lot", year=2024, limit=5)
+
+        assert len(result) == 1
+        assert result[0].tmdb_id == 748230
+        assert result[0].media_type == "movie"
+        assert result[0].year == 2024
+        assert result[0].poster_url == "https://image.tmdb.org/t/p/original/poster.jpg"
+
+    @pytest.mark.asyncio
+    async def test_should_truncate_to_limit(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "results": [
+                        {"id": i, "title": f"M{i}", "release_date": "2020-01-01"} for i in range(10)
+                    ],
+                },
+            ),
+        )
+
+        result = await client.find_movie_candidates("M", year=None, limit=3)
+
+        assert [c.tmdb_id for c in result] == [0, 1, 2]
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_when_no_results(self) -> None:
+        client = _make_client(get_responses=_build_response(json_data={"results": []}))
+
+        result = await client.find_movie_candidates("Nonexistent")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_should_handle_missing_release_date(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={"results": [{"id": 100, "title": "Unknown Year"}]},
+            ),
+        )
+
+        result = await client.find_movie_candidates("Unknown Year")
+
+        assert result[0].year is None
+
+
+@pytest.mark.unit
+class TestFindSeriesCandidates:
+    """Tests for ``find_series_candidates`` — picker-mode raw search."""
+
+    @pytest.mark.asyncio
+    async def test_should_return_raw_candidates_with_tv_media_type(self) -> None:
+        client = _make_client(
+            get_responses=_build_response(
+                json_data={
+                    "results": [
+                        {
+                            "id": 16118,
+                            "name": "Salem's Lot",
+                            "first_air_date": "1979-11-17",
+                            "overview": "Tobe Hooper miniseries",
+                            "poster_path": "/sl.jpg",
+                        },
+                    ],
+                },
+            ),
+        )
+
+        result = await client.find_series_candidates("Salem's Lot", year=1979)
+
+        assert len(result) == 1
+        assert result[0].tmdb_id == 16118
+        assert result[0].media_type == "tv"
+        assert result[0].year == 1979
+        assert result[0].title == "Salem's Lot"
+
+
+@pytest.mark.unit
 class TestGetMovieById:
     """Tests for get_movie_by_id."""
 

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_movie_mapper.py
@@ -62,6 +62,36 @@ class TestMovieMapper:
         assert model.year == 2024
         assert model.duration == 7200
 
+    def test_should_round_trip_needs_enrichment_review_flag(self) -> None:
+        """``to_model`` writes the flag, ``to_entity`` reads it back."""
+        movie_id = MovieId.generate()
+        movie = _create_movie(movie_id=movie_id).with_updates(needs_enrichment_review=True)
+
+        model = MovieMapper.to_model(movie)
+
+        assert model.needs_enrichment_review is True
+
+        # Build a fresh model mirror to exercise the read path
+        # (the model from to_model has SQLAlchemy plumbing we don't
+        # need to round-trip here).
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        read_model = MovieModel(
+            library_id=_LIBRARY_ID,
+            external_id=str(movie_id),
+            title="Test Movie",
+            year=2024,
+            duration=7200,
+            needs_enrichment_review=True,
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = MovieMapper.to_entity(read_model, include_files=False)
+
+        assert entity.needs_enrichment_review is True
+
     def test_to_entity_shallow_returns_empty_files_even_with_legacy_columns(self) -> None:
         """``include_files=False`` must skip the file-loading branch entirely.
 


### PR DESCRIPTION
## Summary

Persists a ``needs_enrichment_review`` flag on Movie (set by the enrichment use case on failure, cleared on success) so misclassified titles surface in a queryable inbox instead of just the application log. Adds three admin endpoints:

- ``GET /api/v1/admin/movies/needs-review`` — flagged movies sorted newest-first.
- ``GET /api/v1/admin/movies/{id}/tmdb-suggestions`` — live TMDB picker payload (movie + TV candidates, year-hinted with no-year fallback) seeded by the movie's scanner-extracted title/year.
- ``POST /api/v1/admin/movies/{id}/relink`` — admin commits a TMDB id. Movie picks stamp the id and force-enrich; TV picks 422 with a pointer to a future promote-to-series flow (cross-BC conversion deferred).

Adds ``find_movie_candidates`` / ``find_series_candidates`` to ``MetadataProvider`` (port) and ``TmdbClient`` (impl) — distinct from ``search_movie`` / ``search_series`` because the picker needs raw lists, not the year-strict single-best-match shape that auto-enrichment uses.

## Test plan

- [x] `pytest tests/modules/media/` (1286 passing, 5 skipped)
- [x] `pytest` full suite (2356 passing, 5 skipped)
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] `alembic upgrade head` applies cleanly on existing dev DB; head moves from `f4a5b6c7d8e9` → `a6b7c8d9e0f1`.
- [x] `op.add_column` direct ALTER (not `batch_alter_table`) — keeps the external-content FTS5 link intact per the 2026-04-14 catch-up migration rationale.
- [x] App boots with `create_app()` — 89 routes registered, including the three new admin paths.
- [x] Manual verification still pending against a live re-scan (admin endpoints exercised once the branch is on the running backend).

## Notes

- **Base branch is `fix/metadata-enrichment-year-cross-type`** (#200) rather than `develop` because the failure-path flag-setting in this PR depends on the cross-type detection logic from #200. Rebase onto `develop` once #200 merges.
- **No frontend** in this PR — admin testing via curl / API client for now. The homeflix-web UI (PR B) consumes these endpoints next.
- **Movie→Series conversion (PR C)** explicitly out of scope. TV picks return 422 with `RELINK_CROSS_TYPE_NOT_SUPPORTED`. Cross-BC orphan handling (watch_progresses / collections references to the deleted movie id) is the real cost there.
- Movie repository's `find_needs_enrichment_review` already supports the `allowed_library_ids` filter shape used elsewhere in the codebase; admin endpoint passes `None` (no ACL).

## Summary by Sourcery

Add an admin-facing workflow to surface movies whose TMDB enrichment failed and allow manual relinking to a specific TMDB ID, including TMDB-backed suggestion picking and persistence of a review flag.

New Features:
- Expose admin REST endpoints to list movies needing enrichment review, fetch TMDB movie/TV suggestions for a given movie, and relink a movie to a chosen TMDB ID with enforced admin auth.
- Introduce TMDB search candidate support in the metadata provider and client to supply lightweight movie and series suggestion cards for the admin picker.

Bug Fixes:
- Ensure failed movie enrichment attempts persist a needs_enrichment_review flag so problematic titles are tracked beyond logs and are cleared on successful re-enrichment.
- Prevent redundant saves on repeated failed enrichments when a movie is already flagged for review.

Enhancements:
- Extend the movie domain, persistence models, and repository to track and query a needs_enrichment_review flag and expose a listing of flagged movies ordered by recency.
- Wire new admin relink use cases into the media DI container and FastAPI app, integrating them with existing enrichment logic for post-relink refresh.

Build:
- Add an Alembic migration to introduce the needs_enrichment_review column and index on the movies table to support efficient admin review queries.

Tests:
- Add unit tests for TMDB client candidate search, enrichment flag behavior, admin review listing, TMDB suggestion fetching, and relink flow, as well as repository and mapper coverage for the new flag.