### PR TITLE
refactor(library): remove dead preset factories

### DIFF
--- a/src/modules/library/domain/entities/library.py
+++ b/src/modules/library/domain/entities/library.py
@@ -16,7 +16,9 @@ from src.modules.library.domain.value_objects.library_id import LibraryId
 from src.modules.library.domain.value_objects.library_name import LibraryName
 from src.modules.library.domain.value_objects.library_settings import LibrarySettings
 from src.modules.library.domain.value_objects.library_type import LibraryType
-from src.modules.library.domain.value_objects.metadata_provider import MetadataProviderConfig
+from src.modules.library.domain.value_objects.metadata_provider import (  # noqa: TCH001 - Pydantic field type, needed at runtime
+    MetadataProviderConfig,
+)
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
 
@@ -246,89 +248,6 @@ class Library(AggregateRoot[LibraryId]):
             metadata_providers=metadata_providers or [],
             settings=settings or LibrarySettings.default(),
             **kwargs,
-        )
-
-    @classmethod
-    def create_movie_library(
-        cls,
-        name: str,
-        paths: Sequence[str],
-        language: str = "en",
-    ) -> Library:
-        """Create a library optimized for movies.
-
-        Args:
-            name: Library display name.
-            paths: Filesystem paths to scan.
-            language: Preferred metadata language.
-
-        Returns:
-            A new movie Library with TMDB as primary provider.
-        """
-        return cls.create(
-            name=name,
-            library_type=LibraryType.MOVIES,
-            paths=paths,
-            language=language,
-            metadata_providers=[
-                MetadataProviderConfig.tmdb(priority=1),
-                MetadataProviderConfig.omdb(priority=2),
-            ],
-        )
-
-    @classmethod
-    def create_series_library(
-        cls,
-        name: str,
-        paths: Sequence[str],
-        language: str = "en",
-    ) -> Library:
-        """Create a library optimized for TV series.
-
-        Args:
-            name: Library display name.
-            paths: Filesystem paths to scan.
-            language: Preferred metadata language.
-
-        Returns:
-            A new series Library with TVDB as primary provider.
-        """
-        return cls.create(
-            name=name,
-            library_type=LibraryType.SERIES,
-            paths=paths,
-            language=language,
-            metadata_providers=[
-                MetadataProviderConfig.tvdb(priority=1),
-                MetadataProviderConfig.tmdb(priority=2),
-            ],
-        )
-
-    @classmethod
-    def create_anime_library(
-        cls,
-        name: str,
-        paths: Sequence[str],
-    ) -> Library:
-        """Create a library optimized for anime.
-
-        Args:
-            name: Library display name.
-            paths: Filesystem paths to scan.
-
-        Returns:
-            A new anime Library with Japanese metadata and English subtitles.
-        """
-        return cls.create(
-            name=name,
-            library_type=LibraryType.SERIES,
-            paths=paths,
-            language="ja",
-            metadata_providers=[
-                MetadataProviderConfig.tvdb(priority=1),
-                MetadataProviderConfig.tmdb(priority=2),
-            ],
-            settings=LibrarySettings.for_anime(),
         )
 
 

--- a/src/modules/library/domain/value_objects/library_settings.py
+++ b/src/modules/library/domain/value_objects/library_settings.py
@@ -46,34 +46,5 @@ class LibrarySettings(CompoundValueObject):
         """
         return cls()
 
-    @classmethod
-    def for_anime(cls) -> "LibrarySettings":
-        """Create settings optimized for anime libraries.
-
-        Returns:
-            LibrarySettings with Japanese audio, English subtitles,
-            and always-on subtitle mode.
-        """
-        return cls(
-            preferred_audio_language=LanguageCode("ja"),
-            preferred_subtitle_language=LanguageCode("en"),
-            subtitle_mode=SubtitleMode.ALWAYS,
-        )
-
-    @classmethod
-    def for_foreign_films(cls, subtitle_language: str = "en") -> "LibrarySettings":
-        """Create settings optimized for foreign film libraries.
-
-        Args:
-            subtitle_language: Preferred subtitle language code.
-
-        Returns:
-            LibrarySettings with foreign audio mode.
-        """
-        return cls(
-            preferred_subtitle_language=LanguageCode(subtitle_language),
-            subtitle_mode=SubtitleMode.FOREIGN_AUDIO_ONLY,
-        )
-
 
 __all__ = ["LibrarySettings"]

--- a/tests/modules/library/unit/domain/entities/test_library.py
+++ b/tests/modules/library/unit/domain/entities/test_library.py
@@ -215,46 +215,6 @@ class TestLibraryFactoryCreate:
         assert library.settings.preferred_audio_language.value == "en"
 
 
-class TestLibrarySpecializedFactories:
-    """Tests for specialized Library factory methods."""
-
-    def test_create_movie_library_should_use_tmdb_and_omdb(self):
-        library = Library.create_movie_library(
-            name="Movies",
-            paths=["/media/movies"],
-        )
-
-        assert library.library_type == LibraryType.MOVIES
-        providers = library.get_enabled_providers()
-        assert len(providers) == 2
-        assert providers[0].provider.value == "tmdb"
-        assert providers[1].provider.value == "omdb"
-
-    def test_create_series_library_should_use_tvdb_and_tmdb(self):
-        library = Library.create_series_library(
-            name="TV Shows",
-            paths=["/media/series"],
-        )
-
-        assert library.library_type == LibraryType.SERIES
-        providers = library.get_enabled_providers()
-        assert len(providers) == 2
-        assert providers[0].provider.value == "tvdb"
-        assert providers[1].provider.value == "tmdb"
-
-    def test_create_anime_library_should_use_japanese_and_english_subs(self):
-        library = Library.create_anime_library(
-            name="Anime",
-            paths=["/media/anime"],
-        )
-
-        assert library.library_type == LibraryType.SERIES
-        assert library.language.value == "ja"
-        assert library.settings.preferred_audio_language.value == "ja"
-        assert library.settings.preferred_subtitle_language is not None
-        assert library.settings.preferred_subtitle_language.value == "en"
-
-
 class TestLibraryImmutability:
     """Tests for Library frozen (immutable) behavior."""
 

--- a/tests/modules/library/unit/domain/value_objects/test_library_settings.py
+++ b/tests/modules/library/unit/domain/value_objects/test_library_settings.py
@@ -45,21 +45,3 @@ class TestLibrarySettingsFactories:
         assert settings.preferred_audio_language.value == "en"
         assert settings.preferred_subtitle_language is None
         assert settings.subtitle_mode == SubtitleMode.FOREIGN_AUDIO_ONLY
-
-    def test_for_anime_should_return_japanese_audio_english_subtitles(self):
-        settings = LibrarySettings.for_anime()
-
-        assert settings.preferred_audio_language.value == "ja"
-        assert settings.preferred_subtitle_language.value == "en"  # type: ignore[union-attr]
-        assert settings.subtitle_mode == SubtitleMode.ALWAYS
-
-    def test_for_foreign_films_should_return_foreign_audio_mode(self):
-        settings = LibrarySettings.for_foreign_films()
-
-        assert settings.preferred_subtitle_language.value == "en"  # type: ignore[union-attr]
-        assert settings.subtitle_mode == SubtitleMode.FOREIGN_AUDIO_ONLY
-
-    def test_for_foreign_films_should_accept_custom_subtitle_language(self):
-        settings = LibrarySettings.for_foreign_films(subtitle_language="pt")
-
-        assert settings.preferred_subtitle_language.value == "pt"  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

- Delete `Library.create_movie_library` / `create_series_library` / `create_anime_library` and `LibrarySettings.for_anime` / `for_foreign_films` (Fase 5b of the code-smell plan)
- All five had **zero production call sites** — libraries are always created via `CreateLibraryUseCase` with explicit settings from the request; the presets only existed in the aggregate and their own tests
- `LibrarySettings.default()` stays — it is used by `Library.create` as the settings fallback
- `MetadataProviderConfig.tmdb/omdb/tvdb` conveniences stay — still used by tests
- The original review item was "move presets out of the aggregate"; with no consumers, deletion removes the smell entirely (git history preserves the presets if they ever return as a product feature)

## Test plan

- [x] `pytest tests/modules/library` — 93 passed
- [x] `ruff check` + `ruff format` clean

## Summary by Sourcery

Remove unused preset factory methods from the library domain and their associated tests.

Enhancements:
- Delete specialized Library factory methods and preset LibrarySettings helpers that are no longer used in production.
- Simplify the library domain API by relying on the generic Library.create and LibrarySettings.default paths.

Tests:
- Remove unit tests covering the deleted preset factories and settings helpers.