### PR TITLE
refactor(identity): validate user role at the presentation boundary

### DIFF
--- a/src/modules/identity/application/dtos/identity_dtos.py
+++ b/src/modules/identity/application/dtos/identity_dtos.py
@@ -5,11 +5,18 @@ domain VOs) so the application layer is callable from any context
 (tests, CLI, HTTP routes) without forcing the caller to import
 domain VOs. The use cases are responsible for converting str → VO
 and validating format at the application boundary.
+
+``role`` is the exception (ADR-018): inputs carry the ``UserRole``
+enum, converted/validated at the presentation boundary, so an invalid
+role never reaches the use case. Outputs keep ``str`` — they are wire
+payloads.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+
+from src.modules.identity.domain.value_objects.user_role import UserRole
 
 
 @dataclass(frozen=True)
@@ -162,7 +169,7 @@ class UserDetail:
 class ListUsersInput:
     """Input for ``ListUsersUseCase``."""
 
-    role: str | None = None
+    role: UserRole | None = None
     limit: int = 50
     offset: int = 0
 
@@ -187,7 +194,7 @@ class CreateAdminUserInput:
 
     email: str
     password: str
-    role: str = "member"
+    role: UserRole = UserRole.MEMBER
 
 
 @dataclass(frozen=True)
@@ -201,7 +208,7 @@ class UpdateUserRoleInput:
     """
 
     user_id: str
-    role: str
+    role: UserRole
     acting_admin_id: str
 
 

--- a/src/modules/identity/application/use_cases/create_admin_user.py
+++ b/src/modules/identity/application/use_cases/create_admin_user.py
@@ -9,7 +9,6 @@ from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFact
 from src.modules.identity.domain.entities.user import User
 from src.modules.identity.domain.errors import UserEmailAlreadyExistsError
 from src.modules.identity.domain.value_objects.email import Email
-from src.modules.identity.domain.value_objects.user_role import UserRole
 
 
 class CreateAdminUserUseCase:
@@ -39,7 +38,9 @@ class CreateAdminUserUseCase:
     async def execute(self, input_dto: CreateAdminUserInput) -> UserSummary:
         """Hash the password, persist a new user, return the summary."""
         email = Email(input_dto.email)
-        role = UserRole(input_dto.role)
+        # role arrives as a validated UserRole — converted at the
+        # presentation boundary (ADR-018).
+        role = input_dto.role
         hashed = self._password_hasher.hash(input_dto.password)
 
         async with self._uow_factory() as uow:

--- a/src/modules/identity/application/use_cases/list_users.py
+++ b/src/modules/identity/application/use_cases/list_users.py
@@ -6,7 +6,6 @@ from src.modules.identity.application.dtos.identity_dtos import (
 )
 from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.modules.identity.domain.entities.user import User
-from src.modules.identity.domain.value_objects.user_role import UserRole
 
 
 class ListUsersUseCase:
@@ -24,11 +23,11 @@ class ListUsersUseCase:
 
     async def execute(self, input_dto: ListUsersInput) -> list[UserSummary]:
         """Return the requested page of users."""
-        role = UserRole(input_dto.role) if input_dto.role else None
-
         async with self._uow_factory() as uow:
             users = await uow.users.list_paginated(
-                role=role,
+                # role arrives as a validated UserRole | None —
+                # converted at the presentation boundary (ADR-018).
+                role=input_dto.role,
                 limit=input_dto.limit,
                 offset=input_dto.offset,
             )

--- a/src/modules/identity/application/use_cases/update_user_role.py
+++ b/src/modules/identity/application/use_cases/update_user_role.py
@@ -30,7 +30,9 @@ class UpdateUserRoleUseCase:
     async def execute(self, input_dto: UpdateUserRoleInput) -> UserSummary:
         """Apply the requested role and return the refreshed summary."""
         user_id = UserId(input_dto.user_id)
-        new_role = UserRole(input_dto.role)
+        # role arrives as a validated UserRole — converted at the
+        # presentation boundary (ADR-018).
+        new_role = input_dto.role
 
         async with self._uow_factory() as uow:
             user = await uow.users.find_by_id(user_id)

--- a/src/modules/identity/presentation/routes/admin_user_routes.py
+++ b/src/modules/identity/presentation/routes/admin_user_routes.py
@@ -34,6 +34,7 @@ from src.modules.identity.application.use_cases.list_users import ListUsersUseCa
 from src.modules.identity.application.use_cases.update_user_role import (
     UpdateUserRoleUseCase,
 )
+from src.modules.identity.domain.value_objects.user_role import UserRole
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.identity.presentation.schemas import (
@@ -47,7 +48,7 @@ router = APIRouter(prefix="/api/v1/admin/users", tags=["Admin — Users"])
 @router.get("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_admin_users(
-    role: str | None = None,
+    role: UserRole | None = None,
     limit: int = 50,
     offset: int = 0,
     _admin: UserModel = Depends(current_admin_user),

--- a/src/modules/identity/presentation/schemas/admin_user_schemas.py
+++ b/src/modules/identity/presentation/schemas/admin_user_schemas.py
@@ -1,6 +1,15 @@
-"""Pydantic request schemas for the admin user endpoints."""
+"""Pydantic request schemas for the admin user endpoints.
+
+``role`` fields are typed with the ``UserRole`` enum (ADR-018): an
+invalid role fails validation at the HTTP boundary as a 422 — with
+the allowed values documented in the OpenAPI schema — instead of
+travelling through the application layer as a raw string and blowing
+up inside the use case.
+"""
 
 from pydantic import BaseModel, Field
+
+from src.modules.identity.domain.value_objects.user_role import UserRole
 
 
 class CreateAdminUserRequest(BaseModel):
@@ -14,7 +23,7 @@ class CreateAdminUserRequest(BaseModel):
 
     email: str = Field(..., max_length=320)
     password: str = Field(..., min_length=8, max_length=128)
-    role: str = Field(default="member")
+    role: UserRole = Field(default=UserRole.MEMBER)
 
 
 class UpdateUserRoleRequest(BaseModel):
@@ -26,7 +35,7 @@ class UpdateUserRoleRequest(BaseModel):
     splitting the route.
     """
 
-    role: str
+    role: UserRole
 
 
 __all__ = ["CreateAdminUserRequest", "UpdateUserRoleRequest"]

--- a/tests/modules/identity/e2e/test_admin_user_role_validation.py
+++ b/tests/modules/identity/e2e/test_admin_user_role_validation.py
@@ -1,0 +1,94 @@
+"""End-to-end tests for role validation at the admin user endpoints.
+
+``role`` is typed with the ``UserRole`` enum in the request schemas
+(ADR-018), so an invalid role must be rejected as a 422 at the HTTP
+boundary — with the allowed values in the OpenAPI schema — instead of
+travelling into the use case as a raw string.
+"""
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from httpx import AsyncClient
+
+from tests.modules.identity.e2e.conftest import SeededUser
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+ADMIN_USERS_PATH = "/api/v1/admin/users"
+
+
+async def _login(client: AsyncClient, user: SeededUser) -> None:
+    response = await client.post(
+        LOGIN_PATH,
+        data={"username": user.email, "password": user.password},
+    )
+    assert response.status_code in (200, 204)
+
+
+@pytest.mark.e2e
+class TestAdminUserRoleValidation:
+    async def test_create_should_reject_unknown_role_with_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await seed_user_with_profile(is_admin=True)
+        await _login(client, admin)
+
+        response = await client.post(
+            ADMIN_USERS_PATH,
+            json={
+                "email": "new@homeflix.local",
+                "password": "initial-pass-123",
+                "role": "superadmin",
+            },
+        )
+
+        assert response.status_code == 422
+
+    async def test_update_should_reject_unknown_role_with_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await seed_user_with_profile(is_admin=True)
+        await _login(client, admin)
+
+        response = await client.patch(
+            f"{ADMIN_USERS_PATH}/usr_aaaaaaaaaaaa",
+            json={"role": "adminn"},
+        )
+
+        assert response.status_code == 422
+
+    async def test_list_should_reject_unknown_role_filter_with_422(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await seed_user_with_profile(is_admin=True)
+        await _login(client, admin)
+
+        response = await client.get(ADMIN_USERS_PATH, params={"role": "bogus"})
+
+        assert response.status_code == 422
+
+    async def test_create_should_accept_valid_role(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await seed_user_with_profile(is_admin=True)
+        await _login(client, admin)
+
+        response = await client.post(
+            ADMIN_USERS_PATH,
+            json={
+                "email": "fresh@homeflix.local",
+                "password": "initial-pass-123",
+                "role": "admin",
+            },
+        )
+
+        assert response.status_code == 201
+        assert response.json()["data"]["role"] == "admin"

--- a/tests/modules/identity/unit/application/use_cases/test_create_admin_user.py
+++ b/tests/modules/identity/unit/application/use_cases/test_create_admin_user.py
@@ -10,6 +10,7 @@ from src.modules.identity.application.use_cases.create_admin_user import (
 from src.modules.identity.domain.entities.user import User
 from src.modules.identity.domain.errors import UserEmailAlreadyExistsError
 from src.modules.identity.domain.value_objects.email import Email
+from src.modules.identity.domain.value_objects.user_role import UserRole
 
 from .conftest import FakeIdentityUnitOfWork, FakeIdentityUnitOfWorkFactory
 
@@ -36,7 +37,7 @@ class TestCreateAdminUserUseCase:
             CreateAdminUserInput(
                 email="new@example.com",
                 password="hunter22ish",
-                role="member",
+                role=UserRole.MEMBER,
             ),
         )
 

--- a/tests/modules/identity/unit/application/use_cases/test_list_users.py
+++ b/tests/modules/identity/unit/application/use_cases/test_list_users.py
@@ -52,7 +52,7 @@ class TestListUsersUseCase:
         await _seed_user(fake_uow, email="root@example.com", role=UserRole.ADMIN)
 
         rows = await ListUsersUseCase(uow_factory=fake_uow_factory).execute(
-            ListUsersInput(role="admin"),
+            ListUsersInput(role=UserRole.ADMIN),
         )
 
         assert [r.email for r in rows] == ["root@example.com"]

--- a/tests/modules/identity/unit/application/use_cases/test_update_user_role.py
+++ b/tests/modules/identity/unit/application/use_cases/test_update_user_role.py
@@ -36,7 +36,7 @@ class TestUpdateUserRoleUseCase:
         result = await UpdateUserRoleUseCase(uow_factory=fake_uow_factory).execute(
             UpdateUserRoleInput(
                 user_id=str(target.id),
-                role="admin",
+                role=UserRole.ADMIN,
                 acting_admin_id=str(UserId.generate()),
             ),
         )
@@ -54,7 +54,7 @@ class TestUpdateUserRoleUseCase:
             await UpdateUserRoleUseCase(uow_factory=fake_uow_factory).execute(
                 UpdateUserRoleInput(
                     user_id=str(only_admin.id),
-                    role="member",
+                    role=UserRole.MEMBER,
                     acting_admin_id=str(only_admin.id),
                 ),
             )
@@ -70,7 +70,7 @@ class TestUpdateUserRoleUseCase:
         result = await UpdateUserRoleUseCase(uow_factory=fake_uow_factory).execute(
             UpdateUserRoleInput(
                 user_id=str(a2.id),
-                role="member",
+                role=UserRole.MEMBER,
                 acting_admin_id=str(a2.id),
             ),
         )
@@ -85,7 +85,7 @@ class TestUpdateUserRoleUseCase:
             await UpdateUserRoleUseCase(uow_factory=fake_uow_factory).execute(
                 UpdateUserRoleInput(
                     user_id=str(UserId.generate()),
-                    role="admin",
+                    role=UserRole.ADMIN,
                     acting_admin_id=str(UserId.generate()),
                 ),
             )


### PR DESCRIPTION
## Summary

- Type `role` with the `UserRole` enum at every boundary it crosses (ADR-018, step 4c): `CreateAdminUserRequest` / `UpdateUserRoleRequest` schemas, the `GET /admin/users` query param, and the application input DTOs (`CreateAdminUserInput`, `UpdateUserRoleInput`, `ListUsersInput`)
- Drop the `UserRole(input_dto.role)` conversions inside the use cases — the value arrives validated; an invalid role is now a 422 at the HTTP boundary with the enum documented in OpenAPI, instead of a `ValueError` deep in the use case
- Output DTOs keep `role: str` — they are wire payloads (existing convention)
- New e2e suite covering 422 rejection on create/update/list-filter and the happy path

## Test plan

- [x] Full suite: 2727 passed, 5 skipped
- [x] `ruff check` + `ruff format` clean

## Related issues

- ADR-018 under review in #255; independent of the #256/#257 stack

## Summary by Sourcery

Validate and propagate user roles as the UserRole enum at the presentation and application boundaries for admin user operations, and add end-to-end coverage for HTTP 422 behavior on invalid roles.

Bug Fixes:
- Ensure invalid admin user roles are rejected with HTTP 422 at the HTTP boundary instead of raising ValueError inside use cases.

Enhancements:
- Type admin user role fields with the UserRole enum in request schemas, route params, and application input DTOs while keeping output DTO roles as strings.
- Simplify identity use cases by removing redundant string-to-UserRole conversions and passing through already validated roles.

Tests:
- Add end-to-end tests verifying 422 responses for invalid roles on create, update, and list admin user endpoints and acceptance of valid roles.
- Adjust unit tests for identity use cases to use the UserRole enum in inputs.