### PR TITLE
refactor(settings): single registry for SettingKey to VO mapping

### DIFF
--- a/src/modules/settings/application/use_cases/list_settings.py
+++ b/src/modules/settings/application/use_cases/list_settings.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from src.modules.settings.application.dtos import SettingDetail
-from src.modules.settings.domain.value_objects import SettingKey
-from src.modules.settings.infrastructure.runtime_settings import _DEFAULT_FACTORIES
+from src.modules.settings.domain.value_objects import SettingKey, vo_type_for
 
 if TYPE_CHECKING:
     from src.modules.settings.application.unit_of_work import (
@@ -56,7 +55,7 @@ def _to_detail(setting: Setting) -> SettingDetail:
 
 
 def _default_detail(key: SettingKey) -> SettingDetail:
-    vo_type = _DEFAULT_FACTORIES[key]
+    vo_type = vo_type_for(key)
     return SettingDetail(
         key=key.value,
         value=vo_type().model_dump(mode="json"),

--- a/src/modules/settings/application/use_cases/update_setting.py
+++ b/src/modules/settings/application/use_cases/update_setting.py
@@ -9,8 +9,8 @@ from src.modules.settings.domain.entities import Setting
 from src.modules.settings.domain.value_objects import (
     SettingKey,
     SettingSource,
+    vo_type_for,
 )
-from src.modules.settings.infrastructure.runtime_settings import _DEFAULT_FACTORIES
 
 if TYPE_CHECKING:
     from src.modules.settings.application.unit_of_work import (
@@ -53,7 +53,7 @@ class UpdateSettingUseCase:
     async def execute(self, input_dto: UpdateSettingInput) -> SettingDetail:
         """Validate, upsert, invalidate cache, return the refreshed detail."""
         key = SettingKey(input_dto.key)
-        vo_type = _DEFAULT_FACTORIES[key]
+        vo_type = vo_type_for(key)
         value_vo = vo_type.model_validate(input_dto.value)
 
         setting = Setting(

--- a/src/modules/settings/domain/entities/setting.py
+++ b/src/modules/settings/domain/entities/setting.py
@@ -2,21 +2,16 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Self
+from typing import Self
 
 from pydantic import model_validator
 
 from src.building_blocks.domain.entity import AggregateRoot
 from src.modules.settings.domain.value_objects import (
-    AvatarConfig,
     ConfigVO,
-    IntroDetectionConfig,
-    ScanDedupConfig,
-    SchedulerConfig,
     SettingKey,
     SettingSource,
-    StreamingConfig,
-    ThumbnailBackfillConfig,
+    vo_type_for,
 )
 
 
@@ -33,8 +28,8 @@ class Setting(AggregateRoot[SettingKey]):
     Attributes:
         id: Which configuration bucket this row carries.
         value: The current configuration. Its concrete type must
-            match the type expected for ``id`` (see
-            :attr:`_KEY_TO_VO_TYPE`).
+            match the type registered for ``id`` in the
+            ``setting_vo_registry`` (see :func:`vo_type_for`).
         source: Provenance of the value — migration seed, admin edit,
             or manual SQL override.
         updated_by_user_id: Identifier of the user that last wrote
@@ -59,18 +54,9 @@ class Setting(AggregateRoot[SettingKey]):
     source: SettingSource
     updated_by_user_id: str | None = None
 
-    _KEY_TO_VO_TYPE: ClassVar[dict[SettingKey, type]] = {
-        SettingKey.SCHEDULER: SchedulerConfig,
-        SettingKey.THUMBNAIL_BACKFILL: ThumbnailBackfillConfig,
-        SettingKey.INTRO_DETECTION: IntroDetectionConfig,
-        SettingKey.STREAMING: StreamingConfig,
-        SettingKey.AVATAR: AvatarConfig,
-        SettingKey.SCAN_DEDUP: ScanDedupConfig,
-    }
-
     @model_validator(mode="after")
     def _validate_value_matches_key(self) -> Self:
-        expected = self._KEY_TO_VO_TYPE[self.id]
+        expected = vo_type_for(self.id)
         if not isinstance(self.value, expected):
             raise ValueError(
                 f"Setting with key {self.id.value!r} requires value of type "

--- a/src/modules/settings/domain/value_objects/__init__.py
+++ b/src/modules/settings/domain/value_objects/__init__.py
@@ -14,6 +14,10 @@ from src.modules.settings.domain.value_objects.scan_dedup_config import ScanDedu
 from src.modules.settings.domain.value_objects.scheduler_config import SchedulerConfig
 from src.modules.settings.domain.value_objects.setting_key import SettingKey
 from src.modules.settings.domain.value_objects.setting_source import SettingSource
+from src.modules.settings.domain.value_objects.setting_vo_registry import (
+    SETTING_VO_TYPES,
+    vo_type_for,
+)
 from src.modules.settings.domain.value_objects.streaming_config import StreamingConfig
 from src.modules.settings.domain.value_objects.thumbnail_backfill_config import (
     ThumbnailBackfillConfig,
@@ -32,6 +36,7 @@ ConfigVO = (
 __all__ = [
     "AvatarConfig",
     "ConfigVO",
+    "SETTING_VO_TYPES",
     "IntroDetectionConfig",
     "ScanDedupConfig",
     "SchedulerConfig",
@@ -39,4 +44,5 @@ __all__ = [
     "SettingSource",
     "StreamingConfig",
     "ThumbnailBackfillConfig",
+    "vo_type_for",
 ]

--- a/src/modules/settings/domain/value_objects/setting_vo_registry.py
+++ b/src/modules/settings/domain/value_objects/setting_vo_registry.py
@@ -1,0 +1,53 @@
+"""Single source of truth for the ``SettingKey`` → configuration VO map.
+
+The same mapping used to be copied in the ``Setting`` aggregate, the
+``SettingMapper`` and the ``RuntimeSettings`` facade — adding a bucket
+meant editing four places, and forgetting one broke a different
+subsystem (validation, persistence or runtime defaults). Every layer
+now reads this registry; adding a bucket is the enum member, the VO,
+and **one** entry here (covered by a completeness test).
+"""
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+from src.modules.settings.domain.value_objects.avatar_config import AvatarConfig
+from src.modules.settings.domain.value_objects.intro_detection_config import (
+    IntroDetectionConfig,
+)
+from src.modules.settings.domain.value_objects.scan_dedup_config import ScanDedupConfig
+from src.modules.settings.domain.value_objects.scheduler_config import SchedulerConfig
+from src.modules.settings.domain.value_objects.setting_key import SettingKey
+from src.modules.settings.domain.value_objects.streaming_config import StreamingConfig
+from src.modules.settings.domain.value_objects.thumbnail_backfill_config import (
+    ThumbnailBackfillConfig,
+)
+
+SETTING_VO_TYPES: Final[Mapping[SettingKey, type[CompoundValueObject]]] = MappingProxyType(
+    {
+        SettingKey.SCHEDULER: SchedulerConfig,
+        SettingKey.THUMBNAIL_BACKFILL: ThumbnailBackfillConfig,
+        SettingKey.INTRO_DETECTION: IntroDetectionConfig,
+        SettingKey.STREAMING: StreamingConfig,
+        SettingKey.AVATAR: AvatarConfig,
+        SettingKey.SCAN_DEDUP: ScanDedupConfig,
+    }
+)
+"""Read-only map from setting bucket to the VO type its row carries."""
+
+
+def vo_type_for(key: SettingKey) -> type[CompoundValueObject]:
+    """Return the configuration VO type persisted under ``key``.
+
+    Args:
+        key: The setting bucket identifier.
+
+    Returns:
+        The concrete ``CompoundValueObject`` subclass for the bucket.
+    """
+    return SETTING_VO_TYPES[key]
+
+
+__all__ = ["SETTING_VO_TYPES", "vo_type_for"]

--- a/src/modules/settings/infrastructure/persistence/mappers/setting_mapper.py
+++ b/src/modules/settings/infrastructure/persistence/mappers/setting_mapper.py
@@ -1,19 +1,13 @@
 """Bidirectional mapper between :class:`Setting` and :class:`SettingModel`."""
 
-from typing import Any, ClassVar
+from typing import Any
 
-from src.building_blocks.domain.value_objects import CompoundValueObject
 from src.modules.settings.domain.entities import Setting
 from src.modules.settings.domain.value_objects import (
-    AvatarConfig,
     ConfigVO,
-    IntroDetectionConfig,
-    ScanDedupConfig,
-    SchedulerConfig,
     SettingKey,
     SettingSource,
-    StreamingConfig,
-    ThumbnailBackfillConfig,
+    vo_type_for,
 )
 from src.modules.settings.infrastructure.persistence.models import SettingModel
 
@@ -22,22 +16,14 @@ class SettingMapper:
     """Map between :class:`Setting` domain entity and ORM model.
 
     The mapper owns the polymorphic deserialization: it inspects
-    ``model.key`` to pick the correct ``ConfigVO`` subtype and
-    rehydrates the row's ``value_json`` into it.
+    ``model.key`` to pick the correct ``ConfigVO`` subtype — via the
+    domain's ``setting_vo_registry`` — and rehydrates the row's
+    ``value_json`` into it.
 
     Example:
         >>> model = SettingMapper.to_model(setting)
         >>> setting = SettingMapper.to_entity(model)
     """
-
-    _KEY_TO_VO_TYPE: ClassVar[dict[SettingKey, type[CompoundValueObject]]] = {
-        SettingKey.SCHEDULER: SchedulerConfig,
-        SettingKey.THUMBNAIL_BACKFILL: ThumbnailBackfillConfig,
-        SettingKey.INTRO_DETECTION: IntroDetectionConfig,
-        SettingKey.STREAMING: StreamingConfig,
-        SettingKey.AVATAR: AvatarConfig,
-        SettingKey.SCAN_DEDUP: ScanDedupConfig,
-    }
 
     @staticmethod
     def to_model(entity: Setting) -> SettingModel:
@@ -49,8 +35,8 @@ class SettingMapper:
             updated_by_user_id=entity.updated_by_user_id,
         )
 
-    @classmethod
-    def to_entity(cls, model: SettingModel) -> Setting:
+    @staticmethod
+    def to_entity(model: SettingModel) -> Setting:
         """Convert ORM model to :class:`Setting` entity.
 
         Raises:
@@ -58,7 +44,7 @@ class SettingMapper:
                 :class:`SettingKey`.
         """
         key = SettingKey(model.key)
-        vo_type = cls._KEY_TO_VO_TYPE[key]
+        vo_type = vo_type_for(key)
         payload: dict[str, Any] = dict(model.value_json or {})
         value: ConfigVO = vo_type.model_validate(payload)  # type: ignore[assignment]
         return Setting(

--- a/src/modules/settings/infrastructure/runtime_settings.py
+++ b/src/modules/settings/infrastructure/runtime_settings.py
@@ -29,6 +29,7 @@ from asyncio import Lock
 from typing import TYPE_CHECKING, cast
 
 from src.modules.settings.domain.value_objects import (
+    SETTING_VO_TYPES,
     AvatarConfig,
     ConfigVO,
     IntroDetectionConfig,
@@ -44,15 +45,6 @@ if TYPE_CHECKING:
         SettingsUnitOfWorkFactory,
     )
     from src.modules.settings.domain.entities import Setting
-
-_DEFAULT_FACTORIES: dict[SettingKey, type[ConfigVO]] = {
-    SettingKey.SCHEDULER: SchedulerConfig,
-    SettingKey.THUMBNAIL_BACKFILL: ThumbnailBackfillConfig,
-    SettingKey.INTRO_DETECTION: IntroDetectionConfig,
-    SettingKey.STREAMING: StreamingConfig,
-    SettingKey.AVATAR: AvatarConfig,
-    SettingKey.SCAN_DEDUP: ScanDedupConfig,
-}
 
 
 class RuntimeSettings:
@@ -85,7 +77,7 @@ class RuntimeSettings:
         self._uow_factory = uow_factory
         self._ttl = cache_ttl_seconds
         self._snapshot: dict[SettingKey, ConfigVO] = {
-            key: vo_type() for key, vo_type in _DEFAULT_FACTORIES.items()
+            key: vo_type() for key, vo_type in SETTING_VO_TYPES.items()
         }
         # -inf so the first read always refreshes regardless of where
         # ``time.monotonic()`` happens to be — a fresh CI worker starts
@@ -104,7 +96,7 @@ class RuntimeSettings:
         async with self._uow_factory() as uow:
             rows: list[Setting] = list(await uow.settings.list_all())
         new_snapshot: dict[SettingKey, ConfigVO] = {
-            key: vo_type() for key, vo_type in _DEFAULT_FACTORIES.items()
+            key: vo_type() for key, vo_type in SETTING_VO_TYPES.items()
         }
         for row in rows:
             new_snapshot[row.id] = row.value

--- a/tests/modules/settings/unit/domain/value_objects/test_setting_vo_registry.py
+++ b/tests/modules/settings/unit/domain/value_objects/test_setting_vo_registry.py
@@ -1,0 +1,45 @@
+"""Tests for the SettingKey → configuration VO registry."""
+
+import pytest
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+from src.modules.settings.domain.value_objects import (
+    SETTING_VO_TYPES,
+    SettingKey,
+    vo_type_for,
+)
+
+
+@pytest.mark.unit
+class TestSettingVoRegistry:
+    """The registry is the single source of truth for key → VO."""
+
+    def test_every_setting_key_has_a_registered_vo(self) -> None:
+        # Completeness guard: adding a SettingKey member without
+        # registering its VO must fail here, not in production.
+        missing = [key for key in SettingKey if key not in SETTING_VO_TYPES]
+
+        assert missing == []
+
+    def test_every_registered_vo_is_a_compound_value_object(self) -> None:
+        non_compound = [
+            key
+            for key, vo_type in SETTING_VO_TYPES.items()
+            if not issubclass(vo_type, CompoundValueObject)
+        ]
+
+        assert non_compound == []
+
+    def test_every_registered_vo_is_default_constructible(self) -> None:
+        # RuntimeSettings builds its fallback snapshot via ``vo_type()``;
+        # a VO with a required field would break startup defaults.
+        for vo_type in SETTING_VO_TYPES.values():
+            vo_type()
+
+    def test_vo_type_for_returns_registered_type(self) -> None:
+        for key in SettingKey:
+            assert vo_type_for(key) is SETTING_VO_TYPES[key]
+
+    def test_registry_is_read_only(self) -> None:
+        with pytest.raises(TypeError):
+            SETTING_VO_TYPES[SettingKey.SCHEDULER] = object  # type: ignore[index]


### PR DESCRIPTION
## Summary

- Add `setting_vo_registry.py` to the settings domain — the single source of truth for the `SettingKey` → configuration-VO map (Fase 5a of the code-smell plan)
- Remove the three copies of the map: `Setting._KEY_TO_VO_TYPE` (aggregate), `SettingMapper._KEY_TO_VO_TYPE` (persistence) and `_DEFAULT_FACTORIES` (RuntimeSettings) — all now read the registry
- Fix a layer violation: `list_settings` and `update_setting` use cases imported the **private** `_DEFAULT_FACTORIES` from infrastructure; they now import `vo_type_for` from the domain
- New completeness test: every `SettingKey` member must be registered, every VO must be default-constructible (RuntimeSettings builds fallback snapshots via `vo_type()`), and the registry is read-only (`MappingProxyType`)

## Test plan

- [x] Full suite: 2735 passed, 5 skipped
- [x] `ruff check` + `ruff format` clean

## Summary by Sourcery

Centralize the mapping between SettingKey and configuration value object types into a single domain-level registry and update all settings layers to consume it.

Enhancements:
- Introduce a domain-level SettingKey → ConfigVO registry (SETTING_VO_TYPES/vo_type_for) as the single source of truth for configuration bucket types.
- Refactor the Setting aggregate, persistence mapper, runtime settings facade, and application use cases to depend on the shared registry instead of their own duplicated maps, resolving a domain–infrastructure layering violation.

Tests:
- Add unit tests ensuring every SettingKey is registered, all registered VOs are valid and default-constructible, vo_type_for returns the registered type, and the registry mapping is read-only.