### PR TITLE
refactor(media): type media events with MediaType

### DIFF
--- a/src/modules/media/application/event_handlers/on_media_created.py
+++ b/src/modules/media/application/event_handlers/on_media_created.py
@@ -13,6 +13,7 @@ from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
 )
 from src.modules.media.domain.events import MediaCreatedEvent
+from src.shared_kernel.value_objects.media_type import MediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -55,10 +56,10 @@ class OnMediaCreatedHandler(EventHandler):
 
         input_dto = EnrichMediaInput(media_id=event.media_id, force=False)
 
-        if event.media_type == "movie":
+        if event.media_type is MediaType.MOVIE:
             movie_uc = await self._enrich_movie_factory()
             result = await movie_uc.execute(input_dto)
-        elif event.media_type == "series":
+        elif event.media_type is MediaType.SERIES:
             series_uc = await self._enrich_series_factory()
             result = await series_uc.execute(input_dto)
         else:

--- a/src/modules/media/application/event_handlers/on_media_enriched.py
+++ b/src/modules/media/application/event_handlers/on_media_enriched.py
@@ -10,6 +10,7 @@ from src.modules.media.application.use_cases.detect_movie_conflicts import (
     DetectMovieConflictsUseCase,
 )
 from src.modules.media.domain.events import MediaEnrichedEvent
+from src.shared_kernel.value_objects.media_type import MediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ class OnMediaEnrichedHandler(EventHandler):
         """Dispatch the detector for movie enrichments; ignore other media."""
         if not isinstance(event, MediaEnrichedEvent):
             return
-        if event.media_type != "movie":
+        if event.media_type is not MediaType.MOVIE:
             # Series/episode detection is out of Phase 1 scope.
             return
         if event.tmdb_id <= 0:

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -28,6 +28,7 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.shared_kernel.value_objects.media_type import MediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -109,7 +110,7 @@ class EnrichMovieMetadataUseCase:
             await self._event_bus.publish(
                 MediaEnrichedEvent(
                     media_id=input_dto.media_id,
-                    media_type="movie",
+                    media_type=MediaType.MOVIE,
                     tmdb_id=enriched_tmdb_id,
                 ),
             )

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -36,6 +36,7 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.shared_kernel.value_objects.media_type import MediaType
 
 
 class EnrichSeriesMetadataUseCase:
@@ -105,7 +106,7 @@ class EnrichSeriesMetadataUseCase:
             await self._event_bus.publish(
                 MediaEnrichedEvent(
                     media_id=input_dto.media_id,
-                    media_type="series",
+                    media_type=MediaType.SERIES,
                     tmdb_id=enriched_tmdb_id,
                 ),
             )

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -31,6 +31,11 @@ from src.modules.media.domain.value_objects import (
     Year,
 )
 
+# Aliased to avoid colliding with the scanner port's ``MediaType``
+# (movie | episode, a file-classification enum). This is the catalog
+# discriminator (movie | series) carried on domain events (ADR-016).
+from src.shared_kernel.value_objects.media_type import MediaType as CatalogMediaType
+
 
 class ScanMediaDirectoriesUseCase:
     """Scan filesystem directories and register discovered media files.
@@ -294,7 +299,9 @@ class ScanMediaDirectoriesUseCase:
             duration=Duration(0),
             files=[primary_file],
         )
-        movie.add_event(MediaCreatedEvent(media_id=str(movie_id), media_type="movie"))
+        movie.add_event(
+            MediaCreatedEvent(media_id=str(movie_id), media_type=CatalogMediaType.MOVIE)
+        )
         for path in paths[1:]:
             movie = movie.with_file(
                 await self._build_new_media_file(by_path[path], is_primary=False)

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -25,6 +25,7 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.shared_kernel.value_objects.media_type import MediaType
 
 
 class Movie(FileVariantMixin, AggregateRoot[MovieId]):
@@ -229,7 +230,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
             files=[file],
             **kwargs,
         )
-        movie.add_event(MediaCreatedEvent(media_id=str(movie_id), media_type="movie"))
+        movie.add_event(MediaCreatedEvent(media_id=str(movie_id), media_type=MediaType.MOVIE))
         return movie
 
 

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -22,6 +22,7 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.shared_kernel.value_objects.media_type import MediaType
 
 if TYPE_CHECKING:
     from src.modules.media.domain.entities.season import Season
@@ -234,7 +235,7 @@ class Series(AggregateRoot[SeriesId]):
             start_year=start_year,
             **kwargs,
         )
-        series.add_event(MediaCreatedEvent(media_id=str(series_id), media_type="series"))
+        series.add_event(MediaCreatedEvent(media_id=str(series_id), media_type=MediaType.SERIES))
         return series
 
 

--- a/src/modules/media/domain/events.py
+++ b/src/modules/media/domain/events.py
@@ -3,19 +3,20 @@
 from dataclasses import dataclass
 
 from src.building_blocks.domain.events import DomainEvent
+from src.shared_kernel.value_objects.media_type import MediaType
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MediaCreatedEvent(DomainEvent):
     """Emitted when a new movie or series is created.
 
     Attributes:
         media_id: External ID of the media (mov_xxx or ser_xxx).
-        media_type: Type of media ("movie" or "series").
+        media_type: Type of media (:class:`MediaType`).
     """
 
     media_id: str = ""
-    media_type: str = ""
+    media_type: MediaType
 
 
 @dataclass(frozen=True)
@@ -72,7 +73,7 @@ class IntroClearedEvent(DomainEvent):
     series_id: str = ""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MediaEnrichedEvent(DomainEvent):
     """Emitted when an enrichment pass finishes with a known TMDB id.
 
@@ -90,12 +91,12 @@ class MediaEnrichedEvent(DomainEvent):
     Attributes:
         media_id: External ID of the enriched media (mov_xxx or
             ser_xxx).
-        media_type: ``"movie"`` or ``"series"``.
+        media_type: :class:`MediaType` of the enriched media.
         tmdb_id: TMDB numeric id the enrichment locked onto.
     """
 
     media_id: str = ""
-    media_type: str = ""
+    media_type: MediaType
     tmdb_id: int = 0
 
 

--- a/tests/modules/media/unit/domain/entities/test_movie.py
+++ b/tests/modules/media/unit/domain/entities/test_movie.py
@@ -445,9 +445,11 @@ class TestMovieEvents:
         events = movie.pull_events()
 
         assert len(events) == 1
+        from src.shared_kernel.value_objects.media_type import MediaType
+
         assert isinstance(events[0], MediaCreatedEvent)
         assert events[0].media_id == str(movie.id)
-        assert events[0].media_type == "movie"
+        assert events[0].media_type is MediaType.MOVIE
         assert movie.has_pending_events is False
 
     def test_should_add_and_pull_events(self):

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -185,9 +185,11 @@ class TestSeriesEvents:
         events = series.pull_events()
 
         assert len(events) == 1
+        from src.shared_kernel.value_objects.media_type import MediaType
+
         assert isinstance(events[0], MediaCreatedEvent)
         assert events[0].media_id == str(series.id)
-        assert events[0].media_type == "series"
+        assert events[0].media_type is MediaType.SERIES
         assert series.has_pending_events is False
 
     def test_should_add_and_pull_events(self):


### PR DESCRIPTION
## Summary

Second implementation slice of **ADR-016** — types the media domain events.

- `MediaCreatedEvent.media_type` and `MediaEnrichedEvent.media_type` are now `MediaType` instead of raw `str`. Both events become `kw_only` dataclasses so the field can be required (no misleading `""` default).
- Producers emit `MediaType.MOVIE` / `MediaType.SERIES` (movie/series entities, scan, both enrich use cases).
- The media-BC consumers (`on_media_created`, `on_media_enriched`) compare against the enum instead of string literals.
- `scan_media_directories` aliases the canonical type to `CatalogMediaType` to avoid a name collision with the scanner port's own `MediaType` (`movie | episode`, a file-classification enum — a separate concept).

The cross-BC `catalog_requests` consumer still does `RequestedMediaType(event.media_type)` and keeps working (the enum value is a `str`); hardening that ACL is the next slice (PR 1.4).

## Test plan

- [x] `pytest tests/modules/media tests/modules/catalog_requests tests/modules/collections tests/modules/watch_progress` (1782 passed, 5 skipped)
- [x] Strengthened movie/series event tests to assert the typed enum (`is MediaType.MOVIE` / `SERIES`)
- [x] `mypy src` introduces no new errors
- [x] `ruff check` + `ruff format` clean

## Summary by Sourcery

Type media domain events with the shared MediaType enum instead of raw strings for stronger typing and clearer media discrimination.

Enhancements:
- Change MediaCreatedEvent and MediaEnrichedEvent to use the MediaType enum and require media_type via kw-only dataclass fields.
- Update media creation and enrichment use cases and event handlers to emit and compare MediaType enum values instead of string literals.
- Alias the catalog media type in the scan-media use case to avoid naming collisions with the scanner’s own MediaType and adjust related tests to assert enum values.