### PR TITLE
refactor(catalog_requests): harden media_type ACL on enrich handler

### DIFF
--- a/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
+++ b/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
@@ -12,6 +12,7 @@ from src.modules.catalog_requests.application.ports import (
 )
 from src.modules.catalog_requests.domain.value_objects import RequestedMediaType
 from src.modules.media.domain.events import MediaEnrichedEvent
+from src.shared_kernel.value_objects.media_type import MediaType
 
 if TYPE_CHECKING:
     from src.building_blocks.domain.events import DomainEvent
@@ -21,6 +22,15 @@ if TYPE_CHECKING:
     from src.modules.catalog_requests.domain.entities import CatalogRequest
 
 _logger = logging.getLogger(__name__)
+
+# Explicit ACL mapping from the Media BC's canonical MediaType to this
+# BC's RequestedMediaType. Kept total over MediaType by a contract test
+# so adding a MediaType member without a mapping fails CI rather than
+# silently dropping arrival events in production (ADR-016).
+_MEDIA_TYPE_TO_REQUESTED: dict[MediaType, RequestedMediaType] = {
+    MediaType.MOVIE: RequestedMediaType.MOVIE,
+    MediaType.SERIES: RequestedMediaType.SERIES,
+}
 
 
 class OnMediaEnrichedHandler(EventHandler):
@@ -70,13 +80,9 @@ class OnMediaEnrichedHandler(EventHandler):
         """Handle ``MediaEnrichedEvent`` by marking matching request fulfilled."""
         if not isinstance(event, MediaEnrichedEvent):
             return
-        try:
-            media_type = RequestedMediaType(event.media_type)
-        except ValueError:
-            _logger.warning(
-                "MediaEnrichedEvent carried unknown media_type=%r — skipping",
-                event.media_type,
-            )
+
+        media_type = self._to_requested_media_type(event.media_type)
+        if media_type is None:
             return
 
         async with self._uow_factory() as uow:
@@ -98,6 +104,37 @@ class OnMediaEnrichedHandler(EventHandler):
         )
 
         await self._maybe_publish_arrival(existing, event)
+
+    @staticmethod
+    def _to_requested_media_type(raw: str) -> RequestedMediaType | None:
+        """Translate the event's media_type to this BC's enum via the ACL map.
+
+        Returns ``None`` (and logs at ERROR) when the value can't be
+        mapped — either an unrecognized vocabulary (e.g. a stray TMDB
+        ``"tv"`` that should have been mapped upstream) or a known
+        :class:`MediaType` member missing from the cross-BC map. Both
+        are contract bugs that must be loud, not silently dropped:
+        otherwise the matching catalog request would never be marked
+        fulfilled and would linger in the admin queue forever.
+        """
+        try:
+            canonical = MediaType(raw)
+        except ValueError:
+            _logger.error(
+                "MediaEnrichedEvent carried unrecognized media_type=%r; "
+                "cannot fulfill the matching catalog request",
+                raw,
+            )
+            return None
+
+        mapped = _MEDIA_TYPE_TO_REQUESTED.get(canonical)
+        if mapped is None:
+            _logger.error(
+                "No RequestedMediaType mapping for MediaType.%s; cross-BC "
+                "ACL is incomplete (see _MEDIA_TYPE_TO_REQUESTED)",
+                canonical.name,
+            )
+        return mapped
 
     async def _maybe_publish_arrival(
         self,

--- a/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
+++ b/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
@@ -1,11 +1,15 @@
 """Tests for ``OnMediaEnrichedHandler``."""
 
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
 
 from src.modules.catalog_requests.application.event_handlers import (
     OnMediaEnrichedHandler,
+)
+from src.modules.catalog_requests.application.event_handlers.on_media_enriched import (
+    _MEDIA_TYPE_TO_REQUESTED,
 )
 from src.modules.catalog_requests.application.ports import (
     CatalogArrivalNotification,
@@ -14,6 +18,7 @@ from src.modules.catalog_requests.application.ports import (
 from src.modules.catalog_requests.domain.entities import CatalogRequest
 from src.modules.catalog_requests.domain.value_objects import RequestedMediaType
 from src.modules.media.domain.events import MediaCreatedEvent, MediaEnrichedEvent
+from src.shared_kernel.value_objects.media_type import MediaType
 from tests.modules.catalog_requests.unit.conftest import (
     make_catalog_requests_uow_mock,
 )
@@ -110,21 +115,24 @@ class TestOnMediaEnrichedHandler:
         mocks.catalog_requests.update.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_skips_unknown_media_type(self) -> None:
-        """A garbled event payload (unknown ``media_type``) shouldn't
-        explode the bus — log and move on."""
+    async def test_skips_unknown_media_type(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An unrecognized ``media_type`` must fail observably (ERROR log)
+        and skip — never silently drop, which would leave the matching
+        request unfulfilled forever."""
         mocks = make_catalog_requests_uow_mock()
         handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
 
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id="mov_abc",
-                media_type="episode",
-                tmdb_id=42,
-            ),
-        )
+        with caplog.at_level(logging.ERROR):
+            await handler.handle(
+                MediaEnrichedEvent(
+                    media_id="mov_abc",
+                    media_type="episode",
+                    tmdb_id=42,
+                ),
+            )
 
         mocks.catalog_requests.find_by_tmdb_id.assert_not_called()
+        assert any(record.levelno == logging.ERROR for record in caplog.records)
 
     @pytest.mark.asyncio
     async def test_matches_series_event(self) -> None:
@@ -337,3 +345,18 @@ class TestOnMediaEnrichedHandler:
 
         payload = publisher.publish_catalog_arrival.await_args.args[0]
         assert payload.title == "tmdb/movie/348"
+
+
+@pytest.mark.unit
+class TestMediaTypeAclMapping:
+    """The cross-BC ACL map must stay total over the canonical MediaType."""
+
+    def test_map_covers_every_media_type_member(self) -> None:
+        # If a MediaType member is added without a RequestedMediaType
+        # mapping, arrival events for it would be dropped (logged at
+        # ERROR) and the request never fulfilled. Fail here instead.
+        assert set(_MEDIA_TYPE_TO_REQUESTED) == set(MediaType)
+
+    def test_each_mapping_value_is_a_requested_media_type(self) -> None:
+        for mapped in _MEDIA_TYPE_TO_REQUESTED.values():
+            assert isinstance(mapped, RequestedMediaType)


### PR DESCRIPTION
## Summary

Third implementation slice of **ADR-016** — hardens the cross-BC ACL where `catalog_requests` consumes the Media BC's `MediaEnrichedEvent`.

- Replace the silent `try: RequestedMediaType(event.media_type) except ValueError: warning + drop` with an explicit `_MEDIA_TYPE_TO_REQUESTED` map (`MediaType` → `RequestedMediaType`).
- A value that can't be mapped — an unrecognized vocabulary (e.g. a stray TMDB `"tv"`) or a known `MediaType` member missing from the map — now logs at **ERROR** and skips, instead of a low-signal `warning`. The matching request lingering forever in the admin queue is the concrete harm being made observable.
- New **contract test** keeps the map total over `MediaType`: adding a `MediaType` member without a mapping fails CI rather than silently dropping arrival events.

## Test plan

- [x] `pytest tests/modules/catalog_requests` (35 passed)
- [x] Strengthened the unknown-`media_type` test to assert an ERROR log is emitted
- [x] New contract tests: map covers every `MediaType` member; each value is a `RequestedMediaType`
- [x] `ruff check` + `ruff format` + `mypy` clean

## Summary by Sourcery

Harden the catalog_requests handler’s media_type ACL when consuming MediaEnrichedEvent, ensuring only explicitly mapped media types are processed and contract violations are surfaced loudly.

Bug Fixes:
- Prevent silent dropping of MediaEnrichedEvent messages with unknown or unmapped media_type values by logging them as errors and skipping processing.

Enhancements:
- Introduce an explicit mapping from MediaType to RequestedMediaType to enforce cross-BC vocabulary alignment.
- Add validation logic that converts raw event media_type strings to canonical MediaType before mapping to RequestedMediaType, with observable error reporting for contract issues.

Tests:
- Strengthen the unknown media_type unit test to assert an ERROR log is emitted while still skipping processing.
- Add contract tests ensuring the MediaType-to-RequestedMediaType mapping covers all MediaType members and that all mapped values are valid RequestedMediaType instances.