### PR TITLE
feat(media): promote-to-series for cross-type misclassifications

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -53,6 +53,9 @@ from src.modules.media.application.use_cases.list_recently_added_series import (
     ListRecentlyAddedSeriesUseCase,
 )
 from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
+from src.modules.media.application.use_cases.promote_movie_to_series import (
+    PromoteMovieToSeriesUseCase,
+)
 from src.modules.media.application.use_cases.relink_movie import RelinkMovieUseCase
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
 from src.modules.media.application.use_cases.scan_media_directories import (
@@ -435,6 +438,14 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         RelinkMovieUseCase,
         uow_factory=media_unit_of_work_factory,
         enrich_use_case=enrich_movie_metadata,
+    )
+
+    promote_movie_to_series = providers.Factory(
+        PromoteMovieToSeriesUseCase,
+        uow_factory=media_unit_of_work_factory,
+        metadata_provider=tmdb_client,
+        enrich_series_use_case=enrich_series_metadata,
+        event_bus=event_bus,
     )
 
     # =========================================================================

--- a/src/main.py
+++ b/src/main.py
@@ -152,15 +152,42 @@ def _subscribe_event_handlers(container: ApplicationContainer) -> None:
     Centralises event handler registration so it stays alongside
     the rest of the container configuration.
     """
+    from src.modules.collections.application.event_handlers import (
+        OnMoviePromotedToSeriesHandler as CollectionsOnMoviePromotedHandler,
+    )
     from src.modules.media.application.event_handlers import OnMediaCreatedHandler
-    from src.modules.media.domain.events import MediaCreatedEvent
+    from src.modules.media.domain.events import (
+        MediaCreatedEvent,
+        MoviePromotedToSeriesEvent,
+    )
+    from src.modules.watch_progress.application.event_handlers import (
+        OnMoviePromotedToSeriesHandler as ProgressOnMoviePromotedHandler,
+    )
 
     event_bus = container.infrastructure.event_bus()
-    handler = OnMediaCreatedHandler(
+
+    media_created_handler = OnMediaCreatedHandler(
         enrich_movie_factory=container.media.enrich_movie_metadata,
         enrich_series_factory=container.media.enrich_series_metadata,
     )
-    event_bus.subscribe(MediaCreatedEvent, handler)
+    event_bus.subscribe(MediaCreatedEvent, media_created_handler)
+
+    # Cross-BC fan-out when a movie is promoted into a series.
+    # watch_progress drops the stale rows (positions can't survive a
+    # re-cut episode boundary); collections rewrites watchlist +
+    # custom-list refs so the same content stays on the user's lists.
+    event_bus.subscribe(
+        MoviePromotedToSeriesEvent,
+        ProgressOnMoviePromotedHandler(
+            uow_factory=container.watch_progress.watch_progress_unit_of_work_factory(),
+        ),
+    )
+    event_bus.subscribe(
+        MoviePromotedToSeriesEvent,
+        CollectionsOnMoviePromotedHandler(
+            uow_factory=container.collections.collections_unit_of_work_factory(),
+        ),
+    )
 
 
 def _bootstrap_modules() -> None:

--- a/src/modules/collections/application/event_handlers/__init__.py
+++ b/src/modules/collections/application/event_handlers/__init__.py
@@ -1,0 +1,7 @@
+"""Collections event handlers."""
+
+from src.modules.collections.application.event_handlers.on_movie_promoted_to_series import (
+    OnMoviePromotedToSeriesHandler,
+)
+
+__all__ = ["OnMoviePromotedToSeriesHandler"]

--- a/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
@@ -1,0 +1,60 @@
+"""Cross-BC handler: migrate watchlist / custom-list refs on movie promotion."""
+
+import logging
+
+from src.building_blocks.application.event_bus import EventHandler
+from src.building_blocks.domain.events import DomainEvent
+from src.modules.collections.application.unit_of_work import (
+    CollectionsUnitOfWorkFactory,
+)
+from src.modules.media.domain.events import MoviePromotedToSeriesEvent
+
+_logger = logging.getLogger(__name__)
+
+
+class OnMoviePromotedToSeriesHandler(EventHandler):
+    """Repoint watchlist + custom-list entries to the new series id.
+
+    Unlike watch progress (which gets *deleted* on promotion because
+    a half-watched position can't survive a re-cut episode boundary
+    safely), collection memberships are pure "I want to watch this
+    content" markers — they should survive the structural change so
+    the user's lists don't quietly lose items. The same content is
+    still there, just now organised as a series instead of a movie.
+
+    Both writes run in the same Unit of Work so a partial failure
+    (e.g. watchlist rewritten but DB crashes before custom-lists)
+    rolls back, keeping the two tables consistent.
+    """
+
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def handle(self, event: DomainEvent) -> None:
+        """Handle ``MoviePromotedToSeriesEvent``."""
+        if not isinstance(event, MoviePromotedToSeriesEvent):
+            return
+
+        async with self._uow_factory() as uow:
+            watchlist_updated = await uow.watchlist.rewrite_media_id(
+                from_media_id=event.movie_id,
+                to_media_id=event.series_id,
+                to_media_type="series",
+            )
+            lists_updated = await uow.custom_lists.rewrite_item_media_id(
+                from_media_id=event.movie_id,
+                to_media_id=event.series_id,
+                to_media_type="series",
+            )
+
+        if watchlist_updated or lists_updated:
+            _logger.info(
+                "Repointed %d watchlist + %d custom-list entries " "from movie %s to series %s",
+                watchlist_updated,
+                lists_updated,
+                event.movie_id,
+                event.series_id,
+            )
+
+
+__all__ = ["OnMoviePromotedToSeriesHandler"]

--- a/src/modules/collections/domain/repositories/custom_list_repository.py
+++ b/src/modules/collections/domain/repositories/custom_list_repository.py
@@ -101,5 +101,29 @@ class CustomListRepository(ABC):
     ) -> int:
         """Return the next 0-based position to use for a new item."""
 
+    @abstractmethod
+    async def rewrite_item_media_id(
+        self,
+        from_media_id: str,
+        to_media_id: str,
+        to_media_type: str,
+    ) -> int:
+        """Repoint every custom-list item from one media id to another.
+
+        Cross-BC migration triggered by
+        ``MoviePromotedToSeriesEvent`` — see the matching method on
+        ``WatchlistRepository`` for the rationale. Runs across every
+        profile's lists so the operator doesn't have to clean up per
+        list.
+
+        Args:
+            from_media_id: External id currently stored.
+            to_media_id: External id to migrate to.
+            to_media_type: New ``media_type`` discriminator.
+
+        Returns:
+            Number of items updated.
+        """
+
 
 __all__ = ["CustomListRepository"]

--- a/src/modules/collections/domain/repositories/watchlist_repository.py
+++ b/src/modules/collections/domain/repositories/watchlist_repository.py
@@ -46,5 +46,31 @@ class WatchlistRepository(ABC):
     async def exists(self, media_id: str, profile_id: ProfileId) -> bool:
         """Check whether ``media_id`` is on ``profile_id``'s watchlist."""
 
+    @abstractmethod
+    async def rewrite_media_id(
+        self,
+        from_media_id: str,
+        to_media_id: str,
+        to_media_type: str,
+    ) -> int:
+        """Repoint every row from one media id to another (cross-profile).
+
+        Driven by ``MoviePromotedToSeriesEvent``: when a movie is
+        converted to a series, every profile's watchlist entry for
+        the old ``mov_xxx`` id needs to land on the new ``ser_xxx``
+        id so the list keeps the same set of titles without manual
+        cleanup. ``media_type`` is rewritten too because watchlist
+        rows carry the discriminator alongside the id.
+
+        Args:
+            from_media_id: External id currently stored.
+            to_media_id: External id to migrate to.
+            to_media_type: New ``media_type`` discriminator
+                (``"series"`` for the promote flow).
+
+        Returns:
+            Number of rows updated.
+        """
+
 
 __all__ = ["WatchlistRepository"]

--- a/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
@@ -274,5 +274,25 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         result = await self._session.execute(stmt)
         return result.scalar() or 0
 
+    async def rewrite_item_media_id(
+        self,
+        from_media_id: str,
+        to_media_id: str,
+        to_media_type: str,
+    ) -> int:
+        """Repoint every list item (cross-list, cross-profile) to a new media id."""
+        stmt = select(CustomListItemModel).where(
+            CustomListItemModel.media_id == from_media_id,
+            CustomListItemModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        models = result.scalars().all()
+        for model in models:
+            model.media_id = to_media_id
+            model.media_type = to_media_type
+        if models:
+            await self._session.flush()
+        return len(models)
+
 
 __all__ = ["SQLAlchemyCustomListRepository"]

--- a/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
@@ -118,5 +118,25 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         result = await self._session.execute(stmt)
         return (result.scalar() or 0) > 0
 
+    async def rewrite_media_id(
+        self,
+        from_media_id: str,
+        to_media_id: str,
+        to_media_type: str,
+    ) -> int:
+        """Repoint every watchlist row (across profiles) to a new media id."""
+        stmt = select(WatchlistItemModel).where(
+            WatchlistItemModel.media_id == from_media_id,
+            WatchlistItemModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        models = result.scalars().all()
+        for model in models:
+            model.media_id = to_media_id
+            model.media_type = to_media_type
+        if models:
+            await self._session.flush()
+        return len(models)
+
 
 __all__ = ["SQLAlchemyWatchlistRepository"]

--- a/src/modules/media/application/dtos/admin_relink_dtos.py
+++ b/src/modules/media/application/dtos/admin_relink_dtos.py
@@ -97,15 +97,19 @@ class GetMovieTmdbSuggestionsOutput:
 
 @dataclass(frozen=True)
 class RelinkMovieInput:
-    """Admin's pick from the suggestion picker.
+    """Admin's movie-side pick from the suggestion picker.
+
+    TV picks travel through the dedicated promote-to-series flow
+    (see ``PromoteMovieToSeriesInput``) — keeping the relink command
+    movie-only avoids stitching two unrelated state machines under
+    one endpoint. The use case still rejects ``media_type="tv"``
+    defensively in case a caller bypasses the presentation-layer
+    schema validation.
 
     Attributes:
         movie_id: External movie id to relink.
-        tmdb_id: TMDB id the admin selected.
-        media_type: ``"movie"`` triggers an enrichment refresh against
-            the picked id. ``"tv"`` is rejected by this PR with a
-            "use promote-to-series" error — the cross-BC conversion
-            lives in a follow-up.
+        tmdb_id: TMDB *movie* id the admin selected.
+        media_type: Must be ``"movie"``.
     """
 
     movie_id: str
@@ -133,12 +137,50 @@ class RelinkMovieOutput:
     error: str | None = None
 
 
+@dataclass(frozen=True)
+class PromoteMovieToSeriesInput:
+    """Input for the cross-type promotion endpoint.
+
+    Attributes:
+        movie_id: External movie id to convert.
+        tmdb_id: TMDB *series* id the admin picked from the picker.
+            The use case fetches the series shape from TMDB to know
+            how many episodes to create.
+    """
+
+    movie_id: str
+    tmdb_id: int
+
+
+@dataclass(frozen=True)
+class PromoteMovieToSeriesOutput:
+    """Result of a promotion.
+
+    Attributes:
+        movie_id: External id of the (now soft-deleted) source movie.
+        series_id: External id of the newly-created series.
+        first_episode_id: Episode id that now owns the original
+            movie's file variants. Returned so the UI can deep-link
+            into the new series and the cross-BC handlers know which
+            episode replaced the movie.
+        episodes_created: How many episodes the structure has — driven
+            by the TMDB season's episode count, minimum one.
+    """
+
+    movie_id: str
+    series_id: str
+    first_episode_id: str
+    episodes_created: int
+
+
 __all__ = [
     "GetMovieTmdbSuggestionsInput",
     "GetMovieTmdbSuggestionsOutput",
     "ListMoviesNeedingReviewOutput",
     "MediaType",
     "NeedsReviewMovieOutput",
+    "PromoteMovieToSeriesInput",
+    "PromoteMovieToSeriesOutput",
     "RelinkMovieInput",
     "RelinkMovieOutput",
     "TmdbSuggestionOutput",

--- a/src/modules/media/application/use_cases/promote_movie_to_series.py
+++ b/src/modules/media/application/use_cases/promote_movie_to_series.py
@@ -1,0 +1,259 @@
+"""Use case: convert a Movie into a Series (Salem's Lot case)."""
+
+import logging
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.building_blocks.application.event_bus import EventBus
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    PromoteMovieToSeriesInput,
+    PromoteMovieToSeriesOutput,
+)
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
+from src.modules.media.application.ports import MediaMetadata, MetadataProvider
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
+from src.modules.media.domain.entities import Episode, Movie, Season, Series
+from src.modules.media.domain.events import MoviePromotedToSeriesEvent
+from src.modules.media.domain.value_objects import (
+    Duration,
+    EpisodeId,
+    EpisodeNumber,
+    MovieId,
+    SeasonId,
+    SeasonNumber,
+    SeriesId,
+    Title,
+    TmdbId,
+    Year,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class PromoteMovieToSeriesUseCase:
+    """Convert a misclassified Movie into a Series.
+
+    Driven by ``Salem's Lot (1979)``-style cases: TMDB catalogs the
+    title as a TV miniseries (``/tv/16118``) but the scanner — which
+    classifies by filename pattern — registered it as a Movie. The
+    flow:
+
+        1. Fetch TMDB series details by id (validates that the
+           supplied id really is a series; aborts early on miss).
+        2. Build ``Series + Season(1) + N episodes`` (where ``N`` is
+           the TMDB season's episode count, clamped to ``>= 1``).
+        3. Save the structure, then re-FK every ``media_files`` row
+           from the source movie to the first episode (file path
+           UNIQUE-ness rules out creating fresh rows).
+        4. Soft-delete the source movie.
+        5. Publish ``MoviePromotedToSeriesEvent`` so cross-BC
+           handlers can clear stale ``watch_progresses`` rows and
+           rewrite ``watchlist`` / ``custom_list`` refs.
+        6. Trigger ``EnrichSeriesMetadataUseCase`` to backfill the
+           episode-level metadata (air dates, synopses, thumbnails)
+           that TMDB already has.
+
+    The re-enrich step runs *after* commit so a transient TMDB
+    failure doesn't roll the whole promotion back — admin can hit
+    the regular enrich endpoint to retry just that piece.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+        metadata_provider: Metadata port used to fetch the TMDB
+            series shape (episode count, season metadata).
+        enrich_series_use_case: Series enrichment to run after the
+            structure is in place.
+        event_bus: Event bus used to publish
+            ``MoviePromotedToSeriesEvent``.
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        metadata_provider: MetadataProvider,
+        enrich_series_use_case: EnrichSeriesMetadataUseCase,
+        event_bus: EventBus,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._metadata_provider = metadata_provider
+        self._enrich_series = enrich_series_use_case
+        self._event_bus = event_bus
+
+    async def execute(
+        self,
+        input_dto: PromoteMovieToSeriesInput,
+    ) -> PromoteMovieToSeriesOutput:
+        """Execute the promotion."""
+        if input_dto.tmdb_id <= 0:
+            raise UseCaseValidationException(
+                message="tmdb_id must be a positive integer",
+                message_code="INVALID_TMDB_ID",
+            )
+
+        # Validate the TMDB id up-front, before touching the DB.
+        tmdb_meta = await self._metadata_provider.get_series_by_id(input_dto.tmdb_id)
+        if tmdb_meta is None:
+            raise ResourceNotFoundException.for_resource("TmdbSeries", str(input_dto.tmdb_id))
+
+        series_id, first_episode_id, episodes_count = await self._run_conversion(
+            input_dto, tmdb_meta
+        )
+
+        # Cross-BC fan-out runs after the catalog mutation commits so
+        # handlers observe the post-promote state.
+        await self._event_bus.publish(
+            MoviePromotedToSeriesEvent(
+                movie_id=input_dto.movie_id,
+                series_id=series_id,
+                first_episode_id=first_episode_id,
+            ),
+        )
+
+        # Best-effort metadata backfill — the structure is already
+        # correct, this just populates titles/dates/thumbs per episode.
+        # Swallowed exceptions are visible in the log and retryable
+        # via the existing /series/{id}/enrich endpoint.
+        try:
+            await self._enrich_series.execute(
+                EnrichMediaInput(media_id=series_id, force=True),
+            )
+        except Exception:
+            _logger.exception(
+                "Re-enrich after promotion failed for series %s; "
+                "admin can retry via /series/{id}/enrich",
+                series_id,
+            )
+
+        return PromoteMovieToSeriesOutput(
+            movie_id=input_dto.movie_id,
+            series_id=series_id,
+            first_episode_id=first_episode_id,
+            episodes_created=episodes_count,
+        )
+
+    async def _run_conversion(
+        self,
+        input_dto: PromoteMovieToSeriesInput,
+        tmdb_meta: MediaMetadata,
+    ) -> tuple[str, str, int]:
+        """Build + persist the series, move files, soft-delete the movie.
+
+        Returns ``(series_id, first_episode_id, episodes_count)``.
+        """
+        async with self._uow_factory() as uow:
+            movie = await uow.movies.find_by_id(MovieId(input_dto.movie_id))
+            if movie is None:
+                raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)
+
+            series, first_episode_id = _build_series_from_movie(movie, tmdb_meta, input_dto.tmdb_id)
+            await uow.series.save(series)
+
+            # Re-FK the existing media_files rows onto the new
+            # episode. Reusing rows side-steps the UNIQUE(file_path)
+            # constraint and preserves probe-side track metadata.
+            moved = await uow.movies.transfer_file_variants_to_episode(
+                MovieId(input_dto.movie_id), EpisodeId(first_episode_id)
+            )
+            _logger.info(
+                "Promoted movie %s → series %s, moved %d file variant(s)",
+                input_dto.movie_id,
+                series.id,
+                moved,
+            )
+
+            await uow.movies.delete(MovieId(input_dto.movie_id))
+
+            episodes_count = len(series.seasons[0].episodes)
+
+        return str(series.id), first_episode_id, episodes_count
+
+
+def _build_series_from_movie(
+    movie: Movie,
+    tmdb_meta: MediaMetadata,
+    tmdb_id: int,
+) -> tuple[Series, str]:
+    """Construct the new Series aggregate without files.
+
+    Episodes are created with empty ``files`` lists; the use case
+    re-FKs the existing ``media_files`` rows directly onto the first
+    episode after persisting (see ``transfer_file_variants_to_episode``).
+
+    Returns the Series plus the external id of the first episode so
+    the caller can route the file relocation + event publish without
+    walking the aggregate again.
+    """
+    first_season = tmdb_meta.seasons[0] if tmdb_meta.seasons else None
+    season_number_val = first_season.season_number if first_season else 1
+    season_number = SeasonNumber(season_number_val)
+
+    # Default to "1 placeholder episode" if TMDB returned no episodes
+    # for this season — keeps the structure consistent so the file
+    # always has somewhere to land.
+    episode_metas = list(first_season.episodes) if first_season and first_season.episodes else []
+
+    series_id = SeriesId.generate()
+    episodes: list[Episode] = []
+
+    if not episode_metas:
+        first_episode_id = EpisodeId.generate()
+        episodes.append(
+            Episode(
+                id=first_episode_id,
+                series_id=series_id,
+                season_number=season_number,
+                episode_number=EpisodeNumber(1),
+                title=Title("Episode 1"),
+                duration=Duration(movie.duration.value),
+            )
+        )
+    else:
+        for idx, ep_meta in enumerate(episode_metas):
+            episode_id = EpisodeId.generate()
+            ep_title = ep_meta.title or f"Episode {ep_meta.episode_number}"
+            # First episode inherits the movie's duration so the
+            # player has a sane number until TMDB enrichment refreshes
+            # it; later episodes start at 0 (TMDB will fill them in).
+            ep_duration_seconds = ep_meta.duration_seconds or (
+                movie.duration.value if idx == 0 else 0
+            )
+            episodes.append(
+                Episode(
+                    id=episode_id,
+                    series_id=series_id,
+                    season_number=season_number,
+                    episode_number=EpisodeNumber(ep_meta.episode_number),
+                    title=Title(ep_title),
+                    duration=Duration(ep_duration_seconds),
+                )
+            )
+
+    first_episode_id_str = str(episodes[0].id)
+
+    season = Season(
+        id=SeasonId.generate(),
+        series_id=series_id,
+        season_number=season_number,
+        title=Title(first_season.title) if first_season and first_season.title else None,
+        air_date=None,
+        episodes=episodes,
+    )
+
+    series = Series(
+        id=series_id,
+        library_id=movie.library_id,
+        title=Title(tmdb_meta.title or movie.title.value),
+        start_year=Year(tmdb_meta.year or movie.year.value),
+        tmdb_id=TmdbId(tmdb_id),
+        seasons=[season],
+    )
+
+    return series, first_episode_id_str
+
+
+__all__ = ["PromoteMovieToSeriesUseCase"]

--- a/src/modules/media/domain/events.py
+++ b/src/modules/media/domain/events.py
@@ -72,9 +72,42 @@ class IntroClearedEvent(DomainEvent):
     series_id: str = ""
 
 
+@dataclass(frozen=True)
+class MoviePromotedToSeriesEvent(DomainEvent):
+    """Emitted when an admin promotes a movie into a series.
+
+    Driven by the cross-type relink flow (e.g. ``Salem's Lot (1979)``,
+    which TMDB catalogs as a TV miniseries rather than a film).
+
+    The original movie row is soft-deleted; a new series + season
+    + episodes structure takes its place. All file variants of the
+    movie are reattached to the first episode (``first_episode_id``)
+    so external bounded contexts know where playback state should
+    migrate (or — per the agreed design — where to delete it).
+
+    Cross-BC handlers:
+        - ``watch_progress`` deletes WatchProgress rows for the old
+          movie id (safer than mapping a position across a possibly
+          re-cut episode boundary).
+        - ``collections`` rewrites watchlist + custom-list entries
+          to point at the new series id.
+
+    Attributes:
+        movie_id: External ID of the source movie (mov_xxx).
+        series_id: External ID of the new series (ser_xxx).
+        first_episode_id: External ID of the first episode (epi_xxx)
+            that now owns the movie's file variants.
+    """
+
+    movie_id: str = ""
+    series_id: str = ""
+    first_episode_id: str = ""
+
+
 __all__ = [
     "IntroClearedEvent",
     "IntroDetectedEvent",
     "IntroManuallySetEvent",
     "MediaCreatedEvent",
+    "MoviePromotedToSeriesEvent",
 ]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from src.building_blocks.application.pagination import PaginatedResult
 from src.modules.media.domain.entities.movie import Movie
-from src.modules.media.domain.value_objects import FilePath, Genre, MovieId
+from src.modules.media.domain.value_objects import EpisodeId, FilePath, Genre, MovieId
 
 
 @dataclass(frozen=True)
@@ -426,6 +426,33 @@ class MovieRepository(ABC):
 
         Returns:
             Sequence of flagged movies.
+        """
+        ...
+
+    @abstractmethod
+    async def transfer_file_variants_to_episode(
+        self,
+        movie_id: MovieId,
+        episode_id: EpisodeId,
+    ) -> int:
+        """Re-attach all ``media_files`` rows from a movie to an episode.
+
+        Used by the Movie→Series promotion: the original movie owns
+        one or more file variants on disk, the new series structure
+        needs those variants on its first episode. Reusing the same
+        ``media_files`` rows avoids the ``UNIQUE(file_path)`` clash
+        that would happen if we tried to create new rows alongside
+        the old ones, and keeps the existing track/probe metadata.
+
+        After this call the movie has no remaining file variants and
+        the episode owns every row that used to belong to the movie.
+
+        Args:
+            movie_id: External id of the source movie.
+            episode_id: External id of the target episode.
+
+        Returns:
+            Number of media_files rows moved.
         """
         ...
 

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -18,9 +18,13 @@ from src.building_blocks.application.pagination import (
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
 from src.modules.media.domain.repositories.movie_repository import GenreRow
-from src.modules.media.domain.value_objects import FilePath, Genre, MovieId
+from src.modules.media.domain.value_objects import EpisodeId, FilePath, Genre, MovieId
 from src.modules.media.infrastructure.persistence.mappers import MovieMapper
-from src.modules.media.infrastructure.persistence.models import MediaFileModel, MovieModel
+from src.modules.media.infrastructure.persistence.models import (
+    EpisodeModel,
+    MediaFileModel,
+    MovieModel,
+)
 from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
     fetch_genre_paginated_page,
     fetch_genre_rows,
@@ -518,6 +522,40 @@ class SQLAlchemyMovieRepository(MovieRepository):
         )
         result = await self._session.execute(stmt)
         return [MovieMapper.to_entity(model) for model in result.scalars().all()]
+
+    async def transfer_file_variants_to_episode(
+        self,
+        movie_id: MovieId,
+        episode_id: EpisodeId,
+    ) -> int:
+        """Re-FK media_files from a movie's row to an episode's row.
+
+        Looks up both internal primary keys via the external ids,
+        then a single ``UPDATE`` rewrites the FK pair on every matching
+        row. ``movie_id`` is set to ``NULL`` so the cascade triggered
+        by the subsequent movie soft-delete doesn't sweep the rows
+        we just relocated.
+        """
+        movie_pk_stmt = select(MovieModel.id).where(
+            MovieModel.external_id == str(movie_id),
+        )
+        episode_pk_stmt = select(EpisodeModel.id).where(
+            EpisodeModel.external_id == str(episode_id),
+        )
+        movie_pk = (await self._session.execute(movie_pk_stmt)).scalar_one_or_none()
+        episode_pk = (await self._session.execute(episode_pk_stmt)).scalar_one_or_none()
+        if movie_pk is None or episode_pk is None:
+            return 0
+
+        result = await self._session.execute(
+            text(
+                "UPDATE media_files "
+                "SET movie_id = NULL, episode_id = :episode_pk "
+                "WHERE movie_id = :movie_pk"
+            ),
+            {"movie_pk": movie_pk, "episode_pk": episode_pk},
+        )
+        return result.rowcount or 0
 
     async def find_missing_scrub_preview(self, limit: int) -> Sequence[Movie]:
         """Return up to ``limit`` movies whose ``scrub_preview_path`` is null.

--- a/src/modules/media/presentation/routes/admin_relink_routes.py
+++ b/src/modules/media/presentation/routes/admin_relink_routes.py
@@ -23,6 +23,7 @@ from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.admin_relink_dtos import (
     GetMovieTmdbSuggestionsInput,
+    PromoteMovieToSeriesInput,
     RelinkMovieInput,
 )
 from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
@@ -31,8 +32,11 @@ from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
 from src.modules.media.application.use_cases.list_movies_needing_review import (
     ListMoviesNeedingReviewUseCase,
 )
+from src.modules.media.application.use_cases.promote_movie_to_series import (
+    PromoteMovieToSeriesUseCase,
+)
 from src.modules.media.application.use_cases.relink_movie import RelinkMovieUseCase
-from src.modules.media.presentation.schemas import RelinkMovieRequest
+from src.modules.media.presentation.schemas import PromoteMovieToSeriesRequest, RelinkMovieRequest
 
 router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Movie Relink"])
 
@@ -83,6 +87,23 @@ async def relink_movie(
         ),
     )
     return api_single("relink", asdict(output))
+
+
+@router.post("/movies/{movie_id}/promote-to-series")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def promote_movie_to_series(
+    movie_id: str,
+    body: PromoteMovieToSeriesRequest,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: PromoteMovieToSeriesUseCase = Depends(
+        Provide[ApplicationContainer.media.promote_movie_to_series],
+    ),
+) -> dict[str, Any]:
+    """Convert a misclassified movie into a series using a TMDB tv id."""
+    output = await use_case.execute(
+        PromoteMovieToSeriesInput(movie_id=movie_id, tmdb_id=body.tmdb_id),
+    )
+    return api_single("promote_to_series", asdict(output))
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/schemas/__init__.py
+++ b/src/modules/media/presentation/schemas/__init__.py
@@ -1,6 +1,9 @@
 """Media API request/response schemas."""
 
-from src.modules.media.presentation.schemas.admin_relink_schemas import RelinkMovieRequest
+from src.modules.media.presentation.schemas.admin_relink_schemas import (
+    PromoteMovieToSeriesRequest,
+    RelinkMovieRequest,
+)
 from src.modules.media.presentation.schemas.enrichment_schemas import EnrichRequest
 from src.modules.media.presentation.schemas.file_variant_schemas import (
     AddFileVariantRequest,
@@ -13,6 +16,7 @@ from src.modules.media.presentation.schemas.scan_schemas import ScanMediaRequest
 __all__ = [
     "AddFileVariantRequest",
     "EnrichRequest",
+    "PromoteMovieToSeriesRequest",
     "RelinkMovieRequest",
     "RemoveFileVariantRequest",
     "ScanMediaRequest",

--- a/src/modules/media/presentation/schemas/admin_relink_schemas.py
+++ b/src/modules/media/presentation/schemas/admin_relink_schemas.py
@@ -8,23 +8,39 @@ from pydantic import BaseModel, Field
 class RelinkMovieRequest(BaseModel):
     """Request body for ``POST /admin/movies/{id}/relink``.
 
-    The admin picked one of the cards returned by
-    ``GET /admin/movies/{id}/tmdb-suggestions`` and is committing
-    that choice. ``media_type`` mirrors which TMDB endpoint produced
-    the card so the server knows whether to refresh the movie
-    in-place (``movie``) or short-circuit to the not-yet-implemented
-    promote-to-series flow (``tv``).
+    Only movie picks ride this endpoint — series picks must hit
+    ``POST /admin/movies/{id}/promote-to-series`` instead, since the
+    structural conversion needs cross-BC event fanout that the
+    in-place enrichment refresh doesn't do. Pydantic's ``Literal``
+    enforces the split: a payload with ``media_type="tv"`` is
+    rejected at the schema layer with a 422.
     """
 
     tmdb_id: int = Field(..., ge=1, description="TMDB primary key of the picked entry.")
-    media_type: Literal["movie", "tv"] = Field(
+    media_type: Literal["movie"] = Field(
         ...,
         description=(
-            "Which TMDB endpoint the picked card came from. 'movie' "
-            "triggers an enrichment refresh; 'tv' returns a 422 "
-            "asking to use the future promote-to-series endpoint."
+            "Must be 'movie'. Series picks use the dedicated "
+            "/admin/movies/{id}/promote-to-series endpoint."
         ),
     )
 
 
-__all__ = ["RelinkMovieRequest"]
+class PromoteMovieToSeriesRequest(BaseModel):
+    """Request body for ``POST /admin/movies/{id}/promote-to-series``.
+
+    Admin picked a TV suggestion in the relink picker. Server fetches
+    the TMDB series, builds the ``Series + Season + Episodes`` shape,
+    moves the original movie's file variants onto the first episode,
+    soft-deletes the movie and fans the change out to the
+    watch_progress and collections bounded contexts.
+    """
+
+    tmdb_id: int = Field(
+        ...,
+        ge=1,
+        description="TMDB *series* id the admin picked from the TV column.",
+    )
+
+
+__all__ = ["PromoteMovieToSeriesRequest", "RelinkMovieRequest"]

--- a/src/modules/watch_progress/application/event_handlers/__init__.py
+++ b/src/modules/watch_progress/application/event_handlers/__init__.py
@@ -1,0 +1,7 @@
+"""Watch Progress event handlers."""
+
+from src.modules.watch_progress.application.event_handlers.on_movie_promoted_to_series import (
+    OnMoviePromotedToSeriesHandler,
+)
+
+__all__ = ["OnMoviePromotedToSeriesHandler"]

--- a/src/modules/watch_progress/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/watch_progress/application/event_handlers/on_movie_promoted_to_series.py
@@ -1,0 +1,52 @@
+"""Cross-BC handler: clear movie progress when a movie is promoted to a series."""
+
+import logging
+
+from src.building_blocks.application.event_bus import EventHandler
+from src.building_blocks.domain.events import DomainEvent
+from src.modules.media.domain.events import MoviePromotedToSeriesEvent
+from src.modules.watch_progress.application.unit_of_work import (
+    WatchProgressUnitOfWorkFactory,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class OnMoviePromotedToSeriesHandler(EventHandler):
+    """Wipe every ``watch_progresses`` row pointing at the source movie.
+
+    Why delete (vs. migrate the position to the new first episode):
+    the agreed UX choice during PR-C design — a half-watched 3 h
+    miniseries cut into two 90 min parts will almost always have the
+    user's cursor in the wrong half-second after a naive remap, and
+    forcing the operator to scrub manually next time is far less
+    surprising than silently jumping to the middle of part 2. The
+    promote dialog warns admins about this up front.
+
+    Runs out of the event bus, which is fire-and-forget — failures
+    are logged but the promote use case still reports success. A
+    later retry through the regular session keeps watch_progresses
+    consistent if needed.
+    """
+
+    def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def handle(self, event: DomainEvent) -> None:
+        """Handle ``MoviePromotedToSeriesEvent``."""
+        if not isinstance(event, MoviePromotedToSeriesEvent):
+            return
+
+        async with self._uow_factory() as uow:
+            deleted = await uow.progress.delete_all_for_movie(event.movie_id)
+
+        if deleted:
+            _logger.info(
+                "Cleared %d watch_progress row(s) for promoted movie %s " "(now series %s)",
+                deleted,
+                event.movie_id,
+                event.series_id,
+            )
+
+
+__all__ = ["OnMoviePromotedToSeriesHandler"]

--- a/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
@@ -118,5 +118,28 @@ class WatchProgressRepository(ABC):
             Number of rows soft-deleted.
         """
 
+    @abstractmethod
+    async def delete_all_for_movie(self, movie_id: str) -> int:
+        """Soft-delete every progress row that points at a movie id.
+
+        Cross-BC operation driven by ``MoviePromotedToSeriesEvent``:
+        when a movie is converted to a series the old ``mov_xxx``
+        identity disappears, and re-anchoring a half-watched
+        playback position to a re-cut episode would almost always
+        land the user mid-scene. Wiping the progress is the safest
+        option — the operator can scrub manually next time.
+
+        Unlike ``delete()`` this is *not* profile-scoped: every
+        affected profile's row is removed in one call so the cross-BC
+        handler doesn't need to fan out per profile.
+
+        Args:
+            movie_id: External movie id (``mov_xxx`` format).
+
+        Returns:
+            Number of rows soft-deleted (may be 0 if no one had
+            progress on that movie yet).
+        """
+
 
 __all__ = ["WatchProgressRepository"]

--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -167,5 +167,26 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
             await self._session.flush()
         return len(models)
 
+    async def delete_all_for_movie(self, movie_id: str) -> int:
+        """Soft-delete every (cross-profile) progress row on a movie id.
+
+        Driven by ``MoviePromotedToSeriesEvent`` — see the interface
+        docstring for the rationale (movie ids vanish on promotion,
+        and mapping a half-watched position to a re-cut episode is
+        almost guaranteed to be wrong).
+        """
+        stmt = select(WatchProgressModel).where(
+            WatchProgressModel.media_id == movie_id,
+            WatchProgressModel.media_type == "movie",
+            WatchProgressModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        models = result.scalars().all()
+        for model in models:
+            model.soft_delete()
+        if models:
+            await self._session.flush()
+        return len(models)
+
 
 __all__ = ["SQLAlchemyWatchProgressRepository"]

--- a/tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py
@@ -201,3 +201,40 @@ class TestSQLAlchemyWatchlistRepository:
         saved = await repo.add(item)
 
         assert saved.media_type == CollectionMediaType.SERIES
+
+    async def test_rewrite_media_id_should_repoint_rows_across_profiles(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Driven by the promote-to-series flow — watchlist entries
+        on the old movie id move to the new series id without losing
+        per-profile presence."""
+        repo = SQLAlchemyWatchlistRepository(db_session)
+        await repo.add(_create_item(media_id=SAMPLE_MOVIE_ID))
+        await repo.add(_create_item(media_id=SAMPLE_MOVIE_ID, profile_id=_OTHER_PROFILE_ID))
+
+        updated = await repo.rewrite_media_id(
+            from_media_id=SAMPLE_MOVIE_ID,
+            to_media_id="ser_promotedxxxx",
+            to_media_type="series",
+        )
+
+        assert updated == 2
+        for profile in (_PROFILE_ID, _OTHER_PROFILE_ID):
+            stale = await repo.find_by_media_id(SAMPLE_MOVIE_ID, profile)
+            assert stale is None
+            fresh = await repo.find_by_media_id("ser_promotedxxxx", profile)
+            assert fresh is not None
+            assert fresh.media_type == CollectionMediaType.SERIES
+
+    async def test_rewrite_media_id_should_return_zero_when_nothing_matches(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyWatchlistRepository(db_session)
+
+        updated = await repo.rewrite_media_id(
+            from_media_id="mov_unknown00000",
+            to_media_id="ser_promotedxxxx",
+            to_media_type="series",
+        )
+
+        assert updated == 0

--- a/tests/modules/media/unit/application/use_cases/test_promote_movie_to_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_promote_movie_to_series.py
@@ -1,0 +1,271 @@
+"""Tests for PromoteMovieToSeriesUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.building_blocks.application.event_bus import EventBus
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    PromoteMovieToSeriesInput,
+)
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaOutput
+from src.modules.media.application.ports import (
+    EpisodeMetadata,
+    MediaMetadata,
+    MetadataProvider,
+    SeasonMetadata,
+)
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
+from src.modules.media.application.use_cases.promote_movie_to_series import (
+    PromoteMovieToSeriesUseCase,
+)
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.events import MoviePromotedToSeriesEvent
+from src.modules.media.domain.value_objects import MovieId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_movie() -> Movie:
+    return Movie.create(
+        library_id=_LIBRARY_ID,
+        title="Salem's Lot",
+        year=1979,
+        duration=11400,
+        file_path="/movies/salem.mkv",
+        file_size=4_000_000_000,
+        resolution="1080p",
+    )
+
+
+def _series_meta(episodes: int = 2) -> MediaMetadata:
+    """Build a TMDB series metadata stub with ``episodes`` episodes."""
+    return MediaMetadata(
+        title="Salem's Lot",
+        year=1979,
+        tmdb_id=16118,
+        seasons=[
+            SeasonMetadata(
+                season_number=1,
+                episodes=[
+                    EpisodeMetadata(season_number=1, episode_number=i + 1, title=f"Part {i + 1}")
+                    for i in range(episodes)
+                ],
+            )
+        ],
+    )
+
+
+@pytest.mark.unit
+class TestPromoteMovieToSeries:
+    @pytest.mark.asyncio
+    async def test_should_build_series_with_n_episodes_and_move_files_to_first(self) -> None:
+        movie = _make_movie()
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
+        mocks.movies.transfer_file_variants_to_episode = AsyncMock(return_value=1)
+        mocks.series.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_by_id.return_value = _series_meta(episodes=2)
+
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+        enrich.execute.return_value = EnrichMediaOutput(
+            media_id="ser_placeholder",
+            enriched=True,
+            provider="tmdb",
+        )
+
+        bus = MagicMock(spec=EventBus)
+        bus.publish = AsyncMock()
+
+        use_case = PromoteMovieToSeriesUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+            enrich_series_use_case=enrich,
+            event_bus=bus,
+        )
+
+        output = await use_case.execute(
+            PromoteMovieToSeriesInput(movie_id=str(movie.id), tmdb_id=16118),
+        )
+
+        assert output.episodes_created == 2
+        assert output.movie_id == str(movie.id)
+        assert output.series_id.startswith("ser_")
+        assert output.first_episode_id.startswith("epi_")
+
+        # File variants moved (one mock call with the picked episode id).
+        mocks.movies.transfer_file_variants_to_episode.assert_awaited_once()
+        # Source movie soft-deleted.
+        mocks.movies.delete.assert_awaited_once()
+        # Cross-BC event published with the new ids.
+        bus.publish.assert_awaited_once()
+        event = bus.publish.await_args.args[0]
+        assert isinstance(event, MoviePromotedToSeriesEvent)
+        assert event.movie_id == str(movie.id)
+        assert event.series_id == output.series_id
+        assert event.first_episode_id == output.first_episode_id
+        # Re-enrich was triggered with force=True.
+        enrich.execute.assert_awaited_once()
+        enrich_input = enrich.execute.await_args.args[0]
+        assert enrich_input.force is True
+        assert enrich_input.media_id == output.series_id
+
+    @pytest.mark.asyncio
+    async def test_should_create_placeholder_episode_when_tmdb_has_no_episodes(self) -> None:
+        """TMDB sometimes returns a series with empty episode list (rare
+        edge case). The promote must still create an episode so the
+        movie's file has somewhere to land."""
+        movie = _make_movie()
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
+        mocks.movies.transfer_file_variants_to_episode = AsyncMock(return_value=1)
+        mocks.series.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_by_id.return_value = MediaMetadata(
+            title="Salem's Lot",
+            year=1979,
+            tmdb_id=16118,
+            seasons=[],
+        )
+
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+        enrich.execute.return_value = EnrichMediaOutput(media_id="ser", enriched=True)
+
+        bus = MagicMock(spec=EventBus)
+        bus.publish = AsyncMock()
+
+        use_case = PromoteMovieToSeriesUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+            enrich_series_use_case=enrich,
+            event_bus=bus,
+        )
+
+        output = await use_case.execute(
+            PromoteMovieToSeriesInput(movie_id=str(movie.id), tmdb_id=16118),
+        )
+
+        assert output.episodes_created == 1
+
+    @pytest.mark.asyncio
+    async def test_should_swallow_reenrich_failures_so_structure_survives(self) -> None:
+        """Re-enrich is best-effort after the structural conversion
+        commits — a transient TMDB outage must not roll the promotion
+        back, since the catalog change is already persisted and the
+        admin can retry enrich via the existing endpoint."""
+        movie = _make_movie()
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
+        mocks.movies.transfer_file_variants_to_episode = AsyncMock(return_value=1)
+        mocks.series.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_by_id.return_value = _series_meta(episodes=1)
+
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+        enrich.execute.side_effect = RuntimeError("TMDB timeout")
+
+        bus = MagicMock(spec=EventBus)
+        bus.publish = AsyncMock()
+
+        use_case = PromoteMovieToSeriesUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+            enrich_series_use_case=enrich,
+            event_bus=bus,
+        )
+
+        # Should not raise — promote returns even though enrich threw.
+        output = await use_case.execute(
+            PromoteMovieToSeriesInput(movie_id=str(movie.id), tmdb_id=16118),
+        )
+
+        assert output.episodes_created == 1
+        bus.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_movie_not_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_by_id.return_value = _series_meta()
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+        bus = MagicMock(spec=EventBus)
+        bus.publish = AsyncMock()
+
+        use_case = PromoteMovieToSeriesUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+            enrich_series_use_case=enrich,
+            event_bus=bus,
+        )
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                PromoteMovieToSeriesInput(movie_id=str(MovieId.generate()), tmdb_id=16118),
+            )
+
+        bus.publish.assert_not_awaited()
+        enrich.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_tmdb_id_is_unknown(self) -> None:
+        """If TMDB returns nothing for the picked id, abort before
+        touching the catalog — the picker shouldn't surface a stale
+        id but defend anyway."""
+        mocks = make_media_uow_mock()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_by_id.return_value = None
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+        bus = MagicMock(spec=EventBus)
+        bus.publish = AsyncMock()
+
+        use_case = PromoteMovieToSeriesUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+            enrich_series_use_case=enrich,
+            event_bus=bus,
+        )
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                PromoteMovieToSeriesInput(movie_id=str(MovieId.generate()), tmdb_id=9999999),
+            )
+
+        mocks.movies.find_by_id.assert_not_awaited()
+        bus.publish.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_validate_tmdb_id_is_positive(self) -> None:
+        mocks = make_media_uow_mock()
+        provider = AsyncMock(spec=MetadataProvider)
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+        bus = MagicMock(spec=EventBus)
+        bus.publish = AsyncMock()
+
+        use_case = PromoteMovieToSeriesUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+            enrich_series_use_case=enrich,
+            event_bus=bus,
+        )
+
+        with pytest.raises(UseCaseValidationException):
+            await use_case.execute(
+                PromoteMovieToSeriesInput(movie_id=str(MovieId.generate()), tmdb_id=0),
+            )
+
+        provider.get_series_by_id.assert_not_awaited()

--- a/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
+++ b/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
@@ -316,3 +316,46 @@ class TestSQLAlchemyWatchProgressRepositoryDelete:
         result = await repo.list_in_progress(_PROFILE_ID)
 
         assert result == []
+
+
+@pytest.mark.integration
+class TestDeleteAllForMovie:
+    """Tests for ``delete_all_for_movie`` — driven by the cross-BC
+    promote-to-series handler."""
+
+    async def test_should_clear_every_profile_row_for_the_movie(
+        self, db_session: AsyncSession
+    ) -> None:
+        other_profile = ProfileId("prf_otherprofile")
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress())
+        await repo.save(_create_progress(profile_id=other_profile))
+
+        deleted = await repo.delete_all_for_movie(SAMPLE_MOVIE_ID)
+
+        assert deleted == 2
+        assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)) is None
+        assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, other_profile)) is None
+
+    async def test_should_only_delete_movie_progress_not_episode(
+        self, db_session: AsyncSession
+    ) -> None:
+        """``media_type`` filter prevents accidentally wiping episode
+        progress whose id happens to collide (won't happen with prefixed
+        ids, but defensive)."""
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(
+            _create_progress(media_id=SAMPLE_EPISODE_ID, media_type=WatchableMediaType.EPISODE),
+        )
+
+        deleted = await repo.delete_all_for_movie(SAMPLE_EPISODE_ID)
+
+        assert deleted == 0
+        assert (await repo.find_by_media_id(SAMPLE_EPISODE_ID, _PROFILE_ID)) is not None
+
+    async def test_should_return_zero_when_nothing_matches(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+
+        deleted = await repo.delete_all_for_movie(MISSING_MEDIA_ID)
+
+        assert deleted == 0


### PR DESCRIPTION
## Summary

Closes the Salem's Lot (1979) case end-to-end: an admin picking a TV match in the relink picker now triggers the full Movie→Series conversion instead of the 422 placeholder. This is the "Option C" that was deferred during the previous PRs after weighing the cross-BC cost.

- New endpoint **`POST /admin/movies/{id}/promote-to-series`** (admin-only). Body: `{tmdb_id}`. Calls `PromoteMovieToSeriesUseCase` which fetches the TMDB series, builds `Series + Season(1) + N Episodes` (one per TMDB episode), re-FKs every `media_files` row from the source movie onto the first episode, soft-deletes the movie, publishes `MoviePromotedToSeriesEvent`, and triggers a `force=True` series enrichment.

- New cross-BC event handlers subscribed via `_subscribe_event_handlers` in `main.py`:
  - `watch_progress.OnMoviePromotedToSeriesHandler` — soft-deletes every `watch_progresses` row for the old `mov_xxx` id (across profiles). Confirmed during design that mapping a half-watched position to a re-cut episode is unsafe; deleting is the agreed UX (admin warned in the dialog).
  - `collections.OnMoviePromotedToSeriesHandler` — rewrites `watchlist_items` and `custom_list_items` from the old `mov_xxx` id to the new `ser_xxx` id (cross-profile) so lists keep their items.

- New `WatchProgressRepository.delete_all_for_movie` and `WatchlistRepository.rewrite_media_id` / `CustomListRepository.rewrite_item_media_id` — minimal cross-profile mutation surface used only by the handlers.

- `MovieRepository.transfer_file_variants_to_episode` — single-shot `UPDATE media_files` that re-points the FK pair without touching the rows themselves. Avoids the `UNIQUE(file_path)` clash that would happen if we tried to recreate variants on the new episode while the old movie row still references them.

- Relink endpoint tightened: `media_type: Literal["movie"]`. TV picks now must use the new endpoint — the schema layer rejects misuse with a 422.

## Test plan

- [x] `pytest tests/modules/media/unit/application/use_cases/test_promote_movie_to_series.py` — 6 cases (happy path, placeholder episode for missing TMDB episodes, re-enrich failure tolerance, missing movie, unknown TMDB id, invalid tmdb_id).
- [x] `pytest tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py` — added 3 cases for `delete_all_for_movie` (cross-profile, type filter, no-match).
- [x] `pytest tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py` — added 2 cases for `rewrite_media_id`.
- [x] `pytest` full suite — 2369 passing, 5 skipped.
- [x] `ruff check src/ tests/` clean.
- [x] `ruff format --check src/ tests/` clean.
- [x] `create_app()` boots: 90 routes registered, including the new promote endpoint.
- [ ] Manual smoke (after merge): re-add Salem's Lot, pick the TMDB TV miniseries (tv/16118) in the picker, confirm the movie disappears, a new series appears with two episodes (Part I owns the file variants, Part II shows as missing), watchlist/lists migrate cleanly.

## Notes

- **Re-enrich is best-effort**: a transient TMDB outage during the post-promote enrich won't roll back the conversion. The structure is already correct; admin can retry via `POST /api/v1/series/{id}/enrich`. The use case logs the exception with the new series id so the operator knows where to retry.
- **File distribution is conservative (option B1)**: all variants of the source movie become variants of S01E01. Empty episodes (S01E02 onward) start as "missing" — the user reorganises later by dropping the right files in.
- Movie soft-delete keeps `tmdb_id` and `library_id` on the row, so a future "un-promote" feature has the data it needs (not built in this PR).
- The companion frontend PR on `homeflix-web` adds the confirmation dialog and routes TV picks to this endpoint.

## Summary by Sourcery

Add a backend flow to promote a misclassified movie into a series using a new admin endpoint and domain use case, emitting a cross-context event to update related state.

New Features:
- Introduce PromoteMovieToSeriesUseCase to convert a movie into a series based on TMDB series metadata.
- Add admin API endpoint POST /api/v1/admin/movies/{movie_id}/promote-to-series with dedicated request/response DTOs.
- Emit MoviePromotedToSeriesEvent when a movie is promoted to a series to drive cross-bounded-context updates.

Enhancements:
- Restrict the existing movie relink endpoint to movie-only picks to enforce the new promote-to-series flow.
- Add repository method to move media file variants from a movie to an episode without recreating file rows.

Tests:
- Add unit tests for PromoteMovieToSeriesUseCase covering happy path and edge cases like missing TMDB episodes or re-enrich failures.
- Add integration tests for watch progress deletion and watchlist media-id rewrites used by the promotion flow.

Chores:
- Add watchlist, custom-list, and watch-progress repository operations plus event handlers to migrate or clear state when a movie is promoted to a series.
- Wire new event handlers into the application container and event bus subscriptions.