### PR TITLE
feat(media): bulk mark-distinct for conflict queue

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -11,6 +11,9 @@ from src.modules.media.application.use_cases.add_file_variant import AddFileVari
 from src.modules.media.application.use_cases.bulk_enrich_metadata import (
     BulkEnrichMetadataUseCase,
 )
+from src.modules.media.application.use_cases.bulk_mark_distinct_conflicts import (
+    BulkMarkDistinctConflictsUseCase,
+)
 from src.modules.media.application.use_cases.clear_episode_intro import ClearEpisodeIntroUseCase
 from src.modules.media.application.use_cases.clear_hls_cache import ClearHlsCacheUseCase
 from src.modules.media.application.use_cases.clear_hls_cache_global import (
@@ -572,6 +575,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         ResolveMediaConflictUseCase,
         uow_factory=media_unit_of_work_factory,
         event_bus=event_bus,
+    )
+
+    bulk_mark_distinct_conflicts = providers.Factory(
+        BulkMarkDistinctConflictsUseCase,
+        uow_factory=media_unit_of_work_factory,
     )
 
     # =========================================================================

--- a/src/modules/media/application/dtos/conflict_dtos.py
+++ b/src/modules/media/application/dtos/conflict_dtos.py
@@ -185,6 +185,48 @@ class ResolveMediaConflictOutput:
 
 
 @dataclass(frozen=True)
+class BulkMarkDistinctInput:
+    """Input for the bulk mark-distinct endpoint (ADR-015 Phase 4).
+
+    Attributes:
+        conflict_ids: External ids (``cnf_xxx``) of the pending
+            conflicts to mark as intentionally distinct. Duplicates
+            are de-duplicated; order is preserved.
+    """
+
+    conflict_ids: list[str]
+
+
+@dataclass(frozen=True)
+class BulkSkippedConflict:
+    """One conflict the bulk operation could not resolve.
+
+    Attributes:
+        conflict_id: External id that was skipped.
+        reason: ``"not_found"``, ``"already_resolved"`` or
+            ``"invalid_id"``.
+    """
+
+    conflict_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class BulkMarkDistinctOutput:
+    """Result summary after the bulk mark-distinct use case commits.
+
+    Attributes:
+        requested: How many distinct ids the caller asked to resolve.
+        resolved_ids: Ids that were pending and are now MARK_DISTINCT.
+        skipped: Ids that were not resolved, each with a reason.
+    """
+
+    requested: int
+    resolved_ids: list[str]
+    skipped: list[BulkSkippedConflict]
+
+
+@dataclass(frozen=True)
 class ListConflictsOutput:
     """Paginated list of conflicts.
 
@@ -202,6 +244,9 @@ class ListConflictsOutput:
 
 
 __all__ = [
+    "BulkMarkDistinctInput",
+    "BulkMarkDistinctOutput",
+    "BulkSkippedConflict",
     "ConflictCandidateFile",
     "ConflictCandidateSummary",
     "ConflictSummary",

--- a/src/modules/media/application/use_cases/bulk_mark_distinct_conflicts.py
+++ b/src/modules/media/application/use_cases/bulk_mark_distinct_conflicts.py
@@ -1,0 +1,90 @@
+"""Bulk mark-distinct resolution for queued conflicts (ADR-015 Phase 4)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.media.application.dtos.conflict_dtos import (
+    BulkMarkDistinctInput,
+    BulkMarkDistinctOutput,
+    BulkSkippedConflict,
+)
+from src.modules.media.domain.entities.media_conflict import ResolutionAction
+from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+
+if TYPE_CHECKING:
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+
+class BulkMarkDistinctConflictsUseCase:
+    """Mark many pending conflicts as intentionally distinct in one pass.
+
+    Bulk resolution is intentionally limited to ``MARK_DISTINCT`` (the
+    operator says "these really are different editions"). Unlike the
+    MERGE actions it needs no per-conflict winner and triggers no
+    soft-delete or cross-BC fan-out, so a whole selection can be
+    closed safely in a single transaction.
+
+    Each id is handled independently: ids that don't exist, are
+    already resolved, or are malformed are skipped (with a reason)
+    rather than aborting the batch. The detector will not re-queue a
+    MARK_DISTINCT pair (see ``find_blocking_pair``).
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+    """
+
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(
+        self,
+        input_dto: BulkMarkDistinctInput,
+    ) -> BulkMarkDistinctOutput:
+        """Resolve every pending id as MARK_DISTINCT; skip the rest."""
+        unique_ids = _dedupe_preserving_order(input_dto.conflict_ids)
+
+        resolved_ids: list[str] = []
+        skipped: list[BulkSkippedConflict] = []
+
+        async with self._uow_factory() as uow:
+            for raw_id in unique_ids:
+                try:
+                    conflict_id = MediaConflictId(raw_id)
+                except DomainValidationException:
+                    skipped.append(BulkSkippedConflict(raw_id, "invalid_id"))
+                    continue
+
+                conflict = await uow.media_conflicts.find_by_id(conflict_id)
+                if conflict is None:
+                    skipped.append(BulkSkippedConflict(raw_id, "not_found"))
+                    continue
+                if conflict.is_resolved:
+                    skipped.append(BulkSkippedConflict(raw_id, "already_resolved"))
+                    continue
+
+                resolved = conflict.resolve(ResolutionAction.MARK_DISTINCT)
+                persisted = await uow.media_conflicts.save(resolved)
+                resolved_ids.append(str(persisted.id))
+
+        return BulkMarkDistinctOutput(
+            requested=len(unique_ids),
+            resolved_ids=resolved_ids,
+            skipped=skipped,
+        )
+
+
+def _dedupe_preserving_order(ids: list[str]) -> list[str]:
+    """Drop duplicate ids while keeping first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw_id in ids:
+        if raw_id in seen:
+            continue
+        seen.add(raw_id)
+        out.append(raw_id)
+    return out
+
+
+__all__ = ["BulkMarkDistinctConflictsUseCase"]

--- a/src/modules/media/presentation/routes/admin_conflicts_routes.py
+++ b/src/modules/media/presentation/routes/admin_conflicts_routes.py
@@ -22,14 +22,20 @@ from src.config.containers import ApplicationContainer
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.conflict_dtos import (
+    BulkMarkDistinctInput,
     ListConflictsInput,
     ResolveMediaConflictInput,
+)
+from src.modules.media.application.use_cases.bulk_mark_distinct_conflicts import (
+    BulkMarkDistinctConflictsUseCase,
 )
 from src.modules.media.application.use_cases.list_conflicts import ListConflictsUseCase
 from src.modules.media.application.use_cases.resolve_media_conflict import (
     ResolveMediaConflictUseCase,
 )
 from src.modules.media.domain.entities.media_conflict import ResolutionAction
+
+_MAX_BULK_CONFLICTS = 200
 
 
 class ResolveConflictBody(BaseModel):
@@ -54,6 +60,22 @@ class ResolveConflictBody(BaseModel):
             "mark_distinct."
         ),
         max_length=50,
+    )
+
+
+class BulkMarkDistinctBody(BaseModel):
+    """Request body for ``POST /admin/conflicts/bulk-mark-distinct``.
+
+    ``conflict_ids`` is bounded so a single call can't sweep an
+    unbounded queue; the use case de-duplicates and skips ids that
+    are missing, malformed, or already resolved.
+    """
+
+    conflict_ids: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=_MAX_BULK_CONFLICTS,
+        description="External ids (cnf_xxx) of pending conflicts to mark distinct.",
     )
 
 
@@ -127,6 +149,29 @@ async def resolve_admin_conflict(
         ),
     )
     return api_single("media_conflict_resolution", asdict(output))
+
+
+@router.post("/bulk-mark-distinct")
+@inject
+async def bulk_mark_distinct_conflicts(
+    body: BulkMarkDistinctBody,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: BulkMarkDistinctConflictsUseCase = Depends(
+        Provide[ApplicationContainer.media.bulk_mark_distinct_conflicts],
+    ),
+) -> dict[str, Any]:
+    """Mark a selection of pending conflicts as intentionally distinct.
+
+    Bulk resolution only supports ``mark_distinct`` — it needs no
+    per-conflict winner and triggers no soft-delete, so a whole
+    selection closes safely in one transaction. Ids that are missing,
+    malformed, or already resolved are reported under ``skipped``
+    instead of failing the request.
+    """
+    output = await use_case.execute(
+        BulkMarkDistinctInput(conflict_ids=body.conflict_ids),
+    )
+    return api_single("media_conflict_bulk_resolution", asdict(output))
 
 
 __all__ = ["router"]

--- a/tests/modules/media/e2e/test_admin_conflicts_routes.py
+++ b/tests/modules/media/e2e/test_admin_conflicts_routes.py
@@ -454,3 +454,99 @@ class TestAdminConflictsAuditView:
         await _login_as_admin(client, seed_user_with_profile)
         response = await client.get(f"{CONFLICTS_PATH}?state=frozen")
         assert response.status_code == 422
+
+
+_BULK_PATH = f"{CONFLICTS_PATH}/bulk-mark-distinct"
+
+
+@pytest.mark.e2e
+class TestAdminConflictsBulkMarkDistinct:
+    """``POST /admin/conflicts/bulk-mark-distinct`` (ADR-015 Phase 4)."""
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        response = await client.post(
+            _BULK_PATH,
+            json={"conflict_ids": ["cnf_xxxxxxxxxxxx"]},
+        )
+        assert response.status_code == 401
+
+    async def test_member_returns_403(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile(email="member@example.com", is_admin=False)
+        await _login(client, member)
+        response = await client.post(
+            _BULK_PATH,
+            json={"conflict_ids": ["cnf_xxxxxxxxxxxx"]},
+        )
+        assert response.status_code == 403
+
+    async def test_resolves_selection_and_clears_queue(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        first = await _seed_conflict(
+            session_factory, a_id="mov_aaaaaaaaaaaa", b_id="mov_bbbbbbbbbbbb"
+        )
+        second = await _seed_conflict(
+            session_factory, a_id="mov_cccccccccccc", b_id="mov_dddddddddddd"
+        )
+
+        response = await client.post(
+            _BULK_PATH,
+            json={"conflict_ids": [first, second]},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["requested"] == 2
+        assert sorted(payload["resolved_ids"]) == sorted([first, second])
+        assert payload["skipped"] == []
+
+        # Both leave the pending queue; they surface in the audit view.
+        assert (await client.get(CONFLICTS_PATH)).json()["data"] == []
+        audit = await client.get(f"{CONFLICTS_PATH}?state=resolved&source=manual")
+        assert len(audit.json()["data"]) == 2
+
+    async def test_reports_skipped_for_missing_and_resolved(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        pending = await _seed_conflict(
+            session_factory, a_id="mov_aaaaaaaaaaaa", b_id="mov_bbbbbbbbbbbb"
+        )
+        already = await _seed_conflict(
+            session_factory, a_id="mov_cccccccccccc", b_id="mov_dddddddddddd"
+        )
+        await client.post(_BULK_PATH, json={"conflict_ids": [already]})
+
+        response = await client.post(
+            _BULK_PATH,
+            json={"conflict_ids": [pending, already, "cnf_doesnotexist"]},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["resolved_ids"] == [pending]
+        skipped = {s["conflict_id"]: s["reason"] for s in payload["skipped"]}
+        assert skipped == {
+            already: "already_resolved",
+            "cnf_doesnotexist": "not_found",
+        }
+
+    async def test_empty_body_returns_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        response = await client.post(_BULK_PATH, json={"conflict_ids": []})
+        assert response.status_code == 422

--- a/tests/modules/media/unit/application/use_cases/test_bulk_mark_distinct_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_bulk_mark_distinct_conflicts.py
@@ -1,0 +1,123 @@
+"""Tests for BulkMarkDistinctConflictsUseCase (ADR-015 Phase 4)."""
+
+import pytest
+
+from src.modules.media.application.dtos.conflict_dtos import BulkMarkDistinctInput
+from src.modules.media.application.use_cases.bulk_mark_distinct_conflicts import (
+    BulkMarkDistinctConflictsUseCase,
+)
+from src.modules.media.domain.entities.media_conflict import (
+    MatchReason,
+    MediaConflict,
+    ResolutionAction,
+)
+from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+
+def _pending(conflict_id: str) -> MediaConflict:
+    detected = MediaConflict.detect(
+        candidate_a_id="mov_aaaaaaaaaaaa",
+        candidate_a_type="movie",
+        candidate_a_runtime_minutes=120.0,
+        candidate_b_id="mov_bbbbbbbbbbbb",
+        candidate_b_type="movie",
+        candidate_b_runtime_minutes=120.0,
+        match_reason=MatchReason.TMDB_ID,
+    )
+    return detected.with_updates(id=MediaConflictId(conflict_id))
+
+
+def _resolved(conflict_id: str) -> MediaConflict:
+    return _pending(conflict_id).resolve(ResolutionAction.MARK_DISTINCT)
+
+
+def _save_returns_input(conflict: MediaConflict) -> MediaConflict:
+    return conflict
+
+
+class TestBulkMarkDistinctConflictsUseCase:
+    @pytest.mark.asyncio
+    async def test_resolves_all_pending_ids(self) -> None:
+        mocks = make_media_uow_mock()
+        rows = {
+            "cnf_aaaaaaaaaaaa": _pending("cnf_aaaaaaaaaaaa"),
+            "cnf_bbbbbbbbbbbb": _pending("cnf_bbbbbbbbbbbb"),
+        }
+        mocks.media_conflicts.find_by_id.side_effect = lambda cid: rows[str(cid)]
+        mocks.media_conflicts.save.side_effect = _save_returns_input
+
+        use_case = BulkMarkDistinctConflictsUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            BulkMarkDistinctInput(
+                conflict_ids=["cnf_aaaaaaaaaaaa", "cnf_bbbbbbbbbbbb"],
+            ),
+        )
+
+        assert result.requested == 2
+        assert sorted(result.resolved_ids) == ["cnf_aaaaaaaaaaaa", "cnf_bbbbbbbbbbbb"]
+        assert result.skipped == []
+        # Every saved conflict carries the MARK_DISTINCT resolution.
+        for call in mocks.media_conflicts.save.call_args_list:
+            assert call[0][0].resolution is ResolutionAction.MARK_DISTINCT
+
+    @pytest.mark.asyncio
+    async def test_skips_not_found_and_already_resolved(self) -> None:
+        mocks = make_media_uow_mock()
+        rows: dict[str, MediaConflict | None] = {
+            "cnf_aaaaaaaaaaaa": _pending("cnf_aaaaaaaaaaaa"),
+            "cnf_bbbbbbbbbbbb": _resolved("cnf_bbbbbbbbbbbb"),
+            "cnf_cccccccccccc": None,
+        }
+        mocks.media_conflicts.find_by_id.side_effect = lambda cid: rows[str(cid)]
+        mocks.media_conflicts.save.side_effect = _save_returns_input
+
+        use_case = BulkMarkDistinctConflictsUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            BulkMarkDistinctInput(
+                conflict_ids=[
+                    "cnf_aaaaaaaaaaaa",
+                    "cnf_bbbbbbbbbbbb",
+                    "cnf_cccccccccccc",
+                ],
+            ),
+        )
+
+        assert result.resolved_ids == ["cnf_aaaaaaaaaaaa"]
+        skipped = {s.conflict_id: s.reason for s in result.skipped}
+        assert skipped == {
+            "cnf_bbbbbbbbbbbb": "already_resolved",
+            "cnf_cccccccccccc": "not_found",
+        }
+        mocks.media_conflicts.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_malformed_id_is_skipped_without_repo_lookup(self) -> None:
+        mocks = make_media_uow_mock()
+        use_case = BulkMarkDistinctConflictsUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            BulkMarkDistinctInput(conflict_ids=["not-a-conflict-id"]),
+        )
+
+        assert result.resolved_ids == []
+        assert result.skipped[0].reason == "invalid_id"
+        mocks.media_conflicts.find_by_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_ids_are_deduped(self) -> None:
+        mocks = make_media_uow_mock()
+        pending = _pending("cnf_aaaaaaaaaaaa")
+        mocks.media_conflicts.find_by_id.return_value = pending
+        mocks.media_conflicts.save.side_effect = _save_returns_input
+
+        use_case = BulkMarkDistinctConflictsUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            BulkMarkDistinctInput(
+                conflict_ids=["cnf_aaaaaaaaaaaa", "cnf_aaaaaaaaaaaa"],
+            ),
+        )
+
+        assert result.requested == 1
+        assert result.resolved_ids == ["cnf_aaaaaaaaaaaa"]
+        mocks.media_conflicts.save.assert_called_once()


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/admin/conflicts/bulk-mark-distinct` accepting `{ conflict_ids: [...] }` (Pydantic-bounded to 1–200 ids) and resolving each pending conflict as `MARK_DISTINCT` in a single transaction.
- New `BulkMarkDistinctConflictsUseCase` — de-dupes ids and handles each independently: missing / malformed / already-resolved ids are reported under `skipped` (with a reason) rather than aborting the batch.
- Bulk is intentionally limited to `mark_distinct` (no per-conflict winner, no soft-delete, no cross-BC fan-out); MERGE actions stay one-at-a-time via the existing resolve endpoint.
- ADR-015 Phase 4b (second of three: thresholds → **bulk mark-distinct** → title+year fallback matcher).

## Test plan

- [x] `pytest tests/modules/media/unit/application/use_cases/test_bulk_mark_distinct_conflicts.py` — resolves pending, skips not_found / already_resolved / invalid_id, de-dupes.
- [x] `pytest tests/modules/media/e2e/test_admin_conflicts_routes.py` — auth gate, clears the queue + lands in the manual audit view, partial-skip report, empty body → 422.
- [x] `pytest tests/modules/media` — 1424 passed, 5 skipped.
- [x] `ruff check` + `ruff format --check` clean.

## Summary by Sourcery

Add support for bulk marking media conflicts as distinct via a new admin API endpoint and use case.

New Features:
- Introduce a BulkMarkDistinctConflictsUseCase to resolve multiple pending conflicts as MARK_DISTINCT in a single operation.
- Expose POST /api/v1/admin/conflicts/bulk-mark-distinct to allow admins to mark multiple conflicts as distinct with bounded request size.
- Add DTOs for bulk conflict mark-distinct input, output, and skipped conflicts reporting reasons for non-resolution.

Enhancements:
- Wire the new bulk mark-distinct use case into the media DI container for application-wide availability.

Tests:
- Add unit tests for the BulkMarkDistinctConflictsUseCase covering pending, skipped, malformed, and duplicate ids handling.
- Extend admin conflicts E2E tests to cover auth, queue clearing, skipped reporting, and validation for the bulk mark-distinct endpoint.