### PR TITLE
docs(adr): mark ADR-013 shipped + refresh roadmap

### DIFF
--- a/docs/adr/ADR-013-runtime-settings-db-backed.md
+++ b/docs/adr/ADR-013-runtime-settings-db-backed.md
@@ -1,6 +1,6 @@
 # ADR-013: Runtime settings persistidos em banco para tunables operacionais
 
-**Status:** Proposto
+**Status:** Aceito
 **Data:** 2026-05-21
 **Deciders:** Lucas Cristovam
 **Technical Story:** Planejamento 2026-05-21 de exposição de tunables operacionais via admin panel.
@@ -242,3 +242,4 @@ threshold = settings.intro_detection.min_confidence
 | Data | Autor | Mudança |
 |------|-------|---------|
 | 2026-05-21 | Lucas Cristovam | Criação inicial |
+| 2026-05-23 | Lucas Cristovam | Rollout completo — backend nas PRs #221 (foundation), #222 (scheduler/backfill/intro), #223 (streaming/avatar), #224 (admin routes); frontend em homeflix-web#156 (/admin/system/settings). Status: Aceito. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-010](./ADR-010-identity-bounded-context.md) | Identity Bounded Context | ✅ Aceito | 2026-05-03 |
 | [ADR-011](./ADR-011-authentication-strategy.md) | Authentication Strategy | ✅ Aceito | 2026-05-03 |
 | [ADR-012](./ADR-012-decentralized-error-http-mapping.md) | Registry Descentralizado de Error HTTP Mapping | ✅ Aceito | 2026-05-06 |
-| [ADR-013](./ADR-013-runtime-settings-db-backed.md) | Runtime Settings Persistidos em Banco para Tunables Operacionais | 🟡 Proposto | 2026-05-21 |
+| [ADR-013](./ADR-013-runtime-settings-db-backed.md) | Runtime Settings Persistidos em Banco para Tunables Operacionais | ✅ Aceito | 2026-05-21 |
 | [ADR-014](./ADR-014-settings-per-bucket-aggregate.md) | Settings — Aggregate por Bucket (não Mega-Aggregate) | ✅ Aceito | 2026-05-21 |
 
 ## Como Criar um Novo ADR

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # HomeFlix — Roadmap
 
-> Last updated: 2026-05-06
+> Last updated: 2026-05-23
 
 This roadmap captures **what comes next** after the Phase 1 foundation.
 Items are ordered so each tier builds on the previous one — both in
@@ -57,7 +57,16 @@ patterns are explicitly excluded.
   flag, per-profile watch progress / collections / preferences,
   `allowed_library_ids` ACL filtering catalog reads, profile picker
   + management UI, profile avatar upload (Pillow centre-crop to WebP).
-- 77 REST API endpoints across 7 bounded contexts, 2 200+ tests.
+- **4.3 Runtime Settings (DB-backed)** — ADR-013 + ADR-014. Five
+  operational tunable buckets (scheduler, thumbnail backfill, intro
+  detection, streaming, avatar) moved out of `.env` into the
+  `app_settings` table with per-bucket aggregates, snapshot+TTL
+  facade (`RuntimeSettings`), one-time seed migrations, and a typed
+  admin surface at `/api/v1/admin/settings`. Frontend forms ship at
+  `/admin/system/settings` so edits propagate to consumers in
+  seconds without restart (avatar storage subdir is the one caveat
+  — lazy-cached at startup).
+- 107 REST API endpoints across 9 bounded contexts, 2 530+ tests.
 
 ---
 


### PR DESCRIPTION
## Summary

- Flip ADR-013 (DB-backed runtime settings) status from Proposto → Aceito in both `docs/adr/README.md` and the ADR file itself
- Add a 2026-05-23 row to ADR-013's revision history pointing to the five delivery PRs (#221 foundation · #222 jobs · #223 streaming/avatar · #224 admin routes · homeflix-web#156 admin UI)
- Add Phase 4.3 to `docs/roadmap.md` under Shipped, describing the five tunable buckets, the `RuntimeSettings` snapshot facade, the seed migrations, and the admin surface at `/admin/system/settings`. Cross-links ADR-013 + ADR-014.
- Refresh the end-state line: 107 REST endpoints across 9 BCs, 2 530+ tests (was 77 / 7 / 2 200+); bump "Last updated" to today

## Test plan

- [x] Roadmap counts verified against the running app (`107 /api/v1/* routes`, `pytest --collect-only → 2537 tests`, 9 modules under `src/modules/`)
- [x] ADR README + ADR-013 status flipped to "Aceito"
- [x] No content changes to the ADR itself — body still describes the design as decided; only the status header + revision history moved

## Summary by Sourcery

Mark the runtime settings ADR as accepted and reflect its rollout in the documentation.

Documentation:
- Update ADR-013 and the ADR index to mark the runtime settings decision as accepted and record its rollout details.
- Refresh the roadmap with a shipped Phase 4.3 entry for DB-backed runtime settings, including admin surfaces and cross-links to ADR-013/ADR-014, and update endpoint/test counts and last-updated metadata.