### PR TITLE
feat(media): title+year dedup fallback for un-enriched dups

### DIFF
--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     )
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
     from src.modules.media.domain.entities.movie import Movie
+    from src.modules.settings.domain.value_objects import ScanDedupConfig
     from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = logging.getLogger(__name__)
@@ -92,14 +93,15 @@ class DetectMovieConflictsUseCase:
         detected_events: list[MediaConflictDetectedEvent] = []
         merged_events: list[MovieMergedEvent] = []
 
-        abs_threshold, relative_threshold = await self._delta_thresholds()
+        config = await self._scan_config()
+        abs_threshold = None if config is None else config.runtime_delta_abs_minutes
+        relative_threshold = None if config is None else config.runtime_delta_relative
+        # Fallback is opt-out via settings, but stays off entirely when
+        # no runtime-settings source is wired (e.g. unit tests).
+        fallback_enabled = config is not None and config.title_year_fallback_enabled
 
         async with self._uow_factory() as uow:
             candidates = await uow.movies.find_all_by_tmdb_id(input_dto.tmdb_id)
-            others = [m for m in candidates if str(m.id) != input_dto.media_id]
-            if not others:
-                return DetectMovieConflictsOutput(conflicts_created=0, conflict_ids=[])
-
             self_movie = next(
                 (m for m in candidates if str(m.id) == input_dto.media_id),
                 None,
@@ -114,8 +116,12 @@ class DetectMovieConflictsUseCase:
                 return DetectMovieConflictsOutput(conflicts_created=0, conflict_ids=[])
 
             self_runtime = _runtime_minutes(self_movie)
+            others = [m for m in candidates if str(m.id) != input_dto.media_id]
+            handled_ids = {input_dto.media_id}
 
+            # --- Strong pass: TMDB-id collisions (auto-merge eligible). ---
             for other in others:
+                handled_ids.add(str(other.id))
                 blocker = await uow.media_conflicts.find_blocking_pair(
                     input_dto.media_id,
                     str(other.id),
@@ -137,28 +143,43 @@ class DetectMovieConflictsUseCase:
                     merged_events.append(merged_event)
                     continue
 
-                conflict = MediaConflict.detect(
-                    candidate_a_id=input_dto.media_id,
-                    candidate_a_type="movie",
-                    candidate_a_runtime_minutes=self_runtime,
-                    candidate_b_id=str(other.id),
-                    candidate_b_type="movie",
-                    candidate_b_runtime_minutes=_runtime_minutes(other),
+                persisted, detected = await self._queue_conflict(
+                    uow=uow,
+                    self_id=input_dto.media_id,
+                    self_runtime=self_runtime,
+                    other=other,
                     match_reason=MatchReason.TMDB_ID,
-                    abs_threshold_minutes=abs_threshold,
+                    abs_threshold=abs_threshold,
                     relative_threshold=relative_threshold,
                 )
-                persisted = await uow.media_conflicts.save(conflict)
                 created_ids.append(str(persisted.id))
-                detected_events.append(
-                    MediaConflictDetectedEvent(
-                        conflict_id=str(persisted.id),
-                        candidate_a_id=persisted.candidate_a_id,
-                        candidate_b_id=persisted.candidate_b_id,
-                        match_reason=persisted.match_reason.value,
-                        suggested_action=persisted.suggested_action.value,
-                    ),
+                detected_events.append(detected)
+
+            # --- Fallback pass: (normalized_original_title, year). ---
+            # Catches catalog entries whose enrichment never locked a
+            # TMDB id. Weaker identity → always queue, never auto-merge.
+            if fallback_enabled:
+                fallback_matches = await self._collect_title_year_matches(
+                    uow, self_movie, exclude=handled_ids
                 )
+                for other in fallback_matches:
+                    blocker = await uow.media_conflicts.find_blocking_pair(
+                        input_dto.media_id,
+                        str(other.id),
+                    )
+                    if blocker is not None:
+                        continue
+                    persisted, detected = await self._queue_conflict(
+                        uow=uow,
+                        self_id=input_dto.media_id,
+                        self_runtime=self_runtime,
+                        other=other,
+                        match_reason=MatchReason.TITLE_YEAR_FALLBACK,
+                        abs_threshold=abs_threshold,
+                        relative_threshold=relative_threshold,
+                    )
+                    created_ids.append(str(persisted.id))
+                    detected_events.append(detected)
 
         # Publish outside the UoW so a slow subscriber doesn't hold
         # the write transaction open. Auto-merge events fan out to
@@ -173,17 +194,71 @@ class DetectMovieConflictsUseCase:
             conflict_ids=created_ids,
         )
 
-    async def _delta_thresholds(self) -> tuple[float | None, float | None]:
-        """Read the tunable runtime-delta bounds from ``scan_dedup``.
+    async def _scan_config(self) -> ScanDedupConfig | None:
+        """Read the ``scan_dedup`` bucket, or ``None`` when not wired.
 
-        Returns ``(None, None)`` when no runtime-settings source is
-        wired, so :meth:`MediaConflict.detect` falls back to the
-        class-level defaults.
+        ``None`` makes the detector fall back to the ADR-015 class
+        defaults for the thresholds and disables the title+year
+        fallback pass entirely (the unit-test path).
         """
         if self._runtime_settings is None:
-            return None, None
-        config = await self._runtime_settings.scan_dedup()
-        return config.runtime_delta_abs_minutes, config.runtime_delta_relative
+            return None
+        return await self._runtime_settings.scan_dedup()
+
+    async def _queue_conflict(
+        self,
+        *,
+        uow: object,
+        self_id: str,
+        self_runtime: float | None,
+        other: Movie,
+        match_reason: MatchReason,
+        abs_threshold: float | None,
+        relative_threshold: float | None,
+    ) -> tuple[MediaConflict, MediaConflictDetectedEvent]:
+        """Persist a pending conflict for the pair and build its event."""
+        conflict = MediaConflict.detect(
+            candidate_a_id=self_id,
+            candidate_a_type="movie",
+            candidate_a_runtime_minutes=self_runtime,
+            candidate_b_id=str(other.id),
+            candidate_b_type="movie",
+            candidate_b_runtime_minutes=_runtime_minutes(other),
+            match_reason=match_reason,
+            abs_threshold_minutes=abs_threshold,
+            relative_threshold=relative_threshold,
+        )
+        persisted = await uow.media_conflicts.save(conflict)  # type: ignore[attr-defined]
+        event = MediaConflictDetectedEvent(
+            conflict_id=str(persisted.id),
+            candidate_a_id=persisted.candidate_a_id,
+            candidate_b_id=persisted.candidate_b_id,
+            match_reason=persisted.match_reason.value,
+            suggested_action=persisted.suggested_action.value,
+        )
+        return persisted, event
+
+    async def _collect_title_year_matches(
+        self,
+        uow: object,
+        self_movie: Movie,
+        *,
+        exclude: set[str],
+    ) -> list[Movie]:
+        """Find same-year movies whose normalized title matches ``self_movie``.
+
+        Compares on ``original_title`` (falling back to ``title``) using
+        the deterministic :attr:`Title.normalized` key, so casing /
+        accent differences still match. Ids in ``exclude`` (self + the
+        TMDB pass) are skipped to avoid double-queuing.
+        """
+        self_key = _normalized_identity_title(self_movie)
+        candidates = await uow.movies.find_all_by_year(self_movie.year.value)  # type: ignore[attr-defined]
+        return [
+            m
+            for m in candidates
+            if str(m.id) not in exclude and _normalized_identity_title(m) == self_key
+        ]
 
     async def _is_orphan(self, movie: Movie) -> bool:
         """``True`` when every file of ``movie`` is missing and the library is healthy.
@@ -263,6 +338,11 @@ def _runtime_minutes(movie: Movie) -> float | None:
     if movie.duration.value <= 0:
         return None
     return movie.duration.value / 60.0
+
+
+def _normalized_identity_title(movie: Movie) -> str:
+    """Comparison key for the title+year fallback (original title preferred)."""
+    return (movie.original_title or movie.title).normalized
 
 
 __all__ = ["DetectMovieConflictsUseCase"]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -430,6 +430,27 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_all_by_year(self, year: int) -> list[Movie]:
+        """Return every non-deleted movie released in ``year``.
+
+        Used by the ADR-015 dedup fallback: when a movie lacks a TMDB
+        match the detector pairs candidates by
+        ``(normalized_original_title, year)``. This narrows by the
+        cheap, indexed ``year`` column; the caller normalizes and
+        compares titles in memory.
+
+        No ACL filter — collision detection is operator-scoped and
+        intentionally cross-library.
+
+        Args:
+            year: The release year to look up.
+
+        Returns:
+            All movies released in ``year``, in arbitrary order.
+        """
+        ...
+
+    @abstractmethod
     async def find_by_file_path(self, file_path: FilePath) -> Movie | None:
         """Find a movie by its file path.
 

--- a/src/modules/media/domain/value_objects/title.py
+++ b/src/modules/media/domain/value_objects/title.py
@@ -1,6 +1,7 @@
 """Title value object for media content."""
 
 import re
+import unicodedata
 from typing import ClassVar
 
 from pydantic import model_validator
@@ -52,6 +53,26 @@ class Title(StringValueObject):
             raise ValueError(f"Title cannot exceed {cls.MAX_LENGTH} characters")
 
         return normalized
+
+    @property
+    def normalized(self) -> str:
+        """Canonical comparison key for content-identity matching.
+
+        Lower-cases (case-fold), strips diacritics (NFKD decomposition
+        dropping combining marks), and collapses whitespace, so titles
+        that differ only in casing or accents compare equal. Used by
+        the scanner's ``(normalized_original_title, year)`` dedup
+        fallback (ADR-015); deterministic so repeated scans agree.
+
+        Example:
+            >>> Title("A Viagem de Chihiro").normalized
+            'a viagem de chihiro'
+            >>> Title("Amélie").normalized == Title("AMELIE").normalized
+            True
+        """
+        decomposed = unicodedata.normalize("NFKD", self.value)
+        without_marks = "".join(c for c in decomposed if not unicodedata.combining(c))
+        return re.sub(r"\s+", " ", without_marks).strip().casefold()
 
 
 __all__ = ["Title"]

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -552,6 +552,23 @@ class SQLAlchemyMovieRepository(MovieRepository):
         result = await self._session.execute(stmt)
         return [MovieMapper.to_entity(model) for model in result.scalars().all()]
 
+    async def find_all_by_year(self, year: int) -> list[Movie]:
+        """Return every non-deleted movie released in ``year``.
+
+        Feeds the ADR-015 ``(normalized_original_title, year)`` dedup
+        fallback. No ACL filter — see the ABC docstring.
+        """
+        stmt = (
+            select(MovieModel)
+            .where(
+                MovieModel.year == year,
+                MovieModel.deleted_at.is_(None),
+            )
+            .options(selectinload(MovieModel.file_variants))
+        )
+        result = await self._session.execute(stmt)
+        return [MovieMapper.to_entity(model) for model in result.scalars().all()]
+
     async def find_by_file_path(self, file_path: FilePath) -> Movie | None:
         """Find a movie by any of its file variant paths.
 

--- a/src/modules/settings/domain/value_objects/scan_dedup_config.py
+++ b/src/modules/settings/domain/value_objects/scan_dedup_config.py
@@ -23,6 +23,12 @@ class ScanDedupConfig(CompoundValueObject):
             fraction of the shorter runtime (``0.10`` = 10%). Deltas at
             or below this are treated as the same release regardless of
             the absolute bound.
+        title_year_fallback_enabled: When ``True`` (default), the
+            detector also flags duplicates by
+            ``(normalized_original_title, year)`` — catching catalog
+            entries whose enrichment never locked a TMDB id. Fallback
+            matches always queue for the operator and are never
+            silently auto-merged, since the identity is weaker.
 
     Example:
         >>> cfg = ScanDedupConfig()
@@ -31,6 +37,7 @@ class ScanDedupConfig(CompoundValueObject):
 
     runtime_delta_abs_minutes: float = Field(default=5.0, ge=0.0)
     runtime_delta_relative: float = Field(default=0.10, ge=0.0, le=1.0)
+    title_year_fallback_enabled: bool = Field(default=True)
 
 
 __all__ = ["ScanDedupConfig"]

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -280,6 +280,38 @@ class TestSQLAlchemyMovieRepository:
 
         assert found is None
 
+    async def test_find_all_by_year_returns_only_that_year(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """find_all_by_year filters by year and skips other years."""
+        repo = SQLAlchemyMovieRepository(db_session)
+        await repo.save(
+            _create_movie(title="A", year=1997, file_path="/movies/a.mkv")
+        )
+        await repo.save(
+            _create_movie(title="B", year=1997, file_path="/movies/b.mkv")
+        )
+        await repo.save(
+            _create_movie(title="C", year=2001, file_path="/movies/c.mkv")
+        )
+
+        found = await repo.find_all_by_year(1997)
+
+        assert sorted(m.title.value for m in found) == ["A", "B"]
+
+    async def test_find_all_by_year_excludes_deleted(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """Soft-deleted movies are not returned."""
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _create_movie(title="Gone", year=1997, file_path="/movies/gone.mkv")
+        await repo.save(movie)
+        await repo.delete(_id_of(movie))
+
+        assert await repo.find_all_by_year(1997) == []
+
     async def test_save_movie_with_all_optional_fields(
         self,
         db_session: AsyncSession,

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -286,15 +286,9 @@ class TestSQLAlchemyMovieRepository:
     ) -> None:
         """find_all_by_year filters by year and skips other years."""
         repo = SQLAlchemyMovieRepository(db_session)
-        await repo.save(
-            _create_movie(title="A", year=1997, file_path="/movies/a.mkv")
-        )
-        await repo.save(
-            _create_movie(title="B", year=1997, file_path="/movies/b.mkv")
-        )
-        await repo.save(
-            _create_movie(title="C", year=2001, file_path="/movies/c.mkv")
-        )
+        await repo.save(_create_movie(title="A", year=1997, file_path="/movies/a.mkv"))
+        await repo.save(_create_movie(title="B", year=1997, file_path="/movies/b.mkv"))
+        await repo.save(_create_movie(title="C", year=2001, file_path="/movies/c.mkv"))
 
         found = await repo.find_all_by_year(1997)
 

--- a/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
@@ -41,6 +41,9 @@ def _build_movie(
     external_id: str,
     duration_seconds: int = 7200,
     file_paths: list[str] | None = None,
+    title: str = "Example",
+    year: int = 2020,
+    tmdb_id: int | None = 27205,
 ) -> Movie:
     files = [
         MediaFile(
@@ -54,11 +57,11 @@ def _build_movie(
     return Movie(
         id=MovieId(external_id),
         library_id="lib_test12345678",
-        title=Title("Example"),
-        year=Year(2020),
+        title=Title(title),
+        year=Year(year),
         duration=Duration(duration_seconds),
         files=files,
-        tmdb_id=TmdbId(27205),
+        tmdb_id=None if tmdb_id is None else TmdbId(tmdb_id),
     )
 
 
@@ -209,6 +212,163 @@ async def _stamp_conflict_id(conflict: MediaConflict) -> MediaConflict:
     return conflict.with_updates(
         id=MediaConflictId("cnf_stamped12345"),
     )
+
+
+def _settings_with(*, fallback: bool = True) -> AsyncMock:
+    rs = AsyncMock()
+    rs.scan_dedup.return_value = ScanDedupConfig(title_year_fallback_enabled=fallback)
+    return rs
+
+
+class TestTitleYearFallback:
+    """ADR-015 Phase 4c — (normalized_original_title, year) fallback."""
+
+    @pytest.mark.asyncio
+    async def test_matches_unenriched_duplicate_by_title_and_year(self) -> None:
+        mocks = make_media_uow_mock()
+        enriched = _build_movie(
+            external_id="mov_aaaaaaaaaaaa",
+            title="Princess Mononoke",
+            year=1997,
+            tmdb_id=27205,
+            file_paths=["/movies/a.mkv"],
+        )
+        unenriched = _build_movie(
+            external_id="mov_bbbbbbbbbbbb",
+            title="PRINCESS MONONOKE",
+            year=1997,
+            tmdb_id=None,
+            file_paths=["/movies/b.mkv"],
+        )
+        # No TMDB collision; the dup only surfaces via title+year.
+        mocks.movies.find_all_by_tmdb_id.return_value = [enriched]
+        mocks.movies.find_all_by_year.return_value = [enriched, unenriched]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            runtime_settings=_settings_with(fallback=True),
+        )
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_aaaaaaaaaaaa", tmdb_id=27205),
+        )
+
+        assert result.conflicts_created == 1
+        saved = mocks.media_conflicts.save.call_args[0][0]
+        assert saved.match_reason is MatchReason.TITLE_YEAR_FALLBACK
+        mocks.movies.find_all_by_year.assert_awaited_once_with(1997)
+
+    @pytest.mark.asyncio
+    async def test_fallback_disabled_skips_year_lookup(self) -> None:
+        mocks = make_media_uow_mock()
+        enriched = _build_movie(external_id="mov_aaaaaaaaaaaa", tmdb_id=27205)
+        mocks.movies.find_all_by_tmdb_id.return_value = [enriched]
+
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            runtime_settings=_settings_with(fallback=False),
+        )
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_aaaaaaaaaaaa", tmdb_id=27205),
+        )
+
+        assert result.conflicts_created == 0
+        mocks.movies.find_all_by_year.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_runtime_settings_disables_fallback(self) -> None:
+        mocks = make_media_uow_mock()
+        enriched = _build_movie(external_id="mov_aaaaaaaaaaaa", tmdb_id=27205)
+        mocks.movies.find_all_by_tmdb_id.return_value = [enriched]
+
+        use_case = DetectMovieConflictsUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_aaaaaaaaaaaa", tmdb_id=27205),
+        )
+
+        assert result.conflicts_created == 0
+        mocks.movies.find_all_by_year.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fallback_match_queues_never_auto_merges_orphan(self) -> None:
+        mocks = make_media_uow_mock()
+        enriched = _build_movie(
+            external_id="mov_aaaaaaaaaaaa",
+            title="Princess Mononoke",
+            year=1997,
+            tmdb_id=27205,
+            file_paths=["/movies/a.mkv"],
+        )
+        orphan = _build_movie(
+            external_id="mov_bbbbbbbbbbbb",
+            title="Princess Mononoke",
+            year=1997,
+            tmdb_id=None,
+            file_paths=["/movies/missing.mkv"],
+        )
+        mocks.movies.find_all_by_tmdb_id.return_value = [enriched]
+        mocks.movies.find_all_by_year.return_value = [enriched, orphan]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+
+        # Orphan would auto-merge under a TMDB match — but the weaker
+        # title+year identity must always queue instead.
+        library_health = _FakeLibraryHealth(
+            accessible_files={"/movies/a.mkv"},
+            healthy_libraries={"lib_test12345678"},
+        )
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            library_health=library_health,
+            runtime_settings=_settings_with(fallback=True),
+        )
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_aaaaaaaaaaaa", tmdb_id=27205),
+        )
+
+        assert result.conflicts_created == 1
+        saved = mocks.media_conflicts.save.call_args[0][0]
+        assert saved.match_reason is MatchReason.TITLE_YEAR_FALLBACK
+        assert saved.is_resolved is False
+        mocks.movies.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fallback_skips_ids_already_handled_by_tmdb_pass(self) -> None:
+        mocks = make_media_uow_mock()
+        enriched = _build_movie(
+            external_id="mov_aaaaaaaaaaaa",
+            title="Princess Mononoke",
+            year=1997,
+            tmdb_id=27205,
+            file_paths=["/movies/a.mkv"],
+        )
+        # Same TMDB id AND same title+year — must produce a single
+        # conflict (TMDB pass), not a duplicate from the fallback.
+        other = _build_movie(
+            external_id="mov_bbbbbbbbbbbb",
+            title="Princess Mononoke",
+            year=1997,
+            tmdb_id=27205,
+            file_paths=["/movies/b.mkv"],
+        )
+        mocks.movies.find_all_by_tmdb_id.return_value = [enriched, other]
+        mocks.movies.find_all_by_year.return_value = [enriched, other]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            runtime_settings=_settings_with(fallback=True),
+        )
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_aaaaaaaaaaaa", tmdb_id=27205),
+        )
+
+        assert result.conflicts_created == 1
+        assert mocks.media_conflicts.save.call_count == 1
+        saved = mocks.media_conflicts.save.call_args[0][0]
+        assert saved.match_reason is MatchReason.TMDB_ID
 
 
 class TestAutoMergeOrphans:

--- a/tests/modules/media/unit/domain/value_objects/test_title.py
+++ b/tests/modules/media/unit/domain/value_objects/test_title.py
@@ -159,3 +159,29 @@ class TestTitleImmutability:
 
         with pytest.raises(DomainValidationException):
             title.root = "Interstellar"  # type: ignore[misc]
+
+
+class TestTitleNormalized:
+    """Tests for the content-identity ``normalized`` comparison key."""
+
+    def test_lowercases(self):
+        from src.modules.media.domain.value_objects import Title
+
+        assert Title("The Matrix").normalized == "the matrix"
+
+    def test_strips_diacritics(self):
+        from src.modules.media.domain.value_objects import Title
+
+        assert Title("Amélie").normalized == "amelie"
+
+    def test_case_and_accent_insensitive_equality(self):
+        from src.modules.media.domain.value_objects import Title
+
+        assert Title("A Viagem de Chihiro").normalized == Title(
+            "A VIAGEM DE CHIHIRO"
+        ).normalized
+
+    def test_distinct_titles_stay_distinct(self):
+        from src.modules.media.domain.value_objects import Title
+
+        assert Title("Spirited Away").normalized != Title("Princess Mononoke").normalized

--- a/tests/modules/media/unit/domain/value_objects/test_title.py
+++ b/tests/modules/media/unit/domain/value_objects/test_title.py
@@ -177,9 +177,7 @@ class TestTitleNormalized:
     def test_case_and_accent_insensitive_equality(self):
         from src.modules.media.domain.value_objects import Title
 
-        assert Title("A Viagem de Chihiro").normalized == Title(
-            "A VIAGEM DE CHIHIRO"
-        ).normalized
+        assert Title("A Viagem de Chihiro").normalized == Title("A VIAGEM DE CHIHIRO").normalized
 
     def test_distinct_titles_stay_distinct(self):
         from src.modules.media.domain.value_objects import Title

--- a/tests/modules/settings/unit/domain/value_objects/test_scan_dedup_config.py
+++ b/tests/modules/settings/unit/domain/value_objects/test_scan_dedup_config.py
@@ -12,6 +12,12 @@ class TestScanDedupConfig:
 
         assert config.runtime_delta_abs_minutes == 5.0
         assert config.runtime_delta_relative == 0.10
+        assert config.title_year_fallback_enabled is True
+
+    def test_fallback_can_be_disabled(self) -> None:
+        config = ScanDedupConfig(title_year_fallback_enabled=False)
+
+        assert config.title_year_fallback_enabled is False
 
     def test_negative_abs_minutes_raises(self) -> None:
         with pytest.raises(DomainValidationException):


### PR DESCRIPTION
## Summary

- Add a second detection pass in `DetectMovieConflictsUseCase` keyed on `(normalized_original_title, year)`, catching duplicates whose enrichment never locked a TMDB id (the strong TMDB pass misses them).
- `Title.normalized` — deterministic comparison key (case-fold + NFKD diacritic strip + collapsed whitespace), so casing/accent differences still match.
- New `MovieRepository.find_all_by_year(year)` (indexed `year` column; titles normalized + compared in memory — no schema migration, avoids the FTS-trigger landmine).
- Gated by `scan_dedup.title_year_fallback_enabled` (default **on**); disabled entirely when no runtime-settings source is wired.
- **Safety:** fallback matches always queue for the operator and are **never silently auto-merged** — the identity is weaker than a TMDB-id match. They also skip ids already handled by the TMDB pass (no double-queue).
- ADR-015 Phase 4c (last of three: thresholds → bulk mark-distinct → **title+year fallback**).

## Test plan

- [x] `test_title.py` — `normalized` lower-cases, strips diacritics, case/accent-insensitive equality, keeps distinct titles distinct.
- [x] `test_scan_dedup_config.py` — `title_year_fallback_enabled` default `True` + toggle.
- [x] `test_movie_repository.py` (integration) — `find_all_by_year` filters by year, excludes soft-deleted.
- [x] `test_detect_movie_conflicts.py` — matches un-enriched dup by title+year; disabled flag / no settings skips the year lookup; fallback match queues and never auto-merges an orphan; skips ids already handled by the TMDB pass.
- [x] `pytest tests/modules/media tests/modules/settings` — 1489 passed, 5 skipped.
- [x] `ruff check` + `ruff format --check` clean.

## Migration steps

None — no schema change.

## Summary by Sourcery

Introduce a configurable title-plus-year fallback pass in movie conflict detection to catch unenriched duplicates while keeping TMDB-based detection as the primary path.

New Features:
- Add a normalized title property for movie titles to provide a deterministic, case- and accent-insensitive comparison key.
- Extend movie conflict detection to run a secondary duplicate-detection pass keyed on normalized title and year, gated by a runtime setting and always queuing conflicts instead of auto-merging.
- Add a repository method to retrieve all non-deleted movies for a given year to support the title-plus-year fallback logic.
- Introduce a runtime configuration flag to enable or disable the title-plus-year fallback duplicate detection.

Enhancements:
- Refactor movie conflict detection to centralize conflict creation and event emission, and to reuse scan configuration across passes.

Tests:
- Add unit tests for normalized title behavior, the new title-plus-year fallback duplicate detection scenarios, and the new scan dedup configuration flag.
- Add integration tests for fetching movies by year and ensuring soft-deleted movies are excluded.