### PR TITLE
refactor(notifications): validate payload media_type

### DIFF
--- a/src/modules/notifications/domain/entities/notification.py
+++ b/src/modules/notifications/domain/entities/notification.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from src.building_blocks.domain import AggregateRoot
 from src.modules.notifications.domain.value_objects import (
     NotificationId,
     NotificationKind,
 )
+from src.shared_kernel.value_objects.media_type import MediaType
+
+_PAYLOAD_MEDIA_TYPE_KEY = "media_type"
 
 
 class Notification(AggregateRoot[NotificationId]):
@@ -61,6 +64,25 @@ class Notification(AggregateRoot[NotificationId]):
     body: str | None = None
     payload: dict[str, Any] = Field(default_factory=dict)
     read_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def _validate_payload_media_type(self) -> Notification:
+        """Reject a ``media_type`` in the payload that isn't a real MediaType.
+
+        The payload is free-form JSON, but the renderer keys deep-links
+        off ``media_type``. Validating it here (ADR-016) turns a producer
+        typo into an immediate error at write time instead of a silently
+        broken click-through that only surfaces in the frontend.
+        """
+        raw = self.payload.get(_PAYLOAD_MEDIA_TYPE_KEY)
+        if raw is not None:
+            try:
+                MediaType(raw)
+            except ValueError as exc:
+                raise ValueError(
+                    f"payload {_PAYLOAD_MEDIA_TYPE_KEY!r} must be a valid MediaType, got {raw!r}"
+                ) from exc
+        return self
 
     @classmethod
     def create(

--- a/tests/modules/notifications/unit/domain/entities/test_notification.py
+++ b/tests/modules/notifications/unit/domain/entities/test_notification.py
@@ -4,11 +4,13 @@ from datetime import UTC, datetime
 
 import pytest
 
+from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.notifications.domain.entities import Notification
 from src.modules.notifications.domain.value_objects import (
     NotificationId,
     NotificationKind,
 )
+from src.shared_kernel.value_objects.media_type import MediaType
 
 
 @pytest.mark.unit
@@ -62,3 +64,38 @@ class TestNotification:
         read = notification.mark_read(read_at=fixed)
 
         assert read.read_at == fixed
+
+
+@pytest.mark.unit
+class TestNotificationPayloadMediaType:
+    """The free-form payload's ``media_type`` is validated (ADR-016)."""
+
+    @pytest.mark.parametrize("value", [MediaType.MOVIE, MediaType.SERIES, "movie", "series"])
+    def test_accepts_valid_media_type(self, value: object) -> None:
+        notification = Notification.create(
+            recipient_user_id="usr_alice",
+            kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
+            title="Alien",
+            payload={"media_type": value},
+        )
+
+        assert notification.payload["media_type"] == value
+
+    def test_rejects_unknown_media_type(self) -> None:
+        with pytest.raises(DomainValidationException, match="media_type"):
+            Notification.create(
+                recipient_user_id="usr_alice",
+                kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
+                title="Alien",
+                payload={"media_type": "film"},
+            )
+
+    def test_payload_without_media_type_is_allowed(self) -> None:
+        notification = Notification.create(
+            recipient_user_id="usr_alice",
+            kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
+            title="Alien",
+            payload={"tmdb_id": 348},
+        )
+
+        assert "media_type" not in notification.payload


### PR DESCRIPTION
## Summary

Final implementation slice of **ADR-016** — closes the last raw-`str` `media_type` harm in the rollout.

- Add a `model_validator` on `Notification` that rejects a payload `media_type` which isn't a valid `MediaType`. The payload stays free-form JSON (no schema migration, new kinds still don't need an ALTER TABLE), but the renderer keys deep-links off `media_type`, so a producer typo now fails loudly at write time instead of silently breaking the click-through on the frontend.
- Runs on every construction (create / with_updates / mapper rehydrate), so it also guards the persistence round-trip.

### Deferred (per ADR-016 "Diferido" bucket)

The internal `Literal["movie","series"]` DTOs (catalog/search/featured/by-genre) and `ConflictCandidateSummary.media_type` are already type-safe literals (no raw-`str` harm), and the TMDB `"tv"` edge DTOs intentionally stay at the boundary. Consolidating those onto `MediaType` — plus migrating `RequestedMediaType`/`CollectionMediaType` and dropping the alias — is the deferred follow-up, not a harm fix.

## Test plan

- [x] `pytest tests/modules/notifications tests/modules/catalog_requests` (53 passed)
- [x] New tests: valid `MediaType`/str accepted, unknown value raises `DomainValidationException`, no-`media_type` payload allowed
- [x] `ruff check` + `ruff format` + `mypy` clean

## Summary by Sourcery

Validate notification payload media_type against the MediaType value object to prevent invalid notification payloads.

Enhancements:
- Add a model-level validator on Notification to ensure payload media_type values correspond to a valid MediaType while keeping the payload schema free-form.

Tests:
- Add unit tests covering acceptance of valid media_type values, rejection of unknown media_type values, and behavior when media_type is absent from the payload.