### PR TITLE
feat(notifications): mark-all-read endpoint

### DIFF
--- a/src/config/containers/notifications.py
+++ b/src/config/containers/notifications.py
@@ -5,6 +5,7 @@ from dependency_injector import containers, providers
 from src.modules.notifications.application.use_cases import (
     CreateNotificationUseCase,
     ListUserNotificationsUseCase,
+    MarkAllNotificationsReadUseCase,
     MarkNotificationReadUseCase,
 )
 from src.modules.notifications.infrastructure.acl import NotificationPublisherAdapter
@@ -53,6 +54,11 @@ class NotificationsContainer(containers.DeclarativeContainer):  # type: ignore[m
 
     mark_notification_read = providers.Factory(
         MarkNotificationReadUseCase,
+        uow_factory=notifications_unit_of_work_factory,
+    )
+
+    mark_all_notifications_read = providers.Factory(
+        MarkAllNotificationsReadUseCase,
         uow_factory=notifications_unit_of_work_factory,
     )
 

--- a/src/modules/notifications/application/dtos/__init__.py
+++ b/src/modules/notifications/application/dtos/__init__.py
@@ -3,6 +3,8 @@
 from src.modules.notifications.application.dtos.notification_dtos import (
     CreateNotificationInput,
     ListUserNotificationsInput,
+    MarkAllNotificationsReadInput,
+    MarkAllNotificationsReadOutput,
     MarkNotificationReadInput,
     NotificationOutput,
 )
@@ -10,6 +12,8 @@ from src.modules.notifications.application.dtos.notification_dtos import (
 __all__ = [
     "CreateNotificationInput",
     "ListUserNotificationsInput",
+    "MarkAllNotificationsReadInput",
+    "MarkAllNotificationsReadOutput",
     "MarkNotificationReadInput",
     "NotificationOutput",
 ]

--- a/src/modules/notifications/application/dtos/notification_dtos.py
+++ b/src/modules/notifications/application/dtos/notification_dtos.py
@@ -67,6 +67,33 @@ class MarkNotificationReadInput:
 
 
 @dataclass(frozen=True)
+class MarkAllNotificationsReadInput:
+    """Input for ``MarkAllNotificationsReadUseCase``.
+
+    Attributes:
+        recipient_user_id: External id of the caller. The route
+            fills this from the auth context so a user can't
+            clear another user's inbox.
+    """
+
+    recipient_user_id: str
+
+
+@dataclass(frozen=True)
+class MarkAllNotificationsReadOutput:
+    """Output for ``MarkAllNotificationsReadUseCase``.
+
+    Attributes:
+        marked_read: How many rows transitioned from unread to
+            read on this call. ``0`` when the inbox was already
+            clean — the route still returns 200 so the frontend
+            doesn't have to branch on the empty case.
+    """
+
+    marked_read: int
+
+
+@dataclass(frozen=True)
 class NotificationOutput:
     """Output representation of a notification.
 

--- a/src/modules/notifications/application/use_cases/__init__.py
+++ b/src/modules/notifications/application/use_cases/__init__.py
@@ -6,6 +6,9 @@ from src.modules.notifications.application.use_cases.create_notification import 
 from src.modules.notifications.application.use_cases.list_user_notifications import (
     ListUserNotificationsUseCase,
 )
+from src.modules.notifications.application.use_cases.mark_all_notifications_read import (
+    MarkAllNotificationsReadUseCase,
+)
 from src.modules.notifications.application.use_cases.mark_notification_read import (
     MarkNotificationReadUseCase,
 )
@@ -13,5 +16,6 @@ from src.modules.notifications.application.use_cases.mark_notification_read impo
 __all__ = [
     "CreateNotificationUseCase",
     "ListUserNotificationsUseCase",
+    "MarkAllNotificationsReadUseCase",
     "MarkNotificationReadUseCase",
 ]

--- a/src/modules/notifications/application/use_cases/mark_all_notifications_read.py
+++ b/src/modules/notifications/application/use_cases/mark_all_notifications_read.py
@@ -1,0 +1,44 @@
+"""Mark every unread notification of one user as read."""
+
+from src.modules.notifications.application.dtos import (
+    MarkAllNotificationsReadInput,
+    MarkAllNotificationsReadOutput,
+)
+from src.modules.notifications.application.unit_of_work import (
+    NotificationsUnitOfWorkFactory,
+)
+
+
+class MarkAllNotificationsReadUseCase:
+    """Bulk-clear the caller's unread inbox.
+
+    Backs the "Marcar todas como lidas" affordance in the header
+    bell. Implemented as a single bulk ``UPDATE`` at the repo
+    layer — no per-row read of aggregates — so a long-untouched
+    inbox flips in one round-trip. Already-read rows are left
+    alone so their original ``read_at`` doesn't get rewritten.
+    Idempotent: a second call returns ``marked_read=0`` without
+    a DB write.
+    """
+
+    def __init__(self, uow_factory: NotificationsUnitOfWorkFactory) -> None:
+        """Initialize the use case.
+
+        Args:
+            uow_factory: Factory that opens a fresh notifications UoW.
+        """
+        self._uow_factory = uow_factory
+
+    async def execute(
+        self,
+        input_dto: MarkAllNotificationsReadInput,
+    ) -> MarkAllNotificationsReadOutput:
+        """Execute the use case."""
+        async with self._uow_factory() as uow:
+            marked = await uow.notifications.mark_all_read_for_user(
+                input_dto.recipient_user_id,
+            )
+        return MarkAllNotificationsReadOutput(marked_read=marked)
+
+
+__all__ = ["MarkAllNotificationsReadUseCase"]

--- a/src/modules/notifications/domain/repositories/notification_repository.py
+++ b/src/modules/notifications/domain/repositories/notification_repository.py
@@ -94,5 +94,23 @@ class NotificationRepository(ABC):
             Number of non-deleted notifications with ``read_at IS NULL``.
         """
 
+    @abstractmethod
+    async def mark_all_read_for_user(self, recipient_user_id: str) -> int:
+        """Stamp every unread notification of a user as read.
+
+        Powers the "Marcar todas como lidas" action in the header
+        bell. Implemented as a single bulk ``UPDATE`` instead of an
+        N+1 fetch-then-update so a long-untouched inbox flips in
+        one round-trip. Already-read rows are left alone so the
+        original ``read_at`` doesn't move.
+
+        Args:
+            recipient_user_id: External id of the recipient.
+
+        Returns:
+            Count of rows that were flipped from unread to read on
+            this call. ``0`` when the inbox was already clean.
+        """
+
 
 __all__ = ["NotificationRepository"]

--- a/src/modules/notifications/infrastructure/persistence/repositories/notification_repository.py
+++ b/src/modules/notifications/infrastructure/persistence/repositories/notification_repository.py
@@ -1,6 +1,8 @@
 """SQLAlchemy implementation of ``NotificationRepository``."""
 
-from sqlalchemy import func, select
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.notifications.domain.entities import Notification
@@ -100,6 +102,22 @@ class SQLAlchemyNotificationRepository(NotificationRepository):
         )
         result = await self._session.execute(stmt)
         return int(result.scalar_one() or 0)
+
+    async def mark_all_read_for_user(self, recipient_user_id: str) -> int:
+        """Bulk-flip every unread notification of a user to read."""
+        now = datetime.now(UTC)
+        stmt = (
+            update(NotificationModel)
+            .where(
+                NotificationModel.recipient_user_id == recipient_user_id,
+                NotificationModel.read_at.is_(None),
+                NotificationModel.deleted_at.is_(None),
+            )
+            .values(read_at=now, updated_at=now)
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        return result.rowcount or 0
 
 
 __all__ = ["SQLAlchemyNotificationRepository"]

--- a/src/modules/notifications/presentation/routes/notification_routes.py
+++ b/src/modules/notifications/presentation/routes/notification_routes.py
@@ -12,10 +12,12 @@ from src.modules.identity.infrastructure.auth import current_active_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.notifications.application.dtos import (
     ListUserNotificationsInput,
+    MarkAllNotificationsReadInput,
     MarkNotificationReadInput,
 )
 from src.modules.notifications.application.use_cases import (
     ListUserNotificationsUseCase,
+    MarkAllNotificationsReadUseCase,
     MarkNotificationReadUseCase,
 )
 
@@ -78,6 +80,28 @@ async def mark_notification_read(
         ),
     )
     return api_single("notification", asdict(result))
+
+
+@router.post("/read-all")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def mark_all_notifications_read(
+    user: UserModel = Depends(current_active_user),
+    use_case: MarkAllNotificationsReadUseCase = Depends(
+        Provide[ApplicationContainer.notifications.mark_all_notifications_read],
+    ),
+) -> dict[str, Any]:
+    """Flip every unread notification of the caller to read.
+
+    Backs the "Marcar todas como lidas" affordance in the header
+    bell. Idempotent — an empty inbox returns ``marked_read=0``
+    so the frontend doesn't have to branch on the empty case.
+    Scoped to the caller; another user's notifications are never
+    touched.
+    """
+    result = await use_case.execute(
+        MarkAllNotificationsReadInput(recipient_user_id=user.external_id),
+    )
+    return api_single("notifications_read_all", asdict(result))
 
 
 __all__ = ["router"]

--- a/tests/modules/notifications/unit/application/use_cases/test_mark_all_notifications_read.py
+++ b/tests/modules/notifications/unit/application/use_cases/test_mark_all_notifications_read.py
@@ -1,0 +1,43 @@
+"""Tests for ``MarkAllNotificationsReadUseCase``."""
+
+import pytest
+
+from src.modules.notifications.application.dtos import MarkAllNotificationsReadInput
+from src.modules.notifications.application.use_cases import (
+    MarkAllNotificationsReadUseCase,
+)
+from tests.modules.notifications.unit.conftest import make_notifications_uow_mock
+
+
+@pytest.mark.unit
+class TestMarkAllNotificationsReadUseCase:
+    """Tests for the bulk-clear handler."""
+
+    @pytest.mark.asyncio
+    async def test_returns_count_of_flipped_rows(self) -> None:
+        mocks = make_notifications_uow_mock()
+        mocks.notifications.mark_all_read_for_user.return_value = 4
+        use_case = MarkAllNotificationsReadUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            MarkAllNotificationsReadInput(recipient_user_id="usr_alice"),
+        )
+
+        assert result.marked_read == 4
+        mocks.notifications.mark_all_read_for_user.assert_awaited_once_with(
+            "usr_alice",
+        )
+
+    @pytest.mark.asyncio
+    async def test_idempotent_empty_inbox(self) -> None:
+        """An already-clean inbox returns ``marked_read=0`` without
+        any need for the caller to branch on the empty case."""
+        mocks = make_notifications_uow_mock()
+        mocks.notifications.mark_all_read_for_user.return_value = 0
+        use_case = MarkAllNotificationsReadUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            MarkAllNotificationsReadInput(recipient_user_id="usr_alice"),
+        )
+
+        assert result.marked_read == 0


### PR DESCRIPTION
## Summary
- `NotificationRepository.mark_all_read_for_user(user_id) -> int` abstract method + SQLAlchemy impl as a single bulk `UPDATE ... WHERE recipient_user_id = ? AND read_at IS NULL AND deleted_at IS NULL`. Returns `result.rowcount` so the caller knows how many rows actually flipped.
- `MarkAllNotificationsReadUseCase` + matching DTOs (`MarkAllNotificationsReadInput` / `Output`). Scoped to the caller by construction — the use case never accepts an arbitrary user id.
- `POST /api/v1/notifications/read-all` route gated by `current_active_user`; response shape `{ "type": "notifications_read_all", "data": { "marked_read": N } }`. Idempotent — an already-clean inbox returns `marked_read=0`.
- Container wiring under `notifications.mark_all_notifications_read`.

## Test plan
- [x] `make test` — 2477 passed (2 new unit tests covering the use case + idempotent empty-inbox path).
- [x] `make lint` (ruff check + format check).
- [ ] Manual: log in, register a couple of catalog requests with `notify_on_arrival`, enrich the matching titles to produce notifications, call `POST /api/v1/notifications/read-all`, verify `marked_read` matches the previous unread count and that `GET /api/v1/notifications` now shows `unread_count=0`.

## Summary by Sourcery

Add a bulk 'mark all notifications as read' capability exposed via a new API endpoint and wired through the notifications use case and repository layers.

New Features:
- Introduce MarkAllNotificationsRead use case and DTOs to clear all unread notifications for the current user.
- Expose a POST /api/v1/notifications/read-all endpoint returning the count of notifications marked as read for the caller.

Enhancements:
- Extend the notification repository with a bulk mark_all_read_for_user operation implemented as a single SQL update for efficiency.
- Wire the new use case into the dependency injection container for notifications.

Tests:
- Add unit tests covering the MarkAllNotificationsRead use case, including the idempotent empty-inbox behavior.