### PR TITLE
refactor(identity): extract AdminQuorum domain service

### DIFF
--- a/src/modules/identity/application/use_cases/delete_admin_user.py
+++ b/src/modules/identity/application/use_cases/delete_admin_user.py
@@ -7,10 +7,10 @@ from src.modules.identity.application.dtos.identity_dtos import DeleteAdminUserI
 from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.modules.identity.domain.errors import (
     CannotDeleteSelfError,
-    CannotDemoteLastAdminError,
     UserNotFoundException,
 )
 from src.modules.identity.domain.events import UserDeletedEvent
+from src.modules.identity.domain.services import AdminQuorum
 from src.modules.identity.domain.value_objects.user_role import UserRole
 from src.shared_kernel.value_objects.user_id import UserId
 
@@ -57,14 +57,9 @@ class DeleteAdminUserUseCase:
             if user is None or user.id is None:
                 raise UserNotFoundException.for_resource("User", input_dto.user_id)
 
-            if user.role == UserRole.ADMIN:
+            if user.role is UserRole.ADMIN:
                 admin_count = await uow.users.count_active_admins()
-                if admin_count <= 1:
-                    raise CannotDemoteLastAdminError(
-                        message=(
-                            "Cannot delete the last active admin — " "promote another user first."
-                        ),
-                    )
+                AdminQuorum.ensure_can_remove_admin(user, admin_count)
 
             profiles = await uow.profiles.find_by_user(user.id)
             profile_ids = tuple(str(p.id) for p in profiles if p.id is not None)

--- a/src/modules/identity/application/use_cases/update_user_role.py
+++ b/src/modules/identity/application/use_cases/update_user_role.py
@@ -5,10 +5,8 @@ from src.modules.identity.application.dtos.identity_dtos import (
     UserSummary,
 )
 from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
-from src.modules.identity.domain.errors import (
-    CannotDemoteLastAdminError,
-    UserNotFoundException,
-)
+from src.modules.identity.domain.errors import UserNotFoundException
+from src.modules.identity.domain.services import AdminQuorum
 from src.modules.identity.domain.value_objects.user_role import UserRole
 from src.shared_kernel.value_objects.user_id import UserId
 
@@ -39,14 +37,10 @@ class UpdateUserRoleUseCase:
             if user is None or user.id is None:
                 raise UserNotFoundException.for_resource("User", input_dto.user_id)
 
-            if user.role != new_role and user.role == UserRole.ADMIN:
+            demoting_admin = user.role is UserRole.ADMIN and new_role is not UserRole.ADMIN
+            if demoting_admin:
                 admin_count = await uow.users.count_active_admins()
-                if admin_count <= 1:
-                    raise CannotDemoteLastAdminError(
-                        message=(
-                            "Cannot demote the last active admin — " "promote another user first."
-                        ),
-                    )
+                AdminQuorum.ensure_can_remove_admin(user, admin_count)
 
             if user.role != new_role:
                 updated = user.with_role(new_role)

--- a/src/modules/identity/domain/services/__init__.py
+++ b/src/modules/identity/domain/services/__init__.py
@@ -1,0 +1,5 @@
+"""Identity domain services."""
+
+from src.modules.identity.domain.services.admin_quorum import AdminQuorum
+
+__all__ = ["AdminQuorum"]

--- a/src/modules/identity/domain/services/admin_quorum.py
+++ b/src/modules/identity/domain/services/admin_quorum.py
@@ -1,0 +1,42 @@
+"""Domain service guarding the always-one-active-admin invariant (ADR-019)."""
+
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.errors import CannotDemoteLastAdminError
+from src.modules.identity.domain.value_objects.user_role import UserRole
+
+
+class AdminQuorum:
+    """Enforces that the system never drops to zero active admins.
+
+    The count of active admins is a repository concern, so the guard
+    takes it as input: the use case fetches ``count_active_admins()`` and
+    passes it here. Call this on every operation that strips a user's
+    admin access — demote-to-member, delete, or deactivate — so the rule
+    lives in one place instead of being re-implemented (and diverging)
+    per use case (ADR-019).
+    """
+
+    @staticmethod
+    def ensure_can_remove_admin(user: User, active_admin_count: int) -> None:
+        """Reject removing ``user``'s admin access when they are the last one.
+
+        A no-op when ``user`` is not an admin — callers can invoke it
+        unconditionally on a remove/demote/deactivate path without first
+        checking the role.
+
+        Args:
+            user: The user whose admin access is about to be stripped.
+            active_admin_count: Current number of active admins,
+                including ``user`` when they are one.
+
+        Raises:
+            CannotDemoteLastAdminError: When ``user`` is the only active
+                admin, which would leave the system with none.
+        """
+        if user.role is UserRole.ADMIN and active_admin_count <= 1:
+            raise CannotDemoteLastAdminError(
+                message="Cannot remove the last active admin — promote another user first.",
+            )
+
+
+__all__ = ["AdminQuorum"]

--- a/tests/modules/identity/unit/domain/services/test_admin_quorum.py
+++ b/tests/modules/identity/unit/domain/services/test_admin_quorum.py
@@ -1,0 +1,29 @@
+"""Tests for the ``AdminQuorum`` domain service."""
+
+import pytest
+
+from src.modules.identity.domain.entities.user import User
+from src.modules.identity.domain.errors import CannotDemoteLastAdminError
+from src.modules.identity.domain.services import AdminQuorum
+from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.user_role import UserRole
+
+
+def _user(role: UserRole) -> User:
+    return User.create(email=Email("admin@homeflix.local"), role=role)
+
+
+@pytest.mark.unit
+class TestAdminQuorum:
+    """The guard refuses to strip the last active admin (ADR-019)."""
+
+    def test_raises_when_admin_is_the_last_one(self) -> None:
+        with pytest.raises(CannotDemoteLastAdminError):
+            AdminQuorum.ensure_can_remove_admin(_user(UserRole.ADMIN), active_admin_count=1)
+
+    def test_allows_when_other_admins_remain(self) -> None:
+        AdminQuorum.ensure_can_remove_admin(_user(UserRole.ADMIN), active_admin_count=2)
+
+    def test_no_op_for_non_admin(self) -> None:
+        # A member never threatens the quorum, even at count 0.
+        AdminQuorum.ensure_can_remove_admin(_user(UserRole.MEMBER), active_admin_count=0)


### PR DESCRIPTION
## Summary

- Extract the always-one-active-admin invariant into a new `AdminQuorum` domain service (`src/modules/identity/domain/services/admin_quorum.py`), per ADR-017
- Replace the duplicated inline guard in `DeleteAdminUserUseCase` and `UpdateUserRoleUseCase` with `AdminQuorum.ensure_can_remove_admin()`
- The guard is a no-op for non-admin users, so remove/demote/deactivate paths can call it unconditionally
- Add unit tests covering last-admin rejection, multi-admin pass-through, and non-admin no-op

## Test plan

- [x] `pytest tests/modules/identity/` — 211 passed
- [x] `ruff check` + `ruff format --check` clean

## Summary by Sourcery

Extract a dedicated domain service to enforce the always-one-active-admin invariant and update use cases and tests to rely on it.

Enhancements:
- Introduce an AdminQuorum domain service to centralize enforcement of the always-one-active-admin invariant.
- Update admin deletion and role update use cases to delegate last-admin checks to the AdminQuorum service.

Tests:
- Add unit tests for the AdminQuorum service covering last-admin rejection, multi-admin allowance, and non-admin no-op behavior.