### PR TITLE
feat(media): async scan + bulk-enrich runs with admin history

### DIFF
--- a/migrations/versions/2026_05_18_add_scan_runs.py
+++ b/migrations/versions/2026_05_18_add_scan_runs.py
@@ -1,0 +1,91 @@
+"""Create scan_runs table.
+
+Backs the admin scan + bulk-enrich history page. A single table
+handles both kinds (discriminated by ``kind``) and both trigger
+sources (admin-initiated ``manual`` vs scheduler ``scheduled``).
+Per-kind counters live in the ``summary`` JSON column to avoid a
+wide table where half the columns are null for whichever kind
+didn't run.
+
+Revision ID: c8d9e0f1a2b3
+Revises: b7c8d9e0f1a2
+Create Date: 2026-05-18 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "c8d9e0f1a2b3"
+down_revision: str | Sequence[str] | None = "b7c8d9e0f1a2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``scan_runs`` table."""
+    op.create_table(
+        "scan_runs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("external_id", sa.String(length=50), nullable=False),
+        sa.Column("kind", sa.String(length=20), nullable=False),
+        sa.Column("trigger", sa.String(length=20), nullable=False),
+        sa.Column("library_id", sa.String(length=50), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("summary", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("errors", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_scan_runs_external_id",
+        "scan_runs",
+        ["external_id"],
+        unique=True,
+    )
+    op.create_index("ix_scan_runs_kind", "scan_runs", ["kind"], unique=False)
+    op.create_index("ix_scan_runs_trigger", "scan_runs", ["trigger"], unique=False)
+    op.create_index(
+        "ix_scan_runs_library_id",
+        "scan_runs",
+        ["library_id"],
+        unique=False,
+    )
+    op.create_index("ix_scan_runs_status", "scan_runs", ["status"], unique=False)
+    op.create_index(
+        "ix_scan_runs_deleted_at",
+        "scan_runs",
+        ["deleted_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``scan_runs`` table."""
+    op.drop_index("ix_scan_runs_deleted_at", table_name="scan_runs")
+    op.drop_index("ix_scan_runs_status", table_name="scan_runs")
+    op.drop_index("ix_scan_runs_library_id", table_name="scan_runs")
+    op.drop_index("ix_scan_runs_trigger", table_name="scan_runs")
+    op.drop_index("ix_scan_runs_kind", table_name="scan_runs")
+    op.drop_index("ix_scan_runs_external_id", table_name="scan_runs")
+    op.drop_table("scan_runs")

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -25,6 +25,9 @@ from src.infrastructure.scheduling import (
 from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyIdentityUnitOfWorkFactory,
 )
+from src.modules.library.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyLibraryUnitOfWorkFactory,
+)
 from src.modules.media.infrastructure.acl import (
     ProfileLibraryAccessAdapter,
     ProgressLookupAdapter,
@@ -100,6 +103,16 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         identity_uow_factory=_identity_uow_factory_for_profile_library_access,
     )
 
+    # Library UoW factory built at the composition root so the
+    # Media container can read libraries (for the trigger-scan use
+    # case) without the parent having to forward-reference the
+    # Library container — which would create a parse-order cycle
+    # (Library already depends on Media via the catalog repo).
+    _library_uow_factory_for_media = providers.Singleton(
+        SqlAlchemyLibraryUnitOfWorkFactory,
+        session_factory=infrastructure.session_factory,
+    )
+
     # Catalog Requests is built before Media so its ACL adapter can be
     # plumbed into the Media container as the ``CatalogRequestLookupPort``
     # implementation. Catalog Requests itself takes no Media dependency,
@@ -116,6 +129,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         progress_lookup=_progress_lookup_adapter,
         profile_library_access=_profile_library_access_adapter,
         catalog_request_lookup=catalog_requests.catalog_request_lookup,
+        library_uow_factory=_library_uow_factory_for_media,
         tmdb_api_key=config.provided.tmdb_api_key,
         hls_cache_directory=config.provided.hls_cache_directory,
         hls_cache_max_size_mb=config.provided.hls_cache_max_size_mb,
@@ -171,12 +185,8 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     library_scan_scheduler = providers.Singleton(
         LibraryScanScheduler,
         library_uow_factory=library.library_unit_of_work_factory,
-        media_uow_factory=media.media_unit_of_work_factory,
-        file_scanner=infrastructure.file_scanner,
-        variant_detector=infrastructure.variant_detector,
-        event_bus=infrastructure.event_bus,
+        scan_run_service=media.scan_run_service,
         reconcile_interval_minutes=config.provided.scheduler_reconcile_interval_minutes,
-        probe_service=media.media_probe_service,
     )
 
     thumbnail_backfill_job = providers.Singleton(

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -6,6 +6,7 @@ Provides repositories and use cases for the Media module.
 from dependency_injector import containers, providers
 
 from src.modules.media.application.event_handlers import OnMediaCreatedHandler
+from src.modules.media.application.services.scan_run_service import ScanRunService
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
 from src.modules.media.application.use_cases.bulk_enrich_metadata import (
     BulkEnrichMetadataUseCase,
@@ -42,6 +43,7 @@ from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
 from src.modules.media.application.use_cases.get_person_bio import GetPersonBioUseCase
 from src.modules.media.application.use_cases.get_related_movies import GetRelatedMoviesUseCase
 from src.modules.media.application.use_cases.get_related_series import GetRelatedSeriesUseCase
+from src.modules.media.application.use_cases.get_scan_run import GetScanRunUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
@@ -59,6 +61,7 @@ from src.modules.media.application.use_cases.list_recently_added_movies import (
 from src.modules.media.application.use_cases.list_recently_added_series import (
     ListRecentlyAddedSeriesUseCase,
 )
+from src.modules.media.application.use_cases.list_scan_runs import ListScanRunsUseCase
 from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
 from src.modules.media.application.use_cases.promote_movie_to_series import (
     PromoteMovieToSeriesUseCase,
@@ -73,6 +76,13 @@ from src.modules.media.application.use_cases.serve_hls_file import ServeHlsFileU
 from src.modules.media.application.use_cases.set_episode_intro import SetEpisodeIntroUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
 from src.modules.media.application.use_cases.stream_file_range import StreamFileRangeUseCase
+from src.modules.media.application.use_cases.sweep_interrupted_scan_runs import (
+    SweepInterruptedScanRunsUseCase,
+)
+from src.modules.media.application.use_cases.trigger_bulk_enrich import (
+    TriggerBulkEnrichUseCase,
+)
+from src.modules.media.application.use_cases.trigger_scan import TriggerScanUseCase
 from src.modules.media.infrastructure.audio import (
     AudioExtractor,
     ChromaprintIntroDetector,
@@ -124,6 +134,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # ``Profile.allowed_library_ids`` via the Identity UoW so this
     # BC only ever sees ``ProfileLibraryAccessPort``.
     profile_library_access = providers.Dependency()
+
+    # Wired at the composition root — the trigger-scan use case
+    # needs to look up the requested library before opening the
+    # ``scan_runs`` row. Keeps the cross-BC dependency explicit.
+    library_uow_factory = providers.Dependency()
 
     # Must be wired from parent container (Settings.hls_cache_directory / hls_cache_max_size_mb)
     hls_cache_directory = providers.Dependency(default="./hls_cache")
@@ -439,6 +454,43 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         enrich_movie=enrich_movie_metadata,
         enrich_series=enrich_series_metadata,
         uow_factory=media_unit_of_work_factory,
+    )
+
+    # =========================================================================
+    # Scan + Enrich admin runs
+    # =========================================================================
+
+    scan_run_service = providers.Singleton(
+        ScanRunService,
+        scan_use_case=scan_media_directories,
+        bulk_enrich_use_case=bulk_enrich_metadata,
+        media_uow_factory=media_unit_of_work_factory,
+    )
+
+    trigger_scan = providers.Factory(
+        TriggerScanUseCase,
+        scan_run_service=scan_run_service,
+        library_uow_factory=library_uow_factory,
+    )
+
+    trigger_bulk_enrich = providers.Factory(
+        TriggerBulkEnrichUseCase,
+        scan_run_service=scan_run_service,
+    )
+
+    list_scan_runs = providers.Factory(
+        ListScanRunsUseCase,
+        media_uow_factory=media_unit_of_work_factory,
+    )
+
+    get_scan_run = providers.Factory(
+        GetScanRunUseCase,
+        media_uow_factory=media_unit_of_work_factory,
+    )
+
+    sweep_interrupted_scan_runs = providers.Factory(
+        SweepInterruptedScanRunsUseCase,
+        media_uow_factory=media_unit_of_work_factory,
     )
 
     # =========================================================================

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -18,23 +18,14 @@ from apscheduler.triggers.cron import CronTrigger
 
 from src.config.logging import get_logger
 from src.modules.library.domain.value_objects.library_id import LibraryId
-from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
-from src.modules.media.application.use_cases.scan_media_directories import (
-    ScanMediaDirectoriesUseCase,
-)
+from src.modules.media.domain.entities.scan_run import ScanRunTrigger
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    from src.building_blocks.application.event_bus import EventBus
     from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
-    from src.modules.media.application.ports import (
-        FileSystemScanner,
-        MediaProbePort,
-        VariantDetectorPort,
-    )
-    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-    from src.shared_kernel.value_objects.file_path import FilePath
+    from src.modules.library.domain.entities.library import Library
+    from src.modules.media.application.services.scan_run_service import ScanRunService
 
 _logger = get_logger()
 
@@ -58,20 +49,12 @@ class LibraryScanScheduler:
     def __init__(
         self,
         library_uow_factory: LibraryUnitOfWorkFactory,
-        media_uow_factory: MediaUnitOfWorkFactory,
-        file_scanner: FileSystemScanner,
-        variant_detector: VariantDetectorPort,
-        event_bus: EventBus,
+        scan_run_service: ScanRunService,
         reconcile_interval_minutes: int,
-        probe_service: MediaProbePort | None = None,
     ) -> None:
         self._library_uow_factory = library_uow_factory
-        self._media_uow_factory = media_uow_factory
-        self._file_scanner = file_scanner
-        self._variant_detector = variant_detector
-        self._event_bus = event_bus
+        self._scan_run_service = scan_run_service
         self._reconcile_interval_minutes = reconcile_interval_minutes
-        self._probe_service = probe_service
         self._scheduler = AsyncIOScheduler(timezone="UTC")
 
     async def start(self) -> None:
@@ -195,52 +178,33 @@ class LibraryScanScheduler:
     async def _run_scan(self, library_id: str) -> None:
         """Run a single library scan and record completion.
 
-        Loads the library in a short-lived UoW, releases it before the
-        long-running scan, then opens a fresh UoW to persist
-        ``last_scan_at`` on success. The scan use case drives its own
-        media UoW per file group so failures on one group roll back
-        only that transaction.
+        Opens a ``scan_runs`` row tagged ``trigger='scheduled'`` so
+        admin history surfaces background runs alongside
+        manually-triggered ones, then delegates to ``ScanRunService``
+        which writes the terminal state and emits log lines.
         """
         _logger.info("[scheduler] Running scan", library_id=library_id)
 
-        paths = await self._load_library_paths(library_id)
-        if paths is None:
+        library = await self._load_library(library_id)
+        if library is None:
             return
 
-        use_case = ScanMediaDirectoriesUseCase(
-            file_scanner=self._file_scanner,
-            variant_detector=self._variant_detector,
-            uow_factory=self._media_uow_factory,
-            probe_service=self._probe_service,
-            event_bus=self._event_bus,
+        run = await self._scan_run_service.open_scan(
+            library_id=library_id,
+            trigger=ScanRunTrigger.SCHEDULED,
         )
-        try:
-            result = await use_case.execute(
-                ScanMediaInput(library_id=library_id, directories=paths)
-            )
-        except Exception as exc:
+        if run.id is None:  # pragma: no cover — repo always assigns
             _logger.error(
-                "[scheduler] Scan failed",
+                "[scheduler] open_scan returned a row without id; skipping",
                 library_id=library_id,
-                error=str(exc),
-                exc_info=True,
             )
             return
 
+        await self._scan_run_service.run_scan(run.id, library)
         await self._mark_library_scanned(library_id)
 
-        _logger.info(
-            "[scheduler] Scan done",
-            library_id=library_id,
-            movies_created=result.movies_created,
-            movies_updated=result.movies_updated,
-            episodes_created=result.episodes_created,
-            episodes_updated=result.episodes_updated,
-            errors=len(result.errors),
-        )
-
-    async def _load_library_paths(self, library_id: str) -> list[FilePath] | None:
-        """Return the library's configured paths, or ``None`` if it vanished."""
+    async def _load_library(self, library_id: str) -> Library | None:
+        """Return the library row, or ``None`` if it vanished."""
         async with self._library_uow_factory() as uow:
             library = await uow.libraries.find_by_id(LibraryId(library_id))
             if library is None:
@@ -249,7 +213,7 @@ class LibraryScanScheduler:
                     library_id=library_id,
                 )
                 return None
-            return list(library.paths)
+            return library
 
     async def _mark_library_scanned(self, library_id: str) -> None:
         """Persist the completed-scan timestamp in its own UoW."""

--- a/src/main.py
+++ b/src/main.py
@@ -33,6 +33,7 @@ from src.modules.library.presentation.routes.library_routes import (
 )
 from src.modules.media.presentation.routes import (
     admin_relink_router,
+    admin_scan_router,
     admin_system_router,
     catalog_router,
     collection_router,
@@ -56,6 +57,7 @@ from src.modules.watch_progress.presentation.routes import progress_router
 #: list (drift between the two would mean tests miss DI-resolved deps).
 WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.media.presentation.routes.admin_relink_routes",
+    "src.modules.media.presentation.routes.admin_scan_routes",
     "src.modules.media.presentation.routes.admin_system_routes",
     "src.modules.media.presentation.routes.catalog_routes",
     "src.modules.media.presentation.routes.collection_routes",
@@ -119,6 +121,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Subscribe domain event handlers
     _subscribe_event_handlers(container)
+
+    # Close any ``scan_runs`` rows that were ``running`` when the
+    # previous process died. The sweeper marks them ``interrupted``
+    # so the admin Scan / Enrich pages never show a perpetually-
+    # active row that nobody is actually working on.
+    sweep_scan_runs = container.media.sweep_interrupted_scan_runs()
+    await sweep_scan_runs.execute()
 
     # Start background scheduler (library scans + thumbnail backfill +
     # intro detection). The provider depends on the session_factory
@@ -285,6 +294,7 @@ def create_app() -> FastAPI:
     # Register routes
     register_health_routes(app)
     app.include_router(admin_relink_router)
+    app.include_router(admin_scan_router)
     app.include_router(admin_system_router)
     app.include_router(catalog_router)
     app.include_router(collection_router)

--- a/src/main.py
+++ b/src/main.py
@@ -126,7 +126,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # previous process died. The sweeper marks them ``interrupted``
     # so the admin Scan / Enrich pages never show a perpetually-
     # active row that nobody is actually working on.
-    sweep_scan_runs = container.media.sweep_interrupted_scan_runs()
+    # The provider chain transitively depends on the session_factory
+    # Resource, so the Factory call resolves asynchronously and
+    # must be awaited before ``.execute()``.
+    sweep_scan_runs = await container.media.sweep_interrupted_scan_runs()
     await sweep_scan_runs.execute()
 
     # Start background scheduler (library scans + thumbnail backfill +

--- a/src/modules/media/application/dtos/scan_run_dtos.py
+++ b/src/modules/media/application/dtos/scan_run_dtos.py
@@ -1,0 +1,83 @@
+"""DTOs for scan + enrich run history (admin surface)."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ScanRunOutput:
+    """API-facing shape of a scan/enrich run row.
+
+    Always serializable to JSON; counter columns live inside
+    ``summary`` so the frontend can render whichever counters
+    apply per kind without the response shape changing.
+    """
+
+    id: str
+    kind: str
+    trigger: str
+    library_id: str | None
+    status: str
+    started_at: str
+    finished_at: str | None
+    summary: dict[str, int]
+    errors_count: int
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class TriggerScanInput:
+    """Input for ``TriggerScanUseCase``.
+
+    Carries the library to scan plus a flag the route uses to set
+    the ``trigger`` column — the route passes ``manual``, the
+    scheduler can call the same path with ``scheduled``.
+    """
+
+    library_id: str
+    trigger: str = "manual"
+
+
+@dataclass(frozen=True)
+class TriggerBulkEnrichInput:
+    """Input for ``TriggerBulkEnrichUseCase``.
+
+    Bulk enrich isn't library-scoped today — the underlying use
+    case sweeps every movie + series with missing metadata. The
+    ``force`` flag re-enriches even rows that already have
+    metadata (used after a TMDB outage when partial data may have
+    been written).
+    """
+
+    force: bool = False
+    trigger: str = "manual"
+
+
+@dataclass(frozen=True)
+class ListScanRunsInput:
+    """Input for ``ListScanRunsUseCase``.
+
+    All filters are optional — the unfiltered call returns the
+    most recent runs across every kind/trigger/library.
+    """
+
+    kind: str | None = None
+    trigger: str | None = None
+    library_id: str | None = None
+    limit: int = 50
+    offset: int = 0
+
+
+@dataclass(frozen=True)
+class GetScanRunInput:
+    """Input for ``GetScanRunUseCase``."""
+
+    run_id: str
+
+
+__all__ = [
+    "GetScanRunInput",
+    "ListScanRunsInput",
+    "ScanRunOutput",
+    "TriggerBulkEnrichInput",
+    "TriggerScanInput",
+]

--- a/src/modules/media/application/services/__init__.py
+++ b/src/modules/media/application/services/__init__.py
@@ -1,0 +1,1 @@
+"""Media application services — non-use-case orchestrators."""

--- a/src/modules/media/application/services/scan_run_service.py
+++ b/src/modules/media/application/services/scan_run_service.py
@@ -1,0 +1,148 @@
+"""Orchestrator that wraps a scan / bulk-enrich execution with run-row bookkeeping.
+
+The "run a scan" flow always boils down to three steps: open a
+``running`` row, do the work, write the terminal state. Wrapping it
+once in this service keeps the trigger use cases (HTTP-facing) and
+the scheduler (background job) on the same path — both end up
+calling :meth:`run_scan` / :meth:`run_bulk_enrich`. The HTTP route
+spawns the call via :func:`asyncio.create_task` for fire-and-forget;
+the scheduler awaits it directly inside its existing job loop.
+
+Failures inside the work raise; the service catches them so the
+row can transition to ``failed`` with the message in ``errors``,
+then re-raises (or in fire-and-forget mode, just logs). On
+process restart any rows still marked ``running`` get swept to
+``interrupted`` by the lifespan startup hook (see
+:class:`SweepInterruptedScanRunsUseCase`).
+"""
+
+import logging
+
+from src.modules.library.domain.entities.library import Library
+from src.modules.media.application.dtos.enrichment_dtos import BulkEnrichInput
+from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases.bulk_enrich_metadata import (
+    BulkEnrichMetadataUseCase,
+)
+from src.modules.media.application.use_cases.scan_media_directories import (
+    ScanMediaDirectoriesUseCase,
+)
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+_logger = logging.getLogger(__name__)
+
+
+class ScanRunService:
+    """Wraps scan + bulk-enrich execution with run-row lifecycle writes.
+
+    Single instance held in the DI container — the underlying use
+    cases + UoW factory are reused across every run. The service
+    itself holds no per-run state; the durable record lives in
+    ``scan_runs``.
+    """
+
+    def __init__(
+        self,
+        scan_use_case: ScanMediaDirectoriesUseCase,
+        bulk_enrich_use_case: BulkEnrichMetadataUseCase,
+        media_uow_factory: MediaUnitOfWorkFactory,
+    ) -> None:
+        self._scan = scan_use_case
+        self._bulk_enrich = bulk_enrich_use_case
+        self._media_uow_factory = media_uow_factory
+
+    async def open_scan(
+        self,
+        library_id: str,
+        trigger: ScanRunTrigger,
+    ) -> ScanRun:
+        """Write the ``running`` row for a scan; return the saved aggregate."""
+        async with self._media_uow_factory() as uow:
+            return await uow.scan_runs.save(
+                ScanRun.start(
+                    kind=ScanRunKind.SCAN,
+                    trigger=trigger,
+                    library_id=library_id,
+                ),
+            )
+
+    async def open_bulk_enrich(self, trigger: ScanRunTrigger) -> ScanRun:
+        """Write the ``running`` row for a bulk enrich; return the aggregate."""
+        async with self._media_uow_factory() as uow:
+            return await uow.scan_runs.save(
+                ScanRun.start(
+                    kind=ScanRunKind.ENRICH,
+                    trigger=trigger,
+                    library_id=None,
+                ),
+            )
+
+    async def run_scan(self, run_id: ScanRunId, library: Library) -> None:
+        """Execute the scan and write the terminal row.
+
+        Args:
+            run_id: External id of the already-opened ``running`` row.
+            library: Pre-loaded library so the runner doesn't re-hit
+                the library UoW from inside the background task.
+        """
+        try:
+            output = await self._scan.execute(
+                ScanMediaInput(
+                    library_id=str(library.id),
+                    directories=list(library.paths),
+                ),
+            )
+            summary = {
+                "movies_created": output.movies_created,
+                "movies_updated": output.movies_updated,
+                "episodes_created": output.episodes_created,
+                "episodes_updated": output.episodes_updated,
+            }
+            await self._finalize_succeeded(run_id, summary, output.errors)
+        except Exception as exc:
+            _logger.exception("Scan run %s crashed for library %s", run_id, library.id)
+            await self._finalize_failed(run_id, str(exc))
+
+    async def run_bulk_enrich(self, run_id: ScanRunId, force: bool) -> None:
+        """Execute the bulk enrich and write the terminal row."""
+        try:
+            output = await self._bulk_enrich.execute(BulkEnrichInput(force=force))
+            summary = {
+                "movies_enriched": output.movies_enriched,
+                "series_enriched": output.series_enriched,
+                "skipped": output.skipped,
+            }
+            await self._finalize_succeeded(run_id, summary, output.errors)
+        except Exception as exc:
+            _logger.exception("Bulk enrich run %s crashed", run_id)
+            await self._finalize_failed(run_id, str(exc))
+
+    async def _finalize_succeeded(
+        self,
+        run_id: ScanRunId,
+        summary: dict[str, int],
+        errors: list[str],
+    ) -> None:
+        async with self._media_uow_factory() as uow:
+            run = await uow.scan_runs.find_by_id(run_id)
+            if run is None:  # pragma: no cover — defensive, deleted mid-run
+                _logger.warning("scan_run %s disappeared before finalize", run_id)
+                return
+            await uow.scan_runs.save(run.succeed(summary, errors))
+
+    async def _finalize_failed(self, run_id: ScanRunId, error_message: str) -> None:
+        async with self._media_uow_factory() as uow:
+            run = await uow.scan_runs.find_by_id(run_id)
+            if run is None:  # pragma: no cover
+                _logger.warning("scan_run %s disappeared before failure", run_id)
+                return
+            await uow.scan_runs.save(run.fail(error_message))
+
+
+__all__ = ["ScanRunService"]

--- a/src/modules/media/application/unit_of_work.py
+++ b/src/modules/media/application/unit_of_work.py
@@ -8,22 +8,28 @@ depend only on this abstraction so they stay framework-agnostic.
 from abc import ABC, abstractmethod
 
 from src.building_blocks.application.unit_of_work import UnitOfWork
-from src.modules.media.domain.repositories import MovieRepository, SeriesRepository
+from src.modules.media.domain.repositories import (
+    MovieRepository,
+    ScanRunRepository,
+    SeriesRepository,
+)
 
 
 class MediaUnitOfWork(UnitOfWork):
-    """Transactional boundary for operations on movies and series.
+    """Transactional boundary for operations on movies, series and scan runs.
 
-    Subclasses populate ``movies`` and ``series`` on ``__aenter__`` so
-    writes within the same ``async with`` block share a transaction.
-    Outside the context manager the attributes are not guaranteed to
-    exist — accessing them raises ``AttributeError``, which surfaces
-    misuse at the call site instead of silently operating against
-    a stale or foreign session.
+    Subclasses populate ``movies``, ``series`` and ``scan_runs`` on
+    ``__aenter__`` so writes within the same ``async with`` block
+    share a transaction. Outside the context manager the attributes
+    are not guaranteed to exist — accessing them raises
+    ``AttributeError``, which surfaces misuse at the call site
+    instead of silently operating against a stale or foreign
+    session.
     """
 
     movies: MovieRepository
     series: SeriesRepository
+    scan_runs: ScanRunRepository
 
 
 class MediaUnitOfWorkFactory(ABC):

--- a/src/modules/media/application/use_cases/_to_scan_run_output.py
+++ b/src/modules/media/application/use_cases/_to_scan_run_output.py
@@ -1,0 +1,25 @@
+"""Internal helper projecting a ``ScanRun`` aggregate into the API DTO."""
+
+from src.modules.media.application.dtos.scan_run_dtos import ScanRunOutput
+from src.modules.media.domain.entities.scan_run import ScanRun
+
+
+def scan_run_to_output(run: ScanRun) -> ScanRunOutput:
+    """Convert a ``ScanRun`` to ``ScanRunOutput`` (timestamps as ISO-8601)."""
+    if run.id is None:
+        raise ValueError("Cannot project an unpersisted ScanRun to output")
+    return ScanRunOutput(
+        id=str(run.id),
+        kind=run.kind.value,
+        trigger=run.trigger.value,
+        library_id=run.library_id,
+        status=run.status.value,
+        started_at=run.started_at.isoformat(),
+        finished_at=run.finished_at.isoformat() if run.finished_at else None,
+        summary={k: int(v) for k, v in run.summary.items()},
+        errors_count=len(run.errors),
+        errors=list(run.errors),
+    )
+
+
+__all__ = ["scan_run_to_output"]

--- a/src/modules/media/application/use_cases/get_scan_run.py
+++ b/src/modules/media/application/use_cases/get_scan_run.py
@@ -1,0 +1,37 @@
+"""GetScanRunUseCase — admin detail view for a single run."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.scan_run_dtos import (
+    GetScanRunInput,
+    ScanRunOutput,
+)
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases._to_scan_run_output import (
+    scan_run_to_output,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+
+class GetScanRunUseCase:
+    """Hydrate a single ``scan_runs`` row by external id.
+
+    Drives the admin detail page (used by both Scan and Enrich
+    screens after the operator clicks a row) and the polling loop
+    on the trigger UX — the frontend hits this endpoint every few
+    seconds while ``status == "running"``.
+    """
+
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
+
+    async def execute(self, input_dto: GetScanRunInput) -> ScanRunOutput:
+        """Return the run or raise ``ResourceNotFoundException``."""
+        run_id = ScanRunId(input_dto.run_id)
+        async with self._media_uow_factory() as uow:
+            run = await uow.scan_runs.find_by_id(run_id)
+        if run is None:
+            raise ResourceNotFoundException.for_resource("ScanRun", input_dto.run_id)
+        return scan_run_to_output(run)
+
+
+__all__ = ["GetScanRunUseCase"]

--- a/src/modules/media/application/use_cases/list_scan_runs.py
+++ b/src/modules/media/application/use_cases/list_scan_runs.py
@@ -1,0 +1,41 @@
+"""ListScanRunsUseCase — paginated scan/enrich history for the admin page."""
+
+from src.modules.media.application.dtos.scan_run_dtos import (
+    ListScanRunsInput,
+    ScanRunOutput,
+)
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases._to_scan_run_output import (
+    scan_run_to_output,
+)
+from src.modules.media.domain.entities.scan_run import ScanRunKind, ScanRunTrigger
+
+
+class ListScanRunsUseCase:
+    """Page through ``scan_runs`` newest-first, optionally narrowed.
+
+    The page caps at 50 rows — the admin Scan / Enrich screens
+    render this as a flat table without virtualised scrolling, so
+    keep the result set scannable.
+    """
+
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
+
+    async def execute(self, input_dto: ListScanRunsInput) -> list[ScanRunOutput]:
+        """Return the requested page of run rows."""
+        kind = ScanRunKind(input_dto.kind) if input_dto.kind else None
+        trigger = ScanRunTrigger(input_dto.trigger) if input_dto.trigger else None
+
+        async with self._media_uow_factory() as uow:
+            runs = await uow.scan_runs.list_paginated(
+                kind=kind,
+                trigger=trigger,
+                library_id=input_dto.library_id,
+                limit=input_dto.limit,
+                offset=input_dto.offset,
+            )
+        return [scan_run_to_output(r) for r in runs]
+
+
+__all__ = ["ListScanRunsUseCase"]

--- a/src/modules/media/application/use_cases/sweep_interrupted_scan_runs.py
+++ b/src/modules/media/application/use_cases/sweep_interrupted_scan_runs.py
@@ -1,0 +1,41 @@
+"""SweepInterruptedScanRunsUseCase — startup hook to repair orphan ``running`` rows."""
+
+import logging
+
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.entities.scan_run import ScanRunStatus
+
+_logger = logging.getLogger(__name__)
+
+
+class SweepInterruptedScanRunsUseCase:
+    """Mark every ``running`` ``scan_runs`` row as ``interrupted``.
+
+    Runs once during ``lifespan`` startup. If the process was
+    killed while a scan or bulk enrich was in flight, the row
+    would otherwise stay in ``running`` forever and the admin
+    page would show a perpetually-active job that never finishes.
+    Re-running the scan is the operator's call; the sweeper just
+    closes the row so the listing is honest about state.
+    """
+
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
+
+    async def execute(self) -> int:
+        """Sweep + return the number of rows transitioned."""
+        async with self._media_uow_factory() as uow:
+            running = await uow.scan_runs.list_by_status(ScanRunStatus.RUNNING)
+            for run in running:
+                await uow.scan_runs.save(run.mark_interrupted())
+
+        if running:
+            _logger.warning(
+                "Marked %d orphan scan_runs as 'interrupted' on startup. "
+                "Re-run the scan/enrich manually if needed.",
+                len(running),
+            )
+        return len(running)
+
+
+__all__ = ["SweepInterruptedScanRunsUseCase"]

--- a/src/modules/media/application/use_cases/trigger_bulk_enrich.py
+++ b/src/modules/media/application/use_cases/trigger_bulk_enrich.py
@@ -1,0 +1,61 @@
+"""TriggerBulkEnrichUseCase — admin fires a background metadata refresh."""
+
+import asyncio
+import logging
+
+from src.modules.media.application.dtos.scan_run_dtos import (
+    ScanRunOutput,
+    TriggerBulkEnrichInput,
+)
+from src.modules.media.application.services.scan_run_service import ScanRunService
+from src.modules.media.application.use_cases._to_scan_run_output import (
+    scan_run_to_output,
+)
+from src.modules.media.domain.entities.scan_run import ScanRunTrigger
+
+_logger = logging.getLogger(__name__)
+
+
+class TriggerBulkEnrichUseCase:
+    """Open an ``enrich`` ``scan_runs`` row and spawn the work in the background.
+
+    Bulk enrich today is global (every movie + series with missing
+    metadata) rather than library-scoped. The history row keeps
+    ``library_id=None`` to reflect that — the operator gets a
+    single row for "I asked TMDB to backfill everything at 14:32".
+    """
+
+    def __init__(self, scan_run_service: ScanRunService) -> None:
+        self._service = scan_run_service
+
+    async def execute(self, input_dto: TriggerBulkEnrichInput) -> ScanRunOutput:
+        """Open the row, schedule the enrich, return immediately."""
+        trigger = ScanRunTrigger(input_dto.trigger)
+        run = await self._service.open_bulk_enrich(trigger=trigger)
+
+        if run.id is None:  # pragma: no cover
+            raise RuntimeError("open_bulk_enrich returned a row without id")
+
+        task = asyncio.create_task(
+            self._service.run_bulk_enrich(run.id, input_dto.force),
+            name=f"enrich-run-{run.id}",
+        )
+        task.add_done_callback(_log_task_failure)
+        return scan_run_to_output(run)
+
+
+def _log_task_failure(task: asyncio.Task) -> None:
+    if task.cancelled():
+        _logger.info("Enrich task %s was cancelled", task.get_name())
+        return
+    exc = task.exception()
+    if exc is not None:
+        _logger.exception(
+            "Enrich task %s exited unexpectedly: %s",
+            task.get_name(),
+            exc,
+            exc_info=exc,
+        )
+
+
+__all__ = ["TriggerBulkEnrichUseCase"]

--- a/src/modules/media/application/use_cases/trigger_scan.py
+++ b/src/modules/media/application/use_cases/trigger_scan.py
@@ -1,0 +1,96 @@
+"""TriggerScanUseCase — admin starts a fire-and-forget library scan."""
+
+import asyncio
+import logging
+
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
+from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.media.application.dtos.scan_run_dtos import (
+    ScanRunOutput,
+    TriggerScanInput,
+)
+from src.modules.media.application.services.scan_run_service import ScanRunService
+from src.modules.media.application.use_cases._to_scan_run_output import (
+    scan_run_to_output,
+)
+from src.modules.media.domain.entities.scan_run import ScanRunTrigger
+
+_logger = logging.getLogger(__name__)
+
+
+class LibraryNotFoundForScanError(Exception):
+    """Admin POSTed a scan for a library id that doesn't exist."""
+
+    def __init__(self, library_id: str) -> None:
+        super().__init__(f"Library {library_id} not found")
+        self.library_id = library_id
+
+
+class TriggerScanUseCase:
+    """Open a ``scan_runs`` row + fire the scan as a background task.
+
+    Synchronous wait-for-completion was the v0 behaviour
+    (``POST /api/v1/scan`` blocks for tens of seconds on large
+    libraries). v1 returns immediately with the run id; the
+    admin Scan page polls ``GET /api/v1/admin/scans/{id}`` for
+    progress.
+    """
+
+    def __init__(
+        self,
+        scan_run_service: ScanRunService,
+        library_uow_factory: LibraryUnitOfWorkFactory,
+    ) -> None:
+        self._service = scan_run_service
+        self._library_uow_factory = library_uow_factory
+
+    async def execute(self, input_dto: TriggerScanInput) -> ScanRunOutput:
+        """Validate the library, open the row, schedule the work."""
+        async with self._library_uow_factory() as luow:
+            library = await luow.libraries.find_by_id(LibraryId(input_dto.library_id))
+        if library is None:
+            raise LibraryNotFoundForScanError(input_dto.library_id)
+
+        trigger = ScanRunTrigger(input_dto.trigger)
+        run = await self._service.open_scan(
+            library_id=str(library.id),
+            trigger=trigger,
+        )
+
+        if run.id is None:  # pragma: no cover — repo always assigns
+            raise RuntimeError("open_scan returned a row without id")
+
+        # Spawn the actual scan as a background task. We deliberately
+        # do *not* await it — the admin page would time out on a
+        # 30-second scan if we did, and the row is the durable
+        # record for the operator to poll against. Failures inside
+        # run_scan write themselves to the row's terminal state.
+        task = asyncio.create_task(
+            self._service.run_scan(run.id, library),
+            name=f"scan-run-{run.id}",
+        )
+        task.add_done_callback(_log_task_failure)
+        return scan_run_to_output(run)
+
+
+def _log_task_failure(task: asyncio.Task) -> None:
+    """Surface unexpected task crashes in the logs.
+
+    Normal failure paths inside ``ScanRunService.run_scan`` write
+    the error to the row and don't re-raise. Anything that lands
+    here is a programmer error (e.g. cancellation) we want to see.
+    """
+    if task.cancelled():
+        _logger.info("Scan task %s was cancelled", task.get_name())
+        return
+    exc = task.exception()
+    if exc is not None:
+        _logger.exception(
+            "Scan task %s exited unexpectedly: %s",
+            task.get_name(),
+            exc,
+            exc_info=exc,
+        )
+
+
+__all__ = ["LibraryNotFoundForScanError", "TriggerScanUseCase"]

--- a/src/modules/media/domain/entities/__init__.py
+++ b/src/modules/media/domain/entities/__init__.py
@@ -2,6 +2,12 @@
 
 from src.modules.media.domain.entities.episode import Episode
 from src.modules.media.domain.entities.movie import Movie
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
 from src.modules.media.domain.entities.season import Season
 from src.modules.media.domain.entities.series import Series
 
@@ -12,6 +18,10 @@ Series.model_rebuild()
 __all__ = [
     "Episode",
     "Movie",
+    "ScanRun",
+    "ScanRunKind",
+    "ScanRunStatus",
+    "ScanRunTrigger",
     "Season",
     "Series",
 ]

--- a/src/modules/media/domain/entities/scan_run.py
+++ b/src/modules/media/domain/entities/scan_run.py
@@ -1,0 +1,142 @@
+"""ScanRun aggregate — admin scan + bulk-enrich history row."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any, Self
+
+from pydantic import Field
+
+from src.building_blocks.domain import AggregateRoot
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+
+class ScanRunKind(str, Enum):
+    """What was being run."""
+
+    SCAN = "scan"
+    ENRICH = "enrich"
+
+
+class ScanRunTrigger(str, Enum):
+    """Who started the run."""
+
+    MANUAL = "manual"
+    SCHEDULED = "scheduled"
+
+
+class ScanRunStatus(str, Enum):
+    """Lifecycle state of a run."""
+
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+_MAX_ERRORS_RETAINED = 50
+
+
+class ScanRun(AggregateRoot[ScanRunId]):
+    """A single execution of a catalog scan or bulk metadata enrich.
+
+    History row for the admin panel: every run (manual or
+    scheduled) writes a ``running`` row up front, then transitions
+    to a terminal state when the async work finishes. Counters are
+    kept per-kind in the ``summary`` dict to avoid a wide table
+    with mostly-null columns.
+
+    Why not split into two tables: the admin history page renders
+    a unified timeline and both kinds share the same
+    ``running → succeeded/failed/interrupted`` lifecycle. One table
+    keeps the page query simple and the operator's mental model
+    coherent ("here's what happened to the catalog recently").
+
+    Attributes:
+        id: External id (``run_xxx``).
+        kind: Scan or enrich.
+        trigger: Manual (admin button) or scheduled (background
+            poller). Filterable on the list page so the operator
+            can ignore cron noise.
+        library_id: External id of the targeted library. ``None``
+            for enrich runs that aren't library-scoped.
+        started_at: When the runner began work.
+        finished_at: ``None`` while ``running``; set on terminal
+            transitions.
+        status: Current lifecycle state.
+        summary: Per-kind counter dict. For scans:
+            ``movies_created`` / ``movies_updated`` /
+            ``episodes_created`` / ``episodes_updated``.
+            For enrich: ``enriched`` / ``skipped`` / ``failed``.
+        errors: First N error messages emitted during the run.
+            Truncated to ``_MAX_ERRORS_RETAINED`` so a degenerate
+            scan can't bloat the row.
+    """
+
+    id: ScanRunId | None = Field(default=None)
+
+    kind: ScanRunKind
+    trigger: ScanRunTrigger
+    library_id: str | None = None
+    started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    finished_at: datetime | None = None
+    status: ScanRunStatus = ScanRunStatus.RUNNING
+    summary: dict[str, Any] = Field(default_factory=dict)
+    errors: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def start(
+        cls,
+        *,
+        kind: ScanRunKind,
+        trigger: ScanRunTrigger,
+        library_id: str | None,
+    ) -> Self:
+        """Open a new run row in the ``running`` state."""
+        return cls(
+            kind=kind,
+            trigger=trigger,
+            library_id=library_id,
+            started_at=datetime.now(UTC),
+            status=ScanRunStatus.RUNNING,
+        )
+
+    def succeed(self, summary: dict[str, Any], errors: list[str]) -> Self:
+        """Return a copy stamped with ``succeeded`` + the final counters."""
+        return self.with_updates(
+            status=ScanRunStatus.SUCCEEDED,
+            finished_at=datetime.now(UTC),
+            summary=summary,
+            errors=list(errors[:_MAX_ERRORS_RETAINED]),
+        )
+
+    def fail(self, error_message: str, summary: dict[str, Any] | None = None) -> Self:
+        """Return a copy stamped with ``failed`` + the error message.
+
+        Used when the runner itself raised (vs. completing with a
+        bag of per-file errors). ``summary`` may carry partial
+        counters if some work succeeded before the crash.
+        """
+        return self.with_updates(
+            status=ScanRunStatus.FAILED,
+            finished_at=datetime.now(UTC),
+            summary=summary or self.summary,
+            errors=[error_message],
+        )
+
+    def mark_interrupted(self) -> Self:
+        """Mark a ``running`` row as interrupted by a process restart."""
+        return self.with_updates(
+            status=ScanRunStatus.INTERRUPTED,
+            finished_at=datetime.now(UTC),
+            errors=["Process restarted while the run was in progress."],
+        )
+
+
+__all__ = [
+    "ScanRun",
+    "ScanRunKind",
+    "ScanRunStatus",
+    "ScanRunTrigger",
+]

--- a/src/modules/media/domain/repositories/__init__.py
+++ b/src/modules/media/domain/repositories/__init__.py
@@ -1,9 +1,11 @@
 """Media domain repository interfaces."""
 
 from src.modules.media.domain.repositories.movie_repository import MovieRepository
+from src.modules.media.domain.repositories.scan_run_repository import ScanRunRepository
 from src.modules.media.domain.repositories.series_repository import SeriesRepository
 
 __all__ = [
     "MovieRepository",
+    "ScanRunRepository",
     "SeriesRepository",
 ]

--- a/src/modules/media/domain/repositories/scan_run_repository.py
+++ b/src/modules/media/domain/repositories/scan_run_repository.py
@@ -1,0 +1,84 @@
+"""ScanRun repository interface."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+
+class ScanRunRepository(ABC):
+    """Repository for the ``ScanRun`` aggregate.
+
+    Backs the admin scan + bulk-enrich history page. Writes are
+    cheap (one row per trigger + one update on completion), reads
+    are bounded by ``limit`` so the list page stays paged.
+    """
+
+    @abstractmethod
+    async def save(self, run: ScanRun) -> ScanRun:
+        """Persist a run (insert when ``id`` is fresh, update when known).
+
+        The repository assigns a new :class:`ScanRunId` on insert and
+        re-reads the row so callers see server-applied timestamps.
+        """
+        ...
+
+    @abstractmethod
+    async def find_by_id(self, run_id: ScanRunId) -> ScanRun | None:
+        """Look up a non-deleted run by its external id."""
+        ...
+
+    @abstractmethod
+    async def list_paginated(
+        self,
+        *,
+        kind: ScanRunKind | None = None,
+        trigger: ScanRunTrigger | None = None,
+        library_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Sequence[ScanRun]:
+        """List runs newest-first, optionally narrowed by kind/trigger/library.
+
+        Args:
+            kind: Filter to scans or enriches.
+            trigger: Filter to manual or scheduled runs.
+            library_id: Filter to a single library's runs (useful
+                when the operator clicks a library detail and wants
+                to see only its history).
+            limit: Page size cap.
+            offset: Rows to skip from the head of the result.
+
+        Returns:
+            Runs ordered by ``started_at`` descending.
+        """
+        ...
+
+    @abstractmethod
+    async def count(
+        self,
+        *,
+        kind: ScanRunKind | None = None,
+        trigger: ScanRunTrigger | None = None,
+        library_id: str | None = None,
+    ) -> int:
+        """Count matching non-deleted runs."""
+        ...
+
+    @abstractmethod
+    async def list_by_status(self, status: ScanRunStatus) -> Sequence[ScanRun]:
+        """List every run in a given status (no pagination).
+
+        Used by the lifespan startup hook to sweep rows that were
+        ``running`` when the process died.
+        """
+        ...
+
+
+__all__ = ["ScanRunRepository"]

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -21,6 +21,7 @@ from src.modules.media.domain.value_objects.media_id import (
     parse_media_id,
 )
 from src.modules.media.domain.value_objects.resolution import Resolution
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
 from src.modules.media.domain.value_objects.season_number import SeasonNumber
 from src.modules.media.domain.value_objects.title import Title
 from src.modules.media.domain.value_objects.tmdb_id import TmdbId
@@ -51,6 +52,7 @@ __all__ = [
     "MediaId",
     "MovieId",
     "Resolution",
+    "ScanRunId",
     "SeasonId",
     "SeasonNumber",
     "SeriesId",

--- a/src/modules/media/domain/value_objects/scan_run_id.py
+++ b/src/modules/media/domain/value_objects/scan_run_id.py
@@ -1,0 +1,20 @@
+"""ScanRunId external id."""
+
+from typing import ClassVar
+
+from src.building_blocks.domain.external_id import ExternalId
+
+
+class ScanRunId(ExternalId):
+    """External ID for scan/enrich runs.
+
+    A single ``scan_runs`` table backs both kinds of admin runs
+    (catalog scan + bulk metadata enrich), so the prefix is the
+    generic ``run`` rather than something kind-specific. Format:
+    ``run_{base62_12chars}``.
+    """
+
+    EXPECTED_PREFIX: ClassVar[str] = "run"
+
+
+__all__ = ["ScanRunId"]

--- a/src/modules/media/infrastructure/persistence/mappers/__init__.py
+++ b/src/modules/media/infrastructure/persistence/mappers/__init__.py
@@ -4,6 +4,9 @@ from src.modules.media.infrastructure.persistence.mappers.media_file_mapper impo
     MediaFileMapper,
 )
 from src.modules.media.infrastructure.persistence.mappers.movie_mapper import MovieMapper
+from src.modules.media.infrastructure.persistence.mappers.scan_run_mapper import (
+    ScanRunMapper,
+)
 from src.modules.media.infrastructure.persistence.mappers.series_mapper import (
     EpisodeMapper,
     SeasonMapper,
@@ -14,6 +17,7 @@ __all__ = [
     "EpisodeMapper",
     "MediaFileMapper",
     "MovieMapper",
+    "ScanRunMapper",
     "SeasonMapper",
     "SeriesMapper",
 ]

--- a/src/modules/media/infrastructure/persistence/mappers/scan_run_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/scan_run_mapper.py
@@ -1,0 +1,63 @@
+"""Translate between :class:`ScanRun` aggregates and the ORM row."""
+
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+from src.modules.media.infrastructure.persistence.models.scan_run import ScanRunModel
+
+
+class ScanRunMapper:
+    """Pure functions converting entity ↔ ``ScanRunModel``."""
+
+    @staticmethod
+    def to_entity(model: ScanRunModel) -> ScanRun:
+        """Hydrate the aggregate from a row, including timestamps."""
+        return ScanRun(
+            id=ScanRunId(model.external_id),
+            kind=ScanRunKind(model.kind),
+            trigger=ScanRunTrigger(model.trigger),
+            library_id=model.library_id,
+            started_at=model.started_at,
+            finished_at=model.finished_at,
+            status=ScanRunStatus(model.status),
+            summary=dict(model.summary or {}),
+            errors=list(model.errors or []),
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    @staticmethod
+    def to_model(entity: ScanRun) -> ScanRunModel:
+        """Build a fresh ``ScanRunModel`` from a brand-new aggregate."""
+        if entity.id is None:
+            raise ValueError("ScanRun must have an id before mapping to model")
+        return ScanRunModel(
+            external_id=str(entity.id),
+            kind=entity.kind.value,
+            trigger=entity.trigger.value,
+            library_id=entity.library_id,
+            started_at=entity.started_at,
+            finished_at=entity.finished_at,
+            status=entity.status.value,
+            summary=dict(entity.summary),
+            errors=list(entity.errors),
+        )
+
+    @staticmethod
+    def update_model(model: ScanRunModel, entity: ScanRun) -> None:
+        """Copy mutable fields from the entity onto an existing row."""
+        model.kind = entity.kind.value
+        model.trigger = entity.trigger.value
+        model.library_id = entity.library_id
+        model.started_at = entity.started_at
+        model.finished_at = entity.finished_at
+        model.status = entity.status.value
+        model.summary = dict(entity.summary)
+        model.errors = list(entity.errors)
+
+
+__all__ = ["ScanRunMapper"]

--- a/src/modules/media/infrastructure/persistence/models/__init__.py
+++ b/src/modules/media/infrastructure/persistence/models/__init__.py
@@ -3,6 +3,7 @@
 from src.modules.media.infrastructure.persistence.models.episode import EpisodeModel
 from src.modules.media.infrastructure.persistence.models.media_file import MediaFileModel
 from src.modules.media.infrastructure.persistence.models.movie import MovieModel
+from src.modules.media.infrastructure.persistence.models.scan_run import ScanRunModel
 from src.modules.media.infrastructure.persistence.models.season import SeasonModel
 from src.modules.media.infrastructure.persistence.models.series import SeriesModel
 
@@ -10,6 +11,7 @@ __all__ = [
     "EpisodeModel",
     "MediaFileModel",
     "MovieModel",
+    "ScanRunModel",
     "SeasonModel",
     "SeriesModel",
 ]

--- a/src/modules/media/infrastructure/persistence/models/scan_run.py
+++ b/src/modules/media/infrastructure/persistence/models/scan_run.py
@@ -1,0 +1,59 @@
+"""ScanRun ORM model — admin scan/enrich history."""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.base import Base
+
+
+class ScanRunModel(Base):
+    """SQLAlchemy model for the ``scan_runs`` table.
+
+    Backs both admin-trigger types ("scan a library", "bulk re-enrich
+    metadata") and the scheduler's periodic runs. Discrimination
+    columns: ``kind`` (``scan`` | ``enrich``) tells *what* ran;
+    ``trigger`` (``manual`` | ``scheduled``) tells *who* started it.
+
+    The per-kind counters live inside ``summary`` (JSON) — scans
+    track movies/episodes created+updated, enrich tracks
+    enriched/skipped/failed. Keeping them in JSON avoids a wide
+    column with mostly-null counters for whichever kind didn't run.
+
+    Attributes:
+        kind: ``scan`` or ``enrich``.
+        trigger: ``manual`` (admin-initiated) or ``scheduled``
+            (background poller).
+        library_id: External id of the targeted library. ``None``
+            for enrich runs that span every library.
+        started_at: When the runner began work.
+        finished_at: ``None`` while the row is still in
+            ``running``; set on the terminal state.
+        status: ``running`` | ``succeeded`` | ``failed`` |
+            ``interrupted``. ``interrupted`` is the post-restart
+            sweep value for rows that were ``running`` when the
+            process died.
+        summary: Per-kind counter dict serialized as JSON.
+        errors: First N error messages emitted during the run.
+            Truncated to keep the row size sane.
+    """
+
+    kind: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    trigger: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    library_id: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    summary: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    errors: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+
+
+__all__ = ["ScanRunModel"]

--- a/src/modules/media/infrastructure/persistence/repositories/__init__.py
+++ b/src/modules/media/infrastructure/persistence/repositories/__init__.py
@@ -3,6 +3,9 @@
 from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
     SQLAlchemyMovieRepository,
 )
+from src.modules.media.infrastructure.persistence.repositories.scan_run_repository import (
+    SqlAlchemyScanRunRepository,
+)
 from src.modules.media.infrastructure.persistence.repositories.series_repository import (
     SQLAlchemySeriesRepository,
 )
@@ -10,4 +13,5 @@ from src.modules.media.infrastructure.persistence.repositories.series_repository
 __all__ = [
     "SQLAlchemyMovieRepository",
     "SQLAlchemySeriesRepository",
+    "SqlAlchemyScanRunRepository",
 ]

--- a/src/modules/media/infrastructure/persistence/repositories/scan_run_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/scan_run_repository.py
@@ -1,0 +1,112 @@
+"""SQLAlchemy implementation of ``ScanRunRepository``."""
+
+from collections.abc import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.repositories.scan_run_repository import ScanRunRepository
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+from src.modules.media.infrastructure.persistence.mappers.scan_run_mapper import (
+    ScanRunMapper,
+)
+from src.modules.media.infrastructure.persistence.models.scan_run import ScanRunModel
+
+
+class SqlAlchemyScanRunRepository(ScanRunRepository):
+    """Async SQLAlchemy repository for the ``ScanRun`` aggregate."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def save(self, run: ScanRun) -> ScanRun:
+        """Insert when id-less, update when known."""
+        run = run.with_updates(id=ScanRunId.generate_if_absent(run.id))
+
+        stmt = select(ScanRunModel).where(ScanRunModel.external_id == str(run.id))
+        existing = (await self._session.execute(stmt)).scalar_one_or_none()
+
+        if existing is not None:
+            ScanRunMapper.update_model(existing, run)
+            await self._session.flush()
+        else:
+            model = ScanRunMapper.to_model(run)
+            self._session.add(model)
+            await self._session.flush()
+
+        if run.id is None:  # pragma: no cover — generate_if_absent assigns one
+            raise RuntimeError("ScanRun id was not assigned before save")
+        saved = await self.find_by_id(run.id)
+        if saved is None:  # pragma: no cover — row was just written
+            raise RuntimeError(f"ScanRun {run.id} disappeared between flush and reload")
+        return saved
+
+    async def find_by_id(self, run_id: ScanRunId) -> ScanRun | None:
+        """Look up a non-deleted run by external id."""
+        stmt = select(ScanRunModel).where(
+            ScanRunModel.external_id == str(run_id),
+            ScanRunModel.deleted_at.is_(None),
+        )
+        model = (await self._session.execute(stmt)).scalar_one_or_none()
+        return None if model is None else ScanRunMapper.to_entity(model)
+
+    async def list_paginated(
+        self,
+        *,
+        kind: ScanRunKind | None = None,
+        trigger: ScanRunTrigger | None = None,
+        library_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Sequence[ScanRun]:
+        """List non-deleted runs newest-first with optional filters."""
+        stmt = select(ScanRunModel).where(ScanRunModel.deleted_at.is_(None))
+        if kind is not None:
+            stmt = stmt.where(ScanRunModel.kind == kind.value)
+        if trigger is not None:
+            stmt = stmt.where(ScanRunModel.trigger == trigger.value)
+        if library_id is not None:
+            stmt = stmt.where(ScanRunModel.library_id == library_id)
+        stmt = stmt.order_by(ScanRunModel.started_at.desc()).limit(limit).offset(offset)
+        result = await self._session.execute(stmt)
+        return [ScanRunMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def count(
+        self,
+        *,
+        kind: ScanRunKind | None = None,
+        trigger: ScanRunTrigger | None = None,
+        library_id: str | None = None,
+    ) -> int:
+        """Count non-deleted runs matching the filter."""
+        stmt = select(func.count(ScanRunModel.id)).where(ScanRunModel.deleted_at.is_(None))
+        if kind is not None:
+            stmt = stmt.where(ScanRunModel.kind == kind.value)
+        if trigger is not None:
+            stmt = stmt.where(ScanRunModel.trigger == trigger.value)
+        if library_id is not None:
+            stmt = stmt.where(ScanRunModel.library_id == library_id)
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
+    async def list_by_status(self, status: ScanRunStatus) -> Sequence[ScanRun]:
+        """List non-deleted runs in a given status."""
+        stmt = (
+            select(ScanRunModel)
+            .where(
+                ScanRunModel.deleted_at.is_(None),
+                ScanRunModel.status == status.value,
+            )
+            .order_by(ScanRunModel.started_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return [ScanRunMapper.to_entity(m) for m in result.scalars().all()]
+
+
+__all__ = ["SqlAlchemyScanRunRepository"]

--- a/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -10,6 +10,9 @@ from src.modules.media.application.unit_of_work import (
 from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
     SQLAlchemyMovieRepository,
 )
+from src.modules.media.infrastructure.persistence.repositories.scan_run_repository import (
+    SqlAlchemyScanRunRepository,
+)
 from src.modules.media.infrastructure.persistence.repositories.series_repository import (
     SQLAlchemySeriesRepository,
 )
@@ -18,14 +21,16 @@ from src.modules.media.infrastructure.persistence.repositories.series_repository
 class SqlAlchemyMediaUnitOfWork(SqlAlchemyUnitOfWork, MediaUnitOfWork):
     """SQLAlchemy-backed Unit of Work for the media bounded context.
 
-    Exposes ``movies`` and ``series`` repositories bound to the active
-    transaction. Lifecycle (session open/commit/rollback/close,
-    nested-use guard) lives in :class:`SqlAlchemyUnitOfWork`.
+    Exposes ``movies``, ``series`` and ``scan_runs`` repositories
+    bound to the active transaction. Lifecycle (session
+    open/commit/rollback/close, nested-use guard) lives in
+    :class:`SqlAlchemyUnitOfWork`.
     """
 
     def _build_repositories(self, session: AsyncSession) -> None:
         self.movies = SQLAlchemyMovieRepository(session)
         self.series = SQLAlchemySeriesRepository(session)
+        self.scan_runs = SqlAlchemyScanRunRepository(session)
 
 
 class SqlAlchemyMediaUnitOfWorkFactory(MediaUnitOfWorkFactory):

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -3,6 +3,9 @@
 from src.modules.media.presentation.routes.admin_relink_routes import (
     router as admin_relink_router,
 )
+from src.modules.media.presentation.routes.admin_scan_routes import (
+    router as admin_scan_router,
+)
 from src.modules.media.presentation.routes.admin_system_routes import (
     router as admin_system_router,
 )
@@ -19,6 +22,7 @@ from src.modules.media.presentation.routes.stream_routes import router as stream
 
 __all__ = [
     "admin_relink_router",
+    "admin_scan_router",
     "admin_system_router",
     "catalog_router",
     "collection_router",

--- a/src/modules/media/presentation/routes/admin_scan_routes.py
+++ b/src/modules/media/presentation/routes/admin_scan_routes.py
@@ -1,0 +1,134 @@
+"""Admin REST API routes for scan + bulk-enrich history."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from src.building_blocks.presentation import api_list, api_single
+from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.media.application.dtos.scan_run_dtos import (
+    GetScanRunInput,
+    ListScanRunsInput,
+    TriggerBulkEnrichInput,
+    TriggerScanInput,
+)
+from src.modules.media.application.use_cases.get_scan_run import GetScanRunUseCase
+from src.modules.media.application.use_cases.list_scan_runs import ListScanRunsUseCase
+from src.modules.media.application.use_cases.trigger_bulk_enrich import (
+    TriggerBulkEnrichUseCase,
+)
+from src.modules.media.application.use_cases.trigger_scan import (
+    LibraryNotFoundForScanError,
+    TriggerScanUseCase,
+)
+
+router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Scan & Enrich"])
+
+
+class TriggerScanRequest(BaseModel):
+    """Body for ``POST /api/v1/admin/scans``."""
+
+    library_id: str
+
+
+class TriggerBulkEnrichRequest(BaseModel):
+    """Body for ``POST /api/v1/admin/enrichments``."""
+
+    force: bool = False
+
+
+@router.get("/scans")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_admin_scans(
+    kind: str | None = None,
+    trigger: str | None = None,
+    library_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: ListScanRunsUseCase = Depends(
+        Provide[ApplicationContainer.media.list_scan_runs],
+    ),
+) -> dict[str, Any]:
+    """List scan + bulk-enrich runs, newest-first.
+
+    Filters are all optional; ``kind=scan`` returns only catalog
+    scans, ``trigger=scheduled`` only background-poller rows. The
+    admin Scan and Enrich pages each prefill a different ``kind``
+    filter but otherwise share the same backing endpoint.
+    """
+    rows = await use_case.execute(
+        ListScanRunsInput(
+            kind=kind,
+            trigger=trigger,
+            library_id=library_id,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+    return api_list([asdict(r) for r in rows])
+
+
+@router.get("/scans/{run_id}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_admin_scan(
+    run_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: GetScanRunUseCase = Depends(
+        Provide[ApplicationContainer.media.get_scan_run],
+    ),
+) -> dict[str, Any]:
+    """Fetch a single run; used by the page-poll loop while ``status=running``."""
+    output = await use_case.execute(GetScanRunInput(run_id=run_id))
+    return api_single("scan_run", asdict(output))
+
+
+@router.post("/scans", status_code=202)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def trigger_admin_scan(
+    body: TriggerScanRequest,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: TriggerScanUseCase = Depends(
+        Provide[ApplicationContainer.media.trigger_scan],
+    ),
+) -> dict[str, Any]:
+    """Open a ``running`` row + dispatch the scan to a background task.
+
+    Returns 202 with the newly-created run shape so the admin page
+    can route to its detail view and start polling immediately.
+    The actual ffprobe + DB writes run after the response is sent.
+    """
+    try:
+        output = await use_case.execute(
+            TriggerScanInput(library_id=body.library_id, trigger="manual"),
+        )
+    except LibraryNotFoundForScanError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Library {exc.library_id} not found",
+        ) from exc
+    return api_single("scan_run", asdict(output))
+
+
+@router.post("/enrichments", status_code=202)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def trigger_admin_bulk_enrich(
+    body: TriggerBulkEnrichRequest,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: TriggerBulkEnrichUseCase = Depends(
+        Provide[ApplicationContainer.media.trigger_bulk_enrich],
+    ),
+) -> dict[str, Any]:
+    """Open an ``enrich`` ``running`` row + dispatch the bulk refresh."""
+    output = await use_case.execute(
+        TriggerBulkEnrichInput(force=body.force, trigger="manual"),
+    )
+    return api_single("scan_run", asdict(output))
+
+
+__all__ = ["router"]

--- a/tests/infrastructure/scheduling/test_scheduler_service.py
+++ b/tests/infrastructure/scheduling/test_scheduler_service.py
@@ -12,7 +12,7 @@ libraries without touching a real database.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -23,7 +23,13 @@ from src.infrastructure.scheduling.scheduler_service import (
 from src.modules.library.domain.entities.library import Library
 from src.modules.library.domain.value_objects.library_id import LibraryId
 from src.modules.library.domain.value_objects.library_type import LibraryType
-from src.shared_kernel.value_objects.file_path import FilePath
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
 
 
 class _FakeJob:
@@ -79,16 +85,35 @@ def library_repo() -> AsyncMock:
     return AsyncMock()
 
 
+def _make_run(library_id: str | None = "lib_test12345678") -> ScanRun:
+    """Build a stub ``ScanRun`` that already has an id assigned."""
+    return ScanRun(
+        id=ScanRunId.generate(),
+        kind=ScanRunKind.SCAN,
+        trigger=ScanRunTrigger.SCHEDULED,
+        library_id=library_id,
+        status=ScanRunStatus.RUNNING,
+    )
+
+
 @pytest.fixture
-def scheduler(library_repo: AsyncMock) -> LibraryScanScheduler:
+def scan_run_service() -> AsyncMock:
+    """Service mock — ``open_scan`` returns a fresh run with an id."""
+    service = AsyncMock()
+    service.open_scan.return_value = _make_run()
+    return service
+
+
+@pytest.fixture
+def scheduler(
+    library_repo: AsyncMock,
+    scan_run_service: AsyncMock,
+) -> LibraryScanScheduler:
     uow = _build_uow(library_repo)
     library_uow_factory = MagicMock(return_value=uow)
     instance = LibraryScanScheduler(
         library_uow_factory=library_uow_factory,
-        media_uow_factory=MagicMock(),
-        file_scanner=MagicMock(),
-        variant_detector=MagicMock(),
-        event_bus=MagicMock(),
+        scan_run_service=scan_run_service,
         reconcile_interval_minutes=5,
     )
     instance._scheduler = _FakeScheduler()
@@ -163,26 +188,17 @@ class TestReconcile:
 class TestRunScan:
     @pytest.mark.asyncio
     async def test_updates_last_scan_at_on_success(
-        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
+        self,
+        scheduler: LibraryScanScheduler,
+        library_repo: AsyncMock,
+        scan_run_service: AsyncMock,
     ) -> None:
         lib = _make_library("A", "0 * * * *")
         library_repo.find_by_id.return_value = lib
         library_repo.save = AsyncMock()
+        scan_run_service.open_scan.return_value = _make_run(str(lib.id))
 
-        fake_use_case = AsyncMock()
-        fake_use_case.execute.return_value = MagicMock(
-            movies_created=1,
-            movies_updated=0,
-            episodes_created=0,
-            episodes_updated=0,
-            errors=[],
-        )
-
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
-            return_value=fake_use_case,
-        ):
-            await scheduler._run_scan(str(lib.id))
+        await scheduler._run_scan(str(lib.id))
 
         library_repo.save.assert_awaited_once()
         saved = library_repo.save.await_args.args[0]
@@ -192,93 +208,44 @@ class TestRunScan:
 
     @pytest.mark.asyncio
     async def test_skips_when_library_deleted_mid_run(
-        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
+        self,
+        scheduler: LibraryScanScheduler,
+        library_repo: AsyncMock,
+        scan_run_service: AsyncMock,
     ) -> None:
         library_repo.find_by_id.return_value = None
         library_repo.save = AsyncMock()
 
         await scheduler._run_scan(str(LibraryId.generate()))
 
+        # No scan_runs row opened, no library save.
+        scan_run_service.open_scan.assert_not_awaited()
+        scan_run_service.run_scan.assert_not_awaited()
         library_repo.save.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_does_not_mark_scan_completed_on_failure(
-        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
+    async def test_delegates_to_scan_run_service_with_scheduled_trigger(
+        self,
+        scheduler: LibraryScanScheduler,
+        library_repo: AsyncMock,
+        scan_run_service: AsyncMock,
     ) -> None:
+        """The scheduler routes through ``ScanRunService`` so each run
+        becomes a ``scan_runs`` row tagged ``scheduled``."""
         lib = _make_library("A", "0 * * * *")
         library_repo.find_by_id.return_value = lib
         library_repo.save = AsyncMock()
+        run = _make_run(str(lib.id))
+        scan_run_service.open_scan.return_value = run
 
-        fake_use_case = AsyncMock()
-        fake_use_case.execute.side_effect = RuntimeError("scan blew up")
+        await scheduler._run_scan(str(lib.id))
 
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
-            return_value=fake_use_case,
-        ):
-            await scheduler._run_scan(str(lib.id))
+        scan_run_service.open_scan.assert_awaited_once()
+        kwargs = scan_run_service.open_scan.await_args.kwargs
+        assert kwargs["library_id"] == str(lib.id)
+        assert kwargs["trigger"] == ScanRunTrigger.SCHEDULED
 
-        library_repo.save.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_builds_scan_use_case_with_injected_dependencies(
-        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
-    ) -> None:
-        """Guard the fix for the pre-UoW scheduler bug: the use case is built
-        from the injected ``media_uow_factory`` + ports, never from per-session
-        concrete repositories."""
-        lib = _make_library("A", "0 * * * *")
-        library_repo.find_by_id.return_value = lib
-        library_repo.save = AsyncMock()
-
-        fake_use_case = AsyncMock()
-        fake_use_case.execute.return_value = MagicMock(
-            movies_created=0,
-            movies_updated=0,
-            episodes_created=0,
-            episodes_updated=0,
-            errors=[],
-        )
-
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
-            return_value=fake_use_case,
-        ) as use_case_cls:
-            await scheduler._run_scan(str(lib.id))
-
-        use_case_cls.assert_called_once()
-        kwargs = use_case_cls.call_args.kwargs
-        assert kwargs["uow_factory"] is scheduler._media_uow_factory
-        assert kwargs["file_scanner"] is scheduler._file_scanner
-        assert kwargs["variant_detector"] is scheduler._variant_detector
-        assert kwargs["event_bus"] is scheduler._event_bus
-        assert kwargs["probe_service"] is scheduler._probe_service
-
-    @pytest.mark.asyncio
-    async def test_passes_file_path_objects_to_scan_input(
-        self, scheduler: LibraryScanScheduler, library_repo: AsyncMock
-    ) -> None:
-        """Library paths must reach the use case as ``FilePath`` instances —
-        the scanner unwraps ``.value`` and crashes if given raw strings."""
-        lib = _make_library("A", "0 * * * *")
-        library_repo.find_by_id.return_value = lib
-        library_repo.save = AsyncMock()
-
-        fake_use_case = AsyncMock()
-        fake_use_case.execute.return_value = MagicMock(
-            movies_created=0,
-            movies_updated=0,
-            episodes_created=0,
-            episodes_updated=0,
-            errors=[],
-        )
-
-        with patch(
-            "src.infrastructure.scheduling.scheduler_service.ScanMediaDirectoriesUseCase",
-            return_value=fake_use_case,
-        ):
-            await scheduler._run_scan(str(lib.id))
-
-        fake_use_case.execute.assert_awaited_once()
-        scan_input = fake_use_case.execute.await_args.args[0]
-        assert all(isinstance(p, FilePath) for p in scan_input.directories)
+        scan_run_service.run_scan.assert_awaited_once()
+        run_args = scan_run_service.run_scan.await_args.args
+        assert run_args[0] == run.id
+        assert run_args[1] is lib

--- a/tests/modules/media/integration/persistence/repositories/test_scan_run_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_scan_run_repository.py
@@ -1,0 +1,113 @@
+"""Integration tests for SqlAlchemyScanRunRepository."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.infrastructure.persistence.repositories.scan_run_repository import (
+    SqlAlchemyScanRunRepository,
+)
+
+
+def _new_scan(library_id: str | None = "lib_test12345678") -> ScanRun:
+    return ScanRun.start(
+        kind=ScanRunKind.SCAN,
+        trigger=ScanRunTrigger.MANUAL,
+        library_id=library_id,
+    )
+
+
+@pytest.mark.integration
+class TestSaveAndFind:
+    async def test_save_should_assign_external_id_on_first_persist(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyScanRunRepository(db_session)
+        saved = await repo.save(_new_scan())
+
+        assert saved.id is not None
+        assert str(saved.id).startswith("run_")
+        assert saved.status == ScanRunStatus.RUNNING
+
+    async def test_save_should_update_in_place_on_terminal_transition(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SqlAlchemyScanRunRepository(db_session)
+        opened = await repo.save(_new_scan())
+
+        finalized = opened.succeed({"movies_created": 5}, ["err1"])
+        await repo.save(finalized)
+        again = await repo.find_by_id(opened.id)  # type: ignore[arg-type]
+
+        assert again is not None
+        assert again.status == ScanRunStatus.SUCCEEDED
+        assert again.summary == {"movies_created": 5}
+        assert again.errors == ["err1"]
+        assert again.finished_at is not None
+
+
+@pytest.mark.integration
+class TestListAndCount:
+    async def test_list_paginated_should_filter_by_kind(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyScanRunRepository(db_session)
+        await repo.save(_new_scan())
+        await repo.save(
+            ScanRun.start(
+                kind=ScanRunKind.ENRICH,
+                trigger=ScanRunTrigger.MANUAL,
+                library_id=None,
+            ),
+        )
+
+        scans = await repo.list_paginated(kind=ScanRunKind.SCAN)
+        enriches = await repo.list_paginated(kind=ScanRunKind.ENRICH)
+
+        assert len(scans) == 1
+        assert len(enriches) == 1
+        assert scans[0].kind == ScanRunKind.SCAN
+        assert enriches[0].kind == ScanRunKind.ENRICH
+
+    async def test_list_paginated_should_filter_by_trigger(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyScanRunRepository(db_session)
+        await repo.save(_new_scan())
+        await repo.save(
+            ScanRun.start(
+                kind=ScanRunKind.SCAN,
+                trigger=ScanRunTrigger.SCHEDULED,
+                library_id="lib_test12345678",
+            ),
+        )
+
+        manual = await repo.list_paginated(trigger=ScanRunTrigger.MANUAL)
+        scheduled = await repo.list_paginated(trigger=ScanRunTrigger.SCHEDULED)
+
+        assert len(manual) == 1
+        assert len(scheduled) == 1
+
+    async def test_count_should_respect_filters(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyScanRunRepository(db_session)
+        for _ in range(3):
+            await repo.save(_new_scan())
+
+        assert await repo.count(kind=ScanRunKind.SCAN) == 3
+        assert await repo.count(kind=ScanRunKind.ENRICH) == 0
+
+
+@pytest.mark.integration
+class TestListByStatus:
+    async def test_should_return_only_matching_status(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyScanRunRepository(db_session)
+        opened = await repo.save(_new_scan())
+        await repo.save(opened.succeed({}, []))
+        await repo.save(_new_scan())  # second row stays running
+
+        running = await repo.list_by_status(ScanRunStatus.RUNNING)
+        succeeded = await repo.list_by_status(ScanRunStatus.SUCCEEDED)
+
+        assert len(running) == 1
+        assert len(succeeded) == 1

--- a/tests/modules/media/unit/application/services/test_scan_run_service.py
+++ b/tests/modules/media/unit/application/services/test_scan_run_service.py
@@ -1,0 +1,159 @@
+"""Unit tests for ScanRunService."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.media.application.services.scan_run_service import ScanRunService
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+
+def _make_uow_factory(scan_runs_repo: AsyncMock) -> MagicMock:
+    """Build an async-context UoW factory whose ``scan_runs`` is the supplied mock."""
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.scan_runs = scan_runs_repo
+    factory = MagicMock(return_value=uow)
+    return factory
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestOpenScan:
+    async def test_should_persist_running_row_with_scan_kind(self) -> None:
+        scan_runs_repo = AsyncMock()
+        saved = ScanRun(
+            id=ScanRunId.generate(),
+            kind=ScanRunKind.SCAN,
+            trigger=ScanRunTrigger.MANUAL,
+            library_id="lib_test12345678",
+        )
+        scan_runs_repo.save.return_value = saved
+        service = ScanRunService(
+            scan_use_case=AsyncMock(),
+            bulk_enrich_use_case=AsyncMock(),
+            media_uow_factory=_make_uow_factory(scan_runs_repo),
+        )
+
+        result = await service.open_scan(
+            library_id="lib_test12345678",
+            trigger=ScanRunTrigger.MANUAL,
+        )
+
+        assert result is saved
+        scan_runs_repo.save.assert_awaited_once()
+        opened = scan_runs_repo.save.await_args.args[0]
+        assert opened.kind == ScanRunKind.SCAN
+        assert opened.trigger == ScanRunTrigger.MANUAL
+        assert opened.library_id == "lib_test12345678"
+        assert opened.status == ScanRunStatus.RUNNING
+
+
+class TestRunScan:
+    async def test_should_persist_succeeded_row_with_summary(self) -> None:
+        run_id = ScanRunId.generate()
+        existing = ScanRun(
+            id=run_id,
+            kind=ScanRunKind.SCAN,
+            trigger=ScanRunTrigger.MANUAL,
+            library_id="lib_test12345678",
+        )
+        scan_runs_repo = AsyncMock()
+        scan_runs_repo.find_by_id.return_value = existing
+
+        scan_uc = AsyncMock()
+        scan_uc.execute.return_value = MagicMock(
+            movies_created=2,
+            movies_updated=1,
+            episodes_created=0,
+            episodes_updated=0,
+            errors=["err1"],
+        )
+        library = MagicMock(id="lib_test12345678", paths=["/movies"])
+
+        service = ScanRunService(
+            scan_use_case=scan_uc,
+            bulk_enrich_use_case=AsyncMock(),
+            media_uow_factory=_make_uow_factory(scan_runs_repo),
+        )
+        await service.run_scan(run_id, library)
+
+        scan_runs_repo.save.assert_awaited_once()
+        saved = scan_runs_repo.save.await_args.args[0]
+        assert saved.status == ScanRunStatus.SUCCEEDED
+        assert saved.summary == {
+            "movies_created": 2,
+            "movies_updated": 1,
+            "episodes_created": 0,
+            "episodes_updated": 0,
+        }
+        assert saved.errors == ["err1"]
+
+    async def test_should_persist_failed_row_on_crash(self) -> None:
+        run_id = ScanRunId.generate()
+        existing = ScanRun(
+            id=run_id,
+            kind=ScanRunKind.SCAN,
+            trigger=ScanRunTrigger.MANUAL,
+            library_id="lib_test12345678",
+        )
+        scan_runs_repo = AsyncMock()
+        scan_runs_repo.find_by_id.return_value = existing
+
+        scan_uc = AsyncMock()
+        scan_uc.execute.side_effect = RuntimeError("ffmpeg exploded")
+        library = MagicMock(id="lib_test12345678", paths=["/movies"])
+
+        service = ScanRunService(
+            scan_use_case=scan_uc,
+            bulk_enrich_use_case=AsyncMock(),
+            media_uow_factory=_make_uow_factory(scan_runs_repo),
+        )
+        await service.run_scan(run_id, library)
+
+        saved = scan_runs_repo.save.await_args.args[0]
+        assert saved.status == ScanRunStatus.FAILED
+        assert "ffmpeg exploded" in saved.errors[0]
+
+
+class TestRunBulkEnrich:
+    async def test_should_persist_succeeded_row_with_enrich_summary(self) -> None:
+        run_id = ScanRunId.generate()
+        existing = ScanRun(
+            id=run_id,
+            kind=ScanRunKind.ENRICH,
+            trigger=ScanRunTrigger.MANUAL,
+        )
+        scan_runs_repo = AsyncMock()
+        scan_runs_repo.find_by_id.return_value = existing
+
+        enrich_uc = AsyncMock()
+        enrich_uc.execute.return_value = MagicMock(
+            movies_enriched=4,
+            series_enriched=2,
+            skipped=1,
+            errors=[],
+        )
+
+        service = ScanRunService(
+            scan_use_case=AsyncMock(),
+            bulk_enrich_use_case=enrich_uc,
+            media_uow_factory=_make_uow_factory(scan_runs_repo),
+        )
+        await service.run_bulk_enrich(run_id, force=False)
+
+        saved = scan_runs_repo.save.await_args.args[0]
+        assert saved.status == ScanRunStatus.SUCCEEDED
+        assert saved.summary == {
+            "movies_enriched": 4,
+            "series_enriched": 2,
+            "skipped": 1,
+        }

--- a/tests/modules/media/unit/application/use_cases/test_list_scan_runs.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_scan_runs.py
@@ -1,0 +1,81 @@
+"""Unit tests for ListScanRunsUseCase and GetScanRunUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.scan_run_dtos import (
+    GetScanRunInput,
+    ListScanRunsInput,
+)
+from src.modules.media.application.use_cases.get_scan_run import GetScanRunUseCase
+from src.modules.media.application.use_cases.list_scan_runs import ListScanRunsUseCase
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+
+def _build_uow_factory(scan_runs_repo: AsyncMock) -> MagicMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.scan_runs = scan_runs_repo
+    return MagicMock(return_value=uow)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestListScanRunsUseCase:
+    async def test_should_project_runs_to_output_dtos(self) -> None:
+        repo = AsyncMock()
+        repo.list_paginated.return_value = [
+            ScanRun(
+                id=ScanRunId.generate(),
+                kind=ScanRunKind.SCAN,
+                trigger=ScanRunTrigger.MANUAL,
+                library_id="lib_test12345678",
+            ),
+        ]
+
+        result = await ListScanRunsUseCase(
+            media_uow_factory=_build_uow_factory(repo),
+        ).execute(ListScanRunsInput(kind="scan"))
+
+        assert len(result) == 1
+        assert result[0].kind == "scan"
+        assert result[0].status == "running"
+        repo.list_paginated.assert_awaited_once()
+        kwargs = repo.list_paginated.await_args.kwargs
+        assert kwargs["kind"] == ScanRunKind.SCAN
+
+
+class TestGetScanRunUseCase:
+    async def test_should_return_run_when_found(self) -> None:
+        run_id = ScanRunId.generate()
+        repo = AsyncMock()
+        repo.find_by_id.return_value = ScanRun(
+            id=run_id,
+            kind=ScanRunKind.ENRICH,
+            trigger=ScanRunTrigger.MANUAL,
+        )
+
+        result = await GetScanRunUseCase(
+            media_uow_factory=_build_uow_factory(repo),
+        ).execute(GetScanRunInput(run_id=str(run_id)))
+
+        assert result.id == str(run_id)
+        assert result.kind == "enrich"
+
+    async def test_should_raise_when_not_found(self) -> None:
+        repo = AsyncMock()
+        repo.find_by_id.return_value = None
+
+        with pytest.raises(ResourceNotFoundException):
+            await GetScanRunUseCase(
+                media_uow_factory=_build_uow_factory(repo),
+            ).execute(GetScanRunInput(run_id=str(ScanRunId.generate())))

--- a/tests/modules/media/unit/application/use_cases/test_sweep_interrupted_scan_runs.py
+++ b/tests/modules/media/unit/application/use_cases/test_sweep_interrupted_scan_runs.py
@@ -1,0 +1,68 @@
+"""Unit tests for SweepInterruptedScanRunsUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.media.application.use_cases.sweep_interrupted_scan_runs import (
+    SweepInterruptedScanRunsUseCase,
+)
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+
+def _build_uow_factory(scan_runs_repo: AsyncMock) -> MagicMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.scan_runs = scan_runs_repo
+    return MagicMock(return_value=uow)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestSweepInterruptedScanRunsUseCase:
+    async def test_should_transition_every_running_row_to_interrupted(self) -> None:
+        repo = AsyncMock()
+        repo.list_by_status.return_value = [
+            ScanRun(
+                id=ScanRunId.generate(),
+                kind=ScanRunKind.SCAN,
+                trigger=ScanRunTrigger.MANUAL,
+                library_id="lib_test12345678",
+            ),
+            ScanRun(
+                id=ScanRunId.generate(),
+                kind=ScanRunKind.ENRICH,
+                trigger=ScanRunTrigger.SCHEDULED,
+                library_id=None,
+            ),
+        ]
+
+        count = await SweepInterruptedScanRunsUseCase(
+            media_uow_factory=_build_uow_factory(repo),
+        ).execute()
+
+        assert count == 2
+        assert repo.save.await_count == 2
+        for call in repo.save.await_args_list:
+            saved = call.args[0]
+            assert saved.status == ScanRunStatus.INTERRUPTED
+            assert saved.finished_at is not None
+
+    async def test_should_be_noop_when_no_running_rows(self) -> None:
+        repo = AsyncMock()
+        repo.list_by_status.return_value = []
+
+        count = await SweepInterruptedScanRunsUseCase(
+            media_uow_factory=_build_uow_factory(repo),
+        ).execute()
+
+        assert count == 0
+        repo.save.assert_not_awaited()

--- a/tests/modules/media/unit/application/use_cases/test_trigger_scan.py
+++ b/tests/modules/media/unit/application/use_cases/test_trigger_scan.py
@@ -1,0 +1,80 @@
+"""Unit tests for TriggerScanUseCase."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.media.application.dtos.scan_run_dtos import TriggerScanInput
+from src.modules.media.application.use_cases.trigger_scan import (
+    LibraryNotFoundForScanError,
+    TriggerScanUseCase,
+)
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+
+def _build_library_uow_factory(library_repo: AsyncMock) -> MagicMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.libraries = library_repo
+    return MagicMock(return_value=uow)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestTriggerScanUseCase:
+    async def test_should_open_running_row_and_spawn_background_task(self) -> None:
+        library = MagicMock(id="lib_test12345678", paths=["/movies"])
+        library_repo = AsyncMock()
+        library_repo.find_by_id.return_value = library
+
+        service = AsyncMock()
+        opened = ScanRun(
+            id=ScanRunId.generate(),
+            kind=ScanRunKind.SCAN,
+            trigger=ScanRunTrigger.MANUAL,
+            library_id="lib_test12345678",
+        )
+        service.open_scan.return_value = opened
+        # Force the background task to complete quickly without doing anything.
+        service.run_scan = AsyncMock(return_value=None)
+
+        use_case = TriggerScanUseCase(
+            scan_run_service=service,
+            library_uow_factory=_build_library_uow_factory(library_repo),
+        )
+
+        result = await use_case.execute(
+            TriggerScanInput(library_id="lib_test12345678", trigger="manual"),
+        )
+
+        assert result.id == str(opened.id)
+        assert result.status == "running"
+        service.open_scan.assert_awaited_once()
+        # Background task is fire-and-forget; let the loop run it.
+        await asyncio.sleep(0)
+        service.run_scan.assert_awaited_once()
+
+    async def test_should_raise_when_library_not_found(self) -> None:
+        library_repo = AsyncMock()
+        library_repo.find_by_id.return_value = None
+
+        service = AsyncMock()
+        use_case = TriggerScanUseCase(
+            scan_run_service=service,
+            library_uow_factory=_build_library_uow_factory(library_repo),
+        )
+
+        with pytest.raises(LibraryNotFoundForScanError):
+            await use_case.execute(
+                TriggerScanInput(library_id=str(LibraryId.generate()), trigger="manual"),
+            )
+        service.open_scan.assert_not_awaited()


### PR DESCRIPTION
## Summary

- New ``scan_runs`` table backs every catalog scan and bulk metadata enrich. Discriminated by ``kind`` (``scan``/``enrich``) and ``trigger`` (``manual``/``scheduled``); per-kind counters live in a JSON ``summary`` so the same row schema covers both worlds.
- Trigger endpoints are now fire-and-forget: ``POST /api/v1/admin/scans`` and ``POST /api/v1/admin/enrichments`` return 202 + the new run id immediately; the work runs in an asyncio background task that writes the terminal state on its own. The admin Scan / Enrich pages will poll ``GET /api/v1/admin/scans/{id}`` instead of hanging the request for 30+ seconds.
- ``ScanRunService`` is the single orchestrator both the HTTP path and the periodic scheduler call. The scheduler now writes rows tagged ``trigger='scheduled'`` so the operator sees background activity in the same history view.
- Lifespan startup runs ``SweepInterruptedScanRunsUseCase`` so any ``running`` row left behind by a crash transitions to ``interrupted`` instead of looking perpetually active.

## Test plan

- [x] ``poetry run pytest`` — 2426 passed
- [x] ``poetry run ruff check src tests`` + ``ruff format --check`` — clean
- [x] ``poetry run alembic upgrade head`` runs cleanly on the dev DB
- [x] Boot sanity (``create_app()``) — 104 routes including the four new admin scan/enrich endpoints
- [ ] Manual (after frontend lands): trigger a scan + bulk enrich, watch the history page populate, kill the process mid-run and confirm the next boot marks the row ``interrupted``

## Summary by Sourcery

Introduce a unified scan run tracking system for media scans and bulk metadata enrichments, with async admin triggers and startup recovery for interrupted runs.

New Features:
- Add ScanRun aggregate, repository, and SQL schema to record scan and bulk-enrich executions with per-run summaries and statuses.
- Expose new admin REST endpoints to trigger scans and bulk enriches asynchronously and to list and inspect historical scan runs.
- Provide a ScanRunService and use cases to orchestrate scan and enrich runs, including background execution and DTO projections for the admin UI.

Enhancements:
- Refactor LibraryScanScheduler to delegate scan execution to ScanRunService and record scheduled runs in the shared scan_runs history.
- Wire new scan run services and use cases into the dependency injection containers and application lifespan to sweep interrupted runs on startup.

Build:
- Add a database migration to create the scan_runs table with appropriate indices for querying by kind, trigger, library, status, and external id.

Tests:
- Add unit tests for ScanRunService, scan run listing, retrieval, triggering, and sweeping, plus integration tests for the SQLAlchemy scan run repository.