### PR TITLE
feat(media): scheduled catalog dedup sweep (ADR-015 Phase 6.5)

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -23,6 +23,7 @@ from src.infrastructure.health import DatabaseProbe, FilesystemProbe
 from src.infrastructure.scheduling import (
     IntroDetectionJob,
     LibraryScanScheduler,
+    ScanDedupSweepJob,
     ThumbnailBackfillJob,
 )
 from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work import (
@@ -242,6 +243,12 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         audio_extractor=media.audio_extractor,
         chromaprint_service=media.chromaprint_service,
         intro_detector=media.intro_detector,
+        runtime_settings=settings.runtime_settings,
+    )
+
+    scan_dedup_sweep_job = providers.Singleton(
+        ScanDedupSweepJob,
+        sweep_use_case=media.sweep_movie_conflicts,
         runtime_settings=settings.runtime_settings,
     )
 

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -92,6 +92,9 @@ from src.modules.media.application.use_cases.stream_file_range import StreamFile
 from src.modules.media.application.use_cases.sweep_interrupted_scan_runs import (
     SweepInterruptedScanRunsUseCase,
 )
+from src.modules.media.application.use_cases.sweep_movie_conflicts import (
+    SweepMovieConflictsUseCase,
+)
 from src.modules.media.application.use_cases.trigger_bulk_enrich import (
     TriggerBulkEnrichUseCase,
 )
@@ -580,6 +583,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     bulk_mark_distinct_conflicts = providers.Factory(
         BulkMarkDistinctConflictsUseCase,
         uow_factory=media_unit_of_work_factory,
+    )
+
+    sweep_movie_conflicts = providers.Factory(
+        SweepMovieConflictsUseCase,
+        uow_factory=media_unit_of_work_factory,
+        detect_use_case=detect_movie_conflicts,
     )
 
     # =========================================================================

--- a/src/infrastructure/scheduling/__init__.py
+++ b/src/infrastructure/scheduling/__init__.py
@@ -1,12 +1,18 @@
 """Background scheduling infrastructure.
 
 The scheduler coordinates recurring work (library scans, scrub-preview
-thumbnail backfill, intro detection) without coupling the domain or
-application layers to any specific scheduling backend.
+thumbnail backfill, intro detection, scan-dedup sweep) without coupling
+the domain or application layers to any specific scheduling backend.
 """
 
 from src.infrastructure.scheduling.intro_detection_job import IntroDetectionJob
+from src.infrastructure.scheduling.scan_dedup_sweep_job import ScanDedupSweepJob
 from src.infrastructure.scheduling.scheduler_service import LibraryScanScheduler
 from src.infrastructure.scheduling.thumbnail_backfill_job import ThumbnailBackfillJob
 
-__all__ = ["IntroDetectionJob", "LibraryScanScheduler", "ThumbnailBackfillJob"]
+__all__ = [
+    "IntroDetectionJob",
+    "LibraryScanScheduler",
+    "ScanDedupSweepJob",
+    "ThumbnailBackfillJob",
+]

--- a/src/infrastructure/scheduling/scan_dedup_sweep_job.py
+++ b/src/infrastructure/scheduling/scan_dedup_sweep_job.py
@@ -1,0 +1,64 @@
+"""Periodic background job that re-runs the catalog-wide dedup sweep.
+
+Each tick reads the current ``scan_dedup`` runtime settings and, when
+the sweep is still enabled, invokes
+:class:`SweepMovieConflictsUseCase`. The job is intentionally a thin
+adapter — all aggregation and error handling lives in the use case.
+
+ADR-015 Phase 6.5.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.config.logging import get_logger
+
+if TYPE_CHECKING:
+    from src.modules.media.application.use_cases.sweep_movie_conflicts import (
+        SweepMovieConflictsUseCase,
+    )
+    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+
+_logger = get_logger()
+
+
+class ScanDedupSweepJob:
+    """One periodic scan-dedup sweep, gated on the current runtime setting.
+
+    The job is registered once at startup with the configured interval;
+    on every tick it re-reads ``scan_dedup`` so an operator toggling the
+    sweep off mid-day stops new passes from running without waiting for
+    a restart. (The interval itself only takes effect on the next
+    startup — APScheduler doesn't live-rescheduled registered jobs.)
+
+    Args:
+        sweep_use_case: The catalog-wide sweep.
+        runtime_settings: Snapshot facade for
+            :class:`ScanDedupConfig` — read fresh each tick.
+    """
+
+    def __init__(
+        self,
+        sweep_use_case: SweepMovieConflictsUseCase,
+        runtime_settings: RuntimeSettings,
+    ) -> None:
+        self._sweep_use_case = sweep_use_case
+        self._runtime_settings = runtime_settings
+
+    async def run(self) -> None:
+        """Execute one sweep pass when the runtime config still enables it."""
+        config = await self._runtime_settings.scan_dedup()
+        if not config.sweep_enabled:
+            _logger.debug("[scan-dedup-sweep] disabled at tick; skipping")
+            return
+
+        result = await self._sweep_use_case.execute()
+        _logger.info(
+            "[scan-dedup-sweep] tick complete",
+            movies_scanned=result.movies_scanned,
+            conflicts_created=result.conflicts_created,
+        )
+
+
+__all__ = ["ScanDedupSweepJob"]

--- a/src/main.py
+++ b/src/main.py
@@ -211,6 +211,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 minutes=intro_cfg.interval_minutes,
                 job_id="homeflix:intro-detection",
             )
+        scan_dedup_cfg = await runtime_settings.scan_dedup()
+        if scan_dedup_cfg.sweep_enabled:
+            sweep_job = await container.scan_dedup_sweep_job()
+            scheduler.add_interval_job(
+                sweep_job.run,
+                minutes=scan_dedup_cfg.sweep_interval_minutes,
+                job_id="homeflix:scan-dedup-sweep",
+            )
         app.state.scheduler = scheduler
 
     logger.info("Application ready")

--- a/src/modules/media/application/dtos/conflict_dtos.py
+++ b/src/modules/media/application/dtos/conflict_dtos.py
@@ -15,11 +15,15 @@ class DetectMovieConflictsInput:
 
     Attributes:
         media_id: External id of the just-enriched movie (``mov_xxx``).
-        tmdb_id: TMDB numeric id the enrichment locked onto.
+        tmdb_id: TMDB numeric id the enrichment locked onto. ``None``
+            when the detector is run by the scheduled sweep (ADR-015
+            Phase 6.5) against a movie that never matched a TMDB id —
+            the TMDB-id pass is skipped and only the title+year
+            fallback runs.
     """
 
     media_id: str
-    tmdb_id: int
+    tmdb_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -227,6 +231,24 @@ class BulkMarkDistinctOutput:
 
 
 @dataclass(frozen=True)
+class SweepMovieConflictsOutput:
+    """Result summary after a scheduled (or manual) dedup sweep.
+
+    Attributes:
+        movies_scanned: How many movies the sweep walked. Equal to the
+            catalog size at the moment the sweep snapshotted ``list_all``.
+        conflicts_created: Total ``MediaConflict`` rows persisted across
+            all per-movie detector invocations. Auto-merges are counted
+            here too — they create a resolved-AUTO row.
+        conflict_ids: External ids of the new rows, in insertion order.
+    """
+
+    movies_scanned: int
+    conflicts_created: int
+    conflict_ids: list[str]
+
+
+@dataclass(frozen=True)
 class ListConflictsOutput:
     """Paginated list of conflicts.
 
@@ -256,4 +278,5 @@ __all__ = [
     "ListConflictsOutput",
     "ResolveMediaConflictInput",
     "ResolveMediaConflictOutput",
+    "SweepMovieConflictsOutput",
 ]

--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -101,22 +101,30 @@ class DetectMovieConflictsUseCase:
         fallback_enabled = config is not None and config.title_year_fallback_enabled
 
         async with self._uow_factory() as uow:
-            candidates = await uow.movies.find_all_by_tmdb_id(input_dto.tmdb_id)
-            self_movie = next(
-                (m for m in candidates if str(m.id) == input_dto.media_id),
-                None,
-            )
+            if input_dto.tmdb_id is None:
+                # Sweep path (ADR-015 Phase 6.5): the movie carries no
+                # TMDB id, so there is no strong pass to run. We only
+                # need the self entity for the fallback comparison.
+                self_movie = await uow.movies.find_by_id(MovieId(input_dto.media_id))
+                others: list[Movie] = []
+            else:
+                candidates = await uow.movies.find_all_by_tmdb_id(input_dto.tmdb_id)
+                self_movie = next(
+                    (m for m in candidates if str(m.id) == input_dto.media_id),
+                    None,
+                )
+                others = [m for m in candidates if str(m.id) != input_dto.media_id]
+
             if self_movie is None:
-                # Defensive: detector fired but the enriched movie
-                # vanished between commit and handler dispatch.
+                # Defensive: detector fired but the movie vanished
+                # between commit and handler dispatch.
                 _logger.warning(
-                    "Enriched movie %s not found during conflict detection",
+                    "Movie %s not found during conflict detection",
                     input_dto.media_id,
                 )
                 return DetectMovieConflictsOutput(conflicts_created=0, conflict_ids=[])
 
             self_runtime = _runtime_minutes(self_movie)
-            others = [m for m in candidates if str(m.id) != input_dto.media_id]
             handled_ids = {input_dto.media_id}
 
             # --- Strong pass: TMDB-id collisions (auto-merge eligible). ---

--- a/src/modules/media/application/use_cases/sweep_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/sweep_movie_conflicts.py
@@ -1,0 +1,96 @@
+"""Scheduled / manual catalog-wide dedup sweep (ADR-015 Phase 6.5)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.dtos.conflict_dtos import (
+    DetectMovieConflictsInput,
+    SweepMovieConflictsOutput,
+)
+
+if TYPE_CHECKING:
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.application.use_cases.detect_movie_conflicts import (
+        DetectMovieConflictsUseCase,
+    )
+
+_logger = logging.getLogger(__name__)
+
+
+class SweepMovieConflictsUseCase:
+    """Walk every movie in the catalog and run the conflict detector.
+
+    Event-driven detection (``OnMediaEnrichedHandler``) only fires when
+    a movie is freshly enriched. That misses two real-world cases:
+
+    - A duplicate that was already in the catalog when the *first* copy
+      was enriched (the second copy comes in later and is never
+      re-enriched, so no event ever reaches the detector).
+    - A pair where neither side ever locked a TMDB id; the title+year
+      fallback (ADR-015 Phase 4) is the only thing that can catch them,
+      but it too only runs from the enrich handler.
+
+    This sweep is the periodic re-check: snapshot the catalog, then
+    invoke :class:`DetectMovieConflictsUseCase` once per movie. Each
+    detector run opens its own UoW so a single failing pair never aborts
+    the whole pass. The sweep itself never re-enriches anyone — it only
+    re-evaluates the existing catalog state.
+
+    Args:
+        uow_factory: Used to take a cheap snapshot of every movie id
+            (and its tmdb_id) at the start of the sweep. The detector
+            re-opens its own UoW per movie.
+        detect_use_case: The per-movie detector. Receives the optional
+            ``tmdb_id`` (``None`` for un-enriched entries → fallback
+            pass only).
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        detect_use_case: DetectMovieConflictsUseCase,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._detect_use_case = detect_use_case
+
+    async def execute(self) -> SweepMovieConflictsOutput:
+        """Run a single sweep pass and return the aggregate counters."""
+        async with self._uow_factory() as uow:
+            movies = list(await uow.movies.list_all())
+
+        snapshot = [(str(m.id), m.tmdb_id.value if m.tmdb_id else None) for m in movies]
+
+        created_ids: list[str] = []
+        for media_id, tmdb_id in snapshot:
+            try:
+                result = await self._detect_use_case.execute(
+                    DetectMovieConflictsInput(media_id=media_id, tmdb_id=tmdb_id),
+                )
+            except Exception:
+                # Best-effort: a single bad row must not abort the
+                # whole sweep. Detector already logs the per-pair
+                # context internally; here we just keep going.
+                _logger.exception(
+                    "[scan-dedup-sweep] detect failed for movie %s; continuing",
+                    media_id,
+                )
+                continue
+            created_ids.extend(result.conflict_ids)
+
+        _logger.info(
+            "[scan-dedup-sweep] pass complete",
+            extra={
+                "movies_scanned": len(snapshot),
+                "conflicts_created": len(created_ids),
+            },
+        )
+        return SweepMovieConflictsOutput(
+            movies_scanned=len(snapshot),
+            conflicts_created=len(created_ids),
+            conflict_ids=created_ids,
+        )
+
+
+__all__ = ["SweepMovieConflictsUseCase"]

--- a/src/modules/media/presentation/routes/admin_conflicts_routes.py
+++ b/src/modules/media/presentation/routes/admin_conflicts_routes.py
@@ -33,6 +33,9 @@ from src.modules.media.application.use_cases.list_conflicts import ListConflicts
 from src.modules.media.application.use_cases.resolve_media_conflict import (
     ResolveMediaConflictUseCase,
 )
+from src.modules.media.application.use_cases.sweep_movie_conflicts import (
+    SweepMovieConflictsUseCase,
+)
 from src.modules.media.domain.entities.media_conflict import ResolutionAction
 
 _MAX_BULK_CONFLICTS = 200
@@ -172,6 +175,31 @@ async def bulk_mark_distinct_conflicts(
         BulkMarkDistinctInput(conflict_ids=body.conflict_ids),
     )
     return api_single("media_conflict_bulk_resolution", asdict(output))
+
+
+@router.post("/sweep")
+@inject
+async def sweep_admin_conflicts(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: SweepMovieConflictsUseCase = Depends(
+        Provide[ApplicationContainer.media.sweep_movie_conflicts],
+    ),
+) -> dict[str, Any]:
+    """Trigger a one-off catalog-wide dedup sweep (ADR-015 Phase 6.5).
+
+    Re-runs the conflict detector against every movie in the catalog,
+    no enrichment required. Use it to catch duplicates the event-driven
+    handler missed — e.g. a second copy that landed *after* the first
+    was already enriched, or a pair where neither side ever locked a
+    TMDB id (handled by the title+year fallback).
+
+    The same pass also runs automatically when the scheduled sweep is
+    enabled in the ``scan_dedup`` settings bucket. The manual endpoint
+    ignores that flag so the operator can re-check on demand even when
+    the recurring job is off.
+    """
+    output = await use_case.execute()
+    return api_single("media_conflict_sweep", asdict(output))
 
 
 __all__ = ["router"]

--- a/src/modules/settings/domain/value_objects/scan_dedup_config.py
+++ b/src/modules/settings/domain/value_objects/scan_dedup_config.py
@@ -29,6 +29,17 @@ class ScanDedupConfig(CompoundValueObject):
             entries whose enrichment never locked a TMDB id. Fallback
             matches always queue for the operator and are never
             silently auto-merged, since the identity is weaker.
+        sweep_enabled: When ``True``, a periodic background job
+            (ADR-015 Phase 6.5) walks every movie in the catalog and
+            re-runs the conflict detector — catching duplicates that
+            never fire ``MediaEnrichedEvent`` (un-enriched entries,
+            collisions introduced after the original enrich). Off by
+            default; manual trigger via the admin endpoint still works
+            regardless of this flag.
+        sweep_interval_minutes: Minutes between successive sweep
+            ticks when the job is enabled. Defaults to ``1440`` (one
+            run per day); the floor of ``15`` matches the operator
+            settings minimums elsewhere.
 
     Example:
         >>> cfg = ScanDedupConfig()
@@ -38,6 +49,8 @@ class ScanDedupConfig(CompoundValueObject):
     runtime_delta_abs_minutes: float = Field(default=5.0, ge=0.0)
     runtime_delta_relative: float = Field(default=0.10, ge=0.0, le=1.0)
     title_year_fallback_enabled: bool = Field(default=True)
+    sweep_enabled: bool = Field(default=False)
+    sweep_interval_minutes: int = Field(default=1440, ge=15)
 
 
 __all__ = ["ScanDedupConfig"]

--- a/tests/infrastructure/scheduling/test_scan_dedup_sweep_job.py
+++ b/tests/infrastructure/scheduling/test_scan_dedup_sweep_job.py
@@ -1,0 +1,41 @@
+"""Tests for ScanDedupSweepJob (ADR-015 Phase 6.5)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infrastructure.scheduling.scan_dedup_sweep_job import ScanDedupSweepJob
+from src.modules.media.application.dtos.conflict_dtos import (
+    SweepMovieConflictsOutput,
+)
+from src.modules.settings.domain.value_objects import ScanDedupConfig
+
+
+@pytest.mark.asyncio
+async def test_run_invokes_sweep_when_enabled() -> None:
+    sweep = AsyncMock()
+    sweep.execute.return_value = SweepMovieConflictsOutput(
+        movies_scanned=3,
+        conflicts_created=1,
+        conflict_ids=["cnf_abc12345abcd"],
+    )
+    runtime_settings = AsyncMock()
+    runtime_settings.scan_dedup.return_value = ScanDedupConfig(sweep_enabled=True)
+
+    job = ScanDedupSweepJob(sweep_use_case=sweep, runtime_settings=runtime_settings)
+    await job.run()
+
+    sweep.execute.assert_awaited_once()
+    runtime_settings.scan_dedup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_skips_sweep_when_disabled() -> None:
+    sweep = AsyncMock()
+    runtime_settings = AsyncMock()
+    runtime_settings.scan_dedup.return_value = ScanDedupConfig(sweep_enabled=False)
+
+    job = ScanDedupSweepJob(sweep_use_case=sweep, runtime_settings=runtime_settings)
+    await job.run()
+
+    sweep.execute.assert_not_called()

--- a/tests/modules/media/e2e/test_admin_conflicts_routes.py
+++ b/tests/modules/media/e2e/test_admin_conflicts_routes.py
@@ -550,3 +550,39 @@ class TestAdminConflictsBulkMarkDistinct:
         await _login_as_admin(client, seed_user_with_profile)
         response = await client.post(_BULK_PATH, json={"conflict_ids": []})
         assert response.status_code == 422
+
+
+_SWEEP_PATH = f"{CONFLICTS_PATH}/sweep"
+
+
+@pytest.mark.e2e
+class TestAdminConflictsSweep:
+    """``POST /admin/conflicts/sweep`` (ADR-015 Phase 6.5)."""
+
+    async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        response = await client.post(_SWEEP_PATH)
+        assert response.status_code == 401
+
+    async def test_member_returns_403(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile(email="member@example.com", is_admin=False)
+        await _login(client, member)
+        response = await client.post(_SWEEP_PATH)
+        assert response.status_code == 403
+
+    async def test_empty_catalog_returns_zero_counters(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        response = await client.post(_SWEEP_PATH)
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["movies_scanned"] == 0
+        assert payload["conflicts_created"] == 0
+        assert payload["conflict_ids"] == []

--- a/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
@@ -334,6 +334,60 @@ class TestTitleYearFallback:
         mocks.movies.delete.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_sweep_path_none_tmdb_skips_tmdb_pass_runs_fallback(self) -> None:
+        # ADR-015 Phase 6.5 — the sweep invokes the detector with
+        # ``tmdb_id=None`` for movies that never matched TMDB. The
+        # detector must skip ``find_all_by_tmdb_id`` entirely and still
+        # run the title+year fallback pass.
+        mocks = make_media_uow_mock()
+        unenriched_self = _build_movie(
+            external_id="mov_aaaaaaaaaaaa",
+            title="Princess Mononoke",
+            year=1997,
+            tmdb_id=None,
+            file_paths=["/movies/a.mkv"],
+        )
+        unenriched_dup = _build_movie(
+            external_id="mov_bbbbbbbbbbbb",
+            title="Princess Mononoke",
+            year=1997,
+            tmdb_id=None,
+            file_paths=["/movies/b.mkv"],
+        )
+        mocks.movies.find_by_id.return_value = unenriched_self
+        mocks.movies.find_all_by_year.return_value = [unenriched_self, unenriched_dup]
+        mocks.media_conflicts.find_blocking_pair.return_value = None
+        mocks.media_conflicts.save.side_effect = _stamp_conflict_id
+
+        use_case = DetectMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            runtime_settings=_settings_with(fallback=True),
+        )
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_aaaaaaaaaaaa", tmdb_id=None),
+        )
+
+        assert result.conflicts_created == 1
+        mocks.movies.find_all_by_tmdb_id.assert_not_called()
+        saved = mocks.media_conflicts.save.call_args[0][0]
+        assert saved.match_reason is MatchReason.TITLE_YEAR_FALLBACK
+
+    @pytest.mark.asyncio
+    async def test_sweep_path_none_tmdb_returns_empty_when_self_vanished(self) -> None:
+        # If the sweep's snapshot id no longer resolves (movie deleted
+        # mid-pass), the detector returns 0 instead of crashing.
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
+
+        use_case = DetectMovieConflictsUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            DetectMovieConflictsInput(media_id="mov_aaaaaaaaaaaa", tmdb_id=None),
+        )
+
+        assert result.conflicts_created == 0
+        mocks.media_conflicts.save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_fallback_skips_ids_already_handled_by_tmdb_pass(self) -> None:
         mocks = make_media_uow_mock()
         enriched = _build_movie(

--- a/tests/modules/media/unit/application/use_cases/test_sweep_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_sweep_movie_conflicts.py
@@ -1,0 +1,139 @@
+"""Tests for SweepMovieConflictsUseCase (ADR-015 Phase 6.5)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.application.dtos.conflict_dtos import (
+    DetectMovieConflictsInput,
+    DetectMovieConflictsOutput,
+)
+from src.modules.media.application.use_cases.sweep_movie_conflicts import (
+    SweepMovieConflictsUseCase,
+)
+from src.modules.media.domain.entities.movie import Movie
+from src.modules.media.domain.value_objects import (
+    Duration,
+    MovieId,
+    Title,
+    TmdbId,
+    Year,
+)
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+
+def _movie(*, external_id: str, tmdb_id: int | None) -> Movie:
+    return Movie(
+        id=MovieId(external_id),
+        library_id="lib_test12345678",
+        title=Title("Example"),
+        year=Year(2020),
+        duration=Duration(7200),
+        files=[],
+        tmdb_id=None if tmdb_id is None else TmdbId(tmdb_id),
+    )
+
+
+class TestSweepMovieConflictsUseCase:
+    @pytest.mark.asyncio
+    async def test_invokes_detect_per_movie_with_each_tmdb_id(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_all.return_value = [
+            _movie(external_id="mov_aaaaaaaaaaaa", tmdb_id=27205),
+            _movie(external_id="mov_bbbbbbbbbbbb", tmdb_id=None),
+        ]
+        detect = AsyncMock()
+        detect.execute.return_value = DetectMovieConflictsOutput(
+            conflicts_created=0,
+            conflict_ids=[],
+        )
+
+        use_case = SweepMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            detect_use_case=detect,
+        )
+        result = await use_case.execute()
+
+        assert result.movies_scanned == 2
+        assert result.conflicts_created == 0
+        assert detect.execute.await_count == 2
+        first_call = detect.execute.await_args_list[0].args[0]
+        second_call = detect.execute.await_args_list[1].args[0]
+        assert isinstance(first_call, DetectMovieConflictsInput)
+        assert first_call.media_id == "mov_aaaaaaaaaaaa"
+        assert first_call.tmdb_id == 27205
+        assert second_call.media_id == "mov_bbbbbbbbbbbb"
+        assert second_call.tmdb_id is None
+
+    @pytest.mark.asyncio
+    async def test_aggregates_created_conflict_ids_across_movies(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_all.return_value = [
+            _movie(external_id="mov_aaaaaaaaaaaa", tmdb_id=27205),
+            _movie(external_id="mov_bbbbbbbbbbbb", tmdb_id=27205),
+        ]
+        detect = AsyncMock()
+        detect.execute.side_effect = [
+            DetectMovieConflictsOutput(conflicts_created=1, conflict_ids=["cnf_one12345678"]),
+            DetectMovieConflictsOutput(
+                conflicts_created=2, conflict_ids=["cnf_two12345678", "cnf_three1234"]
+            ),
+        ]
+
+        use_case = SweepMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            detect_use_case=detect,
+        )
+        result = await use_case.execute()
+
+        assert result.movies_scanned == 2
+        assert result.conflicts_created == 3
+        assert result.conflict_ids == [
+            "cnf_one12345678",
+            "cnf_two12345678",
+            "cnf_three1234",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_continues_after_per_movie_detector_exception(self) -> None:
+        # One bad row must not abort the whole sweep.
+        mocks = make_media_uow_mock()
+        mocks.movies.list_all.return_value = [
+            _movie(external_id="mov_aaaaaaaaaaaa", tmdb_id=27205),
+            _movie(external_id="mov_bbbbbbbbbbbb", tmdb_id=42),
+        ]
+        detect = AsyncMock()
+        detect.execute.side_effect = [
+            RuntimeError("boom"),
+            DetectMovieConflictsOutput(
+                conflicts_created=1,
+                conflict_ids=["cnf_ok1234567890"],
+            ),
+        ]
+
+        use_case = SweepMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            detect_use_case=detect,
+        )
+        result = await use_case.execute()
+
+        assert result.movies_scanned == 2
+        assert result.conflicts_created == 1
+        assert result.conflict_ids == ["cnf_ok1234567890"]
+
+    @pytest.mark.asyncio
+    async def test_empty_catalog_returns_zero_counters(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_all.return_value = []
+        detect = AsyncMock()
+
+        use_case = SweepMovieConflictsUseCase(
+            uow_factory=mocks.factory,
+            detect_use_case=detect,
+        )
+        result = await use_case.execute()
+
+        assert result.movies_scanned == 0
+        assert result.conflicts_created == 0
+        assert result.conflict_ids == []
+        detect.execute.assert_not_called()

--- a/tests/modules/settings/unit/domain/value_objects/test_scan_dedup_config.py
+++ b/tests/modules/settings/unit/domain/value_objects/test_scan_dedup_config.py
@@ -13,11 +13,23 @@ class TestScanDedupConfig:
         assert config.runtime_delta_abs_minutes == 5.0
         assert config.runtime_delta_relative == 0.10
         assert config.title_year_fallback_enabled is True
+        assert config.sweep_enabled is False
+        assert config.sweep_interval_minutes == 1440
 
     def test_fallback_can_be_disabled(self) -> None:
         config = ScanDedupConfig(title_year_fallback_enabled=False)
 
         assert config.title_year_fallback_enabled is False
+
+    def test_sweep_can_be_enabled_and_interval_tuned(self) -> None:
+        config = ScanDedupConfig(sweep_enabled=True, sweep_interval_minutes=60)
+
+        assert config.sweep_enabled is True
+        assert config.sweep_interval_minutes == 60
+
+    def test_sweep_interval_below_floor_raises(self) -> None:
+        with pytest.raises(DomainValidationException):
+            ScanDedupConfig(sweep_interval_minutes=5)
 
     def test_negative_abs_minutes_raises(self) -> None:
         with pytest.raises(DomainValidationException):


### PR DESCRIPTION
## Summary
- Event-driven detection only fires from ``MediaEnrichedEvent`` — it misses duplicates that land **after** the first copy was enriched, and pairs where neither side ever matched a TMDB id. Phase 6.5 closes that gap with a periodic sweep that walks the catalog and re-runs the detector per movie.
- New ``POST /api/v1/admin/conflicts/sweep`` admin endpoint runs the same pass synchronously so the operator can re-check on demand even when the recurring job is off. Returns ``{movies_scanned, conflicts_created, conflict_ids}``.
- ``scan_dedup`` runtime bucket gains two knobs: ``sweep_enabled`` (default off) and ``sweep_interval_minutes`` (default 1440, floor 15) — so the recurring job is opt-in and tunable without a deploy.
- ``DetectMovieConflictsInput.tmdb_id`` becomes optional: when ``None`` the detector skips the TMDB pass entirely, loads the self movie via ``find_by_id``, and runs only the title+year fallback — needed so the sweep can re-evaluate un-enriched entries too.
- ``SweepMovieConflictsUseCase`` snapshots ``movies.list_all()`` and dispatches the detector per movie. A failing per-movie detect is logged and skipped so one bad row never aborts the sweep.
- ``ScanDedupSweepJob`` registered alongside the existing intro-detection / thumbnail-backfill jobs in the lifespan; gated on the live ``sweep_enabled`` flag on every tick so toggling it off mid-day stops new passes without a restart.

## Test plan
- [x] ``poetry run pytest`` (full suite — 2 654 passed, 5 skipped)
- [x] ``poetry run ruff check src tests`` + ``poetry run ruff format --check src tests``
- [x] New unit tests cover: sweep iterates + aggregates, single bad detect doesn't abort the pass, empty catalog short-circuits, detector handles ``tmdb_id=None`` via ``find_by_id`` + fallback pass, sweep job tick gates on ``sweep_enabled``, ``ScanDedupConfig`` defaults + floor enforcement
- [x] New e2e test covers the manual ``POST /admin/conflicts/sweep`` route end-to-end (auth gate + empty-catalog response)
- [ ] Smoke: toggle ``sweep_enabled`` in the admin panel + verify the job runs on the configured interval (frontend lands in a follow-up PR)

## Related issues
- Continues ADR-015 — Phase 6.5 (scheduled dedup sweep) was the one open item left after 6.1–6.4 shipped.

## Summary by Sourcery

Add a catalog-wide movie deduplication sweep and wire it into both an admin endpoint and the background scheduler.

New Features:
- Introduce a SweepMovieConflicts use case that walks all movies and reruns conflict detection per title, including entries without a TMDB id.
- Expose a protected POST /admin/conflicts/sweep endpoint for operators to trigger a one-off catalog-wide dedup sweep and receive summary counters.
- Add a ScanDedupSweepJob background job that periodically runs the dedup sweep based on runtime scan_dedup settings.

Enhancements:
- Allow DetectMovieConflictsInput.tmdb_id to be optional so conflict detection can run using only title and year when no TMDB id is present.
- Extend scan-dedup runtime configuration with flags to enable the sweep and control its interval, and register the sweep job at application startup.

Tests:
- Add unit tests for the sweep use case, the scan-dedup sweep job, the updated conflict detector behavior when tmdb_id is None, and the new admin sweep route including auth and empty-catalog handling.
- Extend ScanDedupConfig tests to cover the new sweep settings and interval validation.