### PR TITLE
refactor(collections): domain invariants in domain layer (ADR-017)

### DIFF
--- a/docs/adr/ADR-017-domain-invariants-in-domain-layer.md
+++ b/docs/adr/ADR-017-domain-invariants-in-domain-layer.md
@@ -1,0 +1,129 @@
+# ADR-017: Invariantes de domínio na camada de domínio
+
+**Status:** Proposto
+**Data:** 2026-06-04
+**Deciders:** Lucas Cristovam
+**Technical Story:** Revisão de code smells (Fase 3) — invariantes de negócio implementadas (e duplicadas) na application layer em vez do domínio.
+
+---
+
+## Contexto
+
+Duas invariantes de negócio vivem hoje na application layer, fora do domínio:
+
+**1. "Sempre ao menos um admin ativo" (Identity)**
+
+O guard contra remover o último admin estava **duplicado** em dois use cases, com mensagens já divergentes entre si:
+
+- `update_user_role.py` — `"Cannot demote the last active admin — promote another user first."`
+- `delete_admin_user.py` — `"Cannot delete the last active admin — promote another user first."`
+
+A entidade `User` já possui `deactivate()` (`user.py:90`), ainda sem use case correspondente. Quando o endpoint de desativação for criado, nada força o autor a lembrar do guard — um esquecimento produz **admin lockout**: o sistema fica sem nenhum usuário capaz de administrar (criar usuários, gerenciar bibliotecas, settings), exigindo correção manual no banco.
+
+**2. "Máximo de 10 listas por profile" (Collections)**
+
+O check de `MAX_LISTS` vivia no use case (`create_custom_list.py`), enquanto o limite irmão `MAX_ITEMS_PER_LIST` é imposto **dentro** do aggregate (`CustomList.increment_item_count`). A mesma classe de regra — limite numérico do aggregate — vivia em camadas diferentes, sem critério.
+
+**Característica comum:** ambas são invariantes *set-level* — dependem de um fato **contado pelo repositório** (quantos admins ativos, quantas listas do profile), não do estado interno de uma única instância. Foi por isso que historicamente escorregaram para o use case: o domínio não tem acesso ao repositório.
+
+## Decisão
+
+Nós iremos **manter invariantes de negócio na camada de domínio**, mesmo quando dependem de um fato derivado do repositório. O padrão é **fato derivado como parâmetro**: a application layer busca a contagem; o domínio recebe o número e **decide**.
+
+Dois mecanismos, conforme o escopo da invariante:
+
+1. **Domain service** quando a invariante atravessa múltiplas operações. `AdminQuorum.ensure_can_remove_admin(user, active_admin_count)` (`identity/domain/services/admin_quorum.py`) é chamado por todo path que remove acesso admin — demote, delete e, futuramente, deactivate. É no-op para não-admins, então os callers o invocam incondicionalmente no path de remoção. Mensagem e `message_code` passam a ter fonte única.
+
+2. **Factory do aggregate** quando a invariante guarda a criação. `CustomList.create(profile_id, name, *, existing_count)` recebe a contagem como **keyword-only obrigatório** — é impossível construir via factory sem fornecer o fato, eliminando o bypass por omissão. Alinha o aggregate ao seu próprio padrão (`MAX_ITEMS_PER_LIST` já era imposto internamente).
+
+**O que permanece no use case:** orquestração, busca das contagens (`count_active_admins()`, `custom_lists.count(profile_id)`) e checks que exigem query além de contagem — a unicidade de nome de lista (`find_by_name`) continua na application por ora; movê-la exigiria o mesmo padrão (`name_taken: bool`) sem dano concreto hoje que o justifique.
+
+## Consequências
+
+### Positivas
+
+- Cada invariante tem **fonte única**: uma mensagem, um `message_code`, um lugar para mudar a regra.
+- Paths futuros ficam protegidos por construção: o deactivate use case chamará o mesmo `AdminQuorum`; nenhuma lista é criável via factory sem o check de limite.
+- As invariantes viram **unit tests puros** (sem mock de repositório): `AdminQuorum` e o limite do `CustomList.create` testados direto no domínio.
+- `CustomList` fica internamente consistente — os dois limites numéricos do aggregate vivem no aggregate.
+
+### Negativas
+
+- O parâmetro obrigatório adiciona ruído nos testes: ~38 call sites de `CustomList.create` atualizados com `existing_count=0`.
+- O domínio **confia** no fato passado pela application — um caller que informe contagem errada burla a regra (mitigado pelo keyword-only explícito e testes de contrato dos use cases).
+- O fato derivado pode estar defasado no momento do commit (TOCTOU — ver Riscos).
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| TOCTOU: duas requests concorrentes leem a mesma contagem e ambas passam (ex.: dois deletes simultâneos dos dois últimos admins) | Baixa | Médio | Janela **pré-existente** — o check no use case tinha exatamente a mesma corrida; app doméstico com pouquíssimos usuários concorrentes; correção definitiva (lock/constraint) só se o dano se materializar |
+| Novo path que remove acesso admin esquece de chamar `AdminQuorum` | Média | Alto | Docstring do serviço enumera os paths (demote/delete/deactivate); revisão de PR cobra o guard em mudanças no Identity |
+| Caller passa `existing_count` incorreto | Baixa | Médio | Keyword-only obrigatório torna o argumento consciente; testes do use case verificam que a contagem do repositório é a passada |
+
+## Alternativas Consideradas
+
+### 1. Manter os checks nos use cases (status quo)
+
+**Rejeitado porque:** a duplicação já havia divergido (duas mensagens para a mesma regra) e o custo do esquecimento é alto e silencioso (admin lockout). O sintoma é Shotgun Surgery: mudar a regra exige caçar todos os use cases que a copiaram.
+
+### 2. Passar o repositório para o domínio
+
+Domain service recebendo `UserRepository` e contando internamente.
+
+**Rejeitado porque:** o domínio é puro e síncrono; injetar uma interface async de repositório acopla o domínio à infraestrutura e quebra a regra de dependência (ADR-008). O fato derivado como parâmetro preserva a pureza com o mesmo poder de decisão.
+
+### 3. Constraint no banco
+
+Impor "count ≤ N por profile" / "ao menos 1 admin" no schema.
+
+**Rejeitado porque:** nenhuma das duas é expressável como constraint declarativa portátil (SQLite e PostgreSQL); exigiria triggers — regra de negócio escondida na infraestrutura, invisível para o domínio e para os testes unitários.
+
+## Referências
+
+- ADR-008 — Screaming Architecture com Módulos (regra de dependência; domínio puro)
+- ADR-010 — Identity Bounded Context (modelo two-tier ADMIN/MEMBER)
+- PR #253 — `refactor(identity): extract AdminQuorum domain service`
+- Revisão de code smells de maio/2026 (Fase 3 do plano de remediação)
+
+---
+
+## Notas de Implementação
+
+O padrão "fato derivado como parâmetro", nos dois mecanismos:
+
+```python
+# Domain service — invariante atravessa operações (demote/delete/deactivate)
+class AdminQuorum:
+    @staticmethod
+    def ensure_can_remove_admin(user: User, active_admin_count: int) -> None:
+        if user.role is UserRole.ADMIN and active_admin_count <= 1:
+            raise CannotDemoteLastAdminError(
+                message="Cannot remove the last active admin — promote another user first.",
+            )
+
+# Use case: busca o fato, domínio decide
+admin_count = await uow.users.count_active_admins()
+AdminQuorum.ensure_can_remove_admin(user, admin_count)
+```
+
+```python
+# Factory — invariante guarda a criação; keyword-only impede bypass por omissão
+@classmethod
+def create(
+    cls, profile_id: ProfileId, name: str | ListName, *, existing_count: int
+) -> CustomList:
+    if existing_count >= MAX_LISTS:
+        raise BusinessRuleViolationException(
+            message=f"Cannot create more than {MAX_LISTS} custom lists",
+            message_code="CUSTOM_LIST_LIMIT_EXCEEDED",
+            rule_code="CUSTOM_LIST_LIMIT_EXCEEDED",
+        )
+    return cls(id=ListId.generate(), profile_id=profile_id, name=name, item_count=0)
+```
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-06-04 | Lucas Cristovam | Criação inicial (Proposto) |

--- a/docs/adr/ADR-017-domain-invariants-in-domain-layer.md
+++ b/docs/adr/ADR-017-domain-invariants-in-domain-layer.md
@@ -1,6 +1,6 @@
 # ADR-017: Invariantes de domínio na camada de domínio
 
-**Status:** Proposto
+**Status:** Aceito
 **Data:** 2026-06-04
 **Deciders:** Lucas Cristovam
 **Technical Story:** Revisão de code smells (Fase 3) — invariantes de negócio implementadas (e duplicadas) na application layer em vez do domínio.
@@ -127,3 +127,4 @@ def create(
 | Data | Autor | Mudança |
 |------|-------|---------|
 | 2026-06-04 | Lucas Cristovam | Criação inicial (Proposto) |
+| 2026-06-04 | Lucas Cristovam | Aceito |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-014](./ADR-014-settings-per-bucket-aggregate.md) | Settings — Aggregate por Bucket (não Mega-Aggregate) | ✅ Aceito | 2026-05-21 |
 | [ADR-015](./ADR-015-scanner-deduplication-by-content-identity.md) | Scanner Deduplication by Content Identity | 🟡 Proposto | 2026-05-23 |
 | [ADR-016](./ADR-016-media-type-value-object.md) | MediaType como Value Object compartilhado | 🟡 Proposto | 2026-05-31 |
+| [ADR-017](./ADR-017-domain-invariants-in-domain-layer.md) | Invariantes de domínio na camada de domínio | 🟡 Proposto | 2026-06-04 |
 
 ## Como Criar um Novo ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,7 +26,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-014](./ADR-014-settings-per-bucket-aggregate.md) | Settings — Aggregate por Bucket (não Mega-Aggregate) | ✅ Aceito | 2026-05-21 |
 | [ADR-015](./ADR-015-scanner-deduplication-by-content-identity.md) | Scanner Deduplication by Content Identity | 🟡 Proposto | 2026-05-23 |
 | [ADR-016](./ADR-016-media-type-value-object.md) | MediaType como Value Object compartilhado | 🟡 Proposto | 2026-05-31 |
-| [ADR-017](./ADR-017-domain-invariants-in-domain-layer.md) | Invariantes de domínio na camada de domínio | 🟡 Proposto | 2026-06-04 |
+| [ADR-017](./ADR-017-domain-invariants-in-domain-layer.md) | Invariantes de domínio na camada de domínio | ✅ Aceito | 2026-06-04 |
 
 ## Como Criar um Novo ADR
 

--- a/src/modules/collections/application/use_cases/create_custom_list.py
+++ b/src/modules/collections/application/use_cases/create_custom_list.py
@@ -6,7 +6,7 @@ from src.modules.collections.application.dtos import (
     CustomListOutput,
 )
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
-from src.modules.collections.domain.entities import MAX_LISTS, CustomList
+from src.modules.collections.domain.entities import CustomList
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -25,12 +25,12 @@ class CreateCustomListUseCase:
         profile_id = ProfileId(input_dto.profile_id)
         async with self._uow_factory() as uow:
             current_count = await uow.custom_lists.count(profile_id)
-            if current_count >= MAX_LISTS:
-                raise BusinessRuleViolationException(
-                    message=f"Cannot create more than {MAX_LISTS} custom lists",
-                    message_code="CUSTOM_LIST_LIMIT_EXCEEDED",
-                    rule_code="CUSTOM_LIST_LIMIT_EXCEEDED",
-                )
+            # The factory enforces the MAX_LISTS limit (ADR-017).
+            custom_list = CustomList.create(
+                profile_id=profile_id,
+                name=input_dto.name,
+                existing_count=current_count,
+            )
 
             existing = await uow.custom_lists.find_by_name(input_dto.name.strip(), profile_id)
             if existing:
@@ -40,7 +40,6 @@ class CreateCustomListUseCase:
                     rule_code="CUSTOM_LIST_NAME_DUPLICATE",
                 )
 
-            custom_list = CustomList.create(profile_id=profile_id, name=input_dto.name)
             saved = await uow.custom_lists.add(custom_list)
         return CustomListOutput.from_entity(saved)
 

--- a/src/modules/collections/domain/entities/custom_list.py
+++ b/src/modules/collections/domain/entities/custom_list.py
@@ -91,7 +91,9 @@ class CustomList(AggregateRoot[ListId]):
         item_count: Number of items currently in the list.
 
     Example:
-        >>> custom_list = CustomList.create(name="Action Movies")
+        >>> custom_list = CustomList.create(
+        ...     profile_id=profile_id, name="Action Movies", existing_count=0
+        ... )
     """
 
     id: ListId | None = Field(default=None)
@@ -107,18 +109,40 @@ class CustomList(AggregateRoot[ListId]):
         return ListName(v) if isinstance(v, str) else v
 
     @classmethod
-    def create(cls, profile_id: ProfileId, name: str | ListName) -> CustomList:
+    def create(
+        cls,
+        profile_id: ProfileId,
+        name: str | ListName,
+        *,
+        existing_count: int,
+    ) -> CustomList:
         """Factory method with automatic ID generation.
+
+        Enforces the per-profile list limit (ADR-017): the caller fetches
+        how many lists the profile already has and the factory decides.
+        The keyword-only argument makes the check impossible to bypass
+        by omission.
 
         Args:
             profile_id: Owning profile (``prf_xxx``). Every list is scoped
                 to a single profile so multi-profile households keep
                 their lists separate.
             name: Display name for the list.
+            existing_count: Number of lists the profile already has.
 
         Returns:
             A new CustomList instance.
+
+        Raises:
+            BusinessRuleViolationException: When the profile already has
+                ``MAX_LISTS`` lists.
         """
+        if existing_count >= MAX_LISTS:
+            raise BusinessRuleViolationException(
+                message=f"Cannot create more than {MAX_LISTS} custom lists",
+                message_code="CUSTOM_LIST_LIMIT_EXCEEDED",
+                rule_code="CUSTOM_LIST_LIMIT_EXCEEDED",
+            )
         return cls(
             id=ListId.generate(),
             profile_id=profile_id,

--- a/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
@@ -21,7 +21,7 @@ def _create_list(
     name: str = "Test List",
     profile_id: ProfileId = _PROFILE_ID,
 ) -> CustomList:
-    return CustomList.create(profile_id=profile_id, name=name)
+    return CustomList.create(profile_id=profile_id, name=name, existing_count=0)
 
 
 def _create_item(

--- a/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
@@ -20,7 +20,9 @@ _PROFILE_ID = ProfileId("prf_test12345678")
 
 
 def _create_list(name: str = "Test List", item_count: int = 0) -> CustomList:
-    return CustomList.create(profile_id=_PROFILE_ID, name=name).with_updates(item_count=item_count)
+    return CustomList.create(profile_id=_PROFILE_ID, name=name, existing_count=0).with_updates(
+        item_count=item_count
+    )
 
 
 @pytest.mark.unit

--- a/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
@@ -26,7 +26,9 @@ class TestCreateCustomListUseCase:
         mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 0
         mock_repo.find_by_name.return_value = None
-        saved_list = CustomList.create(profile_id=_PROFILE_ID, name="Action Movies")
+        saved_list = CustomList.create(
+            profile_id=_PROFILE_ID, name="Action Movies", existing_count=0
+        )
         mock_repo.add.return_value = saved_list
         use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
@@ -60,7 +62,7 @@ class TestCreateCustomListUseCase:
         mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 1
         mock_repo.find_by_name.return_value = CustomList.create(
-            profile_id=_PROFILE_ID, name="Action Movies"
+            profile_id=_PROFILE_ID, name="Action Movies", existing_count=0
         )
         use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 
@@ -78,7 +80,9 @@ class TestCreateCustomListUseCase:
         mock_repo = mocks.custom_lists
         mock_repo.count.return_value = 0
         mock_repo.find_by_name.return_value = None
-        saved_list = CustomList.create(profile_id=_PROFILE_ID, name="Action Movies")
+        saved_list = CustomList.create(
+            profile_id=_PROFILE_ID, name="Action Movies", existing_count=0
+        )
         mock_repo.add.return_value = saved_list
         use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
 

--- a/tests/modules/collections/unit/application/use_cases/test_delete_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_delete_custom_list.py
@@ -19,7 +19,7 @@ class TestDeleteCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_delete_successfully(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="To Delete")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="To Delete", existing_count=0)
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.remove.return_value = True

--- a/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
@@ -38,7 +38,7 @@ class TestGetCustomListItemsUseCase:
     async def test_should_return_items_with_metadata(
         self, movie_summary: MediaSummaryFactory
     ) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",
@@ -92,7 +92,7 @@ class TestGetCustomListItemsUseCase:
 
     @pytest.mark.asyncio
     async def test_should_return_empty_list_when_no_items(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Empty List")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Empty List", existing_count=0)
         mocks = make_collections_uow_mock()
         mocks.custom_lists.find_by_id.return_value = custom_list
         mocks.custom_lists.list_items.return_value = []
@@ -112,7 +112,7 @@ class TestGetCustomListItemsUseCase:
 
     @pytest.mark.asyncio
     async def test_should_skip_missing_media(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
         items = [
             CustomListItem.create(
                 media_id="mov_missing00000",
@@ -144,7 +144,7 @@ class TestGetCustomListItemsUseCase:
         movie_summary: MediaSummaryFactory,
         series_summary: MediaSummaryFactory,
     ) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Mixed")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Mixed", existing_count=0)
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",
@@ -186,7 +186,7 @@ class TestGetCustomListItemsUseCase:
     async def test_should_pass_language_to_media_lookup(
         self, movie_summary: MediaSummaryFactory
     ) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",

--- a/tests/modules/collections/unit/application/use_cases/test_list_custom_lists.py
+++ b/tests/modules/collections/unit/application/use_cases/test_list_custom_lists.py
@@ -22,8 +22,8 @@ class TestListCustomListsUseCase:
     @pytest.mark.asyncio
     async def test_should_return_all_lists(self) -> None:
         lists = [
-            CustomList.create(profile_id=_PROFILE_ID, name="Action"),
-            CustomList.create(profile_id=_PROFILE_ID, name="Comedy"),
+            CustomList.create(profile_id=_PROFILE_ID, name="Action", existing_count=0),
+            CustomList.create(profile_id=_PROFILE_ID, name="Comedy", existing_count=0),
         ]
         mocks = make_collections_uow_mock()
         mocks.custom_lists.list_all.return_value = lists

--- a/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
@@ -21,9 +21,9 @@ class TestRemoveItemFromCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_remove_item_successfully(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test").with_updates(
-            item_count=3
-        )
+        custom_list = CustomList.create(
+            profile_id=_PROFILE_ID, name="Test", existing_count=0
+        ).with_updates(item_count=3)
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
@@ -64,7 +64,7 @@ class TestRemoveItemFromCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_item_not_in_list(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
@@ -84,9 +84,9 @@ class TestRemoveItemFromCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_decrement_item_count_after_removal(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test").with_updates(
-            item_count=5
-        )
+        custom_list = CustomList.create(
+            profile_id=_PROFILE_ID, name="Test", existing_count=0
+        ).with_updates(item_count=5)
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list

--- a/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
@@ -23,7 +23,7 @@ class TestRenameCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_rename_successfully(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Old Name")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Old Name", existing_count=0)
         renamed = custom_list.rename("New Name")
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
@@ -64,8 +64,8 @@ class TestRenameCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_raise_when_name_taken_by_other_list(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="My List")
-        other_list = CustomList.create(profile_id=_PROFILE_ID, name="Taken Name")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="My List", existing_count=0)
+        other_list = CustomList.create(profile_id=_PROFILE_ID, name="Taken Name", existing_count=0)
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list
@@ -85,7 +85,7 @@ class TestRenameCustomListUseCase:
 
     @pytest.mark.asyncio
     async def test_should_allow_renaming_to_same_name(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Same Name")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Same Name", existing_count=0)
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
         mock_repo.find_by_id.return_value = custom_list

--- a/tests/modules/collections/unit/domain/entities/test_custom_list.py
+++ b/tests/modules/collections/unit/domain/entities/test_custom_list.py
@@ -6,6 +6,7 @@ from src.building_blocks.domain import BusinessRuleViolationException
 from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.collections.domain.entities import (
     MAX_ITEMS_PER_LIST,
+    MAX_LISTS,
     CustomList,
     CustomListItem,
 )
@@ -41,7 +42,9 @@ class TestCustomListCreation:
         assert custom_list.name.value == "Action Movies"
 
     def test_should_create_via_factory_with_auto_id(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Action Movies")
+        custom_list = CustomList.create(
+            profile_id=_PROFILE_ID, name="Action Movies", existing_count=0
+        )
 
         assert custom_list.id is not None
         assert isinstance(custom_list.id, ListId)
@@ -49,17 +52,19 @@ class TestCustomListCreation:
 
     def test_factory_should_accept_list_name_instance(self) -> None:
         name = ListName("Action Movies")
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name=name)
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name=name, existing_count=0)
 
         assert custom_list.name.value == "Action Movies"
 
     def test_factory_should_strip_name_whitespace(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="  Action Movies  ")
+        custom_list = CustomList.create(
+            profile_id=_PROFILE_ID, name="  Action Movies  ", existing_count=0
+        )
 
         assert custom_list.name.value == "Action Movies"
 
     def test_factory_should_initialize_item_count_to_zero(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="My List")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="My List", existing_count=0)
 
         assert custom_list.item_count == 0
 
@@ -70,16 +75,33 @@ class TestCustomListCreation:
         assert custom_list.id == list_id
 
     def test_should_be_frozen(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
 
         with pytest.raises(DomainValidationException):
             custom_list.name = "New Name"  # type: ignore[misc, assignment]
 
     def test_should_have_timestamps(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
 
         assert custom_list.created_at is not None
         assert custom_list.updated_at is not None
+
+    def test_factory_should_raise_when_list_limit_reached(self) -> None:
+        with pytest.raises(BusinessRuleViolationException) as exc_info:
+            CustomList.create(profile_id=_PROFILE_ID, name="One Too Many", existing_count=MAX_LISTS)
+
+        assert exc_info.value.message_code == "CUSTOM_LIST_LIMIT_EXCEEDED"
+
+    def test_factory_should_raise_when_count_exceeds_limit(self) -> None:
+        with pytest.raises(BusinessRuleViolationException):
+            CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=MAX_LISTS + 1)
+
+    def test_factory_should_allow_creation_at_limit_minus_one(self) -> None:
+        custom_list = CustomList.create(
+            profile_id=_PROFILE_ID, name="Last Slot", existing_count=MAX_LISTS - 1
+        )
+
+        assert custom_list.name.value == "Last Slot"
 
 
 @pytest.mark.unit
@@ -87,33 +109,33 @@ class TestCustomListRename:
     """Tests for CustomList.rename()."""
 
     def test_should_return_new_instance_with_updated_name(self) -> None:
-        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name")
+        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name", existing_count=0)
         renamed = original.rename("New Name")
 
         assert renamed.name.value == "New Name"
         assert original.name.value == "Old Name"
 
     def test_should_accept_list_name_instance(self) -> None:
-        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name")
+        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name", existing_count=0)
         new_name = ListName("New Name")
         renamed = original.rename(new_name)
 
         assert renamed.name.value == "New Name"
 
     def test_should_preserve_id(self) -> None:
-        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name")
+        original = CustomList.create(profile_id=_PROFILE_ID, name="Old Name", existing_count=0)
         renamed = original.rename("New Name")
 
         assert renamed.id == original.id
 
     def test_should_strip_new_name_whitespace(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Original")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Original", existing_count=0)
         renamed = custom_list.rename("  Renamed  ")
 
         assert renamed.name.value == "Renamed"
 
     def test_should_preserve_item_count(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Original")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Original", existing_count=0)
         incremented = custom_list.increment_item_count()
         renamed = incremented.rename("Renamed")
 
@@ -125,14 +147,14 @@ class TestCustomListItemCount:
     """Tests for increment/decrement item count."""
 
     def test_should_increment_item_count(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
         updated = custom_list.increment_item_count()
 
         assert updated.item_count == 1
         assert custom_list.item_count == 0
 
     def test_should_increment_multiple_times(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
         updated = custom_list.increment_item_count()
         updated = updated.increment_item_count()
         updated = updated.increment_item_count()
@@ -176,7 +198,7 @@ class TestCustomListItemCount:
         assert updated.item_count == 4
 
     def test_should_not_go_below_zero_on_decrement(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
         updated = custom_list.decrement_item_count()
 
         assert updated.item_count == 0
@@ -194,8 +216,8 @@ class TestCustomListEquality:
         assert list_a == list_b
 
     def test_should_not_be_equal_with_different_ids(self) -> None:
-        list_a = CustomList.create(profile_id=_PROFILE_ID, name="A")
-        list_b = CustomList.create(profile_id=_PROFILE_ID, name="A")
+        list_a = CustomList.create(profile_id=_PROFILE_ID, name="A", existing_count=0)
+        list_b = CustomList.create(profile_id=_PROFILE_ID, name="A", existing_count=0)
 
         assert list_a != list_b
 
@@ -206,7 +228,7 @@ class TestCustomListEquality:
         assert list_a != list_b
 
     def test_should_be_hashable(self) -> None:
-        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test")
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
 
         assert hash(custom_list) is not None
         assert {custom_list}


### PR DESCRIPTION
## Summary

- Add **ADR-017 — Invariantes de domínio na camada de domínio**: the *derived-fact-as-parameter* pattern — application fetches repository counts, domain decides. Covers the `AdminQuorum` service (PR #253) and the `CustomList` creation limit
- Move the per-profile `MAX_LISTS` check from `CreateCustomListUseCase` into `CustomList.create()`, aligning the aggregate with its own pattern (`MAX_ITEMS_PER_LIST` was already enforced internally)
- `existing_count` is a **required keyword-only** argument — the limit cannot be bypassed by omission; ~38 test call sites updated with `existing_count=0`
- New domain unit tests: rejection at/above the limit, creation allowed at limit−1

## Test plan

- [x] `pytest tests/modules/collections/` — 187 passed
- [x] `ruff check` + `ruff format` clean

## Related issues

- Companion to #253 (AdminQuorum domain service)
- ADR index updated in `docs/adr/README.md`

## Summary by Sourcery

Enforce the per-profile custom list limit as a domain invariant in the CustomList aggregate and align application use cases and tests with the new factory contract.

New Features:
- Introduce a required keyword-only existing_count parameter to CustomList.create so the domain can enforce per-profile list creation limits based on repository counts.
- Document the domain-invariants-in-domain-layer pattern in a new ADR-017 and add it to the ADR index.

Enhancements:
- Move the MAX_LISTS enforcement from the CreateCustomList use case into the CustomList.create factory to centralize business rules in the domain layer.

Documentation:
- Add ADR-017 describing the derived-fact-as-parameter pattern for domain invariants and register it in the ADR README.

Tests:
- Update collection module unit and integration tests to pass the new existing_count argument when creating CustomList instances and add coverage for behavior at, above, and below the list limit.