### PR TITLE
feat(preferences): validate playback language tags

### DIFF
--- a/src/modules/preferences/application/use_cases/get_preferences.py
+++ b/src/modules/preferences/application/use_cases/get_preferences.py
@@ -33,8 +33,8 @@ class GetPreferencesUseCase:
 def _to_output(entity: PlaybackPreferences) -> PreferencesOutput:
     """Project the entity into the transport DTO."""
     return PreferencesOutput(
-        audio_lang=entity.audio_lang,
-        subtitle_lang=entity.subtitle_lang,
+        audio_lang=entity.audio_lang.value,
+        subtitle_lang=entity.subtitle_lang.value,
         subtitle_mode=entity.subtitle_mode.value,
         default_quality=entity.default_quality.value,
         speed=entity.speed.value,

--- a/src/modules/preferences/application/use_cases/update_preferences.py
+++ b/src/modules/preferences/application/use_cases/update_preferences.py
@@ -39,8 +39,8 @@ class UpdatePreferencesUseCase:
             saved = await uow.preferences.save(updated)
 
         return PreferencesOutput(
-            audio_lang=saved.audio_lang,
-            subtitle_lang=saved.subtitle_lang,
+            audio_lang=saved.audio_lang.value,
+            subtitle_lang=saved.subtitle_lang.value,
             subtitle_mode=saved.subtitle_mode.value,
             default_quality=saved.default_quality.value,
             speed=saved.speed.value,

--- a/src/modules/preferences/domain/entities/playback_preferences.py
+++ b/src/modules/preferences/domain/entities/playback_preferences.py
@@ -13,6 +13,7 @@ from src.modules.preferences.domain.value_objects import (
     Speed,
     SubtitleMode,
 )
+from src.shared_kernel.value_objects.language_tag import LanguageTag
 from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
 DEFAULT_AUDIO_LANG = "pt-BR"
@@ -31,9 +32,11 @@ class PlaybackPreferences(AggregateRoot[PreferencesId]):
     (``PreferencesId``) stay in lockstep without an extra mapping
     table.
 
-    Languages are kept as plain strings (not ``LanguageCode``) because
-    the frontend persists IETF tags like ``"pt-BR"``/``"en-US"`` that
-    don't match the shared kernel's strict ISO 639-1 shape.
+    Languages are :class:`LanguageTag` (IETF tags like ``"pt-BR"`` /
+    ``"en-US"``) rather than the strict ISO 639-1 ``LanguageCode`` used
+    for media tracks: the player persists region-qualified tags that the
+    strict code rejects. The tag is still validated on write, so garbage
+    can't round-trip to the database or out to the client.
 
     Example:
         >>> profile = ProfileId("prf_test12345678")
@@ -47,11 +50,17 @@ class PlaybackPreferences(AggregateRoot[PreferencesId]):
     id: PreferencesId | None = Field(default=None)
 
     profile_id: ProfileId
-    audio_lang: str = DEFAULT_AUDIO_LANG
-    subtitle_lang: str = DEFAULT_SUBTITLE_LANG
+    audio_lang: LanguageTag = Field(default_factory=lambda: LanguageTag(DEFAULT_AUDIO_LANG))
+    subtitle_lang: LanguageTag = Field(default_factory=lambda: LanguageTag(DEFAULT_SUBTITLE_LANG))
     subtitle_mode: SubtitleMode = DEFAULT_SUBTITLE_MODE
     default_quality: Quality = DEFAULT_QUALITY
     speed: Speed = Field(default_factory=lambda: Speed(DEFAULT_SPEED))
+
+    @field_validator("audio_lang", "subtitle_lang", mode="before")
+    @classmethod
+    def _coerce_language_tag(cls, value: Any) -> LanguageTag:
+        """Accept raw IETF strings alongside ``LanguageTag`` instances."""
+        return value if isinstance(value, LanguageTag) else LanguageTag(value)
 
     @field_validator("speed", mode="before")
     @classmethod

--- a/src/modules/preferences/infrastructure/persistence/mappers/preferences_mapper.py
+++ b/src/modules/preferences/infrastructure/persistence/mappers/preferences_mapper.py
@@ -40,8 +40,8 @@ class PreferencesMapper:
         return PreferencesModel(
             external_id=str(entity.id),
             profile_id=str(entity.profile_id),
-            audio_lang=entity.audio_lang,
-            subtitle_lang=entity.subtitle_lang,
+            audio_lang=entity.audio_lang.value,
+            subtitle_lang=entity.subtitle_lang.value,
             subtitle_mode=entity.subtitle_mode.value,
             default_quality=entity.default_quality.value,
             speed=entity.speed.value,
@@ -58,8 +58,8 @@ class PreferencesMapper:
         ``model`` in the first place, and it's part of the singleton
         invariant enforced by the unique index.
         """
-        model.audio_lang = entity.audio_lang
-        model.subtitle_lang = entity.subtitle_lang
+        model.audio_lang = entity.audio_lang.value
+        model.subtitle_lang = entity.subtitle_lang.value
         model.subtitle_mode = entity.subtitle_mode.value
         model.default_quality = entity.default_quality.value
         model.speed = entity.speed.value

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -4,6 +4,7 @@ from src.shared_kernel.value_objects.episode_composite_id import EpisodeComposit
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.image_url import ImageUrl
 from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.language_tag import LanguageTag
 from src.shared_kernel.value_objects.media_type import CollectionMediaType, MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
@@ -16,6 +17,7 @@ __all__ = [
     "FilePath",
     "ImageUrl",
     "LanguageCode",
+    "LanguageTag",
     "MediaType",
     "ProfileId",
     "SubtitleTrack",

--- a/src/shared_kernel/value_objects/language_tag.py
+++ b/src/shared_kernel/value_objects/language_tag.py
@@ -1,0 +1,80 @@
+"""IETF language tag value object (BCP-47 subset)."""
+
+import re
+from typing import ClassVar
+
+from pydantic import model_validator
+
+from src.building_blocks.domain.value_objects import StringValueObject
+
+
+class LanguageTag(StringValueObject):
+    """An IETF BCP-47 language tag, e.g. ``"pt"``, ``"pt-BR"``, ``"en-US"``.
+
+    Distinct from :class:`LanguageCode`, which is the strict ISO 639-1
+    two-letter form used for metadata and media tracks. The video player
+    persists region-qualified tags (``"pt-BR"``) that the strict code
+    rejects, so playback preferences carry this looser — but still
+    validated — shape instead of a bare ``str`` that would let garbage
+    like ``""`` or ``"portugues"`` round-trip to the database and out to
+    the client.
+
+    Normalization follows BCP-47 casing: the primary language subtag is
+    lowercased, a two-letter region subtag is uppercased, and a
+    four-letter script subtag is title-cased — so ``"PT-br"`` and
+    ``"pt-BR"`` both canonicalize to ``"pt-BR"``.
+
+    Example:
+        >>> LanguageTag("pt-BR").value
+        'pt-BR'
+        >>> LanguageTag("EN").value
+        'en'
+        >>> LanguageTag("pt-br").primary_subtag
+        'pt'
+    """
+
+    # Primary subtag (2-3 letters) + optional region/script/variant subtags.
+    _PATTERN: ClassVar[re.Pattern[str]] = re.compile(r"^[A-Za-z]{2,3}(-[A-Za-z0-9]{1,8})*$")
+    _RULE_CODE: ClassVar[str] = "SHARED.LANGUAGE_TAG.INVALID"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate(cls, value: str) -> str:
+        """Validate the tag shape and return its canonical casing."""
+        if not isinstance(value, str):
+            raise ValueError("Language tag must be a string")
+
+        value = value.strip()
+        if not cls._PATTERN.match(value):
+            raise ValueError(
+                f"Invalid IETF language tag: '{value}'. Expected forms like "
+                f"'pt', 'pt-BR', 'en-US' [{cls._RULE_CODE}]"
+            )
+        return cls._normalize(value)
+
+    @staticmethod
+    def _normalize(value: str) -> str:
+        """Apply BCP-47 casing conventions to each subtag."""
+        primary, *subtags = value.split("-")
+        canonical = [primary.lower()]
+        for sub in subtags:
+            if len(sub) == 2 and sub.isalpha():
+                canonical.append(sub.upper())  # region, e.g. BR / US
+            elif len(sub) == 4 and sub.isalpha():
+                canonical.append(sub.title())  # script, e.g. Hans
+            else:
+                canonical.append(sub.lower())
+        return "-".join(canonical)
+
+    @property
+    def primary_subtag(self) -> str:
+        """The primary language subtag, e.g. ``"pt"`` from ``"pt-BR"``.
+
+        This is the bridge to :class:`LanguageCode`: a match against a
+        media track's strict ISO 639-1 code should compare on this part,
+        not the full region-qualified tag.
+        """
+        return self.value.split("-")[0]
+
+
+__all__ = ["LanguageTag"]

--- a/tests/modules/preferences/unit/domain/entities/test_playback_preferences.py
+++ b/tests/modules/preferences/unit/domain/entities/test_playback_preferences.py
@@ -17,8 +17,8 @@ class TestDefaultFactory:
         prefs = PlaybackPreferences.default_for(_PROFILE_ID)
 
         assert prefs.profile_id == _PROFILE_ID
-        assert prefs.audio_lang == "pt-BR"
-        assert prefs.subtitle_lang == "pt-BR"
+        assert prefs.audio_lang.value == "pt-BR"
+        assert prefs.subtitle_lang.value == "pt-BR"
         assert prefs.subtitle_mode is SubtitleMode.FOREIGN_ONLY
         assert prefs.default_quality is Quality.BEST
         assert prefs.speed == Speed(1.0)
@@ -47,7 +47,7 @@ class TestApplyUpdates:
         assert updated.speed.value == 1.5
         assert updated.subtitle_mode is SubtitleMode.ALWAYS
         # Untouched fields remain at defaults
-        assert updated.audio_lang == "pt-BR"
+        assert updated.audio_lang.value == "pt-BR"
         assert updated.default_quality is Quality.BEST
 
     def test_should_coerce_quality_from_string(self) -> None:
@@ -69,3 +69,14 @@ class TestApplyUpdates:
         prefs = PlaybackPreferences.default_for(_PROFILE_ID)
         with pytest.raises(DomainValidationException):
             prefs.apply_updates(default_quality="ultra")
+
+    def test_should_reject_garbage_audio_lang(self) -> None:
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
+        with pytest.raises(DomainValidationException):
+            prefs.apply_updates(audio_lang="portugues")
+
+    def test_should_normalize_language_tag(self) -> None:
+        prefs = PlaybackPreferences.default_for(_PROFILE_ID)
+        updated = prefs.apply_updates(audio_lang="en-us", subtitle_lang="PT-br")
+        assert updated.audio_lang.value == "en-US"
+        assert updated.subtitle_lang.value == "pt-BR"

--- a/tests/shared_kernel/unit/value_objects/test_language_tag.py
+++ b/tests/shared_kernel/unit/value_objects/test_language_tag.py
@@ -1,0 +1,59 @@
+"""Tests for the ``LanguageTag`` value object."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.shared_kernel.value_objects.language_tag import LanguageTag
+
+
+@pytest.mark.unit
+class TestLanguageTagValidation:
+    """Shape validation rejects anything that isn't a BCP-47-ish tag."""
+
+    @pytest.mark.parametrize("raw", ["pt", "en", "pt-BR", "en-US", "zh-Hans", "zh-Hans-CN"])
+    def test_accepts_valid_tags(self, raw: str) -> None:
+        assert LanguageTag(raw).value == raw
+
+    @pytest.mark.parametrize("raw", ["", "portugues", "p", "pt_BR", "123", "-BR", "pt-"])
+    def test_rejects_garbage(self, raw: str) -> None:
+        with pytest.raises(DomainValidationException):
+            LanguageTag(raw)
+
+    def test_rejects_non_string(self) -> None:
+        with pytest.raises(DomainValidationException):
+            LanguageTag(42)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestLanguageTagNormalization:
+    """BCP-47 casing is canonicalized so equal tags compare equal."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("PT", "pt"),
+            ("pt-br", "pt-BR"),
+            ("EN-us", "en-US"),
+            ("zh-hans", "zh-Hans"),
+        ],
+    )
+    def test_normalizes_casing(self, raw: str, expected: str) -> None:
+        assert LanguageTag(raw).value == expected
+
+    def test_strips_whitespace(self) -> None:
+        assert LanguageTag("  pt-BR  ").value == "pt-BR"
+
+    def test_equal_after_normalization(self) -> None:
+        assert LanguageTag("pt-br") == LanguageTag("PT-BR")
+
+
+@pytest.mark.unit
+class TestLanguageTagPrimarySubtag:
+    """``primary_subtag`` bridges to the strict ISO 639-1 LanguageCode."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("pt-BR", "pt"), ("en-US", "en"), ("pt", "pt"), ("zh-Hans-CN", "zh")],
+    )
+    def test_returns_language_part(self, raw: str, expected: str) -> None:
+        assert LanguageTag(raw).primary_subtag == expected


### PR DESCRIPTION
## Summary

Fase 2 of the code-smell remediation, re-scoped after a calibration finding (see below).

- Introduce a `LanguageTag` value object (IETF BCP-47 subset) in the shared kernel: accepts `pt`, `pt-BR`, `en-US`, normalizes BCP-47 casing (`PT-br` → `pt-BR`), and **rejects garbage** (`""`, `"portugues"`, `"pt_BR"`).
- Type `PlaybackPreferences.audio_lang` / `subtitle_lang` with it (str coercion at the boundary, `.value` on the way out). Garbage language tags can no longer round-trip to the DB or out to the client.
- `LanguageTag.primary_subtag` (`"pt"` from `"pt-BR"`) is the bridge to the strict ISO 639-1 `LanguageCode` for any future track matching.

### Scope note (calibration)

The original review flagged a "silent fallback in the player" as High. On inspection that isn't a live backend bug: `TrackSelector` is registered in the DI container but **never injected/called** (dead code), and `PlaybackPreferences` languages are only **served to the frontend** — never compared to a track in the backend. The real, modest harm is the unvalidated language string, which this PR fixes. `TrackSelector`'s smells (`.value == .value`, anemia) are left untouched as dead-code polish, and no ADR was written (per the agreed re-scope).

## Test plan

- [x] `pytest tests/modules/preferences tests/shared_kernel` (161 passed)
- [x] New `LanguageTag` unit tests: validation, normalization, `primary_subtag`
- [x] New entity tests: rejects garbage `audio_lang`, normalizes tags
- [x] `ruff check` + `ruff format` clean; `mypy src` no new errors

## Summary by Sourcery

Validate and normalize playback language preferences using a dedicated IETF language tag value object.

New Features:
- Introduce a shared LanguageTag value object representing validated, normalized IETF BCP-47 language tags with access to the primary subtag.

Bug Fixes:
- Prevent invalid or garbage playback language tags from being persisted or returned by validating playback preference language fields.

Enhancements:
- Type playback preference audio and subtitle language fields as LanguageTag and adapt persistence and use case mappings to work with the value object instead of raw strings.

Tests:
- Add unit tests for the LanguageTag value object and extend playback preferences tests to cover validation, normalization, and rejection of invalid language tags.