### PR TITLE
feat(media): admin HLS cache stats + global clear

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -12,6 +12,9 @@ from src.modules.media.application.use_cases.bulk_enrich_metadata import (
 )
 from src.modules.media.application.use_cases.clear_episode_intro import ClearEpisodeIntroUseCase
 from src.modules.media.application.use_cases.clear_hls_cache import ClearHlsCacheUseCase
+from src.modules.media.application.use_cases.clear_hls_cache_global import (
+    ClearHlsCacheGlobalUseCase,
+)
 from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
 from src.modules.media.application.use_cases.delete_series import DeleteSeriesUseCase
 from src.modules.media.application.use_cases.enrich_movie_metadata import (
@@ -29,6 +32,9 @@ from src.modules.media.application.use_cases.get_collection_by_tmdb_id import (
 from src.modules.media.application.use_cases.get_featured_media import GetFeaturedMediaUseCase
 from src.modules.media.application.use_cases.get_file_tracks import GetFileTracksUseCase
 from src.modules.media.application.use_cases.get_file_variants import GetFileVariantsUseCase
+from src.modules.media.application.use_cases.get_hls_cache_stats import (
+    GetHlsCacheStatsUseCase,
+)
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
     GetMovieTmdbSuggestionsUseCase,
@@ -345,6 +351,16 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     clear_hls_cache = providers.Factory(
         ClearHlsCacheUseCase,
+        hls=hls_service,
+    )
+
+    clear_hls_cache_global = providers.Factory(
+        ClearHlsCacheGlobalUseCase,
+        hls=hls_service,
+    )
+
+    get_hls_cache_stats = providers.Factory(
+        GetHlsCacheStatsUseCase,
         hls=hls_service,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ from src.modules.library.presentation.routes.library_routes import (
 )
 from src.modules.media.presentation.routes import (
     admin_relink_router,
+    admin_system_router,
     catalog_router,
     collection_router,
     enrichment_router,
@@ -51,6 +52,7 @@ from src.modules.watch_progress.presentation.routes import progress_router
 #: list (drift between the two would mean tests miss DI-resolved deps).
 WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.media.presentation.routes.admin_relink_routes",
+    "src.modules.media.presentation.routes.admin_system_routes",
     "src.modules.media.presentation.routes.catalog_routes",
     "src.modules.media.presentation.routes.collection_routes",
     "src.modules.media.presentation.routes.search_routes",
@@ -253,6 +255,7 @@ def create_app() -> FastAPI:
     # Register routes
     register_health_routes(app)
     app.include_router(admin_relink_router)
+    app.include_router(admin_system_router)
     app.include_router(catalog_router)
     app.include_router(collection_router)
     app.include_router(search_router)

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -10,7 +10,10 @@ from src.modules.media.application.ports.file_scanner_port import (
     ScannedFile,
 )
 from src.modules.media.application.ports.file_streamer_port import FileStreamerPort
-from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.ports.hls_playlist_port import (
+    HlsCacheStats,
+    HlsPlaylistPort,
+)
 from src.modules.media.application.ports.intro_detector_port import (
     DetectedIntro,
     EpisodeFingerprint,
@@ -56,6 +59,7 @@ __all__ = [
     "EpisodeMetadata",
     "FileStreamerPort",
     "FileSystemScanner",
+    "HlsCacheStats",
     "HlsPlaylistPort",
     "IntroDetectorPort",
     "LocalizedFields",

--- a/src/modules/media/application/ports/hls_playlist_port.py
+++ b/src/modules/media/application/ports/hls_playlist_port.py
@@ -8,9 +8,35 @@ the application layer.
 """
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 from src.modules.media.application.ports.media_probe_port import ProbeResult
+
+
+@dataclass(frozen=True)
+class HlsCacheStats:
+    """Snapshot of HLS cache occupancy + configured limit.
+
+    Used by the admin System page so the operator can eyeball how
+    much disk the cache is sitting on relative to its ceiling, and
+    when it was last cleared.
+
+    Attributes:
+        size_bytes: Bytes currently used on disk under the cache
+            root (walk + sum, no per-bucket breakdown).
+        max_bytes: Configured ceiling (from ``Settings``). The
+            evictor enforces this; the admin page renders the
+            ratio.
+        last_cleared_at: Wallclock time of the last "clear all"
+            invocation, or ``None`` when the cache hasn't been
+            cleared globally since the marker started being kept.
+    """
+
+    size_bytes: int
+    max_bytes: int
+    last_cleared_at: datetime | None
 
 
 class HlsPlaylistPort(ABC):
@@ -53,9 +79,19 @@ class HlsPlaylistPort(ABC):
         ...
 
     @abstractmethod
-    def clear_cache(self, file_path: str) -> None:
-        """Discard the cache entry for ``file_path``."""
+    def clear_cache(self, file_path: str | None) -> None:
+        """Discard cache entries.
+
+        A concrete ``file_path`` drops only that source file's buckets;
+        passing ``None`` wipes the entire cache root (used by the
+        admin "clean slate" affordance).
+        """
+        ...
+
+    @abstractmethod
+    def get_cache_stats(self) -> HlsCacheStats:
+        """Return cache occupancy + configured limit + last clear time."""
         ...
 
 
-__all__ = ["HlsPlaylistPort"]
+__all__ = ["HlsCacheStats", "HlsPlaylistPort"]

--- a/src/modules/media/application/use_cases/clear_hls_cache_global.py
+++ b/src/modules/media/application/use_cases/clear_hls_cache_global.py
@@ -1,0 +1,27 @@
+"""ClearHlsCacheGlobalUseCase — wipe every cached HLS bucket."""
+
+from src.modules.media.application.ports import HlsPlaylistPort
+
+
+class ClearHlsCacheGlobalUseCase:
+    """Discard the entire HLS cache.
+
+    Distinct from :class:`ClearHlsCacheUseCase` which targets one
+    source file: this is the admin "clean slate" affordance triggered
+    from the System page, e.g. after the operator changes a transcode
+    setting and wants every subsequent play to re-encode from scratch.
+
+    The underlying port call also stamps the cache's last-cleared
+    marker so :class:`GetHlsCacheStatsUseCase` can show *when* the
+    cache was last wiped on the admin page.
+    """
+
+    def __init__(self, hls: HlsPlaylistPort) -> None:
+        self._hls = hls
+
+    def execute(self) -> None:
+        """Clear every cached HLS file."""
+        self._hls.clear_cache(None)
+
+
+__all__ = ["ClearHlsCacheGlobalUseCase"]

--- a/src/modules/media/application/use_cases/get_hls_cache_stats.py
+++ b/src/modules/media/application/use_cases/get_hls_cache_stats.py
@@ -1,0 +1,24 @@
+"""GetHlsCacheStatsUseCase — admin survey of HLS cache occupancy."""
+
+from src.modules.media.application.ports import HlsCacheStats, HlsPlaylistPort
+
+
+class GetHlsCacheStatsUseCase:
+    """Return the current HLS cache size + max + last-cleared.
+
+    Used by the admin System page to render the occupancy bar and
+    decide whether to surface a "running close to the limit" hint.
+    Cheap — the underlying ``HlsService.get_cache_stats`` walks the
+    cache root and sums file sizes; same shape ``evict_lru`` already
+    runs per write.
+    """
+
+    def __init__(self, hls: HlsPlaylistPort) -> None:
+        self._hls = hls
+
+    def execute(self) -> HlsCacheStats:
+        """Return the cache snapshot."""
+        return self._hls.get_cache_stats()
+
+
+__all__ = ["GetHlsCacheStatsUseCase"]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -38,10 +38,14 @@ import shutil
 import subprocess
 import threading
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.ports.hls_playlist_port import (
+    HlsCacheStats,
+    HlsPlaylistPort,
+)
 from src.modules.media.application.ports.media_probe_port import ProbeResult
 from src.modules.media.infrastructure.streaming._subprocess import (
     SUBPROCESS_TEXT_KWARGS,
@@ -445,6 +449,58 @@ class HlsService(HlsPlaylistPort):
                     self._kill_processes(path_hash)
             shutil.rmtree(self._cache_dir, ignore_errors=True)
             self._cache_dir.mkdir(parents=True, exist_ok=True)
+            self._touch_last_cleared_marker()
+
+    def get_cache_stats(self) -> HlsCacheStats:
+        """Return total bytes on disk + the configured ceiling + last clear.
+
+        The walk visits every file under the cache root and sums
+        ``st_size``. Cheap enough for an admin survey — the same
+        approach already runs inside ``evict_lru`` whenever the
+        cache fills up — but not something to hammer; the admin
+        page polls on demand only.
+        """
+        total = 0
+        if self._cache_dir.exists():
+            for entry in self._cache_dir.rglob("*"):
+                if entry.is_file():
+                    try:
+                        total += entry.stat().st_size
+                    except OSError:
+                        # File raced with eviction / clear; skip.
+                        continue
+        return HlsCacheStats(
+            size_bytes=total,
+            max_bytes=self._max_cache_bytes,
+            last_cleared_at=self._read_last_cleared_marker(),
+        )
+
+    # -- Last-cleared marker --------------------------------------------------
+    #
+    # A small zero-byte file at ``<cache_dir>/.last_cleared`` whose
+    # mtime captures when ``clear_cache`` was last called with
+    # ``file_path=None``. Cheaper than wiring a new table and
+    # survives restarts (in-memory state would not).
+
+    def _last_cleared_marker_path(self) -> Path:
+        return self._cache_dir / ".last_cleared"
+
+    def _touch_last_cleared_marker(self) -> None:
+        marker = self._last_cleared_marker_path()
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.touch(exist_ok=True)
+        except OSError:
+            # Don't let a marker write error mask a successful clear.
+            pass
+
+    def _read_last_cleared_marker(self) -> datetime | None:
+        marker = self._last_cleared_marker_path()
+        try:
+            ts = marker.stat().st_mtime
+        except OSError:
+            return None
+        return datetime.fromtimestamp(ts, tz=UTC)
 
     # -- Private: process management -------------------------------------------
 

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -3,6 +3,9 @@
 from src.modules.media.presentation.routes.admin_relink_routes import (
     router as admin_relink_router,
 )
+from src.modules.media.presentation.routes.admin_system_routes import (
+    router as admin_system_router,
+)
 from src.modules.media.presentation.routes.catalog_routes import router as catalog_router
 from src.modules.media.presentation.routes.collection_routes import router as collection_router
 from src.modules.media.presentation.routes.enrichment_routes import router as enrichment_router
@@ -16,6 +19,7 @@ from src.modules.media.presentation.routes.stream_routes import router as stream
 
 __all__ = [
     "admin_relink_router",
+    "admin_system_router",
     "catalog_router",
     "collection_router",
     "enrichment_router",

--- a/src/modules/media/presentation/routes/admin_system_routes.py
+++ b/src/modules/media/presentation/routes/admin_system_routes.py
@@ -1,0 +1,67 @@
+"""Admin REST API routes for the System area (HLS cache, health)."""
+
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.presentation import api_single
+from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.media.application.use_cases.clear_hls_cache_global import (
+    ClearHlsCacheGlobalUseCase,
+)
+from src.modules.media.application.use_cases.get_hls_cache_stats import (
+    GetHlsCacheStatsUseCase,
+)
+
+router = APIRouter(prefix="/api/v1/admin", tags=["Admin — System"])
+
+
+@router.get("/hls-cache")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_hls_cache_stats(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: GetHlsCacheStatsUseCase = Depends(
+        Provide[ApplicationContainer.media.get_hls_cache_stats],
+    ),
+) -> dict[str, Any]:
+    """Return current HLS cache size, configured limit and last-cleared.
+
+    Drives the admin System page's occupancy card. Walks the cache
+    root server-side — fine for an on-demand call, not something
+    the operator polls in a tight loop.
+    """
+    stats = use_case.execute()
+    return api_single(
+        "hls_cache_stats",
+        {
+            "size_bytes": stats.size_bytes,
+            "max_bytes": stats.max_bytes,
+            "last_cleared_at": (
+                stats.last_cleared_at.isoformat() if stats.last_cleared_at else None
+            ),
+        },
+    )
+
+
+@router.delete("/hls-cache", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def clear_hls_cache_global(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: ClearHlsCacheGlobalUseCase = Depends(
+        Provide[ApplicationContainer.media.clear_hls_cache_global],
+    ),
+) -> None:
+    """Wipe every cached HLS bucket.
+
+    Distinct from the per-movie clear under ``/stream/...`` — the
+    admin button hits this global endpoint when the operator wants
+    a clean slate (e.g. after changing a transcode setting and
+    wanting freshly-generated segments going forward).
+    """
+    use_case.execute()
+
+
+__all__ = ["router"]

--- a/tests/modules/media/unit/application/use_cases/test_clear_hls_cache_global.py
+++ b/tests/modules/media/unit/application/use_cases/test_clear_hls_cache_global.py
@@ -1,0 +1,21 @@
+"""Tests for ClearHlsCacheGlobalUseCase."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.use_cases.clear_hls_cache_global import (
+    ClearHlsCacheGlobalUseCase,
+)
+
+
+@pytest.mark.unit
+class TestClearHlsCacheGlobalUseCase:
+    def test_should_delegate_global_clear_to_port(self) -> None:
+        hls = MagicMock(spec=HlsPlaylistPort)
+        use_case = ClearHlsCacheGlobalUseCase(hls=hls)
+
+        use_case.execute()
+
+        hls.clear_cache.assert_called_once_with(None)

--- a/tests/modules/media/unit/application/use_cases/test_get_hls_cache_stats.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_hls_cache_stats.py
@@ -1,0 +1,43 @@
+"""Tests for GetHlsCacheStatsUseCase."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.modules.media.application.ports.hls_playlist_port import (
+    HlsCacheStats,
+    HlsPlaylistPort,
+)
+from src.modules.media.application.use_cases.get_hls_cache_stats import (
+    GetHlsCacheStatsUseCase,
+)
+
+
+@pytest.mark.unit
+class TestGetHlsCacheStatsUseCase:
+    def test_should_return_stats_from_port(self) -> None:
+        hls = MagicMock(spec=HlsPlaylistPort)
+        snapshot = HlsCacheStats(
+            size_bytes=1234,
+            max_bytes=5000,
+            last_cleared_at=datetime(2026, 5, 17, 10, 0, tzinfo=UTC),
+        )
+        hls.get_cache_stats.return_value = snapshot
+
+        result = GetHlsCacheStatsUseCase(hls=hls).execute()
+
+        assert result is snapshot
+        hls.get_cache_stats.assert_called_once_with()
+
+    def test_should_pass_through_none_last_cleared(self) -> None:
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.get_cache_stats.return_value = HlsCacheStats(
+            size_bytes=0,
+            max_bytes=10,
+            last_cleared_at=None,
+        )
+
+        result = GetHlsCacheStatsUseCase(hls=hls).execute()
+
+        assert result.last_cleared_at is None

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -626,12 +626,65 @@ class TestHlsServiceClearCache:
         service.clear_cache()
 
         assert tmp_path.exists()  # Recreated
-        assert list(tmp_path.iterdir()) == []
+        # The cache dir holds only the ``.last_cleared`` marker after a
+        # global clear — every per-source bucket is gone.
+        remaining = [p.name for p in tmp_path.iterdir() if p.name != ".last_cleared"]
+        assert remaining == []
 
     def test_should_not_fail_when_cache_missing(self, tmp_path: Path) -> None:
         service = HlsService(cache_dir=str(tmp_path))
         # Should not raise
         service.clear_cache("/nonexistent.mkv")
+
+    def test_should_stamp_last_cleared_marker_on_global_clear(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+
+        service.clear_cache(None)
+
+        assert (tmp_path / ".last_cleared").exists()
+
+    def test_should_not_stamp_marker_on_per_file_clear(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path))
+
+        service.clear_cache("/movies/test.mkv")
+
+        assert not (tmp_path / ".last_cleared").exists()
+
+
+@pytest.mark.unit
+class TestHlsServiceGetCacheStats:
+    """Tests for ``HlsService.get_cache_stats``."""
+
+    def test_should_report_zero_bytes_when_cache_empty(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"), max_cache_size_mb=100)
+
+        stats = service.get_cache_stats()
+
+        assert stats.size_bytes == 0
+        assert stats.max_bytes == 100 * 1024 * 1024
+        assert stats.last_cleared_at is None
+
+    def test_should_sum_file_sizes_across_nested_buckets(self, tmp_path: Path) -> None:
+        cache = tmp_path / "hls"
+        service = HlsService(cache_dir=str(cache), max_cache_size_mb=50)
+        (cache / "h1").mkdir(parents=True)
+        (cache / "h1" / "master.m3u8").write_bytes(b"x" * 10)
+        (cache / "h2" / "nested").mkdir(parents=True)
+        (cache / "h2" / "nested" / "seg.ts").write_bytes(b"y" * 25)
+
+        stats = service.get_cache_stats()
+
+        assert stats.size_bytes == 35
+        assert stats.max_bytes == 50 * 1024 * 1024
+
+    def test_should_expose_last_cleared_after_global_clear(self, tmp_path: Path) -> None:
+        service = HlsService(cache_dir=str(tmp_path / "hls"))
+
+        service.clear_cache(None)
+        stats = service.get_cache_stats()
+
+        assert stats.last_cleared_at is not None
+        assert stats.last_cleared_at.tzinfo is not None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- New ``GET /api/v1/admin/hls-cache`` returns current bytes-on-disk, the configured ceiling (``hls_cache_max_size_mb``) and the last-global-clear time so the admin System page can render the occupancy bar.
- New ``DELETE /api/v1/admin/hls-cache`` wipes every cached bucket via a dedicated ``ClearHlsCacheGlobalUseCase`` (kept separate from the per-file ``ClearHlsCacheUseCase`` so a missing ``file_path`` can't accidentally trigger a full wipe).
- ``HlsService.clear_cache(None)`` stamps a zero-byte ``.last_cleared`` marker inside the cache root — survives restarts, no new schema; ``get_cache_stats`` reads its mtime.

## Test plan

- [x] ``poetry run pytest`` — 2388 passed
- [x] ``poetry run ruff check src tests`` + ``poetry run ruff format --check src tests`` — clean
- [x] Boot sanity (``create_app()``) — 95 routes including the two new admin endpoints
- [ ] Manual: hit ``GET /api/v1/admin/hls-cache`` as an admin once frontend wires up; ``DELETE`` flushes the cache and last-cleared timestamp updates

## Summary by Sourcery

Expose admin-level HLS cache observability and global clearing capabilities.

New Features:
- Add admin REST endpoints to fetch HLS cache stats and to trigger a global cache clear.
- Introduce an HlsCacheStats snapshot type and a GetHlsCacheStatsUseCase to surface cache occupancy and last-cleared time to the admin UI.
- Add a ClearHlsCacheGlobalUseCase wired through DI to perform an admin-initiated full HLS cache wipe.

Enhancements:
- Extend HlsService and HlsPlaylistPort with a get_cache_stats operation and support for global clears via a None file_path.
- Persist and expose the last global HLS cache clear time via a filesystem marker so it survives restarts.
- Wire the new admin System routes and media container providers into the FastAPI application startup.

Tests:
- Add unit tests for HlsService cache stats and last-cleared marker behavior.
- Add unit tests for the new ClearHlsCacheGlobalUseCase and GetHlsCacheStatsUseCase.