### PR TITLE
refactor(media): share localized metadata merge

### DIFF
--- a/src/modules/media/application/use_cases/_localized_metadata_helpers.py
+++ b/src/modules/media/application/use_cases/_localized_metadata_helpers.py
@@ -1,0 +1,53 @@
+"""Shared helper for merging per-language metadata overrides.
+
+Both the movie and series enrich use cases need to fold the provider's
+``localized`` payload into the entity's existing ``localized`` dict. The
+two copies had already drifted — the movie variant carried ``tagline``
+while the series variant silently dropped it — so the merge now lives in
+one place and is applied uniformly to both media types.
+"""
+
+from src.modules.media.application.ports import MediaMetadata
+
+
+def merge_localized_metadata(
+    updates: dict[str, object],
+    existing: dict[str, dict[str, object]],
+    metadata: MediaMetadata,
+) -> None:
+    """Merge per-language overrides from ``metadata`` into ``updates``.
+
+    Builds one entry per language with only the fields the provider
+    actually returned (falsy values are dropped), then merges them over
+    the entity's current ``localized`` dict. ``tagline`` is carried for
+    every media type so a localized tagline from the provider is never
+    discarded; entities that have no use for it simply ignore the key.
+
+    Args:
+        updates: The mutable updates dict the use case applies to the
+            entity. ``"localized"`` is set here when there is anything
+            to merge.
+        existing: The entity's current ``localized`` mapping.
+        metadata: Provider metadata carrying the ``localized`` overrides.
+    """
+    if not metadata.localized:
+        return
+
+    localized: dict[str, dict[str, object]] = {}
+    for lang, fields in metadata.localized.items():
+        candidates = {
+            "title": fields.title,
+            "synopsis": fields.synopsis,
+            "tagline": fields.tagline,
+            "genres": fields.genres or None,
+            "logo_path": fields.logo_url,
+        }
+        loc_entry: dict[str, object] = {k: v for k, v in candidates.items() if v}
+        if loc_entry:
+            localized[lang] = loc_entry
+
+    if localized:
+        updates["localized"] = {**existing, **localized}
+
+
+__all__ = ["merge_localized_metadata"]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -10,6 +10,9 @@ from src.modules.media.application.dtos.enrichment_dtos import (
 )
 from src.modules.media.application.ports import MediaMetadata, MetadataProvider
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases._localized_metadata_helpers import (
+    merge_localized_metadata,
+)
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.events import MediaEnrichedEvent
 from src.modules.media.domain.value_objects import (
@@ -334,31 +337,7 @@ def _apply_credits(
         updates["content_rating"] = ContentRating(metadata.content_rating)
     if metadata.trailer_url and (force or not movie.trailer_url):
         updates["trailer_url"] = metadata.trailer_url
-    _apply_localized(updates, movie.localized, metadata)
-
-
-def _apply_localized(
-    updates: dict[str, object],
-    existing: dict[str, dict[str, object]],
-    metadata: MediaMetadata,
-) -> None:
-    """Merge per-language overrides from metadata into ``updates``."""
-    if not metadata.localized:
-        return
-    localized: dict[str, dict[str, object]] = {}
-    for lang, fields in metadata.localized.items():
-        candidates = {
-            "title": fields.title,
-            "synopsis": fields.synopsis,
-            "tagline": fields.tagline,
-            "genres": fields.genres or None,
-            "logo_path": fields.logo_url,
-        }
-        loc_entry: dict[str, object] = {k: v for k, v in candidates.items() if v}
-        if loc_entry:
-            localized[lang] = loc_entry
-    if localized:
-        updates["localized"] = {**existing, **localized}
+    merge_localized_metadata(updates, movie.localized, metadata)
 
 
 __all__ = ["EnrichMovieMetadataUseCase"]

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -18,6 +18,9 @@ from src.modules.media.application.ports import (
     SeasonMetadata,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases._localized_metadata_helpers import (
+    merge_localized_metadata,
+)
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.events import MediaEnrichedEvent
 from src.modules.media.domain.value_objects import (
@@ -149,31 +152,6 @@ class EnrichSeriesMetadataUseCase:
         return None, None
 
 
-def _apply_localized(
-    updates: dict[str, object],
-    existing: dict[str, dict[str, object]],
-    metadata: MediaMetadata,
-) -> None:
-    """Apply localized metadata overrides from provider."""
-    if not metadata.localized:
-        return
-    localized: dict[str, dict[str, object]] = {}
-    for lang, fields in metadata.localized.items():
-        loc_entry: dict[str, object] = {}
-        if fields.title:
-            loc_entry["title"] = fields.title
-        if fields.synopsis:
-            loc_entry["synopsis"] = fields.synopsis
-        if fields.genres:
-            loc_entry["genres"] = fields.genres
-        if fields.logo_url:
-            loc_entry["logo_path"] = fields.logo_url
-        if loc_entry:
-            localized[lang] = loc_entry
-    if localized:
-        updates["localized"] = {**existing, **localized}
-
-
 def _set_if_missing(
     updates: dict[str, object],
     metadata: MediaMetadata,
@@ -236,7 +214,7 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
             for p in metadata.cast
         ]
 
-    _apply_localized(updates, series.localized, metadata)
+    merge_localized_metadata(updates, series.localized, metadata)
 
     if updates:
         series = series.with_updates(**updates)

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -596,3 +596,31 @@ class TestApplySeriesFields:
         saved = mocks.series.save.call_args[0][0]
         assert "pt-BR" in saved.localized
         assert saved.localized["pt-BR"]["synopsis"] == "Drama de crime."
+
+    async def test_should_carry_localized_tagline(self) -> None:
+        # Regression: the series localized merge used to drop tagline
+        # while the movie merge kept it. The shared helper now carries it
+        # for both media types so a provider tagline is never discarded.
+        series = _make_series()
+        metadata = MediaMetadata(
+            title="Breaking Bad",
+            tmdb_id=1396,
+            localized={
+                "pt-BR": LocalizedFields(
+                    title="Breaking Bad",
+                    tagline="Toda escolha tem consequências.",
+                ),
+            },
+        )
+
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        saved = mocks.series.save.call_args[0][0]
+        assert saved.localized["pt-BR"]["tagline"] == "Toda escolha tem consequências."


### PR DESCRIPTION
## Summary

- Extract `merge_localized_metadata()` into `_localized_metadata_helpers.py` as the single source for folding a provider's per-language overrides into an entity's `localized` dict.
- Replace the two drifted copies in `enrich_movie_metadata` and `enrich_series_metadata` with calls to the shared helper.

### Behavior change (intentional)

The movie copy carried `tagline`; the series copy silently dropped it. The shared helper carries `tagline` for **both** media types, so a localized tagline returned by the provider is no longer discarded for series. Entities with no use for the key simply ignore it.

## Test plan

- [x] `pytest tests/modules/media -k "enrich or localiz"` (90 passed)
- [x] New regression test: series now carries a localized `tagline`
- [x] `ruff check` + `ruff format --check` clean

## Summary by Sourcery

Deduplicate media localized metadata merging by introducing a shared helper and updating movie and series enrich flows to use it.

Bug Fixes:
- Ensure localized taglines from providers are preserved for series instead of being silently dropped.

Enhancements:
- Introduce a centralized helper for merging per-language localized metadata for both movies and series.

Tests:
- Add a regression test verifying that series metadata retains localized taglines.