### PR TITLE
feat(media): embed candidate file variants in conflict list

### DIFF
--- a/src/modules/media/application/dtos/conflict_dtos.py
+++ b/src/modules/media/application/dtos/conflict_dtos.py
@@ -60,6 +60,32 @@ class ListConflictsInput:
 
 
 @dataclass(frozen=True)
+class ConflictCandidateFile:
+    """Display-side projection of one file variant of a candidate.
+
+    Gives the operator the on-disk context needed to tell two
+    catalog entries apart (which is the 720p rip, which path moved,
+    etc.) without leaving the conflict queue.
+
+    Attributes:
+        file_path: Absolute path of the variant on disk.
+        resolution: Resolution label (e.g. ``"1080p"``).
+        file_size: Size in bytes; the UI formats it for display.
+        video_codec: Codec label (``"h265"``…) or ``None`` when
+            unprobed.
+        hdr_format: HDR label (``"dolby_vision"``…) or ``None``.
+        is_primary: Whether this is the preferred variant.
+    """
+
+    file_path: str
+    resolution: str
+    file_size: int
+    video_codec: str | None
+    hdr_format: str | None
+    is_primary: bool
+
+
+@dataclass(frozen=True)
 class ConflictCandidateSummary:
     """Display-side projection of one side of a conflict pair.
 
@@ -70,12 +96,16 @@ class ConflictCandidateSummary:
             the underlying entity has disappeared (soft-deleted or
             hard-deleted out of band).
         year: Release year, when available.
+        files: File variants of the candidate, so the operator can
+            compare paths / resolutions side by side. Empty when the
+            entity has vanished or carries no variants.
     """
 
     media_id: str
     media_type: str
     title: str | None
     year: int | None
+    files: list[ConflictCandidateFile]
 
 
 @dataclass(frozen=True)
@@ -172,6 +202,7 @@ class ListConflictsOutput:
 
 
 __all__ = [
+    "ConflictCandidateFile",
     "ConflictCandidateSummary",
     "ConflictSummary",
     "DetectMovieConflictsInput",

--- a/src/modules/media/application/use_cases/list_conflicts.py
+++ b/src/modules/media/application/use_cases/list_conflicts.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.media.application.dtos.conflict_dtos import (
+    ConflictCandidateFile,
     ConflictCandidateSummary,
     ConflictSummary,
     ListConflictsInput,
@@ -20,6 +21,7 @@ from src.modules.media.domain.value_objects import MovieId
 if TYPE_CHECKING:
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
     from src.modules.media.domain.entities.movie import Movie
+    from src.modules.media.domain.value_objects import MediaFile
 
 _VALID_STATES = ("pending", "resolved")
 _VALID_SOURCES = ("manual", "auto")
@@ -167,12 +169,26 @@ def _build_candidate(
                 media_type=media_type,
                 title=movie.title.value,
                 year=movie.year.value,
+                files=[_build_file(f) for f in movie.files],
             )
     return ConflictCandidateSummary(
         media_id=media_id,
         media_type=media_type,
         title=None,
         year=None,
+        files=[],
+    )
+
+
+def _build_file(file: MediaFile) -> ConflictCandidateFile:
+    """Project a ``MediaFile`` variant into its display DTO."""
+    return ConflictCandidateFile(
+        file_path=file.file_path.value,
+        resolution=file.resolution.value,
+        file_size=file.file_size,
+        video_codec=None if file.video_codec is None else file.video_codec.value,
+        hdr_format=None if file.hdr_format is None else file.hdr_format.value,
+        is_primary=file.is_primary,
     )
 
 

--- a/tests/modules/media/e2e/test_admin_conflicts_routes.py
+++ b/tests/modules/media/e2e/test_admin_conflicts_routes.py
@@ -191,6 +191,27 @@ class TestAdminConflictsList:
             "different_edit_suspected",
         }
 
+    async def test_candidate_embeds_file_variants(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        _, a_id, b_id = await _seed_pair_with_conflict(session_factory)
+
+        response = await client.get(CONFLICTS_PATH)
+
+        assert response.status_code == 200
+        row = response.json()["data"][0]
+        files = row["candidate_a"]["files"]
+        assert len(files) == 1
+        assert files[0]["file_path"] == f"/movies/{a_id}.mkv"
+        assert files[0]["resolution"] == "1080p"
+        assert files[0]["file_size"] == 1_000_000_000
+        assert files[0]["is_primary"] is True
+        assert row["candidate_b"]["files"][0]["file_path"] == f"/movies/{b_id}.mkv"
+
     async def test_pagination_returns_next_cursor(
         self,
         client: AsyncClient,

--- a/tests/modules/media/unit/application/use_cases/test_list_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_conflicts.py
@@ -15,11 +15,15 @@ from src.modules.media.domain.entities.media_conflict import (
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.value_objects import (
     Duration,
+    MediaFile,
     MovieId,
+    Resolution,
     Title,
+    VideoCodec,
     Year,
 )
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+from src.shared_kernel.value_objects.file_path import FilePath
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
@@ -43,13 +47,20 @@ def _conflict(
     return detected.with_updates(id=MediaConflictId(conflict_id))
 
 
-def _movie(*, external_id: str, title: str, year: int = 2020) -> Movie:
+def _movie(
+    *,
+    external_id: str,
+    title: str,
+    year: int = 2020,
+    files: list[MediaFile] | None = None,
+) -> Movie:
     return Movie(
         id=MovieId(external_id),
         library_id="lib_test12345678",
         title=Title(title),
         year=Year(year),
         duration=Duration(7200),
+        files=files or [],
     )
 
 
@@ -118,6 +129,46 @@ class TestListConflictsUseCase:
         assert summary.candidate_a.title == "Lhs"
         assert summary.candidate_b.title is None
         assert summary.candidate_b.year is None
+
+    @pytest.mark.asyncio
+    async def test_projects_file_variants_for_movie_candidates(self) -> None:
+        mocks = make_media_uow_mock()
+        conflict = _conflict(a_id="mov_aaaaaaaaaaaa", b_id="mov_bbbbbbbbbbbb")
+        mocks.media_conflicts.list_pending.return_value = PaginatedResult(
+            items=[conflict],
+            pagination=Pagination(next_cursor=None, has_more=False),
+        )
+        mocks.movies.find_by_ids.return_value = {
+            "mov_aaaaaaaaaaaa": _movie(
+                external_id="mov_aaaaaaaaaaaa",
+                title="Lhs",
+                files=[
+                    MediaFile(
+                        file_path=FilePath("/movies/lhs_1080p.mkv"),
+                        file_size=4_000_000_000,
+                        resolution=Resolution("1080p"),
+                        video_codec=VideoCodec.H265,
+                        is_primary=True,
+                    ),
+                ],
+            ),
+            "mov_bbbbbbbbbbbb": _movie(external_id="mov_bbbbbbbbbbbb", title="Rhs"),
+        }
+
+        use_case = ListConflictsUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(ListConflictsInput())
+
+        summary = result.items[0]
+        assert len(summary.candidate_a.files) == 1
+        file = summary.candidate_a.files[0]
+        assert file.file_path == "/movies/lhs_1080p.mkv"
+        assert file.resolution == "1080p"
+        assert file.file_size == 4_000_000_000
+        assert file.video_codec == "h265"
+        assert file.hdr_format is None
+        assert file.is_primary is True
+        # A movie with no variants surfaces an empty list, not None.
+        assert summary.candidate_b.files == []
 
     @pytest.mark.asyncio
     async def test_series_candidate_skips_movie_lookup_for_that_side(self) -> None:


### PR DESCRIPTION
## Summary

- Add `ConflictCandidateFile` DTO and a `files` list on `ConflictCandidateSummary`, projecting each candidate's file variants (path, resolution, size, codec, HDR, primary flag).
- Populate it in `ListConflictsUseCase._build_candidate` from `movie.files`; vanished or variant-less candidates surface an empty list.
- Serialization is automatic — the route already `asdict`s the DTO, so the new nested field flows straight to the `/admin/conflicts` response.
- Gives the operator on-disk context (which entry is the 720p rip, which path moved) before deciding a merge.

## Test plan

- [x] `pytest tests/modules/media/unit/application/use_cases/test_list_conflicts.py` — new projection test (path/resolution/size/codec/primary) + empty-list fallback.
- [x] `pytest tests/modules/media/e2e/test_admin_conflicts_routes.py` — candidate row embeds `files` for both sides.
- [x] `pytest tests/modules/media/` — full module suite (1411 passed).
- [x] `ruff check` + `ruff format --check` clean.

## Summary by Sourcery

Embed media file variant details into conflict candidates returned by the admin conflicts listing API to give operators on-disk context when resolving conflicts.

New Features:
- Expose a list of file variants on each conflict candidate, including path, resolution, size, codec, HDR format, and primary flag, in the conflicts DTO and API response.

Tests:
- Add unit coverage to ensure movie conflict candidates project file variant attributes and fall back to an empty list when no variants exist.
- Add end-to-end test verifying that the /admin/conflicts route embeds file variants for each candidate in the response payload.