### PR TITLE
feat(infra): real readiness probes for /health/ready

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -17,6 +17,7 @@ from src.config.containers.media import MediaContainer
 from src.config.containers.preferences import PreferencesContainer
 from src.config.containers.watch_progress import WatchProgressContainer
 from src.config.settings import Settings
+from src.infrastructure.health import DatabaseProbe, FilesystemProbe
 from src.infrastructure.scheduling import (
     IntroDetectionJob,
     LibraryScanScheduler,
@@ -111,6 +112,20 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     _library_uow_factory_for_media = providers.Singleton(
         SqlAlchemyLibraryUnitOfWorkFactory,
         session_factory=infrastructure.session_factory,
+    )
+
+    # Real readiness probes that back ``GET /health/ready`` — see
+    # ``src/infrastructure/health/probes.py``. Singletons because
+    # the probes are stateless and the underlying deps
+    # (session_factory, library UoW) are already shared singletons.
+    database_probe = providers.Singleton(
+        DatabaseProbe,
+        session_factory=infrastructure.session_factory,
+    )
+
+    filesystem_probe = providers.Singleton(
+        FilesystemProbe,
+        library_uow_factory=_library_uow_factory_for_media,
     )
 
     # Catalog Requests is built before Media so its ACL adapter can be

--- a/src/infrastructure/health/__init__.py
+++ b/src/infrastructure/health/__init__.py
@@ -1,0 +1,10 @@
+"""Real readiness probes for ``GET /health/ready``."""
+
+from src.infrastructure.health.probes import (
+    DatabaseProbe,
+    FilesystemProbe,
+    ProbeResult,
+    ProbeStatus,
+)
+
+__all__ = ["DatabaseProbe", "FilesystemProbe", "ProbeResult", "ProbeStatus"]

--- a/src/infrastructure/health/probes.py
+++ b/src/infrastructure/health/probes.py
@@ -1,0 +1,164 @@
+"""Readiness probes that back ``GET /health/ready``.
+
+The route used to return hardcoded ``healthy`` strings — a stale
+placeholder from when the admin panel still needed *something* to
+render against. This module replaces them with real checks:
+
+- :class:`DatabaseProbe` runs ``SELECT 1`` so an unreachable DB
+  surfaces as ``unhealthy`` rather than a silent green dot.
+- :class:`FilesystemProbe` walks every library's configured paths
+  and asserts each one exists + is a directory — a typical "mount
+  dropped" or "drive unplugged" outage shows up here.
+
+Each probe is a small async callable returning a frozen
+:class:`ProbeResult` so the route can mix-and-match probes without
+each one knowing about the response envelope.
+"""
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
+
+_logger = logging.getLogger(__name__)
+
+
+class ProbeStatus(str, Enum):
+    """Three-state outcome of a single probe."""
+
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    DEGRADED = "degraded"
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Outcome of a single probe run.
+
+    Attributes:
+        name: Short key the route surfaces in ``checks``
+            (e.g. ``"database"``, ``"filesystem"``).
+        status: Three-state outcome — ``healthy``,
+            ``unhealthy``, ``degraded``.
+        message: Operator-facing hint when something is wrong
+            (e.g. ``"path /mnt/movies missing"``). ``None`` for
+            healthy probes.
+    """
+
+    name: str
+    status: ProbeStatus
+    message: str | None = None
+
+
+class DatabaseProbe:
+    """Probe that issues ``SELECT 1`` against the configured session.
+
+    Wraps any error from the driver as ``unhealthy`` with the
+    exception message captured. Connection-pool timeouts, missing
+    tables and revoked credentials all manifest here.
+    """
+
+    name = "database"
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def execute(self) -> ProbeResult:
+        """Return the probe result; never raises."""
+        try:
+            async with self._session_factory() as session:
+                await session.execute(text("SELECT 1"))
+        except Exception as exc:  # probes must not bubble up
+            _logger.warning("Database probe failed: %s", exc)
+            return ProbeResult(
+                name=self.name,
+                status=ProbeStatus.UNHEALTHY,
+                message=f"{type(exc).__name__}: {exc}",
+            )
+        return ProbeResult(name=self.name, status=ProbeStatus.HEALTHY)
+
+
+class FilesystemProbe:
+    """Probe that walks every library's configured paths.
+
+    ``healthy``: every path on every library resolves to an
+    existing directory.
+    ``degraded``: at least one library is fully fine but at least
+    one other library has a missing / inaccessible path. Catalog
+    keeps working for the OK libraries; the broken one will fail
+    on next scan.
+    ``unhealthy``: every library has at least one bad path, or
+    listing libraries itself raises (DB layer broken).
+    """
+
+    name = "filesystem"
+
+    def __init__(self, library_uow_factory: LibraryUnitOfWorkFactory) -> None:
+        self._library_uow_factory = library_uow_factory
+
+    async def execute(self) -> ProbeResult:
+        """Return the probe result; never raises."""
+        try:
+            async with self._library_uow_factory() as uow:
+                libraries = await uow.libraries.find_all()
+        except Exception as exc:  # probes must not bubble up
+            _logger.warning("Filesystem probe failed listing libraries: %s", exc)
+            return ProbeResult(
+                name=self.name,
+                status=ProbeStatus.UNHEALTHY,
+                message=f"{type(exc).__name__}: {exc}",
+            )
+
+        if not libraries:
+            # No libraries configured yet — nothing to probe, but
+            # that's a fresh install, not a fault. Report healthy
+            # so the operator's admin Health page doesn't light up
+            # red before they've finished setup.
+            return ProbeResult(name=self.name, status=ProbeStatus.HEALTHY)
+
+        broken: list[str] = []
+        ok_libraries = 0
+        for library in libraries:
+            paths = list(library.paths)
+            if not paths:
+                broken.append(f"{library.name}: no paths configured")
+                continue
+            missing = [p for p in paths if not _path_is_readable_dir(p.value)]
+            if missing:
+                broken.append(
+                    f"{library.name}: missing {', '.join(p.value for p in missing)}",
+                )
+            else:
+                ok_libraries += 1
+
+        if not broken:
+            return ProbeResult(name=self.name, status=ProbeStatus.HEALTHY)
+
+        # At least one library is fine — degraded; otherwise hard
+        # unhealthy.
+        status = ProbeStatus.DEGRADED if ok_libraries > 0 else ProbeStatus.UNHEALTHY
+        return ProbeResult(
+            name=self.name,
+            status=status,
+            message="; ".join(broken),
+        )
+
+
+def _path_is_readable_dir(path: str) -> bool:
+    """Return ``True`` iff ``path`` resolves to an existing directory.
+
+    Catches every ``OSError`` (permission denied, broken symlink,
+    network mount timeout) so the probe stays deterministic.
+    """
+    try:
+        return Path(path).is_dir()
+    except OSError:
+        return False
+
+
+__all__ = ["DatabaseProbe", "FilesystemProbe", "ProbeResult", "ProbeStatus"]

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from src.building_blocks.presentation import RequestContextMiddleware
@@ -348,20 +348,48 @@ def register_health_routes(app: FastAPI) -> None:
         }
 
     @app.get("/health/ready", tags=["Health"])  # type: ignore[misc]
-    async def readiness_check() -> dict[str, Any]:
-        """Readiness check - verifies all dependencies are available."""
-        checks = {
-            "database": "healthy",  # TODO: Actually check database
-            "filesystem": "healthy",  # TODO: Check media directories
-        }
+    async def readiness_check(request: Request) -> dict[str, Any]:
+        """Readiness check covering every probe + a top-level rollup.
 
-        all_healthy = all(status == "healthy" for status in checks.values())
+        Top-level ``status``:
 
-        return {
-            "status": "ready" if all_healthy else "not_ready",
+        - ``ready`` — every probe healthy.
+        - ``degraded`` — at least one probe is partially OK
+          (e.g. one library mount missing while others are fine).
+        - ``not_ready`` — at least one probe is fully unhealthy.
+
+        ``messages`` is only emitted for probes that are not
+        healthy, so the bare healthy payload stays terse.
+        """
+        from src.infrastructure.health import ProbeResult, ProbeStatus
+
+        container: ApplicationContainer = request.app.state.container
+        database_probe = await container.database_probe()
+        filesystem_probe = await container.filesystem_probe()
+
+        results: list[ProbeResult] = [
+            await database_probe.execute(),
+            await filesystem_probe.execute(),
+        ]
+
+        checks = {r.name: r.status.value for r in results}
+        messages = {r.name: r.message for r in results if r.message}
+
+        if any(r.status == ProbeStatus.UNHEALTHY for r in results):
+            rollup = "not_ready"
+        elif any(r.status == ProbeStatus.DEGRADED for r in results):
+            rollup = "degraded"
+        else:
+            rollup = "ready"
+
+        payload: dict[str, Any] = {
+            "status": rollup,
             "timestamp": datetime.now(UTC).isoformat(),
             "checks": checks,
         }
+        if messages:
+            payload["messages"] = messages
+        return payload
 
     @app.get("/", tags=["Root"])  # type: ignore[misc]
     async def root() -> dict[str, str]:

--- a/tests/infrastructure/health/test_probes.py
+++ b/tests/infrastructure/health/test_probes.py
@@ -1,0 +1,149 @@
+"""Unit tests for the readiness probes."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.infrastructure.health.probes import (
+    DatabaseProbe,
+    FilesystemProbe,
+    ProbeStatus,
+)
+
+
+def _session_factory_from(execute_side_effect: Any | None = None) -> MagicMock:
+    """Build an async-context session factory whose ``execute`` is configurable."""
+    session = AsyncMock()
+    if execute_side_effect is not None:
+        session.execute.side_effect = execute_side_effect
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    return MagicMock(return_value=session)
+
+
+def _library_uow_factory(libraries: list[Any]) -> MagicMock:
+    """Async-context UoW whose ``libraries.find_all`` returns ``libraries``."""
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.libraries = AsyncMock()
+    uow.libraries.find_all.return_value = libraries
+    return MagicMock(return_value=uow)
+
+
+def _library_stub(name: str, paths: list[str]) -> MagicMock:
+    stub = MagicMock()
+    stub.name = name
+    stub.paths = [MagicMock(value=p) for p in paths]
+    return stub
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestDatabaseProbe:
+    async def test_should_be_healthy_when_select_succeeds(self) -> None:
+        probe = DatabaseProbe(session_factory=_session_factory_from())
+
+        result = await probe.execute()
+
+        assert result.status == ProbeStatus.HEALTHY
+        assert result.message is None
+        assert result.name == "database"
+
+    async def test_should_be_unhealthy_when_session_raises(self) -> None:
+        probe = DatabaseProbe(
+            session_factory=_session_factory_from(RuntimeError("connection lost")),
+        )
+
+        result = await probe.execute()
+
+        assert result.status == ProbeStatus.UNHEALTHY
+        assert result.message is not None
+        assert "connection lost" in result.message
+
+
+class TestFilesystemProbe:
+    async def test_should_be_healthy_when_every_path_exists(
+        self,
+        tmp_path,
+    ) -> None:
+        existing = tmp_path / "movies"
+        existing.mkdir()
+        probe = FilesystemProbe(
+            library_uow_factory=_library_uow_factory(
+                [_library_stub("A", [str(existing)])],
+            ),
+        )
+
+        result = await probe.execute()
+
+        assert result.status == ProbeStatus.HEALTHY
+        assert result.message is None
+
+    async def test_should_be_healthy_when_no_libraries_configured(self) -> None:
+        # Fresh install with zero libraries — we don't want the
+        # admin Health page to scream red before setup completes.
+        probe = FilesystemProbe(library_uow_factory=_library_uow_factory([]))
+
+        result = await probe.execute()
+
+        assert result.status == ProbeStatus.HEALTHY
+
+    async def test_should_be_degraded_when_one_library_has_missing_path(
+        self,
+        tmp_path,
+    ) -> None:
+        ok = tmp_path / "ok"
+        ok.mkdir()
+        probe = FilesystemProbe(
+            library_uow_factory=_library_uow_factory(
+                [
+                    _library_stub("A", [str(ok)]),
+                    _library_stub("B", [str(tmp_path / "missing")]),
+                ],
+            ),
+        )
+
+        result = await probe.execute()
+
+        assert result.status == ProbeStatus.DEGRADED
+        assert result.message is not None
+        assert "B" in result.message
+        assert "missing" in result.message
+
+    async def test_should_be_unhealthy_when_every_library_is_broken(
+        self,
+        tmp_path,
+    ) -> None:
+        probe = FilesystemProbe(
+            library_uow_factory=_library_uow_factory(
+                [
+                    _library_stub("A", [str(tmp_path / "missing-a")]),
+                    _library_stub("B", []),  # no paths configured at all
+                ],
+            ),
+        )
+
+        result = await probe.execute()
+
+        assert result.status == ProbeStatus.UNHEALTHY
+        assert result.message is not None
+
+    async def test_should_be_unhealthy_when_listing_libraries_raises(self) -> None:
+        broken_uow = AsyncMock()
+        broken_uow.__aenter__.return_value = broken_uow
+        broken_uow.__aexit__.return_value = None
+        broken_uow.libraries = AsyncMock()
+        broken_uow.libraries.find_all.side_effect = RuntimeError("DB down")
+
+        probe = FilesystemProbe(library_uow_factory=MagicMock(return_value=broken_uow))
+
+        result = await probe.execute()
+
+        assert result.status == ProbeStatus.UNHEALTHY
+        assert result.message is not None
+        assert "DB down" in result.message


### PR DESCRIPTION
## Summary

- ``DatabaseProbe`` runs ``SELECT 1`` so an unreachable DB or revoked credentials surface as ``unhealthy`` instead of a silent green dot.
- ``FilesystemProbe`` walks every library's configured paths via the existing UoW factory and reports ``degraded`` when at least one library is still fine (catalog keeps working for the OK libraries) or ``unhealthy`` when none are. A fresh install with zero libraries stays ``healthy`` so the admin Health page doesn't scream red before setup completes.
- Response shape grows: top-level ``status`` is now ``ready`` / ``degraded`` / ``not_ready``, and an optional ``messages`` map carries the operator-facing hint string for any probe that isn't healthy. The ``checks`` block stays as it was so existing frontend code keeps working.

## Test plan

- [x] ``poetry run pytest`` — 2441 passed
- [x] ``poetry run ruff check src tests`` + ``ruff format --check`` — clean
- [x] Boot sanity (``create_app()``) — 105 routes
- [ ] Manual: ``curl http://localhost:8005/health/ready`` with the dev DB up — expect ``ready``; then break a library path on disk and expect ``degraded`` with the path in ``messages.filesystem``

## Summary by Sourcery

Implement real infrastructure-backed readiness checks for the /health/ready endpoint with rolled-up readiness status and operator messages.

New Features:
- Introduce database and filesystem readiness probes to validate core dependencies for /health/ready.
- Expose a richer readiness response with ready/degraded/not_ready rollup status and optional per-probe messages.

Enhancements:
- Wire the new health probes into the main application container and readiness route while keeping the existing checks block stable for consumers.

Tests:
- Add unit tests covering database and filesystem probe behaviors, including success, degraded, and failure scenarios.