### PR TITLE
feat(settings): tunable scan-dedup runtime-delta thresholds

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -560,6 +560,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         uow_factory=media_unit_of_work_factory,
         library_health=library_health,
         event_bus=event_bus,
+        runtime_settings=runtime_settings,
     )
 
     list_conflicts = providers.Factory(

--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     )
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
     from src.modules.media.domain.entities.movie import Movie
+    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = logging.getLogger(__name__)
 
@@ -63,6 +64,11 @@ class DetectMovieConflictsUseCase:
             and every collision goes to the queue.
         event_bus: Optional event bus. When ``None`` no events are
             published — handy for unit tests.
+        runtime_settings: Optional ``scan_dedup`` runtime settings
+            source (ADR-013). When provided, the runtime-delta
+            thresholds that classify a pending conflict come from the
+            persisted bucket; ``None`` keeps the ADR-015 class-level
+            defaults.
     """
 
     def __init__(
@@ -70,10 +76,12 @@ class DetectMovieConflictsUseCase:
         uow_factory: MediaUnitOfWorkFactory,
         library_health: LibraryHealthPort | None = None,
         event_bus: EventBus | None = None,
+        runtime_settings: RuntimeSettings | None = None,
     ) -> None:
         self._uow_factory = uow_factory
         self._library_health = library_health
         self._event_bus = event_bus
+        self._runtime_settings = runtime_settings
 
     async def execute(
         self,
@@ -83,6 +91,8 @@ class DetectMovieConflictsUseCase:
         created_ids: list[str] = []
         detected_events: list[MediaConflictDetectedEvent] = []
         merged_events: list[MovieMergedEvent] = []
+
+        abs_threshold, relative_threshold = await self._delta_thresholds()
 
         async with self._uow_factory() as uow:
             candidates = await uow.movies.find_all_by_tmdb_id(input_dto.tmdb_id)
@@ -135,6 +145,8 @@ class DetectMovieConflictsUseCase:
                     candidate_b_type="movie",
                     candidate_b_runtime_minutes=_runtime_minutes(other),
                     match_reason=MatchReason.TMDB_ID,
+                    abs_threshold_minutes=abs_threshold,
+                    relative_threshold=relative_threshold,
                 )
                 persisted = await uow.media_conflicts.save(conflict)
                 created_ids.append(str(persisted.id))
@@ -160,6 +172,18 @@ class DetectMovieConflictsUseCase:
             conflicts_created=len(created_ids),
             conflict_ids=created_ids,
         )
+
+    async def _delta_thresholds(self) -> tuple[float | None, float | None]:
+        """Read the tunable runtime-delta bounds from ``scan_dedup``.
+
+        Returns ``(None, None)`` when no runtime-settings source is
+        wired, so :meth:`MediaConflict.detect` falls back to the
+        class-level defaults.
+        """
+        if self._runtime_settings is None:
+            return None, None
+        config = await self._runtime_settings.scan_dedup()
+        return config.runtime_delta_abs_minutes, config.runtime_delta_relative
 
     async def _is_orphan(self, movie: Movie) -> bool:
         """``True`` when every file of ``movie`` is missing and the library is healthy.

--- a/src/modules/media/domain/entities/media_conflict.py
+++ b/src/modules/media/domain/entities/media_conflict.py
@@ -182,12 +182,34 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         candidate_b_type: str,
         candidate_b_runtime_minutes: float | None,
         match_reason: MatchReason,
+        abs_threshold_minutes: float | None = None,
+        relative_threshold: float | None = None,
     ) -> Self:
         """Build a fresh ``MediaConflict`` from a detected pair.
 
         Computes ``runtime_delta_minutes`` (when both runtimes are
-        available) and derives ``suggested_action`` using the
-        class-level thresholds.
+        available) and derives ``suggested_action`` from the
+        runtime-delta heuristic.
+
+        Args:
+            candidate_a_id: External id of one side (e.g. ``mov_xxx``).
+            candidate_a_type: ``"movie"`` (Phase 1) or ``"series"``.
+            candidate_a_runtime_minutes: Runtime of side A, in minutes,
+                or ``None`` when unknown.
+            candidate_b_id: External id of the other side.
+            candidate_b_type: Same contract as ``candidate_a_type``.
+            candidate_b_runtime_minutes: Runtime of side B, in minutes,
+                or ``None`` when unknown.
+            match_reason: Which identity rule fired the collision.
+            abs_threshold_minutes: Absolute runtime-delta ceiling, in
+                minutes. ``None`` falls back to
+                :attr:`RUNTIME_DELTA_ABS_MINUTES_THRESHOLD`. Supplied by
+                the detector from the ``scan_dedup`` runtime settings
+                bucket (ADR-013) so operators can tune it without a
+                deploy.
+            relative_threshold: Relative ceiling as a fraction of the
+                shorter runtime. ``None`` falls back to
+                :attr:`RUNTIME_DELTA_RELATIVE_THRESHOLD`.
 
         Returns:
             New ``MediaConflict`` instance, pending and unsaved.
@@ -197,7 +219,11 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
             candidate_b_runtime_minutes,
         )
         action = cls._derive_suggested_action(
-            delta, candidate_a_runtime_minutes, candidate_b_runtime_minutes
+            delta,
+            candidate_a_runtime_minutes,
+            candidate_b_runtime_minutes,
+            abs_threshold_minutes=abs_threshold_minutes,
+            relative_threshold=relative_threshold,
         )
         return cls(
             candidate_a_id=candidate_a_id,
@@ -215,8 +241,15 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         delta_minutes: float | None,
         runtime_a: float | None,
         runtime_b: float | None,
+        *,
+        abs_threshold_minutes: float | None = None,
+        relative_threshold: float | None = None,
     ) -> SuggestedAction:
-        """Apply the two-bound rule from ADR-015 to derive the hint."""
+        """Apply the two-bound rule from ADR-015 to derive the hint.
+
+        ``None`` thresholds fall back to the class-level defaults, so
+        callers that don't tune the bounds keep the ADR-015 behaviour.
+        """
         if delta_minutes is None or runtime_a is None or runtime_b is None:
             return SuggestedAction.LIKELY_SAME_RELEASE
 
@@ -224,8 +257,19 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         if smaller <= 0:
             return SuggestedAction.LIKELY_SAME_RELEASE
 
-        exceeds_abs = delta_minutes > cls.RUNTIME_DELTA_ABS_MINUTES_THRESHOLD
-        exceeds_rel = (delta_minutes / smaller) > cls.RUNTIME_DELTA_RELATIVE_THRESHOLD
+        abs_bound = (
+            cls.RUNTIME_DELTA_ABS_MINUTES_THRESHOLD
+            if abs_threshold_minutes is None
+            else abs_threshold_minutes
+        )
+        rel_bound = (
+            cls.RUNTIME_DELTA_RELATIVE_THRESHOLD
+            if relative_threshold is None
+            else relative_threshold
+        )
+
+        exceeds_abs = delta_minutes > abs_bound
+        exceeds_rel = (delta_minutes / smaller) > rel_bound
         if exceeds_abs and exceeds_rel:
             return SuggestedAction.DIFFERENT_EDIT_SUSPECTED
         return SuggestedAction.LIKELY_SAME_RELEASE

--- a/src/modules/settings/domain/entities/setting.py
+++ b/src/modules/settings/domain/entities/setting.py
@@ -11,6 +11,7 @@ from src.modules.settings.domain.value_objects import (
     AvatarConfig,
     ConfigVO,
     IntroDetectionConfig,
+    ScanDedupConfig,
     SchedulerConfig,
     SettingKey,
     SettingSource,
@@ -64,6 +65,7 @@ class Setting(AggregateRoot[SettingKey]):
         SettingKey.INTRO_DETECTION: IntroDetectionConfig,
         SettingKey.STREAMING: StreamingConfig,
         SettingKey.AVATAR: AvatarConfig,
+        SettingKey.SCAN_DEDUP: ScanDedupConfig,
     }
 
     @model_validator(mode="after")

--- a/src/modules/settings/domain/value_objects/__init__.py
+++ b/src/modules/settings/domain/value_objects/__init__.py
@@ -10,6 +10,7 @@ from src.modules.settings.domain.value_objects.avatar_config import AvatarConfig
 from src.modules.settings.domain.value_objects.intro_detection_config import (
     IntroDetectionConfig,
 )
+from src.modules.settings.domain.value_objects.scan_dedup_config import ScanDedupConfig
 from src.modules.settings.domain.value_objects.scheduler_config import SchedulerConfig
 from src.modules.settings.domain.value_objects.setting_key import SettingKey
 from src.modules.settings.domain.value_objects.setting_source import SettingSource
@@ -24,6 +25,7 @@ ConfigVO = (
     | IntroDetectionConfig
     | StreamingConfig
     | AvatarConfig
+    | ScanDedupConfig
 )
 """Union of all configuration VOs persisted in ``app_settings``."""
 
@@ -31,6 +33,7 @@ __all__ = [
     "AvatarConfig",
     "ConfigVO",
     "IntroDetectionConfig",
+    "ScanDedupConfig",
     "SchedulerConfig",
     "SettingKey",
     "SettingSource",

--- a/src/modules/settings/domain/value_objects/scan_dedup_config.py
+++ b/src/modules/settings/domain/value_objects/scan_dedup_config.py
@@ -1,0 +1,36 @@
+"""Scanner deduplication tunables — content-identity conflict detector."""
+
+from pydantic import Field
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+
+
+class ScanDedupConfig(CompoundValueObject):
+    """Operational knobs for the post-enrich conflict detector (ADR-015).
+
+    Controls the runtime-delta heuristic that classifies a detected
+    content-identity collision as either a likely same release or a
+    suspected different edit (Director's Cut / Theatrical). A pair is
+    only flagged as a suspected different edit when its runtime delta
+    exceeds BOTH bounds — either alone is satisfied by routine
+    encoding/cropping differences and would over-trigger.
+
+    Attributes:
+        runtime_delta_abs_minutes: Absolute runtime-delta ceiling, in
+            minutes. Deltas at or below this are treated as the same
+            release regardless of the relative bound.
+        runtime_delta_relative: Relative runtime-delta ceiling as a
+            fraction of the shorter runtime (``0.10`` = 10%). Deltas at
+            or below this are treated as the same release regardless of
+            the absolute bound.
+
+    Example:
+        >>> cfg = ScanDedupConfig()
+        >>> stricter = cfg.with_updates(runtime_delta_abs_minutes=3.0)
+    """
+
+    runtime_delta_abs_minutes: float = Field(default=5.0, ge=0.0)
+    runtime_delta_relative: float = Field(default=0.10, ge=0.0, le=1.0)
+
+
+__all__ = ["ScanDedupConfig"]

--- a/src/modules/settings/domain/value_objects/setting_key.py
+++ b/src/modules/settings/domain/value_objects/setting_key.py
@@ -20,6 +20,7 @@ class SettingKey(StrEnum):
     INTRO_DETECTION = "intro_detection"
     STREAMING = "streaming"
     AVATAR = "avatar"
+    SCAN_DEDUP = "scan_dedup"
 
 
 __all__ = ["SettingKey"]

--- a/src/modules/settings/infrastructure/persistence/mappers/setting_mapper.py
+++ b/src/modules/settings/infrastructure/persistence/mappers/setting_mapper.py
@@ -8,6 +8,7 @@ from src.modules.settings.domain.value_objects import (
     AvatarConfig,
     ConfigVO,
     IntroDetectionConfig,
+    ScanDedupConfig,
     SchedulerConfig,
     SettingKey,
     SettingSource,
@@ -35,6 +36,7 @@ class SettingMapper:
         SettingKey.INTRO_DETECTION: IntroDetectionConfig,
         SettingKey.STREAMING: StreamingConfig,
         SettingKey.AVATAR: AvatarConfig,
+        SettingKey.SCAN_DEDUP: ScanDedupConfig,
     }
 
     @staticmethod

--- a/src/modules/settings/infrastructure/runtime_settings.py
+++ b/src/modules/settings/infrastructure/runtime_settings.py
@@ -32,6 +32,7 @@ from src.modules.settings.domain.value_objects import (
     AvatarConfig,
     ConfigVO,
     IntroDetectionConfig,
+    ScanDedupConfig,
     SchedulerConfig,
     SettingKey,
     StreamingConfig,
@@ -50,6 +51,7 @@ _DEFAULT_FACTORIES: dict[SettingKey, type[ConfigVO]] = {
     SettingKey.INTRO_DETECTION: IntroDetectionConfig,
     SettingKey.STREAMING: StreamingConfig,
     SettingKey.AVATAR: AvatarConfig,
+    SettingKey.SCAN_DEDUP: ScanDedupConfig,
 }
 
 
@@ -163,6 +165,11 @@ class RuntimeSettings:
         """Return the current :class:`AvatarConfig` snapshot."""
         await self._ensure_fresh()
         return cast(AvatarConfig, self._snapshot[SettingKey.AVATAR])
+
+    async def scan_dedup(self) -> ScanDedupConfig:
+        """Return the current :class:`ScanDedupConfig` snapshot."""
+        await self._ensure_fresh()
+        return cast(ScanDedupConfig, self._snapshot[SettingKey.SCAN_DEDUP])
 
 
 __all__ = ["RuntimeSettings"]

--- a/src/modules/settings/presentation/routes/admin_settings_routes.py
+++ b/src/modules/settings/presentation/routes/admin_settings_routes.py
@@ -25,6 +25,7 @@ from src.modules.settings.application.use_cases import (
 from src.modules.settings.domain.value_objects import (
     AvatarConfig,
     IntroDetectionConfig,
+    ScanDedupConfig,
     SchedulerConfig,
     SettingKey,
     StreamingConfig,
@@ -145,6 +146,26 @@ async def update_avatar_settings(
     detail = await use_case.execute(
         UpdateSettingInput(
             key=SettingKey.AVATAR.value,
+            value=body.model_dump(mode="json"),
+            acting_admin_id=admin.external_id,
+        ),
+    )
+    return api_single("setting", asdict(detail))
+
+
+@router.patch("/scan-dedup")
+@inject
+async def update_scan_dedup_settings(
+    body: ScanDedupConfig,
+    admin: UserModel = Depends(current_admin_user),
+    use_case: UpdateSettingUseCase = Depends(
+        Provide[ApplicationContainer.settings.update_setting],
+    ),
+) -> dict[str, Any]:
+    """Replace the persisted :class:`ScanDedupConfig`."""
+    detail = await use_case.execute(
+        UpdateSettingInput(
+            key=SettingKey.SCAN_DEDUP.value,
             value=body.model_dump(mode="json"),
             acting_admin_id=admin.external_id,
         ),

--- a/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
@@ -14,6 +14,7 @@ from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     ResolutionAction,
     ResolutionSource,
+    SuggestedAction,
 )
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.events import (
@@ -31,6 +32,7 @@ from src.modules.media.domain.value_objects import (
     Year,
 )
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+from src.modules.settings.domain.value_objects import ScanDedupConfig
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
@@ -124,6 +126,35 @@ class TestDetectMovieConflictsUseCase:
         assert isinstance(published, MediaConflictDetectedEvent)
         assert published.candidate_a_id == "mov_abcdefghijkl"
         assert published.candidate_b_id == "mov_mnopqrstuvwx"
+
+    @pytest.mark.asyncio
+    async def test_tunable_thresholds_from_settings_flag_different_edit(self) -> None:
+        # delta 7320 - 7200 = 120s = 2.0 min — LIKELY_SAME under the
+        # ADR-015 defaults, but DIFFERENT_EDIT under the strict bucket.
+        mocks = make_media_uow_mock()
+        self_movie = _build_movie(external_id="mov_abcdefghijkl", duration_seconds=7200)
+        other = _build_movie(external_id="mov_mnopqrstuvwx", duration_seconds=7320)
+        mocks.movies.find_all_by_tmdb_id.return_value = [self_movie, other]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+
+        runtime_settings = AsyncMock()
+        runtime_settings.scan_dedup.return_value = ScanDedupConfig(
+            runtime_delta_abs_minutes=1.0,
+            runtime_delta_relative=0.005,
+        )
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            runtime_settings=runtime_settings,
+        )
+
+        await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_abcdefghijkl", tmdb_id=27205),
+        )
+
+        saved_conflict = mocks.media_conflicts.save.call_args[0][0]
+        assert saved_conflict.suggested_action is SuggestedAction.DIFFERENT_EDIT_SUSPECTED
+        runtime_settings.scan_dedup.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_existing_pending_pair_is_skipped(self) -> None:

--- a/tests/modules/media/unit/domain/entities/test_media_conflict.py
+++ b/tests/modules/media/unit/domain/entities/test_media_conflict.py
@@ -74,6 +74,64 @@ class TestDetect:
         assert conflict.suggested_action is SuggestedAction.LIKELY_SAME_RELEASE
 
 
+class TestTunableThresholds:
+    """``detect`` honours caller-supplied runtime-delta bounds (ADR-015 Phase 4)."""
+
+    def test_stricter_thresholds_flag_a_default_likely_same_pair(self) -> None:
+        # 5 min / 4.2% delta — LIKELY_SAME under the defaults.
+        baseline = MediaConflict.detect(
+            candidate_a_id=_A,
+            candidate_a_type="movie",
+            candidate_a_runtime_minutes=120.0,
+            candidate_b_id=_B,
+            candidate_b_type="movie",
+            candidate_b_runtime_minutes=125.0,
+            match_reason=MatchReason.TMDB_ID,
+        )
+        assert baseline.suggested_action is SuggestedAction.LIKELY_SAME_RELEASE
+
+        stricter = MediaConflict.detect(
+            candidate_a_id=_A,
+            candidate_a_type="movie",
+            candidate_a_runtime_minutes=120.0,
+            candidate_b_id=_B,
+            candidate_b_type="movie",
+            candidate_b_runtime_minutes=125.0,
+            match_reason=MatchReason.TMDB_ID,
+            abs_threshold_minutes=2.0,
+            relative_threshold=0.01,
+        )
+        assert stricter.suggested_action is SuggestedAction.DIFFERENT_EDIT_SUSPECTED
+
+    def test_looser_thresholds_absorb_a_default_different_edit_pair(self) -> None:
+        looser = MediaConflict.detect(
+            candidate_a_id=_A,
+            candidate_a_type="movie",
+            candidate_a_runtime_minutes=138.0,
+            candidate_b_id=_B,
+            candidate_b_type="movie",
+            candidate_b_runtime_minutes=192.0,
+            match_reason=MatchReason.TMDB_ID,
+            abs_threshold_minutes=60.0,
+            relative_threshold=0.50,
+        )
+        assert looser.suggested_action is SuggestedAction.LIKELY_SAME_RELEASE
+
+    def test_none_thresholds_fall_back_to_class_defaults(self) -> None:
+        explicit = MediaConflict.detect(
+            candidate_a_id=_A,
+            candidate_a_type="movie",
+            candidate_a_runtime_minutes=138.0,
+            candidate_b_id=_B,
+            candidate_b_type="movie",
+            candidate_b_runtime_minutes=192.0,
+            match_reason=MatchReason.TMDB_ID,
+            abs_threshold_minutes=None,
+            relative_threshold=None,
+        )
+        assert explicit.suggested_action is SuggestedAction.DIFFERENT_EDIT_SUSPECTED
+
+
 class TestInvariants:
     """Domain invariants enforced by the aggregate."""
 

--- a/tests/modules/settings/e2e/test_admin_settings_routes.py
+++ b/tests/modules/settings/e2e/test_admin_settings_routes.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 
 from src.modules.settings.domain.value_objects import (
     IntroDetectionConfig,
+    ScanDedupConfig,
     SchedulerConfig,
 )
 from tests.modules.settings.e2e.conftest import SeededUser
@@ -92,6 +93,7 @@ class TestAdminSettingsList:
                 "intro_detection",
                 "streaming",
                 "avatar",
+                "scan_dedup",
             ]
         )
         for entry in body["data"]:
@@ -189,3 +191,37 @@ class TestAdminSettingsPatch:
         list_resp = await client.get(SETTINGS_ROOT)
         scheduler_entry = next(d for d in list_resp.json()["data"] if d["key"] == "scheduler")
         assert scheduler_entry["value"]["reconcile_interval_minutes"] == 7
+
+    async def test_scan_dedup_full_replace_persists_thresholds(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await _login_as_admin(client, seed_user_with_profile)
+
+        body = ScanDedupConfig(
+            runtime_delta_abs_minutes=3.0,
+            runtime_delta_relative=0.05,
+        ).model_dump(mode="json")
+        response = await client.patch(f"{SETTINGS_ROOT}/scan-dedup", json=body)
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["key"] == "scan_dedup"
+        assert payload["source"] == "admin"
+        assert payload["updated_by_user_id"] == admin.user_external_id
+        assert payload["value"]["runtime_delta_abs_minutes"] == 3.0
+        assert payload["value"]["runtime_delta_relative"] == 0.05
+
+    async def test_scan_dedup_rejects_out_of_range_relative(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+
+        body = ScanDedupConfig().model_dump(mode="json")
+        body["runtime_delta_relative"] = 1.5
+        response = await client.patch(f"{SETTINGS_ROOT}/scan-dedup", json=body)
+
+        assert response.status_code == 422

--- a/tests/modules/settings/unit/domain/value_objects/test_scan_dedup_config.py
+++ b/tests/modules/settings/unit/domain/value_objects/test_scan_dedup_config.py
@@ -1,0 +1,32 @@
+"""Unit tests for :class:`ScanDedupConfig`."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.settings.domain.value_objects import ScanDedupConfig
+
+
+class TestScanDedupConfig:
+    def test_default_values_match_adr_thresholds(self) -> None:
+        config = ScanDedupConfig()
+
+        assert config.runtime_delta_abs_minutes == 5.0
+        assert config.runtime_delta_relative == 0.10
+
+    def test_negative_abs_minutes_raises(self) -> None:
+        with pytest.raises(DomainValidationException):
+            ScanDedupConfig(runtime_delta_abs_minutes=-1.0)
+
+    def test_relative_above_one_raises(self) -> None:
+        with pytest.raises(DomainValidationException):
+            ScanDedupConfig(runtime_delta_relative=1.5)
+
+    def test_relative_below_zero_raises(self) -> None:
+        with pytest.raises(DomainValidationException):
+            ScanDedupConfig(runtime_delta_relative=-0.01)
+
+    def test_with_updates_revalidates_bounds(self) -> None:
+        config = ScanDedupConfig()
+
+        with pytest.raises(DomainValidationException):
+            config.with_updates(runtime_delta_relative=2.0)


### PR DESCRIPTION
## Summary

- Add a new `scan_dedup` runtime-settings bucket (ADR-013/ADR-014) — `ScanDedupConfig` with `runtime_delta_abs_minutes` (default 5.0) and `runtime_delta_relative` (default 0.10), registered across `SettingKey`, the `Setting` aggregate, `SettingMapper`, `RuntimeSettings`, and a `PATCH /admin/settings/scan-dedup` route.
- Parametrize `MediaConflict.detect()` / `_derive_suggested_action()` with optional abs + relative thresholds (default to the ADR-015 class constants).
- Inject `RuntimeSettings` into `DetectMovieConflictsUseCase`; it reads `scan_dedup()` once per run and feeds the bounds into detection, so the `LIKELY_SAME_RELEASE` vs `DIFFERENT_EDIT_SUSPECTED` classification is tunable without a deploy. No runtime-settings source → class defaults (unchanged behaviour).
- ADR-015 Phase 4a (first of three: thresholds → bulk mark-distinct → title+year fallback matcher).

## Test plan

- [x] `pytest tests/modules/settings/unit/domain/value_objects/test_scan_dedup_config.py` — defaults + bound validation.
- [x] `pytest tests/modules/media/unit/domain/entities/test_media_conflict.py` — stricter/looser thresholds flip the suggested action; `None` falls back to defaults.
- [x] `pytest tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py` — detector reads `scan_dedup` and applies the bucket thresholds.
- [x] `pytest tests/modules/settings/e2e/test_admin_settings_routes.py` — `PATCH /scan-dedup` round-trip + bucket appears in the list + 422 on out-of-range.
- [x] `pytest tests/modules/media tests/modules/settings` — 1468 passed, 5 skipped.
- [x] `ruff check` + `ruff format --check` clean.

## Migration steps

None — the `app_settings` table already exists (single-table key/value JSON per ADR-013); the new bucket relies on Pydantic field defaults when no row is present.

## Summary by Sourcery

Introduce tunable runtime-delta thresholds for media conflict detection and expose them as a new scan-dedup runtime settings bucket, wiring them into movie conflict detection and admin settings APIs.

New Features:
- Add ScanDedupConfig value object with configurable absolute and relative runtime-delta thresholds and register it as a new scan_dedup settings bucket.
- Expose PATCH /admin/settings/scan-dedup endpoint for updating scan-dedup runtime configuration.
- Make MediaConflict.detect accept optional absolute and relative runtime-delta thresholds and use them when deriving the suggested action.
- Inject RuntimeSettings into DetectMovieConflictsUseCase so conflict detection uses persisted scan_dedup thresholds at runtime instead of fixed class defaults.

Tests:
- Add unit tests for ScanDedupConfig defaults and validation rules.
- Extend media conflict entity tests to cover caller-supplied thresholds and default fallback behaviour.
- Extend DetectMovieConflicts use case tests to verify thresholds are read from runtime settings.
- Extend admin settings E2E tests to cover scan_dedup bucket persistence and validation.