### PR TITLE
feat(media): admin resolution of detected conflicts (ADR-015 Phase 2 backend)

### DIFF
--- a/migrations/versions/2026_05_23_add_winner_id_to_media_conflicts.py
+++ b/migrations/versions/2026_05_23_add_winner_id_to_media_conflicts.py
@@ -1,0 +1,39 @@
+"""Add winner_id column to media_conflicts.
+
+Backs ADR-015 Phase 2 — the resolve endpoint persists which side
+survived for MERGE actions so the admin queue can render audit
+trail entries ("merged into mov_xxx") without joining onto the
+soft-deleted loser row.
+
+Revision ID: 4e5f60718293
+Revises: 3d4e5f607182
+Create Date: 2026-05-23 17:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "4e5f60718293"
+down_revision: str | Sequence[str] | None = "3d4e5f607182"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``winner_id`` column."""
+    with op.batch_alter_table("media_conflicts") as batch_op:
+        batch_op.add_column(sa.Column("winner_id", sa.String(length=50), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the ``winner_id`` column."""
+    with op.batch_alter_table("media_conflicts") as batch_op:
+        batch_op.drop_column("winner_id")

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -75,6 +75,9 @@ from src.modules.media.application.use_cases.promote_movie_to_series import (
 )
 from src.modules.media.application.use_cases.relink_movie import RelinkMovieUseCase
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
+from src.modules.media.application.use_cases.resolve_media_conflict import (
+    ResolveMediaConflictUseCase,
+)
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
@@ -556,6 +559,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     list_conflicts = providers.Factory(
         ListConflictsUseCase,
         uow_factory=media_unit_of_work_factory,
+    )
+
+    resolve_media_conflict = providers.Factory(
+        ResolveMediaConflictUseCase,
+        uow_factory=media_unit_of_work_factory,
+        event_bus=event_bus,
     )
 
     # =========================================================================

--- a/src/main.py
+++ b/src/main.py
@@ -244,6 +244,9 @@ async def _subscribe_event_handlers(container: ApplicationContainer) -> None:
         OnMediaEnrichedHandler,
     )
     from src.modules.collections.application.event_handlers import (
+        OnMovieMergedHandler as CollectionsOnMovieMergedHandler,
+    )
+    from src.modules.collections.application.event_handlers import (
         OnMoviePromotedToSeriesHandler as CollectionsOnMoviePromotedHandler,
     )
     from src.modules.collections.application.event_handlers import (
@@ -257,7 +260,11 @@ async def _subscribe_event_handlers(container: ApplicationContainer) -> None:
     from src.modules.media.domain.events import (
         MediaCreatedEvent,
         MediaEnrichedEvent,
+        MovieMergedEvent,
         MoviePromotedToSeriesEvent,
+    )
+    from src.modules.watch_progress.application.event_handlers import (
+        OnMovieMergedHandler as ProgressOnMovieMergedHandler,
     )
     from src.modules.watch_progress.application.event_handlers import (
         OnMoviePromotedToSeriesHandler as ProgressOnMoviePromotedHandler,
@@ -313,6 +320,19 @@ async def _subscribe_event_handlers(container: ApplicationContainer) -> None:
             uow_factory=catalog_requests_uow_factory,
             notification_publisher=notification_publisher,
         ),
+    )
+
+    # Cross-BC fan-out when two movies are merged via the conflict
+    # queue (ADR-015 Phase 2). watch_progress drops the loser's
+    # rows; collections rewrites watchlist + custom-list entries so
+    # users' lists keep the surviving id.
+    event_bus.subscribe(
+        MovieMergedEvent,
+        ProgressOnMovieMergedHandler(uow_factory=watch_progress_uow_factory),
+    )
+    event_bus.subscribe(
+        MovieMergedEvent,
+        CollectionsOnMovieMergedHandler(uow_factory=collections_uow_factory),
     )
 
     # Cross-BC fan-out when a movie is promoted into a series.

--- a/src/modules/collections/application/event_handlers/__init__.py
+++ b/src/modules/collections/application/event_handlers/__init__.py
@@ -1,5 +1,8 @@
 """Collections event handlers."""
 
+from src.modules.collections.application.event_handlers.on_movie_merged import (
+    OnMovieMergedHandler,
+)
 from src.modules.collections.application.event_handlers.on_movie_promoted_to_series import (
     OnMoviePromotedToSeriesHandler,
 )
@@ -7,4 +10,8 @@ from src.modules.collections.application.event_handlers.on_user_deleted import (
     OnUserDeletedHandler,
 )
 
-__all__ = ["OnMoviePromotedToSeriesHandler", "OnUserDeletedHandler"]
+__all__ = [
+    "OnMovieMergedHandler",
+    "OnMoviePromotedToSeriesHandler",
+    "OnUserDeletedHandler",
+]

--- a/src/modules/collections/application/event_handlers/on_movie_merged.py
+++ b/src/modules/collections/application/event_handlers/on_movie_merged.py
@@ -1,0 +1,62 @@
+"""Cross-BC handler: repoint watchlist / custom-list refs on a movie merge."""
+
+import logging
+
+from src.building_blocks.application.event_bus import EventHandler
+from src.building_blocks.domain.events import DomainEvent
+from src.modules.collections.application.unit_of_work import (
+    CollectionsUnitOfWorkFactory,
+)
+from src.modules.media.domain.events import MovieMergedEvent
+
+_logger = logging.getLogger(__name__)
+
+
+class OnMovieMergedHandler(EventHandler):
+    """Rewrite watchlist + custom-list entries from loser → winner movie.
+
+    Counterpart to ``OnMoviePromotedToSeriesHandler``: when two Movie
+    entities are merged via the conflict queue (ADR-015 Phase 2), the
+    loser's external id becomes invalid (soft-deleted) but the
+    user-facing intent ("I want to watch this content") is unchanged.
+    Rewriting both tables in a single Unit of Work keeps watchlist
+    and custom-lists consistent.
+
+    The underlying repository methods are idempotent and unique-aware
+    — if a user already has the winner movie on their list, the loser
+    entry is removed rather than producing a duplicate row.
+    """
+
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def handle(self, event: DomainEvent) -> None:
+        """Handle ``MovieMergedEvent``."""
+        if not isinstance(event, MovieMergedEvent):
+            return
+
+        async with self._uow_factory() as uow:
+            watchlist_updated = await uow.watchlist.rewrite_media_id(
+                from_media_id=event.loser_id,
+                to_media_id=event.winner_id,
+                to_media_type="movie",
+            )
+            lists_updated = await uow.custom_lists.rewrite_item_media_id(
+                from_media_id=event.loser_id,
+                to_media_id=event.winner_id,
+                to_media_type="movie",
+            )
+
+        if watchlist_updated or lists_updated:
+            _logger.info(
+                "Repointed %d watchlist + %d custom-list entries from "
+                "loser %s to winner %s (conflict %s)",
+                watchlist_updated,
+                lists_updated,
+                event.loser_id,
+                event.winner_id,
+                event.conflict_id,
+            )
+
+
+__all__ = ["OnMovieMergedHandler"]

--- a/src/modules/media/application/dtos/conflict_dtos.py
+++ b/src/modules/media/application/dtos/conflict_dtos.py
@@ -95,6 +95,46 @@ class ConflictSummary:
 
 
 @dataclass(frozen=True)
+class ResolveMediaConflictInput:
+    """Input for the admin resolution endpoint.
+
+    Attributes:
+        conflict_id: External id of the conflict to resolve.
+        action: Which disposition the operator picked.
+        winner_id: Required for ``MERGE_KEEP_BOTH`` / ``MERGE_REPLACE``;
+            forbidden for ``MARK_DISTINCT``. Must equal one of the
+            conflict's candidate ids.
+    """
+
+    conflict_id: str
+    action: str
+    winner_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ResolveMediaConflictOutput:
+    """Result summary after the resolve use case commits.
+
+    Attributes:
+        conflict_id: External id of the resolved conflict.
+        action: The persisted resolution value.
+        winner_id: Surviving candidate for MERGE actions; ``None``
+            for MARK_DISTINCT.
+        loser_id: Soft-deleted candidate for MERGE actions; ``None``
+            for MARK_DISTINCT.
+        variants_transferred: For ``MERGE_KEEP_BOTH``, how many
+            file variants moved from loser → winner. ``0`` for the
+            other actions.
+    """
+
+    conflict_id: str
+    action: str
+    winner_id: str | None
+    loser_id: str | None
+    variants_transferred: int
+
+
+@dataclass(frozen=True)
 class ListConflictsOutput:
     """Paginated list of conflicts.
 
@@ -118,4 +158,6 @@ __all__ = [
     "DetectMovieConflictsOutput",
     "ListConflictsInput",
     "ListConflictsOutput",
+    "ResolveMediaConflictInput",
+    "ResolveMediaConflictOutput",
 ]

--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -76,11 +76,14 @@ class DetectMovieConflictsUseCase:
             self_runtime = _runtime_minutes(self_movie)
 
             for other in others:
-                existing = await uow.media_conflicts.find_pending_by_pair(
+                blocker = await uow.media_conflicts.find_blocking_pair(
                     input_dto.media_id,
                     str(other.id),
                 )
-                if existing is not None:
+                if blocker is not None:
+                    # Either pending (no need to re-queue) or
+                    # MARK_DISTINCT-resolved (operator already said
+                    # the pair is intentionally distinct).
                     continue
 
                 conflict = MediaConflict.detect(

--- a/src/modules/media/application/use_cases/resolve_media_conflict.py
+++ b/src/modules/media/application/use_cases/resolve_media_conflict.py
@@ -1,0 +1,204 @@
+"""Admin-driven resolution of a queued media conflict (ADR-015 Phase 2)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.building_blocks.domain.errors import (
+    BusinessRuleViolationException,
+    DomainValidationException,
+)
+from src.modules.media.application.dtos.conflict_dtos import (
+    ResolveMediaConflictInput,
+    ResolveMediaConflictOutput,
+)
+from src.modules.media.domain.entities.media_conflict import (
+    MediaConflict,
+    ResolutionAction,
+)
+from src.modules.media.domain.events import MovieMergedEvent
+from src.modules.media.domain.rule_codes import MediaRuleCodes
+from src.modules.media.domain.value_objects import MovieId
+from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+
+if TYPE_CHECKING:
+    from src.building_blocks.application.event_bus import EventBus
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+_logger = logging.getLogger(__name__)
+
+
+class ResolveMediaConflictUseCase:
+    """Apply an admin's chosen disposition to a pending conflict.
+
+    Phase 1 only writes Movie-vs-Movie conflicts, so this use case
+    handles the same shape:
+
+    - ``MARK_DISTINCT``: just stamps the row; the detector will not
+      re-queue the pair (see ``find_blocking_pair``).
+    - ``MERGE_REPLACE``: soft-deletes the loser movie; downstream
+      ``MovieMergedEvent`` handlers repoint watch progress + list
+      memberships from loser → winner.
+    - ``MERGE_KEEP_BOTH``: first transfers the loser's file variants
+      onto the winner, then proceeds as ``MERGE_REPLACE``.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+        event_bus: Optional event bus. When ``None`` no events are
+            published — handy for unit tests.
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        event_bus: EventBus | None = None,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._event_bus = event_bus
+
+    async def execute(
+        self,
+        input_dto: ResolveMediaConflictInput,
+    ) -> ResolveMediaConflictOutput:
+        """Resolve a single conflict by id.
+
+        Returns:
+            Summary of the resolution (action, winner/loser ids,
+            variants transferred).
+        """
+        try:
+            action = ResolutionAction(input_dto.action)
+        except ValueError as exc:
+            raise DomainValidationException(
+                message=f"Unknown resolution action '{input_dto.action}'",
+                message_code=MediaRuleCodes.INVALID_MEDIA_ID_FORMAT,
+                object_type="MediaConflict",
+            ) from exc
+
+        event_to_publish: MovieMergedEvent | None = None
+        variants_transferred = 0
+
+        async with self._uow_factory() as uow:
+            conflict = await uow.media_conflicts.find_by_id(
+                MediaConflictId(input_dto.conflict_id),
+            )
+            if conflict is None:
+                raise ResourceNotFoundException.for_resource(
+                    "MediaConflict",
+                    input_dto.conflict_id,
+                )
+            if conflict.is_resolved:
+                raise BusinessRuleViolationException(
+                    message="MediaConflict is already resolved",
+                    message_code=MediaRuleCodes.MEDIA_CONFLICT_ALREADY_RESOLVED,
+                    rule_code=MediaRuleCodes.MEDIA_CONFLICT_ALREADY_RESOLVED,
+                )
+
+            if action is not ResolutionAction.MARK_DISTINCT:
+                _ensure_movie_pair(conflict)
+                _ensure_winner_in_pair(conflict, input_dto.winner_id)
+            elif input_dto.winner_id is not None:
+                raise DomainValidationException(
+                    message="winner_id must be None for mark_distinct",
+                    message_code="MEDIA_CONFLICT_WINNER_NOT_ALLOWED",
+                    object_type="MediaConflict",
+                )
+
+            resolved = conflict.resolve(action, winner_id=input_dto.winner_id)
+            persisted = await uow.media_conflicts.save(resolved)
+
+            if action is ResolutionAction.MARK_DISTINCT:
+                return ResolveMediaConflictOutput(
+                    conflict_id=str(persisted.id),
+                    action=action.value,
+                    winner_id=None,
+                    loser_id=None,
+                    variants_transferred=0,
+                )
+
+            # MERGE branches: aggregate has validated winner_id is
+            # populated and matches a candidate, so loser_id() returns
+            # a non-None string. We re-fetch defensively in case the
+            # invariants ever change.
+            winner_id = persisted.winner_id
+            loser_id = persisted.loser_id()
+            if winner_id is None or loser_id is None:
+                raise BusinessRuleViolationException(
+                    message="MERGE resolution did not populate winner/loser",
+                    message_code=MediaRuleCodes.MEDIA_CONFLICT_ALREADY_RESOLVED,
+                    rule_code=MediaRuleCodes.MEDIA_CONFLICT_ALREADY_RESOLVED,
+                )
+
+            if action is ResolutionAction.MERGE_KEEP_BOTH:
+                variants_transferred = await uow.movies.transfer_file_variants_between_movies(
+                    source_movie_id=MovieId(loser_id),
+                    target_movie_id=MovieId(winner_id),
+                )
+
+            deleted = await uow.movies.delete(MovieId(loser_id))
+            if not deleted:
+                # The loser already vanished before we got here —
+                # treat the resolve as still successful (the conflict
+                # row is stamped) but log so the operator notices.
+                _logger.warning(
+                    "Loser movie %s missing during merge resolve of %s",
+                    loser_id,
+                    persisted.id,
+                )
+
+            event_to_publish = MovieMergedEvent(
+                conflict_id=str(persisted.id),
+                winner_id=winner_id,
+                loser_id=loser_id,
+                keep_loser_variants=action is ResolutionAction.MERGE_KEEP_BOTH,
+            )
+
+        # Publish outside the UoW so a slow handler doesn't hold the
+        # write transaction open. Cross-BC handlers (watch_progress,
+        # collections) repoint FK refs from loser → winner.
+        if event_to_publish is not None and self._event_bus is not None:
+            await self._event_bus.publish(event_to_publish)
+
+        return ResolveMediaConflictOutput(
+            conflict_id=str(persisted.id),
+            action=action.value,
+            winner_id=persisted.winner_id,
+            loser_id=persisted.loser_id(),
+            variants_transferred=variants_transferred,
+        )
+
+
+def _ensure_movie_pair(conflict: MediaConflict) -> None:
+    """Reject cross-type conflicts the use case is not equipped to handle."""
+    if conflict.candidate_a_type != "movie" or conflict.candidate_b_type != "movie":
+        raise DomainValidationException(
+            message="ResolveMediaConflictUseCase only handles movie-vs-movie conflicts",
+            message_code="MEDIA_CONFLICT_UNSUPPORTED_CANDIDATE_TYPE",
+            object_type="MediaConflict",
+        )
+
+
+def _ensure_winner_in_pair(conflict: MediaConflict, winner_id: str | None) -> None:
+    """Pre-validate ``winner_id`` so the aggregate's pydantic check never fires.
+
+    Validating here keeps the resulting ``DomainValidationException`` free
+    of pydantic-injected ``input`` metadata (which would carry the
+    aggregate's datetime fields and trip the JSON response serializer).
+    """
+    if winner_id is None:
+        raise DomainValidationException(
+            message="winner_id is required for merge_keep_both / merge_replace",
+            message_code="MEDIA_CONFLICT_WINNER_REQUIRED",
+            object_type="MediaConflict",
+        )
+    if winner_id not in {conflict.candidate_a_id, conflict.candidate_b_id}:
+        raise DomainValidationException(
+            message="winner_id must be one of the conflict's candidates",
+            message_code="MEDIA_CONFLICT_WINNER_NOT_IN_PAIR",
+            object_type="MediaConflict",
+        )
+
+
+__all__ = ["ResolveMediaConflictUseCase"]

--- a/src/modules/media/domain/entities/media_conflict.py
+++ b/src/modules/media/domain/entities/media_conflict.py
@@ -69,6 +69,9 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
             resolves the conflict.
         resolution: Action the admin chose. Always paired with
             ``resolved_at`` — both ``None`` or both set.
+        winner_id: For ``MERGE_*`` resolutions, the external id of the
+            candidate that survived. ``None`` for pending rows and
+            for ``MARK_DISTINCT`` (no winner — both sides survive).
     """
 
     # Class-level thresholds — ADR-015: delta must exceed BOTH the
@@ -91,6 +94,7 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
 
     resolved_at: datetime | None = None
     resolution: ResolutionAction | None = None
+    winner_id: str | None = None
 
     @model_validator(mode="after")
     def _validate_candidates_distinct(self) -> Self:
@@ -113,6 +117,20 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         b_set = self.resolution is not None
         if a_set != b_set:
             raise ValueError("resolved_at and resolution must both be set or both be None")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_winner_id_paired_with_merge(self) -> Self:
+        """``winner_id`` is required for MERGE resolutions and forbidden otherwise."""
+        if self.resolution in {ResolutionAction.MERGE_KEEP_BOTH, ResolutionAction.MERGE_REPLACE}:
+            if self.winner_id is None:
+                raise ValueError(
+                    "winner_id is required for MERGE_KEEP_BOTH / MERGE_REPLACE resolutions",
+                )
+            if self.winner_id not in {self.candidate_a_id, self.candidate_b_id}:
+                raise ValueError("winner_id must be one of the conflict's candidates")
+        elif self.winner_id is not None:
+            raise ValueError("winner_id must be None for pending or MARK_DISTINCT rows")
         return self
 
     @classmethod
@@ -174,7 +192,7 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
             return SuggestedAction.DIFFERENT_EDIT_SUSPECTED
         return SuggestedAction.LIKELY_SAME_RELEASE
 
-    def resolve(self, action: ResolutionAction) -> Self:
+    def resolve(self, action: ResolutionAction, *, winner_id: str | None = None) -> Self:
         """Stamp the conflict as resolved with the chosen action.
 
         Idempotency: resolving an already-resolved conflict raises —
@@ -183,13 +201,22 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
 
         Args:
             action: Operator's chosen disposition.
+            winner_id: External id of the surviving candidate. Required
+                when ``action`` is ``MERGE_KEEP_BOTH`` or
+                ``MERGE_REPLACE``; must be ``None`` for
+                ``MARK_DISTINCT``. Validated against the candidate pair
+                so a stray id cannot land in the row.
 
         Returns:
-            New instance with ``resolved_at`` and ``resolution`` set.
+            New instance with ``resolved_at``, ``resolution`` and (for
+            MERGE actions) ``winner_id`` set.
 
         Raises:
             BusinessRuleViolationException: When the conflict has
                 already been resolved.
+            DomainValidationException: When ``winner_id`` is missing
+                for a MERGE action, provided for ``MARK_DISTINCT``, or
+                not one of the candidate ids.
         """
         if self.is_resolved:
             raise BusinessRuleViolationException(
@@ -200,12 +227,24 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         return self.with_updates(
             resolved_at=datetime.now(UTC),
             resolution=action,
+            winner_id=winner_id,
         )
 
     @property
     def is_resolved(self) -> bool:
         """``True`` once the operator has dispositioned the conflict."""
         return self.resolved_at is not None
+
+    @property
+    def is_marked_distinct(self) -> bool:
+        """``True`` when the operator declared the pair to be distinct."""
+        return self.resolution is ResolutionAction.MARK_DISTINCT
+
+    def loser_id(self) -> str | None:
+        """For MERGE resolutions, the id of the soft-deleted side."""
+        if self.winner_id is None:
+            return None
+        return self.candidate_b_id if self.winner_id == self.candidate_a_id else self.candidate_a_id
 
 
 def _compute_runtime_delta(a: float | None, b: float | None) -> float | None:

--- a/src/modules/media/domain/events.py
+++ b/src/modules/media/domain/events.py
@@ -126,6 +126,34 @@ class MediaConflictDetectedEvent(DomainEvent):
 
 
 @dataclass(frozen=True)
+class MovieMergedEvent(DomainEvent):
+    """Emitted when an admin merges two movies via the conflict queue.
+
+    Triggered by ADR-015 Phase 2 resolution endpoint. Carries the
+    cross-BC fan-out signal: ``watch_progress`` deletes the loser's
+    progress rows and ``collections`` repoints watchlist / custom-list
+    items from loser → winner. The loser movie itself is already
+    soft-deleted by the resolve use case before the event publishes,
+    so handlers don't need to touch the catalog row.
+
+    Attributes:
+        conflict_id: External id of the resolved conflict (``cnf_xxx``).
+        winner_id: External id of the surviving movie (``mov_xxx``).
+        loser_id: External id of the soft-deleted movie (``mov_xxx``).
+        keep_loser_variants: ``True`` when the resolution was
+            ``MERGE_KEEP_BOTH`` — the loser's file variants were
+            transferred to the winner; cross-BC handlers can treat
+            this identically to ``MERGE_REPLACE`` (rows still need to
+            be repointed). Surfaced for analytics / audit.
+    """
+
+    conflict_id: str = ""
+    winner_id: str = ""
+    loser_id: str = ""
+    keep_loser_variants: bool = False
+
+
+@dataclass(frozen=True)
 class MoviePromotedToSeriesEvent(DomainEvent):
     """Emitted when an admin promotes a movie into a series.
 
@@ -164,5 +192,6 @@ __all__ = [
     "MediaConflictDetectedEvent",
     "MediaCreatedEvent",
     "MediaEnrichedEvent",
+    "MovieMergedEvent",
     "MoviePromotedToSeriesEvent",
 ]

--- a/src/modules/media/domain/repositories/media_conflict_repository.py
+++ b/src/modules/media/domain/repositories/media_conflict_repository.py
@@ -37,24 +37,25 @@ class MediaConflictRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_pending_by_pair(
+    async def find_blocking_pair(
         self,
         candidate_a_id: str,
         candidate_b_id: str,
     ) -> MediaConflict | None:
-        """Find an unresolved conflict for the given candidate pair.
+        """Return any row that should suppress re-queueing for the pair.
 
-        The detector calls this before persisting a new row so the
-        same pair doesn't re-queue on every enrichment pass. The
-        comparison is unordered: ``(A, B)`` and ``(B, A)`` match
-        the same row.
-
-        Args:
-            candidate_a_id: One side of the pair.
-            candidate_b_id: The other side of the pair.
+        Used by the detector to skip pairs already queued *or* already
+        resolved as ``MARK_DISTINCT`` — the operator's "these are
+        intentionally distinct" verdict must persist across future
+        enrichment passes. Comparison is unordered: ``(A, B)`` and
+        ``(B, A)`` match the same row.
 
         Returns:
-            The pending conflict if one exists, ``None`` otherwise.
+            The blocking conflict (most recent if multiple), or
+            ``None`` when neither a pending nor a MARK_DISTINCT row
+            exists. MERGE-resolved rows do not block — by the time
+            they are queried the loser is soft-deleted and the
+            detector cannot rediscover the pair anyway.
         """
         ...
 

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -493,6 +493,31 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def transfer_file_variants_between_movies(
+        self,
+        source_movie_id: MovieId,
+        target_movie_id: MovieId,
+    ) -> int:
+        """Re-attach all ``media_files`` rows from one movie to another.
+
+        Used by the ADR-015 Phase 2 ``MERGE_KEEP_BOTH`` resolution: the
+        loser movie's file variants are reassigned to the winner so
+        the operator can pick the best stream at playback time across
+        what used to be two catalog entries. Reuses the underlying
+        rows to avoid the ``UNIQUE(file_path)`` clash that would
+        happen if we tried to create new rows alongside the old
+        ones, and keeps the existing track/probe metadata intact.
+
+        Args:
+            source_movie_id: External id of the loser movie.
+            target_movie_id: External id of the winner movie.
+
+        Returns:
+            Number of media_files rows moved.
+        """
+        ...
+
+    @abstractmethod
     async def find_missing_scrub_preview(self, limit: int) -> Sequence[Movie]:
         """Return up to ``limit`` movies that have no scrub-preview thumbnails yet.
 

--- a/src/modules/media/infrastructure/persistence/mappers/media_conflict_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/media_conflict_mapper.py
@@ -29,6 +29,7 @@ class MediaConflictMapper:
             suggested_action=SuggestedAction(model.suggested_action),
             resolved_at=model.resolved_at,
             resolution=None if model.resolution is None else ResolutionAction(model.resolution),
+            winner_id=model.winner_id,
             created_at=model.created_at,
             updated_at=model.updated_at,
         )
@@ -49,6 +50,7 @@ class MediaConflictMapper:
             suggested_action=entity.suggested_action.value,
             resolved_at=entity.resolved_at,
             resolution=None if entity.resolution is None else entity.resolution.value,
+            winner_id=entity.winner_id,
         )
 
     @staticmethod
@@ -63,6 +65,7 @@ class MediaConflictMapper:
         model.suggested_action = entity.suggested_action.value
         model.resolved_at = entity.resolved_at
         model.resolution = None if entity.resolution is None else entity.resolution.value
+        model.winner_id = entity.winner_id
 
 
 __all__ = ["MediaConflictMapper"]

--- a/src/modules/media/infrastructure/persistence/models/media_conflict.py
+++ b/src/modules/media/infrastructure/persistence/models/media_conflict.py
@@ -46,6 +46,7 @@ class MediaConflictModel(Base):
         index=True,
     )
     resolution: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    winner_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
 
 __all__ = ["MediaConflictModel"]

--- a/src/modules/media/infrastructure/persistence/repositories/media_conflict_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/media_conflict_repository.py
@@ -9,7 +9,10 @@ from src.building_blocks.application.pagination import (
     decode_cursor,
     encode_cursor,
 )
-from src.modules.media.domain.entities.media_conflict import MediaConflict
+from src.modules.media.domain.entities.media_conflict import (
+    MediaConflict,
+    ResolutionAction,
+)
 from src.modules.media.domain.repositories.media_conflict_repository import (
     MediaConflictRepository,
 )
@@ -63,15 +66,17 @@ class SqlAlchemyMediaConflictRepository(MediaConflictRepository):
         model = (await self._session.execute(stmt)).scalar_one_or_none()
         return None if model is None else MediaConflictMapper.to_entity(model)
 
-    async def find_pending_by_pair(
+    async def find_blocking_pair(
         self,
         candidate_a_id: str,
         candidate_b_id: str,
     ) -> MediaConflict | None:
-        """Return the pending row for the unordered pair, if any.
+        """Return any pending or MARK_DISTINCT row for the unordered pair.
 
-        The detector queries this before persisting to avoid
-        re-queuing the same pair on every enrichment pass.
+        Newest row wins when multiple candidates exist — typical only
+        when the same pair was queued, marked distinct, and then a
+        future enrich pass tried to re-queue (which this query
+        prevents from succeeding).
         """
         a_b = (MediaConflictModel.candidate_a_id == candidate_a_id) & (
             MediaConflictModel.candidate_b_id == candidate_b_id
@@ -79,10 +84,22 @@ class SqlAlchemyMediaConflictRepository(MediaConflictRepository):
         b_a = (MediaConflictModel.candidate_a_id == candidate_b_id) & (
             MediaConflictModel.candidate_b_id == candidate_a_id
         )
-        stmt = select(MediaConflictModel).where(
-            or_(a_b, b_a),
-            MediaConflictModel.resolved_at.is_(None),
-            MediaConflictModel.deleted_at.is_(None),
+        # Block on either pending rows OR MARK_DISTINCT-resolved rows.
+        # MERGE-resolved rows are excluded — the loser is soft-deleted
+        # by the time we get here, so the detector cannot rediscover
+        # the pair.
+        stmt = (
+            select(MediaConflictModel)
+            .where(
+                or_(a_b, b_a),
+                MediaConflictModel.deleted_at.is_(None),
+                or_(
+                    MediaConflictModel.resolved_at.is_(None),
+                    MediaConflictModel.resolution == ResolutionAction.MARK_DISTINCT.value,
+                ),
+            )
+            .order_by(MediaConflictModel.id.desc())
+            .limit(1)
         )
         model = (await self._session.execute(stmt)).scalar_one_or_none()
         return None if model is None else MediaConflictMapper.to_entity(model)

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -650,6 +650,41 @@ class SQLAlchemyMovieRepository(MovieRepository):
         )
         return result.rowcount or 0
 
+    async def transfer_file_variants_between_movies(
+        self,
+        source_movie_id: MovieId,
+        target_movie_id: MovieId,
+    ) -> int:
+        """Re-FK media_files from one movie's row to another's.
+
+        Mirrors ``transfer_file_variants_to_episode`` — looks up both
+        internal primary keys via the external ids, then a single
+        ``UPDATE`` rewrites the ``movie_id`` on every matching row.
+        """
+        src_pk_stmt = select(MovieModel.id).where(
+            MovieModel.external_id == str(source_movie_id),
+        )
+        tgt_pk_stmt = select(MovieModel.id).where(
+            MovieModel.external_id == str(target_movie_id),
+        )
+        src_pk = (await self._session.execute(src_pk_stmt)).scalar_one_or_none()
+        tgt_pk = (await self._session.execute(tgt_pk_stmt)).scalar_one_or_none()
+        if src_pk is None or tgt_pk is None:
+            return 0
+
+        result = await self._session.execute(
+            text(
+                "UPDATE media_files SET movie_id = :tgt_pk WHERE movie_id = :src_pk",
+            ),
+            {"src_pk": src_pk, "tgt_pk": tgt_pk},
+        )
+        # Raw UPDATE bypasses the identity map, so any cached
+        # MovieModel instances still report the old file_variants
+        # relationship. Expire them so the next query reloads fresh
+        # from the database.
+        self._session.expire_all()
+        return result.rowcount or 0
+
     async def find_missing_scrub_preview(self, limit: int) -> Sequence[Movie]:
         """Return up to ``limit`` movies whose ``scrub_preview_path`` is null.
 

--- a/src/modules/media/presentation/routes/admin_conflicts_routes.py
+++ b/src/modules/media/presentation/routes/admin_conflicts_routes.py
@@ -1,25 +1,59 @@
-"""Admin REST API for the media-conflict queue (ADR-015 Phase 1).
+"""Admin REST API for the media-conflict queue (ADR-015).
 
-Read-only surface for ``/api/v1/admin/conflicts``: lists pending
-content-identity collisions detected by the post-enrich hook so the
-operator can decide how to resolve them. Resolution endpoints land
-in Phase 2.
+``GET /`` lists pending content-identity collisions detected by the
+post-enrich hook (Phase 1). ``POST /{id}/resolve`` applies the
+operator's chosen disposition (Phase 2): mark-distinct, merge-keep-both,
+or merge-replace.
 """
 
 from dataclasses import asdict
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Path, Query
+from pydantic import BaseModel, Field
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
-from src.building_blocks.presentation import api_list
+from src.building_blocks.presentation import api_list, api_single
 from src.building_blocks.presentation.responses import Pagination
 from src.config.containers import ApplicationContainer
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
-from src.modules.media.application.dtos.conflict_dtos import ListConflictsInput
+from src.modules.media.application.dtos.conflict_dtos import (
+    ListConflictsInput,
+    ResolveMediaConflictInput,
+)
 from src.modules.media.application.use_cases.list_conflicts import ListConflictsUseCase
+from src.modules.media.application.use_cases.resolve_media_conflict import (
+    ResolveMediaConflictUseCase,
+)
+from src.modules.media.domain.entities.media_conflict import ResolutionAction
+
+
+class ResolveConflictBody(BaseModel):
+    """Request body for ``POST /admin/conflicts/{id}/resolve``.
+
+    Pydantic validates the action enum + the winner_id format
+    (string, length-bounded to match the external id contract) before
+    the use case runs; the aggregate's invariants (winner must be one
+    of the candidates, MARK_DISTINCT forbids winner_id) surface as
+    422 via the standard domain → HTTP mapping.
+    """
+
+    action: ResolutionAction = Field(
+        ...,
+        description="Resolution disposition picked by the operator.",
+    )
+    winner_id: str | None = Field(
+        default=None,
+        description=(
+            "External id of the surviving candidate. Required for "
+            "merge_keep_both / merge_replace; forbidden for "
+            "mark_distinct."
+        ),
+        max_length=50,
+    )
+
 
 router = APIRouter(prefix="/api/v1/admin/conflicts", tags=["Admin — Conflicts"])
 
@@ -50,6 +84,39 @@ async def list_admin_conflicts(
             next_cursor=output.next_cursor,
         ),
     )
+
+
+@router.post("/{conflict_id}/resolve")
+@inject
+async def resolve_admin_conflict(
+    body: ResolveConflictBody,
+    conflict_id: str = Path(..., min_length=1, max_length=50),
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: ResolveMediaConflictUseCase = Depends(
+        Provide[ApplicationContainer.media.resolve_media_conflict],
+    ),
+) -> dict[str, Any]:
+    """Apply the operator's resolution to a pending conflict.
+
+    - ``mark_distinct``: the pair is intentionally distinct
+      (Director's Cut / Theatrical, etc.); the detector will not
+      re-queue it on future enrichment passes.
+    - ``merge_replace``: soft-deletes the loser movie. Cross-BC
+      handlers drop the loser's watch progress and repoint
+      watchlist / custom-list entries to the winner.
+    - ``merge_keep_both``: same as ``merge_replace`` plus the loser's
+      file variants are transferred to the winner so the operator
+      can pick the best stream at playback time across what used to
+      be two catalog entries.
+    """
+    output = await use_case.execute(
+        ResolveMediaConflictInput(
+            conflict_id=conflict_id,
+            action=body.action.value,
+            winner_id=body.winner_id,
+        ),
+    )
+    return api_single("media_conflict_resolution", asdict(output))
 
 
 __all__ = ["router"]

--- a/src/modules/watch_progress/application/event_handlers/__init__.py
+++ b/src/modules/watch_progress/application/event_handlers/__init__.py
@@ -1,5 +1,8 @@
 """Watch Progress event handlers."""
 
+from src.modules.watch_progress.application.event_handlers.on_movie_merged import (
+    OnMovieMergedHandler,
+)
 from src.modules.watch_progress.application.event_handlers.on_movie_promoted_to_series import (
     OnMoviePromotedToSeriesHandler,
 )
@@ -7,4 +10,8 @@ from src.modules.watch_progress.application.event_handlers.on_user_deleted impor
     OnUserDeletedHandler,
 )
 
-__all__ = ["OnMoviePromotedToSeriesHandler", "OnUserDeletedHandler"]
+__all__ = [
+    "OnMovieMergedHandler",
+    "OnMoviePromotedToSeriesHandler",
+    "OnUserDeletedHandler",
+]

--- a/src/modules/watch_progress/application/event_handlers/on_movie_merged.py
+++ b/src/modules/watch_progress/application/event_handlers/on_movie_merged.py
@@ -1,0 +1,52 @@
+"""Cross-BC handler: clear loser-side progress on a movie merge."""
+
+import logging
+
+from src.building_blocks.application.event_bus import EventHandler
+from src.building_blocks.domain.events import DomainEvent
+from src.modules.media.domain.events import MovieMergedEvent
+from src.modules.watch_progress.application.unit_of_work import (
+    WatchProgressUnitOfWorkFactory,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class OnMovieMergedHandler(EventHandler):
+    """Wipe every ``watch_progresses`` row pointing at the loser movie.
+
+    Mirrors the ``OnMoviePromotedToSeriesHandler`` reasoning: when two
+    Movie entities are merged via the conflict queue (ADR-015 Phase 2),
+    the loser is soft-deleted. The losing side's progress rows would
+    otherwise reference a soft-deleted media id — stale data the
+    catalog reads can't render. Dropping them is safer than mapping
+    positions across what may be two different cuts of the same
+    title (Director's Cut vs Theatrical, 720p vs 1080p remaster).
+
+    Runs out of the event bus, which is fire-and-forget — failures
+    are logged but the resolve use case still reports success.
+    """
+
+    def __init__(self, uow_factory: WatchProgressUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def handle(self, event: DomainEvent) -> None:
+        """Handle ``MovieMergedEvent``."""
+        if not isinstance(event, MovieMergedEvent):
+            return
+
+        async with self._uow_factory() as uow:
+            deleted = await uow.progress.delete_all_for_movie(event.loser_id)
+
+        if deleted:
+            _logger.info(
+                "Cleared %d watch_progress row(s) for merged loser movie %s "
+                "(winner %s, conflict %s)",
+                deleted,
+                event.loser_id,
+                event.winner_id,
+                event.conflict_id,
+            )
+
+
+__all__ = ["OnMovieMergedHandler"]

--- a/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
@@ -1,0 +1,67 @@
+"""Tests for the collections OnMovieMergedHandler (ADR-015 Phase 2)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.collections.application.event_handlers.on_movie_merged import (
+    OnMovieMergedHandler,
+)
+from src.modules.media.domain.events import (
+    MediaCreatedEvent,
+    MovieMergedEvent,
+)
+
+
+def _uow_mock() -> tuple[MagicMock, AsyncMock, AsyncMock]:
+    """Return (factory, watchlist_repo, custom_lists_repo)."""
+    watchlist = AsyncMock()
+    custom_lists = AsyncMock()
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.watchlist = watchlist
+    uow.custom_lists = custom_lists
+    factory = MagicMock(return_value=uow)
+    return factory, watchlist, custom_lists
+
+
+class TestOnMovieMergedHandlerCollections:
+    @pytest.mark.asyncio
+    async def test_rewrites_watchlist_and_custom_lists(self) -> None:
+        factory, watchlist, custom_lists = _uow_mock()
+        watchlist.rewrite_media_id.return_value = 1
+        custom_lists.rewrite_item_media_id.return_value = 2
+        handler = OnMovieMergedHandler(uow_factory=factory)
+
+        await handler.handle(
+            MovieMergedEvent(
+                conflict_id="cnf_xxxxxxxxxxxx",
+                winner_id="mov_winneraaaaa",
+                loser_id="mov_loserbbbbbb",
+            ),
+        )
+
+        watchlist.rewrite_media_id.assert_awaited_once_with(
+            from_media_id="mov_loserbbbbbb",
+            to_media_id="mov_winneraaaaa",
+            to_media_type="movie",
+        )
+        custom_lists.rewrite_item_media_id.assert_awaited_once_with(
+            from_media_id="mov_loserbbbbbb",
+            to_media_id="mov_winneraaaaa",
+            to_media_type="movie",
+        )
+
+    @pytest.mark.asyncio
+    async def test_ignores_unrelated_events(self) -> None:
+        factory, watchlist, custom_lists = _uow_mock()
+        handler = OnMovieMergedHandler(uow_factory=factory)
+
+        await handler.handle(
+            MediaCreatedEvent(media_id="mov_abcdefghijkl", media_type="movie"),
+        )
+
+        factory.assert_not_called()
+        watchlist.rewrite_media_id.assert_not_called()
+        custom_lists.rewrite_item_media_id.assert_not_called()

--- a/tests/modules/media/e2e/test_admin_conflicts_routes.py
+++ b/tests/modules/media/e2e/test_admin_conflicts_routes.py
@@ -6,9 +6,22 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     MediaConflict,
+)
+from src.modules.media.domain.value_objects import (
+    Duration,
+    FilePath,
+    MediaFile,
+    MovieId,
+    Resolution,
+    Title,
+    Year,
+)
+from src.modules.media.infrastructure.persistence.repositories import (
+    SQLAlchemyMovieRepository,
 )
 from src.modules.media.infrastructure.persistence.repositories.media_conflict_repository import (
     SqlAlchemyMediaConflictRepository,
@@ -57,6 +70,59 @@ async def _seed_conflict(
         saved = await repo.save(conflict)
         await session.commit()
         return str(saved.id)
+
+
+async def _seed_movie(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    external_id: str,
+    title: str,
+    file_path: str,
+) -> None:
+    """Insert one Movie aggregate via the repository."""
+    async with session_factory() as session:
+        repo = SQLAlchemyMovieRepository(session)
+        await repo.save(
+            Movie(
+                id=MovieId(external_id),
+                library_id="lib_test12345678",
+                title=Title(title),
+                year=Year(2020),
+                duration=Duration(7200),
+                files=[
+                    MediaFile(
+                        file_path=FilePath(file_path),
+                        file_size=1_000_000_000,
+                        resolution=Resolution("1080p"),
+                        is_primary=True,
+                    ),
+                ],
+            ),
+        )
+        await session.commit()
+
+
+async def _seed_pair_with_conflict(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    a_id: str = "mov_winnerwinaaa",
+    b_id: str = "mov_loserloseraa",
+) -> tuple[str, str, str]:
+    """Convenience: seed both movies + a pending conflict between them."""
+    await _seed_movie(
+        session_factory,
+        external_id=a_id,
+        title="Winner Movie",
+        file_path=f"/movies/{a_id}.mkv",
+    )
+    await _seed_movie(
+        session_factory,
+        external_id=b_id,
+        title="Loser Movie",
+        file_path=f"/movies/{b_id}.mkv",
+    )
+    conflict_id = await _seed_conflict(session_factory, a_id=a_id, b_id=b_id)
+    return conflict_id, a_id, b_id
 
 
 @pytest.mark.e2e
@@ -143,3 +209,164 @@ class TestAdminConflictsList:
         assert len(body["data"]) == 2
         assert body["metadata"]["pagination"]["has_more"] is True
         assert body["metadata"]["pagination"]["next_cursor"] is not None
+
+
+@pytest.mark.e2e
+class TestAdminConflictsResolveAuth:
+    """``POST /admin/conflicts/{id}/resolve`` — auth gate."""
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        response = await client.post(
+            f"{CONFLICTS_PATH}/cnf_xxxxxxxxxxxx/resolve",
+            json={"action": "mark_distinct"},
+        )
+        assert response.status_code == 401
+
+    async def test_member_returns_403(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile(email="member@example.com", is_admin=False)
+        await _login(client, member)
+        response = await client.post(
+            f"{CONFLICTS_PATH}/cnf_xxxxxxxxxxxx/resolve",
+            json={"action": "mark_distinct"},
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.e2e
+class TestAdminConflictsResolveSuccess:
+    """``POST /admin/conflicts/{id}/resolve`` — happy paths."""
+
+    async def test_mark_distinct_stamps_and_persists(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        conflict_id, _, _ = await _seed_pair_with_conflict(session_factory)
+
+        response = await client.post(
+            f"{CONFLICTS_PATH}/{conflict_id}/resolve",
+            json={"action": "mark_distinct"},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["action"] == "mark_distinct"
+        assert payload["winner_id"] is None
+        assert payload["loser_id"] is None
+        assert payload["variants_transferred"] == 0
+
+        # The pending list now excludes it.
+        list_resp = await client.get(CONFLICTS_PATH)
+        assert list_resp.json()["data"] == []
+
+    async def test_merge_replace_soft_deletes_loser(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        conflict_id, winner_id, loser_id = await _seed_pair_with_conflict(session_factory)
+
+        response = await client.post(
+            f"{CONFLICTS_PATH}/{conflict_id}/resolve",
+            json={"action": "merge_replace", "winner_id": winner_id},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["winner_id"] == winner_id
+        assert payload["loser_id"] == loser_id
+        assert payload["variants_transferred"] == 0
+
+        # Loser is soft-deleted; verify via repository lookup.
+        async with session_factory() as session:
+            repo = SQLAlchemyMovieRepository(session)
+            assert await repo.find_by_id(MovieId(loser_id)) is None
+            assert await repo.find_by_id(MovieId(winner_id)) is not None
+
+    async def test_merge_keep_both_transfers_variants(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        conflict_id, winner_id, _ = await _seed_pair_with_conflict(session_factory)
+
+        response = await client.post(
+            f"{CONFLICTS_PATH}/{conflict_id}/resolve",
+            json={"action": "merge_keep_both", "winner_id": winner_id},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["variants_transferred"] == 1
+
+
+@pytest.mark.e2e
+class TestAdminConflictsResolveFailures:
+    """``POST /admin/conflicts/{id}/resolve`` — error paths."""
+
+    async def test_unknown_conflict_returns_404(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        response = await client.post(
+            f"{CONFLICTS_PATH}/cnf_doesnotexist/resolve",
+            json={"action": "mark_distinct"},
+        )
+        assert response.status_code == 404
+
+    async def test_already_resolved_returns_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Default mapping for BusinessRuleViolationException is 422.
+        # If the operator wants 409 specifically for this rule code,
+        # a per-BC override can be registered (ADR-012) later.
+        await _login_as_admin(client, seed_user_with_profile)
+        conflict_id, _, _ = await _seed_pair_with_conflict(session_factory)
+
+        first = await client.post(
+            f"{CONFLICTS_PATH}/{conflict_id}/resolve",
+            json={"action": "mark_distinct"},
+        )
+        assert first.status_code == 200
+
+        second = await client.post(
+            f"{CONFLICTS_PATH}/{conflict_id}/resolve",
+            json={"action": "mark_distinct"},
+        )
+        assert second.status_code == 422
+        body = second.json()
+        assert body["code"] == "BUSINESS_RULE_VIOLATION"
+        assert "already resolved" in body["message"].lower()
+
+    async def test_winner_not_in_pair_returns_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        conflict_id, _, _ = await _seed_pair_with_conflict(session_factory)
+
+        response = await client.post(
+            f"{CONFLICTS_PATH}/{conflict_id}/resolve",
+            json={
+                "action": "merge_replace",
+                "winner_id": "mov_unrelatedaaa",
+            },
+        )
+        assert response.status_code == 422

--- a/tests/modules/media/integration/persistence/repositories/test_media_conflict_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_media_conflict_repository.py
@@ -59,7 +59,7 @@ class TestSaveAndFind:
 
 
 @pytest.mark.integration
-class TestFindPendingByPair:
+class TestFindBlockingPair:
     async def test_returns_match_when_orientation_swapped(
         self,
         db_session: AsyncSession,
@@ -68,7 +68,7 @@ class TestFindPendingByPair:
         original = await repo.save(_new_conflict(a_id="mov_aaaaaaaaaaaa", b_id="mov_bbbbbbbbbbbb"))
 
         # Same pair, reversed ids.
-        result = await repo.find_pending_by_pair(
+        result = await repo.find_blocking_pair(
             "mov_bbbbbbbbbbbb",
             "mov_aaaaaaaaaaaa",
         )
@@ -76,27 +76,52 @@ class TestFindPendingByPair:
         assert result is not None
         assert result.id == original.id
 
-    async def test_returns_none_when_pair_is_resolved(
+    async def test_merge_resolved_pair_does_not_block(
         self,
         db_session: AsyncSession,
     ) -> None:
+        # MERGE-resolved rows must not suppress re-queueing: by the
+        # time we look up the pair the loser is soft-deleted, so the
+        # detector cannot rediscover it anyway. The aggregate is
+        # excluded so a re-import under a fresh id can be detected.
         repo = SqlAlchemyMediaConflictRepository(db_session)
         saved = await repo.save(_new_conflict())
-        await repo.save(saved.resolve(ResolutionAction.MERGE_REPLACE))
+        await repo.save(
+            saved.resolve(ResolutionAction.MERGE_REPLACE, winner_id=saved.candidate_a_id)
+        )
 
-        result = await repo.find_pending_by_pair(
+        result = await repo.find_blocking_pair(
             saved.candidate_a_id,
             saved.candidate_b_id,
         )
 
         assert result is None
 
+    async def test_mark_distinct_pair_blocks_re_queueing(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        # MARK_DISTINCT is the operator's "do not re-flag this pair"
+        # verdict; it must persist across future enrich passes.
+        repo = SqlAlchemyMediaConflictRepository(db_session)
+        saved = await repo.save(_new_conflict())
+        resolved = await repo.save(saved.resolve(ResolutionAction.MARK_DISTINCT))
+
+        result = await repo.find_blocking_pair(
+            saved.candidate_a_id,
+            saved.candidate_b_id,
+        )
+
+        assert result is not None
+        assert result.id == resolved.id
+        assert result.is_marked_distinct is True
+
     async def test_returns_none_when_pair_is_unknown(
         self,
         db_session: AsyncSession,
     ) -> None:
         repo = SqlAlchemyMediaConflictRepository(db_session)
-        result = await repo.find_pending_by_pair("mov_aaaaaaaaaaaa", "mov_bbbbbbbbbbbb")
+        result = await repo.find_blocking_pair("mov_aaaaaaaaaaaa", "mov_bbbbbbbbbbbb")
         assert result is None
 
 
@@ -109,7 +134,12 @@ class TestListPending:
         repo = SqlAlchemyMediaConflictRepository(db_session)
         pending = await repo.save(_new_conflict(a_id="mov_aaaaaaaaaaaa", b_id="mov_bbbbbbbbbbbb"))
         resolved = await repo.save(_new_conflict(a_id="mov_cccccccccccc", b_id="mov_dddddddddddd"))
-        await repo.save(resolved.resolve(ResolutionAction.MERGE_KEEP_BOTH))
+        await repo.save(
+            resolved.resolve(
+                ResolutionAction.MERGE_KEEP_BOTH,
+                winner_id=resolved.candidate_a_id,
+            ),
+        )
 
         page = await repo.list_pending(limit=10)
 

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -2,7 +2,7 @@
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
@@ -69,6 +69,76 @@ async def _seed_movies(repo: SQLAlchemyMovieRepository, count: int) -> list[Movi
     for movie in movies:
         await repo.save(movie)
     return movies
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryTransferFileVariantsBetweenMovies:
+    async def test_moves_every_media_file_row_from_source_to_target(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # The legacy ``movies.file_path`` column is written alongside
+        # ``media_files`` rows during ``save`` and is not touched by
+        # the transfer (the resolve use case soft-deletes the loser
+        # immediately after, so the legacy column is unreachable in
+        # production). The assertion focuses on the table this
+        # method actually rewires.
+        from sqlalchemy import text
+
+        source_id: MovieId
+        target_id: MovieId
+        async with session_factory() as setup_session:
+            repo = SQLAlchemyMovieRepository(setup_session)
+            source = _create_movie(title="Loser", file_path="/movies/loser.mkv")
+            target = _create_movie(title="Winner", file_path="/movies/winner.mkv")
+            await repo.save(source)
+            await repo.save(target)
+            await setup_session.commit()
+            source_id = _id_of(source)
+            target_id = _id_of(target)
+
+        async with session_factory() as transfer_session:
+            transfer_repo = SQLAlchemyMovieRepository(transfer_session)
+            moved = await transfer_repo.transfer_file_variants_between_movies(
+                source_movie_id=source_id,
+                target_movie_id=target_id,
+            )
+            await transfer_session.commit()
+            assert moved == 1
+
+        async with session_factory() as verify_session:
+            counts = (
+                await verify_session.execute(
+                    text(
+                        "SELECT movies.external_id, COUNT(media_files.id) "
+                        "FROM movies LEFT JOIN media_files "
+                        "ON media_files.movie_id = movies.id "
+                        "GROUP BY movies.external_id",
+                    ),
+                )
+            ).fetchall()
+            by_ext = dict(counts)
+            assert by_ext[str(source_id)] == 0
+            assert by_ext[str(target_id)] == 2
+
+    async def test_missing_source_returns_zero(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with session_factory() as setup_session:
+            repo = SQLAlchemyMovieRepository(setup_session)
+            target = _create_movie(title="Winner", file_path="/movies/winner.mkv")
+            await repo.save(target)
+            await setup_session.commit()
+            target_id = _id_of(target)
+
+        async with session_factory() as transfer_session:
+            transfer_repo = SQLAlchemyMovieRepository(transfer_session)
+            moved = await transfer_repo.transfer_file_variants_between_movies(
+                source_movie_id=MovieId.generate(),
+                target_movie_id=target_id,
+            )
+            assert moved == 0
 
 
 @pytest.mark.integration

--- a/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
@@ -56,7 +56,7 @@ class TestDetectMovieConflictsUseCase:
         self_movie = _build_movie(external_id="mov_abcdefghijkl", duration_seconds=7200)
         other = _build_movie(external_id="mov_mnopqrstuvwx", duration_seconds=7320)
         mocks.movies.find_all_by_tmdb_id.return_value = [self_movie, other]
-        mocks.media_conflicts.find_pending_by_pair.return_value = None
+        mocks.media_conflicts.find_blocking_pair.return_value = None
         mocks.media_conflicts.save.side_effect = _stamp_conflict_id
 
         event_bus = AsyncMock()
@@ -96,7 +96,7 @@ class TestDetectMovieConflictsUseCase:
             candidate_b_runtime_minutes=120.0,
             match_reason=MatchReason.TMDB_ID,
         )
-        mocks.media_conflicts.find_pending_by_pair.return_value = existing
+        mocks.media_conflicts.find_blocking_pair.return_value = existing
 
         event_bus = AsyncMock()
         use_case = DetectMovieConflictsUseCase(uow_factory=mocks.factory, event_bus=event_bus)

--- a/tests/modules/media/unit/application/use_cases/test_resolve_media_conflict.py
+++ b/tests/modules/media/unit/application/use_cases/test_resolve_media_conflict.py
@@ -1,0 +1,183 @@
+"""Tests for ResolveMediaConflictUseCase (ADR-015 Phase 2)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.building_blocks.domain.errors import (
+    BusinessRuleViolationException,
+    DomainValidationException,
+)
+from src.modules.media.application.dtos.conflict_dtos import ResolveMediaConflictInput
+from src.modules.media.application.use_cases.resolve_media_conflict import (
+    ResolveMediaConflictUseCase,
+)
+from src.modules.media.domain.entities.media_conflict import (
+    MatchReason,
+    MediaConflict,
+)
+from src.modules.media.domain.events import MovieMergedEvent
+from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_CONFLICT_ID = "cnf_xxxxxxxxxxxx"
+_WINNER = "mov_winnerwinaaa"
+_LOSER = "mov_loserloseraa"
+
+
+def _pending(
+    *,
+    a_id: str = _WINNER,
+    b_id: str = _LOSER,
+) -> MediaConflict:
+    base = MediaConflict.detect(
+        candidate_a_id=a_id,
+        candidate_a_type="movie",
+        candidate_a_runtime_minutes=120.0,
+        candidate_b_id=b_id,
+        candidate_b_type="movie",
+        candidate_b_runtime_minutes=125.0,
+        match_reason=MatchReason.TMDB_ID,
+    )
+    return base.with_updates(id=MediaConflictId(_CONFLICT_ID))
+
+
+async def _save_passthrough(conflict: MediaConflict) -> MediaConflict:
+    """Mock repository ``save`` that returns the input unchanged (already has id)."""
+    return conflict
+
+
+class TestMarkDistinct:
+    @pytest.mark.asyncio
+    async def test_stamps_conflict_and_emits_no_event(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.media_conflicts.find_by_id.return_value = _pending()
+        mocks.media_conflicts.save.side_effect = _save_passthrough
+
+        event_bus = AsyncMock()
+        use_case = ResolveMediaConflictUseCase(uow_factory=mocks.factory, event_bus=event_bus)
+
+        result = await use_case.execute(
+            ResolveMediaConflictInput(conflict_id=_CONFLICT_ID, action="mark_distinct"),
+        )
+
+        assert result.action == "mark_distinct"
+        assert result.winner_id is None
+        assert result.loser_id is None
+        assert result.variants_transferred == 0
+
+        mocks.media_conflicts.save.assert_awaited_once()
+        saved = mocks.media_conflicts.save.await_args[0][0]
+        assert saved.is_marked_distinct is True
+
+        # Cross-BC handlers are MERGE-only — MARK_DISTINCT publishes nothing.
+        event_bus.publish.assert_not_awaited()
+        mocks.movies.delete.assert_not_called()
+        mocks.movies.transfer_file_variants_between_movies.assert_not_called()
+
+
+class TestMergeReplace:
+    @pytest.mark.asyncio
+    async def test_deletes_loser_and_emits_merged_event(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.media_conflicts.find_by_id.return_value = _pending()
+        mocks.media_conflicts.save.side_effect = _save_passthrough
+        mocks.movies.delete.return_value = True
+
+        event_bus = AsyncMock()
+        use_case = ResolveMediaConflictUseCase(uow_factory=mocks.factory, event_bus=event_bus)
+
+        result = await use_case.execute(
+            ResolveMediaConflictInput(
+                conflict_id=_CONFLICT_ID,
+                action="merge_replace",
+                winner_id=_WINNER,
+            ),
+        )
+
+        assert result.winner_id == _WINNER
+        assert result.loser_id == _LOSER
+        assert result.variants_transferred == 0
+
+        # No variant transfer for MERGE_REPLACE.
+        mocks.movies.transfer_file_variants_between_movies.assert_not_called()
+        # Loser was soft-deleted (Movie.delete is soft-delete in this repo).
+        mocks.movies.delete.assert_awaited_once()
+        loser_arg = mocks.movies.delete.await_args[0][0]
+        assert str(loser_arg) == _LOSER
+
+        event_bus.publish.assert_awaited_once()
+        published = event_bus.publish.await_args[0][0]
+        assert isinstance(published, MovieMergedEvent)
+        assert published.winner_id == _WINNER
+        assert published.loser_id == _LOSER
+        assert published.keep_loser_variants is False
+
+
+class TestMergeKeepBoth:
+    @pytest.mark.asyncio
+    async def test_transfers_variants_then_deletes_loser(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.media_conflicts.find_by_id.return_value = _pending()
+        mocks.media_conflicts.save.side_effect = _save_passthrough
+        mocks.movies.transfer_file_variants_between_movies.return_value = 2
+        mocks.movies.delete.return_value = True
+
+        event_bus = AsyncMock()
+        use_case = ResolveMediaConflictUseCase(uow_factory=mocks.factory, event_bus=event_bus)
+
+        result = await use_case.execute(
+            ResolveMediaConflictInput(
+                conflict_id=_CONFLICT_ID,
+                action="merge_keep_both",
+                winner_id=_WINNER,
+            ),
+        )
+
+        assert result.variants_transferred == 2
+        mocks.movies.transfer_file_variants_between_movies.assert_awaited_once()
+        transfer_kwargs = mocks.movies.transfer_file_variants_between_movies.await_args.kwargs
+        assert str(transfer_kwargs["source_movie_id"]) == _LOSER
+        assert str(transfer_kwargs["target_movie_id"]) == _WINNER
+
+        event_bus.publish.assert_awaited_once()
+        assert event_bus.publish.await_args[0][0].keep_loser_variants is True
+
+
+class TestFailureModes:
+    @pytest.mark.asyncio
+    async def test_unknown_conflict_id_raises_not_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.media_conflicts.find_by_id.return_value = None
+        use_case = ResolveMediaConflictUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                ResolveMediaConflictInput(conflict_id=_CONFLICT_ID, action="mark_distinct"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_already_resolved_conflict_raises_409(self) -> None:
+        mocks = make_media_uow_mock()
+        from src.modules.media.domain.entities.media_conflict import ResolutionAction
+
+        already_resolved = _pending().resolve(ResolutionAction.MARK_DISTINCT)
+        mocks.media_conflicts.find_by_id.return_value = already_resolved
+        use_case = ResolveMediaConflictUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(BusinessRuleViolationException):
+            await use_case.execute(
+                ResolveMediaConflictInput(conflict_id=_CONFLICT_ID, action="mark_distinct"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_string_raises_validation(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ResolveMediaConflictUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(DomainValidationException):
+            await use_case.execute(
+                ResolveMediaConflictInput(conflict_id=_CONFLICT_ID, action="not_a_real_action"),
+            )
+        mocks.factory.assert_not_called()

--- a/tests/modules/media/unit/domain/entities/test_media_conflict.py
+++ b/tests/modules/media/unit/domain/entities/test_media_conflict.py
@@ -121,20 +121,44 @@ class TestResolve:
 
     def test_resolve_stamps_timestamp_and_action(self) -> None:
         conflict = _detect()
-        resolved = conflict.resolve(ResolutionAction.MERGE_KEEP_BOTH)
+        resolved = conflict.resolve(ResolutionAction.MERGE_KEEP_BOTH, winner_id=_A)
 
         assert resolved.is_resolved is True
         assert resolved.resolution is ResolutionAction.MERGE_KEEP_BOTH
         assert resolved.resolved_at is not None
+        assert resolved.winner_id == _A
+        assert resolved.loser_id() == _B
 
     def test_resolve_returns_a_new_instance(self) -> None:
         conflict = _detect()
         resolved = conflict.resolve(ResolutionAction.MARK_DISTINCT)
         assert resolved is not conflict
         assert conflict.is_resolved is False  # original untouched
+        assert resolved.is_marked_distinct is True
+        assert resolved.winner_id is None
+        assert resolved.loser_id() is None
 
     def test_resolving_twice_raises(self) -> None:
         conflict = _detect()
-        resolved = conflict.resolve(ResolutionAction.MERGE_REPLACE)
+        resolved = conflict.resolve(ResolutionAction.MERGE_REPLACE, winner_id=_B)
         with pytest.raises(BusinessRuleViolationException):
             resolved.resolve(ResolutionAction.MARK_DISTINCT)
+
+
+class TestWinnerIdInvariants:
+    """``winner_id`` semantics enforced by the aggregate."""
+
+    def test_merge_requires_winner_id(self) -> None:
+        conflict = _detect()
+        with pytest.raises(DomainValidationException):
+            conflict.resolve(ResolutionAction.MERGE_REPLACE)
+
+    def test_mark_distinct_rejects_winner_id(self) -> None:
+        conflict = _detect()
+        with pytest.raises(DomainValidationException):
+            conflict.resolve(ResolutionAction.MARK_DISTINCT, winner_id=_A)
+
+    def test_winner_id_must_be_one_of_candidates(self) -> None:
+        conflict = _detect()
+        with pytest.raises(DomainValidationException):
+            conflict.resolve(ResolutionAction.MERGE_REPLACE, winner_id="mov_cccccccccccc")

--- a/tests/modules/watch_progress/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/watch_progress/unit/application/event_handlers/test_on_movie_merged.py
@@ -1,0 +1,54 @@
+"""Tests for the watch_progress OnMovieMergedHandler (ADR-015 Phase 2)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.media.domain.events import (
+    MediaCreatedEvent,
+    MovieMergedEvent,
+)
+from src.modules.watch_progress.application.event_handlers.on_movie_merged import (
+    OnMovieMergedHandler,
+)
+
+
+def _uow_mock() -> tuple[MagicMock, AsyncMock]:
+    """Return (factory, progress_repo) for a single-UoW invocation."""
+    progress = AsyncMock()
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.progress = progress
+    factory = MagicMock(return_value=uow)
+    return factory, progress
+
+
+class TestOnMovieMergedHandlerWatchProgress:
+    @pytest.mark.asyncio
+    async def test_deletes_loser_progress_rows(self) -> None:
+        factory, progress = _uow_mock()
+        progress.delete_all_for_movie.return_value = 3
+        handler = OnMovieMergedHandler(uow_factory=factory)
+
+        await handler.handle(
+            MovieMergedEvent(
+                conflict_id="cnf_xxxxxxxxxxxx",
+                winner_id="mov_winneraaaaa",
+                loser_id="mov_loserbbbbbb",
+            ),
+        )
+
+        progress.delete_all_for_movie.assert_awaited_once_with("mov_loserbbbbbb")
+
+    @pytest.mark.asyncio
+    async def test_ignores_unrelated_events(self) -> None:
+        factory, progress = _uow_mock()
+        handler = OnMovieMergedHandler(uow_factory=factory)
+
+        await handler.handle(
+            MediaCreatedEvent(media_id="mov_abcdefghijkl", media_type="movie"),
+        )
+
+        factory.assert_not_called()
+        progress.delete_all_for_movie.assert_not_called()


### PR DESCRIPTION
## Summary

- Implements the **backend half of ADR-015 Phase 2**: an admin endpoint that closes pending conflicts queued by Phase 1.
- `POST /api/v1/admin/conflicts/{id}/resolve` accepts an action body (`mark_distinct` / `merge_replace` / `merge_keep_both`) and an optional `winner_id`. Validated against the candidate pair and against current resolution state.
- New `MovieMergedEvent` carries the cross-BC fan-out signal — `watch_progress` drops the loser's rows (positions can't survive a re-cut edit) and `collections` rewrites watchlist + custom-list entries from loser → winner. Mirrors the existing `MoviePromotedToSeriesEvent` pattern.
- `MARK_DISTINCT` is the "these really are distinct" verdict (Director's Cut, Theatrical, etc.) — `find_pending_by_pair` becomes `find_blocking_pair` and now also returns MARK_DISTINCT rows so the detector suppresses re-queueing the same pair on future enrichment passes.
- `MERGE_KEEP_BOTH` reuses `FileVariantMixin` (ADR-006): a new `MovieRepository.transfer_file_variants_between_movies` re-FKs the loser's `media_files` rows onto the winner before the loser is soft-deleted.
- Aggregate gains a `winner_id` field with full invariants (required for MERGE, forbidden for MARK_DISTINCT, must be one of the candidates). Migration `2026_05_23_add_winner_id_to_media_conflicts` is an additive nullable column.
- Use case pre-validates `winner_id` so the resulting `DomainValidationException` doesn't carry pydantic's `input` metadata (which would otherwise include datetime fields and crash the JSON response serializer).

## Out of scope (deferred)

- Frontend `/admin/conflicts` page in `homeflix-web` — separate PR (cross-repo).
- Auto-merge silencioso for orphan + healthy-library case (ADR-015 Phase 3).
- `(normalized_original_title, year)` fallback matcher + bulk sweep (ADR-015 Phase 4).

## Test plan

- [x] 15 new domain unit tests (`MediaConflict` + winner_id invariants + resolve lifecycle)
- [x] 5 new use case unit tests (`ResolveMediaConflictUseCase`: MARK_DISTINCT, MERGE_REPLACE, MERGE_KEEP_BOTH happy + 404 + 409)
- [x] 2 cross-BC handler unit tests (watch_progress + collections handlers ignore unrelated events, fan-out correctly)
- [x] 2 new integration tests (`transfer_file_variants_between_movies` happy + missing source)
- [x] 4 new repository integration tests (`find_blocking_pair` for swapped orientations / merge-resolved / mark-distinct-blocks / unknown)
- [x] 6 new e2e tests (auth gate ×2, mark_distinct, merge_replace soft-delete, merge_keep_both transfers, 404, 422 already-resolved, 422 winner not in pair)
- [x] Full project suite: 2 588 passed, 5 skipped
- [x] `ruff check` + `ruff format --check` clean
- [x] Alembic migration round-trips (upgrade → downgrade → upgrade)
- [x] App boots; new POST route registered at `/api/v1/admin/conflicts/{conflict_id}/resolve`