### PR TITLE
feat(catalog-requests): tie request to the user that registered it

### DIFF
--- a/migrations/versions/2026_05_20_add_requester_user_id_to_catalog_requests.py
+++ b/migrations/versions/2026_05_20_add_requester_user_id_to_catalog_requests.py
@@ -1,0 +1,52 @@
+"""Add requester_user_id column to catalog_requests.
+
+The "auto-fulfilled" loop from PR #214 flips a pending request to
+fulfilled when the matching title finishes enrichment, but nothing
+ties the request back to the user who registered it. Layer B
+(in-app notifications) needs that anchor so the "notify on
+arrival" ping reaches the correct inbox instead of broadcasting
+across the household.
+
+Nullable for backwards compatibility with rows created before the
+column existed — those stay anonymous and never produce a
+notification.
+
+Revision ID: e0f1a2b3c4d5
+Revises: d9e0f1a2b3c4
+Create Date: 2026-05-20 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "e0f1a2b3c4d5"
+down_revision: str | Sequence[str] | None = "d9e0f1a2b3c4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``requester_user_id`` column."""
+    op.add_column(
+        "catalog_requests",
+        sa.Column("requester_user_id", sa.String(length=50), nullable=True),
+    )
+    op.create_index(
+        "ix_catalog_requests_requester_user_id",
+        "catalog_requests",
+        ["requester_user_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``requester_user_id`` column + index."""
+    op.drop_index("ix_catalog_requests_requester_user_id", table_name="catalog_requests")
+    op.drop_column("catalog_requests", "requester_user_id")

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -32,6 +32,7 @@ class CreateCatalogRequestInput:
     tmdb_id: int
     media_type: RequestedMediaType
     title: str | None = None
+    requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
     notify_on_arrival: bool = False
 
@@ -43,6 +44,7 @@ class SubscribeCatalogNotificationInput:
     tmdb_id: int
     media_type: RequestedMediaType
     title: str | None = None
+    requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
 
 
@@ -72,6 +74,8 @@ class CatalogRequestOutput:
         media_type: ``"movie"`` or ``"series"``.
         title: Snapshot of the title taken at request time. ``None``
             on legacy rows created before the column existed.
+        requester_user_id: External id (``usr_xxx``) of the user who
+            registered the request. ``None`` on legacy rows.
         collection_tmdb_id: Originating TMDB collection id, if any.
         notify_on_arrival: Whether the user opted in to a notification.
         is_fulfilled: ``True`` when the title is already in the catalog.
@@ -83,6 +87,7 @@ class CatalogRequestOutput:
     tmdb_id: int
     media_type: str
     title: str | None
+    requester_user_id: str | None
     collection_tmdb_id: int | None
     notify_on_arrival: bool
     is_fulfilled: bool
@@ -97,6 +102,7 @@ class CatalogRequestOutput:
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
             title=entity.title,
+            requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
             notify_on_arrival=entity.notify_on_arrival,
             is_fulfilled=entity.is_fulfilled,

--- a/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
+++ b/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
@@ -63,18 +63,27 @@ class RequestCatalogInclusionUseCase:
             )
             if existing is not None:
                 # Repeat submit: flip the notify flag on if the caller
-                # asked for it, and backfill the title when a legacy
-                # row was created before the column existed. Either
-                # write opens the same persisted path so the response
-                # stays a single round-trip.
+                # asked for it, and backfill the title /
+                # requester_user_id when a legacy row was created
+                # before those columns existed. We don't *replace*
+                # an existing requester_user_id — first-owner wins
+                # so an A-then-B subscribe doesn't reroute A's
+                # notification away.
                 title_backfill = (
                     input_dto.title if existing.title is None and input_dto.title else None
                 )
+                user_backfill = (
+                    input_dto.requester_user_id
+                    if existing.requester_user_id is None and input_dto.requester_user_id
+                    else None
+                )
                 wants_notify = input_dto.notify_on_arrival and not existing.notify_on_arrival
-                if title_backfill or wants_notify:
+                if title_backfill or user_backfill or wants_notify:
                     updates: dict[str, object] = {}
                     if title_backfill:
                         updates["title"] = title_backfill
+                    if user_backfill:
+                        updates["requester_user_id"] = user_backfill
                     if wants_notify:
                         updates["notify_on_arrival"] = True
                     updated = existing.with_updates(**updates)
@@ -86,6 +95,7 @@ class RequestCatalogInclusionUseCase:
                 tmdb_id=input_dto.tmdb_id,
                 media_type=input_dto.media_type,
                 title=input_dto.title,
+                requester_user_id=input_dto.requester_user_id,
                 collection_tmdb_id=input_dto.collection_tmdb_id,
                 notify_on_arrival=input_dto.notify_on_arrival,
             )

--- a/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
+++ b/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
@@ -57,11 +57,18 @@ class SubscribeCatalogNotificationUseCase:
                 title_backfill = (
                     input_dto.title if existing.title is None and input_dto.title else None
                 )
-                if existing.notify_on_arrival and not title_backfill:
+                user_backfill = (
+                    input_dto.requester_user_id
+                    if existing.requester_user_id is None and input_dto.requester_user_id
+                    else None
+                )
+                if existing.notify_on_arrival and not title_backfill and not user_backfill:
                     return CatalogRequestOutput.from_entity(existing)
                 updates: dict[str, object] = {"notify_on_arrival": True}
                 if title_backfill:
                     updates["title"] = title_backfill
+                if user_backfill:
+                    updates["requester_user_id"] = user_backfill
                 updated = existing.with_updates(**updates)
                 persisted = await uow.catalog_requests.update(updated)
                 return CatalogRequestOutput.from_entity(persisted)
@@ -70,6 +77,7 @@ class SubscribeCatalogNotificationUseCase:
                 tmdb_id=input_dto.tmdb_id,
                 media_type=input_dto.media_type,
                 title=input_dto.title,
+                requester_user_id=input_dto.requester_user_id,
                 collection_tmdb_id=input_dto.collection_tmdb_id,
                 notify_on_arrival=True,
             )

--- a/src/modules/catalog_requests/domain/entities/catalog_request.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_request.py
@@ -35,6 +35,10 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
             was registered. The admin queue uses this to render
             "Title (tmdb/id)" inline without re-querying TMDB. May
             be ``None`` on rows created before the column existed.
+        requester_user_id: External id (``usr_xxx``) of the user who
+            registered the request. Layer B of the arrival flow
+            uses this anchor to ping the right inbox; ``None`` on
+            legacy rows skips the notification.
         collection_tmdb_id: TMDB collection id that surfaced this
             request, if any. Lets us scope listings to a single
             franchise (e.g. "all pending requests in the Alien
@@ -63,6 +67,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
     tmdb_id: int
     media_type: RequestedMediaType
     title: str | None = None
+    requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
     notify_on_arrival: bool = False
     requested_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -74,6 +79,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         tmdb_id: int,
         media_type: RequestedMediaType,
         title: str | None = None,
+        requester_user_id: str | None = None,
         collection_tmdb_id: int | None = None,
         notify_on_arrival: bool = False,
     ) -> CatalogRequest:
@@ -87,6 +93,10 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
                 (older clients, programmatic ingest), the field stays
                 ``None`` and the admin queue falls back to the bare
                 ``tmdb/<id>`` link.
+            requester_user_id: External id (``usr_xxx``) of the user
+                creating the request. Powers the per-user arrival
+                notification; ``None`` skips the ping (legacy or
+                anonymous seed).
             collection_tmdb_id: Optional franchise id that surfaced
                 this request.
             notify_on_arrival: Whether to subscribe to the arrival
@@ -100,6 +110,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
             tmdb_id=tmdb_id,
             media_type=media_type,
             title=title,
+            requester_user_id=requester_user_id,
             collection_tmdb_id=collection_tmdb_id,
             notify_on_arrival=notify_on_arrival,
             requested_at=datetime.now(UTC),

--- a/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
@@ -40,6 +40,7 @@ class CatalogRequestMapper:
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
             title=entity.title,
+            requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
             notify_on_arrival=entity.notify_on_arrival,
             requested_at=entity.requested_at,
@@ -54,6 +55,7 @@ class CatalogRequestMapper:
             tmdb_id=model.tmdb_id,
             media_type=RequestedMediaType(model.media_type),
             title=model.title,
+            requester_user_id=model.requester_user_id,
             collection_tmdb_id=model.collection_tmdb_id,
             notify_on_arrival=model.notify_on_arrival,
             requested_at=model.requested_at,
@@ -72,10 +74,13 @@ class CatalogRequestMapper:
         Only mutable fields are written back: ``tmdb_id`` /
         ``media_type`` are part of the natural key and never change
         after creation, so updating them would be a bug. ``title``
-        is mutable so a re-submit from a client that finally knows
-        the title can backfill the snapshot on legacy rows.
+        and ``requester_user_id`` are mutable so a re-submit from
+        a client that finally knows the title (or comes from a
+        different user) can backfill the snapshot / replace the
+        recipient on legacy rows.
         """
         model.title = entity.title
+        model.requester_user_id = entity.requester_user_id
         model.collection_tmdb_id = entity.collection_tmdb_id
         model.notify_on_arrival = entity.notify_on_arrival
         model.fulfilled_at = entity.fulfilled_at

--- a/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
@@ -25,6 +25,13 @@ class CatalogRequestModel(Base):
             inline without re-querying TMDB. ``None`` on rows created
             before this column existed (the admin page falls back to
             the bare ``tmdb/<id>`` link in that case).
+        requester_user_id: External id (``usr_xxx``) of the user who
+            registered the request. Layer B of the catalog-request
+            arrival flow uses this anchor to send the "title is
+            now available" notification to the right inbox instead
+            of broadcasting across the household. ``None`` on legacy
+            rows or programmatic seeds — those stay anonymous and
+            never produce a notification.
         collection_tmdb_id: Originating TMDB collection id, if any.
         notify_on_arrival: Whether the user opted in to a "title
             now available" notification.
@@ -38,6 +45,11 @@ class CatalogRequestModel(Base):
     tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     media_type: Mapped[str] = mapped_column(String(20), nullable=False)
     title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    requester_user_id: Mapped[str | None] = mapped_column(
+        String(50),
+        nullable=True,
+        index=True,
+    )
     collection_tmdb_id: Mapped[int | None] = mapped_column(
         Integer,
         nullable=True,

--- a/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
@@ -22,6 +22,8 @@ from src.modules.catalog_requests.application.use_cases.list_catalog_requests im
     ListCatalogRequestsInput,
 )
 from src.modules.catalog_requests.domain.value_objects import RequestedMediaType
+from src.modules.identity.infrastructure.auth import current_active_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 
 router = APIRouter(prefix="/api/v1/catalog-requests", tags=["Catalog Requests"])
 
@@ -69,6 +71,7 @@ class SubscribeNotifyRequest(BaseModel):
 @inject  # type: ignore[misc]
 async def create_catalog_request(
     body: CreateCatalogRequestRequest,
+    user: UserModel = Depends(current_active_user),
     use_case: RequestCatalogInclusionUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.request_catalog_inclusion],
     ),
@@ -77,13 +80,17 @@ async def create_catalog_request(
 
     Idempotent on ``(tmdb_id, media_type)``: a repeat call returns
     the existing request unchanged. Passing ``notify_on_arrival=true``
-    on a repeat call flips notifications on if they were off.
+    on a repeat call flips notifications on if they were off. The
+    request is tagged with the caller's user id so the arrival
+    notification (Layer B) reaches the right inbox; a repeat by a
+    different user keeps the original owner (first-owner wins).
     """
     result = await use_case.execute(
         CreateCatalogRequestInput(
             tmdb_id=body.tmdb_id,
             media_type=body.media_type,
             title=body.title,
+            requester_user_id=user.external_id,
             collection_tmdb_id=body.collection_tmdb_id,
             notify_on_arrival=body.notify_on_arrival,
         ),
@@ -96,6 +103,7 @@ async def create_catalog_request(
 async def subscribe_catalog_notification(
     tmdb_id: int,
     body: SubscribeNotifyRequest,
+    user: UserModel = Depends(current_active_user),
     use_case: SubscribeCatalogNotificationUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.subscribe_catalog_notification],
     ),
@@ -103,13 +111,16 @@ async def subscribe_catalog_notification(
     """Subscribe to the "title now available" notification.
 
     Creates a ``CatalogRequest`` if none exists yet, or just flips
-    ``notify_on_arrival`` to ``True`` on the existing one.
+    ``notify_on_arrival`` to ``True`` on the existing one. The
+    requester user id is backfilled when the existing row was
+    created without one (legacy / programmatic seed).
     """
     result = await use_case.execute(
         SubscribeCatalogNotificationInput(
             tmdb_id=tmdb_id,
             media_type=body.media_type,
             title=body.title,
+            requester_user_id=user.external_id,
             collection_tmdb_id=body.collection_tmdb_id,
         ),
     )

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_request_catalog_inclusion.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_request_catalog_inclusion.py
@@ -149,3 +149,70 @@ class TestRequestCatalogInclusionUseCase:
 
         assert result.title == "Alien"
         mocks.catalog_requests.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_persists_requester_user_id_on_new_request(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = None
+        mocks.catalog_requests.add.side_effect = lambda req: req
+        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            CreateCatalogRequestInput(
+                tmdb_id=348,
+                media_type=RequestedMediaType.MOVIE,
+                requester_user_id="usr_abc123",
+            ),
+        )
+
+        assert result.requester_user_id == "usr_abc123"
+
+    @pytest.mark.asyncio
+    async def test_backfills_requester_user_id_on_legacy_repeat(self) -> None:
+        """Legacy rows with ``requester_user_id=None`` accept a
+        backfill from a re-submit so notifications start landing in
+        the user's inbox without an out-of-band migration."""
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_requests.update.side_effect = lambda req: req
+        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            CreateCatalogRequestInput(
+                tmdb_id=348,
+                media_type=RequestedMediaType.MOVIE,
+                requester_user_id="usr_abc123",
+            ),
+        )
+
+        assert result.requester_user_id == "usr_abc123"
+        mocks.catalog_requests.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_first_owner_wins_when_second_user_submits(self) -> None:
+        """First-owner-wins: user A's request keeps A as
+        ``requester_user_id`` even when user B re-submits, so A's
+        notification never gets re-routed to B."""
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+            requester_user_id="usr_alice",
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            CreateCatalogRequestInput(
+                tmdb_id=348,
+                media_type=RequestedMediaType.MOVIE,
+                requester_user_id="usr_bob",
+            ),
+        )
+
+        assert result.requester_user_id == "usr_alice"
+        mocks.catalog_requests.update.assert_not_called()


### PR DESCRIPTION
## Summary
Anchor each catalog request to its requester so the next layer of the arrival flow (in-app notification) can ping the right inbox instead of broadcasting across the household.

- Migration adds a nullable ``requester_user_id String(50)`` column + index. Existing rows stay ``NULL`` — those rows produce no notification and remain anonymous
- Domain entity, ORM model, mapper, application DTOs and presentation schemas carry the field end-to-end (output DTO too, so the admin queue can later attribute requests to a user)
- Both write routes (``POST /catalog-requests`` and ``POST /catalog-requests/{tmdb_id}/notify``) now require ``current_active_user`` and forward ``user.external_id`` to the use cases
- Use cases follow **first-owner-wins** semantics: a repeat submit from a different user keeps the original ``requester_user_id``, but a legacy row with ``requester_user_id=None`` gets backfilled on the next submit so notifications start landing without an out-of-band migration
- 3 new unit tests on ``RequestCatalogInclusionUseCase`` (persist new / backfill legacy / first-owner-wins). Existing tests still pass — ``requester_user_id`` defaults to ``None``

## Test plan
- [ ] ``POST /catalog-requests`` from user A as admin → row has ``requester_user_id = usr_A``
- [ ] Repeat ``POST /catalog-requests`` from user B → row still has ``requester_user_id = usr_A`` (no overwrite)
- [ ] Legacy row with ``NULL`` requester → next submit (either endpoint) populates the column
- [ ] ``POST /catalog-requests/{tmdb_id}/notify`` from user C on a row with no requester yet → row gets ``requester_user_id = usr_C``
- [ ] Anonymous (unauthenticated) requests are now blocked at the route level

## Follow-ups (deferred)
- **Backend P2**: new ``notifications`` BC + cross-BC port + handler dispatches on fulfillment
- **Frontend P3**: header badge + dropdown UI

## Summary by Sourcery

Associate catalog requests with the user who created them and ensure notification flows can target the correct inbox while preserving backwards compatibility and first-owner semantics.

New Features:
- Track a requester_user_id on catalog requests from API through domain, application DTOs, persistence models, and responses to anchor requests to a specific user.
- Require an authenticated active user on catalog request creation and notification subscription endpoints so requests are always tied to a user.

Enhancements:
- Implement backfill and first-owner-wins semantics in catalog request use cases so legacy anonymous rows can be attributed on resubmit without reassigning existing owners.

Build:
- Add a database migration to introduce a nullable requester_user_id column and index on the catalog_requests table.

Tests:
- Add unit tests covering persistence of requester_user_id on new requests, backfilling for legacy rows, and preserving the original requester when a different user re-submits.