### PR TITLE
feat(media): admin catalog text search via FTS5

### DIFF
--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -224,6 +224,7 @@ class ListMoviesInput:
     library_id: str | None = None
     has_tmdb_id: bool | None = None
     needs_enrichment_review: bool | None = None
+    q: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -233,6 +233,7 @@ class ListSeriesInput:
     # the user-facing list means "no extra constraint".
     library_id: str | None = None
     has_tmdb_id: bool | None = None
+    q: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/use_cases/list_movies.py
+++ b/src/modules/media/application/use_cases/list_movies.py
@@ -83,6 +83,7 @@ class ListMoviesUseCase:
                 library_id=input_dto.library_id,
                 has_tmdb_id=input_dto.has_tmdb_id,
                 needs_enrichment_review=input_dto.needs_enrichment_review,
+                q=input_dto.q,
             )
 
         return ListMoviesOutput(

--- a/src/modules/media/application/use_cases/list_series.py
+++ b/src/modules/media/application/use_cases/list_series.py
@@ -77,6 +77,7 @@ class ListSeriesUseCase:
                 allowed_library_ids=allowed,
                 library_id=input_dto.library_id,
                 has_tmdb_id=input_dto.has_tmdb_id,
+                q=input_dto.q,
             )
 
         return ListSeriesOutput(

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -100,6 +100,7 @@ class MovieRepository(ABC):
         library_id: str | None = None,
         has_tmdb_id: bool | None = None,
         needs_enrichment_review: bool | None = None,
+        q: str | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies in a single page using cursor-based pagination.
 
@@ -137,6 +138,9 @@ class MovieRepository(ABC):
                 applies no filter.
             needs_enrichment_review: Optional admin filter — ``True``
                 keeps only rows the enricher flagged for review.
+            q: Optional case-insensitive substring match against
+                ``title`` / ``original_title``. ``None`` or an empty /
+                whitespace-only string applies no filter.
 
         Returns:
             ``PaginatedResult`` containing the page items, the

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -95,6 +95,7 @@ class SeriesRepository(ABC):
         allowed_library_ids: Sequence[str] | None = None,
         library_id: str | None = None,
         has_tmdb_id: bool | None = None,
+        q: str | None = None,
     ) -> PaginatedResult[Series]:
         """List series in a single page using cursor-based pagination.
 
@@ -127,6 +128,9 @@ class SeriesRepository(ABC):
             has_tmdb_id: Optional admin filter — ``True`` keeps only
                 enriched rows, ``False`` only un-enriched, ``None``
                 applies no filter.
+            q: Optional case-insensitive substring match against
+                ``title`` / ``original_title``. ``None`` or an empty /
+                whitespace-only string applies no filter.
 
         Returns:
             ``PaginatedResult`` containing the page items, the

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -40,12 +40,18 @@ def _movie_filter_conditions(
     library_id: str | None,
     has_tmdb_id: bool | None,
     needs_enrichment_review: bool | None,
+    fts_matching_ids: Sequence[int] | None,
 ) -> list:
     """Build SQLAlchemy ``WHERE`` clauses for the optional movie filters.
 
     Pulled out as a helper so ``list_paginated`` and its
     ``COUNT(*)`` partner stay in lock-step — adding a new filter
     means one edit here rather than two parallel branches drifting.
+
+    ``fts_matching_ids`` is the result of pre-querying the
+    ``movies_fts`` virtual table for the operator's ``q`` text.
+    Caller resolves it once, before the page query, so the same
+    id set scopes both ``SELECT`` and ``COUNT(*)``.
     """
     conditions: list = []
     if allowed_library_ids is not None:
@@ -62,6 +68,8 @@ def _movie_filter_conditions(
             if needs_enrichment_review
             else MovieModel.needs_enrichment_review.is_(False),
         )
+    if fts_matching_ids is not None:
+        conditions.append(MovieModel.id.in_(fts_matching_ids))
     return conditions
 
 
@@ -206,6 +214,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
         library_id: str | None = None,
         has_tmdb_id: bool | None = None,
         needs_enrichment_review: bool | None = None,
+        q: str | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies in a single cursor-paginated page.
 
@@ -226,12 +235,34 @@ class SQLAlchemyMovieRepository(MovieRepository):
         satisfy *both* constraints. Admin pages call without ACL
         kwargs and pass these filters; the user-facing list does the
         inverse.
+
+        ``q`` is delegated to the ``movies_fts`` virtual table so the
+        same i18n-aware tokenizer + indexed surface (title,
+        original_title, synopsis, tagline, genres, cast, directors,
+        writers, collection_name, localized_*) used by the catalog
+        search overlay backs the admin's text filter. The FTS5
+        ``MATCH`` resolves to a set of internal ids that is then
+        composed as ``id IN (...)`` so cursor pagination remains
+        ordered by ``id DESC`` rather than relevance — the admin
+        flow benefits more from a stable page-by-page walk than a
+        ranked top-N.
         """
+        fts_matching_ids: list[int] | None = None
+        if q and q.strip():
+            fts_matching_ids = await _movie_fts_matching_ids(self._session, q)
+            if not fts_matching_ids:
+                return PaginatedResult(
+                    items=[],
+                    pagination=Pagination(next_cursor=None, has_more=False),
+                    total_count=0 if include_total else None,
+                )
+
         conditions = _movie_filter_conditions(
             allowed_library_ids=allowed_library_ids,
             library_id=library_id,
             has_tmdb_id=has_tmdb_id,
             needs_enrichment_review=needs_enrichment_review,
+            fts_matching_ids=fts_matching_ids,
         )
 
         decoded = decode_cursor(cursor)
@@ -729,6 +760,34 @@ class SQLAlchemyMovieRepository(MovieRepository):
         ]
         hits.sort(key=lambda h: h[1])
         return hits[:limit]
+
+
+async def _movie_fts_matching_ids(session: AsyncSession, query: str) -> list[int]:
+    """Resolve ``query`` against ``movies_fts`` and return matching ids.
+
+    Used by the admin Catalog list to delegate text matching to the
+    same FTS5 index that powers the catalog search overlay — same
+    tokenizer, same column surface (title, original_title, synopsis,
+    tagline, genres, cast, directors, writers, collection_name and
+    every ``localized_*`` projection of the JSON ``localized`` blob).
+
+    Returns ``[]`` when the sanitized query is empty or no rows
+    match — caller treats both as "no hits" and short-circuits with
+    an empty page.
+
+    No ``LIMIT``: the caller composes the result as ``id IN (...)``
+    and re-orders by ``id DESC`` for cursor pagination, so it needs
+    the full hit set rather than a relevance-ranked top-N.
+    """
+    fts_query = _prepare_fts_query(query)
+    if not fts_query:
+        return []
+    sql = """
+        SELECT rowid FROM movies_fts
+        WHERE movies_fts MATCH :query
+    """
+    result = await session.execute(text(sql), {"query": fts_query})
+    return [row[0] for row in result.fetchall()]
 
 
 def _prepare_fts_query(query: str) -> str:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -52,11 +52,14 @@ def _series_filter_conditions(
     allowed_library_ids: Sequence[str] | None,
     library_id: str | None,
     has_tmdb_id: bool | None,
+    fts_matching_ids: Sequence[int] | None,
 ) -> list:
     """Build SQLAlchemy ``WHERE`` clauses for the optional series filters.
 
     Mirrors ``_movie_filter_conditions`` so both repositories surface
-    the same admin-facing filter contract.
+    the same admin-facing filter contract. ``fts_matching_ids`` is
+    the result of pre-querying ``series_fts`` for the operator's
+    ``q`` text; the caller resolves it once before the page query.
     """
     conditions: list = []
     if allowed_library_ids is not None:
@@ -67,7 +70,35 @@ def _series_filter_conditions(
         conditions.append(
             SeriesModel.tmdb_id.is_not(None) if has_tmdb_id else SeriesModel.tmdb_id.is_(None),
         )
+    if fts_matching_ids is not None:
+        conditions.append(SeriesModel.id.in_(fts_matching_ids))
     return conditions
+
+
+async def _series_fts_matching_ids(session: AsyncSession, query: str) -> list[int]:
+    """Resolve ``query`` against ``series_fts`` and return matching ids.
+
+    Mirrors ``_movie_fts_matching_ids`` — same FTS5 column surface
+    minus the movie-specific ``tagline`` / ``writers`` /
+    ``collection_name`` / ``directors`` projections (series don't
+    carry those fields).
+
+    Returns ``[]`` when the sanitized query is empty or has no
+    matches; caller short-circuits with an empty page.
+    """
+    from src.modules.media.infrastructure.persistence.repositories.movie_repository import (
+        _prepare_fts_query,
+    )
+
+    fts_query = _prepare_fts_query(query)
+    if not fts_query:
+        return []
+    sql = """
+        SELECT rowid FROM series_fts
+        WHERE series_fts MATCH :query
+    """
+    result = await session.execute(text(sql), {"query": fts_query})
+    return [row[0] for row in result.fetchall()]
 
 
 class SQLAlchemySeriesRepository(SeriesRepository):
@@ -225,6 +256,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         allowed_library_ids: Sequence[str] | None = None,
         library_id: str | None = None,
         has_tmdb_id: bool | None = None,
+        q: str | None = None,
     ) -> PaginatedResult[Series]:
         """List series in a single cursor-paginated page.
 
@@ -240,11 +272,30 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         Admin filters (``library_id``, ``has_tmdb_id``) compose with
         the per-profile ``allowed_library_ids`` ACL — see the matching
         helper on the movie repository for the contract.
+
+        ``q`` is delegated to the ``series_fts`` virtual table for
+        i18n-aware matching across title / original_title / synopsis
+        / genres / cast plus every ``localized_*`` projection. The
+        FTS5 ``MATCH`` resolves to a set of internal ids that is
+        then composed as ``id IN (...)`` so cursor pagination stays
+        ordered by ``id DESC`` (consistent page-by-page admin walk)
+        rather than relevance.
         """
+        fts_matching_ids: list[int] | None = None
+        if q and q.strip():
+            fts_matching_ids = await _series_fts_matching_ids(self._session, q)
+            if not fts_matching_ids:
+                return PaginatedResult(
+                    items=[],
+                    pagination=Pagination(next_cursor=None, has_more=False),
+                    total_count=0 if include_total else None,
+                )
+
         conditions = _series_filter_conditions(
             allowed_library_ids=allowed_library_ids,
             library_id=library_id,
             has_tmdb_id=has_tmdb_id,
+            fts_matching_ids=fts_matching_ids,
         )
 
         decoded = decode_cursor(cursor)

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -59,6 +59,7 @@ async def list_movies(
     library_id: str | None = None,
     has_tmdb_id: bool | None = None,
     needs_review: bool | None = None,
+    q: str | None = None,
     profile_id: str = Depends(resolve_profile_id),
     use_case: ListMoviesUseCase = Depends(
         Provide[ApplicationContainer.media.list_movies],
@@ -90,6 +91,11 @@ async def list_movies(
             ``/admin/movies/needs-review`` listing but stays inside
             the standard paginated list so the admin Catalog page
             can apply it alongside other filters.
+        q: Optional case-insensitive substring match against the
+            movie's ``title`` / ``original_title``. Empty /
+            whitespace-only values apply no filter — kept inside the
+            standard paginated list so it composes with the other
+            admin filters and cursor pagination.
     """
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
@@ -102,6 +108,7 @@ async def list_movies(
             library_id=library_id,
             has_tmdb_id=has_tmdb_id,
             needs_enrichment_review=needs_review,
+            q=q,
         )
     )
     extras: dict[str, Any] | None = (

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -65,6 +65,7 @@ async def list_series(
     lang: str = "en",
     library_id: str | None = None,
     has_tmdb_id: bool | None = None,
+    q: str | None = None,
     profile_id: str = Depends(resolve_profile_id),
     use_case: ListSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.list_series],
@@ -74,7 +75,10 @@ async def list_series(
 
     Mirrors ``GET /api/v1/movies`` for the common params; series
     don't carry a ``needs_review`` flag yet, so the filter set
-    drops that one.
+    drops that one. ``q`` is an optional case-insensitive substring
+    match against ``title`` / ``original_title`` so the admin
+    Catalog page can layer text search on top of the other filters
+    without breaking cursor pagination.
     """
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
@@ -86,6 +90,7 @@ async def list_series(
             lang=lang,
             library_id=library_id,
             has_tmdb_id=has_tmdb_id,
+            q=q,
         )
     )
     extras: dict[str, Any] | None = (

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -641,6 +641,26 @@ class TestSQLAlchemyMovieRepositoryListPaginatedAdminFilters:
 
         assert {m.title.value for m in page.items} == {"Match"}
 
+    async def test_q_blank_should_short_circuit_the_fts_round_trip(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Empty / whitespace-only ``q`` skips the FTS5 lookup so the
+        regular ``id DESC`` page still lands every non-deleted row.
+
+        End-to-end coverage for the FTS5 hit path lives in the
+        ``/api/v1/movies?q=...`` smoke flow — the in-memory SQLite
+        test database doesn't have the ``movies_fts`` virtual table
+        (it ships via Alembic, not ``Base.metadata.create_all``)
+        and bootstrapping it here would duplicate the chain of
+        migrations that build the localized JSON projections."""
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(_create_movie(title="A", file_path="/m/a.mkv"))
+        await repo.save(_create_movie(title="B", file_path="/m/b.mkv"))
+
+        page = await repo.list_paginated(cursor=None, limit=10, q="   ")
+
+        assert {m.title.value for m in page.items} == {"A", "B"}
+
 
 @pytest.mark.integration
 class TestSQLAlchemyMovieRepositoryListRecentlyAdded:

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -856,6 +856,26 @@ class TestSQLAlchemySeriesRepositoryListPaginated:
 
 
 @pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryListPaginatedAdminFilters:
+    """Integration coverage for the admin Catalog ``q`` short-circuit
+    on ``list_paginated``. The FTS5 hit path itself is exercised by
+    the live ``/api/v1/series?q=...`` smoke flow because
+    ``series_fts`` ships via Alembic, not
+    ``Base.metadata.create_all``."""
+
+    async def test_q_blank_should_short_circuit_the_fts_round_trip(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(_create_series(title="A"))
+        await repo.save(_create_series(title="B"))
+
+        page = await repo.list_paginated(cursor=None, limit=10, q="   ")
+
+        assert {s.title.value for s in page.items} == {"A", "B"}
+
+
+@pytest.mark.integration
 class TestSQLAlchemySeriesRepositoryListRecentlyAdded:
     """Integration tests for the bounded "top N newest" projection."""
 

--- a/tests/modules/media/unit/application/use_cases/test_list_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies.py
@@ -79,6 +79,7 @@ class TestListMoviesUseCase:
             library_id=None,
             has_tmdb_id=None,
             needs_enrichment_review=None,
+            q=None,
         )
 
     @pytest.mark.asyncio
@@ -120,6 +121,7 @@ class TestListMoviesUseCase:
             library_id=None,
             has_tmdb_id=None,
             needs_enrichment_review=None,
+            q=None,
         )
 
     @pytest.mark.asyncio
@@ -178,6 +180,7 @@ class TestListMoviesUseCase:
             library_id=None,
             has_tmdb_id=None,
             needs_enrichment_review=None,
+            q=None,
         )
 
     @pytest.mark.asyncio

--- a/tests/modules/media/unit/application/use_cases/test_list_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series.py
@@ -67,6 +67,7 @@ class TestListSeriesUseCase:
             allowed_library_ids=[_LIBRARY_ID],
             library_id=None,
             has_tmdb_id=None,
+            q=None,
         )
 
     @pytest.mark.asyncio
@@ -113,6 +114,7 @@ class TestListSeriesUseCase:
             allowed_library_ids=[_LIBRARY_ID],
             library_id=None,
             has_tmdb_id=None,
+            q=None,
         )
 
     @pytest.mark.asyncio
@@ -200,6 +202,7 @@ class TestListSeriesUseCase:
             allowed_library_ids=[_LIBRARY_ID],
             library_id=None,
             has_tmdb_id=None,
+            q=None,
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `q` query param to `GET /api/v1/movies` and `/api/v1/series`; the admin Catalog tables use it to filter rows by title (and everything else FTS5 indexes)
- Delegate the text match to the existing `movies_fts` / `series_fts` virtual tables so the operator hits the same i18n-aware tokenizer + indexed surface as the catalog search overlay (title, original_title, synopsis, tagline, genres, cast, directors, writers, collection_name, plus `localized_*` projections of the JSON `localized` blob)
- FTS5 `MATCH` resolves to internal ids that compose as `id IN (...)` on the regular `list_paginated` query — cursor pagination stays ordered by `id DESC`, admin filters (`library_id`, `has_tmdb_id`, `needs_review`) and the per-profile ACL still apply

## Test plan
- [ ] `q=spirited` returns Spirited Away (matches `original_title`)
- [ ] `q=faroeste` returns westerns (matches `localized_genres` in pt-BR)
- [ ] `q=ledger` returns The Dark Knight (matches `cast`)
- [ ] Empty / whitespace `q` is a no-op — the page still lands every row
- [ ] `q` composes with the library filter and the "Flagged" review filter
- [ ] Cursor pagination still walks the matched set page-by-page in `id DESC`

## Summary by Sourcery

Add full-text search-based `q` filtering to admin movie and series catalog listings while preserving existing pagination and admin filters.

New Features:
- Introduce optional `q` text query parameter to movie and series list APIs to filter admin catalog results via FTS5-backed search across key metadata fields.

Enhancements:
- Delegate movie and series repository queries to FTS virtual tables to resolve matching ids, composing them with existing filters without changing cursor pagination semantics.

Tests:
- Add integration and unit tests to cover propagation of the `q` parameter and the short-circuit behavior for blank or whitespace-only queries.