### PR TITLE
refactor(media): type media ids as VOs in domain events

### DIFF
--- a/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
+++ b/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
@@ -162,7 +162,7 @@ class OnMediaEnrichedHandler(EventHandler):
                     recipient_user_id=request.requester_user_id,
                     title=request.title or f"tmdb/{event.media_type}/{event.tmdb_id}",
                     tmdb_id=event.tmdb_id,
-                    media_id=event.media_id,
+                    media_id=event.media_id.value,
                     media_type=event.media_type,
                 ),
             )

--- a/src/modules/collections/application/event_handlers/on_movie_merged.py
+++ b/src/modules/collections/application/event_handlers/on_movie_merged.py
@@ -37,13 +37,13 @@ class OnMovieMergedHandler(EventHandler):
 
         async with self._uow_factory() as uow:
             watchlist_updated = await uow.watchlist.rewrite_media_id(
-                from_media_id=event.loser_id,
-                to_media_id=event.winner_id,
+                from_media_id=event.loser_id.value,
+                to_media_id=event.winner_id.value,
                 to_media_type="movie",
             )
             lists_updated = await uow.custom_lists.rewrite_item_media_id(
-                from_media_id=event.loser_id,
-                to_media_id=event.winner_id,
+                from_media_id=event.loser_id.value,
+                to_media_id=event.winner_id.value,
                 to_media_type="movie",
             )
 

--- a/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
@@ -37,13 +37,13 @@ class OnMoviePromotedToSeriesHandler(EventHandler):
 
         async with self._uow_factory() as uow:
             watchlist_updated = await uow.watchlist.rewrite_media_id(
-                from_media_id=event.movie_id,
-                to_media_id=event.series_id,
+                from_media_id=event.movie_id.value,
+                to_media_id=event.series_id.value,
                 to_media_type="series",
             )
             lists_updated = await uow.custom_lists.rewrite_item_media_id(
-                from_media_id=event.movie_id,
-                to_media_id=event.series_id,
+                from_media_id=event.movie_id.value,
+                to_media_id=event.series_id.value,
                 to_media_type="series",
             )
 

--- a/src/modules/media/application/event_handlers/on_media_created.py
+++ b/src/modules/media/application/event_handlers/on_media_created.py
@@ -26,7 +26,9 @@ class OnMediaCreatedHandler(EventHandler):
 
     Example:
         >>> handler = OnMediaCreatedHandler(movie_uc_factory, series_uc_factory)
-        >>> await handler.handle(MediaCreatedEvent(media_id="mov_abc", media_type="movie"))
+        >>> await handler.handle(
+        ...     MediaCreatedEvent(media_id=MovieId("mov_2xK9mPqR7nL4"), media_type="movie")
+        ... )
     """
 
     def __init__(
@@ -54,7 +56,7 @@ class OnMediaCreatedHandler(EventHandler):
 
         _logger.info("Auto-enriching %s %s", event.media_type, event.media_id)
 
-        input_dto = EnrichMediaInput(media_id=event.media_id, force=False)
+        input_dto = EnrichMediaInput(media_id=event.media_id.value, force=False)
 
         if event.media_type is MediaType.MOVIE:
             movie_uc = await self._enrich_movie_factory()

--- a/src/modules/media/application/event_handlers/on_media_enriched.py
+++ b/src/modules/media/application/event_handlers/on_media_enriched.py
@@ -55,7 +55,7 @@ class OnMediaEnrichedHandler(EventHandler):
         use_case = await self._detect_movie_conflicts_factory()
         result = await use_case.execute(
             DetectMovieConflictsInput(
-                media_id=event.media_id,
+                media_id=event.media_id.value,
                 tmdb_id=event.tmdb_id,
             ),
         )

--- a/src/modules/media/application/use_cases/clear_episode_intro.py
+++ b/src/modules/media/application/use_cases/clear_episode_intro.py
@@ -60,12 +60,12 @@ class ClearEpisodeIntroUseCase:
             if had_marker:
                 await uow.series.update_episode_intro(episode_id, None)
 
-            series_id = str(episode.series_id)
+            series_id = episode.series_id
 
         if had_marker and self._event_bus is not None:
             await self._event_bus.publish(
                 IntroClearedEvent(
-                    episode_id=str(episode_id),
+                    episode_id=episode_id,
                     series_id=series_id,
                 )
             )

--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -240,8 +240,8 @@ class DetectMovieConflictsUseCase:
         persisted = await uow.media_conflicts.save(conflict)  # type: ignore[attr-defined]
         event = MediaConflictDetectedEvent(
             conflict_id=str(persisted.id),
-            candidate_a_id=persisted.candidate_a_id,
-            candidate_b_id=persisted.candidate_b_id,
+            candidate_a_id=MovieId(persisted.candidate_a_id),
+            candidate_b_id=MovieId(persisted.candidate_b_id),
             match_reason=persisted.match_reason.value,
             suggested_action=persisted.suggested_action.value,
         )
@@ -317,6 +317,9 @@ class DetectMovieConflictsUseCase:
         loser_id = persisted.loser_id()
         if loser_id is None:  # pragma: no cover — guarded by aggregate
             raise RuntimeError("auto-merge resolved row missing loser_id")
+        winner_id = self_movie.id
+        if winner_id is None:  # pragma: no cover — loaded from the repository
+            raise RuntimeError("auto-merge winner movie missing id")
 
         deleted = await uow.movies.delete(MovieId(loser_id))  # type: ignore[attr-defined]
         if not deleted:
@@ -328,8 +331,8 @@ class DetectMovieConflictsUseCase:
 
         event = MovieMergedEvent(
             conflict_id=str(persisted.id),
-            winner_id=str(self_movie.id),
-            loser_id=loser_id,
+            winner_id=winner_id,
+            loser_id=MovieId(loser_id),
             keep_loser_variants=False,
             is_auto=True,
         )

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -109,7 +109,7 @@ class EnrichMovieMetadataUseCase:
         if enriched_tmdb_id is not None and self._event_bus is not None:
             await self._event_bus.publish(
                 MediaEnrichedEvent(
-                    media_id=input_dto.media_id,
+                    media_id=MovieId(input_dto.media_id),
                     media_type=MediaType.MOVIE,
                     tmdb_id=enriched_tmdb_id,
                 ),

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -105,7 +105,7 @@ class EnrichSeriesMetadataUseCase:
         if enriched_tmdb_id is not None and self._event_bus is not None:
             await self._event_bus.publish(
                 MediaEnrichedEvent(
-                    media_id=input_dto.media_id,
+                    media_id=SeriesId(input_dto.media_id),
                     media_type=MediaType.SERIES,
                     tmdb_id=enriched_tmdb_id,
                 ),

--- a/src/modules/media/application/use_cases/promote_movie_to_series.py
+++ b/src/modules/media/application/use_cases/promote_movie_to_series.py
@@ -108,9 +108,9 @@ class PromoteMovieToSeriesUseCase:
         # handlers observe the post-promote state.
         await self._event_bus.publish(
             MoviePromotedToSeriesEvent(
-                movie_id=input_dto.movie_id,
-                series_id=series_id,
-                first_episode_id=first_episode_id,
+                movie_id=MovieId(input_dto.movie_id),
+                series_id=SeriesId(series_id),
+                first_episode_id=EpisodeId(first_episode_id),
             ),
         )
 

--- a/src/modules/media/application/use_cases/resolve_media_conflict.py
+++ b/src/modules/media/application/use_cases/resolve_media_conflict.py
@@ -147,8 +147,8 @@ class ResolveMediaConflictUseCase:
 
             event_to_publish = MovieMergedEvent(
                 conflict_id=str(persisted.id),
-                winner_id=winner_id,
-                loser_id=loser_id,
+                winner_id=MovieId(winner_id),
+                loser_id=MovieId(loser_id),
                 keep_loser_variants=action is ResolutionAction.MERGE_KEEP_BOTH,
             )
 

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -299,9 +299,7 @@ class ScanMediaDirectoriesUseCase:
             duration=Duration(0),
             files=[primary_file],
         )
-        movie.add_event(
-            MediaCreatedEvent(media_id=str(movie_id), media_type=CatalogMediaType.MOVIE)
-        )
+        movie.add_event(MediaCreatedEvent(media_id=movie_id, media_type=CatalogMediaType.MOVIE))
         for path in paths[1:]:
             movie = movie.with_file(
                 await self._build_new_media_file(by_path[path], is_primary=False)

--- a/src/modules/media/application/use_cases/set_episode_intro.py
+++ b/src/modules/media/application/use_cases/set_episode_intro.py
@@ -87,12 +87,12 @@ class SetEpisodeIntroUseCase:
             episode.with_intro_marker(marker)
 
             await uow.series.update_episode_intro(episode_id, marker)
-            series_id = str(episode.series_id)
+            series_id = episode.series_id
 
         if self._event_bus is not None:
             await self._event_bus.publish(
                 IntroManuallySetEvent(
-                    episode_id=str(episode_id),
+                    episode_id=episode_id,
                     series_id=series_id,
                     start_seconds=marker.start_seconds,
                     end_seconds=marker.end_seconds,

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -230,7 +230,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
             files=[file],
             **kwargs,
         )
-        movie.add_event(MediaCreatedEvent(media_id=str(movie_id), media_type=MediaType.MOVIE))
+        movie.add_event(MediaCreatedEvent(media_id=movie_id, media_type=MediaType.MOVIE))
         return movie
 
 

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -235,7 +235,7 @@ class Series(AggregateRoot[SeriesId]):
             start_year=start_year,
             **kwargs,
         )
-        series.add_event(MediaCreatedEvent(media_id=str(series_id), media_type=MediaType.SERIES))
+        series.add_event(MediaCreatedEvent(media_id=series_id, media_type=MediaType.SERIES))
         return series
 
 

--- a/src/modules/media/domain/events.py
+++ b/src/modules/media/domain/events.py
@@ -3,6 +3,12 @@
 from dataclasses import dataclass
 
 from src.building_blocks.domain.events import DomainEvent
+from src.shared_kernel.value_objects.media_id import (
+    EpisodeId,
+    MovieId,
+    SeasonId,
+    SeriesId,
+)
 from src.shared_kernel.value_objects.media_type import MediaType
 
 
@@ -15,32 +21,32 @@ class MediaCreatedEvent(DomainEvent):
         media_type: Type of media (:class:`MediaType`).
     """
 
-    media_id: str = ""
+    media_id: MovieId | SeriesId
     media_type: MediaType
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class IntroDetectedEvent(DomainEvent):
     """Emitted when the auto-detection job persists an intro marker.
 
     Attributes:
         episode_id: External ID of the episode (epi_xxx).
-        season_id: External ID of the parent season (sea_xxx).
+        season_id: External ID of the parent season (ssn_xxx).
         series_id: External ID of the parent series (ser_xxx).
         start_seconds: Start of the detected intro segment.
         end_seconds: End of the detected intro segment.
         confidence: Detection confidence in ``[0.0, 1.0]``.
     """
 
-    episode_id: str = ""
-    season_id: str = ""
-    series_id: str = ""
+    episode_id: EpisodeId
+    season_id: SeasonId
+    series_id: SeriesId
     start_seconds: int = 0
     end_seconds: int = 0
     confidence: float = 0.0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class IntroManuallySetEvent(DomainEvent):
     """Emitted when a user sets or edits an intro marker via the API.
 
@@ -51,13 +57,13 @@ class IntroManuallySetEvent(DomainEvent):
         end_seconds: End of the manually-set intro segment.
     """
 
-    episode_id: str = ""
-    series_id: str = ""
+    episode_id: EpisodeId
+    series_id: SeriesId
     start_seconds: int = 0
     end_seconds: int = 0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class IntroClearedEvent(DomainEvent):
     """Emitted when an episode's intro marker is removed.
 
@@ -69,8 +75,8 @@ class IntroClearedEvent(DomainEvent):
         series_id: External ID of the parent series (ser_xxx).
     """
 
-    episode_id: str = ""
-    series_id: str = ""
+    episode_id: EpisodeId
+    series_id: SeriesId
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -95,12 +101,12 @@ class MediaEnrichedEvent(DomainEvent):
         tmdb_id: TMDB numeric id the enrichment locked onto.
     """
 
-    media_id: str = ""
+    media_id: MovieId | SeriesId
     media_type: MediaType
     tmdb_id: int = 0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MediaConflictDetectedEvent(DomainEvent):
     """Emitted when the dedup detector queues a new conflict.
 
@@ -120,13 +126,13 @@ class MediaConflictDetectedEvent(DomainEvent):
     """
 
     conflict_id: str = ""
-    candidate_a_id: str = ""
-    candidate_b_id: str = ""
+    candidate_a_id: MovieId | SeriesId
+    candidate_b_id: MovieId | SeriesId
     match_reason: str = ""
     suggested_action: str = ""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MovieMergedEvent(DomainEvent):
     """Emitted when two movies are merged via the conflict queue.
 
@@ -156,13 +162,13 @@ class MovieMergedEvent(DomainEvent):
     """
 
     conflict_id: str = ""
-    winner_id: str = ""
-    loser_id: str = ""
+    winner_id: MovieId
+    loser_id: MovieId
     keep_loser_variants: bool = False
     is_auto: bool = False
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MoviePromotedToSeriesEvent(DomainEvent):
     """Emitted when an admin promotes a movie into a series.
 
@@ -189,9 +195,9 @@ class MoviePromotedToSeriesEvent(DomainEvent):
             that now owns the movie's file variants.
     """
 
-    movie_id: str = ""
-    series_id: str = ""
-    first_episode_id: str = ""
+    movie_id: MovieId
+    series_id: SeriesId
+    first_episode_id: EpisodeId
 
 
 __all__ = [

--- a/src/modules/watch_progress/application/event_handlers/on_movie_merged.py
+++ b/src/modules/watch_progress/application/event_handlers/on_movie_merged.py
@@ -36,7 +36,7 @@ class OnMovieMergedHandler(EventHandler):
             return
 
         async with self._uow_factory() as uow:
-            deleted = await uow.progress.delete_all_for_movie(event.loser_id)
+            deleted = await uow.progress.delete_all_for_movie(event.loser_id.value)
 
         if deleted:
             _logger.info(

--- a/src/modules/watch_progress/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/watch_progress/application/event_handlers/on_movie_promoted_to_series.py
@@ -38,7 +38,7 @@ class OnMoviePromotedToSeriesHandler(EventHandler):
             return
 
         async with self._uow_factory() as uow:
-            deleted = await uow.progress.delete_all_for_movie(event.movie_id)
+            deleted = await uow.progress.delete_all_for_movie(event.movie_id.value)
 
         if deleted:
             _logger.info(

--- a/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
+++ b/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
@@ -18,6 +18,7 @@ from src.modules.catalog_requests.application.ports import (
 from src.modules.catalog_requests.domain.entities import CatalogRequest
 from src.modules.catalog_requests.domain.value_objects import RequestedMediaType
 from src.modules.media.domain.events import MediaCreatedEvent, MediaEnrichedEvent
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 from src.shared_kernel.value_objects.media_type import MediaType
 from tests.modules.catalog_requests.unit.conftest import (
     make_catalog_requests_uow_mock,
@@ -48,7 +49,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),
@@ -69,7 +70,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),
@@ -91,7 +92,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),
@@ -108,7 +109,7 @@ class TestOnMediaEnrichedHandler:
         handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
 
         await handler.handle(
-            MediaCreatedEvent(media_id="mov_abc", media_type="movie"),
+            MediaCreatedEvent(media_id=MovieId("mov_abcabcabcabc"), media_type="movie"),
         )
 
         mocks.catalog_requests.find_by_tmdb_id.assert_not_called()
@@ -125,7 +126,7 @@ class TestOnMediaEnrichedHandler:
         with caplog.at_level(logging.ERROR):
             await handler.handle(
                 MediaEnrichedEvent(
-                    media_id="mov_abc",
+                    media_id=MovieId("mov_abcabcabcabc"),
                     media_type="episode",
                     tmdb_id=42,
                 ),
@@ -147,7 +148,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="ser_xyz",
+                media_id=SeriesId("ser_xyzxyzxyzxyz"),
                 media_type="series",
                 tmdb_id=1399,
             ),
@@ -182,7 +183,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),
@@ -194,7 +195,7 @@ class TestOnMediaEnrichedHandler:
         assert payload.recipient_user_id == "usr_alice"
         assert payload.title == "Alien"
         assert payload.tmdb_id == 348
-        assert payload.media_id == "mov_abc"
+        assert payload.media_id == "mov_abcabcabcabc"
         assert payload.media_type == "movie"
 
     @pytest.mark.asyncio
@@ -217,7 +218,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),
@@ -247,7 +248,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),
@@ -275,7 +276,7 @@ class TestOnMediaEnrichedHandler:
         # No publisher injected: should not raise, fulfillment still happens.
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),
@@ -307,7 +308,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),
@@ -337,7 +338,7 @@ class TestOnMediaEnrichedHandler:
 
         await handler.handle(
             MediaEnrichedEvent(
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
                 tmdb_id=348,
             ),

--- a/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
@@ -11,6 +11,7 @@ from src.modules.media.domain.events import (
     MediaCreatedEvent,
     MovieMergedEvent,
 )
+from src.shared_kernel.value_objects.media_id import MovieId
 
 
 def _uow_mock() -> tuple[MagicMock, AsyncMock, AsyncMock]:
@@ -37,19 +38,19 @@ class TestOnMovieMergedHandlerCollections:
         await handler.handle(
             MovieMergedEvent(
                 conflict_id="cnf_xxxxxxxxxxxx",
-                winner_id="mov_winneraaaaa",
-                loser_id="mov_loserbbbbbb",
+                winner_id=MovieId("mov_winneraaaaaa"),
+                loser_id=MovieId("mov_loserbbbbbbb"),
             ),
         )
 
         watchlist.rewrite_media_id.assert_awaited_once_with(
-            from_media_id="mov_loserbbbbbb",
-            to_media_id="mov_winneraaaaa",
+            from_media_id="mov_loserbbbbbbb",
+            to_media_id="mov_winneraaaaaa",
             to_media_type="movie",
         )
         custom_lists.rewrite_item_media_id.assert_awaited_once_with(
-            from_media_id="mov_loserbbbbbb",
-            to_media_id="mov_winneraaaaa",
+            from_media_id="mov_loserbbbbbbb",
+            to_media_id="mov_winneraaaaaa",
             to_media_type="movie",
         )
 
@@ -59,7 +60,7 @@ class TestOnMovieMergedHandlerCollections:
         handler = OnMovieMergedHandler(uow_factory=factory)
 
         await handler.handle(
-            MediaCreatedEvent(media_id="mov_abcdefghijkl", media_type="movie"),
+            MediaCreatedEvent(media_id=MovieId("mov_abcdefghijkl"), media_type="movie"),
         )
 
         factory.assert_not_called()

--- a/tests/modules/media/integration/application/use_cases/test_intro_use_cases.py
+++ b/tests/modules/media/integration/application/use_cases/test_intro_use_cases.py
@@ -152,7 +152,7 @@ class TestSetEpisodeIntroIntegration:
         event_bus.publish.assert_awaited_once()
         published = event_bus.publish.await_args_list[0].args[0]
         assert isinstance(published, IntroManuallySetEvent)
-        assert published.episode_id == str(episode_id)
+        assert published.episode_id == episode_id
 
     async def test_rejects_intro_exceeding_duration(
         self,

--- a/tests/modules/media/unit/application/use_cases/test_clear_episode_intro.py
+++ b/tests/modules/media/unit/application/use_cases/test_clear_episode_intro.py
@@ -74,8 +74,8 @@ class TestClearEpisodeIntroUseCase:
         event_bus.publish.assert_awaited_once()
         published_event = event_bus.publish.await_args_list[0].args[0]
         assert isinstance(published_event, IntroClearedEvent)
-        assert published_event.episode_id == str(episode.id)
-        assert published_event.series_id == str(episode.series_id)
+        assert published_event.episode_id == episode.id
+        assert published_event.series_id == episode.series_id
 
     @pytest.mark.asyncio
     async def test_idempotent_when_marker_already_absent(self) -> None:

--- a/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
@@ -127,8 +127,8 @@ class TestDetectMovieConflictsUseCase:
         event_bus.publish.assert_awaited_once()
         published = event_bus.publish.await_args[0][0]
         assert isinstance(published, MediaConflictDetectedEvent)
-        assert published.candidate_a_id == "mov_abcdefghijkl"
-        assert published.candidate_b_id == "mov_mnopqrstuvwx"
+        assert published.candidate_a_id.value == "mov_abcdefghijkl"
+        assert published.candidate_b_id.value == "mov_mnopqrstuvwx"
 
     @pytest.mark.asyncio
     async def test_tunable_thresholds_from_settings_flag_different_edit(self) -> None:
@@ -476,8 +476,8 @@ class TestAutoMergeOrphans:
         published = event_bus.publish.await_args[0][0]
         assert isinstance(published, MovieMergedEvent)
         assert published.is_auto is True
-        assert published.winner_id == "mov_abcdefghijkl"
-        assert published.loser_id == "mov_mnopqrstuvwx"
+        assert published.winner_id.value == "mov_abcdefghijkl"
+        assert published.loser_id.value == "mov_mnopqrstuvwx"
 
     @pytest.mark.asyncio
     async def test_unhealthy_library_falls_back_to_pending_queue(self) -> None:

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -547,7 +547,7 @@ class TestEnrichMovieMetadataEvents:
         assert isinstance(published, MediaEnrichedEvent)
         assert published.media_type == "movie"
         assert published.tmdb_id == 27205
-        assert published.media_id == str(movie.id)
+        assert published.media_id == movie.id
 
     @pytest.mark.asyncio
     async def test_no_event_when_enrichment_fails(self) -> None:

--- a/tests/modules/media/unit/application/use_cases/test_promote_movie_to_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_promote_movie_to_series.py
@@ -111,9 +111,9 @@ class TestPromoteMovieToSeries:
         bus.publish.assert_awaited_once()
         event = bus.publish.await_args.args[0]
         assert isinstance(event, MoviePromotedToSeriesEvent)
-        assert event.movie_id == str(movie.id)
-        assert event.series_id == output.series_id
-        assert event.first_episode_id == output.first_episode_id
+        assert event.movie_id == movie.id
+        assert event.series_id.value == output.series_id
+        assert event.first_episode_id.value == output.first_episode_id
         # Re-enrich was triggered with force=True.
         enrich.execute.assert_awaited_once()
         enrich_input = enrich.execute.await_args.args[0]

--- a/tests/modules/media/unit/application/use_cases/test_resolve_media_conflict.py
+++ b/tests/modules/media/unit/application/use_cases/test_resolve_media_conflict.py
@@ -110,8 +110,8 @@ class TestMergeReplace:
         event_bus.publish.assert_awaited_once()
         published = event_bus.publish.await_args[0][0]
         assert isinstance(published, MovieMergedEvent)
-        assert published.winner_id == _WINNER
-        assert published.loser_id == _LOSER
+        assert published.winner_id.value == _WINNER
+        assert published.loser_id.value == _LOSER
         assert published.keep_loser_variants is False
 
 

--- a/tests/modules/media/unit/application/use_cases/test_set_episode_intro.py
+++ b/tests/modules/media/unit/application/use_cases/test_set_episode_intro.py
@@ -111,8 +111,8 @@ class TestSetEpisodeIntroUseCase:
         event_bus.publish.assert_awaited_once()
         published_event = event_bus.publish.await_args_list[0].args[0]
         assert isinstance(published_event, IntroManuallySetEvent)
-        assert published_event.episode_id == str(episode.id)
-        assert published_event.series_id == str(episode.series_id)
+        assert published_event.episode_id == episode.id
+        assert published_event.series_id == episode.series_id
         assert published_event.start_seconds == 5
         assert published_event.end_seconds == 70
 

--- a/tests/modules/media/unit/domain/entities/test_movie.py
+++ b/tests/modules/media/unit/domain/entities/test_movie.py
@@ -448,7 +448,7 @@ class TestMovieEvents:
         from src.shared_kernel.value_objects.media_type import MediaType
 
         assert isinstance(events[0], MediaCreatedEvent)
-        assert events[0].media_id == str(movie.id)
+        assert events[0].media_id == movie.id
         assert events[0].media_type is MediaType.MOVIE
         assert movie.has_pending_events is False
 

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -188,7 +188,7 @@ class TestSeriesEvents:
         from src.shared_kernel.value_objects.media_type import MediaType
 
         assert isinstance(events[0], MediaCreatedEvent)
-        assert events[0].media_id == str(series.id)
+        assert events[0].media_id == series.id
         assert events[0].media_type is MediaType.SERIES
         assert series.has_pending_events is False
 

--- a/tests/modules/watch_progress/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/watch_progress/unit/application/event_handlers/test_on_movie_merged.py
@@ -11,6 +11,7 @@ from src.modules.media.domain.events import (
 from src.modules.watch_progress.application.event_handlers.on_movie_merged import (
     OnMovieMergedHandler,
 )
+from src.shared_kernel.value_objects.media_id import MovieId
 
 
 def _uow_mock() -> tuple[MagicMock, AsyncMock]:
@@ -34,12 +35,12 @@ class TestOnMovieMergedHandlerWatchProgress:
         await handler.handle(
             MovieMergedEvent(
                 conflict_id="cnf_xxxxxxxxxxxx",
-                winner_id="mov_winneraaaaa",
-                loser_id="mov_loserbbbbbb",
+                winner_id=MovieId("mov_winneraaaaaa"),
+                loser_id=MovieId("mov_loserbbbbbbb"),
             ),
         )
 
-        progress.delete_all_for_movie.assert_awaited_once_with("mov_loserbbbbbb")
+        progress.delete_all_for_movie.assert_awaited_once_with("mov_loserbbbbbbb")
 
     @pytest.mark.asyncio
     async def test_ignores_unrelated_events(self) -> None:
@@ -47,7 +48,7 @@ class TestOnMovieMergedHandlerWatchProgress:
         handler = OnMovieMergedHandler(uow_factory=factory)
 
         await handler.handle(
-            MediaCreatedEvent(media_id="mov_abcdefghijkl", media_type="movie"),
+            MediaCreatedEvent(media_id=MovieId("mov_abcdefghijkl"), media_type="movie"),
         )
 
         factory.assert_not_called()


### PR DESCRIPTION
## Summary

- Type all media-id fields across the eight media domain events (`MediaCreatedEvent`, `MediaEnrichedEvent`, `Intro*`, `MediaConflictDetectedEvent`, `MovieMergedEvent`, `MoviePromotedToSeriesEvent`) as `MovieId`/`SeriesId`/`SeasonId`/`EpisodeId` from the shared_kernel (ADR-018 deferred bucket — events first, they are the cross-BC contract)
- All events are now `kw_only` with required id fields — no more `= ""` sentinel defaults
- Publish sites pass entity VOs directly (several `str(...)` wrappers removed); `detect_movie_conflicts` auto-merge gains an explicit guard for the winner id instead of stringifying a possible `None`
- Cross-BC handlers (`watch_progress`, `collections`, `catalog_requests`) unwrap with `.value` at their still-untyped DTO/repo boundaries — those interiors migrate in the next PRs
- `conflict_id` (`cnf_xxx`) intentionally stays `str`: not a media id, out of this bucket's scope

## Test plan

- [x] Full suite: 2694 passed, 5 skipped
- [x] `ruff check` + `ruff format` clean
- [x] Event test fixtures migrated to valid base62 ids + VO constructions; assertions compare VO == VO or `.value`

## Related issues

- ADR-018 deferred bucket (media_id typing — step 1 of 4: events → watch_progress → collections → catalog_requests)

## Summary by Sourcery

Type media identifiers in media domain events as value objects and propagate the new typing through handlers, use cases, and tests.

Enhancements:
- Replace string media identifier fields in media domain events with strongly-typed MovieId/SeriesId/SeasonId/EpisodeId value objects and make these events keyword-only with required IDs.
- Adjust application use cases and cross-bounded-context event handlers to construct media ID value objects when publishing events and unwrap them at DTO/repository boundaries.
- Strengthen movie auto-merge logic by explicitly validating the presence of a winner movie ID before emitting merge events.

Tests:
- Update unit and integration tests to construct and assert against media ID value objects, including using their underlying string values where needed.