### PR TITLE
feat(catalog): TMDB lookup endpoint for the request dialog

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -85,6 +85,9 @@ from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
+from src.modules.media.application.use_cases.search_tmdb_titles import (
+    SearchTmdbTitlesUseCase,
+)
 from src.modules.media.application.use_cases.serve_hls_file import ServeHlsFileUseCase
 from src.modules.media.application.use_cases.set_episode_intro import SetEpisodeIntroUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
@@ -540,6 +543,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     get_movie_tmdb_suggestions = providers.Factory(
         GetMovieTmdbSuggestionsUseCase,
         uow_factory=media_unit_of_work_factory,
+        metadata_provider=tmdb_client,
+    )
+
+    search_tmdb_titles = providers.Factory(
+        SearchTmdbTitlesUseCase,
         metadata_provider=tmdb_client,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -48,6 +48,7 @@ from src.modules.media.presentation.routes import (
     search_router,
     series_router,
     stream_router,
+    tmdb_lookup_router,
 )
 from src.modules.notifications.presentation.routes import notification_router
 from src.modules.preferences.presentation.routes.preferences_routes import (
@@ -76,6 +77,7 @@ WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.media.presentation.routes.scan_routes",
     "src.modules.media.presentation.routes.series_routes",
     "src.modules.media.presentation.routes.stream_routes",
+    "src.modules.media.presentation.routes.tmdb_lookup_routes",
     "src.modules.watch_progress.presentation.routes.progress_routes",
     "src.modules.collections.presentation.routes.watchlist_routes",
     "src.modules.collections.presentation.routes.custom_list_routes",
@@ -443,6 +445,7 @@ def create_app() -> FastAPI:
     app.include_router(scan_router)
     app.include_router(series_router)
     app.include_router(stream_router)
+    app.include_router(tmdb_lookup_router)
     app.include_router(progress_router)
     app.include_router(watchlist_router)
     app.include_router(custom_list_router)

--- a/src/modules/media/application/dtos/tmdb_lookup_dtos.py
+++ b/src/modules/media/application/dtos/tmdb_lookup_dtos.py
@@ -1,0 +1,76 @@
+"""DTOs for the TMDB lookup endpoint that powers the request dialog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+LookupMediaType = Literal["movie", "tv"]
+
+
+@dataclass(frozen=True)
+class SearchTmdbTitlesInput:
+    """Input for the catalog-request lookup use case.
+
+    Attributes:
+        query: Free-form text from the dialog input. Accepts a bare
+            TMDB id (``603``), an IMDb id (``tt0133093``), a TMDB
+            URL (``https://www.themoviedb.org/movie/603``), an IMDb
+            URL (``https://www.imdb.com/title/tt0133093/``) or a
+            plain title. The use case parses the shape internally.
+        limit: Maximum candidates per kind on the free-text search
+            branch (movie + tv each return up to ``limit``). Ignored
+            on the by-id branches — those return at most one match
+            per kind. Caller (route) clamps to a sensible range.
+    """
+
+    query: str
+    limit: int = 5
+
+
+@dataclass(frozen=True)
+class TmdbLookupCandidate:
+    """One row in the request-dialog picker.
+
+    Attributes:
+        tmdb_id: TMDB primary key.
+        media_type: ``"movie"`` (``/movie/{id}``) or ``"tv"`` (``/tv/{id}``).
+        title: Display title from TMDB.
+        year: Release / first-air year, or ``None`` when the source
+            lacks a usable date.
+        overview: Synopsis (possibly empty).
+        poster_url: Absolute poster URL, or ``None``.
+    """
+
+    tmdb_id: int
+    media_type: LookupMediaType
+    title: str
+    year: int | None
+    overview: str | None
+    poster_url: str | None
+
+
+@dataclass(frozen=True)
+class SearchTmdbTitlesOutput:
+    """Response shape returned to the request dialog.
+
+    Attributes:
+        query: Echo of the cleaned input. Lets the UI tell the
+            user what was actually searched after stripping.
+        kind: Which detection branch ran — ``"tmdb_id"`` /
+            ``"imdb_id"`` / ``"text"``. Useful for analytics +
+            for the UI to render a hint ("Matched by TMDB id …").
+        candidates: Picker rows, movies first, then series.
+    """
+
+    query: str
+    kind: Literal["tmdb_id", "imdb_id", "text"]
+    candidates: list[TmdbLookupCandidate] = field(default_factory=list)
+
+
+__all__ = [
+    "LookupMediaType",
+    "SearchTmdbTitlesInput",
+    "SearchTmdbTitlesOutput",
+    "TmdbLookupCandidate",
+]

--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -422,6 +422,52 @@ class MetadataProvider(ABC):
         ...
 
     @abstractmethod
+    async def get_movie_summary_by_id(self, tmdb_id: int) -> "SearchCandidate | None":
+        """Cheap card-level fetch for one movie by id.
+
+        Powers the catalog-request lookup dialog: when the user
+        pastes a bare TMDB id, this returns the single matching
+        candidate so the picker can render it. Distinct from
+        :meth:`get_movie_by_id` (which pulls full ``MediaMetadata``
+        with credits / recommendations / collection — way more than
+        a picker preview needs).
+
+        Args:
+            tmdb_id: TMDB numeric id.
+
+        Returns:
+            ``SearchCandidate`` when the id resolves to a movie;
+            ``None`` on 404 / network failure / malformed payload.
+        """
+        ...
+
+    @abstractmethod
+    async def get_series_summary_by_id(self, tmdb_id: int) -> "SearchCandidate | None":
+        """Cheap card-level fetch for one TV series by id."""
+        ...
+
+    @abstractmethod
+    async def find_by_imdb_id(self, imdb_id: str) -> list["SearchCandidate"]:
+        """Resolve an IMDb id (``tt1234567``) to TMDB candidates.
+
+        Powers the catalog-request lookup endpoint: when the user
+        pastes an IMDb id or URL, the dialog asks TMDB which titles it
+        corresponds to. The provider's ``/find`` route returns both
+        movie and TV hits — the same IMDb id can carry both when, for
+        example, an anime film also has a series entry. Callers render
+        the full list and let the user pick.
+
+        Args:
+            imdb_id: IMDb id (``tt`` followed by 7+ digits).
+
+        Returns:
+            All candidates matched by the id, in arbitrary order
+            (caller stable-sorts). Empty list when the provider has
+            no match for the id or the call fails.
+        """
+        ...
+
+    @abstractmethod
     async def get_movie_recommendations(self, tmdb_id: int) -> list[int]:
         """Return TMDB ids of movies recommended for ``tmdb_id``.
 

--- a/src/modules/media/application/use_cases/search_tmdb_titles.py
+++ b/src/modules/media/application/use_cases/search_tmdb_titles.py
@@ -1,0 +1,182 @@
+"""Use case: TMDB lookup that powers the "Request a title" dialog.
+
+Accepts any of TMDB id / IMDb id / TMDB URL / IMDb URL / plain title
+and returns a single list of picker candidates. The user picks one
+card and the frontend POSTs the chosen ``(tmdb_id, media_type)`` to
+``/catalog-requests`` to create the actual request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from src.modules.media.application.dtos.tmdb_lookup_dtos import (
+    SearchTmdbTitlesInput,
+    SearchTmdbTitlesOutput,
+    TmdbLookupCandidate,
+)
+
+if TYPE_CHECKING:
+    from src.modules.media.application.ports import MetadataProvider, SearchCandidate
+
+
+# TMDB URL example: https://www.themoviedb.org/movie/603-the-matrix
+_TMDB_URL_RE = re.compile(
+    r"themoviedb\.org/(?P<kind>movie|tv)/(?P<id>\d+)",
+    re.IGNORECASE,
+)
+# IMDb URL example: https://www.imdb.com/title/tt0133093/
+_IMDB_URL_RE = re.compile(
+    r"imdb\.com/title/(?P<id>tt\d{6,})",
+    re.IGNORECASE,
+)
+# Bare IMDb id, the canonical "tt" prefix + 7+ digits.
+_IMDB_BARE_RE = re.compile(r"^tt\d{6,}$", re.IGNORECASE)
+# Bare numeric TMDB id.
+_TMDB_BARE_RE = re.compile(r"^\d+$")
+
+
+@dataclass(frozen=True)
+class _ParsedQuery:
+    """Outcome of input parsing — one of three branches."""
+
+    kind: Literal["tmdb_id", "imdb_id", "text"]
+    # tmdb_id branch: the numeric id + which media type to fetch
+    # ("movie" / "tv" / None for ambiguous bare numeric).
+    tmdb_id: int | None = None
+    media_type: Literal["movie", "tv"] | None = None
+    # imdb_id branch: the canonical "tt..." string.
+    imdb_id: str | None = None
+    # text branch: the cleaned free-text query.
+    text: str | None = None
+
+
+def parse_lookup_query(raw: str) -> _ParsedQuery | None:
+    """Detect which shape ``raw`` is and return the routing hint.
+
+    Returns ``None`` when ``raw`` is empty / whitespace-only — the
+    caller short-circuits to an empty result before paying for any
+    TMDB call.
+    """
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+
+    if url_match := _TMDB_URL_RE.search(cleaned):
+        kind = url_match.group("kind").lower()
+        return _ParsedQuery(
+            kind="tmdb_id",
+            tmdb_id=int(url_match.group("id")),
+            media_type="movie" if kind == "movie" else "tv",
+        )
+
+    if imdb_match := _IMDB_URL_RE.search(cleaned):
+        return _ParsedQuery(kind="imdb_id", imdb_id=imdb_match.group("id").lower())
+
+    if _IMDB_BARE_RE.fullmatch(cleaned):
+        return _ParsedQuery(kind="imdb_id", imdb_id=cleaned.lower())
+
+    if _TMDB_BARE_RE.fullmatch(cleaned):
+        # Bare numeric — TMDB ids are not unique across the movie /
+        # tv namespaces, so the use case fetches both summaries and
+        # returns whichever exist. Leave media_type unset to flag
+        # "try both."
+        return _ParsedQuery(kind="tmdb_id", tmdb_id=int(cleaned))
+
+    return _ParsedQuery(kind="text", text=cleaned)
+
+
+class SearchTmdbTitlesUseCase:
+    """Resolve a free-form query into TMDB picker candidates.
+
+    The result list is short (≤ 2 for by-id branches, ≤ ``2*limit``
+    for the text branch) and intentionally not paginated — the
+    request dialog renders all hits inline.
+
+    Args:
+        metadata_provider: TMDB-side metadata port. Same singleton
+            already wired into the rest of the media BC.
+    """
+
+    def __init__(self, metadata_provider: MetadataProvider) -> None:
+        self._provider = metadata_provider
+
+    async def execute(self, input_dto: SearchTmdbTitlesInput) -> SearchTmdbTitlesOutput:
+        """Parse ``input_dto.query`` and return the matching TMDB candidates."""
+        parsed = parse_lookup_query(input_dto.query)
+        if parsed is None:
+            return SearchTmdbTitlesOutput(query="", kind="text", candidates=[])
+
+        if parsed.kind == "tmdb_id":
+            candidates = await self._fetch_by_tmdb_id(
+                parsed.tmdb_id,  # type: ignore[arg-type]  # guaranteed non-None on this branch
+                parsed.media_type,
+            )
+            display = parsed.text or input_dto.query.strip()
+            return SearchTmdbTitlesOutput(
+                query=display,
+                kind="tmdb_id",
+                candidates=candidates,
+            )
+
+        if parsed.kind == "imdb_id":
+            results = await self._provider.find_by_imdb_id(parsed.imdb_id)  # type: ignore[arg-type]
+            return SearchTmdbTitlesOutput(
+                query=parsed.imdb_id or "",
+                kind="imdb_id",
+                candidates=[_to_dto(c) for c in results],
+            )
+
+        # text branch
+        text = parsed.text or ""
+        limit = max(1, min(input_dto.limit, 20))
+        movies, series = await asyncio.gather(
+            self._provider.find_movie_candidates(text, year=None, limit=limit),
+            self._provider.find_series_candidates(text, year=None, limit=limit),
+        )
+        return SearchTmdbTitlesOutput(
+            query=text,
+            kind="text",
+            candidates=[_to_dto(c) for c in (*movies, *series)],
+        )
+
+    async def _fetch_by_tmdb_id(
+        self,
+        tmdb_id: int,
+        media_type: Literal["movie", "tv"] | None,
+    ) -> list[TmdbLookupCandidate]:
+        """Resolve a TMDB id; ambiguous bare numerics try both kinds."""
+        if media_type == "movie":
+            hit = await self._provider.get_movie_summary_by_id(tmdb_id)
+            return [_to_dto(hit)] if hit else []
+        if media_type == "tv":
+            hit = await self._provider.get_series_summary_by_id(tmdb_id)
+            return [_to_dto(hit)] if hit else []
+
+        movie_hit, series_hit = await asyncio.gather(
+            self._provider.get_movie_summary_by_id(tmdb_id),
+            self._provider.get_series_summary_by_id(tmdb_id),
+        )
+        results: list[TmdbLookupCandidate] = []
+        if movie_hit is not None:
+            results.append(_to_dto(movie_hit))
+        if series_hit is not None:
+            results.append(_to_dto(series_hit))
+        return results
+
+
+def _to_dto(candidate: SearchCandidate) -> TmdbLookupCandidate:
+    return TmdbLookupCandidate(
+        tmdb_id=candidate.tmdb_id,
+        media_type=candidate.media_type,
+        title=candidate.title,
+        year=candidate.year,
+        overview=candidate.overview,
+        poster_url=candidate.poster_url,
+    )
+
+
+__all__ = ["SearchTmdbTitlesUseCase", "parse_lookup_query"]

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -193,6 +193,56 @@ class TmdbClient(MetadataProvider):
         results = resp.json().get("results", [])
         return [_to_series_candidate(r, self._image_url) for r in results[:limit]]
 
+    async def get_movie_summary_by_id(self, tmdb_id: int) -> SearchCandidate | None:
+        """Cheap ``/movie/{id}`` fetch shaped as a picker candidate."""
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/movie/{tmdb_id}",
+                params=self._params(),
+            )
+        except httpx.HTTPError:
+            return None
+        if resp.status_code == 404:
+            return None
+        if resp.status_code != 200:
+            return None
+        return _to_movie_candidate(resp.json(), self._image_url)
+
+    async def get_series_summary_by_id(self, tmdb_id: int) -> SearchCandidate | None:
+        """Cheap ``/tv/{id}`` fetch shaped as a picker candidate."""
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/tv/{tmdb_id}",
+                params=self._params(),
+            )
+        except httpx.HTTPError:
+            return None
+        if resp.status_code == 404:
+            return None
+        if resp.status_code != 200:
+            return None
+        return _to_series_candidate(resp.json(), self._image_url)
+
+    async def find_by_imdb_id(self, imdb_id: str) -> list[SearchCandidate]:
+        """Resolve an IMDb id via ``/find`` and return movie + TV hits.
+
+        The response carries separate ``movie_results`` and
+        ``tv_results`` arrays — same IMDb id can match both shapes
+        (rare, but happens for adaptations). Movies come first to
+        match the conventional "film over series" expectation when the
+        user pastes ``tt`` from a movie page; tests can stable-sort
+        on ``media_type`` afterwards if they need a stricter order.
+        """
+        resp = await self._client.get(
+            f"{self._base_url}/find/{imdb_id}",
+            params=self._params(external_source="imdb_id"),
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        movies = [_to_movie_candidate(r, self._image_url) for r in payload.get("movie_results", [])]
+        series = [_to_series_candidate(r, self._image_url) for r in payload.get("tv_results", [])]
+        return [*movies, *series]
+
     @staticmethod
     def _pick_year_match(
         results: list[dict[str, object]],

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -25,6 +25,9 @@ from src.modules.media.presentation.routes.scan_routes import router as scan_rou
 from src.modules.media.presentation.routes.search_routes import router as search_router
 from src.modules.media.presentation.routes.series_routes import router as series_router
 from src.modules.media.presentation.routes.stream_routes import router as stream_router
+from src.modules.media.presentation.routes.tmdb_lookup_routes import (
+    router as tmdb_lookup_router,
+)
 
 __all__ = [
     "admin_conflicts_router",
@@ -42,4 +45,5 @@ __all__ = [
     "search_router",
     "series_router",
     "stream_router",
+    "tmdb_lookup_router",
 ]

--- a/src/modules/media/presentation/routes/tmdb_lookup_routes.py
+++ b/src/modules/media/presentation/routes/tmdb_lookup_routes.py
@@ -1,0 +1,66 @@
+"""Catalog lookup endpoint that powers the "Request a title" dialog.
+
+A thin authenticated proxy in front of the external metadata
+provider (today: TMDB) so the provider key stays server-side and
+the public URL doesn't leak which adapter is in use. The dialog
+calls this with whatever the user pasted — TMDB id, IMDb id, TMDB
+/ IMDb URL, or plain title — and gets back a list of picker
+candidates with title, year, overview, poster. The user picks one
+card and the frontend POSTs the chosen ``(tmdb_id, media_type)``
+to ``/catalog-requests``.
+"""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, Query
+
+from src.building_blocks.presentation import api_single
+from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_active_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.media.application.dtos.tmdb_lookup_dtos import SearchTmdbTitlesInput
+from src.modules.media.application.use_cases.search_tmdb_titles import (
+    SearchTmdbTitlesUseCase,
+)
+
+_MIN_LIMIT = 1
+_MAX_LIMIT = 10
+_DEFAULT_LIMIT = 5
+_MAX_QUERY_LEN = 500
+
+router = APIRouter(prefix="/api/v1/catalog", tags=["Catalog Lookup"])
+
+
+@router.get("/lookup")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def lookup_catalog_title(
+    q: str = Query(..., min_length=1, max_length=_MAX_QUERY_LEN),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=_MIN_LIMIT, le=_MAX_LIMIT),
+    _user: UserModel = Depends(current_active_user),
+    use_case: SearchTmdbTitlesUseCase = Depends(
+        Provide[ApplicationContainer.media.search_tmdb_titles],
+    ),
+) -> dict[str, Any]:
+    """Resolve ``q`` into picker candidates for the request dialog.
+
+    ``q`` accepts five shapes; the parser routes each to the cheapest
+    provider call:
+
+    - TMDB URL → one ``/movie/{id}`` or ``/tv/{id}`` fetch
+    - IMDb URL or bare ``ttXXXXXXX`` → one ``/find/{id}`` fetch
+    - bare numeric → both ``/movie/{id}`` + ``/tv/{id}`` in parallel
+    - anything else → ``/search/movie`` + ``/search/tv`` in parallel,
+      ``limit`` each
+
+    Returns at most two candidates on the by-id branches and at most
+    ``2 * limit`` on the free-text branch. Movies appear before
+    series so a paste from a film URL renders the expected card
+    first; the UI can re-sort if it prefers.
+    """
+    output = await use_case.execute(SearchTmdbTitlesInput(query=q, limit=limit))
+    return api_single("catalog_lookup", asdict(output))
+
+
+__all__ = ["router"]

--- a/tests/modules/media/e2e/test_tmdb_lookup_routes.py
+++ b/tests/modules/media/e2e/test_tmdb_lookup_routes.py
@@ -1,0 +1,150 @@
+"""End-to-end tests for ``GET /api/v1/catalog/lookup``."""
+
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock
+
+import pytest
+from dependency_injector import providers
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from src.modules.media.application.ports import SearchCandidate
+from tests.modules.media.e2e.conftest import SeededUser
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+LOOKUP_PATH = "/api/v1/catalog/lookup"
+
+
+async def _login(client: AsyncClient, user: SeededUser) -> None:
+    resp = await client.post(
+        LOGIN_PATH,
+        data={"username": user.email, "password": user.password},
+    )
+    assert resp.status_code == 204
+
+
+def _override_tmdb_client(app: FastAPI, fake: AsyncMock) -> None:
+    """Swap the real TMDB client for a mock so the e2e doesn't hit the network."""
+    app.state.container.media.tmdb_client.override(providers.Object(fake))
+
+
+@pytest.mark.e2e
+class TestTmdbLookupAuth:
+    async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        resp = await client.get(LOOKUP_PATH, params={"q": "matrix"})
+        assert resp.status_code == 401
+
+
+@pytest.mark.e2e
+class TestTmdbLookupRouting:
+    async def test_plain_text_returns_combined_candidates(
+        self,
+        app: FastAPI,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        fake = AsyncMock()
+        fake.find_movie_candidates.return_value = [
+            SearchCandidate(
+                tmdb_id=603,
+                media_type="movie",
+                title="The Matrix",
+                year=1999,
+                overview="A hacker…",
+                poster_url="https://image.tmdb.org/m.jpg",
+            ),
+        ]
+        fake.find_series_candidates.return_value = []
+        _override_tmdb_client(app, fake)
+
+        user = await seed_user_with_profile(email="u@example.com", is_admin=False)
+        await _login(client, user)
+        resp = await client.get(LOOKUP_PATH, params={"q": "matrix"})
+
+        assert resp.status_code == 200
+        payload = resp.json()["data"]
+        assert payload["kind"] == "text"
+        assert payload["query"] == "matrix"
+        assert len(payload["candidates"]) == 1
+        assert payload["candidates"][0]["tmdb_id"] == 603
+
+    async def test_tmdb_movie_url_calls_movie_summary_only(
+        self,
+        app: FastAPI,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        fake = AsyncMock()
+        fake.get_movie_summary_by_id.return_value = SearchCandidate(
+            tmdb_id=603,
+            media_type="movie",
+            title="The Matrix",
+            year=1999,
+            overview=None,
+            poster_url=None,
+        )
+        _override_tmdb_client(app, fake)
+
+        user = await seed_user_with_profile(email="u@example.com", is_admin=False)
+        await _login(client, user)
+        resp = await client.get(
+            LOOKUP_PATH,
+            params={"q": "https://www.themoviedb.org/movie/603-the-matrix"},
+        )
+
+        assert resp.status_code == 200
+        payload = resp.json()["data"]
+        assert payload["kind"] == "tmdb_id"
+        assert len(payload["candidates"]) == 1
+        assert payload["candidates"][0]["media_type"] == "movie"
+        fake.get_movie_summary_by_id.assert_awaited_once_with(603)
+        fake.get_series_summary_by_id.assert_not_called()
+        fake.find_movie_candidates.assert_not_called()
+
+    async def test_imdb_id_calls_find(
+        self,
+        app: FastAPI,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        fake = AsyncMock()
+        fake.find_by_imdb_id.return_value = [
+            SearchCandidate(
+                tmdb_id=603,
+                media_type="movie",
+                title="The Matrix",
+                year=1999,
+                overview=None,
+                poster_url=None,
+            ),
+        ]
+        _override_tmdb_client(app, fake)
+
+        user = await seed_user_with_profile(email="u@example.com", is_admin=False)
+        await _login(client, user)
+        resp = await client.get(LOOKUP_PATH, params={"q": "tt0133093"})
+
+        assert resp.status_code == 200
+        payload = resp.json()["data"]
+        assert payload["kind"] == "imdb_id"
+        fake.find_by_imdb_id.assert_awaited_once_with("tt0133093")
+
+    async def test_empty_q_returns_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        user = await seed_user_with_profile(email="u@example.com", is_admin=False)
+        await _login(client, user)
+        resp = await client.get(LOOKUP_PATH, params={"q": ""})
+        assert resp.status_code == 422
+
+    async def test_limit_above_max_returns_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        user = await seed_user_with_profile(email="u@example.com", is_admin=False)
+        await _login(client, user)
+        resp = await client.get(LOOKUP_PATH, params={"q": "matrix", "limit": 999})
+        assert resp.status_code == 422

--- a/tests/modules/media/unit/application/use_cases/test_parse_lookup_query.py
+++ b/tests/modules/media/unit/application/use_cases/test_parse_lookup_query.py
@@ -1,0 +1,74 @@
+"""Tests for the catalog-request lookup query parser."""
+
+import pytest
+
+from src.modules.media.application.use_cases.search_tmdb_titles import (
+    parse_lookup_query,
+)
+
+
+class TestParseLookupQuery:
+    @pytest.mark.parametrize("raw", ["", "   ", "\n\t"])
+    def test_empty_or_whitespace_returns_none(self, raw: str) -> None:
+        assert parse_lookup_query(raw) is None
+
+    def test_tmdb_movie_url(self) -> None:
+        parsed = parse_lookup_query("https://www.themoviedb.org/movie/603-the-matrix")
+        assert parsed is not None
+        assert parsed.kind == "tmdb_id"
+        assert parsed.tmdb_id == 603
+        assert parsed.media_type == "movie"
+
+    def test_tmdb_tv_url(self) -> None:
+        parsed = parse_lookup_query("https://www.themoviedb.org/tv/1399")
+        assert parsed is not None
+        assert parsed.kind == "tmdb_id"
+        assert parsed.tmdb_id == 1399
+        assert parsed.media_type == "tv"
+
+    def test_imdb_url(self) -> None:
+        parsed = parse_lookup_query("https://www.imdb.com/title/tt0133093/")
+        assert parsed is not None
+        assert parsed.kind == "imdb_id"
+        assert parsed.imdb_id == "tt0133093"
+
+    def test_imdb_url_case_insensitive(self) -> None:
+        parsed = parse_lookup_query("HTTPS://IMDB.COM/title/TT0133093/")
+        assert parsed is not None
+        assert parsed.kind == "imdb_id"
+        # Canonical lowercase, regardless of input casing.
+        assert parsed.imdb_id == "tt0133093"
+
+    def test_bare_imdb_id(self) -> None:
+        parsed = parse_lookup_query("tt0133093")
+        assert parsed is not None
+        assert parsed.kind == "imdb_id"
+        assert parsed.imdb_id == "tt0133093"
+
+    def test_bare_tmdb_numeric_is_ambiguous(self) -> None:
+        parsed = parse_lookup_query("603")
+        assert parsed is not None
+        assert parsed.kind == "tmdb_id"
+        assert parsed.tmdb_id == 603
+        # Ambiguous — caller fetches both /movie and /tv.
+        assert parsed.media_type is None
+
+    def test_plain_text_falls_back_to_text_branch(self) -> None:
+        parsed = parse_lookup_query("  The Matrix  ")
+        assert parsed is not None
+        assert parsed.kind == "text"
+        assert parsed.text == "The Matrix"
+
+    def test_text_branch_for_unknown_url(self) -> None:
+        # A URL that's neither TMDB nor IMDb falls through to the
+        # text branch — the search hopefully still finds something.
+        parsed = parse_lookup_query("https://example.com/movie/foo")
+        assert parsed is not None
+        assert parsed.kind == "text"
+        assert parsed.text == "https://example.com/movie/foo"
+
+    def test_too_short_imdb_id_is_text(self) -> None:
+        # "tt1" is not a real IMDb id (min 6 digits). Fall through.
+        parsed = parse_lookup_query("tt1")
+        assert parsed is not None
+        assert parsed.kind == "text"

--- a/tests/modules/media/unit/application/use_cases/test_search_tmdb_titles.py
+++ b/tests/modules/media/unit/application/use_cases/test_search_tmdb_titles.py
@@ -1,0 +1,176 @@
+"""Tests for SearchTmdbTitlesUseCase routing."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.modules.media.application.dtos.tmdb_lookup_dtos import (
+    SearchTmdbTitlesInput,
+)
+from src.modules.media.application.ports import SearchCandidate
+from src.modules.media.application.use_cases.search_tmdb_titles import (
+    SearchTmdbTitlesUseCase,
+)
+
+
+def _movie_candidate(tmdb_id: int = 603, title: str = "The Matrix") -> SearchCandidate:
+    return SearchCandidate(
+        tmdb_id=tmdb_id,
+        media_type="movie",
+        title=title,
+        year=1999,
+        overview="A computer hacker learns…",
+        poster_url="https://image.tmdb.org/p.jpg",
+    )
+
+
+def _series_candidate(tmdb_id: int = 1399, title: str = "Game of Thrones") -> SearchCandidate:
+    return SearchCandidate(
+        tmdb_id=tmdb_id,
+        media_type="tv",
+        title=title,
+        year=2011,
+        overview="Seven noble families fight…",
+        poster_url="https://image.tmdb.org/g.jpg",
+    )
+
+
+class TestTmdbUrlBranch:
+    @pytest.mark.asyncio
+    async def test_tmdb_movie_url_calls_movie_summary_only(self) -> None:
+        provider = AsyncMock()
+        provider.get_movie_summary_by_id.return_value = _movie_candidate()
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        out = await use_case.execute(
+            SearchTmdbTitlesInput(query="https://www.themoviedb.org/movie/603"),
+        )
+
+        assert out.kind == "tmdb_id"
+        assert len(out.candidates) == 1
+        assert out.candidates[0].tmdb_id == 603
+        provider.get_movie_summary_by_id.assert_awaited_once_with(603)
+        provider.get_series_summary_by_id.assert_not_called()
+        provider.find_movie_candidates.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tmdb_tv_url_calls_series_summary_only(self) -> None:
+        provider = AsyncMock()
+        provider.get_series_summary_by_id.return_value = _series_candidate()
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        out = await use_case.execute(
+            SearchTmdbTitlesInput(query="https://www.themoviedb.org/tv/1399"),
+        )
+
+        assert out.kind == "tmdb_id"
+        assert len(out.candidates) == 1
+        assert out.candidates[0].media_type == "tv"
+        provider.get_series_summary_by_id.assert_awaited_once_with(1399)
+        provider.get_movie_summary_by_id.assert_not_called()
+
+
+class TestImdbBranch:
+    @pytest.mark.asyncio
+    async def test_imdb_url_calls_find(self) -> None:
+        provider = AsyncMock()
+        provider.find_by_imdb_id.return_value = [_movie_candidate()]
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        out = await use_case.execute(
+            SearchTmdbTitlesInput(query="https://www.imdb.com/title/tt0133093/"),
+        )
+
+        assert out.kind == "imdb_id"
+        assert out.query == "tt0133093"
+        provider.find_by_imdb_id.assert_awaited_once_with("tt0133093")
+
+    @pytest.mark.asyncio
+    async def test_bare_imdb_id_calls_find(self) -> None:
+        provider = AsyncMock()
+        provider.find_by_imdb_id.return_value = [
+            _movie_candidate(),
+            _series_candidate(),
+        ]
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        out = await use_case.execute(SearchTmdbTitlesInput(query="tt0133093"))
+
+        assert out.kind == "imdb_id"
+        assert [c.tmdb_id for c in out.candidates] == [603, 1399]
+
+
+class TestBareNumericBranch:
+    @pytest.mark.asyncio
+    async def test_bare_numeric_tries_both_kinds_in_parallel(self) -> None:
+        provider = AsyncMock()
+        provider.get_movie_summary_by_id.return_value = _movie_candidate(603)
+        provider.get_series_summary_by_id.return_value = _series_candidate(603)
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        out = await use_case.execute(SearchTmdbTitlesInput(query="603"))
+
+        provider.get_movie_summary_by_id.assert_awaited_once_with(603)
+        provider.get_series_summary_by_id.assert_awaited_once_with(603)
+        # Movies first, then series.
+        assert [c.media_type for c in out.candidates] == ["movie", "tv"]
+
+    @pytest.mark.asyncio
+    async def test_bare_numeric_drops_kind_with_no_match(self) -> None:
+        provider = AsyncMock()
+        provider.get_movie_summary_by_id.return_value = _movie_candidate(603)
+        provider.get_series_summary_by_id.return_value = None
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        out = await use_case.execute(SearchTmdbTitlesInput(query="603"))
+
+        assert len(out.candidates) == 1
+        assert out.candidates[0].media_type == "movie"
+
+
+class TestTextBranch:
+    @pytest.mark.asyncio
+    async def test_plain_text_calls_both_searches_with_limit(self) -> None:
+        provider = AsyncMock()
+        provider.find_movie_candidates.return_value = [_movie_candidate()]
+        provider.find_series_candidates.return_value = [_series_candidate()]
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        out = await use_case.execute(
+            SearchTmdbTitlesInput(query="  matrix  ", limit=3),
+        )
+
+        assert out.kind == "text"
+        assert out.query == "matrix"
+        provider.find_movie_candidates.assert_awaited_once_with("matrix", year=None, limit=3)
+        provider.find_series_candidates.assert_awaited_once_with("matrix", year=None, limit=3)
+        # Movies first.
+        assert [c.media_type for c in out.candidates] == ["movie", "tv"]
+
+    @pytest.mark.asyncio
+    async def test_limit_is_clamped_to_provider_friendly_range(self) -> None:
+        provider = AsyncMock()
+        provider.find_movie_candidates.return_value = []
+        provider.find_series_candidates.return_value = []
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        await use_case.execute(SearchTmdbTitlesInput(query="x", limit=1000))
+
+        # Use case caps at 20 internally even if a misbehaving caller
+        # passes through the route validation somehow.
+        provider.find_movie_candidates.assert_awaited_once_with("x", year=None, limit=20)
+
+
+class TestEmptyInput:
+    @pytest.mark.asyncio
+    async def test_whitespace_only_returns_empty_without_calling_provider(self) -> None:
+        provider = AsyncMock()
+
+        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        out = await use_case.execute(SearchTmdbTitlesInput(query="   "))
+
+        assert out.candidates == []
+        assert out.kind == "text"
+        provider.find_movie_candidates.assert_not_called()
+        provider.find_series_candidates.assert_not_called()
+        provider.find_by_imdb_id.assert_not_called()


### PR DESCRIPTION
## Summary
- New ``GET /api/v1/catalog/lookup?q=...&limit=N`` endpoint that powers the upcoming "Request a title" frontend dialog. Authenticated (any active user), thin proxy in front of TMDB so the provider key stays server-side.
- The parser accepts five input shapes and routes each to the cheapest provider call:
  - TMDB URL (``themoviedb.org/movie/603`` or ``/tv/1399``) → single ``/movie/{id}`` or ``/tv/{id}`` summary
  - IMDb URL or bare ``ttXXXXXXX`` → single ``/find/{id}``
  - bare numeric → parallel ``/movie/{id}`` + ``/tv/{id}`` (TMDB ids aren't unique across namespaces)
  - anything else → parallel ``/search/movie`` + ``/search/tv``
- The public URL is provider-neutral (``/catalog/lookup``) so the API contract doesn't leak that TMDB is the adapter; internal Python names (``tmdb_lookup_routes.py``, ``SearchTmdbTitlesUseCase``, ``tmdb_lookup_dtos``) stay TMDB-specific to be honest about the implementation.
- Extends ``MetadataProvider`` with ``find_by_imdb_id`` + ``get_{movie,series}_summary_by_id`` (light fetches; the existing ``get_movie_by_id`` pulls credits/collection/recommendations which is overkill for a picker preview) — TmdbClient implements both.

## Test plan
- [x] ``poetry run pytest`` (2 681 passed, 5 skipped)
- [x] ``poetry run ruff check src tests`` + ``poetry run ruff format --check src tests``
- [x] Unit tests cover all five parser branches + use case routing (text / TMDB URL / IMDb URL / bare IMDb / bare numeric / empty input)
- [x] E2E covers the route end-to-end against an in-memory app with the TMDB client overridden by a mock — auth 401, plain text, TMDB URL, IMDb id, ``q=""`` 422, ``limit=999`` 422
- [ ] Smoke against a real TMDB key once the frontend lands

## Related issues
- Backend half of the new catalog-request UX. The frontend dialog (separate PR on homeflix-web) consumes this endpoint and the existing ``POST /catalog-requests`` to persist the chosen candidate.

## Summary by Sourcery

Add an authenticated catalog lookup endpoint backed by TMDB and the corresponding use case to support the request dialog.

New Features:
- Introduce a TMDB-backed use case that parses various query shapes (TMDB/IMDb URLs, ids, and text) into catalog picker candidates.
- Expose a new GET /api/v1/catalog/lookup endpoint that proxies lookup requests to the metadata provider without exposing the TMDB key.

Enhancements:
- Extend the metadata provider port and TMDB client with lightweight movie/series summary and IMDb-id lookup capabilities for efficient catalog requests.
- Wire the new search use case into the media dependency injection container and route registration.

Tests:
- Add unit tests for the TMDB lookup query parser and use case routing across all supported input shapes.
- Add end-to-end tests for the catalog lookup route covering auth, validation, and provider interaction.