### PR TITLE
refactor: align stray VOs with canonical base

### DIFF
--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -21,7 +21,7 @@ from src.modules.media.application.use_cases._media_file_helpers import (
 )
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import SeriesId
-from src.shared_kernel.episode_composite_id import EpisodeCompositeId
+from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
 
 
 class GetSeriesByIdUseCase:

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -16,7 +16,7 @@ from src.modules.watch_progress.domain.value_objects import (
     WatchableMediaType,
     WatchStatus,
 )
-from src.shared_kernel.episode_composite_id import EpisodeCompositeId
+from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 if TYPE_CHECKING:

--- a/src/modules/watch_progress/domain/entities/__init__.py
+++ b/src/modules/watch_progress/domain/entities/__init__.py
@@ -1,5 +1,13 @@
 """Watch Progress entities."""
 
 from src.modules.watch_progress.domain.entities.watch_progress import WatchProgress
+from src.modules.watch_progress.domain.value_objects.episode_candidate import (
+    EpisodeCandidate,
+)
+
+# ``EpisodeCandidate`` declares ``progress: WatchProgress | None`` as a forward
+# reference (the value_objects package is imported by WatchProgress, so the VO
+# cannot eager-import the entity). Resolve it here, after both are loaded.
+EpisodeCandidate.model_rebuild()
 
 __all__ = ["WatchProgress"]

--- a/src/modules/watch_progress/domain/value_objects/episode_candidate.py
+++ b/src/modules/watch_progress/domain/value_objects/episode_candidate.py
@@ -14,15 +14,17 @@ produce them.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
+
+from pydantic import ConfigDict
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
 
 if TYPE_CHECKING:
     from src.modules.watch_progress.domain.entities import WatchProgress
 
 
-@dataclass(frozen=True)
-class EpisodeCandidate:
+class EpisodeCandidate(CompoundValueObject):
     """A single episode weighed by the continue-watching selector.
 
     Attributes:
@@ -38,13 +40,24 @@ class EpisodeCandidate:
             episode has never been played.
     """
 
+    # ``progress`` references ``WatchProgress``, which transitively imports
+    # this module via ``value_objects/__init__``. Defer build so Pydantic
+    # resolves the forward reference once ``entities/__init__`` calls
+    # ``EpisodeCandidate.model_rebuild()``.
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        frozen=True,
+        validate_assignment=True,
+        extra="forbid",
+        defer_build=True,
+    )
+
     series_id: str
     media_id: str
     season_number: int
     episode_number: int
     episode_title: str
     duration_seconds: int
-    progress: WatchProgress | None
+    progress: WatchProgress | None = None
 
 
 __all__ = ["EpisodeCandidate"]

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -1,5 +1,6 @@
 """Shared value objects used across multiple modules."""
 
+from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.image_url import ImageUrl
 from src.shared_kernel.value_objects.language_code import LanguageCode
@@ -11,6 +12,7 @@ from src.shared_kernel.value_objects.user_id import UserId
 __all__ = [
     "AudioTrack",
     "CollectionMediaType",
+    "EpisodeCompositeId",
     "FilePath",
     "ImageUrl",
     "LanguageCode",

--- a/src/shared_kernel/value_objects/episode_composite_id.py
+++ b/src/shared_kernel/value_objects/episode_composite_id.py
@@ -8,11 +8,11 @@ utilities so the format is defined in a single place.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.value_objects import CompoundValueObject
 
 
-@dataclass(frozen=True)
-class EpisodeCompositeId:
+class EpisodeCompositeId(CompoundValueObject):
     """Composite episode identifier used by the frontend.
 
     Attributes:
@@ -79,7 +79,7 @@ class EpisodeCompositeId:
                 season_number=int(season_str),
                 episode_number=int(episode_str),
             )
-        except ValueError:
+        except (ValueError, DomainValidationException):
             return None
 
 

--- a/tests/shared_kernel/unit/test_episode_composite_id.py
+++ b/tests/shared_kernel/unit/test_episode_composite_id.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.shared_kernel.episode_composite_id import EpisodeCompositeId
+from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
 
 
 class TestEpisodeCompositeIdBuild:


### PR DESCRIPTION
## Summary

- Migrate `EpisodeCandidate` from `@dataclass(frozen=True)` to `CompoundValueObject`. Uses `defer_build=True` + `EpisodeCandidate.model_rebuild()` in `watch_progress/domain/entities/__init__.py` so the forward reference to `WatchProgress` resolves without import cycles.
- Migrate `EpisodeCompositeId` to `src/shared_kernel/value_objects/episode_composite_id.py` as `CompoundValueObject`. Keeps `build()` / `parse()` factories; `parse()` now also catches `DomainValidationException` to preserve the `None`-on-invalid contract.
- Updates 2 production imports (`media/get_series_by_id`, `watch_progress/get_continue_watching`) and 1 test import; old `src/shared_kernel/episode_composite_id.py` removed (git detects rename, 91% similarity).

These were the only two domain VOs in the codebase still bypassing the canonical base in `src/building_blocks/domain/value_objects.py`. All other 56 VOs were already conformant.

## Test plan

- [x] `pytest tests/modules/watch_progress/` — 88 passed
- [x] `pytest tests/shared_kernel/ tests/modules/watch_progress/ tests/modules/media/` — 1516 passed
- [x] Full suite: `pytest` — 2477 passed, 5 skipped
- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] Smoke: `EpisodeCandidate(...)` constructs via kwargs, value-equality holds, mutation raises `DomainValidationException`
- [x] Smoke: `EpisodeCompositeId.build("ser_X", 1, 2).media_id == "epi_ser_X_1_2"` and `parse()` round-trips

## Summary by Sourcery

Align remaining episode-related value objects with the canonical CompoundValueObject base and update references accordingly.

Bug Fixes:
- Ensure EpisodeCompositeId.parse() returns None for both malformed strings and domain validation failures to preserve its original contract.

Enhancements:
- Convert EpisodeCandidate to a CompoundValueObject with immutable, validated fields and proper handling of the forward reference to WatchProgress.
- Migrate EpisodeCompositeId into the shared_kernel.value_objects package and reimplement it as a CompoundValueObject while keeping the existing build()/parse() API.

Chores:
- Update module imports and shared_kernel.value_objects exports to reference the new EpisodeCompositeId location and remove the old module.