### PR TITLE
docs(adr): mark ADR-015 accepted, roadmap 6.1-6.4 shipped

### DIFF
--- a/docs/adr/ADR-015-scanner-deduplication-by-content-identity.md
+++ b/docs/adr/ADR-015-scanner-deduplication-by-content-identity.md
@@ -1,6 +1,6 @@
 # ADR-015: Scanner Deduplication by Content Identity
 
-**Status:** Proposto
+**Status:** Aceito
 **Data:** 2026-05-23
 **Deciders:** Lucas Cristovam
 **Technical Story:** Discussão de design — reorganização de pastas, troca por remaster, duplicatas acidentais
@@ -157,3 +157,4 @@ class MediaConflict(AggregateRoot):
 | Data | Autor | Mudança |
 |------|-------|---------|
 | 2026-05-23 | Lucas Cristovam | Criação inicial — Proposto |
+| 2026-05-24 | Lucas Cristovam | Fases 1–4 implementadas e enviadas — Aceito. Bulk resolve entregue como **mark-distinct only** (sem critério `min_runtime_delta`); merge segue 1-a-1. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,7 @@ patterns are explicitly excluded.
 
 ---
 
-## Shipped (Phases 1–4 + ADR-015 Phase 1)
+## Shipped (Phases 1–4 + ADR-015 Phases 1–4)
 
 ### Phase 1 — Foundation
 
@@ -80,7 +80,28 @@ patterns are explicitly excluded.
   the pending queue with title/year projections of both sides.
   Polymorphic schema (`candidate_*_type` discriminator) ready for
   Series/Episodes in later phases without a migration.
-- 108 REST API endpoints across 9 bounded contexts, 2 560+ tests.
+- **6.2 Admin resolve UI + endpoint** — ADR-015 Phase 2.
+  `POST /api/v1/admin/conflicts/{id}/resolve` (mark-distinct /
+  merge-replace / merge-keep-both). MERGE soft-deletes the loser and
+  fans out `MovieMergedEvent` to `watch_progress` + `collections`
+  (repoint progress / list memberships, transfer file variants).
+  `/admin/conflicts` page in homeflix-web with file-variant context
+  per candidate.
+- **6.3 Silent auto-merge** — ADR-015 Phase 3. Library-root health
+  probe (`LibraryHealthPort`) distinguishes a real orphan
+  (file missing, library mounted) from transient I/O; orphans are
+  absorbed silently with a resolved-AUTO audit row + `is_auto`
+  `MovieMergedEvent`. Audit view (pending / resolved-manual /
+  resolved-auto tabs).
+- **6.4 Tunables + bulk + fallback** — ADR-015 Phase 4.
+  `scan_dedup` runtime-settings bucket (ADR-013) makes the
+  runtime-delta thresholds tunable without a deploy;
+  `POST /api/v1/admin/conflicts/bulk-mark-distinct` closes a whole
+  selection in one transaction; `(normalized_original_title, year)`
+  fallback matcher catches duplicates that never locked a TMDB id
+  (queue-only, never auto-merged). Settings card + multi-select UI in
+  homeflix-web.
+- 111 REST API endpoints across 9 bounded contexts, 2 600+ tests.
 
 ---
 
@@ -123,34 +144,18 @@ patterns are explicitly excluded.
 | **Scope** | Detect available HW encoders at startup, prefer HW pipeline in HLS generation, graceful fallback to software |
 | **Depends on** | 2.1 (Docker — GPU passthrough config) |
 
-### Phase 6 — Scanner Deduplication (remaining ADR-015 phases)
+### Phase 6 — Scanner Deduplication (ADR-015)
 
-#### 6.2 Admin resolve UI + endpoint
+✅ **Shipped (6.1–6.4)** — see the Shipped section above. ADR-015 is
+**Accepted**. One deferred idea remains optional:
 
-| | |
-|---|---|
-| **Teaches** | Cross-BC fan-out (similar to `MoviePromotedToSeriesEvent`), aggregate merge with FK migration, transactional safety on destructive ops |
-| **Unlocks** | Operator can actually resolve queued conflicts (merge-keep-both / merge-replace / mark-distinct) |
-| **Scope** | `POST /api/v1/admin/conflicts/{id}/resolve` with action body, merge use case that moves file variants + watch progress + custom list memberships from loser → winner, soft-delete loser, frontend `/admin/conflicts` page in homeflix-web |
-| **Depends on** | 6.1 (shipped) |
-
-#### 6.3 Auto-merge silencioso (orphan + healthy library)
+#### 6.5 Scheduled dedup sweep (optional)
 
 | | |
 |---|---|
-| **Teaches** | Storage health probing, idempotent auto-actions with audit trail |
-| **Unlocks** | "Moved a file/folder" use case stops requiring admin clicks — the new path simply absorbs the orphaned entity |
-| **Scope** | Library-root health check before classifying as orphan, `MediaAutoMerged` event for audit, separate admin UI showing auto-action log |
-| **Depends on** | 6.2 |
-
-#### 6.4 Bulk resolve + tunable thresholds
-
-| | |
-|---|---|
-| **Teaches** | Bulk operations with criteria filters, surfacing tunables through the existing RuntimeSettings (ADR-013) pattern |
-| **Unlocks** | One-shot cleanup for large historical backlogs; threshold tuning without redeploy |
-| **Scope** | `scan_dedup` bucket in `app_settings` (runtime delta thresholds), bulk-resolve endpoint with `min_runtime_delta` filter, fallback `(normalized_original_title, year)` matcher for un-enriched candidates |
-| **Depends on** | 6.2 |
+| **Teaches** | Periodic batch jobs over the whole catalog vs event-driven hooks |
+| **Unlocks** | Catches duplicates without waiting for a re-enrich of each title — a recurring whole-catalog re-check |
+| **Scope** | Scheduler job (reuse `SchedulerConfig`) that walks existing movies and runs detection without re-enriching; today detection only fires on `MediaEnrichedEvent`, so a bulk re-enrich is the current way to re-check the backlog |
 
 ### Phase 5 — Observability & Resilience
 


### PR DESCRIPTION
## Summary

- ADR-015 status **Proposto → Aceito** with a revision-history entry noting Phases 1–4 shipped and that bulk resolve landed as **mark-distinct only** (no `min_runtime_delta` criterion; merge stays 1-at-a-time).
- Roadmap: move scanner-dedup 6.2 (admin resolve), 6.3 (silent auto-merge), 6.4 (tunables + bulk + fallback) into the Shipped section; replace the "remaining ADR-015 phases" block with an optional **6.5 scheduled dedup sweep** follow-up.

## Test plan

- [x] Docs only — no code paths touched.

## Summary by Sourcery

Update documentation to reflect ADR-015 scanner deduplication phases 1–4 as shipped and the ADR as accepted, and adjust the roadmap to move completed work into the shipped section while leaving an optional follow-up phase.

Documentation:
- Expand the roadmap shipped section to describe ADR-015 phases 2–4 features and metrics.
- Reorganize the scanner deduplication roadmap to mark phases 6.1–6.4 as shipped and introduce an optional 6.5 scheduled dedup sweep.
- Update ADR-015 status to accepted with a revision note summarizing shipped phases and the bulk-resolve behavior.