### PR TITLE
feat(catalog_requests): admin endpoints for the request queue

### DIFF
--- a/src/config/containers/catalog_requests.py
+++ b/src/config/containers/catalog_requests.py
@@ -3,6 +3,7 @@
 from dependency_injector import containers, providers
 
 from src.modules.catalog_requests.application.use_cases import (
+    DismissCatalogRequestUseCase,
     ListCatalogRequestsUseCase,
     RequestCatalogInclusionUseCase,
     SubscribeCatalogNotificationUseCase,
@@ -61,5 +62,10 @@ class CatalogRequestsContainer(containers.DeclarativeContainer):  # type: ignore
 
     list_catalog_requests = providers.Factory(
         ListCatalogRequestsUseCase,
+        uow_factory=catalog_requests_unit_of_work_factory,
+    )
+
+    dismiss_catalog_request = providers.Factory(
+        DismissCatalogRequestUseCase,
         uow_factory=catalog_requests_unit_of_work_factory,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,10 @@ from src.building_blocks.presentation.exception_handlers import register_excepti
 from src.config.containers import ApplicationContainer
 from src.config.logging import get_logger, setup_logging
 from src.config.settings import get_settings
-from src.modules.catalog_requests.presentation.routes import catalog_request_router
+from src.modules.catalog_requests.presentation.routes import (
+    admin_catalog_request_router,
+    catalog_request_router,
+)
 from src.modules.collections.presentation.routes import custom_list_router, watchlist_router
 from src.modules.identity.infrastructure.auth import auth_backend, fastapi_users
 from src.modules.identity.presentation.routes import profile_router, users_router
@@ -62,6 +65,7 @@ WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.collections.presentation.routes.watchlist_routes",
     "src.modules.collections.presentation.routes.custom_list_routes",
     "src.modules.catalog_requests.presentation.routes.catalog_request_routes",
+    "src.modules.catalog_requests.presentation.routes.admin_catalog_request_routes",
     "src.modules.library.presentation.routes.library_routes",
     "src.modules.preferences.presentation.routes.preferences_routes",
     "src.modules.identity.presentation.routes.profile_routes",
@@ -263,6 +267,7 @@ def create_app() -> FastAPI:
     app.include_router(watchlist_router)
     app.include_router(custom_list_router)
     app.include_router(catalog_request_router)
+    app.include_router(admin_catalog_request_router)
     app.include_router(library_router)
     app.include_router(preferences_router)
 

--- a/src/modules/catalog_requests/application/dtos/__init__.py
+++ b/src/modules/catalog_requests/application/dtos/__init__.py
@@ -3,11 +3,13 @@
 from src.modules.catalog_requests.application.dtos.catalog_request_dtos import (
     CatalogRequestOutput,
     CreateCatalogRequestInput,
+    DismissCatalogRequestInput,
     SubscribeCatalogNotificationInput,
 )
 
 __all__ = [
     "CatalogRequestOutput",
     "CreateCatalogRequestInput",
+    "DismissCatalogRequestInput",
     "SubscribeCatalogNotificationInput",
 ]

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -41,6 +41,22 @@ class SubscribeCatalogNotificationInput:
 
 
 @dataclass(frozen=True)
+class DismissCatalogRequestInput:
+    """Input for ``DismissCatalogRequestUseCase``.
+
+    The admin "Dismiss" action removes a pending request from the
+    queue when the household no longer wants to track it (e.g. the
+    title becomes available on a service the household uses, or the
+    initial request was a misclick on an obscure tmdb id).
+
+    Attributes:
+        request_id: External catalog-request id (``req_xxx``).
+    """
+
+    request_id: str
+
+
+@dataclass(frozen=True)
 class CatalogRequestOutput:
     """Output representation of a catalog request.
 
@@ -82,5 +98,6 @@ class CatalogRequestOutput:
 __all__ = [
     "CatalogRequestOutput",
     "CreateCatalogRequestInput",
+    "DismissCatalogRequestInput",
     "SubscribeCatalogNotificationInput",
 ]

--- a/src/modules/catalog_requests/application/use_cases/__init__.py
+++ b/src/modules/catalog_requests/application/use_cases/__init__.py
@@ -1,5 +1,8 @@
 """Catalog Requests use cases."""
 
+from src.modules.catalog_requests.application.use_cases.dismiss_catalog_request import (
+    DismissCatalogRequestUseCase,
+)
 from src.modules.catalog_requests.application.use_cases.list_catalog_requests import (
     ListCatalogRequestsUseCase,
 )
@@ -11,6 +14,7 @@ from src.modules.catalog_requests.application.use_cases.subscribe_catalog_notifi
 )
 
 __all__ = [
+    "DismissCatalogRequestUseCase",
     "ListCatalogRequestsUseCase",
     "RequestCatalogInclusionUseCase",
     "SubscribeCatalogNotificationUseCase",

--- a/src/modules/catalog_requests/application/use_cases/dismiss_catalog_request.py
+++ b/src/modules/catalog_requests/application/use_cases/dismiss_catalog_request.py
@@ -1,0 +1,34 @@
+"""DismissCatalogRequestUseCase — admin removes a pending request."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.catalog_requests.application.dtos import DismissCatalogRequestInput
+from src.modules.catalog_requests.application.unit_of_work import (
+    CatalogRequestsUnitOfWorkFactory,
+)
+from src.modules.catalog_requests.domain.value_objects import CatalogRequestId
+
+
+class DismissCatalogRequestUseCase:
+    """Soft-delete a catalog request by its external id.
+
+    Driven by the admin "Catalog requests" page — the operator
+    drops a pending request the household no longer wants tracked.
+    Soft-delete keeps the row recoverable via direct DB intervention
+    (matches every other aggregate in the codebase) but list queries
+    skip it from this point on.
+    """
+
+    def __init__(self, uow_factory: CatalogRequestsUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(self, input_dto: DismissCatalogRequestInput) -> None:
+        """Soft-delete the request, or raise when nothing matches."""
+        request_id = CatalogRequestId(input_dto.request_id)
+        async with self._uow_factory() as uow:
+            deleted = await uow.catalog_requests.delete(request_id)
+
+        if not deleted:
+            raise ResourceNotFoundException.for_resource("CatalogRequest", input_dto.request_id)
+
+
+__all__ = ["DismissCatalogRequestUseCase"]

--- a/src/modules/catalog_requests/domain/repositories/catalog_request_repository.py
+++ b/src/modules/catalog_requests/domain/repositories/catalog_request_repository.py
@@ -4,7 +4,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from src.modules.catalog_requests.domain.entities import CatalogRequest
-from src.modules.catalog_requests.domain.value_objects import RequestedMediaType
+from src.modules.catalog_requests.domain.value_objects import (
+    CatalogRequestId,
+    RequestedMediaType,
+)
 
 
 class CatalogRequestRepository(ABC):
@@ -94,6 +97,25 @@ class CatalogRequestRepository(ABC):
 
         Returns:
             The persisted aggregate, refreshed from the database.
+        """
+
+    @abstractmethod
+    async def delete(self, request_id: CatalogRequestId) -> bool:
+        """Soft-delete a request by its external id.
+
+        Backs the admin "dismiss" action — the operator drops a
+        pending request that the household no longer wants tracked.
+        Soft-delete matches every other aggregate in the codebase:
+        the row stays with ``deleted_at`` set, list queries skip it,
+        and a future "restore" can flip the timestamp back to
+        ``NULL`` via DB intervention.
+
+        Args:
+            request_id: External id (``req_xxx``).
+
+        Returns:
+            ``True`` when a row was soft-deleted, ``False`` when no
+            matching active row was found.
         """
 
 

--- a/src/modules/catalog_requests/infrastructure/persistence/repositories/catalog_request_repository.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/repositories/catalog_request_repository.py
@@ -7,7 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.catalog_requests.domain.entities import CatalogRequest
 from src.modules.catalog_requests.domain.repositories import CatalogRequestRepository
-from src.modules.catalog_requests.domain.value_objects import RequestedMediaType
+from src.modules.catalog_requests.domain.value_objects import (
+    CatalogRequestId,
+    RequestedMediaType,
+)
 from src.modules.catalog_requests.infrastructure.persistence.mappers import (
     CatalogRequestMapper,
 )
@@ -106,6 +109,20 @@ class SQLAlchemyCatalogRequestRepository(CatalogRequestRepository):
         await self._session.flush()
         await self._session.refresh(model)
         return CatalogRequestMapper.to_entity(model)
+
+    async def delete(self, request_id: CatalogRequestId) -> bool:
+        """Soft-delete a pending request by external id."""
+        stmt = select(CatalogRequestModel).where(
+            CatalogRequestModel.external_id == str(request_id),
+            CatalogRequestModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            return False
+        model.soft_delete()
+        await self._session.flush()
+        return True
 
 
 __all__ = ["SQLAlchemyCatalogRequestRepository"]

--- a/src/modules/catalog_requests/presentation/routes/__init__.py
+++ b/src/modules/catalog_requests/presentation/routes/__init__.py
@@ -1,7 +1,10 @@
 """Catalog Requests REST routes."""
 
+from src.modules.catalog_requests.presentation.routes.admin_catalog_request_routes import (
+    router as admin_catalog_request_router,
+)
 from src.modules.catalog_requests.presentation.routes.catalog_request_routes import (
     router as catalog_request_router,
 )
 
-__all__ = ["catalog_request_router"]
+__all__ = ["admin_catalog_request_router", "catalog_request_router"]

--- a/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
@@ -1,0 +1,57 @@
+"""Admin REST API routes for the catalog-request queue."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.presentation import api_list
+from src.config.containers import ApplicationContainer
+from src.modules.catalog_requests.application.dtos import DismissCatalogRequestInput
+from src.modules.catalog_requests.application.use_cases import (
+    DismissCatalogRequestUseCase,
+    ListCatalogRequestsUseCase,
+)
+from src.modules.catalog_requests.application.use_cases.list_catalog_requests import (
+    ListCatalogRequestsInput,
+)
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+
+router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Catalog Requests"])
+
+
+@router.get("/catalog-requests")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_admin_catalog_requests(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: ListCatalogRequestsUseCase = Depends(
+        Provide[ApplicationContainer.catalog_requests.list_catalog_requests],
+    ),
+) -> dict[str, Any]:
+    """List every pending catalog request across the household.
+
+    Same shape as the user-facing ``GET /api/v1/catalog-requests``
+    but admin-only; the admin endpoint exists so the panel page can
+    sit behind ``RequireAdmin`` even though the user-facing endpoint
+    is intentionally available to any authenticated profile.
+    """
+    items = await use_case.execute(ListCatalogRequestsInput())
+    return api_list([asdict(item) for item in items])
+
+
+@router.delete("/catalog-requests/{request_id}", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def dismiss_catalog_request(
+    request_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: DismissCatalogRequestUseCase = Depends(
+        Provide[ApplicationContainer.catalog_requests.dismiss_catalog_request],
+    ),
+) -> None:
+    """Soft-delete a catalog request the household no longer wants tracked."""
+    await use_case.execute(DismissCatalogRequestInput(request_id=request_id))
+
+
+__all__ = ["router"]

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_dismiss_catalog_request.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_dismiss_catalog_request.py
@@ -1,0 +1,44 @@
+"""Tests for DismissCatalogRequestUseCase."""
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.catalog_requests.application.dtos import DismissCatalogRequestInput
+from src.modules.catalog_requests.application.use_cases import (
+    DismissCatalogRequestUseCase,
+)
+from src.modules.catalog_requests.domain.value_objects import CatalogRequestId
+from tests.modules.catalog_requests.unit.conftest import (
+    make_catalog_requests_uow_mock,
+)
+
+
+class TestDismissCatalogRequestUseCase:
+    """Tests for the admin dismiss flow — soft-delete by external id."""
+
+    @pytest.mark.asyncio
+    async def test_should_soft_delete_when_request_exists(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.delete.return_value = True
+        use_case = DismissCatalogRequestUseCase(uow_factory=mocks.factory)
+
+        await use_case.execute(DismissCatalogRequestInput(request_id="req_abc123def456"))
+
+        mocks.catalog_requests.delete.assert_awaited_once()
+        passed = mocks.catalog_requests.delete.await_args.args[0]
+        assert isinstance(passed, CatalogRequestId)
+        assert str(passed) == "req_abc123def456"
+
+    @pytest.mark.asyncio
+    async def test_should_raise_not_found_when_request_missing(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.delete.return_value = False
+        use_case = DismissCatalogRequestUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                DismissCatalogRequestInput(request_id="req_missing00000"),
+            )
+
+        assert exc_info.value.resource_type == "CatalogRequest"
+        assert exc_info.value.resource_id == "req_missing00000"


### PR DESCRIPTION
## Summary

Backend half of **P5** of the admin panel rollout. Two new admin-only endpoints under ``/api/v1/admin/catalog-requests`` so the operator can survey + dismiss pending TMDB requests from the panel UI instead of curl.

### Endpoints

| Method | Path | Purpose |
|--------|------|---------|
| `GET` | `/api/v1/admin/catalog-requests` | List every pending request across the household. Admin-only via `current_admin_user`. Same DTO shape as the user-facing endpoint. |
| `DELETE` | `/api/v1/admin/catalog-requests/{request_id}` | Soft-delete a request the household no longer wants tracked. |

### What's new

- `CatalogRequestRepository.delete()` abstract + SQL impl — single soft-delete method mirroring the shape every other aggregate already uses (`deleted_at` flipped, row recoverable via DB intervention).
- `DismissCatalogRequestUseCase` — thin use case wrapping the new repo method, raises `ResourceNotFoundException` when nothing matches.
- New admin routes file `presentation/routes/admin_catalog_request_routes.py` under prefix `/api/v1/admin` with the standard ``current_admin_user`` dependency. Wired in `main.py` plus the DI wiring config.
- Container provider for ``dismiss_catalog_request`` alongside the existing ``list_catalog_requests``.

### What's *not* new

The existing ``ListCatalogRequestsUseCase`` returns the right shape for the admin view too — the admin GET endpoint reuses it directly. No parallel "admin list" use case needed.

## Test plan

- [x] `pytest tests/modules/catalog_requests/` — 11 passing, including the 2 new tests on `DismissCatalogRequestUseCase` (success + not-found).
- [x] `pytest` full suite — 2380 passing, 5 skipped.
- [x] `ruff check src/ tests/` clean.
- [x] `ruff format --check src/ tests/` clean.
- [x] `create_app()` boots: 93 routes registered (was 91, +2 for the admin GET + DELETE).

## Notes

- **Single-row-per-(tmdb_id, media_type)** is the existing model. The original design spec's "subscribers count" hypothesis is dropped on this PR — the entity has no per-user subscription tracking, ``notify_on_arrival`` is a single boolean on the row.
- **No migrations.** ``deleted_at`` was already on the table (soft-delete base columns).
- Frontend PR consumes these endpoints next.

## Summary by Sourcery

Add admin API support to list and dismiss catalog requests via soft deletion.

New Features:
- Expose admin-only GET endpoint to list all pending catalog requests across the household.
- Expose admin-only DELETE endpoint to dismiss (soft-delete) an individual catalog request by external id.
- Introduce DismissCatalogRequestUseCase and input DTO to drive the admin dismiss flow.

Enhancements:
- Extend the catalog request repository with a soft-delete operation and wire it through the SQLAlchemy implementation and DI container.
- Export the new admin catalog request router and register it in the FastAPI app so routes are available under the admin prefix.

Tests:
- Add unit tests for DismissCatalogRequestUseCase covering successful deletion and not-found behavior.