### PR TITLE
fix(media): pass runtime_settings to AudioExtractor integration test

### DIFF
--- a/tests/modules/media/integration/audio/test_audio_extractor_real.py
+++ b/tests/modules/media/integration/audio/test_audio_extractor_real.py
@@ -11,6 +11,7 @@ import shutil
 import struct
 import wave
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -18,6 +19,14 @@ from src.modules.media.infrastructure.audio.audio_extractor import (
     AudioExtractor,
     _ffmpeg_path,
 )
+from src.modules.settings.domain.value_objects import StreamingConfig
+
+
+def _fake_runtime_settings() -> MagicMock:
+    runtime = MagicMock()
+    runtime.streaming_snapshot_sync.return_value = StreamingConfig()
+    return runtime
+
 
 pytestmark = pytest.mark.skipif(
     shutil.which("ffmpeg") is None,
@@ -58,7 +67,7 @@ class TestAudioExtractorReal:
         source = tmp_path / "source.wav"
         _write_sine_wav(source, duration_seconds=3.0)
 
-        extractor = AudioExtractor()
+        extractor = AudioExtractor(_fake_runtime_settings())
         captured_path: Path | None = None
         with extractor.extract_temporary(str(source), duration_seconds=2) as wav_path:
             assert wav_path is not None
@@ -82,5 +91,7 @@ class TestAudioExtractorReal:
         assert not captured_path.exists()
 
     def test_returns_none_when_input_does_not_exist(self, tmp_path: Path) -> None:
-        result = AudioExtractor().extract(str(tmp_path / "missing.mkv"), duration_seconds=5)
+        result = AudioExtractor(_fake_runtime_settings()).extract(
+            str(tmp_path / "missing.mkv"), duration_seconds=5
+        )
         assert result is None


### PR DESCRIPTION
## Summary
- ``AudioExtractor.__init__`` requires ``runtime_settings`` since PR #223 (settings migration), but the integration test was still instantiating it with no args.
- The test is skipped on machines without ffmpeg on ``PATH`` (CI), so the breakage stayed latent until a local run with ffmpeg installed surfaced it.
- Reuses the same ``StreamingConfig``-backed MagicMock pattern already in place in the unit-test counterpart.

## Test plan
- [ ] CI Lint + Test pass on the PR
- [ ] On a machine with ffmpeg installed: ``poetry run pytest tests/modules/media/integration/audio/test_audio_extractor_real.py -v`` now passes both cases (previously crashed at construction)

## Summary by Sourcery

Update media audio extractor integration tests to construct AudioExtractor with required runtime settings.

Bug Fixes:
- Fix AudioExtractor integration tests that were instantiating the extractor without required runtime settings, causing crashes when ffmpeg is available.

Tests:
- Add a shared fake runtime_settings helper in the audio extractor integration tests to mirror the unit test configuration.