### PR TITLE
chore(infra): enable SQLite foreign_keys pragma + clean orphans

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -64,11 +64,25 @@ def do_run_migrations(connection: Connection) -> None:
 
 async def run_async_migrations() -> None:
     """Create an async engine and run migrations."""
+    from sqlalchemy import event
+
+    from src.infrastructure.persistence.database import _enable_sqlite_foreign_keys
+
     connectable = async_engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
+
+    # Migrations that DELETE rows (orphan cleanups, data backfills)
+    # need cascade enforcement to match runtime behavior; otherwise
+    # a cleanup written assuming FKs would silently leave children.
+    if connectable.dialect.name == "sqlite":
+        event.listen(
+            connectable.sync_engine,
+            "connect",
+            _enable_sqlite_foreign_keys,
+        )
 
     async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations)

--- a/migrations/versions/2026_05_17_clean_orphan_media_files.py
+++ b/migrations/versions/2026_05_17_clean_orphan_media_files.py
@@ -1,0 +1,79 @@
+"""Clean orphan ``media_files`` rows left by FK-less manual deletes.
+
+SQLite ships with foreign-key enforcement OFF by default and the
+pragma is *per connection*. Until the companion engine change in
+``database.py`` started running ``PRAGMA foreign_keys = ON``, the
+declarative ``ON DELETE CASCADE`` on ``media_files.movie_id`` and
+``media_files.episode_id`` stayed dormant — a manual
+``DELETE FROM movies`` (or ``DELETE FROM episodes``) from an
+external tool left orphan ``media_files`` rows behind. Those
+orphans then block re-scans because ``media_files.file_path`` has
+a ``UNIQUE`` constraint: re-creating the parent row tries to
+re-insert the same path and fails.
+
+This migration is a one-shot cleanup. Fresh installs see zero
+rows deleted; existing dev DBs (incl. Lucas's where the bug was
+first noticed) get healed in place. The pragma fix in
+``database.py`` makes sure new orphans can't accumulate from
+this point on.
+
+Revision ID: b7c8d9e0f1a2
+Revises: a6b7c8d9e0f1
+Create Date: 2026-05-17 11:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "b7c8d9e0f1a2"
+down_revision: str | Sequence[str] | None = "a6b7c8d9e0f1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    """Delete media_files whose movie_id or episode_id is dangling."""
+    bind = op.get_bind()
+
+    movie_orphans = bind.execute(
+        sa.text(
+            "DELETE FROM media_files "
+            "WHERE movie_id IS NOT NULL "
+            "  AND NOT EXISTS ("
+            "    SELECT 1 FROM movies WHERE movies.id = media_files.movie_id"
+            "  )"
+        )
+    ).rowcount
+
+    episode_orphans = bind.execute(
+        sa.text(
+            "DELETE FROM media_files "
+            "WHERE episode_id IS NOT NULL "
+            "  AND NOT EXISTS ("
+            "    SELECT 1 FROM episodes WHERE episodes.id = media_files.episode_id"
+            "  )"
+        )
+    ).rowcount
+
+    if movie_orphans or episode_orphans:
+        _logger.info(
+            "Cleaned %d orphan media_files (movies side) "
+            "and %d orphan media_files (episodes side).",
+            movie_orphans,
+            episode_orphans,
+        )
+
+
+def downgrade() -> None:
+    """No-op — deleted orphans cannot be recovered."""

--- a/src/infrastructure/persistence/database.py
+++ b/src/infrastructure/persistence/database.py
@@ -5,13 +5,43 @@ This module provides async SQLAlchemy engine and session factory setup.
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine.interfaces import DBAPIConnection
+    from sqlalchemy.pool import ConnectionPoolEntry
+
+
+def _enable_sqlite_foreign_keys(
+    dbapi_connection: "DBAPIConnection",
+    _connection_record: "ConnectionPoolEntry",
+) -> None:
+    """Run ``PRAGMA foreign_keys = ON`` on every new SQLite connection.
+
+    SQLite ships with FK enforcement OFF by default and the pragma
+    is *per connection* — declarative ``ON DELETE CASCADE`` clauses
+    in our models stay inert until each connection turns FKs on. A
+    manual ``DELETE FROM movies`` from an external tool then leaves
+    orphan rows in ``media_files`` etc., which break re-scans via
+    the ``UNIQUE(file_path)`` constraint.
+
+    Attached as a ``connect`` listener on the sync engine that the
+    async wrapper drives — ``AsyncEngine.sync_engine`` is the
+    standard hook because pool events are sync-side.
+    """
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute("PRAGMA foreign_keys=ON")
+    finally:
+        cursor.close()
 
 
 class Database:
@@ -97,6 +127,16 @@ class Database:
             engine_kwargs["max_overflow"] = self._max_overflow
 
         self._engine = create_async_engine(self._database_url, **engine_kwargs)
+
+        if is_sqlite:
+            # Pool events fire on the sync engine even under
+            # ``AsyncEngine``; without this the pragma never runs
+            # and CASCADE constraints stay dormant.
+            event.listen(
+                self._engine.sync_engine,
+                "connect",
+                _enable_sqlite_foreign_keys,
+            )
 
         self._session_factory = async_sessionmaker(
             bind=self._engine,

--- a/tests/infrastructure/persistence/test_database.py
+++ b/tests/infrastructure/persistence/test_database.py
@@ -1,6 +1,7 @@
 """Integration tests for Database class."""
 
 import pytest
+from sqlalchemy import text
 
 from src.infrastructure.persistence import Base
 from src.infrastructure.persistence.database import Database
@@ -117,3 +118,51 @@ class TestDatabase:
         with pytest.raises(RuntimeError, match="Database not connected"):
             async with db.session():
                 pass
+
+    async def test_sqlite_connections_enable_foreign_keys(self) -> None:
+        """``PRAGMA foreign_keys`` ships OFF by default on SQLite and is
+        per-connection — the connect listener installed by Database
+        must flip it on every time a connection is checked out, or
+        ON DELETE CASCADE silently fails (the original Salem's Lot
+        orphan story)."""
+        db = Database("sqlite+aiosqlite:///:memory:")
+        await db.connect()
+        try:
+            async with db.session() as session:
+                result = await session.execute(text("PRAGMA foreign_keys"))
+                assert result.scalar() == 1
+        finally:
+            await db.disconnect()
+
+    async def test_sqlite_cascade_actually_fires_on_delete(self) -> None:
+        """End-to-end check: with the pragma on, deleting a parent
+        row cleans up child rows via ON DELETE CASCADE — the
+        guarantee that lets us simplify the orphan-cleanup migration
+        from a recurring sweep into a one-shot heal."""
+        db = Database("sqlite+aiosqlite:///:memory:")
+        await db.connect()
+        try:
+            async with db.engine.begin() as conn:
+                await conn.execute(
+                    text("CREATE TABLE parents (id INTEGER PRIMARY KEY)"),
+                )
+                await conn.execute(
+                    text(
+                        "CREATE TABLE children ("
+                        "  id INTEGER PRIMARY KEY,"
+                        "  parent_id INTEGER REFERENCES parents(id) ON DELETE CASCADE"
+                        ")"
+                    ),
+                )
+                await conn.execute(text("INSERT INTO parents (id) VALUES (1)"))
+                await conn.execute(
+                    text("INSERT INTO children (id, parent_id) VALUES (10, 1)"),
+                )
+
+            async with db.session() as session:
+                await session.execute(text("DELETE FROM parents WHERE id = 1"))
+                await session.commit()
+                remaining = await session.execute(text("SELECT COUNT(*) FROM children"))
+                assert remaining.scalar() == 0
+        finally:
+            await db.disconnect()


### PR DESCRIPTION
## Summary

Closes the loophole from the Salem's Lot incident: SQLite ships with foreign-key enforcement OFF by default and the pragma is *per-connection*, so the declarative ``ON DELETE CASCADE`` on ``media_files.movie_id`` / ``media_files.episode_id`` was inert — a manual ``DELETE FROM movies`` from an external tool left orphan ``media_files`` rows behind, and the ``UNIQUE(file_path)`` constraint then blocked re-scans of the same path.

- Adds a ``connect`` event listener on the async engine's sync side that runs ``PRAGMA foreign_keys = ON`` on every new SQLite connection.
- Mirrors the listener on Alembic's connection so migrations that DELETE rows expecting CASCADE behavior match runtime semantics.
- One-shot migration ``b7c8d9e0f1a2`` sweeps existing orphan ``media_files`` (movies side + episodes side). Fresh installs: no-op. Existing dev DBs: healed in place. Lucas's local already verified zero orphans after running locally.

## Test plan

- [x] `pytest tests/infrastructure/persistence/test_database.py` — 12 passing, including the two new tests `test_sqlite_connections_enable_foreign_keys` and `test_sqlite_cascade_actually_fires_on_delete`.
- [x] `pytest` full suite — 2358 passing, 5 skipped.
- [x] `ruff check src/ tests/ migrations/` clean.
- [x] `ruff format --check` clean.
- [x] `alembic upgrade head` applies cleanly; head moves `a6b7c8d9e0f1` → `b7c8d9e0f1a2`.
- [x] Verified locally that orphan check (`SELECT mf.id FROM media_files mf LEFT JOIN movies m ON m.id = mf.movie_id WHERE mf.movie_id IS NOT NULL AND m.id IS NULL`) returns 0 rows after migration.

## Notes

- The pragma is dialect-gated (only attached when `dialect.name == "sqlite"`) so PostgreSQL deployments are unaffected.
- Migrations under Alembic now also get the pragma — important for any future migration that does data DELETEs (the orphan cleanup here used IS NULL checks rather than relying on cascade, so it's safe either way).
- `dbapi_connection.cursor()` cleanup uses `try/finally` so a failed PRAGMA still releases the cursor.

## Summary by Sourcery

Ensure SQLite foreign key constraints are enforced consistently and clean up existing orphan media_files rows.

Bug Fixes:
- Enable SQLite foreign key enforcement for all application and migration connections so ON DELETE CASCADE behaves as defined.
- Add a one-time migration to delete orphan media_files rows left behind by earlier FK-less deletes.

Enhancements:
- Wire a SQLite-specific connect listener into the async database engine and Alembic environment to apply PRAGMA foreign_keys=ON on each new connection.

Tests:
- Add integration tests verifying SQLite connections have foreign_keys enabled and that ON DELETE CASCADE removes dependent rows.