### PR TITLE
refactor(media): type MediaConflict candidate types with MediaType

### DIFF
--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -20,6 +20,7 @@ from src.modules.media.domain.events import (
     MovieMergedEvent,
 )
 from src.modules.media.domain.value_objects import MovieId
+from src.shared_kernel.value_objects.media_type import MediaType
 
 if TYPE_CHECKING:
     from src.building_blocks.application.event_bus import EventBus
@@ -227,10 +228,10 @@ class DetectMovieConflictsUseCase:
         """Persist a pending conflict for the pair and build its event."""
         conflict = MediaConflict.detect(
             candidate_a_id=self_id,
-            candidate_a_type="movie",
+            candidate_a_type=MediaType.MOVIE,
             candidate_a_runtime_minutes=self_runtime,
             candidate_b_id=str(other.id),
-            candidate_b_type="movie",
+            candidate_b_type=MediaType.MOVIE,
             candidate_b_runtime_minutes=_runtime_minutes(other),
             match_reason=match_reason,
             abs_threshold_minutes=abs_threshold,
@@ -299,10 +300,10 @@ class DetectMovieConflictsUseCase:
         # ``async with`` block above.
         conflict = MediaConflict.detect(
             candidate_a_id=str(self_movie.id),
-            candidate_a_type="movie",
+            candidate_a_type=MediaType.MOVIE,
             candidate_a_runtime_minutes=self_runtime,
             candidate_b_id=str(orphan.id),
-            candidate_b_type="movie",
+            candidate_b_type=MediaType.MOVIE,
             candidate_b_runtime_minutes=_runtime_minutes(orphan),
             match_reason=MatchReason.TMDB_ID,
         )

--- a/src/modules/media/application/use_cases/list_conflicts.py
+++ b/src/modules/media/application/use_cases/list_conflicts.py
@@ -17,6 +17,7 @@ from src.modules.media.domain.entities.media_conflict import (
     ResolutionSource,
 )
 from src.modules.media.domain.value_objects import MovieId
+from src.shared_kernel.value_objects.media_type import MediaType
 
 if TYPE_CHECKING:
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
@@ -118,7 +119,7 @@ def _collect_movie_ids(conflicts: list[MediaConflict]) -> list[MovieId]:
             (c.candidate_a_id, c.candidate_a_type),
             (c.candidate_b_id, c.candidate_b_type),
         ):
-            if candidate_type != "movie" or candidate_id in seen:
+            if candidate_type is not MediaType.MOVIE or candidate_id in seen:
                 continue
             seen.add(candidate_id)
             out.append(MovieId(candidate_id))

--- a/src/modules/media/application/use_cases/resolve_media_conflict.py
+++ b/src/modules/media/application/use_cases/resolve_media_conflict.py
@@ -22,6 +22,7 @@ from src.modules.media.domain.events import MovieMergedEvent
 from src.modules.media.domain.rule_codes import MediaRuleCodes
 from src.modules.media.domain.value_objects import MovieId
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+from src.shared_kernel.value_objects.media_type import MediaType
 
 if TYPE_CHECKING:
     from src.building_blocks.application.event_bus import EventBus
@@ -168,7 +169,10 @@ class ResolveMediaConflictUseCase:
 
 def _ensure_movie_pair(conflict: MediaConflict) -> None:
     """Reject cross-type conflicts the use case is not equipped to handle."""
-    if conflict.candidate_a_type != "movie" or conflict.candidate_b_type != "movie":
+    if (
+        conflict.candidate_a_type is not MediaType.MOVIE
+        or conflict.candidate_b_type is not MediaType.MOVIE
+    ):
         raise DomainValidationException(
             message="ResolveMediaConflictUseCase only handles movie-vs-movie conflicts",
             message_code="MEDIA_CONFLICT_UNSUPPORTED_CANDIDATE_TYPE",

--- a/src/modules/media/domain/entities/media_conflict.py
+++ b/src/modules/media/domain/entities/media_conflict.py
@@ -15,6 +15,9 @@ from src.building_blocks.domain.errors import (
 )
 from src.modules.media.domain.rule_codes import MediaRuleCodes
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+from src.shared_kernel.value_objects.media_type import (
+    MediaType,  # noqa: TCH001 — runtime for Pydantic
+)
 
 
 class MatchReason(str, Enum):
@@ -106,9 +109,9 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
     id: MediaConflictId | None = Field(default=None)
 
     candidate_a_id: str
-    candidate_a_type: str
+    candidate_a_type: MediaType
     candidate_b_id: str
-    candidate_b_type: str
+    candidate_b_type: MediaType
 
     match_reason: MatchReason
     runtime_delta_minutes: float | None = None
@@ -179,10 +182,10 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         cls,
         *,
         candidate_a_id: str,
-        candidate_a_type: str,
+        candidate_a_type: MediaType,
         candidate_a_runtime_minutes: float | None,
         candidate_b_id: str,
-        candidate_b_type: str,
+        candidate_b_type: MediaType,
         candidate_b_runtime_minutes: float | None,
         match_reason: MatchReason,
         abs_threshold_minutes: float | None = None,

--- a/src/modules/media/infrastructure/persistence/mappers/media_conflict_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/media_conflict_mapper.py
@@ -11,6 +11,7 @@ from src.modules.media.domain.value_objects.media_conflict_id import MediaConfli
 from src.modules.media.infrastructure.persistence.models.media_conflict import (
     MediaConflictModel,
 )
+from src.shared_kernel.value_objects.media_type import MediaType
 
 
 class MediaConflictMapper:
@@ -22,9 +23,9 @@ class MediaConflictMapper:
         return MediaConflict(
             id=MediaConflictId(model.external_id),
             candidate_a_id=model.candidate_a_id,
-            candidate_a_type=model.candidate_a_type,
+            candidate_a_type=MediaType(model.candidate_a_type),
             candidate_b_id=model.candidate_b_id,
-            candidate_b_type=model.candidate_b_type,
+            candidate_b_type=MediaType(model.candidate_b_type),
             match_reason=MatchReason(model.match_reason),
             runtime_delta_minutes=model.runtime_delta_minutes,
             suggested_action=SuggestedAction(model.suggested_action),
@@ -48,9 +49,9 @@ class MediaConflictMapper:
         return MediaConflictModel(
             external_id=str(entity.id),
             candidate_a_id=entity.candidate_a_id,
-            candidate_a_type=entity.candidate_a_type,
+            candidate_a_type=entity.candidate_a_type.value,
             candidate_b_id=entity.candidate_b_id,
-            candidate_b_type=entity.candidate_b_type,
+            candidate_b_type=entity.candidate_b_type.value,
             match_reason=entity.match_reason.value,
             runtime_delta_minutes=entity.runtime_delta_minutes,
             suggested_action=entity.suggested_action.value,
@@ -66,9 +67,9 @@ class MediaConflictMapper:
     def update_model(model: MediaConflictModel, entity: MediaConflict) -> None:
         """Copy mutable fields from the entity onto an existing row."""
         model.candidate_a_id = entity.candidate_a_id
-        model.candidate_a_type = entity.candidate_a_type
+        model.candidate_a_type = entity.candidate_a_type.value
         model.candidate_b_id = entity.candidate_b_id
-        model.candidate_b_type = entity.candidate_b_type
+        model.candidate_b_type = entity.candidate_b_type.value
         model.match_reason = entity.match_reason.value
         model.runtime_delta_minutes = entity.runtime_delta_minutes
         model.suggested_action = entity.suggested_action.value

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -4,7 +4,7 @@ from src.shared_kernel.value_objects.episode_composite_id import EpisodeComposit
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.image_url import ImageUrl
 from src.shared_kernel.value_objects.language_code import LanguageCode
-from src.shared_kernel.value_objects.media_type import CollectionMediaType
+from src.shared_kernel.value_objects.media_type import CollectionMediaType, MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 from src.shared_kernel.value_objects.user_id import UserId
@@ -16,6 +16,7 @@ __all__ = [
     "FilePath",
     "ImageUrl",
     "LanguageCode",
+    "MediaType",
     "ProfileId",
     "SubtitleTrack",
     "UserId",

--- a/src/shared_kernel/value_objects/media_type.py
+++ b/src/shared_kernel/value_objects/media_type.py
@@ -1,23 +1,37 @@
-"""Media type enum for collections (watchlist, custom lists)."""
+"""Canonical media-type discriminator shared across bounded contexts (ADR-016)."""
 
 from enum import StrEnum
 
 
-class CollectionMediaType(StrEnum):
-    """Type of media that can be added to a collection.
+class MediaType(StrEnum):
+    """The kind of catalog title: a movie or a series.
 
-    Uses StrEnum so the value serializes directly as a string
-    in DTOs and database columns.
+    Canonical, project-wide discriminator for the "movie | series"
+    concept (ADR-016). Lives in the shared kernel because media domain
+    events carry it and other bounded contexts (catalog_requests,
+    collections) consume it. Uses StrEnum so the value serializes
+    directly as a string in DTOs and database columns.
+
+    TMDB's ``"tv"`` vocabulary is NOT a member: it stays at the edge
+    (TMDB DTOs/adapters) and is mapped to :attr:`SERIES` explicitly at
+    the ACL. Playback granularity (``movie | episode``) is a different
+    concept modelled by ``WatchableMediaType`` and is intentionally not
+    unified here.
 
     Example:
-        >>> CollectionMediaType.MOVIE.value
+        >>> MediaType.MOVIE.value
         'movie'
-        >>> CollectionMediaType("series")
-        <CollectionMediaType.SERIES: 'series'>
+        >>> MediaType("series")
+        <MediaType.SERIES: 'series'>
     """
 
     MOVIE = "movie"
     SERIES = "series"
 
 
-__all__ = ["CollectionMediaType"]
+# Back-compat alias — collections still imports ``CollectionMediaType``.
+# Removed once collections migrates to ``MediaType`` (ADR-016, deferred).
+CollectionMediaType = MediaType
+
+
+__all__ = ["CollectionMediaType", "MediaType"]

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_media_conflict_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_media_conflict_mapper.py
@@ -1,0 +1,73 @@
+"""Unit tests for MediaConflictMapper."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.modules.media.infrastructure.persistence.mappers.media_conflict_mapper import (
+    MediaConflictMapper,
+)
+from src.modules.media.infrastructure.persistence.models.media_conflict import (
+    MediaConflictModel,
+)
+from src.shared_kernel.value_objects.media_type import MediaType
+
+_NOW = datetime(2026, 5, 31, 12, 0, tzinfo=UTC)
+
+
+def _model(
+    *, candidate_a_type: str = "movie", candidate_b_type: str = "movie"
+) -> MediaConflictModel:
+    model = MediaConflictModel(
+        external_id="cnf_aaaaaaaaaaaa",
+        candidate_a_id="mov_aaaaaaaaaaaa",
+        candidate_a_type=candidate_a_type,
+        candidate_b_id="mov_bbbbbbbbbbbb",
+        candidate_b_type=candidate_b_type,
+        match_reason="tmdb_id",
+        runtime_delta_minutes=0.0,
+        suggested_action="likely_same_release",
+        resolved_at=None,
+        resolution=None,
+        winner_id=None,
+        resolution_source=None,
+    )
+    model.created_at = _NOW
+    model.updated_at = _NOW
+    return model
+
+
+class TestMediaConflictMapperToEntity:
+    """``to_entity`` hydrates the aggregate from a row."""
+
+    def test_candidate_types_become_media_type_enum(self) -> None:
+        entity = MediaConflictMapper.to_entity(_model())
+
+        assert entity.candidate_a_type is MediaType.MOVIE
+        assert entity.candidate_b_type is MediaType.MOVIE
+
+    def test_unknown_candidate_type_fails_loudly(self) -> None:
+        # ADR-016: a corrupted persisted discriminator must surface as an
+        # observable error at the boundary, not round-trip silently and
+        # leave the conflict permanently unresolvable downstream.
+        with pytest.raises(ValueError):
+            MediaConflictMapper.to_entity(_model(candidate_a_type="movies"))
+
+
+class TestMediaConflictMapperRoundTrip:
+    """Entity → model → entity preserves the typed discriminator."""
+
+    def test_round_trip_preserves_candidate_types(self) -> None:
+        entity = MediaConflictMapper.to_entity(_model())
+        model = MediaConflictMapper.to_model(entity)
+
+        # to_model writes the raw enum value back to the String column...
+        assert model.candidate_a_type == "movie"
+        assert model.candidate_b_type == "movie"
+
+        # ...and reading it back yields the typed enum again.
+        model.created_at = _NOW
+        model.updated_at = _NOW
+        rehydrated = MediaConflictMapper.to_entity(model)
+        assert rehydrated.candidate_a_type is MediaType.MOVIE
+        assert rehydrated.candidate_b_type is MediaType.MOVIE


### PR DESCRIPTION
## Summary

First implementation slice of **ADR-016** — replaces the raw-`str` media-type discriminator on the persisted `MediaConflict` aggregate.

- Introduce a canonical `MediaType` enum (`movie`/`series`) in `shared_kernel` by generalizing the existing `CollectionMediaType` (kept as a back-compat alias so `collections` is untouched). It lives in `shared_kernel` because media domain events carry it and other BCs consume it (ADR-008/009).
- Type `MediaConflict.candidate_a_type` / `candidate_b_type` (and `MediaConflict.detect()`) as `MediaType`.
- The mapper validates the persisted string via `MediaType(...)` on read: a corrupted discriminator now **fails loudly at the boundary** instead of round-tripping silently and leaving the conflict permanently unresolvable (the original Critical finding).
- The detector now passes `MediaType.MOVIE`; the remaining `!= "movie"` literal comparisons in `resolve_media_conflict` and `list_conflicts` use the enum.

No schema migration: the column stays `String(20)` and the serialized values are unchanged (`"movie"`/`"series"`).

## Test plan

- [x] `pytest tests/modules/media tests/modules/collections tests/shared_kernel tests/modules/catalog_requests` (1782 passed, 5 skipped)
- [x] New mapper unit test: round-trip preserves the typed enum; an unknown persisted value raises (observable failure)
- [x] `mypy src` introduces no new errors (pre-existing baseline unchanged)
- [x] `ruff check` + `ruff format` clean

## Summary by Sourcery

Introduce a canonical MediaType enum and type MediaConflict candidate media kinds with it to enforce consistent movie/series discrimination across bounded contexts.

New Features:
- Add shared-kernel MediaType enum as the canonical movie/series discriminator, with a back-compat alias for collections.

Bug Fixes:
- Validate persisted media conflict candidate types via MediaType to surface corrupted discriminators as observable errors instead of silently round-tripping.

Enhancements:
- Refine MediaConflict aggregate, mapper, and media use cases to use MediaType instead of raw strings for candidate media types.

Tests:
- Add unit tests covering MediaConflictMapper enum hydration, failure on unknown persisted types, and round-trip preservation of the discriminator.