### PR TITLE
feat(media): admin overview stats aggregator

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -130,6 +130,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         profile_library_access=_profile_library_access_adapter,
         catalog_request_lookup=catalog_requests.catalog_request_lookup,
         library_uow_factory=_library_uow_factory_for_media,
+        identity_uow_factory=_identity_uow_factory_for_profile_library_access,
         tmdb_api_key=config.provided.tmdb_api_key,
         hls_cache_directory=config.provided.hls_cache_directory,
         hls_cache_max_size_mb=config.provided.hls_cache_max_size_mb,

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -40,6 +40,9 @@ from src.modules.media.application.use_cases.get_movie_by_id import GetMovieById
 from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
     GetMovieTmdbSuggestionsUseCase,
 )
+from src.modules.media.application.use_cases.get_overview_stats import (
+    GetOverviewStatsUseCase,
+)
 from src.modules.media.application.use_cases.get_person_bio import GetPersonBioUseCase
 from src.modules.media.application.use_cases.get_related_movies import GetRelatedMoviesUseCase
 from src.modules.media.application.use_cases.get_related_series import GetRelatedSeriesUseCase
@@ -139,6 +142,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # needs to look up the requested library before opening the
     # ``scan_runs`` row. Keeps the cross-BC dependency explicit.
     library_uow_factory = providers.Dependency()
+
+    # Wired at the composition root — the OverviewStats aggregator
+    # reads the users count from identity. Same pattern as
+    # ``library_uow_factory`` above: a read-only cross-BC count
+    # for admin dashboard aggregation, not domain coupling.
+    identity_uow_factory = providers.Dependency()
 
     # Must be wired from parent container (Settings.hls_cache_directory / hls_cache_max_size_mb)
     hls_cache_directory = providers.Dependency(default="./hls_cache")
@@ -494,12 +503,29 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     )
 
     # =========================================================================
+    # Use Cases — Admin Overview aggregator
+    # =========================================================================
+
+    # Declared here so it can reach ``list_movies_needing_review``
+    # below — order in the container is purely for readability.
+    # The actual provider is appended after the review use case
+    # so its reference resolves cleanly.
+
+    # =========================================================================
     # Use Cases — Admin Relink
     # =========================================================================
 
     list_movies_needing_review = providers.Factory(
         ListMoviesNeedingReviewUseCase,
         uow_factory=media_unit_of_work_factory,
+    )
+
+    get_overview_stats = providers.Factory(
+        GetOverviewStatsUseCase,
+        media_uow_factory=media_unit_of_work_factory,
+        identity_uow_factory=identity_uow_factory,
+        list_movies_needing_review=list_movies_needing_review,
+        hls_playlist=hls_service,
     )
 
     get_movie_tmdb_suggestions = providers.Factory(

--- a/src/main.py
+++ b/src/main.py
@@ -32,6 +32,7 @@ from src.modules.library.presentation.routes.library_routes import (
     router as library_router,
 )
 from src.modules.media.presentation.routes import (
+    admin_overview_router,
     admin_relink_router,
     admin_scan_router,
     admin_system_router,
@@ -56,6 +57,7 @@ from src.modules.watch_progress.presentation.routes import progress_router
 #: tests can build a container with the same wiring without copying the
 #: list (drift between the two would mean tests miss DI-resolved deps).
 WIRED_ROUTE_MODULES: tuple[str, ...] = (
+    "src.modules.media.presentation.routes.admin_overview_routes",
     "src.modules.media.presentation.routes.admin_relink_routes",
     "src.modules.media.presentation.routes.admin_scan_routes",
     "src.modules.media.presentation.routes.admin_system_routes",
@@ -296,6 +298,7 @@ def create_app() -> FastAPI:
 
     # Register routes
     register_health_routes(app)
+    app.include_router(admin_overview_router)
     app.include_router(admin_relink_router)
     app.include_router(admin_scan_router)
     app.include_router(admin_system_router)

--- a/src/modules/media/application/dtos/overview_stats_dtos.py
+++ b/src/modules/media/application/dtos/overview_stats_dtos.py
@@ -1,0 +1,59 @@
+"""DTOs for the admin Overview dashboard stats."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LastScanSnapshot:
+    """The most recent scan run, for the "Last scan" card.
+
+    Distinct from the full scan-runs list — the Overview only
+    needs the headline (when it ran + how it ended), not the full
+    error list.
+    """
+
+    id: str
+    started_at: str
+    finished_at: str | None
+    status: str
+
+
+@dataclass(frozen=True)
+class HlsCacheSnapshot:
+    """Slim HLS cache view for the Overview occupancy card.
+
+    Drops ``last_cleared_at`` versus the dedicated System page —
+    the Overview just shows the ratio.
+    """
+
+    size_bytes: int
+    max_bytes: int
+
+
+@dataclass(frozen=True)
+class OverviewStatsOutput:
+    """Aggregated counts + snapshots backing the admin Overview cards.
+
+    Built by a single use case + single endpoint so all five
+    placeholder cards on the dashboard light up together rather
+    than each one flickering through its own loading state.
+
+    Attributes:
+        movies_count: Total non-deleted movies in the catalog.
+        series_count: Total non-deleted series in the catalog.
+        users_count: Total non-deleted users (admin + member).
+        review_count: Length of the needs-enrichment-review queue.
+        last_scan: Headline of the most recent scan run, or
+            ``None`` when no scan has ever completed.
+        hls_cache: Cache size vs configured limit.
+    """
+
+    movies_count: int
+    series_count: int
+    users_count: int
+    review_count: int
+    last_scan: LastScanSnapshot | None
+    hls_cache: HlsCacheSnapshot
+
+
+__all__ = ["HlsCacheSnapshot", "LastScanSnapshot", "OverviewStatsOutput"]

--- a/src/modules/media/application/use_cases/get_overview_stats.py
+++ b/src/modules/media/application/use_cases/get_overview_stats.py
@@ -1,0 +1,84 @@
+"""GetOverviewStatsUseCase — single aggregator for the admin dashboard."""
+
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.media.application.dtos.overview_stats_dtos import (
+    HlsCacheSnapshot,
+    LastScanSnapshot,
+    OverviewStatsOutput,
+)
+from src.modules.media.application.ports import HlsPlaylistPort
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases.list_movies_needing_review import (
+    ListMoviesNeedingReviewUseCase,
+)
+from src.modules.media.domain.entities.scan_run import ScanRunKind
+
+
+class GetOverviewStatsUseCase:
+    """Aggregate every stat card on the admin Overview into one shot.
+
+    The dashboard renders five "headline" cards (movies count,
+    series count, users count, review queue length, last scan)
+    plus an HLS occupancy card. Hitting one endpoint instead of
+    five keeps the cards in lockstep — no flicker as individual
+    queries resolve — and saves a few request round-trips.
+
+    All reads are non-deleted-only. Cross-BC reads (the users
+    count) go through the identity UoW factory injected at the
+    composition root, same pattern the trigger-scan use case
+    uses to look up a library.
+    """
+
+    def __init__(
+        self,
+        media_uow_factory: MediaUnitOfWorkFactory,
+        identity_uow_factory: IdentityUnitOfWorkFactory,
+        list_movies_needing_review: ListMoviesNeedingReviewUseCase,
+        hls_playlist: HlsPlaylistPort,
+    ) -> None:
+        self._media_uow_factory = media_uow_factory
+        self._identity_uow_factory = identity_uow_factory
+        self._list_review = list_movies_needing_review
+        self._hls = hls_playlist
+
+    async def execute(self) -> OverviewStatsOutput:
+        """Read every card's underlying datum and pack the response."""
+        async with self._media_uow_factory() as media_uow:
+            movies_count = await media_uow.movies.count()
+            series_count = await media_uow.series.count()
+            recent_scans = await media_uow.scan_runs.list_paginated(
+                kind=ScanRunKind.SCAN,
+                limit=1,
+            )
+
+        async with self._identity_uow_factory() as identity_uow:
+            users_count = await identity_uow.users.count()
+
+        review = await self._list_review.execute()
+        review_count = len(review.movies)
+        cache_stats = self._hls.get_cache_stats()
+
+        last_scan = None
+        if recent_scans:
+            run = recent_scans[0]
+            last_scan = LastScanSnapshot(
+                id=str(run.id),
+                started_at=run.started_at.isoformat(),
+                finished_at=run.finished_at.isoformat() if run.finished_at else None,
+                status=run.status.value,
+            )
+
+        return OverviewStatsOutput(
+            movies_count=movies_count,
+            series_count=series_count,
+            users_count=users_count,
+            review_count=review_count,
+            last_scan=last_scan,
+            hls_cache=HlsCacheSnapshot(
+                size_bytes=cache_stats.size_bytes,
+                max_bytes=cache_stats.max_bytes,
+            ),
+        )
+
+
+__all__ = ["GetOverviewStatsUseCase"]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -505,5 +505,15 @@ class MovieRepository(ABC):
         """
         ...
 
+    @abstractmethod
+    async def count(self) -> int:
+        """Return the total number of non-deleted movies.
+
+        Drives the admin Overview stat card. Distinct from
+        :meth:`count_under_paths` (per-library) — this is the
+        catalog-wide tally.
+        """
+        ...
+
 
 __all__ = ["GenreRow", "MovieRepository"]

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -499,5 +499,13 @@ class SeriesRepository(ABC):
         """
         ...
 
+    @abstractmethod
+    async def count(self) -> int:
+        """Return the total number of non-deleted series.
+
+        Drives the admin Overview stat card.
+        """
+        ...
+
 
 __all__ = ["SeriesRepository"]

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -647,6 +647,12 @@ class SQLAlchemyMovieRepository(MovieRepository):
         result = await self._session.execute(stmt)
         return int(result.scalar_one())
 
+    async def count(self) -> int:
+        """Return the total number of non-deleted movies."""
+        stmt = select(func.count()).select_from(MovieModel).where(MovieModel.deleted_at.is_(None))
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
     async def search(
         self,
         query: str,

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -716,6 +716,12 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         result = await self._session.execute(stmt)
         return int(result.scalar_one())
 
+    async def count(self) -> int:
+        """Return the total number of non-deleted series."""
+        stmt = select(func.count()).select_from(SeriesModel).where(SeriesModel.deleted_at.is_(None))
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
     def _ensure_ids(self, series: Series) -> Series:
         """Ensure all entities have IDs, generating them if needed.
 

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -1,5 +1,8 @@
 """Media API routes."""
 
+from src.modules.media.presentation.routes.admin_overview_routes import (
+    router as admin_overview_router,
+)
 from src.modules.media.presentation.routes.admin_relink_routes import (
     router as admin_relink_router,
 )
@@ -21,6 +24,7 @@ from src.modules.media.presentation.routes.series_routes import router as series
 from src.modules.media.presentation.routes.stream_routes import router as stream_router
 
 __all__ = [
+    "admin_overview_router",
     "admin_relink_router",
     "admin_scan_router",
     "admin_system_router",

--- a/src/modules/media/presentation/routes/admin_overview_routes.py
+++ b/src/modules/media/presentation/routes/admin_overview_routes.py
@@ -1,0 +1,39 @@
+"""Admin REST API routes for the Overview dashboard."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.presentation import api_single
+from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.media.application.use_cases.get_overview_stats import (
+    GetOverviewStatsUseCase,
+)
+
+router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Overview"])
+
+
+@router.get("/overview/stats")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_admin_overview_stats(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: GetOverviewStatsUseCase = Depends(
+        Provide[ApplicationContainer.media.get_overview_stats],
+    ),
+) -> dict[str, Any]:
+    """Aggregate every Overview stat card into a single response.
+
+    The dashboard's headline cards (movies / series / users /
+    review queue / last scan) plus the HLS occupancy strip all
+    come from this one call so the page settles in a single
+    loading transition.
+    """
+    stats = await use_case.execute()
+    return api_single("overview_stats", asdict(stats))
+
+
+__all__ = ["router"]

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -1108,6 +1108,33 @@ class TestCountUnderPaths:
 
 
 @pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryCount:
+    """Integration tests for the catalog-wide ``count`` method."""
+
+    async def test_should_return_zero_for_empty_catalog(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        assert await repo.count() == 0
+
+    async def test_should_count_every_non_deleted_movie(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/a.mkv"))
+        await repo.save(_create_movie(title="B", file_path="/b.mkv"))
+        await repo.save(_create_movie(title="C", file_path="/c.mkv"))
+
+        assert await repo.count() == 3
+
+    async def test_should_exclude_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        a = _create_movie(title="A", file_path="/a.mkv")
+        b = _create_movie(title="B", file_path="/b.mkv")
+        await repo.save(a)
+        await repo.save(b)
+        await repo.delete(_id_of(b))
+
+        assert await repo.count() == 1
+
+
+@pytest.mark.integration
 class TestSQLAlchemyMovieRepositoryLibraryIsolation:
     """Cross-library isolation at the persistence layer.
 

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -1170,6 +1170,30 @@ def _series_with_intro(
 
 
 @pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryCount:
+    """Integration tests for the catalog-wide ``count`` method."""
+
+    async def test_should_return_zero_for_empty_catalog(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        assert await repo.count() == 0
+
+    async def test_should_count_every_non_deleted_series(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await _seed_series(repo, 3)
+
+        assert await repo.count() == 3
+
+    async def test_should_exclude_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        keep, doomed = await _seed_series(repo, 2)
+        await repo.delete(_id_of(doomed))
+
+        assert await repo.count() == 1
+        # Sanity-check the surviving row is the one we kept.
+        assert (await repo.find_by_id(_id_of(keep))) is not None
+
+
+@pytest.mark.integration
 class TestSeriesRepositoryIntroPersistence:
     """Tests covering IntroMarker and Season detection-state persistence."""
 

--- a/tests/modules/media/unit/application/use_cases/test_get_overview_stats.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_overview_stats.py
@@ -1,0 +1,114 @@
+"""Unit tests for GetOverviewStatsUseCase."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.media.application.ports.hls_playlist_port import HlsCacheStats
+from src.modules.media.application.use_cases.get_overview_stats import (
+    GetOverviewStatsUseCase,
+)
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
+
+
+def _media_uow_factory(
+    *,
+    movies_count: int,
+    series_count: int,
+    last_scan: ScanRun | None,
+) -> MagicMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.movies = AsyncMock()
+    uow.movies.count.return_value = movies_count
+    uow.series = AsyncMock()
+    uow.series.count.return_value = series_count
+    uow.scan_runs = AsyncMock()
+    uow.scan_runs.list_paginated.return_value = [last_scan] if last_scan else []
+    return MagicMock(return_value=uow)
+
+
+def _identity_uow_factory(users_count: int) -> MagicMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.users = AsyncMock()
+    uow.users.count.return_value = users_count
+    return MagicMock(return_value=uow)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetOverviewStatsUseCase:
+    async def test_should_aggregate_every_card_into_one_response(self) -> None:
+        last_scan = ScanRun(
+            id=ScanRunId.generate(),
+            kind=ScanRunKind.SCAN,
+            trigger=ScanRunTrigger.MANUAL,
+            library_id="lib_test12345678",
+            started_at=datetime(2026, 5, 18, 10, 0, tzinfo=UTC),
+            finished_at=datetime(2026, 5, 18, 10, 5, tzinfo=UTC),
+            status=ScanRunStatus.SUCCEEDED,
+        )
+        review_uc = AsyncMock()
+        review_uc.execute.return_value = MagicMock(movies=[1, 2, 3])  # 3-row list
+        hls = MagicMock()
+        hls.get_cache_stats.return_value = HlsCacheStats(
+            size_bytes=100,
+            max_bytes=1000,
+            last_cleared_at=None,
+        )
+
+        result = await GetOverviewStatsUseCase(
+            media_uow_factory=_media_uow_factory(
+                movies_count=42,
+                series_count=7,
+                last_scan=last_scan,
+            ),
+            identity_uow_factory=_identity_uow_factory(users_count=4),
+            list_movies_needing_review=review_uc,
+            hls_playlist=hls,
+        ).execute()
+
+        assert result.movies_count == 42
+        assert result.series_count == 7
+        assert result.users_count == 4
+        assert result.review_count == 3
+        assert result.last_scan is not None
+        assert result.last_scan.status == "succeeded"
+        assert result.last_scan.id == str(last_scan.id)
+        assert result.hls_cache.size_bytes == 100
+        assert result.hls_cache.max_bytes == 1000
+
+    async def test_should_return_null_last_scan_when_no_scans_recorded(self) -> None:
+        review_uc = AsyncMock()
+        review_uc.execute.return_value = MagicMock(movies=[])
+        hls = MagicMock()
+        hls.get_cache_stats.return_value = HlsCacheStats(
+            size_bytes=0,
+            max_bytes=1000,
+            last_cleared_at=None,
+        )
+
+        result = await GetOverviewStatsUseCase(
+            media_uow_factory=_media_uow_factory(
+                movies_count=0,
+                series_count=0,
+                last_scan=None,
+            ),
+            identity_uow_factory=_identity_uow_factory(users_count=1),
+            list_movies_needing_review=review_uc,
+            hls_playlist=hls,
+        ).execute()
+
+        assert result.last_scan is None
+        assert result.review_count == 0


### PR DESCRIPTION
## Summary

- New ``GET /api/v1/admin/overview/stats`` returns every headline card on the admin dashboard in a single envelope: ``movies_count``, ``series_count``, ``users_count``, ``review_count``, ``last_scan`` snapshot, ``hls_cache`` size+limit. Replaces five separate calls so the page settles in one loading transition.
- Adds ``MovieRepository.count()`` + ``SeriesRepository.count()`` (catalog-wide totals; distinct from the existing per-library ``count_under_paths``).
- ``GetOverviewStatsUseCase`` lives in the media BC and reads the users count via the ``IdentityUnitOfWorkFactory`` injected at the composition root — same pattern ``trigger_scan`` already uses for library lookups. Read-only cross-BC aggregation only; no domain coupling.

## Test plan

- [x] ``poetry run pytest`` — 2434 passed
- [x] ``poetry run ruff check src tests`` + ``ruff format --check`` — clean
- [x] Boot sanity (``create_app()``) — 105 routes including the new ``GET /api/v1/admin/overview/stats``
- [ ] Manual (after frontend lands): hit ``/admin`` as an admin and see every card populate together

## Summary by Sourcery

Add an aggregated admin overview stats endpoint that powers all dashboard headline cards in a single call.

New Features:
- Introduce catalog-wide count operations on movie and series repositories for admin statistics.
- Expose a new authenticated GET /api/v1/admin/overview/stats API that returns movies, series, users, review queue, last scan, and HLS cache stats in one payload.
- Add DTOs and a GetOverviewStats use case to aggregate media and identity data for the admin overview dashboard.

Enhancements:
- Extend dependency injection wiring to provide identity and media unit-of-work factories to the media bounded context for read-only cross-context aggregation.
- Register the new admin overview routes in the FastAPI application startup wiring.

Tests:
- Add integration tests for catalog-wide movie and series count repository methods.
- Add unit tests for the GetOverviewStats use case covering aggregation behavior and empty-scan scenarios.