### PR TITLE
feat(catalog-requests): snapshot title at request time

### DIFF
--- a/migrations/versions/2026_05_19_add_title_to_catalog_requests.py
+++ b/migrations/versions/2026_05_19_add_title_to_catalog_requests.py
@@ -1,0 +1,42 @@
+"""Add title column to catalog_requests.
+
+The admin queue page only had ``tmdb/<id>`` to identify each pending
+request — fine when the operator recognizes the id, painful when
+they don't. Snapshotting the title at request time lets the queue
+table render "Title (tmdb/123)" without a TMDB round-trip on every
+listing. Existing rows keep ``NULL`` and the admin UI falls back to
+the bare id.
+
+Revision ID: d9e0f1a2b3c4
+Revises: c8d9e0f1a2b3
+Create Date: 2026-05-19 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "d9e0f1a2b3c4"
+down_revision: str | Sequence[str] | None = "c8d9e0f1a2b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``title`` column."""
+    op.add_column(
+        "catalog_requests",
+        sa.Column("title", sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``title`` column."""
+    op.drop_column("catalog_requests", "title")

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -17,6 +17,10 @@ class CreateCatalogRequestInput:
     Attributes:
         tmdb_id: TMDB numeric id of the title to request.
         media_type: Whether the target is a movie or a series.
+        title: Snapshot of the TMDB title at request time. Optional
+            so older clients (and programmatic seeds) keep working,
+            but the Collection Detail page sends it in so the admin
+            queue can render the title inline.
         collection_tmdb_id: Optional franchise id that surfaced this
             request (set when the user clicks "Solicitar inclusão"
             from a Collection Detail page).
@@ -27,6 +31,7 @@ class CreateCatalogRequestInput:
 
     tmdb_id: int
     media_type: RequestedMediaType
+    title: str | None = None
     collection_tmdb_id: int | None = None
     notify_on_arrival: bool = False
 
@@ -37,6 +42,7 @@ class SubscribeCatalogNotificationInput:
 
     tmdb_id: int
     media_type: RequestedMediaType
+    title: str | None = None
     collection_tmdb_id: int | None = None
 
 
@@ -64,6 +70,8 @@ class CatalogRequestOutput:
         id: External request id (``req_xxx``).
         tmdb_id: TMDB numeric id of the requested title.
         media_type: ``"movie"`` or ``"series"``.
+        title: Snapshot of the title taken at request time. ``None``
+            on legacy rows created before the column existed.
         collection_tmdb_id: Originating TMDB collection id, if any.
         notify_on_arrival: Whether the user opted in to a notification.
         is_fulfilled: ``True`` when the title is already in the catalog.
@@ -74,6 +82,7 @@ class CatalogRequestOutput:
     id: str
     tmdb_id: int
     media_type: str
+    title: str | None
     collection_tmdb_id: int | None
     notify_on_arrival: bool
     is_fulfilled: bool
@@ -87,6 +96,7 @@ class CatalogRequestOutput:
             id=str(entity.id),
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
+            title=entity.title,
             collection_tmdb_id=entity.collection_tmdb_id,
             notify_on_arrival=entity.notify_on_arrival,
             is_fulfilled=entity.is_fulfilled,

--- a/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
+++ b/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
@@ -62,8 +62,22 @@ class RequestCatalogInclusionUseCase:
                 input_dto.media_type,
             )
             if existing is not None:
-                if input_dto.notify_on_arrival and not existing.notify_on_arrival:
-                    updated = existing.enable_notification()
+                # Repeat submit: flip the notify flag on if the caller
+                # asked for it, and backfill the title when a legacy
+                # row was created before the column existed. Either
+                # write opens the same persisted path so the response
+                # stays a single round-trip.
+                title_backfill = (
+                    input_dto.title if existing.title is None and input_dto.title else None
+                )
+                wants_notify = input_dto.notify_on_arrival and not existing.notify_on_arrival
+                if title_backfill or wants_notify:
+                    updates: dict[str, object] = {}
+                    if title_backfill:
+                        updates["title"] = title_backfill
+                    if wants_notify:
+                        updates["notify_on_arrival"] = True
+                    updated = existing.with_updates(**updates)
                     persisted = await uow.catalog_requests.update(updated)
                     return CatalogRequestOutput.from_entity(persisted)
                 return CatalogRequestOutput.from_entity(existing)
@@ -71,6 +85,7 @@ class RequestCatalogInclusionUseCase:
             request = CatalogRequest.create(
                 tmdb_id=input_dto.tmdb_id,
                 media_type=input_dto.media_type,
+                title=input_dto.title,
                 collection_tmdb_id=input_dto.collection_tmdb_id,
                 notify_on_arrival=input_dto.notify_on_arrival,
             )

--- a/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
+++ b/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
@@ -54,15 +54,22 @@ class SubscribeCatalogNotificationUseCase:
                 input_dto.media_type,
             )
             if existing is not None:
-                if existing.notify_on_arrival:
+                title_backfill = (
+                    input_dto.title if existing.title is None and input_dto.title else None
+                )
+                if existing.notify_on_arrival and not title_backfill:
                     return CatalogRequestOutput.from_entity(existing)
-                updated = existing.enable_notification()
+                updates: dict[str, object] = {"notify_on_arrival": True}
+                if title_backfill:
+                    updates["title"] = title_backfill
+                updated = existing.with_updates(**updates)
                 persisted = await uow.catalog_requests.update(updated)
                 return CatalogRequestOutput.from_entity(persisted)
 
             request = CatalogRequest.create(
                 tmdb_id=input_dto.tmdb_id,
                 media_type=input_dto.media_type,
+                title=input_dto.title,
                 collection_tmdb_id=input_dto.collection_tmdb_id,
                 notify_on_arrival=True,
             )

--- a/src/modules/catalog_requests/domain/entities/catalog_request.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_request.py
@@ -31,6 +31,10 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         id: External ID (``req_xxx`` format).
         tmdb_id: TMDB numeric id of the requested title.
         media_type: Whether the request targets a movie or a series.
+        title: Snapshot of the TMDB title at the moment the request
+            was registered. The admin queue uses this to render
+            "Title (tmdb/id)" inline without re-querying TMDB. May
+            be ``None`` on rows created before the column existed.
         collection_tmdb_id: TMDB collection id that surfaced this
             request, if any. Lets us scope listings to a single
             franchise (e.g. "all pending requests in the Alien
@@ -49,6 +53,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         >>> req = CatalogRequest.create(
         ...     tmdb_id=348,
         ...     media_type=RequestedMediaType.MOVIE,
+        ...     title="Alien",
         ...     collection_tmdb_id=8091,
         ... )
     """
@@ -57,6 +62,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
 
     tmdb_id: int
     media_type: RequestedMediaType
+    title: str | None = None
     collection_tmdb_id: int | None = None
     notify_on_arrival: bool = False
     requested_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -67,6 +73,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         cls,
         tmdb_id: int,
         media_type: RequestedMediaType,
+        title: str | None = None,
         collection_tmdb_id: int | None = None,
         notify_on_arrival: bool = False,
     ) -> CatalogRequest:
@@ -75,6 +82,11 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         Args:
             tmdb_id: TMDB numeric id of the requested title.
             media_type: Whether the request targets a movie or a series.
+            title: Snapshot of the TMDB title at request time.
+                Optional — when the caller doesn't know the title
+                (older clients, programmatic ingest), the field stays
+                ``None`` and the admin queue falls back to the bare
+                ``tmdb/<id>`` link.
             collection_tmdb_id: Optional franchise id that surfaced
                 this request.
             notify_on_arrival: Whether to subscribe to the arrival
@@ -87,6 +99,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
             id=CatalogRequestId.generate(),
             tmdb_id=tmdb_id,
             media_type=media_type,
+            title=title,
             collection_tmdb_id=collection_tmdb_id,
             notify_on_arrival=notify_on_arrival,
             requested_at=datetime.now(UTC),

--- a/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
@@ -39,6 +39,7 @@ class CatalogRequestMapper:
             external_id=str(entity.id),
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
+            title=entity.title,
             collection_tmdb_id=entity.collection_tmdb_id,
             notify_on_arrival=entity.notify_on_arrival,
             requested_at=entity.requested_at,
@@ -52,6 +53,7 @@ class CatalogRequestMapper:
             id=CatalogRequestId(model.external_id),
             tmdb_id=model.tmdb_id,
             media_type=RequestedMediaType(model.media_type),
+            title=model.title,
             collection_tmdb_id=model.collection_tmdb_id,
             notify_on_arrival=model.notify_on_arrival,
             requested_at=model.requested_at,
@@ -69,8 +71,11 @@ class CatalogRequestMapper:
 
         Only mutable fields are written back: ``tmdb_id`` /
         ``media_type`` are part of the natural key and never change
-        after creation, so updating them would be a bug.
+        after creation, so updating them would be a bug. ``title``
+        is mutable so a re-submit from a client that finally knows
+        the title can backfill the snapshot on legacy rows.
         """
+        model.title = entity.title
         model.collection_tmdb_id = entity.collection_tmdb_id
         model.notify_on_arrival = entity.notify_on_arrival
         model.fulfilled_at = entity.fulfilled_at

--- a/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
@@ -20,6 +20,11 @@ class CatalogRequestModel(Base):
     Attributes:
         tmdb_id: TMDB numeric id of the requested title.
         media_type: ``"movie"`` or ``"series"``.
+        title: Snapshot of the TMDB title at the moment the request
+            was registered, so the admin queue can render the title
+            inline without re-querying TMDB. ``None`` on rows created
+            before this column existed (the admin page falls back to
+            the bare ``tmdb/<id>`` link in that case).
         collection_tmdb_id: Originating TMDB collection id, if any.
         notify_on_arrival: Whether the user opted in to a "title
             now available" notification.
@@ -32,6 +37,7 @@ class CatalogRequestModel(Base):
 
     tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     media_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    title: Mapped[str | None] = mapped_column(String(500), nullable=True)
     collection_tmdb_id: Mapped[int | None] = mapped_column(
         Integer,
         nullable=True,

--- a/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
@@ -35,6 +35,10 @@ class CreateCatalogRequestRequest(BaseModel):
     Attributes:
         tmdb_id: TMDB numeric id of the title to request.
         media_type: ``"movie"`` or ``"series"``.
+        title: Snapshot of the TMDB title at request time. Optional
+            for backwards compatibility with older clients; the
+            Collection Detail page sends it in so the admin queue
+            can render the title inline without a TMDB round-trip.
         collection_tmdb_id: Optional TMDB collection id that
             surfaced this request — set when the user clicks
             "Solicitar inclusão" from a Collection Detail page.
@@ -45,6 +49,7 @@ class CreateCatalogRequestRequest(BaseModel):
 
     tmdb_id: int = Field(..., ge=1)
     media_type: RequestedMediaType
+    title: str | None = Field(default=None, max_length=500)
     collection_tmdb_id: int | None = Field(default=None, ge=1)
     notify_on_arrival: bool = False
 
@@ -53,6 +58,7 @@ class SubscribeNotifyRequest(BaseModel):
     """Request body for the notification-subscribe endpoint."""
 
     media_type: RequestedMediaType
+    title: str | None = Field(default=None, max_length=500)
     collection_tmdb_id: int | None = Field(default=None, ge=1)
 
 
@@ -77,6 +83,7 @@ async def create_catalog_request(
         CreateCatalogRequestInput(
             tmdb_id=body.tmdb_id,
             media_type=body.media_type,
+            title=body.title,
             collection_tmdb_id=body.collection_tmdb_id,
             notify_on_arrival=body.notify_on_arrival,
         ),
@@ -102,6 +109,7 @@ async def subscribe_catalog_notification(
         SubscribeCatalogNotificationInput(
             tmdb_id=tmdb_id,
             media_type=body.media_type,
+            title=body.title,
             collection_tmdb_id=body.collection_tmdb_id,
         ),
     )

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_request_catalog_inclusion.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_request_catalog_inclusion.py
@@ -84,3 +84,68 @@ class TestRequestCatalogInclusionUseCase:
 
         assert result.notify_on_arrival is True
         mocks.catalog_requests.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persists_title_on_new_request(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = None
+        mocks.catalog_requests.add.side_effect = lambda req: req
+        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            CreateCatalogRequestInput(
+                tmdb_id=348,
+                media_type=RequestedMediaType.MOVIE,
+                title="Alien",
+            ),
+        )
+
+        assert result.title == "Alien"
+
+    @pytest.mark.asyncio
+    async def test_backfills_title_on_legacy_repeat(self) -> None:
+        """Existing rows with ``title=None`` accept a backfill from a
+        repeat submit so admin queue rendering recovers without an
+        out-of-band migration step."""
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_requests.update.side_effect = lambda req: req
+        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            CreateCatalogRequestInput(
+                tmdb_id=348,
+                media_type=RequestedMediaType.MOVIE,
+                title="Alien",
+            ),
+        )
+
+        assert result.title == "Alien"
+        mocks.catalog_requests.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_keeps_existing_title_on_repeat_without_payload(self) -> None:
+        """A repeat submit that doesn't carry a title must not blank
+        out an already-stored snapshot."""
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+            title="Alien",
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            CreateCatalogRequestInput(
+                tmdb_id=348,
+                media_type=RequestedMediaType.MOVIE,
+            ),
+        )
+
+        assert result.title == "Alien"
+        mocks.catalog_requests.update.assert_not_called()


### PR DESCRIPTION
## Summary
- Persist the TMDB title on the ``catalog_requests`` row so the admin queue can render the title inline without round-tripping back to TMDB on every listing
- New migration adds a nullable ``VARCHAR(500) title`` column. Existing rows stay ``NULL`` — admin UI falls back to the bare ``tmdb/<id>`` link for them
- ORM model, mapper, entity, application DTOs and presentation schemas all carry the title end-to-end
- ``RequestCatalogInclusionUseCase`` and ``SubscribeCatalogNotificationUseCase`` backfill the title when a repeat submit arrives for a legacy row that was created without it; a repeat submit that omits the title leaves the stored value untouched (snapshots never blank out)
- Three new unit tests cover the persist / backfill / preserve cases on the request use case

## Test plan
- [ ] ``POST /api/v1/catalog-requests`` with a ``title`` field persists it and the GET listing returns it
- [ ] Same endpoint omitting ``title`` still works (older clients keep functioning)
- [ ] Repeat submit with ``title`` on a legacy ``NULL`` row backfills the column
- [ ] Repeat submit *without* ``title`` on a row that already has one leaves the stored value untouched
- [ ] Same behaviour on ``POST /api/v1/catalog-requests/{tmdb_id}/notify``
- [ ] Admin listing at ``GET /api/v1/admin/catalog-requests`` returns the new field

## Summary by Sourcery

Persist a snapshot of the TMDB title on catalog requests and backfill it on repeat submissions while keeping APIs backward compatible.

New Features:
- Add optional title field to catalog request creation and notification subscription APIs and propagate it through application DTOs, domain entities, and persistence models so admin listings can display titles without TMDB lookups.

Enhancements:
- Update catalog request and notification use cases to snapshot titles on new requests and conditionally backfill the title on legacy rows without overwriting existing values.
- Extend ORM mappers and update logic to handle the mutable title snapshot field on catalog requests.

Tests:
- Add unit tests covering title persistence on new requests, title backfill on legacy repeats, and preservation of existing titles when repeat submissions omit the field.

Chores:
- Add a database migration introducing a nullable title column on the catalog_requests table.