### PR TITLE
feat(catalog-requests): auto-fulfill pending requests on enrichment

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -423,6 +423,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         EnrichMovieMetadataUseCase,
         uow_factory=media_unit_of_work_factory,
         primary_provider=tmdb_client,
+        event_bus=event_bus,
     )
 
     get_related_movies = providers.Factory(
@@ -449,6 +450,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         EnrichSeriesMetadataUseCase,
         uow_factory=media_unit_of_work_factory,
         primary_provider=tmdb_client,
+        event_bus=event_bus,
     )
 
     get_related_series = providers.Factory(

--- a/src/main.py
+++ b/src/main.py
@@ -177,6 +177,9 @@ def _subscribe_event_handlers(container: ApplicationContainer) -> None:
     Centralises event handler registration so it stays alongside
     the rest of the container configuration.
     """
+    from src.modules.catalog_requests.application.event_handlers import (
+        OnMediaEnrichedHandler,
+    )
     from src.modules.collections.application.event_handlers import (
         OnMoviePromotedToSeriesHandler as CollectionsOnMoviePromotedHandler,
     )
@@ -187,6 +190,7 @@ def _subscribe_event_handlers(container: ApplicationContainer) -> None:
     from src.modules.media.application.event_handlers import OnMediaCreatedHandler
     from src.modules.media.domain.events import (
         MediaCreatedEvent,
+        MediaEnrichedEvent,
         MoviePromotedToSeriesEvent,
     )
     from src.modules.watch_progress.application.event_handlers import (
@@ -203,6 +207,16 @@ def _subscribe_event_handlers(container: ApplicationContainer) -> None:
         enrich_series_factory=container.media.enrich_series_metadata,
     )
     event_bus.subscribe(MediaCreatedEvent, media_created_handler)
+
+    # ``catalog_requests`` flips a pending request to fulfilled the
+    # moment a matching title finishes enrichment with a TMDB id —
+    # closes the loop so the admin queue stops surfacing the row.
+    event_bus.subscribe(
+        MediaEnrichedEvent,
+        OnMediaEnrichedHandler(
+            uow_factory=container.catalog_requests.catalog_requests_unit_of_work_factory(),
+        ),
+    )
 
     # Cross-BC fan-out when a movie is promoted into a series.
     # watch_progress drops the stale rows (positions can't survive a

--- a/src/modules/catalog_requests/application/event_handlers/__init__.py
+++ b/src/modules/catalog_requests/application/event_handlers/__init__.py
@@ -1,0 +1,7 @@
+"""Cross-BC event handlers for the Catalog Requests bounded context."""
+
+from src.modules.catalog_requests.application.event_handlers.on_media_enriched import (
+    OnMediaEnrichedHandler,
+)
+
+__all__ = ["OnMediaEnrichedHandler"]

--- a/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
+++ b/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
@@ -1,0 +1,73 @@
+"""Cross-BC handler: fulfill a pending catalog request when a title arrives."""
+
+import logging
+
+from src.building_blocks.application.event_bus import EventHandler
+from src.building_blocks.domain.events import DomainEvent
+from src.modules.catalog_requests.application.unit_of_work import (
+    CatalogRequestsUnitOfWorkFactory,
+)
+from src.modules.catalog_requests.domain.value_objects import RequestedMediaType
+from src.modules.media.domain.events import MediaEnrichedEvent
+
+_logger = logging.getLogger(__name__)
+
+
+class OnMediaEnrichedHandler(EventHandler):
+    """Close the loop on a pending ``catalog_request`` once the title lands.
+
+    The Media BC publishes ``MediaEnrichedEvent`` after an
+    enrichment pass finishes with a populated ``tmdb_id``. This
+    handler looks up the matching catalog request (if any) and
+    marks it fulfilled so the admin queue stops surfacing the
+    row. No request → no-op (the household never asked for this
+    title). Already-fulfilled request → no-op (the event fired
+    again after a force-refresh).
+
+    Runs out of the event bus, which is fire-and-forget — failures
+    here don't roll back the enrichment that just succeeded. A
+    follow-up enrichment will re-emit and the loop closes on the
+    next pass.
+    """
+
+    def __init__(self, uow_factory: CatalogRequestsUnitOfWorkFactory) -> None:
+        """Initialize the handler.
+
+        Args:
+            uow_factory: Factory for the Catalog Requests UoW.
+        """
+        self._uow_factory = uow_factory
+
+    async def handle(self, event: DomainEvent) -> None:
+        """Handle ``MediaEnrichedEvent`` by marking matching request fulfilled."""
+        if not isinstance(event, MediaEnrichedEvent):
+            return
+        try:
+            media_type = RequestedMediaType(event.media_type)
+        except ValueError:
+            _logger.warning(
+                "MediaEnrichedEvent carried unknown media_type=%r — skipping",
+                event.media_type,
+            )
+            return
+
+        async with self._uow_factory() as uow:
+            existing = await uow.catalog_requests.find_by_tmdb_id(
+                event.tmdb_id,
+                media_type,
+            )
+            if existing is None or existing.is_fulfilled:
+                return
+            fulfilled = existing.mark_fulfilled()
+            await uow.catalog_requests.update(fulfilled)
+
+        _logger.info(
+            "Fulfilled catalog request %s (tmdb/%s/%s → media %s)",
+            existing.id,
+            event.media_type,
+            event.tmdb_id,
+            event.media_id,
+        )
+
+
+__all__ = ["OnMediaEnrichedHandler"]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -3,6 +3,7 @@
 import logging
 
 from src.building_blocks.application.errors import ResourceNotFoundException
+from src.building_blocks.application.event_bus import EventBus
 from src.modules.media.application.dtos.enrichment_dtos import (
     EnrichMediaInput,
     EnrichMediaOutput,
@@ -10,6 +11,7 @@ from src.modules.media.application.dtos.enrichment_dtos import (
 from src.modules.media.application.ports import MediaMetadata, MetadataProvider
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.events import MediaEnrichedEvent
 from src.modules.media.domain.value_objects import (
     CastMember,
     Collection,
@@ -44,10 +46,12 @@ class EnrichMovieMetadataUseCase:
         uow_factory: MediaUnitOfWorkFactory,
         primary_provider: MetadataProvider,
         fallback_provider: MetadataProvider | None = None,
+        event_bus: EventBus | None = None,
     ) -> None:
         self._uow_factory = uow_factory
         self._primary = primary_provider
         self._fallback = fallback_provider
+        self._event_bus = event_bus
 
     async def execute(self, input_dto: EnrichMediaInput) -> EnrichMediaOutput:
         """Execute movie metadata enrichment.
@@ -93,6 +97,19 @@ class EnrichMovieMetadataUseCase:
             if movie.needs_enrichment_review:
                 movie = movie.with_updates(needs_enrichment_review=False)
             await uow.movies.save(movie)
+            enriched_tmdb_id = movie.tmdb_id.value if movie.tmdb_id else None
+
+        # Publish outside the UoW so a slow handler doesn't hold the
+        # write transaction open. ``catalog_requests`` listens for
+        # this event to flip pending requests to fulfilled.
+        if enriched_tmdb_id is not None and self._event_bus is not None:
+            await self._event_bus.publish(
+                MediaEnrichedEvent(
+                    media_id=input_dto.media_id,
+                    media_type="movie",
+                    tmdb_id=enriched_tmdb_id,
+                ),
+            )
 
         return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)
 

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -6,6 +6,7 @@ from datetime import date
 from typing import Any
 
 from src.building_blocks.application.errors import ResourceNotFoundException
+from src.building_blocks.application.event_bus import EventBus
 from src.modules.media.application.dtos.enrichment_dtos import (
     EnrichMediaInput,
     EnrichMediaOutput,
@@ -18,6 +19,7 @@ from src.modules.media.application.ports import (
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Episode, Season, Series
+from src.modules.media.domain.events import MediaEnrichedEvent
 from src.modules.media.domain.value_objects import (
     AirDate,
     CastMember,
@@ -50,10 +52,12 @@ class EnrichSeriesMetadataUseCase:
         uow_factory: MediaUnitOfWorkFactory,
         primary_provider: MetadataProvider,
         fallback_provider: MetadataProvider | None = None,
+        event_bus: EventBus | None = None,
     ) -> None:
         self._uow_factory = uow_factory
         self._primary = primary_provider
         self._fallback = fallback_provider
+        self._event_bus = event_bus
 
     async def execute(self, input_dto: EnrichMediaInput) -> EnrichMediaOutput:
         """Execute series metadata enrichment.
@@ -89,6 +93,19 @@ class EnrichSeriesMetadataUseCase:
 
             series = _apply_series_metadata(series, metadata)
             await uow.series.save(series)
+            enriched_tmdb_id = series.tmdb_id.value if series.tmdb_id else None
+
+        # Publish outside the UoW so a slow handler doesn't hold the
+        # write transaction open. ``catalog_requests`` listens for
+        # this event to flip pending requests to fulfilled.
+        if enriched_tmdb_id is not None and self._event_bus is not None:
+            await self._event_bus.publish(
+                MediaEnrichedEvent(
+                    media_id=input_dto.media_id,
+                    media_type="series",
+                    tmdb_id=enriched_tmdb_id,
+                ),
+            )
 
         return EnrichMediaOutput(media_id=input_dto.media_id, enriched=True, provider=provider_name)
 

--- a/src/modules/media/domain/events.py
+++ b/src/modules/media/domain/events.py
@@ -73,6 +73,33 @@ class IntroClearedEvent(DomainEvent):
 
 
 @dataclass(frozen=True)
+class MediaEnrichedEvent(DomainEvent):
+    """Emitted when an enrichment pass finishes with a known TMDB id.
+
+    Distinct from ``MediaCreatedEvent`` because the TMDB id is only
+    populated *after* enrichment runs — ``MediaCreatedEvent`` fires
+    on scan with just the internal id, so a handler that needs the
+    tmdb id (e.g. ``catalog_requests`` marking a pending request as
+    fulfilled once the title finally lands) can't piggy-back on it.
+
+    Fires both on the first successful enrichment and on a forced
+    refresh that re-runs against TMDB. Downstream handlers should
+    treat it as idempotent: re-firing on an already-fulfilled
+    catalog request must short-circuit, not duplicate state.
+
+    Attributes:
+        media_id: External ID of the enriched media (mov_xxx or
+            ser_xxx).
+        media_type: ``"movie"`` or ``"series"``.
+        tmdb_id: TMDB numeric id the enrichment locked onto.
+    """
+
+    media_id: str = ""
+    media_type: str = ""
+    tmdb_id: int = 0
+
+
+@dataclass(frozen=True)
 class MoviePromotedToSeriesEvent(DomainEvent):
     """Emitted when an admin promotes a movie into a series.
 
@@ -109,5 +136,6 @@ __all__ = [
     "IntroDetectedEvent",
     "IntroManuallySetEvent",
     "MediaCreatedEvent",
+    "MediaEnrichedEvent",
     "MoviePromotedToSeriesEvent",
 ]

--- a/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
+++ b/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
@@ -1,0 +1,146 @@
+"""Tests for ``OnMediaEnrichedHandler``."""
+
+import pytest
+
+from src.modules.catalog_requests.application.event_handlers import (
+    OnMediaEnrichedHandler,
+)
+from src.modules.catalog_requests.domain.entities import CatalogRequest
+from src.modules.catalog_requests.domain.value_objects import RequestedMediaType
+from src.modules.media.domain.events import MediaCreatedEvent, MediaEnrichedEvent
+from tests.modules.catalog_requests.unit.conftest import (
+    make_catalog_requests_uow_mock,
+)
+
+
+@pytest.mark.unit
+class TestOnMediaEnrichedHandler:
+    """Tests for the cross-BC fulfillment handler."""
+
+    @pytest.mark.asyncio
+    async def test_marks_matching_request_as_fulfilled(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+            title="Alien",
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        captured: dict[str, CatalogRequest] = {}
+
+        async def capture_update(req: CatalogRequest) -> CatalogRequest:
+            captured["req"] = req
+            return req
+
+        mocks.catalog_requests.update.side_effect = capture_update
+        handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
+
+        await handler.handle(
+            MediaEnrichedEvent(
+                media_id="mov_abc",
+                media_type="movie",
+                tmdb_id=348,
+            ),
+        )
+
+        assert captured["req"].is_fulfilled is True
+        assert captured["req"].fulfilled_at is not None
+        mocks.catalog_requests.find_by_tmdb_id.assert_awaited_once_with(
+            348,
+            RequestedMediaType.MOVIE,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_no_request_exists(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = None
+        handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
+
+        await handler.handle(
+            MediaEnrichedEvent(
+                media_id="mov_abc",
+                media_type="movie",
+                tmdb_id=348,
+            ),
+        )
+
+        mocks.catalog_requests.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_request_already_fulfilled(self) -> None:
+        """Force-refresh re-emits the event; the second tick must not
+        re-write the fulfilled row, otherwise watchers triple-fire."""
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+        ).mark_fulfilled()
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
+
+        await handler.handle(
+            MediaEnrichedEvent(
+                media_id="mov_abc",
+                media_type="movie",
+                tmdb_id=348,
+            ),
+        )
+
+        mocks.catalog_requests.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ignores_other_event_types(self) -> None:
+        """Defensive guard — the bus could fan an unrelated event in
+        if a subscription gets misconfigured. Drop silently rather
+        than crash, since handlers run fire-and-forget."""
+        mocks = make_catalog_requests_uow_mock()
+        handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
+
+        await handler.handle(
+            MediaCreatedEvent(media_id="mov_abc", media_type="movie"),
+        )
+
+        mocks.catalog_requests.find_by_tmdb_id.assert_not_called()
+        mocks.catalog_requests.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_unknown_media_type(self) -> None:
+        """A garbled event payload (unknown ``media_type``) shouldn't
+        explode the bus — log and move on."""
+        mocks = make_catalog_requests_uow_mock()
+        handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
+
+        await handler.handle(
+            MediaEnrichedEvent(
+                media_id="mov_abc",
+                media_type="episode",
+                tmdb_id=42,
+            ),
+        )
+
+        mocks.catalog_requests.find_by_tmdb_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_matches_series_event(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=1399,
+            media_type=RequestedMediaType.SERIES,
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_requests.update.side_effect = lambda req: req
+        handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
+
+        await handler.handle(
+            MediaEnrichedEvent(
+                media_id="ser_xyz",
+                media_type="series",
+                tmdb_id=1399,
+            ),
+        )
+
+        mocks.catalog_requests.find_by_tmdb_id.assert_awaited_once_with(
+            1399,
+            RequestedMediaType.SERIES,
+        )
+        mocks.catalog_requests.update.assert_called_once()

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -17,6 +17,7 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
     _clean_title,
 )
 from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.events import MediaEnrichedEvent
 from src.modules.media.domain.value_objects import ContentRating, TmdbId
 from src.modules.media.domain.value_objects.cast_member import CastMember
 from tests.modules.media.unit.conftest import MediaUoWMocks, make_media_uow_mock
@@ -515,3 +516,56 @@ class TestApplyMetadataFields:
         assert saved.localized["pt-BR"]["title"] == "A Origem"
         assert saved.localized["pt-BR"]["synopsis"] == "Sonho dentro do sonho."
         assert saved.localized["pt-BR"]["genres"] == ["Ficção Científica"]
+
+
+@pytest.mark.unit
+class TestEnrichMovieMetadataEvents:
+    """Cross-BC handshake: ``MediaEnrichedEvent`` must reach the bus
+    once the movie row picks up its tmdb id, so ``catalog_requests``
+    can flip a pending request to fulfilled."""
+
+    @pytest.mark.asyncio
+    async def test_publishes_event_when_tmdb_id_present(self) -> None:
+        movie = _make_movie()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = _make_metadata()
+
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
+        event_bus = AsyncMock()
+        use_case = EnrichMovieMetadataUseCase(
+            uow_factory=mocks.factory,
+            primary_provider=provider,
+            event_bus=event_bus,
+        )
+
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        event_bus.publish.assert_awaited_once()
+        published = event_bus.publish.await_args.args[0]
+        assert isinstance(published, MediaEnrichedEvent)
+        assert published.media_type == "movie"
+        assert published.tmdb_id == 27205
+        assert published.media_id == str(movie.id)
+
+    @pytest.mark.asyncio
+    async def test_no_event_when_enrichment_fails(self) -> None:
+        movie = _make_movie()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = None
+        provider.search_series.return_value = None
+
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
+        event_bus = AsyncMock()
+        use_case = EnrichMovieMetadataUseCase(
+            uow_factory=mocks.factory,
+            primary_provider=provider,
+            event_bus=event_bus,
+        )
+
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        event_bus.publish.assert_not_called()


### PR DESCRIPTION
## Summary
- Close the loop between the Media BC discovering a TMDB-enriched title and the Catalog Requests queue clearing the matching pending row. Before this PR the admin queue kept surfacing already-fulfilled requests forever because nothing listened for the arrival side of the lifecycle.
- New ``MediaEnrichedEvent(media_id, media_type, tmdb_id)`` on ``modules/media/domain/events.py``. Distinct from ``MediaCreatedEvent`` because the tmdb id is only populated *after* enrichment runs
- ``EnrichMovieMetadataUseCase`` and ``EnrichSeriesMetadataUseCase`` accept an optional ``event_bus`` and publish the new event after a successful enrichment that produced a tmdb id. Publish happens outside the UoW so slow handlers don't hold the write transaction open
- New ``OnMediaEnrichedHandler`` in ``catalog_requests/application/event_handlers/`` looks up the matching request via ``find_by_tmdb_id`` and flips it to fulfilled. Idempotent: no request → no-op, already fulfilled → no-op, unknown ``media_type`` → logged and skipped
- DI: media container threads ``event_bus`` into both enrich use case factories; ``main.py`` subscribes the new handler to ``MediaEnrichedEvent`` alongside the existing cross-BC fan-out
- Tests: 6 new handler cases (match / no-op / already fulfilled / unknown event / unknown media_type / series variant) + 2 enrich use case cases (publishes with tmdb id / silent on failure). Existing tests pass — ``event_bus`` defaults to ``None``

## Test plan
- [ ] Drop a new movie into a scanned library — scan auto-enriches; if a ``catalog_request`` existed for that tmdb id, it now flips to ``fulfilled``
- [ ] Same for a series
- [ ] Force-refresh an already-enriched title that has a fulfilled request — the handler short-circuits, no double-write to ``catalog_requests``
- [ ] Enrichment failure (no TMDB match) does not publish the event
- [ ] Admin queue at ``/admin/requests`` stops showing rows once the matching title lands in the catalog

## Layer follow-ups (deferred per the discussion)
- **Layer B** (next): in-app notification record + endpoint so the user subscribed via ``notify_on_arrival`` actually gets a ping
- **Layer C** (out of scope): external channels (email / push)

## Summary by Sourcery

Introduce a media enrichment event and handler to automatically fulfill matching catalog requests when titles are successfully enriched with TMDB metadata.

New Features:
- Emit a MediaEnrichedEvent after successful movie or series metadata enrichment with a resolved TMDB id.
- Add an OnMediaEnrichedHandler in the catalog requests context to mark matching pending requests as fulfilled when enrichment completes.

Enhancements:
- Wire the event bus into movie and series enrichment use cases and subscribe the new handler in the main application container to close the loop between media enrichment and catalog requests.

Tests:
- Add unit tests for the MediaEnrichedEvent publishing behavior in movie enrichment and for the OnMediaEnrichedHandler across success, no-op, and edge-case scenarios.