### PR TITLE
refactor(shared_kernel): promote LibraryId from library module

### DIFF
--- a/src/modules/library/domain/value_objects/library_id.py
+++ b/src/modules/library/domain/value_objects/library_id.py
@@ -1,25 +1,11 @@
-"""Library external ID value object."""
+"""Library external ID value object.
 
-from typing import ClassVar
+``LibraryId`` moved to the shared_kernel (ADR-018) because it is
+consumed by ``identity`` (profile library ACL) and ``media`` (catalog
+filtering port) in addition to this module. This re-export keeps the
+historical import path working while callers migrate incrementally.
+"""
 
-from src.building_blocks.domain.external_id import ExternalId
-
-
-class LibraryId(ExternalId):
-    """External ID for libraries.
-
-    Format: lib_{base62_12chars}
-    Example: lib_2xK9mPqR7nL4
-
-    Example:
-        >>> library_id = LibraryId.generate()
-        >>> library_id.prefix
-        'lib'
-        >>> LibraryId("lib_2xK9mPqR7nL4")
-        LibraryId('lib_2xK9mPqR7nL4')
-    """
-
-    EXPECTED_PREFIX: ClassVar[str] = "lib"
-
+from src.shared_kernel.value_objects.library_id import LibraryId
 
 __all__ = ["LibraryId"]

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -5,6 +5,7 @@ from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.image_url import ImageUrl
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.language_tag import LanguageTag
+from src.shared_kernel.value_objects.library_id import LibraryId
 from src.shared_kernel.value_objects.media_type import CollectionMediaType, MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
@@ -18,6 +19,7 @@ __all__ = [
     "ImageUrl",
     "LanguageCode",
     "LanguageTag",
+    "LibraryId",
     "MediaType",
     "ProfileId",
     "SubtitleTrack",

--- a/src/shared_kernel/value_objects/library_id.py
+++ b/src/shared_kernel/value_objects/library_id.py
@@ -1,0 +1,25 @@
+"""Library external ID value object."""
+
+from typing import ClassVar
+
+from src.building_blocks.domain.external_id import ExternalId
+
+
+class LibraryId(ExternalId):
+    """External ID for libraries.
+
+    Format: lib_{base62_12chars}
+    Example: lib_2xK9mPqR7nL4
+
+    Example:
+        >>> library_id = LibraryId.generate()
+        >>> library_id.prefix
+        'lib'
+        >>> LibraryId("lib_2xK9mPqR7nL4")
+        LibraryId('lib_2xK9mPqR7nL4')
+    """
+
+    EXPECTED_PREFIX: ClassVar[str] = "lib"
+
+
+__all__ = ["LibraryId"]

--- a/tests/shared_kernel/unit/value_objects/test_library_id.py
+++ b/tests/shared_kernel/unit/value_objects/test_library_id.py
@@ -4,7 +4,7 @@ import pytest
 
 from src.building_blocks.domain.errors import DomainValidationException
 from src.building_blocks.domain.external_id import RANDOM_PART_LENGTH
-from src.modules.library.domain.value_objects.library_id import LibraryId
+from src.shared_kernel.value_objects.library_id import LibraryId
 
 
 class TestLibraryIdCreation:


### PR DESCRIPTION
## Summary

- Move `LibraryId` from `modules/library/domain/value_objects/` to `src/shared_kernel/value_objects/library_id.py` (ADR-018, step 4a)
- It is consumed by `identity` (profile library ACL) and `media` (catalog filtering port) besides its owning module — the shared_kernel is the only home all BCs may import (same precedent as `MediaType` in ADR-016)
- Keep a back-compat re-export at the old path so `library`'s ~13 import sites migrate incrementally (deferred bucket of ADR-018)
- Relocate `test_library_id.py` to `tests/shared_kernel/unit/value_objects/`, mirroring `src/`

## Test plan

- [x] Full suite: 2723 passed, 5 skipped
- [x] `ruff check` + `ruff format` clean

## Related issues

- Prerequisite for 4b (`Profile.allowed_library_ids: list[LibraryId]` + typed `ProfileLibraryAccessPort`)
- ADR-018 under review in #255

## Summary by Sourcery

Promote the LibraryId value object into the shared kernel while keeping backward compatibility for existing library module imports.

Enhancements:
- Expose LibraryId from the shared_kernel value_objects package for use across bounded contexts while preserving its behavior.
- Re-export LibraryId from the library module to maintain the historical import path during incremental migration.

Tests:
- Update and relocate LibraryId unit tests to target the shared_kernel value object implementation.