### PR TITLE
feat(settings): migrate scheduler/backfill/intro jobs to RuntimeSettings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,33 +61,15 @@ TMDB_BASE_URL=https://api.themoviedb.org/3
 OMDB_API_KEY=your_omdb_api_key_here
 
 # -----------------------------------------------------------------------------
-# Scheduler
+# Scheduler / Thumbnail backfill / Intro detection
 # -----------------------------------------------------------------------------
-# Master switch for the background scheduler that runs library scans
-# and the periodic backfill jobs below. Turn off only when something
-# is broken — every job is also gated by its own *_ENABLED flag.
-SCHEDULER_ENABLED=true
-
-# How often the scheduler re-reads libraries from the database to
-# sync cron jobs with their configured schedules. Lower values pick
-# up schedule edits sooner; higher values reduce idle DB chatter.
-SCHEDULER_RECONCILE_INTERVAL_MINUTES=5
-
-# -----------------------------------------------------------------------------
-# Thumbnail backfill
-# -----------------------------------------------------------------------------
-# Periodic job that fills in scrub-preview sprites for movies and
-# episodes that don't have one yet (e.g. items added by a scan but
-# never streamed).
-THUMBNAIL_BACKFILL_ENABLED=true
-THUMBNAIL_BACKFILL_BATCH_SIZE=10        # items per tick
-THUMBNAIL_BACKFILL_INTERVAL_MINUTES=20  # how often the job runs
-
-# Subdirectory (relative to each media file's parent folder) where the
-# generated sprite + VTT pair is written, nested under a per-stem
-# leaf so episodes that share a season folder don't overwrite each
-# other.
-THUMBNAIL_BACKFILL_SUBDIR=.homeflix/thumbnails
+# All scheduler / thumbnail-backfill / intro-detection knobs moved to
+# the ``app_settings`` table in ADR-013 phase 2. Edit them via the
+# admin panel or:
+#   UPDATE app_settings SET value_json='...' WHERE key='scheduler';
+# The legacy ``SCHEDULER_*``, ``THUMBNAIL_BACKFILL_*`` and
+# ``INTRO_DETECTION_*`` env vars no longer take effect; startup logs
+# a warning if any of them are still set.
 
 # -----------------------------------------------------------------------------
 # FFmpeg
@@ -106,41 +88,6 @@ THUMBNAIL_BACKFILL_SUBDIR=.homeflix/thumbnails
 # -----------------------------------------------------------------------------
 DEFAULT_LOCALE=en
 SUPPORTED_LOCALES=en,pt-BR
-
-# -----------------------------------------------------------------------------
-# Intro detection (Skip Intro)
-# -----------------------------------------------------------------------------
-# Periodic background job that locates the shared opening sequence of
-# each TV season via Chromaprint audio fingerprinting. Off by default
-# because it requires the `fpcalc` binary on PATH.
-#   Linux:   apt install libchromaprint-tools
-#   macOS:   brew install chromaprint
-#   Windows: scoop install chromaprint  (or drop fpcalc.exe on PATH)
-INTRO_DETECTION_ENABLED=false
-
-# Job scheduling
-INTRO_DETECTION_BATCH_SIZE=1                # seasons processed per tick
-INTRO_DETECTION_INTERVAL_MINUTES=30         # how often the job runs
-INTRO_DETECTION_AUDIO_WINDOW_SECONDS=600    # leading audio scanned per ep
-INTRO_DETECTION_MIN_CONFIDENCE=0.7          # peer-agreement floor [0.0-1.0]
-
-# Algorithm calibration — only adjust if detections come back too long
-# or too short on real episodes. See `docs/roadmap.md` (3.3) and the
-# detector docstring for the trade-offs.
-#
-# Per-hash hamming-distance ceiling (out of 32 bits) considered a
-# "match". Lower values discriminate better and stop runs from
-# overshooting into shared underscore music; higher values absorb
-# more chromaprint noise.
-INTRO_DETECTION_MAX_HASH_HAMMING=10
-# How many CONSECUTIVE non-matching hashes a run can absorb before
-# terminating. A fresh good hash resets the counter.
-INTRO_DETECTION_TOLERANCE_HASHES=2
-# Floor and cap on persisted match length. Anything below the floor
-# is dropped (likely a recurring sting, not the title sequence);
-# anything above the cap is truncated at start + max.
-INTRO_DETECTION_MIN_INTRO_SECONDS=5
-INTRO_DETECTION_MAX_INTRO_SECONDS=120
 
 # -----------------------------------------------------------------------------
 # Security (for future use)

--- a/migrations/versions/2026_05_22_seed_app_settings_from_env.py
+++ b/migrations/versions/2026_05_22_seed_app_settings_from_env.py
@@ -1,0 +1,143 @@
+"""Seed app_settings from pre-existing env vars.
+
+One-time migration for ADR-013 phase 2 — preserves any operator
+customization of the scheduler / thumbnail-backfill / intro-detection
+knobs that was previously living in the ``.env`` file.
+
+Semantics:
+
+- For each of the three buckets, the migration reads every env var
+  that used to feed the corresponding ``Settings`` field.
+- If *any* env var in a bucket is set, a row is inserted with
+  ``source='migration_seed'`` carrying the Pydantic VO built from
+  (env value where set, Pydantic default otherwise).
+- If no env var in a bucket is set, no row is written — the bucket
+  falls through to the VO's defaults at read time.
+- The insert uses ``INSERT OR IGNORE`` (SQLite) / ``ON CONFLICT DO
+  NOTHING`` (Postgres) so re-running the migration on a database
+  that already has admin edits does not overwrite them.
+
+``downgrade`` removes the rows this migration inserted (filtered by
+``source='migration_seed'``); admin-edited rows from a later phase
+survive a downgrade.
+
+Revision ID: 1b2c3d4e5f60
+Revises: 0a1b2c3d4e5f
+Create Date: 2026-05-22 09:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING, Any
+
+import sqlalchemy as sa
+from alembic import op
+
+from src.modules.settings.domain.value_objects import (
+    IntroDetectionConfig,
+    SchedulerConfig,
+    SettingKey,
+    SettingSource,
+    ThumbnailBackfillConfig,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "1b2c3d4e5f60"
+down_revision: str | Sequence[str] | None = "0a1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Maps a bucket's env-var name -> (VO class, VO field name). The env var
+# is read at migration time only; running code reads
+# ``RuntimeSettings`` instead.
+_SCHEDULER_ENV_MAP: dict[str, str] = {
+    "SCHEDULER_ENABLED": "enabled",
+    "SCHEDULER_RECONCILE_INTERVAL_MINUTES": "reconcile_interval_minutes",
+}
+
+_THUMBNAIL_BACKFILL_ENV_MAP: dict[str, str] = {
+    "THUMBNAIL_BACKFILL_ENABLED": "enabled",
+    "THUMBNAIL_BACKFILL_BATCH_SIZE": "batch_size",
+    "THUMBNAIL_BACKFILL_INTERVAL_MINUTES": "interval_minutes",
+    "THUMBNAIL_BACKFILL_SUBDIR": "subdir",
+}
+
+_INTRO_DETECTION_ENV_MAP: dict[str, str] = {
+    "INTRO_DETECTION_ENABLED": "enabled",
+    "INTRO_DETECTION_BATCH_SIZE": "batch_size",
+    "INTRO_DETECTION_INTERVAL_MINUTES": "interval_minutes",
+    "INTRO_DETECTION_AUDIO_WINDOW_SECONDS": "audio_window_seconds",
+    "INTRO_DETECTION_MIN_CONFIDENCE": "min_confidence",
+    "INTRO_DETECTION_MAX_HASH_HAMMING": "max_hash_hamming",
+    "INTRO_DETECTION_TOLERANCE_HASHES": "tolerance_hashes",
+    "INTRO_DETECTION_MIN_INTRO_SECONDS": "min_intro_seconds",
+    "INTRO_DETECTION_MAX_INTRO_SECONDS": "max_intro_seconds",
+}
+
+
+def _collect_overrides(env_map: dict[str, str]) -> dict[str, str]:
+    """Return ``{field_name: raw env value}`` for every var that is set."""
+    return {field: value for env, field in env_map.items() if (value := os.environ.get(env))}
+
+
+def _maybe_seed_row(
+    connection: sa.Connection,
+    key: SettingKey,
+    overrides: dict[str, str],
+    vo_factory: Any,
+) -> None:
+    """Insert a seed row when at least one env var is set for ``key``."""
+    if not overrides:
+        return
+    vo = vo_factory.model_validate(overrides)
+    payload = vo.model_dump(mode="json")
+    connection.execute(
+        sa.text(
+            "INSERT OR IGNORE INTO app_settings "
+            "(key, value_json, source, updated_at) "
+            "VALUES (:key, :value_json, :source, CURRENT_TIMESTAMP)"
+        ),
+        {
+            "key": key.value,
+            "value_json": json.dumps(payload),
+            "source": SettingSource.MIGRATION_SEED.value,
+        },
+    )
+
+
+def upgrade() -> None:
+    """Seed app_settings rows from any env vars still present."""
+    connection = op.get_bind()
+    _maybe_seed_row(
+        connection,
+        SettingKey.SCHEDULER,
+        _collect_overrides(_SCHEDULER_ENV_MAP),
+        SchedulerConfig,
+    )
+    _maybe_seed_row(
+        connection,
+        SettingKey.THUMBNAIL_BACKFILL,
+        _collect_overrides(_THUMBNAIL_BACKFILL_ENV_MAP),
+        ThumbnailBackfillConfig,
+    )
+    _maybe_seed_row(
+        connection,
+        SettingKey.INTRO_DETECTION,
+        _collect_overrides(_INTRO_DETECTION_ENV_MAP),
+        IntroDetectionConfig,
+    )
+
+
+def downgrade() -> None:
+    """Remove migration-seeded rows; spare any admin-edited ones."""
+    connection = op.get_bind()
+    connection.execute(
+        sa.text("DELETE FROM app_settings WHERE source = :source"),
+        {"source": SettingSource.MIGRATION_SEED.value},
+    )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -152,10 +152,6 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         hls_cache_directory=config.provided.hls_cache_directory,
         hls_cache_max_size_mb=config.provided.hls_cache_max_size_mb,
         ffmpeg_threads=config.provided.ffmpeg_threads,
-        intro_detection_max_hash_hamming=config.provided.intro_detection_max_hash_hamming,
-        intro_detection_tolerance_hashes=config.provided.intro_detection_tolerance_hashes,
-        intro_detection_min_intro_seconds=config.provided.intro_detection_min_intro_seconds,
-        intro_detection_max_intro_seconds=config.provided.intro_detection_max_intro_seconds,
     )
 
     library = providers.Container(
@@ -221,15 +217,14 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         LibraryScanScheduler,
         library_uow_factory=library.library_unit_of_work_factory,
         scan_run_service=media.scan_run_service,
-        reconcile_interval_minutes=config.provided.scheduler_reconcile_interval_minutes,
+        runtime_settings=settings.runtime_settings,
     )
 
     thumbnail_backfill_job = providers.Singleton(
         ThumbnailBackfillJob,
         media_uow_factory=media.media_unit_of_work_factory,
+        runtime_settings=settings.runtime_settings,
         thumbnail_service=media.thumbnail_generation_service,
-        batch_size=config.provided.thumbnail_backfill_batch_size,
-        sprite_subdir=config.provided.thumbnail_backfill_subdir,
     )
 
     intro_detection_job = providers.Singleton(
@@ -238,9 +233,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         audio_extractor=media.audio_extractor,
         chromaprint_service=media.chromaprint_service,
         intro_detector=media.intro_detector,
-        batch_size=config.provided.intro_detection_batch_size,
-        audio_window_seconds=config.provided.intro_detection_audio_window_seconds,
-        min_confidence=config.provided.intro_detection_min_confidence,
+        runtime_settings=settings.runtime_settings,
     )
 
 

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -157,13 +157,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # auto-default (all cores). Wired from ``Settings.ffmpeg_threads``.
     ffmpeg_threads = providers.Dependency(default=None)
 
-    # Intro-detection algorithm tuning knobs. Defaults match the
-    # detector's own defaults; the composition root overrides via
-    # ``Settings.intro_detection_*``.
-    intro_detection_max_hash_hamming = providers.Dependency(default=10)
-    intro_detection_tolerance_hashes = providers.Dependency(default=2)
-    intro_detection_min_intro_seconds = providers.Dependency(default=5.0)
-    intro_detection_max_intro_seconds = providers.Dependency(default=120.0)
+    # Intro-detection algorithm tuning knobs now live in
+    # ``IntroDetectionConfig`` (ADR-013 phase 2). The intro-detection
+    # job snapshots :class:`RuntimeSettings` per run and forwards the
+    # tuning as :class:`IntroDetectorTuning` on each ``detect()`` call,
+    # so the detector itself no longer carries these as constructor
+    # state.
 
     # =========================================================================
     # Unit of Work
@@ -344,13 +343,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     chromaprint_service = providers.Singleton(ChromaprintService)
 
-    intro_detector = providers.Singleton(
-        ChromaprintIntroDetector,
-        max_hash_hamming=intro_detection_max_hash_hamming,
-        tolerance_hashes=intro_detection_tolerance_hashes,
-        min_intro_seconds=intro_detection_min_intro_seconds,
-        max_intro_seconds=intro_detection_max_intro_seconds,
-    )
+    intro_detector = providers.Singleton(ChromaprintIntroDetector)
 
     file_streamer = providers.Factory(LocalFileStreamer)
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -148,113 +148,14 @@ class Settings(BaseSettings):  # type: ignore[misc]
     )
 
     # =========================================================================
-    # Scheduler
+    # Scheduler / background jobs
     # =========================================================================
-
-    scheduler_enabled: bool = Field(
-        default=True,
-        description="Enable the background scheduler (library scans, etc.).",
-    )
-    scheduler_reconcile_interval_minutes: int = Field(
-        default=5,
-        ge=1,
-        description="How often the scheduler re-reads libraries from the "
-        "database to sync cron jobs with configured schedules.",
-    )
-
-    thumbnail_backfill_enabled: bool = Field(
-        default=True,
-        description="Enable the periodic job that fills in scrub-preview "
-        "thumbnails for movies and episodes that don't have one yet.",
-    )
-    thumbnail_backfill_batch_size: int = Field(
-        default=10,
-        ge=1,
-        description="Maximum number of media items processed per backfill "
-        "tick. Lower values reduce CPU spikes; higher values catch up "
-        "faster on a large catalog.",
-    )
-    thumbnail_backfill_interval_minutes: int = Field(
-        default=20,
-        ge=1,
-        description="How often the thumbnail backfill job runs.",
-    )
-    thumbnail_backfill_subdir: str = Field(
-        default=".homeflix/thumbnails",
-        description="Subdirectory (relative to each media file's parent "
-        "folder) where backfilled sprite + VTT files are written.",
-    )
-
-    intro_detection_enabled: bool = Field(
-        default=False,
-        description="Enable the periodic intro-detection job that locates "
-        "the shared opening sequence for each season via Chromaprint "
-        "audio fingerprinting. Off by default because it requires the "
-        "``fpcalc`` binary on PATH; turn it on once Chromaprint is "
-        "installed (``apt install libchromaprint-tools`` / "
-        "``brew install chromaprint``).",
-    )
-    intro_detection_batch_size: int = Field(
-        default=1,
-        ge=1,
-        description="Maximum number of seasons processed per detection "
-        "tick. Each season triggers ffmpeg + fpcalc per episode, so "
-        "values above 2 can saturate the host on large seasons.",
-    )
-    intro_detection_interval_minutes: int = Field(
-        default=30,
-        ge=1,
-        description="How often the intro-detection job runs.",
-    )
-    intro_detection_audio_window_seconds: int = Field(
-        default=600,
-        ge=60,
-        description="How many seconds of leading audio to analyse per "
-        "episode. 600s (10 min) covers all common cold-open + intro "
-        "lengths; trimming this lower speeds up the job at the cost "
-        "of missing intros that start late.",
-    )
-    intro_detection_min_confidence: float = Field(
-        default=0.7,
-        ge=0.0,
-        le=1.0,
-        description="Minimum detector confidence (in ``[0.0, 1.0]``) "
-        "required before an auto-detected intro is persisted. Confidence "
-        "is the fraction of peer episodes whose fingerprint agreed "
-        "with the candidate marker.",
-    )
-    intro_detection_max_hash_hamming: int = Field(
-        default=10,
-        ge=0,
-        le=32,
-        description="Per-hash hamming-distance ceiling (out of 32 bits) "
-        "considered a 'match' between two episode fingerprints. Lower "
-        "values reject more borderline hashes — useful when detections "
-        "overshoot into shared underscore music; higher values absorb "
-        "more chromaprint noise.",
-    )
-    intro_detection_tolerance_hashes: int = Field(
-        default=2,
-        ge=0,
-        description="How many CONSECUTIVE non-matching hashes a run "
-        "can absorb before terminating. A fresh good hash resets the "
-        "counter so isolated chromaprint noise is forgiven indefinitely.",
-    )
-    intro_detection_min_intro_seconds: float = Field(
-        default=5.0,
-        ge=0.0,
-        description="Minimum intro length to accept. Shorter matches "
-        "are dropped — usually they are recurring stingers / bumpers "
-        "rather than the title sequence proper.",
-    )
-    intro_detection_max_intro_seconds: float = Field(
-        default=120.0,
-        ge=10.0,
-        description="Hard cap on persisted intro length. Real intros "
-        "rarely exceed two minutes; longer detections almost always "
-        "include shared underscore that bleeds past the title sequence "
-        "and should be truncated to avoid skipping into the episode.",
-    )
+    # All scheduler / thumbnail-backfill / intro-detection tunables moved
+    # to ``app_settings`` (ADR-013 phase 2). Set them via the admin
+    # panel or ``UPDATE app_settings SET value_json=...`` for ops
+    # overrides. Setting the legacy ``SCHEDULER_*``, ``THUMBNAIL_BACKFILL_*``
+    # or ``INTRO_DETECTION_*`` env vars now has no effect — startup
+    # warns about each one it sees (see ``main.py``).
 
     ffmpeg_threads: int | None = Field(
         default=None,

--- a/src/infrastructure/scheduling/intro_detection_job.py
+++ b/src/infrastructure/scheduling/intro_detection_job.py
@@ -29,7 +29,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from src.config.logging import get_logger
-from src.modules.media.application.ports import EpisodeFingerprint
+from src.modules.media.application.ports import EpisodeFingerprint, IntroDetectorTuning
 from src.modules.media.domain.value_objects import (
     IntroDetectionState,
     IntroMarker,
@@ -47,6 +47,8 @@ if TYPE_CHECKING:
         AudioExtractor,
         ChromaprintService,
     )
+    from src.modules.settings.domain.value_objects import IntroDetectionConfig
+    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = get_logger()
 
@@ -60,6 +62,11 @@ _MAX_ERROR_MESSAGE_LENGTH = 2000
 class IntroDetectionJob:
     """Run a single batch of audio-fingerprint intro detection.
 
+    All operator-tunable knobs (batch size, audio window, confidence
+    floor, detector tuning) are read from
+    :class:`RuntimeSettings` at the start of each ``run()`` so admin
+    edits propagate to the next tick without restart (ADR-013).
+
     Args:
         media_uow_factory: Builds fresh media UoWs. The job opens one
             UoW per state transition so a failure on a single season
@@ -69,13 +76,11 @@ class IntroDetectionJob:
         chromaprint_service: fpcalc wrapper that turns each WAV into a
             raw fingerprint.
         intro_detector: Cross-correlation algorithm that locates the
-            shared intro across the season's fingerprints.
-        batch_size: Maximum number of seasons processed per tick.
-        audio_window_seconds: How many leading seconds of each episode
-            to feed into fpcalc.
-        min_confidence: Auto-detected markers with confidence below
-            this floor are discarded — the season is still flagged
-            ``COMPLETED`` so it is not reprocessed indefinitely.
+            shared intro across the season's fingerprints. Receives
+            its tuning per ``detect()`` call so it stays stateless
+            with respect to runtime config.
+        runtime_settings: Snapshot facade for
+            :class:`IntroDetectionConfig`.
     """
 
     def __init__(
@@ -84,23 +89,19 @@ class IntroDetectionJob:
         audio_extractor: AudioExtractor,
         chromaprint_service: ChromaprintService,
         intro_detector: IntroDetectorPort,
-        *,
-        batch_size: int = 1,
-        audio_window_seconds: int = 600,
-        min_confidence: float = 0.7,
+        runtime_settings: RuntimeSettings,
     ) -> None:
         self._media_uow_factory = media_uow_factory
         self._audio_extractor = audio_extractor
         self._chromaprint_service = chromaprint_service
         self._intro_detector = intro_detector
-        self._batch_size = batch_size
-        self._audio_window_seconds = audio_window_seconds
-        self._min_confidence = min_confidence
+        self._runtime_settings = runtime_settings
 
     async def run(self) -> None:
         """Process one batch of pending seasons."""
+        config = await self._runtime_settings.intro_detection()
         async with self._media_uow_factory() as uow:
-            seasons = list(await uow.series.find_seasons_pending_intro_detection(self._batch_size))
+            seasons = list(await uow.series.find_seasons_pending_intro_detection(config.batch_size))
 
         if not seasons:
             return
@@ -109,7 +110,7 @@ class IntroDetectionJob:
         insufficient = 0
         failed = 0
         for season in seasons:
-            outcome = await self._process_season(season)
+            outcome = await self._process_season(season, config)
             if outcome == IntroDetectionState.COMPLETED:
                 completed += 1
             elif outcome == IntroDetectionState.INSUFFICIENT_EPISODES:
@@ -122,10 +123,14 @@ class IntroDetectionJob:
             seasons_completed=completed,
             seasons_insufficient=insufficient,
             seasons_failed=failed,
-            batch_size=self._batch_size,
+            batch_size=config.batch_size,
         )
 
-    async def _process_season(self, season: Season) -> IntroDetectionState:
+    async def _process_season(
+        self,
+        season: Season,
+        config: IntroDetectionConfig,
+    ) -> IntroDetectionState:
         """Drive one season through the detection pipeline.
 
         Returns the state the season was transitioned to (used by
@@ -157,7 +162,7 @@ class IntroDetectionJob:
             return IntroDetectionState.FAILED
 
         try:
-            return await self._detect_and_persist(season, season_id, log_ctx)
+            return await self._detect_and_persist(season, season_id, log_ctx, config)
         except Exception as exc:
             _logger.exception(
                 "[intro-detection] season processing failed",
@@ -186,6 +191,7 @@ class IntroDetectionJob:
         season: Season,
         season_id: SeasonId,
         log_ctx: dict[str, str | int],
+        config: IntroDetectionConfig,
     ) -> IntroDetectionState:
         candidates = [ep for ep in season.episodes if not _has_manual_marker(ep)]
         candidate_count = len(candidates)
@@ -199,7 +205,7 @@ class IntroDetectionJob:
             )
             return IntroDetectionState.INSUFFICIENT_EPISODES
 
-        fingerprints = await self._build_fingerprints(candidates)
+        fingerprints = await self._build_fingerprints(candidates, config.audio_window_seconds)
         fingerprint_count = len(fingerprints)
         if fingerprint_count < _MIN_EPISODES_FOR_DETECTION:
             await self._mark_state(season_id, IntroDetectionState.INSUFFICIENT_EPISODES)
@@ -211,8 +217,14 @@ class IntroDetectionJob:
             )
             return IntroDetectionState.INSUFFICIENT_EPISODES
 
-        detections = await asyncio.to_thread(self._intro_detector.detect, fingerprints)
-        persisted_count = await self._persist_detections(detections)
+        tuning = IntroDetectorTuning(
+            max_hash_hamming=config.max_hash_hamming,
+            tolerance_hashes=config.tolerance_hashes,
+            min_intro_seconds=config.min_intro_seconds,
+            max_intro_seconds=config.max_intro_seconds,
+        )
+        detections = await asyncio.to_thread(self._intro_detector.detect, fingerprints, tuning)
+        persisted_count = await self._persist_detections(detections, config.min_confidence)
         await self._mark_state(season_id, IntroDetectionState.COMPLETED)
         _logger.info(
             "[intro-detection] season completed",
@@ -224,16 +236,24 @@ class IntroDetectionJob:
         )
         return IntroDetectionState.COMPLETED
 
-    async def _build_fingerprints(self, episodes: list[Episode]) -> list[EpisodeFingerprint]:
+    async def _build_fingerprints(
+        self,
+        episodes: list[Episode],
+        audio_window_seconds: int,
+    ) -> list[EpisodeFingerprint]:
         """Extract audio + fingerprint each episode, dropping failures."""
         results: list[EpisodeFingerprint] = []
         for episode in episodes:
-            fingerprint = await self._fingerprint_episode(episode)
+            fingerprint = await self._fingerprint_episode(episode, audio_window_seconds)
             if fingerprint is not None:
                 results.append(fingerprint)
         return results
 
-    async def _fingerprint_episode(self, episode: Episode) -> EpisodeFingerprint | None:
+    async def _fingerprint_episode(
+        self,
+        episode: Episode,
+        audio_window_seconds: int,
+    ) -> EpisodeFingerprint | None:
         """Run ffmpeg + fpcalc against a single episode.
 
         Returns ``None`` when any step degrades — missing primary file,
@@ -248,7 +268,7 @@ class IntroDetectionJob:
             return None
         episode_id = episode.id
         file_path = primary.file_path.value
-        window = self._audio_window_seconds
+        window = audio_window_seconds
 
         def _extract_and_fingerprint() -> EpisodeFingerprint | None:
             # Per the docstring: any failure here just drops the
@@ -280,7 +300,11 @@ class IntroDetectionJob:
 
         return await asyncio.to_thread(_extract_and_fingerprint)
 
-    async def _persist_detections(self, detections: Mapping[EpisodeId, DetectedIntro]) -> int:
+    async def _persist_detections(
+        self,
+        detections: Mapping[EpisodeId, DetectedIntro],
+        min_confidence: float,
+    ) -> int:
         """Persist auto-detected markers that clear the confidence floor.
 
         Returns the number of markers actually written so the caller
@@ -294,7 +318,7 @@ class IntroDetectionJob:
         persisted = 0
         async with self._media_uow_factory() as uow:
             for episode_id, detected in detections.items():
-                if detected.confidence < self._min_confidence:
+                if detected.confidence < min_confidence:
                     continue
                 marker = _build_auto_marker(detected)
                 await uow.series.update_episode_intro(episode_id, marker)

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
     from src.modules.library.domain.entities.library import Library
     from src.modules.media.application.services.scan_run_service import ScanRunService
+    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = get_logger()
 
@@ -44,26 +45,33 @@ class LibraryScanScheduler:
     service does not maintain its own job database.  Reconciliation
     runs at startup and on a configurable interval so schedule edits
     made through the REST API propagate without a restart.
+
+    The reconcile interval is read from :class:`RuntimeSettings` at
+    ``start()`` time so admin-panel edits land on the next deploy
+    (changing the APScheduler interval at runtime would require
+    rebuilding the registered job and is out of scope for ADR-013
+    phase 2 — documented limitation).
     """
 
     def __init__(
         self,
         library_uow_factory: LibraryUnitOfWorkFactory,
         scan_run_service: ScanRunService,
-        reconcile_interval_minutes: int,
+        runtime_settings: RuntimeSettings,
     ) -> None:
         self._library_uow_factory = library_uow_factory
         self._scan_run_service = scan_run_service
-        self._reconcile_interval_minutes = reconcile_interval_minutes
+        self._runtime_settings = runtime_settings
         self._scheduler = AsyncIOScheduler(timezone="UTC")
 
     async def start(self) -> None:
         """Start the scheduler and register the reconcile + initial jobs."""
+        config = await self._runtime_settings.scheduler()
         self._scheduler.start()
         self._scheduler.add_job(
             self._reconcile,
             trigger="interval",
-            minutes=self._reconcile_interval_minutes,
+            minutes=config.reconcile_interval_minutes,
             id=_RECONCILE_JOB_ID,
             replace_existing=True,
             max_instances=1,
@@ -72,7 +80,7 @@ class LibraryScanScheduler:
         await self._reconcile()
         _logger.info(
             "[scheduler] Started",
-            reconcile_interval_minutes=self._reconcile_interval_minutes,
+            reconcile_interval_minutes=config.reconcile_interval_minutes,
         )
 
     async def stop(self) -> None:

--- a/src/infrastructure/scheduling/thumbnail_backfill_job.py
+++ b/src/infrastructure/scheduling/thumbnail_backfill_job.py
@@ -26,6 +26,7 @@ from src.modules.media.infrastructure.streaming.thumbnail_service import (
 if TYPE_CHECKING:
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
     from src.modules.media.domain.entities import Episode, Movie
+    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = get_logger()
 
@@ -39,29 +40,32 @@ class ThumbnailBackfillJob:
     starting on episodes — acceptable because both eventually drain
     and operators rarely have a million of either.
 
+    All operator-tunable knobs (``batch_size``, sprite ``subdir``)
+    are read from :class:`RuntimeSettings` per ``run()`` so admin
+    edits propagate to the next tick without restart (ADR-013). The
+    on-demand ``process_movie``/``process_episode`` entry points
+    (eager triggers from the HLS route) read the snapshot lazily on
+    each invocation for the same reason.
+
     Args:
         media_uow_factory: Builds fresh media UoWs per tick. The job
             opens its own UoW per item so a single failure rolls back
             only that item's update, not the whole batch.
+        runtime_settings: Snapshot facade for
+            :class:`ThumbnailBackfillConfig`.
         thumbnail_service: Sprite + VTT generator. Default constructs
             its own; tests inject a fake.
-        batch_size: Maximum items processed per ``run()`` call.
-        sprite_subdir: Path relative to the media file's parent folder
-            where ``sprite.jpg`` and ``sprite.vtt`` are written.
     """
 
     def __init__(
         self,
         media_uow_factory: MediaUnitOfWorkFactory,
+        runtime_settings: RuntimeSettings,
         thumbnail_service: ThumbnailGenerationService | None = None,
-        *,
-        batch_size: int = 10,
-        sprite_subdir: str = ".homeflix/thumbnails",
     ) -> None:
         self._media_uow_factory = media_uow_factory
+        self._runtime_settings = runtime_settings
         self._thumbnail_service = thumbnail_service or ThumbnailGenerationService()
-        self._batch_size = batch_size
-        self._sprite_subdir = sprite_subdir
 
     async def run(self) -> None:
         """Process one batch of missing thumbnails.
@@ -72,17 +76,18 @@ class ThumbnailBackfillJob:
         many were skipped (because the source file vanished or ffmpeg
         could not produce a sprite).
         """
-        budget = self._batch_size
+        config = await self._runtime_settings.thumbnail_backfill()
+        budget = config.batch_size
 
         movies = await self._fetch_missing_movies(budget)
-        movies_done, movies_skipped = await self._process_movies(movies)
+        movies_done, movies_skipped = await self._process_movies(movies, config.subdir)
         budget -= len(movies)
 
         episodes_done = 0
         episodes_skipped = 0
         if budget > 0:
             episodes = await self._fetch_missing_episodes(budget)
-            episodes_done, episodes_skipped = await self._process_episodes(episodes)
+            episodes_done, episodes_skipped = await self._process_episodes(episodes, config.subdir)
 
         if movies_done or movies_skipped or episodes_done or episodes_skipped:
             _logger.info(
@@ -91,7 +96,7 @@ class ThumbnailBackfillJob:
                 movies_skipped=movies_skipped,
                 episodes_done=episodes_done,
                 episodes_skipped=episodes_skipped,
-                batch_size=self._batch_size,
+                batch_size=config.batch_size,
             )
 
     async def _fetch_missing_movies(self, limit: int) -> list[Movie]:
@@ -116,7 +121,8 @@ class ThumbnailBackfillJob:
             movie = await uow.movies.find_by_id(MovieId(movie_id))
         if movie is None or movie.scrub_preview_path is not None:
             return False
-        return await self.process_movie(movie)
+        subdir = (await self._runtime_settings.thumbnail_backfill()).subdir
+        return await self.process_movie(movie, subdir)
 
     async def process_episode_by_id(self, episode_id: str) -> bool:
         """Eager-trigger entry point for episodes — see ``process_movie_by_id``."""
@@ -124,9 +130,10 @@ class ThumbnailBackfillJob:
             episode = await uow.series.find_episode_by_id(EpisodeId(episode_id))
         if episode is None or episode.scrub_preview_path is not None:
             return False
-        return await self.process_episode(episode)
+        subdir = (await self._runtime_settings.thumbnail_backfill()).subdir
+        return await self.process_episode(episode, subdir)
 
-    async def process_movie(self, movie: Movie) -> bool:
+    async def process_movie(self, movie: Movie, subdir: str) -> bool:
         """Generate and persist scrub-preview thumbnails for a single movie.
 
         Reusable by both the periodic batch and the eager trigger fired
@@ -143,13 +150,13 @@ class ThumbnailBackfillJob:
         file_path = self._primary_file_path(movie)
         if file_path is None:
             return False
-        result = await self._generate(file_path)
+        result = await self._generate(file_path, subdir)
         if result is None:
             return False
         await self._persist_movie(movie, result)
         return True
 
-    async def process_episode(self, episode: Episode) -> bool:
+    async def process_episode(self, episode: Episode, subdir: str) -> bool:
         """Generate and persist scrub-preview thumbnails for a single episode.
 
         Mirror of ``process_movie`` for episodes. Skips silently if the
@@ -159,27 +166,27 @@ class ThumbnailBackfillJob:
         file_path = self._primary_file_path(episode)
         if file_path is None or episode.id is None:
             return False
-        result = await self._generate(file_path)
+        result = await self._generate(file_path, subdir)
         if result is None:
             return False
         await self._persist_episode(episode, result)
         return True
 
-    async def _process_movies(self, movies: list[Movie]) -> tuple[int, int]:
+    async def _process_movies(self, movies: list[Movie], subdir: str) -> tuple[int, int]:
         done = 0
         skipped = 0
         for movie in movies:
-            if await self.process_movie(movie):
+            if await self.process_movie(movie, subdir):
                 done += 1
             else:
                 skipped += 1
         return done, skipped
 
-    async def _process_episodes(self, episodes: list[Episode]) -> tuple[int, int]:
+    async def _process_episodes(self, episodes: list[Episode], subdir: str) -> tuple[int, int]:
         done = 0
         skipped = 0
         for episode in episodes:
-            if await self.process_episode(episode):
+            if await self.process_episode(episode, subdir):
                 done += 1
             else:
                 skipped += 1
@@ -192,7 +199,7 @@ class ThumbnailBackfillJob:
             return None
         return primary.file_path.value
 
-    async def _generate(self, file_path: str) -> ThumbnailResult | None:
+    async def _generate(self, file_path: str, subdir: str) -> ThumbnailResult | None:
         """Run sprite generation off the event loop and return its result.
 
         ``ThumbnailGenerationService.generate`` is fully synchronous
@@ -214,7 +221,7 @@ class ThumbnailBackfillJob:
         # no-op for them in practice, but the consistent layout means a
         # "Movies/" folder hosting multiple titles flat would survive
         # the same overwrite hazard.
-        output_dir = source.parent / self._sprite_subdir / source.stem
+        output_dir = source.parent / subdir / source.stem
         return await asyncio.to_thread(
             self._thumbnail_service.generate,
             file_path,

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ This is the main entry point for the FastAPI application.
 It serves as the Composition Root where the DI container is configured.
 """
 
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -97,6 +98,41 @@ def create_container() -> ApplicationContainer:
     return container
 
 
+# Env vars that used to feed ``Settings`` directly but moved into the
+# DB-backed ``app_settings`` table in ADR-013 phase 2. Their presence
+# in the process environment is now a silent no-op, so we log a one-off
+# warning at startup to point the operator at the admin panel.
+_DEPRECATED_ENV_VARS: tuple[str, ...] = (
+    "SCHEDULER_ENABLED",
+    "SCHEDULER_RECONCILE_INTERVAL_MINUTES",
+    "THUMBNAIL_BACKFILL_ENABLED",
+    "THUMBNAIL_BACKFILL_BATCH_SIZE",
+    "THUMBNAIL_BACKFILL_INTERVAL_MINUTES",
+    "THUMBNAIL_BACKFILL_SUBDIR",
+    "INTRO_DETECTION_ENABLED",
+    "INTRO_DETECTION_BATCH_SIZE",
+    "INTRO_DETECTION_INTERVAL_MINUTES",
+    "INTRO_DETECTION_AUDIO_WINDOW_SECONDS",
+    "INTRO_DETECTION_MIN_CONFIDENCE",
+    "INTRO_DETECTION_MAX_HASH_HAMMING",
+    "INTRO_DETECTION_TOLERANCE_HASHES",
+    "INTRO_DETECTION_MIN_INTRO_SECONDS",
+    "INTRO_DETECTION_MAX_INTRO_SECONDS",
+)
+
+
+def _warn_about_deprecated_env_vars(logger: Any) -> None:
+    """Log a warning for each ADR-013-migrated env var still set."""
+    stale = [name for name in _DEPRECATED_ENV_VARS if os.environ.get(name) is not None]
+    if not stale:
+        return
+    logger.warning(
+        "Deprecated env vars detected; edit settings via the admin panel "
+        "or app_settings table instead (ADR-013).",
+        deprecated_env_vars=stale,
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Application lifespan handler.
@@ -114,6 +150,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         app_name=settings.app_name,
         environment=settings.app_env,
     )
+
+    _warn_about_deprecated_env_vars(logger)
 
     # Initialize DI container
     container = create_container()
@@ -137,26 +175,31 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await sweep_scan_runs.execute()
 
     # Start background scheduler (library scans + thumbnail backfill +
-    # intro detection). The provider depends on the session_factory
-    # Resource, so it resolves asynchronously — must be awaited. Always
-    # pin a slot on app.state so the shutdown handler can do a single
-    # truthy check.
+    # intro detection). Scheduler-on/off + per-job intervals come from
+    # the RuntimeSettings snapshot (ADR-013 phase 2). Interval changes
+    # only take effect on the next process start; APScheduler does not
+    # support live-rescheduling a registered job and the rebuild path
+    # is out of scope for this phase.
     app.state.scheduler = None
-    if settings.scheduler_enabled:
+    runtime_settings = await container.settings.runtime_settings()
+    scheduler_cfg = await runtime_settings.scheduler()
+    if scheduler_cfg.enabled:
         scheduler = await container.library_scan_scheduler()
         await scheduler.start()
-        if settings.thumbnail_backfill_enabled:
+        backfill_cfg = await runtime_settings.thumbnail_backfill()
+        if backfill_cfg.enabled:
             backfill_job = await container.thumbnail_backfill_job()
             scheduler.add_interval_job(
                 backfill_job.run,
-                minutes=settings.thumbnail_backfill_interval_minutes,
+                minutes=backfill_cfg.interval_minutes,
                 job_id="homeflix:thumbnail-backfill",
             )
-        if settings.intro_detection_enabled:
+        intro_cfg = await runtime_settings.intro_detection()
+        if intro_cfg.enabled:
             intro_job = await container.intro_detection_job()
             scheduler.add_interval_job(
                 intro_job.run,
-                minutes=settings.intro_detection_interval_minutes,
+                minutes=intro_cfg.interval_minutes,
                 job_id="homeflix:intro-detection",
             )
         app.state.scheduler = scheduler

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -18,6 +18,7 @@ from src.modules.media.application.ports.intro_detector_port import (
     DetectedIntro,
     EpisodeFingerprint,
     IntroDetectorPort,
+    IntroDetectorTuning,
 )
 from src.modules.media.application.ports.media_probe_port import (
     MediaProbePort,
@@ -62,6 +63,7 @@ __all__ = [
     "HlsCacheStats",
     "HlsPlaylistPort",
     "IntroDetectorPort",
+    "IntroDetectorTuning",
     "LocalizedFields",
     "MediaMetadata",
     "MediaProbePort",

--- a/src/modules/media/application/ports/intro_detector_port.py
+++ b/src/modules/media/application/ports/intro_detector_port.py
@@ -37,6 +37,31 @@ class EpisodeFingerprint:
 
 
 @dataclass(frozen=True)
+class IntroDetectorTuning:
+    """Operator-tunable knobs for the cross-correlation algorithm.
+
+    Passed per ``detect()`` call so the implementation stays stateless
+    with respect to runtime configuration — the orchestrator (the
+    intro-detection job) snapshots ``RuntimeSettings`` and forwards
+    the relevant fields, letting admin-panel edits propagate to the
+    next tick without re-constructing the detector.
+
+    Attributes:
+        max_hash_hamming: Per-hash Hamming-distance ceiling (out of
+            32 bits) considered a "match".
+        tolerance_hashes: How many consecutive non-matching hashes a
+            run can absorb before terminating.
+        min_intro_seconds: Discard matches shorter than this floor.
+        max_intro_seconds: Hard cap on persisted match length.
+    """
+
+    max_hash_hamming: int = 10
+    tolerance_hashes: int = 2
+    min_intro_seconds: float = 5.0
+    max_intro_seconds: float = 120.0
+
+
+@dataclass(frozen=True)
 class DetectedIntro:
     """Result of running the detector against a single episode.
 
@@ -60,7 +85,9 @@ class IntroDetectorPort(ABC):
 
     @abstractmethod
     def detect(
-        self, fingerprints: Sequence[EpisodeFingerprint]
+        self,
+        fingerprints: Sequence[EpisodeFingerprint],
+        tuning: IntroDetectorTuning,
     ) -> Mapping[EpisodeId, DetectedIntro]:
         """Return a marker per episode where detection converged.
 
@@ -72,6 +99,9 @@ class IntroDetectorPort(ABC):
         Args:
             fingerprints: One per episode in the season under analysis.
                 Order is not significant; episodes are matched by id.
+            tuning: Operator-tunable knobs for this call. Allows
+                admin-panel edits to take effect on the next tick
+                without re-constructing the detector.
 
         Returns:
             A mapping keyed by episode id. May be empty when the season
@@ -82,4 +112,9 @@ class IntroDetectorPort(ABC):
         ...
 
 
-__all__ = ["DetectedIntro", "EpisodeFingerprint", "IntroDetectorPort"]
+__all__ = [
+    "DetectedIntro",
+    "EpisodeFingerprint",
+    "IntroDetectorPort",
+    "IntroDetectorTuning",
+]

--- a/src/modules/media/infrastructure/audio/chromaprint_intro_detector.py
+++ b/src/modules/media/infrastructure/audio/chromaprint_intro_detector.py
@@ -39,17 +39,16 @@ from src.modules.media.application.ports.intro_detector_port import (
     DetectedIntro,
     EpisodeFingerprint,
     IntroDetectorPort,
+    IntroDetectorTuning,
 )
 from src.modules.media.domain.value_objects import EpisodeId
 
 # Defaults tuned against synthetic fixtures and a couple of real
-# anime / sitcom seasons. They are exposed as constructor kwargs so
-# operators can adjust without forking the implementation.
+# anime / sitcom seasons. ``max_hash_hamming``, ``tolerance_hashes``,
+# ``min_intro_seconds`` and ``max_intro_seconds`` are operator-tunable
+# via :class:`IntroDetectorTuning` per ``detect()`` call (ADR-013);
+# the other knobs are algorithm-internal and stay as constructor args.
 _DEFAULT_MAX_ALIGNMENT_SHIFT_SECONDS = 30.0
-_DEFAULT_MAX_HASH_HAMMING = 10  # bits, out of 32
-_DEFAULT_TOLERANCE_HASHES = 2
-_DEFAULT_MIN_INTRO_SECONDS = 5.0
-_DEFAULT_MAX_INTRO_SECONDS = 120.0
 _DEFAULT_MIN_PAIR_AGREEMENT = 0.5
 _DEFAULT_ALIGNMENT_WINDOW_SECONDS = 60.0
 
@@ -76,53 +75,33 @@ class ChromaprintIntroDetector(IntroDetectorPort):
         max_alignment_shift_seconds: How far cold-open lengths between
             two episodes can differ. Wider values cost more search time;
             30s comfortably covers most production patterns.
-        max_hash_hamming: Per-hash hamming distance (out of 32 bits)
-            considered "matching". Tighter values discriminate better
-            but also reject more genuine intro hashes that drifted
-            under encoding noise. ``10`` (≈ 31% bit divergence) is the
-            sweet spot for raw chromaprint hashes from typical TV
-            audio.
-        tolerance_hashes: How many CONSECUTIVE non-matching hashes a
-            run can absorb before terminating. Smooths over isolated
-            spikes inside an otherwise strong match — once a fresh
-            good hash arrives the counter resets, so the run can keep
-            extending. Trailing bad hashes never count toward the
-            reported segment length.
-        min_intro_seconds: Discard matches shorter than this. Stops the
-            detector from firing on incidental musical stings.
-        max_intro_seconds: Hard cap on the persisted match length.
-            Real intros virtually never exceed two minutes; longer
-            detections almost always include shared underscore /
-            transition music that bleeds past the title sequence and
-            should be truncated rather than persisted as-is.
         min_pair_agreement: Episodes whose match-rate against their
             peers falls below this fraction are dropped.
         alignment_window_seconds: How much of each fingerprint to scan
             when picking the alignment shift. Search is bounded so the
             algorithm stays linear in fingerprint length.
+
+    Operator-tunable knobs (``max_hash_hamming``, ``tolerance_hashes``,
+    ``min_intro_seconds``, ``max_intro_seconds``) are passed per
+    ``detect()`` call via :class:`IntroDetectorTuning` so admin-panel
+    edits take effect on the next tick.
     """
 
     def __init__(
         self,
         *,
         max_alignment_shift_seconds: float = _DEFAULT_MAX_ALIGNMENT_SHIFT_SECONDS,
-        max_hash_hamming: int = _DEFAULT_MAX_HASH_HAMMING,
-        tolerance_hashes: int = _DEFAULT_TOLERANCE_HASHES,
-        min_intro_seconds: float = _DEFAULT_MIN_INTRO_SECONDS,
-        max_intro_seconds: float = _DEFAULT_MAX_INTRO_SECONDS,
         min_pair_agreement: float = _DEFAULT_MIN_PAIR_AGREEMENT,
         alignment_window_seconds: float = _DEFAULT_ALIGNMENT_WINDOW_SECONDS,
     ) -> None:
         self._max_alignment_shift_seconds = max_alignment_shift_seconds
-        self._max_hash_hamming = max_hash_hamming
-        self._tolerance_hashes = tolerance_hashes
-        self._min_intro_seconds = min_intro_seconds
-        self._max_intro_seconds = max_intro_seconds
         self._min_pair_agreement = min_pair_agreement
         self._alignment_window_seconds = alignment_window_seconds
 
     def detect(
-        self, fingerprints: Sequence[EpisodeFingerprint]
+        self,
+        fingerprints: Sequence[EpisodeFingerprint],
+        tuning: IntroDetectorTuning,
     ) -> Mapping[EpisodeId, DetectedIntro]:
         """Run the full pairwise + voting pipeline.
 
@@ -144,7 +123,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
 
         for i, fp_a in enumerate(usable):
             for fp_b in usable[i + 1 :]:
-                match = self._pairwise_match(fp_a, fp_b, hash_rates)
+                match = self._pairwise_match(fp_a, fp_b, hash_rates, tuning)
                 if match is None:
                     continue
                 rate_a = hash_rates[fp_a.episode_id]
@@ -156,7 +135,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
                     (match.start_b / rate_b, match.end_b / rate_b)
                 )
 
-        return self._build_consensus(usable, per_episode_segments)
+        return self._build_consensus(usable, per_episode_segments, tuning)
 
     # ── pairwise matching ─────────────────────────────────────────────
 
@@ -165,6 +144,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
         fp_a: EpisodeFingerprint,
         fp_b: EpisodeFingerprint,
         hash_rates: Mapping[EpisodeId, float],
+        tuning: IntroDetectorTuning,
     ) -> _PairwiseMatch | None:
         """Return the best matching range between two fingerprints, or ``None``."""
         a_hashes = fp_a.hashes
@@ -192,7 +172,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
             distances = [
                 _popcount(a_hashes[a_start + k] ^ b_hashes[b_start + k]) for k in range(scan_len)
             ]
-            run_start, run_length = self._longest_run(distances)
+            run_start, run_length = self._longest_run(distances, tuning)
             if run_length == 0:
                 continue
 
@@ -210,11 +190,15 @@ class ChromaprintIntroDetector(IntroDetectorPort):
         # floor — the consensus step would drop it anyway, but doing it
         # here keeps the per-episode segment list cleaner.
         seconds = best.length_hashes / rate
-        if seconds < self._min_intro_seconds:
+        if seconds < tuning.min_intro_seconds:
             return None
         return best
 
-    def _longest_run(self, distances: list[int]) -> tuple[int, int]:
+    def _longest_run(
+        self,
+        distances: list[int],
+        tuning: IntroDetectorTuning,
+    ) -> tuple[int, int]:
         """Return (start, length) of the longest tolerant run.
 
         A "run" is a contiguous span starting on a good hash and
@@ -239,7 +223,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
         consecutive_bad = 0
 
         for i, d in enumerate(distances):
-            is_bad = d > self._max_hash_hamming
+            is_bad = d > tuning.max_hash_hamming
 
             if run_start < 0:
                 # Outside any run — only a good hash can start a new one.
@@ -255,7 +239,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
 
             if is_bad:
                 consecutive_bad += 1
-                if consecutive_bad > self._tolerance_hashes:
+                if consecutive_bad > tuning.tolerance_hashes:
                     run_start = -1
                 continue
 
@@ -276,6 +260,7 @@ class ChromaprintIntroDetector(IntroDetectorPort):
         self,
         fingerprints: Sequence[EpisodeFingerprint],
         per_episode_segments: Mapping[EpisodeId, list[tuple[float, float]]],
+        tuning: IntroDetectorTuning,
     ) -> Mapping[EpisodeId, DetectedIntro]:
         """Aggregate per-pair matches into one marker per episode."""
         result: dict[EpisodeId, DetectedIntro] = {}
@@ -296,9 +281,9 @@ class ChromaprintIntroDetector(IntroDetectorPort):
             # entirely; the user gets a "Skip Intro" button covering
             # the shared region without overshooting deep into the
             # episode.
-            if end_seconds - start_seconds > self._max_intro_seconds:
-                end_seconds = start_seconds + self._max_intro_seconds
-            if end_seconds - start_seconds < self._min_intro_seconds:
+            if end_seconds - start_seconds > tuning.max_intro_seconds:
+                end_seconds = start_seconds + tuning.max_intro_seconds
+            if end_seconds - start_seconds < tuning.min_intro_seconds:
                 continue
             result[episode_id] = DetectedIntro(
                 start_seconds=start_seconds,

--- a/tests/infrastructure/migrations/test_seed_app_settings.py
+++ b/tests/infrastructure/migrations/test_seed_app_settings.py
@@ -1,0 +1,154 @@
+"""Tests for the app_settings seed migration (ADR-013 phase 2).
+
+Exercises ``_collect_overrides`` (env-var harvest) and
+``_maybe_seed_row`` (idempotent insert into ``app_settings``). Drives
+the live SQLAlchemy connection against an in-memory SQLite engine so
+the JSON serialization and ``INSERT OR IGNORE`` semantics are
+verified end-to-end without booting Alembic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from sqlalchemy.engine import Connection
+
+# The migration file lives outside the importable ``src`` tree and its
+# date-prefixed filename is not a valid Python identifier — load it by
+# path so the tests can reach the private helpers.
+_SEED_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "migrations"
+    / "versions"
+    / "2026_05_22_seed_app_settings_from_env.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "_seed_app_settings_migration",
+    _SEED_PATH,
+)
+if _spec is None or _spec.loader is None:
+    msg = f"Could not load seed migration at {_SEED_PATH}"
+    raise RuntimeError(msg)
+_SEED_MODULE = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = _SEED_MODULE
+_spec.loader.exec_module(_SEED_MODULE)
+
+
+@pytest.fixture
+def connection() -> Iterator[Connection]:
+    """A throw-away SQLite connection with the ``app_settings`` table."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE app_settings ("
+                "key TEXT PRIMARY KEY, "
+                "value_json TEXT NOT NULL, "
+                "source TEXT NOT NULL, "
+                "updated_by_user_id TEXT, "
+                "created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
+                "updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+    with engine.connect() as conn, conn.begin():
+        yield conn
+    engine.dispose()
+
+
+@pytest.mark.unit
+class TestCollectOverrides:
+    def test_empty_when_no_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for env in _SEED_MODULE._INTRO_DETECTION_ENV_MAP:
+            monkeypatch.delenv(env, raising=False)
+
+        result = _SEED_MODULE._collect_overrides(_SEED_MODULE._INTRO_DETECTION_ENV_MAP)
+
+        assert result == {}
+
+    def test_returns_only_fields_whose_env_is_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("INTRO_DETECTION_ENABLED", "true")
+        monkeypatch.setenv("INTRO_DETECTION_BATCH_SIZE", "3")
+        monkeypatch.delenv("INTRO_DETECTION_AUDIO_WINDOW_SECONDS", raising=False)
+
+        result = _SEED_MODULE._collect_overrides(_SEED_MODULE._INTRO_DETECTION_ENV_MAP)
+
+        assert result == {"enabled": "true", "batch_size": "3"}
+
+
+@pytest.mark.integration
+class TestMaybeSeedRow:
+    def test_writes_row_when_overrides_present(self, connection: Connection) -> None:
+        from src.modules.settings.domain.value_objects import (
+            SchedulerConfig,
+            SettingKey,
+        )
+
+        _SEED_MODULE._maybe_seed_row(
+            connection,
+            SettingKey.SCHEDULER,
+            {"enabled": "false", "reconcile_interval_minutes": "42"},
+            SchedulerConfig,
+        )
+
+        rows = list(connection.execute(sa.text("SELECT key, value_json, source FROM app_settings")))
+        assert len(rows) == 1
+        key, value_json, source = rows[0]
+        assert key == "scheduler"
+        assert source == "migration_seed"
+        assert json.loads(value_json) == {
+            "enabled": False,
+            "reconcile_interval_minutes": 42,
+        }
+
+    def test_skips_when_no_overrides(self, connection: Connection) -> None:
+        from src.modules.settings.domain.value_objects import (
+            SchedulerConfig,
+            SettingKey,
+        )
+
+        _SEED_MODULE._maybe_seed_row(
+            connection,
+            SettingKey.SCHEDULER,
+            {},
+            SchedulerConfig,
+        )
+
+        rows = list(connection.execute(sa.text("SELECT COUNT(*) FROM app_settings")))
+        assert rows[0][0] == 0
+
+    def test_idempotent_does_not_overwrite_existing_row(self, connection: Connection) -> None:
+        from src.modules.settings.domain.value_objects import (
+            SchedulerConfig,
+            SettingKey,
+        )
+
+        # Seed once with one set of values...
+        _SEED_MODULE._maybe_seed_row(
+            connection,
+            SettingKey.SCHEDULER,
+            {"reconcile_interval_minutes": "10"},
+            SchedulerConfig,
+        )
+        # ...then re-run with different values — the row must not be
+        # overwritten (INSERT OR IGNORE semantics).
+        _SEED_MODULE._maybe_seed_row(
+            connection,
+            SettingKey.SCHEDULER,
+            {"reconcile_interval_minutes": "99"},
+            SchedulerConfig,
+        )
+
+        rows = list(connection.execute(sa.text("SELECT value_json FROM app_settings")))
+        assert len(rows) == 1
+        assert json.loads(rows[0][0])["reconcile_interval_minutes"] == 10

--- a/tests/infrastructure/scheduling/test_intro_detection_job.py
+++ b/tests/infrastructure/scheduling/test_intro_detection_job.py
@@ -34,6 +34,7 @@ from src.modules.media.domain.value_objects import (
     Title,
 )
 from src.modules.media.infrastructure.audio import ChromaprintFingerprint
+from src.modules.settings.domain.value_objects import IntroDetectionConfig
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -129,6 +130,13 @@ def _make_detector(*, detections: dict[EpisodeId, DetectedIntro]) -> MagicMock:
     return detector
 
 
+def _make_runtime_settings(*, intro: IntroDetectionConfig | None = None) -> AsyncMock:
+    """Return a fake :class:`RuntimeSettings` exposing ``intro_detection``."""
+    runtime = AsyncMock()
+    runtime.intro_detection = AsyncMock(return_value=intro or IntroDetectionConfig())
+    return runtime
+
+
 @pytest.mark.unit
 class TestIntroDetectionJob:
     """Orchestration tests for IntroDetectionJob.run."""
@@ -144,6 +152,7 @@ class TestIntroDetectionJob:
             audio_extractor=_make_audio_extractor(),
             chromaprint_service=_make_chromaprint(),
             intro_detector=detector,
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 
@@ -174,7 +183,7 @@ class TestIntroDetectionJob:
             audio_extractor=_make_audio_extractor(),
             chromaprint_service=_make_chromaprint(),
             intro_detector=detector,
-            min_confidence=0.7,
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 
@@ -212,7 +221,7 @@ class TestIntroDetectionJob:
             audio_extractor=_make_audio_extractor(),
             chromaprint_service=_make_chromaprint(),
             intro_detector=detector,
-            min_confidence=0.7,
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 
@@ -250,6 +259,7 @@ class TestIntroDetectionJob:
             audio_extractor=_make_audio_extractor(),
             chromaprint_service=_make_chromaprint(),
             intro_detector=detector,
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 
@@ -274,6 +284,7 @@ class TestIntroDetectionJob:
             audio_extractor=extractor,
             chromaprint_service=_make_chromaprint(),
             intro_detector=detector,
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 
@@ -297,6 +308,7 @@ class TestIntroDetectionJob:
             audio_extractor=_make_audio_extractor(),
             chromaprint_service=_make_chromaprint(),
             intro_detector=broken_detector,
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 
@@ -331,6 +343,7 @@ class TestIntroDetectionJob:
             audio_extractor=_make_audio_extractor(),
             chromaprint_service=chromaprint,
             intro_detector=detector,
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 
@@ -371,6 +384,7 @@ class TestIntroDetectionJob:
             audio_extractor=crashing_extractor,
             chromaprint_service=_make_chromaprint(),
             intro_detector=_make_detector(detections={}),
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 
@@ -434,6 +448,7 @@ class TestIntroDetectionJob:
             audio_extractor=_make_audio_extractor(),
             chromaprint_service=_make_chromaprint(),
             intro_detector=broken_detector,
+            runtime_settings=_make_runtime_settings(),
         )
         # Must not raise — the batch loop survives the failed
         # state-recording on season_a.
@@ -479,7 +494,7 @@ class TestIntroDetectionJob:
             audio_extractor=_make_audio_extractor(),
             chromaprint_service=_make_chromaprint(),
             intro_detector=_make_detector(detections={}),
-            batch_size=1,
+            runtime_settings=_make_runtime_settings(),
         )
         await job.run()
 

--- a/tests/infrastructure/scheduling/test_scheduler_service.py
+++ b/tests/infrastructure/scheduling/test_scheduler_service.py
@@ -111,10 +111,14 @@ def scheduler(
 ) -> LibraryScanScheduler:
     uow = _build_uow(library_repo)
     library_uow_factory = MagicMock(return_value=uow)
+    from src.modules.settings.domain.value_objects import SchedulerConfig
+
+    runtime_settings = AsyncMock()
+    runtime_settings.scheduler = AsyncMock(return_value=SchedulerConfig())
     instance = LibraryScanScheduler(
         library_uow_factory=library_uow_factory,
         scan_run_service=scan_run_service,
-        reconcile_interval_minutes=5,
+        runtime_settings=runtime_settings,
     )
     instance._scheduler = _FakeScheduler()
     return instance

--- a/tests/infrastructure/scheduling/test_thumbnail_backfill_job.py
+++ b/tests/infrastructure/scheduling/test_thumbnail_backfill_job.py
@@ -27,6 +27,7 @@ from src.modules.media.domain.value_objects import (
     Title,
 )
 from src.modules.media.infrastructure.streaming.thumbnail_service import ThumbnailResult
+from src.modules.settings.domain.value_objects import ThumbnailBackfillConfig
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -98,6 +99,19 @@ def _make_thumbnail_service(vtt_path: Path) -> MagicMock:
     return service
 
 
+def _make_runtime_settings(
+    *,
+    batch_size: int = 10,
+    subdir: str = ".homeflix/thumbnails",
+) -> AsyncMock:
+    """Return a fake :class:`RuntimeSettings` exposing ``thumbnail_backfill``."""
+    runtime = AsyncMock()
+    runtime.thumbnail_backfill = AsyncMock(
+        return_value=ThumbnailBackfillConfig(batch_size=batch_size, subdir=subdir),
+    )
+    return runtime
+
+
 @pytest.mark.unit
 class TestThumbnailBackfillJob:
     @pytest.mark.asyncio
@@ -122,8 +136,8 @@ class TestThumbnailBackfillJob:
 
         job = ThumbnailBackfillJob(
             media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(batch_size=2),
             thumbnail_service=service,
-            batch_size=2,
         )
         await job.run()
 
@@ -151,8 +165,8 @@ class TestThumbnailBackfillJob:
 
         job = ThumbnailBackfillJob(
             media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(batch_size=3),
             thumbnail_service=service,
-            batch_size=3,
         )
         await job.run()
 
@@ -176,8 +190,8 @@ class TestThumbnailBackfillJob:
 
         job = ThumbnailBackfillJob(
             media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(batch_size=5),
             thumbnail_service=service,
-            batch_size=5,
         )
         await job.run()
 
@@ -200,8 +214,8 @@ class TestThumbnailBackfillJob:
 
         job = ThumbnailBackfillJob(
             media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(batch_size=5),
             thumbnail_service=service,
-            batch_size=5,
         )
         await job.run()
 
@@ -225,9 +239,8 @@ class TestThumbnailBackfillJob:
 
         job = ThumbnailBackfillJob(
             media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(batch_size=1, subdir="custom/thumbs"),
             thumbnail_service=service,
-            batch_size=1,
-            sprite_subdir="custom/thumbs",
         )
         await job.run()
 
@@ -263,8 +276,8 @@ class TestThumbnailBackfillJob:
 
         job = ThumbnailBackfillJob(
             media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(batch_size=2),
             thumbnail_service=service,
-            batch_size=2,
         )
         await job.run()
 
@@ -287,6 +300,7 @@ class TestThumbnailBackfillJob:
 
         job = ThumbnailBackfillJob(
             media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(),
             thumbnail_service=service,
         )
         ok = await job.process_movie_by_id(str(movie.id))
@@ -312,7 +326,11 @@ class TestThumbnailBackfillJob:
         factory = MagicMock(return_value=uow)
         service = _make_thumbnail_service(tmp_path / "sprite.vtt")
 
-        job = ThumbnailBackfillJob(media_uow_factory=factory, thumbnail_service=service)
+        job = ThumbnailBackfillJob(
+            media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(),
+            thumbnail_service=service,
+        )
         ok = await job.process_movie_by_id(str(movie.id))
 
         assert ok is False
@@ -331,7 +349,11 @@ class TestThumbnailBackfillJob:
         factory = MagicMock(return_value=uow)
         service = _make_thumbnail_service(tmp_path / "sprite.vtt")
 
-        job = ThumbnailBackfillJob(media_uow_factory=factory, thumbnail_service=service)
+        job = ThumbnailBackfillJob(
+            media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(),
+            thumbnail_service=service,
+        )
         ok = await job.process_movie_by_id(str(MovieId.generate()))
 
         assert ok is False
@@ -348,7 +370,11 @@ class TestThumbnailBackfillJob:
         factory = MagicMock(return_value=uow)
         service = _make_thumbnail_service(tmp_path / "sprite.vtt")
 
-        job = ThumbnailBackfillJob(media_uow_factory=factory, thumbnail_service=service)
+        job = ThumbnailBackfillJob(
+            media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(),
+            thumbnail_service=service,
+        )
         ok = await job.process_episode_by_id(str(episode.id))
 
         assert ok is True
@@ -364,8 +390,8 @@ class TestThumbnailBackfillJob:
 
         job = ThumbnailBackfillJob(
             media_uow_factory=factory,
+            runtime_settings=_make_runtime_settings(batch_size=10),
             thumbnail_service=service,
-            batch_size=10,
         )
         # Should be a clean no-op — no persistence calls, no thumbnail
         # generation, and the run shouldn't raise.

--- a/tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py
+++ b/tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py
@@ -13,11 +13,14 @@ import pytest
 from src.modules.media.application.ports import (
     DetectedIntro,
     EpisodeFingerprint,
+    IntroDetectorTuning,
 )
 from src.modules.media.domain.value_objects import EpisodeId
 from src.modules.media.infrastructure.audio.chromaprint_intro_detector import (
     ChromaprintIntroDetector,
 )
+
+_DEFAULT_TUNING = IntroDetectorTuning()
 
 _HASH_RATE = 8.0  # roughly the Chromaprint default; keeps math tidy
 _BIT_MASK = 0xFFFFFFFF
@@ -89,7 +92,7 @@ class TestChromaprintIntroDetector:
             seed=1,
         )
 
-        assert detector.detect([single]) == {}
+        assert detector.detect([single], _DEFAULT_TUNING) == {}
 
     def test_returns_empty_when_episodes_share_nothing(self) -> None:
         detector = ChromaprintIntroDetector()
@@ -102,7 +105,7 @@ class TestChromaprintIntroDetector:
             for seed in range(3)
         ]
 
-        result = detector.detect(episodes)
+        result = detector.detect(episodes, _DEFAULT_TUNING)
 
         assert result == {}
 
@@ -118,7 +121,7 @@ class TestChromaprintIntroDetector:
             for seed in (1, 2, 3, 4)
         ]
 
-        result = detector.detect(episodes)
+        result = detector.detect(episodes, _DEFAULT_TUNING)
 
         assert len(result) == len(episodes)
         for episode in episodes:
@@ -145,7 +148,7 @@ class TestChromaprintIntroDetector:
             for seed, offset in enumerate(offsets, start=10)
         ]
 
-        result = detector.detect(episodes)
+        result = detector.detect(episodes, _DEFAULT_TUNING)
 
         assert len(result) == len(episodes)
         for episode, offset in zip(episodes, offsets, strict=True):
@@ -171,7 +174,7 @@ class TestChromaprintIntroDetector:
             for seed in (1, 2, 3)
         ]
 
-        result = detector.detect(episodes)
+        result = detector.detect(episodes, _DEFAULT_TUNING)
 
         assert len(result) == len(episodes)
         for episode in episodes:
@@ -199,7 +202,7 @@ class TestChromaprintIntroDetector:
             duration_seconds=400 / _HASH_RATE,
         )
 
-        result = detector.detect([*with_intro, outlier])
+        result = detector.detect([*with_intro, outlier], _DEFAULT_TUNING)
 
         assert outlier.episode_id not in result
         # 1 agreeing peer out of 2 possible → confidence == 0.5
@@ -221,7 +224,7 @@ class TestChromaprintIntroDetector:
             for seed in (1, 2, 3)
         ]
 
-        assert detector.detect(episodes) == {}
+        assert detector.detect(episodes, _DEFAULT_TUNING) == {}
 
     def test_returns_empty_for_zero_duration_fingerprints(self) -> None:
         detector = ChromaprintIntroDetector()
@@ -234,7 +237,7 @@ class TestChromaprintIntroDetector:
             for _ in range(3)
         ]
 
-        assert detector.detect(empty) == {}
+        assert detector.detect(empty, _DEFAULT_TUNING) == {}
 
     def test_confidence_is_capped_at_one(self, shared_intro: list[int]) -> None:
         detector = ChromaprintIntroDetector()
@@ -248,7 +251,7 @@ class TestChromaprintIntroDetector:
             for seed in range(3)
         ]
 
-        result = detector.detect(episodes)
+        result = detector.detect(episodes, _DEFAULT_TUNING)
 
         for marker in result.values():
             assert 0.0 <= marker.confidence <= 1.0
@@ -258,7 +261,7 @@ class TestChromaprintIntroDetector:
         # at 5 s. The detector finds the full match, then truncates the
         # END so the persisted segment never goes past the cap.
         long_intro = _make_random_hashes(60, seed=99)
-        detector = ChromaprintIntroDetector(max_intro_seconds=5.0)
+        detector = ChromaprintIntroDetector()
         episodes = [
             _episode(
                 intro_hashes=long_intro,
@@ -269,7 +272,8 @@ class TestChromaprintIntroDetector:
             for seed in (1, 2, 3)
         ]
 
-        result = detector.detect(episodes)
+        tuning = IntroDetectorTuning(max_intro_seconds=5.0)
+        result = detector.detect(episodes, tuning)
 
         assert len(result) == len(episodes)
         for episode in episodes:
@@ -298,7 +302,7 @@ class TestChromaprintIntroDetector:
             for seed in (100, 200, 300)
         ]
 
-        result = detector.detect(episodes)
+        result = detector.detect(episodes, _DEFAULT_TUNING)
 
         for episode in episodes:
             marker = result[episode.episode_id]
@@ -317,10 +321,8 @@ class TestChromaprintIntroDetector:
         # every shift. The detector must still fall back to a 1-hash
         # window so misconfiguration becomes "low quality matches" and
         # not "matching disabled".
-        detector = ChromaprintIntroDetector(
-            alignment_window_seconds=0.05,
-            min_intro_seconds=0.1,
-        )
+        detector = ChromaprintIntroDetector(alignment_window_seconds=0.05)
+        tuning = IntroDetectorTuning(min_intro_seconds=0.1)
         episodes = [
             _episode(
                 intro_hashes=shared_intro,
@@ -331,7 +333,7 @@ class TestChromaprintIntroDetector:
             for seed in range(3)
         ]
 
-        result = detector.detect(episodes)
+        result = detector.detect(episodes, tuning)
 
         # The 1-hash floor cannot detect a 10s intro, but we explicitly
         # do not require correctness here — just that the loop is not


### PR DESCRIPTION
## Summary

ADR-013 phase 2 — every scheduler/backfill/intro-detection tunable now lives in `app_settings` and is read via `RuntimeSettings`. The `.env` no longer carries these knobs.

- **Jobs**: `LibraryScanScheduler`, `ThumbnailBackfillJob`, `IntroDetectionJob` now take `RuntimeSettings` and snapshot the relevant config per `run()`. Admin-panel edits land on the next tick without restart (reconcile-interval changes still need a restart — APScheduler limitation, documented in the docstring).
- **Detector port**: `IntroDetectorPort.detect()` now takes an `IntroDetectorTuning` dataclass per call so the 4 operator-tunable knobs (`max_hash_hamming`, `tolerance_hashes`, `min_intro_seconds`, `max_intro_seconds`) are runtime-mutable. `ChromaprintIntroDetector` becomes stateless wrt those fields.
- **Bootstrap**: `main.py` reads `RuntimeSettings` to decide which jobs to enable and at what interval. Drops `settings.scheduler_enabled`/`thumbnail_backfill_enabled`/`intro_detection_enabled` etc.
- **Seed migration**: one-time alembic migration that reads any pre-existing env vars and writes them into `app_settings` with `source='migration_seed'`. `INSERT OR IGNORE`, so re-running is safe; downgrade removes only the seeded rows (admin-edited rows from later phases survive).
- **Settings cleanup**: all migrated fields dropped from `src/config/settings.py` and `.env.example`. Startup logs a warning listing any legacy env vars still set in the environment.
- **Containers**: `ApplicationContainer` and `MediaContainer` drop the `config.provided.*` forwards for the migrated buckets; the job providers now take `settings.runtime_settings`.

## Out of scope (next PR)

- `StreamingConfig` (`ffmpeg_threads`, `hls_cache_max_size_mb`) and `AvatarConfig` consumers — phase 2 of ADR-013 was scheduler/backfill/intro only.
- Admin UI for editing buckets — last PR in the rollout.

## Test plan

- [x] `pytest tests/` — 2511 passed, 5 skipped (was 2506 + 5 — five new seed-migration tests).
- [x] `pytest tests/infrastructure/scheduling/` — 28 pass after rewiring all three job constructors.
- [x] `pytest tests/modules/media/unit/infrastructure/audio/test_chromaprint_intro_detector.py` — 12 pass after threading `IntroDetectorTuning` through every `detect()` call.
- [x] `pytest tests/infrastructure/migrations/test_seed_app_settings.py` — 5 new tests cover env-harvest helper + idempotent insert + skip-when-no-env.
- [x] `ruff check src tests migrations` clean; `ruff format --check` clean.
- [x] `mypy src` — 280 errors, all pre-existing (down 4 from baseline 284 because some `providers.Dependency()` declarations went away).
- [x] `alembic upgrade head` → `downgrade -2` → `upgrade head` round-trips both new migrations.

## Summary by Sourcery

Migrate scheduler, thumbnail backfill, and intro-detection configuration from static environment-based settings into database-backed RuntimeSettings, updating jobs, detectors, and bootstrapping to consume the new runtime-configurable settings and seeding existing env-based values into app_settings via a one-time migration.

Enhancements:
- Make LibraryScanScheduler, ThumbnailBackfillJob, and IntroDetectionJob read all operator-tunable parameters from RuntimeSettings so admin changes apply at runtime without process restarts where possible.
- Refactor ChromaprintIntroDetector and IntroDetectorPort to accept per-call IntroDetectorTuning, decoupling detector tuning from container wiring and making the detector stateless with respect to operator-configurable knobs.
- Update application startup to derive scheduler enablement and job intervals from RuntimeSettings and warn about deprecated scheduler/backfill/intro-related environment variables.
- Remove now-migrated scheduler, thumbnail backfill, and intro-detection fields from Settings and container dependency wiring in favor of RuntimeSettings-driven configuration.

Deployment:
- Introduce an Alembic migration that seeds app_settings rows for scheduler, thumbnail backfill, and intro-detection settings based on any pre-existing environment variables, and ensures downgrade only removes migration-seeded rows.

Documentation:
- Add and update docstrings and inline comments describing ADR-013 phase 2 behavior, runtime settings flow, and limitations around APScheduler interval reconfiguration.

Tests:
- Extend and adjust unit tests for ThumbnailBackfillJob, IntroDetectionJob, ChromaprintIntroDetector, and LibraryScanScheduler to exercise RuntimeSettings-driven behavior and new IntroDetectorTuning parameterization.
- Add migration tests that validate env-var harvesting and idempotent seeding of app_settings via the new seed migration.