### PR TITLE
feat(media): admin filters + delete-series for the catalog page

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -13,6 +13,7 @@ from src.modules.media.application.use_cases.bulk_enrich_metadata import (
 from src.modules.media.application.use_cases.clear_episode_intro import ClearEpisodeIntroUseCase
 from src.modules.media.application.use_cases.clear_hls_cache import ClearHlsCacheUseCase
 from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
+from src.modules.media.application.use_cases.delete_series import DeleteSeriesUseCase
 from src.modules.media.application.use_cases.enrich_movie_metadata import (
     EnrichMovieMetadataUseCase,
 )
@@ -173,6 +174,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     delete_movie = providers.Factory(
         DeleteMovieUseCase,
+        uow_factory=media_unit_of_work_factory,
+    )
+
+    delete_series = providers.Factory(
+        DeleteSeriesUseCase,
         uow_factory=media_unit_of_work_factory,
     )
 

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -149,6 +149,10 @@ class MovieSummaryOutput:
     """Summary representation of a Movie for list views.
 
     Contains essential fields for displaying movies in a grid/list.
+    The admin Catalog table reads the same shape; the three trailing
+    fields (``library_id``, ``tmdb_id``, ``imdb_id``,
+    ``needs_enrichment_review``) carry operator-facing metadata that
+    user-facing surfaces simply ignore.
 
     Attributes:
         id: External movie ID.
@@ -158,6 +162,17 @@ class MovieSummaryOutput:
         poster_path: Path to poster image (optional).
         resolution: Video resolution.
         genres: List of genre strings.
+        library_id: External library id (``lib_xxx``) the movie lives
+            in. Read by the admin Catalog page to render the
+            "Library" column.
+        tmdb_id: TMDB primary key, or ``None`` when the movie has
+            never been successfully enriched.
+        imdb_id: IMDb id (``tt…``), or ``None`` for rows TMDB lacks
+            it on.
+        needs_enrichment_review: ``True`` when an enrichment attempt
+            couldn't resolve a TMDB match. The admin table renders
+            an inline badge / dim row so operators can spot
+            unresolved items without leaving the page.
     """
 
     id: str
@@ -171,6 +186,10 @@ class MovieSummaryOutput:
     variant_count: int
     available_resolutions: list[str]
     genres: list[str]
+    library_id: str
+    tmdb_id: int | None
+    imdb_id: str | None
+    needs_enrichment_review: bool
 
 
 @dataclass(frozen=True)
@@ -200,6 +219,11 @@ class ListMoviesInput:
     limit: int = DEFAULT_PAGE_SIZE
     include_total: bool = False
     lang: str = "en"
+    # Optional filters used by the admin Catalog page; ``None`` on
+    # the user-facing list means "no extra constraint".
+    library_id: str | None = None
+    has_tmdb_id: bool | None = None
+    needs_enrichment_review: bool | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -137,6 +137,9 @@ class SeriesSummaryOutput:
 
     Contains essential fields for displaying series in a grid/list.
     Does NOT include full episode data to keep response lightweight.
+    The admin Catalog table reads the same shape; the trailing
+    operator-facing fields (``library_id``, ``tmdb_id``, ``imdb_id``)
+    are ignored by user-facing surfaces.
 
     Attributes:
         id: External series ID.
@@ -148,6 +151,11 @@ class SeriesSummaryOutput:
         season_count: Number of seasons.
         total_episodes: Total episode count.
         genres: List of genre strings.
+        library_id: External library id (``lib_xxx``) owning the
+            series. Used by the admin Catalog "Library" column.
+        tmdb_id: TMDB primary key, or ``None`` for un-enriched
+            series.
+        imdb_id: IMDb id (``tt…``), or ``None``.
     """
 
     id: str
@@ -161,6 +169,20 @@ class SeriesSummaryOutput:
     season_count: int
     total_episodes: int
     genres: list[str]
+    library_id: str
+    tmdb_id: int | None
+    imdb_id: str | None
+
+
+@dataclass(frozen=True)
+class DeleteSeriesInput:
+    """Input for ``DeleteSeriesUseCase``.
+
+    Attributes:
+        series_id: External ID of the series (``ser_xxx``).
+    """
+
+    series_id: str
 
 
 @dataclass(frozen=True)
@@ -207,6 +229,10 @@ class ListSeriesInput:
     limit: int = DEFAULT_PAGE_SIZE
     include_total: bool = False
     lang: str = "en"
+    # Optional filters used by the admin Catalog page; ``None`` on
+    # the user-facing list means "no extra constraint".
+    library_id: str | None = None
+    has_tmdb_id: bool | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/use_cases/_movie_summary_helpers.py
+++ b/src/modules/media/application/use_cases/_movie_summary_helpers.py
@@ -26,6 +26,10 @@ def to_movie_summary(movie: Movie, lang: str = "en") -> MovieSummaryOutput:
         variant_count=len(movie.files),
         available_resolutions=[r.value for r in movie.available_resolutions],
         genres=movie.get_genres(lang),
+        library_id=movie.library_id,
+        tmdb_id=movie.tmdb_id.value if movie.tmdb_id else None,
+        imdb_id=movie.imdb_id.value if movie.imdb_id else None,
+        needs_enrichment_review=movie.needs_enrichment_review,
     )
 
 

--- a/src/modules/media/application/use_cases/_series_summary_helpers.py
+++ b/src/modules/media/application/use_cases/_series_summary_helpers.py
@@ -25,6 +25,9 @@ def to_series_summary(series: Series, lang: str = "en") -> SeriesSummaryOutput:
         season_count=series.season_count,
         total_episodes=series.total_episodes,
         genres=series.get_genres(lang),
+        library_id=series.library_id,
+        tmdb_id=series.tmdb_id.value if series.tmdb_id else None,
+        imdb_id=series.imdb_id.value if series.imdb_id else None,
     )
 
 

--- a/src/modules/media/application/use_cases/delete_series.py
+++ b/src/modules/media/application/use_cases/delete_series.py
@@ -1,0 +1,42 @@
+"""DeleteSeriesUseCase - Soft-delete a series by ID."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.series_dtos import DeleteSeriesInput
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.value_objects import SeriesId
+
+
+class DeleteSeriesUseCase:
+    """Soft-delete a series by its external ID.
+
+    Marks the series as deleted in the database. The record (and the
+    cascaded seasons / episodes / media_files children) stays on disk
+    so the soft-delete can be undone later via DB intervention.
+    Mirrors ``DeleteMovieUseCase``.
+
+    Example:
+        >>> use_case = DeleteSeriesUseCase(uow_factory)
+        >>> await use_case.execute(DeleteSeriesInput("ser_abc123"))
+    """
+
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(self, input_dto: DeleteSeriesInput) -> None:
+        """Soft-delete the series.
+
+        Args:
+            input_dto: Contains the ``series_id`` to delete.
+
+        Raises:
+            ResourceNotFoundException: When no series matches the id.
+        """
+        series_id = SeriesId(input_dto.series_id)
+        async with self._uow_factory() as uow:
+            deleted = await uow.series.delete(series_id)
+
+        if not deleted:
+            raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
+
+
+__all__ = ["DeleteSeriesUseCase"]

--- a/src/modules/media/application/use_cases/list_movies.py
+++ b/src/modules/media/application/use_cases/list_movies.py
@@ -80,6 +80,9 @@ class ListMoviesUseCase:
                 limit=input_dto.limit,
                 include_total=input_dto.include_total,
                 allowed_library_ids=allowed,
+                library_id=input_dto.library_id,
+                has_tmdb_id=input_dto.has_tmdb_id,
+                needs_enrichment_review=input_dto.needs_enrichment_review,
             )
 
         return ListMoviesOutput(

--- a/src/modules/media/application/use_cases/list_series.py
+++ b/src/modules/media/application/use_cases/list_series.py
@@ -75,6 +75,8 @@ class ListSeriesUseCase:
                 limit=input_dto.limit,
                 include_total=input_dto.include_total,
                 allowed_library_ids=allowed,
+                library_id=input_dto.library_id,
+                has_tmdb_id=input_dto.has_tmdb_id,
             )
 
         return ListSeriesOutput(

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -97,6 +97,9 @@ class MovieRepository(ABC):
         *,
         include_total: bool = False,
         allowed_library_ids: Sequence[str] | None = None,
+        library_id: str | None = None,
+        has_tmdb_id: bool | None = None,
+        needs_enrichment_review: bool | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies in a single page using cursor-based pagination.
 
@@ -127,6 +130,13 @@ class MovieRepository(ABC):
                 ``COUNT(*)`` are restricted to rows whose
                 ``library_id`` is in the supplied set. ``None``
                 (default) applies no library filter.
+            library_id: Optional admin filter — restrict to a single
+                library (composes with ``allowed_library_ids``).
+            has_tmdb_id: Optional admin filter — ``True`` keeps only
+                enriched rows, ``False`` only un-enriched, ``None``
+                applies no filter.
+            needs_enrichment_review: Optional admin filter — ``True``
+                keeps only rows the enricher flagged for review.
 
         Returns:
             ``PaginatedResult`` containing the page items, the

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -93,6 +93,8 @@ class SeriesRepository(ABC):
         *,
         include_total: bool = False,
         allowed_library_ids: Sequence[str] | None = None,
+        library_id: str | None = None,
+        has_tmdb_id: bool | None = None,
     ) -> PaginatedResult[Series]:
         """List series in a single page using cursor-based pagination.
 
@@ -120,6 +122,11 @@ class SeriesRepository(ABC):
                 ``COUNT(*)`` are restricted to rows whose
                 ``library_id`` is in the supplied set. ``None``
                 (default) applies no library filter.
+            library_id: Optional admin filter — restrict to a single
+                library (composes with ``allowed_library_ids``).
+            has_tmdb_id: Optional admin filter — ``True`` keeps only
+                enriched rows, ``False`` only un-enriched, ``None``
+                applies no filter.
 
         Returns:
             ``PaginatedResult`` containing the page items, the

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -34,6 +34,37 @@ from src.modules.media.infrastructure.persistence.repositories._path_prefix_help
 )
 
 
+def _movie_filter_conditions(
+    *,
+    allowed_library_ids: Sequence[str] | None,
+    library_id: str | None,
+    has_tmdb_id: bool | None,
+    needs_enrichment_review: bool | None,
+) -> list:
+    """Build SQLAlchemy ``WHERE`` clauses for the optional movie filters.
+
+    Pulled out as a helper so ``list_paginated`` and its
+    ``COUNT(*)`` partner stay in lock-step — adding a new filter
+    means one edit here rather than two parallel branches drifting.
+    """
+    conditions: list = []
+    if allowed_library_ids is not None:
+        conditions.append(MovieModel.library_id.in_(allowed_library_ids))
+    if library_id is not None:
+        conditions.append(MovieModel.library_id == library_id)
+    if has_tmdb_id is not None:
+        conditions.append(
+            MovieModel.tmdb_id.is_not(None) if has_tmdb_id else MovieModel.tmdb_id.is_(None),
+        )
+    if needs_enrichment_review is not None:
+        conditions.append(
+            MovieModel.needs_enrichment_review.is_(True)
+            if needs_enrichment_review
+            else MovieModel.needs_enrichment_review.is_(False),
+        )
+    return conditions
+
+
 class SQLAlchemyMovieRepository(MovieRepository):
     """SQLAlchemy implementation of MovieRepository.
 
@@ -172,6 +203,9 @@ class SQLAlchemyMovieRepository(MovieRepository):
         *,
         include_total: bool = False,
         allowed_library_ids: Sequence[str] | None = None,
+        library_id: str | None = None,
+        has_tmdb_id: bool | None = None,
+        needs_enrichment_review: bool | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies in a single cursor-paginated page.
 
@@ -185,17 +219,28 @@ class SQLAlchemyMovieRepository(MovieRepository):
         Soft-deleted rows are filtered out the same way as ``list_all``.
         Fetches ``limit + 1`` rows to detect ``has_more`` cheaply
         without an extra query.
+
+        The admin-facing filters (``library_id``, ``has_tmdb_id``,
+        ``needs_enrichment_review``) compose with the per-profile ACL
+        in ``allowed_library_ids``: when both are present the row must
+        satisfy *both* constraints. Admin pages call without ACL
+        kwargs and pass these filters; the user-facing list does the
+        inverse.
         """
+        conditions = _movie_filter_conditions(
+            allowed_library_ids=allowed_library_ids,
+            library_id=library_id,
+            has_tmdb_id=has_tmdb_id,
+            needs_enrichment_review=needs_enrichment_review,
+        )
+
         decoded = decode_cursor(cursor)
 
         stmt = (
             select(MovieModel)
-            .where(MovieModel.deleted_at.is_(None))
+            .where(MovieModel.deleted_at.is_(None), *conditions)
             .options(selectinload(MovieModel.file_variants))
         )
-
-        if allowed_library_ids is not None:
-            stmt = stmt.where(MovieModel.library_id.in_(allowed_library_ids))
 
         if decoded is not None:
             stmt = stmt.where(MovieModel.id < decoded.id)
@@ -216,10 +261,10 @@ class SQLAlchemyMovieRepository(MovieRepository):
         total_count: int | None = None
         if include_total:
             count_stmt = (
-                select(func.count()).select_from(MovieModel).where(MovieModel.deleted_at.is_(None))
+                select(func.count())
+                .select_from(MovieModel)
+                .where(MovieModel.deleted_at.is_(None), *conditions)
             )
-            if allowed_library_ids is not None:
-                count_stmt = count_stmt.where(MovieModel.library_id.in_(allowed_library_ids))
             total_count = (await self._session.execute(count_stmt)).scalar_one()
 
         return PaginatedResult(

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -47,6 +47,29 @@ from src.modules.media.infrastructure.persistence.repositories._path_prefix_help
 )
 
 
+def _series_filter_conditions(
+    *,
+    allowed_library_ids: Sequence[str] | None,
+    library_id: str | None,
+    has_tmdb_id: bool | None,
+) -> list:
+    """Build SQLAlchemy ``WHERE`` clauses for the optional series filters.
+
+    Mirrors ``_movie_filter_conditions`` so both repositories surface
+    the same admin-facing filter contract.
+    """
+    conditions: list = []
+    if allowed_library_ids is not None:
+        conditions.append(SeriesModel.library_id.in_(allowed_library_ids))
+    if library_id is not None:
+        conditions.append(SeriesModel.library_id == library_id)
+    if has_tmdb_id is not None:
+        conditions.append(
+            SeriesModel.tmdb_id.is_not(None) if has_tmdb_id else SeriesModel.tmdb_id.is_(None),
+        )
+    return conditions
+
+
 class SQLAlchemySeriesRepository(SeriesRepository):
     """SQLAlchemy implementation of SeriesRepository.
 
@@ -200,6 +223,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         *,
         include_total: bool = False,
         allowed_library_ids: Sequence[str] | None = None,
+        library_id: str | None = None,
+        has_tmdb_id: bool | None = None,
     ) -> PaginatedResult[Series]:
         """List series in a single cursor-paginated page.
 
@@ -211,17 +236,24 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         without an extra query. The full season / episode hierarchy is
         loaded via the same options as ``list_all``; if that turns out
         to be a perf issue we'll add a shallow variant later.
+
+        Admin filters (``library_id``, ``has_tmdb_id``) compose with
+        the per-profile ``allowed_library_ids`` ACL — see the matching
+        helper on the movie repository for the contract.
         """
+        conditions = _series_filter_conditions(
+            allowed_library_ids=allowed_library_ids,
+            library_id=library_id,
+            has_tmdb_id=has_tmdb_id,
+        )
+
         decoded = decode_cursor(cursor)
 
         stmt = (
             select(SeriesModel)
-            .where(SeriesModel.deleted_at.is_(None))
+            .where(SeriesModel.deleted_at.is_(None), *conditions)
             .options(*self._series_load_options())
         )
-
-        if allowed_library_ids is not None:
-            stmt = stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
 
         if decoded is not None:
             stmt = stmt.where(SeriesModel.id < decoded.id)
@@ -244,10 +276,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             count_stmt = (
                 select(func.count())
                 .select_from(SeriesModel)
-                .where(SeriesModel.deleted_at.is_(None))
+                .where(SeriesModel.deleted_at.is_(None), *conditions)
             )
-            if allowed_library_ids is not None:
-                count_stmt = count_stmt.where(SeriesModel.library_id.in_(allowed_library_ids))
             total_count = (await self._session.execute(count_stmt)).scalar_one()
 
         return PaginatedResult(

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -56,6 +56,9 @@ async def list_movies(
     limit: int = DEFAULT_PAGE_SIZE,
     include_count: bool = False,
     lang: str = "en",
+    library_id: str | None = None,
+    has_tmdb_id: bool | None = None,
+    needs_review: bool | None = None,
     profile_id: str = Depends(resolve_profile_id),
     use_case: ListMoviesUseCase = Depends(
         Provide[ApplicationContainer.media.list_movies],
@@ -75,6 +78,18 @@ async def list_movies(
             the extra ``COUNT(*)`` query that infinite-scroll
             consumers don't need.
         lang: Language code for localized metadata.
+        library_id: Restrict the page to a single library (e.g.
+            ``lib_abc123``). Composes with the per-profile ACL — the
+            row must satisfy both. Used by the admin Catalog page's
+            library filter.
+        has_tmdb_id: ``true`` keeps only enriched rows (``tmdb_id``
+            set), ``false`` only un-enriched. Omit (``None``) for no
+            filter.
+        needs_review: ``true`` keeps only rows the enricher flagged
+            for admin review. Mirrors the dedicated
+            ``/admin/movies/needs-review`` listing but stays inside
+            the standard paginated list so the admin Catalog page
+            can apply it alongside other filters.
     """
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
@@ -84,6 +99,9 @@ async def list_movies(
             limit=clamped_limit,
             include_total=include_count,
             lang=lang,
+            library_id=library_id,
+            has_tmdb_id=has_tmdb_id,
+            needs_enrichment_review=needs_review,
         )
     )
     extras: dict[str, Any] | None = (

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -21,12 +21,14 @@ from src.modules.media.application.dtos.media_file_dtos import (
     SetPrimaryFileInput,
 )
 from src.modules.media.application.dtos.series_dtos import (
+    DeleteSeriesInput,
     GetSeriesByIdInput,
     ListRecentlyAddedSeriesInput,
     ListSeriesInput,
 )
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
 from src.modules.media.application.use_cases.clear_episode_intro import ClearEpisodeIntroUseCase
+from src.modules.media.application.use_cases.delete_series import DeleteSeriesUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
 from src.modules.media.application.use_cases.get_related_series import (
     GetRelatedSeriesInput,
@@ -61,6 +63,8 @@ async def list_series(
     limit: int = DEFAULT_PAGE_SIZE,
     include_count: bool = False,
     lang: str = "en",
+    library_id: str | None = None,
+    has_tmdb_id: bool | None = None,
     profile_id: str = Depends(resolve_profile_id),
     use_case: ListSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.list_series],
@@ -68,9 +72,9 @@ async def list_series(
 ) -> dict[str, Any]:
     """List one cursor-paginated page of series.
 
-    Same query-param contract as ``GET /api/v1/movies`` — see that
-    endpoint for the full description of ``cursor``, ``limit``,
-    ``include_count``, and the response shape.
+    Mirrors ``GET /api/v1/movies`` for the common params; series
+    don't carry a ``needs_review`` flag yet, so the filter set
+    drops that one.
     """
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
@@ -80,6 +84,8 @@ async def list_series(
             limit=clamped_limit,
             include_total=include_count,
             lang=lang,
+            library_id=library_id,
+            has_tmdb_id=has_tmdb_id,
         )
     )
     extras: dict[str, Any] | None = (
@@ -132,6 +138,26 @@ async def get_series(
         GetSeriesByIdInput(profile_id=profile_id, series_id=series_id, lang=lang)
     )
     return api_single("series", _dataclass_to_dict(result))
+
+
+@router.delete("/{series_id}", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def delete_series(
+    series_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: DeleteSeriesUseCase = Depends(
+        Provide[ApplicationContainer.media.delete_series],
+    ),
+) -> None:
+    """Soft-delete a series by ID.
+
+    Mirrors the movie endpoint: the series row is marked as deleted
+    (``deleted_at`` timestamp) but stays on disk. Children rows
+    (seasons, episodes, ``media_files``) are not touched —
+    ``ON DELETE CASCADE`` only fires on a physical row delete, and
+    soft-delete is the only flavour exposed by the API today.
+    """
+    await use_case.execute(DeleteSeriesInput(series_id=series_id))
 
 
 @router.get("/{series_id}/related")  # type: ignore[misc]

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -561,6 +561,88 @@ class TestSQLAlchemyMovieRepositoryListPaginated:
 
 
 @pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryListPaginatedAdminFilters:
+    """Integration coverage for the admin Catalog filter set on
+    ``list_paginated`` — library_id, has_tmdb_id, needs_enrichment_review."""
+
+    async def test_library_id_should_restrict_to_a_single_library(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/m/a.mkv"))
+        await repo.save(
+            _movie_in_library(library_id=_LIBRARY_ID_OTHER, title="B", file_path="/m/b.mkv")
+        )
+
+        page = await repo.list_paginated(cursor=None, limit=10, library_id=_LIBRARY_ID)
+
+        assert {m.title.value for m in page.items} == {"A"}
+
+    async def test_has_tmdb_id_true_should_keep_only_enriched_rows(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="Plain", file_path="/m/p.mkv"))
+        await repo.save(
+            _create_movie(title="Enriched", file_path="/m/e.mkv").with_updates(tmdb_id=TmdbId(550))
+        )
+
+        page = await repo.list_paginated(cursor=None, limit=10, has_tmdb_id=True)
+
+        assert {m.title.value for m in page.items} == {"Enriched"}
+
+    async def test_has_tmdb_id_false_should_keep_only_unenriched_rows(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="Plain", file_path="/m/p.mkv"))
+        await repo.save(
+            _create_movie(title="Enriched", file_path="/m/e.mkv").with_updates(tmdb_id=TmdbId(550))
+        )
+
+        page = await repo.list_paginated(cursor=None, limit=10, has_tmdb_id=False)
+
+        assert {m.title.value for m in page.items} == {"Plain"}
+
+    async def test_needs_enrichment_review_should_keep_flagged_rows(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="Clean", file_path="/m/c.mkv"))
+        await repo.save(
+            _create_movie(title="Flagged", file_path="/m/f.mkv").with_updates(
+                needs_enrichment_review=True
+            )
+        )
+
+        page = await repo.list_paginated(cursor=None, limit=10, needs_enrichment_review=True)
+
+        assert {m.title.value for m in page.items} == {"Flagged"}
+
+    async def test_filters_should_compose(self, db_session: AsyncSession) -> None:
+        """Multiple filters combine via AND — a row must satisfy every
+        constraint to land in the page."""
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(
+            _create_movie(title="Match", file_path="/m/match.mkv").with_updates(
+                needs_enrichment_review=True
+            )
+        )
+        await repo.save(
+            _create_movie(title="WrongFlag", file_path="/m/wf.mkv").with_updates(tmdb_id=TmdbId(99))
+        )
+
+        page = await repo.list_paginated(
+            cursor=None,
+            limit=10,
+            has_tmdb_id=False,
+            needs_enrichment_review=True,
+        )
+
+        assert {m.title.value for m in page.items} == {"Match"}
+
+
+@pytest.mark.integration
 class TestSQLAlchemyMovieRepositoryListRecentlyAdded:
     """Integration tests for the bounded "top N newest" projection."""
 

--- a/tests/modules/media/unit/application/use_cases/test_delete_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_delete_series.py
@@ -1,0 +1,46 @@
+"""Tests for DeleteSeriesUseCase."""
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.series_dtos import DeleteSeriesInput
+from src.modules.media.application.use_cases.delete_series import DeleteSeriesUseCase
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+
+class TestDeleteSeriesUseCase:
+    """Tests for DeleteSeriesUseCase — mirrors DeleteMovieUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_should_delete_series_when_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.delete.return_value = True
+        use_case = DeleteSeriesUseCase(uow_factory=mocks.factory)
+
+        await use_case.execute(DeleteSeriesInput(series_id="ser_abc123def456"))
+
+        mocks.series.delete.assert_called_once()
+        mocks.factory.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_not_found_when_series_missing(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.delete.return_value = False
+        use_case = DeleteSeriesUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(DeleteSeriesInput(series_id="ser_nonexistent1"))
+
+        assert exc_info.value.resource_type == "Series"
+        assert exc_info.value.resource_id == "ser_nonexistent1"
+
+    @pytest.mark.asyncio
+    async def test_should_call_repository_with_correct_series_id(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.delete.return_value = True
+        use_case = DeleteSeriesUseCase(uow_factory=mocks.factory)
+
+        await use_case.execute(DeleteSeriesInput(series_id="ser_abc123def456"))
+
+        call_arg = mocks.series.delete.call_args[0][0]
+        assert str(call_arg) == "ser_abc123def456"

--- a/tests/modules/media/unit/application/use_cases/test_list_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies.py
@@ -76,6 +76,9 @@ class TestListMoviesUseCase:
             limit=20,
             include_total=False,
             allowed_library_ids=[_LIBRARY_ID],
+            library_id=None,
+            has_tmdb_id=None,
+            needs_enrichment_review=None,
         )
 
     @pytest.mark.asyncio
@@ -114,6 +117,9 @@ class TestListMoviesUseCase:
             limit=15,
             include_total=False,
             allowed_library_ids=[_LIBRARY_ID],
+            library_id=None,
+            has_tmdb_id=None,
+            needs_enrichment_review=None,
         )
 
     @pytest.mark.asyncio
@@ -169,6 +175,9 @@ class TestListMoviesUseCase:
             limit=20,
             include_total=True,
             allowed_library_ids=[_LIBRARY_ID],
+            library_id=None,
+            has_tmdb_id=None,
+            needs_enrichment_review=None,
         )
 
     @pytest.mark.asyncio
@@ -228,3 +237,29 @@ class TestListMoviesUseCase:
         passed = mocks.movies.list_paginated.await_args.kwargs["allowed_library_ids"]
         assert list(passed) == [_LIBRARY_ID]
         assert _LIBRARY_ID_OTHER not in list(passed)
+
+    @pytest.mark.asyncio
+    async def test_should_forward_admin_filters_to_repository(self) -> None:
+        """``library_id`` / ``has_tmdb_id`` / ``needs_enrichment_review``
+        are pass-through filters used by the admin Catalog page. The
+        use case mustn't drop them on the floor."""
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated.return_value = _page([])
+        use_case = ListMoviesUseCase(
+            uow_factory=mocks.factory,
+            profile_library_access=make_profile_library_access(),
+        )
+
+        await use_case.execute(
+            ListMoviesInput(
+                profile_id=_PROFILE_ID,
+                library_id="lib_specific00000",
+                has_tmdb_id=False,
+                needs_enrichment_review=True,
+            ),
+        )
+
+        kwargs = mocks.movies.list_paginated.await_args.kwargs
+        assert kwargs["library_id"] == "lib_specific00000"
+        assert kwargs["has_tmdb_id"] is False
+        assert kwargs["needs_enrichment_review"] is True

--- a/tests/modules/media/unit/application/use_cases/test_list_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series.py
@@ -65,6 +65,8 @@ class TestListSeriesUseCase:
             limit=20,
             include_total=False,
             allowed_library_ids=[_LIBRARY_ID],
+            library_id=None,
+            has_tmdb_id=None,
         )
 
     @pytest.mark.asyncio
@@ -109,6 +111,8 @@ class TestListSeriesUseCase:
             limit=15,
             include_total=False,
             allowed_library_ids=[_LIBRARY_ID],
+            library_id=None,
+            has_tmdb_id=None,
         )
 
     @pytest.mark.asyncio
@@ -194,6 +198,8 @@ class TestListSeriesUseCase:
             limit=20,
             include_total=True,
             allowed_library_ids=[_LIBRARY_ID],
+            library_id=None,
+            has_tmdb_id=None,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Backend prerequisites for **P1** of the admin panel (``/admin/catalog/movies`` and ``/admin/catalog/series``). The frontend PR will land after this merges — the design needs filters and metadata fields that don't exist on the current list endpoints.

### Filters added to ``GET /api/v1/movies`` and ``GET /api/v1/series``

Every filter is **optional** — user-facing pages keep behaving exactly as before. The admin Catalog page passes them via query string.

| Filter | Endpoints | Purpose |
|--------|-----------|---------|
| ``library_id`` | both | Restrict to a single library. **Composes** with the per-profile ACL (no back-door bypass; the row must satisfy both). |
| ``has_tmdb_id`` | both | Separate enriched vs un-enriched rows in the admin "needs attention" view. |
| ``needs_review`` | movies only | Surface rows the enricher flagged for manual relink, without leaving the catalog page. |

### Summary DTO extensions

| DTO | New fields | Why |
|-----|------------|-----|
| ``MovieSummaryOutput`` | ``library_id``, ``tmdb_id``, ``imdb_id``, ``needs_enrichment_review`` | Admin table columns + inline review badge |
| ``SeriesSummaryOutput`` | ``library_id``, ``tmdb_id``, ``imdb_id`` | Admin table columns |

### Series delete

``DELETE /api/v1/series/{id}`` (admin-only, soft-delete) — mirrors the long-standing movie endpoint. Same contract: ``deleted_at`` timestamp set, children (seasons / episodes / ``media_files``) untouched because ``ON DELETE CASCADE`` only fires on physical delete.

## Test plan

- [x] ``pytest tests/`` — 2378 passing, 5 skipped.
- [x] ``ruff check`` clean, ``ruff format --check`` clean.
- [x] New unit tests: ``test_should_forward_admin_filters_to_repository`` on ListMovies; mirror unchanged for series (filter set is smaller).
- [x] New integration tests: ``TestSQLAlchemyMovieRepositoryListPaginatedAdminFilters`` — 5 cases covering each filter individually + composition.
- [x] New unit tests: ``TestDeleteSeriesUseCase`` (3 cases mirroring DeleteMovie).
- [x] ``create_app()`` boots: 91 routes (was 90, +1 for DELETE series).

## Notes

- No migrations.
- No backend ACL bypass — the admin sees what their profile's ``allowed_library_ids`` grants. Discussed in the spec; ACL stays the single source of truth.
- Hard delete still not exposed (would need cross-BC cleanup of orphan refs; out of scope here).

## Summary by Sourcery

Add admin-focused catalog filters to movie and series listings and introduce a soft-delete flow for series aligned with existing movie behavior.

New Features:
- Expose optional admin filters on movie and series list endpoints to restrict by library, TMDB enrichment state, and enrichment review flags.
- Extend movie and series summary DTOs with library and external ID metadata used by the admin catalog views.
- Add an admin-only DELETE series endpoint and corresponding use case to soft-delete series by ID.

Tests:
- Add integration coverage for movie repository admin filters, including composition of multiple constraints.
- Add unit tests ensuring list use cases forward admin filters to repositories for movies and series.
- Add unit tests for the new DeleteSeriesUseCase covering success, not-found, and correct ID propagation.