### PR TITLE
refactor(catalog_requests): centralize repeat-request merge

### DIFF
--- a/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
+++ b/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
@@ -62,34 +62,18 @@ class RequestCatalogInclusionUseCase:
                 input_dto.media_type,
             )
             if existing is not None:
-                # Repeat submit: flip the notify flag on if the caller
-                # asked for it, and backfill the title /
-                # requester_user_id when a legacy row was created
-                # before those columns existed. We don't *replace*
-                # an existing requester_user_id — first-owner wins
-                # so an A-then-B subscribe doesn't reroute A's
-                # notification away.
-                title_backfill = (
-                    input_dto.title if existing.title is None and input_dto.title else None
+                # Repeat submit: let the aggregate fold in the new data
+                # (first-owner-wins backfill + one-way notify opt-in).
+                # ``None`` means nothing changed, so skip the write.
+                reconciled = existing.reconcile(
+                    title=input_dto.title,
+                    requester_user_id=input_dto.requester_user_id,
+                    notify=input_dto.notify_on_arrival,
                 )
-                user_backfill = (
-                    input_dto.requester_user_id
-                    if existing.requester_user_id is None and input_dto.requester_user_id
-                    else None
-                )
-                wants_notify = input_dto.notify_on_arrival and not existing.notify_on_arrival
-                if title_backfill or user_backfill or wants_notify:
-                    updates: dict[str, object] = {}
-                    if title_backfill:
-                        updates["title"] = title_backfill
-                    if user_backfill:
-                        updates["requester_user_id"] = user_backfill
-                    if wants_notify:
-                        updates["notify_on_arrival"] = True
-                    updated = existing.with_updates(**updates)
-                    persisted = await uow.catalog_requests.update(updated)
-                    return CatalogRequestOutput.from_entity(persisted)
-                return CatalogRequestOutput.from_entity(existing)
+                if reconciled is None:
+                    return CatalogRequestOutput.from_entity(existing)
+                persisted = await uow.catalog_requests.update(reconciled)
+                return CatalogRequestOutput.from_entity(persisted)
 
             request = CatalogRequest.create(
                 tmdb_id=input_dto.tmdb_id,

--- a/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
+++ b/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
@@ -54,23 +54,16 @@ class SubscribeCatalogNotificationUseCase:
                 input_dto.media_type,
             )
             if existing is not None:
-                title_backfill = (
-                    input_dto.title if existing.title is None and input_dto.title else None
+                # Same merge as the "Solicitar inclusão" path, but this
+                # entry point always wants the notification on.
+                reconciled = existing.reconcile(
+                    title=input_dto.title,
+                    requester_user_id=input_dto.requester_user_id,
+                    notify=True,
                 )
-                user_backfill = (
-                    input_dto.requester_user_id
-                    if existing.requester_user_id is None and input_dto.requester_user_id
-                    else None
-                )
-                if existing.notify_on_arrival and not title_backfill and not user_backfill:
+                if reconciled is None:
                     return CatalogRequestOutput.from_entity(existing)
-                updates: dict[str, object] = {"notify_on_arrival": True}
-                if title_backfill:
-                    updates["title"] = title_backfill
-                if user_backfill:
-                    updates["requester_user_id"] = user_backfill
-                updated = existing.with_updates(**updates)
-                persisted = await uow.catalog_requests.update(updated)
+                persisted = await uow.catalog_requests.update(reconciled)
                 return CatalogRequestOutput.from_entity(persisted)
 
             request = CatalogRequest.create(

--- a/src/modules/catalog_requests/domain/entities/catalog_request.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_request.py
@@ -132,6 +132,51 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         """
         return self.with_updates(notify_on_arrival=True)
 
+    def reconcile(
+        self,
+        *,
+        title: str | None = None,
+        requester_user_id: str | None = None,
+        notify: bool = False,
+    ) -> CatalogRequest | None:
+        """Fold a repeat request's data into this existing one.
+
+        Both arrival entry points ("Solicitar inclusão" and "Avisar
+        quando chegar") hit the same ``(tmdb_id, media_type)`` row on a
+        re-submit and need to merge the incoming data the same way, so
+        the rule lives here instead of being copied into each use case.
+
+        First-owner-wins backfill: ``title`` and ``requester_user_id``
+        are only filled when currently unset, so a later requester never
+        overwrites the original owner's snapshot or reroutes their
+        notification. ``notify`` is one-way — it opts the request in to
+        the arrival notification but never turns an existing
+        subscription off.
+
+        Args:
+            title: Candidate title snapshot from the repeat request.
+            requester_user_id: Candidate requester from the repeat
+                request.
+            notify: Whether this entry point wants the arrival
+                notification enabled.
+
+        Returns:
+            A new instance with the merged changes, or ``None`` when the
+            incoming data adds nothing — letting the caller skip the
+            write and return the existing row unchanged.
+        """
+        updates: dict[str, object] = {}
+        if self.title is None and title:
+            updates["title"] = title
+        if self.requester_user_id is None and requester_user_id:
+            updates["requester_user_id"] = requester_user_id
+        if notify and not self.notify_on_arrival:
+            updates["notify_on_arrival"] = True
+
+        if not updates:
+            return None
+        return self.with_updates(**updates)
+
     def mark_fulfilled(self, fulfilled_at: datetime | None = None) -> CatalogRequest:
         """Return a copy stamped as fulfilled.
 

--- a/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
+++ b/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
@@ -55,3 +55,58 @@ class TestCatalogRequest:
         assert updated.is_fulfilled is True
         assert updated.fulfilled_at == fixed
         assert request.is_fulfilled is False
+
+    def test_reconcile_backfills_only_unset_fields(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+        )
+
+        reconciled = request.reconcile(
+            title="Alien",
+            requester_user_id="usr_aaaaaaaaaaaa",
+            notify=True,
+        )
+
+        assert reconciled is not None
+        assert reconciled.title == "Alien"
+        assert reconciled.requester_user_id == "usr_aaaaaaaaaaaa"
+        assert reconciled.notify_on_arrival is True
+
+    def test_reconcile_does_not_overwrite_first_owner(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+            title="Alien",
+            requester_user_id="usr_aaaaaaaaaaaa",
+        )
+
+        reconciled = request.reconcile(
+            title="Aliens",
+            requester_user_id="usr_bbbbbbbbbbbb",
+        )
+
+        # First-owner-wins: title and requester are already set, and
+        # notify defaults to False, so nothing changes.
+        assert reconciled is None
+
+    def test_reconcile_notify_is_one_way(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+            notify_on_arrival=True,
+        )
+
+        # Already subscribed and nothing to backfill → no-op.
+        assert request.reconcile(notify=True) is None
+
+    def test_reconcile_returns_none_when_nothing_changes(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=RequestedMediaType.MOVIE,
+            title="Alien",
+            requester_user_id="usr_aaaaaaaaaaaa",
+            notify_on_arrival=True,
+        )
+
+        assert request.reconcile() is None


### PR DESCRIPTION
## Summary

- Add `CatalogRequest.reconcile(title=, requester_user_id=, notify=)` as the single source for merging a repeat request into an existing `(tmdb_id, media_type)` row.
- Encapsulates the first-owner-wins backfill (title / requester_user_id only filled when unset) and the one-way notify opt-in. Returns `None` when nothing changes so the caller can skip the write.
- `RequestCatalogInclusion` and `SubscribeCatalogNotification` use cases now share that logic and differ only in whether they pass `notify=True`.

No behavior change — the end state for every entry point is identical; this only removes the duplicated, subtly-divergent merge blocks.

## Test plan

- [x] `pytest tests/modules/catalog_requests` (33 passed)
- [x] New entity tests: backfill-only-unset, first-owner-wins no-op, one-way notify, returns `None` when unchanged
- [x] Existing use-case tests for both entry points still pass unchanged
- [x] `ruff check` + `ruff format --check` clean

## Summary by Sourcery

Centralize repeat catalog request merge logic in the CatalogRequest aggregate and reuse it across inclusion and notification subscription flows.

New Features:
- Add a CatalogRequest.reconcile API to merge repeat requests into existing catalog entries with first-owner-wins backfill and one-way notification opt-in semantics.

Enhancements:
- Refactor catalog inclusion and notification subscription use cases to delegate repeat-request merging to the new CatalogRequest.reconcile method, eliminating duplicated merge logic.

Tests:
- Add unit coverage for CatalogRequest.reconcile behavior, including backfill-only-on-unset, first-owner-wins no-op, one-way notify, and no-op when unchanged.