### PR TITLE
feat(media): auto-merge orphans + audit view (ADR-015 Phase 3)

### DIFF
--- a/migrations/versions/2026_05_24_add_resolution_source_to_media_conflicts.py
+++ b/migrations/versions/2026_05_24_add_resolution_source_to_media_conflicts.py
@@ -1,0 +1,61 @@
+"""Add resolution_source column to media_conflicts.
+
+Backs ADR-015 Phase 3 — the post-enrich detector silently merges
+orphaned candidates (file missing + library root healthy) into the
+freshly-enriched winner. The new column distinguishes admin-driven
+resolutions (``manual``) from those auto-actions (``auto``) so the
+admin UI can split the queue from the audit trail.
+
+Existing resolved rows from Phase 2 are backfilled to ``manual``
+(via the column default); they were all created by the admin
+``POST /resolve`` endpoint, which is the manual path.
+
+Revision ID: 5f60718293a4
+Revises: 4e5f60718293
+Create Date: 2026-05-24 09:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "5f60718293a4"
+down_revision: str | Sequence[str] | None = "4e5f60718293"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``resolution_source`` column and backfill resolved rows."""
+    with op.batch_alter_table("media_conflicts") as batch_op:
+        batch_op.add_column(
+            sa.Column("resolution_source", sa.String(length=20), nullable=True),
+        )
+
+    # Backfill: every resolved row prior to this migration came from
+    # the manual admin endpoint (Phase 2). Pending rows stay NULL.
+    op.execute(
+        "UPDATE media_conflicts "
+        "SET resolution_source = 'manual' "
+        "WHERE resolved_at IS NOT NULL AND resolution_source IS NULL",
+    )
+
+    op.create_index(
+        "ix_media_conflicts_resolution_source",
+        "media_conflicts",
+        ["resolution_source"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``resolution_source`` column."""
+    op.drop_index("ix_media_conflicts_resolution_source", table_name="media_conflicts")
+    with op.batch_alter_table("media_conflicts") as batch_op:
+        batch_op.drop_column("resolution_source")

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -32,6 +32,7 @@ from src.modules.library.infrastructure.persistence.sqlalchemy_unit_of_work impo
     SqlAlchemyLibraryUnitOfWorkFactory,
 )
 from src.modules.media.infrastructure.acl import (
+    LibraryHealthAdapter,
     ProfileLibraryAccessAdapter,
     ProgressLookupAdapter,
 )
@@ -116,6 +117,15 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         session_factory=infrastructure.session_factory,
     )
 
+    # ADR-015 Phase 3: the auto-merge detector needs to ask "is
+    # this file accessible?" and "is the library root mounted?"
+    # before silently absorbing an orphan candidate. The adapter
+    # combines a Library UoW lookup with raw pathlib.exists.
+    _library_health_adapter = providers.Factory(
+        LibraryHealthAdapter,
+        library_uow_factory=_library_uow_factory_for_media,
+    )
+
     # Real readiness probes that back ``GET /health/ready`` — see
     # ``src/infrastructure/health/probes.py``. Singletons because
     # the probes are stateless and the underlying deps
@@ -156,6 +166,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         profile_library_access=_profile_library_access_adapter,
         catalog_request_lookup=catalog_requests.catalog_request_lookup,
         library_uow_factory=_library_uow_factory_for_media,
+        library_health=_library_health_adapter,
         identity_uow_factory=_identity_uow_factory_for_profile_library_access,
         tmdb_api_key=config.provided.tmdb_api_key,
         hls_cache_directory=config.provided.hls_cache_directory,

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -150,6 +150,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # ``scan_runs`` row. Keeps the cross-BC dependency explicit.
     library_uow_factory = providers.Dependency()
 
+    # Wired at the composition root — ADR-015 Phase 3 detector uses
+    # this port to distinguish a real orphan (file moved/deleted by
+    # the operator) from transient I/O failure (drive unmounted).
+    library_health = providers.Dependency()
+
     # Wired at the composition root — the OverviewStats aggregator
     # reads the users count from identity. Same pattern as
     # ``library_uow_factory`` above: a read-only cross-BC count
@@ -553,6 +558,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     detect_movie_conflicts = providers.Factory(
         DetectMovieConflictsUseCase,
         uow_factory=media_unit_of_work_factory,
+        library_health=library_health,
         event_bus=event_bus,
     )
 

--- a/src/modules/media/application/dtos/conflict_dtos.py
+++ b/src/modules/media/application/dtos/conflict_dtos.py
@@ -42,11 +42,19 @@ class ListConflictsInput:
     """Input for the admin conflict-list endpoint.
 
     Attributes:
+        state: ``"pending"`` (default — the operator queue) or
+            ``"resolved"`` (audit view).
+        source: Optional resolution-source filter, only meaningful
+            when ``state == "resolved"``. ``"manual"`` shows admin
+            decisions, ``"auto"`` shows the post-enrich auto-merges
+            (ADR-015 Phase 3), ``None`` shows both.
         cursor: Opaque pagination cursor from the previous page.
         limit: Page size; the route already clamps to a sensible
             ``[1, MAX_PAGE_SIZE]`` range.
     """
 
+    state: str = "pending"
+    source: str | None = None
     cursor: str | None = None
     limit: int = 20
 
@@ -72,7 +80,7 @@ class ConflictCandidateSummary:
 
 @dataclass(frozen=True)
 class ConflictSummary:
-    """One row in the admin conflict queue.
+    """One row in the admin conflict queue or audit view.
 
     Attributes:
         conflict_id: External id of the conflict (``cnf_xxx``).
@@ -83,6 +91,14 @@ class ConflictSummary:
             minutes, or ``None`` when unavailable.
         suggested_action: Pre-computed hint for the admin UI.
         detected_at: When the conflict landed in the queue.
+        resolved_at: ``None`` while pending; ISO timestamp once the
+            row leaves the queue (manual resolve or auto-merge).
+        resolution: Resolution action that closed the row; ``None``
+            while pending.
+        winner_id: Surviving candidate for MERGE resolutions; ``None``
+            for pending or MARK_DISTINCT rows.
+        resolution_source: ``"manual"`` (admin endpoint) or
+            ``"auto"`` (Phase 3 detector); ``None`` while pending.
     """
 
     conflict_id: str
@@ -92,6 +108,10 @@ class ConflictSummary:
     runtime_delta_minutes: float | None
     suggested_action: str
     detected_at: datetime
+    resolved_at: datetime | None = None
+    resolution: str | None = None
+    winner_id: str | None = None
+    resolution_source: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/ports/library_health_port.py
+++ b/src/modules/media/application/ports/library_health_port.py
@@ -1,0 +1,62 @@
+"""Port for checking filesystem health of library roots + media files.
+
+Used by the ADR-015 Phase 3 auto-merge detector: when a content-identity
+collision is detected, the use case asks whether the *other* candidate's
+file is still on disk and whether its library is mountable. A missing
+file in a healthy library means "operator moved this elsewhere" — safe
+to absorb silently into the freshly-enriched winner. A missing file in
+an unmounted library means the I/O is transient — the safe call is to
+fall back to the manual queue.
+
+Returns plain ``bool`` because there is nothing else to carry; the
+"no domain types in port returns" rule from ADR-009 holds — booleans
+are primitive.
+
+The adapter lives in ``media.infrastructure.acl`` and reads via the
+Library UoW + ``pathlib.Path.exists``.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class LibraryHealthPort(ABC):
+    """Check filesystem accessibility of library roots and media files."""
+
+    @abstractmethod
+    async def is_file_accessible(self, file_path: str) -> bool:
+        """Return ``True`` when ``file_path`` exists on disk right now.
+
+        Args:
+            file_path: Absolute filesystem path as stored on the
+                media entity. The port does not assume any prefix —
+                it just checks ``Path(file_path).exists()``.
+
+        Returns:
+            ``True`` if the file exists, ``False`` otherwise. Callers
+            should pair this with ``is_library_root_accessible`` before
+            treating a ``False`` answer as "operator deleted this".
+        """
+        ...
+
+    @abstractmethod
+    async def is_library_root_accessible(self, library_id: str) -> bool:
+        """Return ``True`` when the library's filesystem root is mounted.
+
+        A library can declare multiple roots (``Library.paths``).
+        Accessibility is "every declared root currently exists on
+        disk" — partial mounts count as inaccessible because the
+        scanner cannot give the operator a complete view. Missing
+        libraries also count as inaccessible (the caller cannot
+        decide "operator deleted this" against a phantom library).
+
+        Args:
+            library_id: Prefixed external id (``lib_xxx``).
+
+        Returns:
+            ``True`` when the library exists and every declared
+            root path resolves on the filesystem.
+        """
+        ...
+
+
+__all__ = ["LibraryHealthPort"]

--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -1,32 +1,66 @@
-"""Post-enrich conflict detector for Movie aggregates (ADR-015 Phase 1)."""
+"""Post-enrich conflict detector for Movie aggregates (ADR-015 Phases 1 + 3)."""
+
+from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
-from src.building_blocks.application.event_bus import EventBus
 from src.modules.media.application.dtos.conflict_dtos import (
     DetectMovieConflictsInput,
     DetectMovieConflictsOutput,
 )
-from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import MediaConflict
-from src.modules.media.domain.entities.media_conflict import MatchReason
-from src.modules.media.domain.entities.movie import Movie
-from src.modules.media.domain.events import MediaConflictDetectedEvent
+from src.modules.media.domain.entities.media_conflict import (
+    MatchReason,
+    ResolutionAction,
+    ResolutionSource,
+)
+from src.modules.media.domain.events import (
+    MediaConflictDetectedEvent,
+    MovieMergedEvent,
+)
+from src.modules.media.domain.value_objects import MovieId
+
+if TYPE_CHECKING:
+    from src.building_blocks.application.event_bus import EventBus
+    from src.modules.media.application.ports.library_health_port import (
+        LibraryHealthPort,
+    )
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.domain.entities.movie import Movie
 
 _logger = logging.getLogger(__name__)
 
 
 class DetectMovieConflictsUseCase:
-    """Materialise content-identity collisions for a freshly-enriched movie.
+    """Materialise (or silently absorb) content-identity collisions.
 
     Triggered by the post-enrich event handler (``MediaEnrichedEvent``).
-    Looks up every other non-deleted movie sharing the same TMDB id,
-    skips pairs already queued as pending, and persists a fresh
-    ``MediaConflict`` for the rest. Each newly-created conflict
-    publishes a ``MediaConflictDetectedEvent`` outside the UoW.
+    Looks up every other non-deleted movie sharing the same TMDB id and
+    decides per-pair:
+
+    - **Auto-merge silently** (ADR-015 Phase 3): when the existing
+      candidate is orphaned (its file does not exist on disk **and**
+      its library root is mounted), the freshly-enriched movie wins
+      and the orphan is soft-deleted. A resolved-AUTO ``MediaConflict``
+      row is persisted for audit and a ``MovieMergedEvent`` (with
+      ``is_auto=True``) fans out to ``watch_progress`` + ``collections``.
+
+    - **Queue for the admin** (ADR-015 Phase 1): otherwise a pending
+      ``MediaConflict`` is created and a ``MediaConflictDetectedEvent``
+      fires so the operator decides via the resolve endpoint.
+
+    - **Skip**: when a blocking row already exists for the pair
+      (pending or MARK_DISTINCT-resolved).
 
     Args:
         uow_factory: Factory that opens a fresh media Unit of Work.
+        library_health: Port answering "is this file / library
+            accessible right now?" — used to distinguish a real
+            orphan ("operator moved the file elsewhere") from a
+            transient I/O failure ("the drive is unmounted right
+            now"). ``None`` disables the auto-merge branch entirely
+            and every collision goes to the queue.
         event_bus: Optional event bus. When ``None`` no events are
             published — handy for unit tests.
     """
@@ -34,22 +68,21 @@ class DetectMovieConflictsUseCase:
     def __init__(
         self,
         uow_factory: MediaUnitOfWorkFactory,
+        library_health: LibraryHealthPort | None = None,
         event_bus: EventBus | None = None,
     ) -> None:
         self._uow_factory = uow_factory
+        self._library_health = library_health
         self._event_bus = event_bus
 
     async def execute(
         self,
         input_dto: DetectMovieConflictsInput,
     ) -> DetectMovieConflictsOutput:
-        """Run the detector for one enriched movie.
-
-        Returns:
-            Summary with the number and ids of conflicts persisted.
-        """
+        """Run the detector for one enriched movie."""
         created_ids: list[str] = []
-        events_to_publish: list[MediaConflictDetectedEvent] = []
+        detected_events: list[MediaConflictDetectedEvent] = []
+        merged_events: list[MovieMergedEvent] = []
 
         async with self._uow_factory() as uow:
             candidates = await uow.movies.find_all_by_tmdb_id(input_dto.tmdb_id)
@@ -57,16 +90,13 @@ class DetectMovieConflictsUseCase:
             if not others:
                 return DetectMovieConflictsOutput(conflicts_created=0, conflict_ids=[])
 
-            # Re-fetch self so we have its current runtime — the
-            # event payload doesn't carry it.
             self_movie = next(
                 (m for m in candidates if str(m.id) == input_dto.media_id),
                 None,
             )
             if self_movie is None:
                 # Defensive: detector fired but the enriched movie
-                # vanished between commit and handler dispatch. Skip
-                # rather than fabricate a pair.
+                # vanished between commit and handler dispatch.
                 _logger.warning(
                     "Enriched movie %s not found during conflict detection",
                     input_dto.media_id,
@@ -86,6 +116,17 @@ class DetectMovieConflictsUseCase:
                     # the pair is intentionally distinct).
                     continue
 
+                if await self._is_orphan(other):
+                    persisted, merged_event = await self._auto_merge_orphan(
+                        uow=uow,
+                        self_movie=self_movie,
+                        self_runtime=self_runtime,
+                        orphan=other,
+                    )
+                    created_ids.append(str(persisted.id))
+                    merged_events.append(merged_event)
+                    continue
+
                 conflict = MediaConflict.detect(
                     candidate_a_id=input_dto.media_id,
                     candidate_a_type="movie",
@@ -97,7 +138,7 @@ class DetectMovieConflictsUseCase:
                 )
                 persisted = await uow.media_conflicts.save(conflict)
                 created_ids.append(str(persisted.id))
-                events_to_publish.append(
+                detected_events.append(
                     MediaConflictDetectedEvent(
                         conflict_id=str(persisted.id),
                         candidate_a_id=persisted.candidate_a_id,
@@ -108,15 +149,89 @@ class DetectMovieConflictsUseCase:
                 )
 
         # Publish outside the UoW so a slow subscriber doesn't hold
-        # the write transaction open.
+        # the write transaction open. Auto-merge events fan out to
+        # cross-BC handlers (watch_progress + collections); detect
+        # events feed audit / notifications.
         if self._event_bus is not None:
-            for event in events_to_publish:
+            for event in (*detected_events, *merged_events):
                 await self._event_bus.publish(event)
 
         return DetectMovieConflictsOutput(
             conflicts_created=len(created_ids),
             conflict_ids=created_ids,
         )
+
+    async def _is_orphan(self, movie: Movie) -> bool:
+        """``True`` when every file of ``movie`` is missing and the library is healthy.
+
+        ``False`` when:
+        - The library health port is not wired (Phase 1 fallback).
+        - Any of the movie's files still exists on disk.
+        - The library root itself is inaccessible (transient I/O —
+          we cannot trust the file-missing signal).
+        """
+        if self._library_health is None:
+            return False
+        for file in movie.files:
+            if await self._library_health.is_file_accessible(file.file_path.value):
+                return False
+        return await self._library_health.is_library_root_accessible(movie.library_id)
+
+    async def _auto_merge_orphan(
+        self,
+        *,
+        uow: object,
+        self_movie: Movie,
+        self_runtime: float | None,
+        orphan: Movie,
+    ) -> tuple[MediaConflict, MovieMergedEvent]:
+        """Persist a resolved-AUTO conflict and soft-delete the orphan."""
+        # ``uow`` is typed ``object`` here because importing
+        # MediaUnitOfWork would form a runtime cycle through this
+        # module — the caller passes the live UoW from the same
+        # ``async with`` block above.
+        conflict = MediaConflict.detect(
+            candidate_a_id=str(self_movie.id),
+            candidate_a_type="movie",
+            candidate_a_runtime_minutes=self_runtime,
+            candidate_b_id=str(orphan.id),
+            candidate_b_type="movie",
+            candidate_b_runtime_minutes=_runtime_minutes(orphan),
+            match_reason=MatchReason.TMDB_ID,
+        )
+        resolved = conflict.resolve(
+            ResolutionAction.MERGE_REPLACE,
+            winner_id=str(self_movie.id),
+            source=ResolutionSource.AUTO,
+        )
+        persisted = await uow.media_conflicts.save(resolved)  # type: ignore[attr-defined]
+
+        loser_id = persisted.loser_id()
+        if loser_id is None:  # pragma: no cover — guarded by aggregate
+            raise RuntimeError("auto-merge resolved row missing loser_id")
+
+        deleted = await uow.movies.delete(MovieId(loser_id))  # type: ignore[attr-defined]
+        if not deleted:
+            _logger.warning(
+                "Orphan movie %s missing during auto-merge of %s",
+                loser_id,
+                persisted.id,
+            )
+
+        event = MovieMergedEvent(
+            conflict_id=str(persisted.id),
+            winner_id=str(self_movie.id),
+            loser_id=loser_id,
+            keep_loser_variants=False,
+            is_auto=True,
+        )
+        _logger.info(
+            "Auto-merged orphan %s into %s (conflict %s)",
+            loser_id,
+            self_movie.id,
+            persisted.id,
+        )
+        return persisted, event
 
 
 def _runtime_minutes(movie: Movie) -> float | None:

--- a/src/modules/media/application/use_cases/list_conflicts.py
+++ b/src/modules/media/application/use_cases/list_conflicts.py
@@ -1,25 +1,41 @@
-"""Admin-side conflict queue listing (ADR-015 Phase 1)."""
+"""Admin-side conflict queue + audit listing (ADR-015 Phases 1 + 3)."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.media.application.dtos.conflict_dtos import (
     ConflictCandidateSummary,
     ConflictSummary,
     ListConflictsInput,
     ListConflictsOutput,
 )
-from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-from src.modules.media.domain.entities.media_conflict import MediaConflict
-from src.modules.media.domain.entities.movie import Movie
+from src.modules.media.domain.entities.media_conflict import (
+    MediaConflict,
+    ResolutionSource,
+)
 from src.modules.media.domain.value_objects import MovieId
+
+if TYPE_CHECKING:
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.domain.entities.movie import Movie
+
+_VALID_STATES = ("pending", "resolved")
+_VALID_SOURCES = ("manual", "auto")
 
 
 class ListConflictsUseCase:
-    """List pending content-identity conflicts for the admin queue.
+    """List content-identity conflicts for the admin UI.
+
+    Default state is ``pending`` (the operator queue). ``resolved``
+    powers the audit view; it accepts an optional ``source`` filter
+    so the UI can split admin actions from Phase 3 auto-merges.
 
     Hydrates each conflict with title/year projections of both
-    candidates so the UI doesn't have to make N follow-up calls.
-    Phase 1 resolves ``"movie"`` candidates via the Movie repository;
-    series candidates simply surface with ``title=None`` until the
-    Series support lands.
+    candidates so the UI doesn't have to make N follow-up calls. The
+    loser of a resolved-MERGE row is soft-deleted, so the repository
+    returns ``None`` for its title — surfaced verbatim.
 
     Args:
         uow_factory: Factory that opens a fresh media Unit of Work.
@@ -29,12 +45,39 @@ class ListConflictsUseCase:
         self._uow_factory = uow_factory
 
     async def execute(self, input_dto: ListConflictsInput) -> ListConflictsOutput:
-        """Return one page of pending conflicts, newest-first."""
-        async with self._uow_factory() as uow:
-            page = await uow.media_conflicts.list_pending(
-                cursor=input_dto.cursor,
-                limit=input_dto.limit,
+        """Return one page of conflicts matching the ``state`` filter."""
+        state = input_dto.state
+        if state not in _VALID_STATES:
+            raise DomainValidationException(
+                message=f"Unknown state '{state}'; must be one of {_VALID_STATES}",
+                message_code="MEDIA_CONFLICT_LIST_INVALID_STATE",
+                object_type="MediaConflict",
             )
+
+        source = _parse_source(input_dto.source)
+
+        if state == "pending" and source is not None:
+            # ``source`` only makes sense for resolved rows. Surface
+            # the misuse instead of silently ignoring.
+            raise DomainValidationException(
+                message="source filter is only valid for state=resolved",
+                message_code="MEDIA_CONFLICT_LIST_SOURCE_FOR_PENDING",
+                object_type="MediaConflict",
+            )
+
+        async with self._uow_factory() as uow:
+            if state == "pending":
+                page = await uow.media_conflicts.list_pending(
+                    cursor=input_dto.cursor,
+                    limit=input_dto.limit,
+                )
+            else:
+                page = await uow.media_conflicts.list_resolved(
+                    source=source,
+                    cursor=input_dto.cursor,
+                    limit=input_dto.limit,
+                )
+
             if not page.items:
                 return ListConflictsOutput(
                     items=[],
@@ -50,6 +93,18 @@ class ListConflictsUseCase:
                 next_cursor=page.pagination.next_cursor,
                 has_more=page.pagination.has_more,
             )
+
+
+def _parse_source(raw: str | None) -> ResolutionSource | None:
+    if raw is None:
+        return None
+    if raw not in _VALID_SOURCES:
+        raise DomainValidationException(
+            message=f"Unknown source '{raw}'; must be one of {_VALID_SOURCES}",
+            message_code="MEDIA_CONFLICT_LIST_INVALID_SOURCE",
+            object_type="MediaConflict",
+        )
+    return ResolutionSource(raw)
 
 
 def _collect_movie_ids(conflicts: list[MediaConflict]) -> list[MovieId]:
@@ -89,6 +144,12 @@ def _build_summary(
         runtime_delta_minutes=conflict.runtime_delta_minutes,
         suggested_action=conflict.suggested_action.value,
         detected_at=conflict.created_at,
+        resolved_at=conflict.resolved_at,
+        resolution=None if conflict.resolution is None else conflict.resolution.value,
+        winner_id=conflict.winner_id,
+        resolution_source=(
+            None if conflict.resolution_source is None else conflict.resolution_source.value
+        ),
     )
 
 

--- a/src/modules/media/domain/entities/__init__.py
+++ b/src/modules/media/domain/entities/__init__.py
@@ -5,6 +5,7 @@ from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     MediaConflict,
     ResolutionAction,
+    ResolutionSource,
     SuggestedAction,
 )
 from src.modules.media.domain.entities.movie import Movie
@@ -27,6 +28,7 @@ __all__ = [
     "MediaConflict",
     "Movie",
     "ResolutionAction",
+    "ResolutionSource",
     "ScanRun",
     "ScanRunKind",
     "ScanRunStatus",

--- a/src/modules/media/domain/entities/media_conflict.py
+++ b/src/modules/media/domain/entities/media_conflict.py
@@ -40,6 +40,20 @@ class ResolutionAction(str, Enum):
     MARK_DISTINCT = "mark_distinct"
 
 
+class ResolutionSource(str, Enum):
+    """Who closed the conflict.
+
+    - ``MANUAL`` — the admin clicked through the resolve flow.
+    - ``AUTO`` — the post-enrich detector noticed one side was
+      orphaned (file missing + library root healthy) and merged it
+      silently. Surfaces in a separate audit view, not the operator
+      queue (see ADR-015 Phase 3).
+    """
+
+    MANUAL = "manual"
+    AUTO = "auto"
+
+
 class MediaConflict(AggregateRoot[MediaConflictId]):
     """A detected duplicate-identity collision awaiting resolution.
 
@@ -72,6 +86,11 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         winner_id: For ``MERGE_*`` resolutions, the external id of the
             candidate that survived. ``None`` for pending rows and
             for ``MARK_DISTINCT`` (no winner — both sides survive).
+        resolution_source: ``MANUAL`` (admin via the resolve dialog)
+            or ``AUTO`` (post-enrich detector silently merging an
+            orphan). ``None`` while pending; always set on resolved
+            rows. Auto rows are only ever produced by ADR-015 Phase 3
+            and always carry a MERGE action.
     """
 
     # Class-level thresholds — ADR-015: delta must exceed BOTH the
@@ -95,6 +114,7 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
     resolved_at: datetime | None = None
     resolution: ResolutionAction | None = None
     winner_id: str | None = None
+    resolution_source: ResolutionSource | None = None
 
     @model_validator(mode="after")
     def _validate_candidates_distinct(self) -> Self:
@@ -131,6 +151,24 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
                 raise ValueError("winner_id must be one of the conflict's candidates")
         elif self.winner_id is not None:
             raise ValueError("winner_id must be None for pending or MARK_DISTINCT rows")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_resolution_source(self) -> Self:
+        """``resolution_source`` is required on resolved rows; AUTO only on MERGE."""
+        if self.resolved_at is None:
+            if self.resolution_source is not None:
+                raise ValueError("resolution_source must be None for pending rows")
+            return self
+        if self.resolution_source is None:
+            raise ValueError("resolution_source must be set on resolved rows")
+        if self.resolution_source is ResolutionSource.AUTO and self.resolution not in {
+            ResolutionAction.MERGE_KEEP_BOTH,
+            ResolutionAction.MERGE_REPLACE,
+        }:
+            raise ValueError(
+                "AUTO resolution_source is only valid for MERGE_KEEP_BOTH / MERGE_REPLACE",
+            )
         return self
 
     @classmethod
@@ -192,7 +230,13 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
             return SuggestedAction.DIFFERENT_EDIT_SUSPECTED
         return SuggestedAction.LIKELY_SAME_RELEASE
 
-    def resolve(self, action: ResolutionAction, *, winner_id: str | None = None) -> Self:
+    def resolve(
+        self,
+        action: ResolutionAction,
+        *,
+        winner_id: str | None = None,
+        source: ResolutionSource = ResolutionSource.MANUAL,
+    ) -> Self:
         """Stamp the conflict as resolved with the chosen action.
 
         Idempotency: resolving an already-resolved conflict raises —
@@ -206,6 +250,9 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
                 ``MERGE_REPLACE``; must be ``None`` for
                 ``MARK_DISTINCT``. Validated against the candidate pair
                 so a stray id cannot land in the row.
+            source: Where the resolution came from — ``MANUAL`` (admin)
+                or ``AUTO`` (Phase 3 silent merge of an orphan).
+                ``AUTO`` is only valid with a MERGE action.
 
         Returns:
             New instance with ``resolved_at``, ``resolution`` and (for
@@ -228,6 +275,7 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
             resolved_at=datetime.now(UTC),
             resolution=action,
             winner_id=winner_id,
+            resolution_source=source,
         )
 
     @property
@@ -239,6 +287,11 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
     def is_marked_distinct(self) -> bool:
         """``True`` when the operator declared the pair to be distinct."""
         return self.resolution is ResolutionAction.MARK_DISTINCT
+
+    @property
+    def is_auto_resolved(self) -> bool:
+        """``True`` when the post-enrich detector silently merged this row."""
+        return self.resolution_source is ResolutionSource.AUTO
 
     def loser_id(self) -> str | None:
         """For MERGE resolutions, the id of the soft-deleted side."""
@@ -258,5 +311,6 @@ __all__ = [
     "MatchReason",
     "MediaConflict",
     "ResolutionAction",
+    "ResolutionSource",
     "SuggestedAction",
 ]

--- a/src/modules/media/domain/events.py
+++ b/src/modules/media/domain/events.py
@@ -127,14 +127,16 @@ class MediaConflictDetectedEvent(DomainEvent):
 
 @dataclass(frozen=True)
 class MovieMergedEvent(DomainEvent):
-    """Emitted when an admin merges two movies via the conflict queue.
+    """Emitted when two movies are merged via the conflict queue.
 
-    Triggered by ADR-015 Phase 2 resolution endpoint. Carries the
-    cross-BC fan-out signal: ``watch_progress`` deletes the loser's
+    Triggered by either the admin resolve endpoint (ADR-015 Phase 2,
+    ``is_auto=False``) or the post-enrich detector silently absorbing
+    an orphaned candidate (ADR-015 Phase 3, ``is_auto=True``). Carries
+    the cross-BC fan-out signal: ``watch_progress`` deletes the loser's
     progress rows and ``collections`` repoints watchlist / custom-list
     items from loser → winner. The loser movie itself is already
-    soft-deleted by the resolve use case before the event publishes,
-    so handlers don't need to touch the catalog row.
+    soft-deleted by the trigger before the event publishes, so handlers
+    don't need to touch the catalog row.
 
     Attributes:
         conflict_id: External id of the resolved conflict (``cnf_xxx``).
@@ -145,12 +147,18 @@ class MovieMergedEvent(DomainEvent):
             transferred to the winner; cross-BC handlers can treat
             this identically to ``MERGE_REPLACE`` (rows still need to
             be repointed). Surfaced for analytics / audit.
+        is_auto: ``True`` when the merge was decided by the auto-merge
+            path (orphan + healthy library), ``False`` when an admin
+            picked the resolution. Cross-BC handlers apply the same
+            fan-out either way; the flag is surfaced for logs and
+            audit reports.
     """
 
     conflict_id: str = ""
     winner_id: str = ""
     loser_id: str = ""
     keep_loser_variants: bool = False
+    is_auto: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/domain/repositories/media_conflict_repository.py
+++ b/src/modules/media/domain/repositories/media_conflict_repository.py
@@ -3,7 +3,10 @@
 from abc import ABC, abstractmethod
 
 from src.building_blocks.application.pagination import PaginatedResult
-from src.modules.media.domain.entities.media_conflict import MediaConflict
+from src.modules.media.domain.entities.media_conflict import (
+    MediaConflict,
+    ResolutionSource,
+)
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
 
 
@@ -74,6 +77,29 @@ class MediaConflictRepository(ABC):
 
         Returns:
             Paginated page of pending conflicts.
+        """
+        ...
+
+    @abstractmethod
+    async def list_resolved(
+        self,
+        *,
+        source: ResolutionSource | None = None,
+        cursor: str | None = None,
+        limit: int = 20,
+    ) -> PaginatedResult[MediaConflict]:
+        """List resolved conflicts (audit view), newest first.
+
+        Args:
+            source: Optional ``ResolutionSource`` filter. ``None``
+                returns every resolved row; ``AUTO`` returns only
+                rows the detector silently merged; ``MANUAL`` returns
+                only rows the admin resolved through the endpoint.
+            cursor: Opaque pagination cursor from the previous page.
+            limit: Page size.
+
+        Returns:
+            Paginated page of resolved conflicts.
         """
         ...
 

--- a/src/modules/media/infrastructure/acl/__init__.py
+++ b/src/modules/media/infrastructure/acl/__init__.py
@@ -1,5 +1,8 @@
 """Anti-corruption layer: adapters translating external BCs to local ports."""
 
+from src.modules.media.infrastructure.acl.library_health_adapter import (
+    LibraryHealthAdapter,
+)
 from src.modules.media.infrastructure.acl.profile_library_access_adapter import (
     ProfileLibraryAccessAdapter,
 )
@@ -7,4 +10,8 @@ from src.modules.media.infrastructure.acl.progress_lookup_adapter import (
     ProgressLookupAdapter,
 )
 
-__all__ = ["ProfileLibraryAccessAdapter", "ProgressLookupAdapter"]
+__all__ = [
+    "LibraryHealthAdapter",
+    "ProfileLibraryAccessAdapter",
+    "ProgressLookupAdapter",
+]

--- a/src/modules/media/infrastructure/acl/library_health_adapter.py
+++ b/src/modules/media/infrastructure/acl/library_health_adapter.py
@@ -1,0 +1,50 @@
+"""Adapter implementing ``LibraryHealthPort`` via the library UoW + pathlib.
+
+This is the only file in the Media BC that combines the Library BC
+(for ``Library.paths`` lookup) with raw filesystem checks. Above the
+adapter, the use cases only see the abstract port — the cross-BC +
+I/O boundaries stay explicit, per ADR-009.
+"""
+
+from pathlib import Path
+
+from src.modules.library.application.unit_of_work import (
+    LibraryUnitOfWorkFactory,
+)
+from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.modules.media.application.ports.library_health_port import (
+    LibraryHealthPort,
+)
+
+
+class LibraryHealthAdapter(LibraryHealthPort):
+    """Resolve filesystem health via the Library UoW + ``pathlib``."""
+
+    def __init__(self, library_uow_factory: LibraryUnitOfWorkFactory) -> None:
+        self._library_uow_factory = library_uow_factory
+
+    async def is_file_accessible(self, file_path: str) -> bool:
+        """Return ``Path(file_path).exists()`` without touching the UoW."""
+        return Path(file_path).exists()
+
+    async def is_library_root_accessible(self, library_id: str) -> bool:
+        """Confirm every declared library root currently mounts.
+
+        Missing libraries (deleted, never seeded) also return
+        ``False`` — the caller's intent is "can I trust a
+        file-missing signal for media inside this library?" and the
+        safer answer for a phantom library is "no, fall back to the
+        manual queue".
+        """
+        async with self._library_uow_factory() as uow:
+            library = await uow.libraries.find_by_id(LibraryId(library_id))
+        if library is None:
+            return False
+        # Partial-mount = unhealthy. The scanner cannot give the
+        # operator a complete view, so treating "some roots mounted"
+        # as healthy would risk auto-merging entities whose file
+        # actually still lives on the missing root.
+        return all(Path(p.value).exists() for p in library.paths)
+
+
+__all__ = ["LibraryHealthAdapter"]

--- a/src/modules/media/infrastructure/persistence/mappers/media_conflict_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/media_conflict_mapper.py
@@ -4,6 +4,7 @@ from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     MediaConflict,
     ResolutionAction,
+    ResolutionSource,
     SuggestedAction,
 )
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
@@ -30,6 +31,11 @@ class MediaConflictMapper:
             resolved_at=model.resolved_at,
             resolution=None if model.resolution is None else ResolutionAction(model.resolution),
             winner_id=model.winner_id,
+            resolution_source=(
+                None
+                if model.resolution_source is None
+                else ResolutionSource(model.resolution_source)
+            ),
             created_at=model.created_at,
             updated_at=model.updated_at,
         )
@@ -51,6 +57,9 @@ class MediaConflictMapper:
             resolved_at=entity.resolved_at,
             resolution=None if entity.resolution is None else entity.resolution.value,
             winner_id=entity.winner_id,
+            resolution_source=(
+                None if entity.resolution_source is None else entity.resolution_source.value
+            ),
         )
 
     @staticmethod
@@ -66,6 +75,9 @@ class MediaConflictMapper:
         model.resolved_at = entity.resolved_at
         model.resolution = None if entity.resolution is None else entity.resolution.value
         model.winner_id = entity.winner_id
+        model.resolution_source = (
+            None if entity.resolution_source is None else entity.resolution_source.value
+        )
 
 
 __all__ = ["MediaConflictMapper"]

--- a/src/modules/media/infrastructure/persistence/models/media_conflict.py
+++ b/src/modules/media/infrastructure/persistence/models/media_conflict.py
@@ -47,6 +47,11 @@ class MediaConflictModel(Base):
     )
     resolution: Mapped[str | None] = mapped_column(String(30), nullable=True)
     winner_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    resolution_source: Mapped[str | None] = mapped_column(
+        String(20),
+        nullable=True,
+        index=True,
+    )
 
 
 __all__ = ["MediaConflictModel"]

--- a/src/modules/media/infrastructure/persistence/repositories/media_conflict_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/media_conflict_repository.py
@@ -12,6 +12,7 @@ from src.building_blocks.application.pagination import (
 from src.modules.media.domain.entities.media_conflict import (
     MediaConflict,
     ResolutionAction,
+    ResolutionSource,
 )
 from src.modules.media.domain.repositories.media_conflict_repository import (
     MediaConflictRepository,
@@ -115,6 +116,39 @@ class SqlAlchemyMediaConflictRepository(MediaConflictRepository):
             MediaConflictModel.resolved_at.is_(None),
             MediaConflictModel.deleted_at.is_(None),
         )
+
+        decoded = decode_cursor(cursor)
+        if decoded is not None:
+            stmt = stmt.where(MediaConflictModel.id < decoded.id)
+
+        stmt = stmt.order_by(MediaConflictModel.id.desc()).limit(limit + 1)
+
+        result = await self._session.execute(stmt)
+        models = list(result.scalars().all())
+
+        has_more = len(models) > limit
+        page_models = models[:limit] if has_more else models
+        next_cursor = encode_cursor(page_models[-1].id) if has_more and page_models else None
+
+        return PaginatedResult(
+            items=[MediaConflictMapper.to_entity(m) for m in page_models],
+            pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
+        )
+
+    async def list_resolved(
+        self,
+        *,
+        source: ResolutionSource | None = None,
+        cursor: str | None = None,
+        limit: int = 20,
+    ) -> PaginatedResult[MediaConflict]:
+        """List resolved conflicts newest-first with opaque cursor pagination."""
+        stmt = select(MediaConflictModel).where(
+            MediaConflictModel.resolved_at.is_not(None),
+            MediaConflictModel.deleted_at.is_(None),
+        )
+        if source is not None:
+            stmt = stmt.where(MediaConflictModel.resolution_source == source.value)
 
         decoded = decode_cursor(cursor)
         if decoded is not None:

--- a/src/modules/media/presentation/routes/admin_conflicts_routes.py
+++ b/src/modules/media/presentation/routes/admin_conflicts_routes.py
@@ -1,13 +1,15 @@
 """Admin REST API for the media-conflict queue (ADR-015).
 
-``GET /`` lists pending content-identity collisions detected by the
-post-enrich hook (Phase 1). ``POST /{id}/resolve`` applies the
-operator's chosen disposition (Phase 2): mark-distinct, merge-keep-both,
-or merge-replace.
+``GET /?state=pending`` (default) lists content-identity collisions
+queued by the post-enrich hook for operator triage (Phase 1).
+``GET /?state=resolved&source=auto`` powers the audit view for
+Phase 3 silent auto-merges; ``source=manual`` shows admin decisions.
+``POST /{id}/resolve`` applies the operator's chosen disposition
+(Phase 2): mark-distinct, merge-keep-both, or merge-replace.
 """
 
 from dataclasses import asdict
-from typing import Any
+from typing import Any, Literal
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Path, Query
@@ -61,6 +63,8 @@ router = APIRouter(prefix="/api/v1/admin/conflicts", tags=["Admin — Conflicts"
 @router.get("")
 @inject
 async def list_admin_conflicts(
+    state: Literal["pending", "resolved"] = Query(default="pending"),
+    source: Literal["manual", "auto"] | None = Query(default=None),
     cursor: str | None = Query(default=None),
     limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
     _admin: UserModel = Depends(current_admin_user),
@@ -68,14 +72,20 @@ async def list_admin_conflicts(
         Provide[ApplicationContainer.media.list_conflicts],
     ),
 ) -> dict[str, Any]:
-    """Return the next page of pending content-identity conflicts.
+    """Return the next page of conflicts matching ``state`` (+ ``source``).
+
+    - ``state=pending`` (default): the operator queue — rows that
+      still need a decision.
+    - ``state=resolved``: audit view of closed rows. Combine with
+      ``source=manual`` (admin) or ``source=auto`` (Phase 3 silent
+      merge of orphans); omit ``source`` to see both.
 
     Items are newest-first. Each item embeds title + year projections
     for both sides so the admin UI does not need an extra round-trip
     to render the queue row.
     """
     output = await use_case.execute(
-        ListConflictsInput(cursor=cursor, limit=limit),
+        ListConflictsInput(state=state, source=source, cursor=cursor, limit=limit),
     )
     return api_list(
         [asdict(item) for item in output.items],

--- a/tests/modules/media/e2e/test_admin_conflicts_routes.py
+++ b/tests/modules/media/e2e/test_admin_conflicts_routes.py
@@ -370,3 +370,66 @@ class TestAdminConflictsResolveFailures:
             },
         )
         assert response.status_code == 422
+
+
+@pytest.mark.e2e
+class TestAdminConflictsAuditView:
+    """ADR-015 Phase 3 — GET supports state + source filters."""
+
+    async def test_state_resolved_shows_resolved_rows(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        conflict_id, _, _ = await _seed_pair_with_conflict(session_factory)
+        # Manually resolve via the endpoint so it appears in audit view.
+        resp = await client.post(
+            f"{CONFLICTS_PATH}/{conflict_id}/resolve",
+            json={"action": "mark_distinct"},
+        )
+        assert resp.status_code == 200
+
+        # Default state=pending excludes the resolved row.
+        pending = await client.get(CONFLICTS_PATH)
+        assert pending.json()["data"] == []
+
+        # state=resolved surfaces it with the resolution metadata.
+        resolved = await client.get(f"{CONFLICTS_PATH}?state=resolved")
+        assert resolved.status_code == 200
+        rows = resolved.json()["data"]
+        assert len(rows) == 1
+        assert rows[0]["conflict_id"] == conflict_id
+        assert rows[0]["resolution"] == "mark_distinct"
+        assert rows[0]["resolution_source"] == "manual"
+
+    async def test_state_resolved_with_source_filter(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        conflict_id, _, _ = await _seed_pair_with_conflict(session_factory)
+        await client.post(
+            f"{CONFLICTS_PATH}/{conflict_id}/resolve",
+            json={"action": "mark_distinct"},
+        )
+
+        # source=manual shows the row; source=auto returns empty
+        # (no auto-merges seeded in this test).
+        manual_resp = await client.get(f"{CONFLICTS_PATH}?state=resolved&source=manual")
+        auto_resp = await client.get(f"{CONFLICTS_PATH}?state=resolved&source=auto")
+
+        assert len(manual_resp.json()["data"]) == 1
+        assert auto_resp.json()["data"] == []
+
+    async def test_invalid_state_returns_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        response = await client.get(f"{CONFLICTS_PATH}?state=frozen")
+        assert response.status_code == 422

--- a/tests/modules/media/integration/persistence/repositories/test_media_conflict_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_media_conflict_repository.py
@@ -7,6 +7,7 @@ from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     MediaConflict,
     ResolutionAction,
+    ResolutionSource,
 )
 from src.modules.media.infrastructure.persistence.repositories.media_conflict_repository import (
     SqlAlchemyMediaConflictRepository,
@@ -167,3 +168,72 @@ class TestListPending:
         )
         assert [c.id for c in second_page.items] == [c1.id]
         assert second_page.pagination.has_more is False
+
+
+@pytest.mark.integration
+class TestListResolved:
+    """ADR-015 Phase 3 — audit view of resolved conflicts."""
+
+    async def test_excludes_pending_rows(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SqlAlchemyMediaConflictRepository(db_session)
+        # Pending: not in result.
+        await repo.save(_new_conflict(a_id="mov_aaaaaaaaaaaa", b_id="mov_bbbbbbbbbbbb"))
+        # Resolved manual:
+        manual = await repo.save(_new_conflict(a_id="mov_cccccccccccc", b_id="mov_dddddddddddd"))
+        await repo.save(
+            manual.resolve(ResolutionAction.MARK_DISTINCT),
+        )
+
+        page = await repo.list_resolved()
+
+        # Only the resolved row appears (pending excluded).
+        assert len(page.items) == 1
+        assert page.items[0].is_resolved is True
+
+    async def test_filters_by_source_auto(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SqlAlchemyMediaConflictRepository(db_session)
+        # Manual resolution:
+        manual = await repo.save(_new_conflict(a_id="mov_aaaaaaaaaaaa", b_id="mov_bbbbbbbbbbbb"))
+        await repo.save(manual.resolve(ResolutionAction.MARK_DISTINCT))
+        # Auto resolution:
+        auto = await repo.save(_new_conflict(a_id="mov_cccccccccccc", b_id="mov_dddddddddddd"))
+        auto_resolved = await repo.save(
+            auto.resolve(
+                ResolutionAction.MERGE_REPLACE,
+                winner_id=auto.candidate_a_id,
+                source=ResolutionSource.AUTO,
+            ),
+        )
+
+        page = await repo.list_resolved(source=ResolutionSource.AUTO)
+
+        assert [c.id for c in page.items] == [auto_resolved.id]
+        assert page.items[0].resolution_source is ResolutionSource.AUTO
+
+    async def test_source_none_returns_both_sources(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SqlAlchemyMediaConflictRepository(db_session)
+        manual = await repo.save(_new_conflict(a_id="mov_aaaaaaaaaaaa", b_id="mov_bbbbbbbbbbbb"))
+        await repo.save(manual.resolve(ResolutionAction.MARK_DISTINCT))
+        auto = await repo.save(_new_conflict(a_id="mov_cccccccccccc", b_id="mov_dddddddddddd"))
+        await repo.save(
+            auto.resolve(
+                ResolutionAction.MERGE_REPLACE,
+                winner_id=auto.candidate_a_id,
+                source=ResolutionSource.AUTO,
+            ),
+        )
+
+        page = await repo.list_resolved()
+
+        assert len(page.items) == 2
+        sources = {c.resolution_source for c in page.items}
+        assert sources == {ResolutionSource.MANUAL, ResolutionSource.AUTO}

--- a/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
@@ -1,20 +1,31 @@
-"""Tests for DetectMovieConflictsUseCase (ADR-015 Phase 1)."""
+"""Tests for DetectMovieConflictsUseCase (ADR-015 Phases 1 + 3)."""
 
 from unittest.mock import AsyncMock
 
 import pytest
 
 from src.modules.media.application.dtos.conflict_dtos import DetectMovieConflictsInput
+from src.modules.media.application.ports.library_health_port import LibraryHealthPort
 from src.modules.media.application.use_cases.detect_movie_conflicts import (
     DetectMovieConflictsUseCase,
 )
 from src.modules.media.domain.entities import MediaConflict
-from src.modules.media.domain.entities.media_conflict import MatchReason
+from src.modules.media.domain.entities.media_conflict import (
+    MatchReason,
+    ResolutionAction,
+    ResolutionSource,
+)
 from src.modules.media.domain.entities.movie import Movie
-from src.modules.media.domain.events import MediaConflictDetectedEvent
+from src.modules.media.domain.events import (
+    MediaConflictDetectedEvent,
+    MovieMergedEvent,
+)
 from src.modules.media.domain.value_objects import (
     Duration,
+    FilePath,
+    MediaFile,
     MovieId,
+    Resolution,
     Title,
     TmdbId,
     Year,
@@ -23,15 +34,49 @@ from src.modules.media.domain.value_objects.media_conflict_id import MediaConfli
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
-def _build_movie(*, external_id: str, duration_seconds: int = 7200) -> Movie:
+def _build_movie(
+    *,
+    external_id: str,
+    duration_seconds: int = 7200,
+    file_paths: list[str] | None = None,
+) -> Movie:
+    files = [
+        MediaFile(
+            file_path=FilePath(p),
+            file_size=1_000_000_000,
+            resolution=Resolution("1080p"),
+            is_primary=True,
+        )
+        for p in (file_paths or [])
+    ]
     return Movie(
         id=MovieId(external_id),
         library_id="lib_test12345678",
         title=Title("Example"),
         year=Year(2020),
         duration=Duration(duration_seconds),
+        files=files,
         tmdb_id=TmdbId(27205),
     )
+
+
+class _FakeLibraryHealth(LibraryHealthPort):
+    """Deterministic LibraryHealthPort for unit tests."""
+
+    def __init__(
+        self,
+        *,
+        accessible_files: set[str] | None = None,
+        healthy_libraries: set[str] | None = None,
+    ) -> None:
+        self._accessible_files = accessible_files or set()
+        self._healthy_libraries = healthy_libraries or set()
+
+    async def is_file_accessible(self, file_path: str) -> bool:
+        return file_path in self._accessible_files
+
+    async def is_library_root_accessible(self, library_id: str) -> bool:
+        return library_id in self._healthy_libraries
 
 
 class TestDetectMovieConflictsUseCase:
@@ -133,3 +178,167 @@ async def _stamp_conflict_id(conflict: MediaConflict) -> MediaConflict:
     return conflict.with_updates(
         id=MediaConflictId("cnf_stamped12345"),
     )
+
+
+class TestAutoMergeOrphans:
+    """ADR-015 Phase 3 — silent absorption of orphan candidates."""
+
+    @pytest.mark.asyncio
+    async def test_orphan_other_triggers_auto_merge_and_skips_queue(self) -> None:
+        # Self has a live file; other's file is missing (orphan) but
+        # the library is mounted → auto-merge other into self.
+        mocks = make_media_uow_mock()
+        self_movie = _build_movie(
+            external_id="mov_abcdefghijkl",
+            file_paths=["/movies/self.mkv"],
+        )
+        orphan = _build_movie(
+            external_id="mov_mnopqrstuvwx",
+            file_paths=["/movies/missing.mkv"],
+        )
+        mocks.movies.find_all_by_tmdb_id.return_value = [self_movie, orphan]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+        mocks.movies.delete.return_value = True
+
+        health = _FakeLibraryHealth(
+            accessible_files={"/movies/self.mkv"},  # orphan's path NOT here
+            healthy_libraries={"lib_test12345678"},
+        )
+        event_bus = AsyncMock()
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            library_health=health,
+            event_bus=event_bus,
+        )
+
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_abcdefghijkl", tmdb_id=27205),
+        )
+
+        assert result.conflicts_created == 1
+        saved_conflict = mocks.media_conflicts.save.call_args[0][0]
+        assert saved_conflict.is_resolved is True
+        assert saved_conflict.resolution is ResolutionAction.MERGE_REPLACE
+        assert saved_conflict.resolution_source is ResolutionSource.AUTO
+        assert saved_conflict.winner_id == "mov_abcdefghijkl"
+
+        mocks.movies.delete.assert_awaited_once()
+        deleted_arg = mocks.movies.delete.await_args[0][0]
+        assert str(deleted_arg) == "mov_mnopqrstuvwx"
+
+        event_bus.publish.assert_awaited_once()
+        published = event_bus.publish.await_args[0][0]
+        assert isinstance(published, MovieMergedEvent)
+        assert published.is_auto is True
+        assert published.winner_id == "mov_abcdefghijkl"
+        assert published.loser_id == "mov_mnopqrstuvwx"
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_library_falls_back_to_pending_queue(self) -> None:
+        # File missing but library inaccessible — could be transient
+        # I/O (drive unmounted); safer to queue the conflict.
+        mocks = make_media_uow_mock()
+        self_movie = _build_movie(
+            external_id="mov_abcdefghijkl",
+            file_paths=["/movies/self.mkv"],
+        )
+        other = _build_movie(
+            external_id="mov_mnopqrstuvwx",
+            file_paths=["/movies/elsewhere.mkv"],
+        )
+        mocks.movies.find_all_by_tmdb_id.return_value = [self_movie, other]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+
+        health = _FakeLibraryHealth(
+            accessible_files={"/movies/self.mkv"},
+            healthy_libraries=set(),  # library NOT in healthy set
+        )
+        event_bus = AsyncMock()
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            library_health=health,
+            event_bus=event_bus,
+        )
+
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_abcdefghijkl", tmdb_id=27205),
+        )
+
+        assert result.conflicts_created == 1
+        saved_conflict = mocks.media_conflicts.save.call_args[0][0]
+        # Falls back to the pending-conflict path; nothing is resolved.
+        assert saved_conflict.is_resolved is False
+        assert saved_conflict.resolution_source is None
+        mocks.movies.delete.assert_not_called()
+
+        # Detection event still fires; no merge event.
+        published_types = [
+            type(call.args[0]).__name__ for call in event_bus.publish.await_args_list
+        ]
+        assert published_types == ["MediaConflictDetectedEvent"]
+
+    @pytest.mark.asyncio
+    async def test_accessible_other_file_falls_back_to_pending_queue(self) -> None:
+        # Other's file IS accessible — not an orphan, so the operator
+        # must decide (Director's Cut? remaster?).
+        mocks = make_media_uow_mock()
+        self_movie = _build_movie(
+            external_id="mov_abcdefghijkl",
+            file_paths=["/movies/self.mkv"],
+        )
+        other = _build_movie(
+            external_id="mov_mnopqrstuvwx",
+            file_paths=["/movies/other.mkv"],
+        )
+        mocks.movies.find_all_by_tmdb_id.return_value = [self_movie, other]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+
+        health = _FakeLibraryHealth(
+            accessible_files={"/movies/self.mkv", "/movies/other.mkv"},
+            healthy_libraries={"lib_test12345678"},
+        )
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            library_health=health,
+        )
+
+        await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_abcdefghijkl", tmdb_id=27205),
+        )
+
+        saved_conflict = mocks.media_conflicts.save.call_args[0][0]
+        assert saved_conflict.is_resolved is False
+        mocks.movies.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_library_health_not_wired_preserves_phase1_behavior(self) -> None:
+        # When the port is None, the use case never tries to detect
+        # orphans — every collision queues as a pending conflict.
+        mocks = make_media_uow_mock()
+        self_movie = _build_movie(
+            external_id="mov_abcdefghijkl",
+            file_paths=["/movies/self.mkv"],
+        )
+        other = _build_movie(
+            external_id="mov_mnopqrstuvwx",
+            file_paths=["/movies/missing.mkv"],
+        )
+        mocks.movies.find_all_by_tmdb_id.return_value = [self_movie, other]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            library_health=None,
+        )
+
+        await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_abcdefghijkl", tmdb_id=27205),
+        )
+
+        saved_conflict = mocks.media_conflicts.save.call_args[0][0]
+        assert saved_conflict.is_resolved is False
+        mocks.movies.delete.assert_not_called()

--- a/tests/modules/media/unit/application/use_cases/test_list_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_conflicts.py
@@ -3,11 +3,14 @@
 import pytest
 
 from src.building_blocks.application.pagination import PaginatedResult, Pagination
+from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.media.application.dtos.conflict_dtos import ListConflictsInput
 from src.modules.media.application.use_cases.list_conflicts import ListConflictsUseCase
 from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     MediaConflict,
+    ResolutionAction,
+    ResolutionSource,
 )
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.value_objects import (
@@ -141,3 +144,76 @@ class TestListConflictsUseCase:
         # with ``title=None`` so the admin UI can still render the row.
         assert summary.candidate_b.title is None
         assert summary.candidate_b.media_type == "series"
+
+
+class TestListResolvedConflicts:
+    """ADR-015 Phase 3 — audit view + source filters."""
+
+    @pytest.mark.asyncio
+    async def test_state_resolved_calls_list_resolved(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.media_conflicts.list_resolved.return_value = PaginatedResult(
+            items=[],
+            pagination=Pagination(next_cursor=None, has_more=False),
+        )
+
+        use_case = ListConflictsUseCase(uow_factory=mocks.factory)
+        await use_case.execute(ListConflictsInput(state="resolved"))
+
+        mocks.media_conflicts.list_resolved.assert_awaited_once_with(
+            source=None,
+            cursor=None,
+            limit=20,
+        )
+        mocks.media_conflicts.list_pending.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_state_resolved_with_source_auto_forwards_filter(self) -> None:
+        mocks = make_media_uow_mock()
+        resolved_auto = _conflict().with_updates(
+            resolved_at=__import__("datetime").datetime.now(),
+            resolution=ResolutionAction.MERGE_REPLACE,
+            winner_id="mov_aaaaaaaaaaaa",
+            resolution_source=ResolutionSource.AUTO,
+        )
+        mocks.media_conflicts.list_resolved.return_value = PaginatedResult(
+            items=[resolved_auto],
+            pagination=Pagination(next_cursor=None, has_more=False),
+        )
+        mocks.movies.find_by_ids.return_value = {}
+
+        use_case = ListConflictsUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            ListConflictsInput(state="resolved", source="auto"),
+        )
+
+        mocks.media_conflicts.list_resolved.assert_awaited_once_with(
+            source=ResolutionSource.AUTO,
+            cursor=None,
+            limit=20,
+        )
+        summary = result.items[0]
+        assert summary.resolution == "merge_replace"
+        assert summary.resolution_source == "auto"
+        assert summary.winner_id == "mov_aaaaaaaaaaaa"
+
+    @pytest.mark.asyncio
+    async def test_invalid_state_raises_validation(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListConflictsUseCase(uow_factory=mocks.factory)
+        with pytest.raises(DomainValidationException):
+            await use_case.execute(ListConflictsInput(state="frozen"))
+
+    @pytest.mark.asyncio
+    async def test_source_filter_with_pending_state_raises_validation(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListConflictsUseCase(uow_factory=mocks.factory)
+        with pytest.raises(DomainValidationException):
+            await use_case.execute(ListConflictsInput(state="pending", source="auto"))
+
+    @pytest.mark.asyncio
+    async def test_invalid_source_raises_validation(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = ListConflictsUseCase(uow_factory=mocks.factory)
+        with pytest.raises(DomainValidationException):
+            await use_case.execute(ListConflictsInput(state="resolved", source="bogus"))

--- a/tests/modules/media/unit/domain/entities/test_media_conflict.py
+++ b/tests/modules/media/unit/domain/entities/test_media_conflict.py
@@ -12,6 +12,7 @@ from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     MediaConflict,
     ResolutionAction,
+    ResolutionSource,
     SuggestedAction,
 )
 
@@ -162,3 +163,47 @@ class TestWinnerIdInvariants:
         conflict = _detect()
         with pytest.raises(DomainValidationException):
             conflict.resolve(ResolutionAction.MERGE_REPLACE, winner_id="mov_cccccccccccc")
+
+
+class TestResolutionSourceInvariants:
+    """``resolution_source`` semantics enforced by the aggregate (ADR-015 Phase 3)."""
+
+    def test_manual_resolution_is_default_source(self) -> None:
+        conflict = _detect()
+        resolved = conflict.resolve(ResolutionAction.MERGE_REPLACE, winner_id=_A)
+        assert resolved.resolution_source is ResolutionSource.MANUAL
+        assert resolved.is_auto_resolved is False
+
+    def test_auto_source_explicitly_marks_aggregate(self) -> None:
+        conflict = _detect()
+        resolved = conflict.resolve(
+            ResolutionAction.MERGE_REPLACE,
+            winner_id=_A,
+            source=ResolutionSource.AUTO,
+        )
+        assert resolved.resolution_source is ResolutionSource.AUTO
+        assert resolved.is_auto_resolved is True
+
+    def test_auto_source_rejected_for_mark_distinct(self) -> None:
+        # AUTO is only for the orphan-merge path; MARK_DISTINCT is
+        # always a deliberate operator decision.
+        conflict = _detect()
+        with pytest.raises(DomainValidationException):
+            conflict.resolve(
+                ResolutionAction.MARK_DISTINCT,
+                source=ResolutionSource.AUTO,
+            )
+
+    def test_resolution_source_forbidden_on_pending_rows(self) -> None:
+        # Directly constructing a pending row with a source set is invalid.
+        with pytest.raises(DomainValidationException):
+            MediaConflict(
+                candidate_a_id=_A,
+                candidate_a_type="movie",
+                candidate_b_id=_B,
+                candidate_b_type="movie",
+                match_reason=MatchReason.TMDB_ID,
+                runtime_delta_minutes=0.0,
+                suggested_action=SuggestedAction.LIKELY_SAME_RELEASE,
+                resolution_source=ResolutionSource.MANUAL,
+            )


### PR DESCRIPTION
## Summary

- Implements **ADR-015 Phase 3 backend**: when the post-enrich detector finds two movies sharing a TMDB id and one is **orphan** (file missing on disk **and** library root still mounted), the freshly-enriched winner silently absorbs it instead of queueing for the admin.
- A resolved-AUTO `MediaConflict` row lands in the audit table; `MovieMergedEvent(is_auto=True)` reuses the Phase 2 cross-BC fan-out (`watch_progress` deletes the loser's rows, `collections` repoints watchlist + custom-list entries).
- New `LibraryHealthPort` (ABC in `media/application/ports`) + `LibraryHealthAdapter` (in `media/infrastructure/acl`) combine a Library UoW lookup with `pathlib.Path.exists` so the use case can answer "is this file accessible?" and "is the library root mounted?" without coupling.
- Library root inaccessible (drive unmounted, transient I/O) falls back to the Phase 1 queue — the safe call is to ask the operator rather than silently delete a Movie whose file might still exist on the missing volume.
- New `ResolutionSource` enum (`MANUAL` | `AUTO`) on the aggregate with invariants enforced: AUTO is forbidden on MARK_DISTINCT; resolution_source moves with resolved_at; manual is the default.
- `GET /api/v1/admin/conflicts` gains `state` (`pending` default | `resolved`) and `source` (`manual` | `auto`, only with `state=resolved`) query params so the operator UI can split the queue from the audit view without a new endpoint.
- Migration `2026_05_24_add_resolution_source_to_media_conflicts` is additive — backfills existing resolved rows to `manual` since every prior resolution came from the Phase 2 admin endpoint.

## Test plan

- [x] 4 new domain unit tests (`ResolutionSource` invariants — default manual, explicit auto, AUTO + MARK_DISTINCT rejected, source forbidden on pending)
- [x] 4 new detector unit tests (orphan + healthy → auto-merge; unhealthy → fallback; accessible files → fallback; port not wired → Phase 1 behaviour)
- [x] 5 new list use-case unit tests (state=resolved + source filter forwarding, invalid state, source+pending, invalid source)
- [x] 3 new repository integration tests (`list_resolved` excludes pending, filters by source=auto, source=None returns both)
- [x] 3 new e2e tests (state=resolved surfaces row + manual source; source=auto returns empty when no auto-merges; invalid state → 422)
- [x] Full project suite: 2 607 passed, 5 skipped
- [x] `ruff check` + `ruff format --check` clean
- [x] Alembic migration round-trips (upgrade → downgrade → upgrade)
- [x] App boots; new query params surface on `/api/v1/admin/conflicts`

## Summary by Sourcery

Implement automatic orphan movie auto-merge with auditability and extend conflict listing to support resolved-history views.

New Features:
- Auto-merge orphan movie candidates detected after enrichment when their files are missing but the library root is accessible, emitting an audit MovieMergedEvent instead of queueing a manual conflict.
- Expose an admin audit view for resolved media conflicts via GET /api/v1/admin/conflicts using new state and source filters to distinguish manual resolutions from auto-merges.

Enhancements:
- Introduce a LibraryHealthPort and LibraryHealthAdapter to encapsulate library and filesystem accessibility checks for media files.
- Extend MediaConflict with a ResolutionSource enum and invariants so each resolved conflict is tagged as manual or auto and surfaced through ConflictSummary.
- Add repository and DTO support to list resolved conflicts with optional resolution-source filtering and include resolution metadata in API responses.

Build:
- Add a new Alembic migration to store resolution_source on media_conflicts and backfill existing resolved rows as manual.

Tests:
- Add unit, integration, and end-to-end tests covering orphan auto-merge behavior, library health fallbacks, resolved-conflict listing with source filters, validation errors for invalid filters, and persistence of resolution_source.