### PR TITLE
refactor(progress): type media_id as WatchableMediaId VO

### DIFF
--- a/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
+++ b/src/modules/media/infrastructure/acl/progress_lookup_adapter.py
@@ -14,6 +14,7 @@ from src.modules.media.application.ports.progress_lookup_port import (
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -33,8 +34,9 @@ class ProgressLookupAdapter(ProgressLookupPort):
         if not media_ids:
             return {}
         profile = ProfileId(profile_id)
+        typed_ids = [WatchableMediaId(media_id) for media_id in media_ids]
         async with self._watch_progress_uow_factory() as uow:
-            progress_map = await uow.progress.find_by_media_ids(list(media_ids), profile)
+            progress_map = await uow.progress.find_by_media_ids(typed_ids, profile)
         return {
             media_id: ProgressSummary(
                 media_id=media_id,

--- a/src/modules/watch_progress/application/dtos/progress_dtos.py
+++ b/src/modules/watch_progress/application/dtos/progress_dtos.py
@@ -60,7 +60,7 @@ class ProgressOutput:
     def from_entity(cls, progress: WatchProgress) -> ProgressOutput:
         """Create output DTO from a WatchProgress entity."""
         return cls(
-            media_id=progress.media_id,
+            media_id=progress.media_id.value,
             media_type=progress.media_type,
             position_seconds=progress.position_seconds,
             duration_seconds=progress.duration_seconds,

--- a/src/modules/watch_progress/application/event_handlers/on_movie_merged.py
+++ b/src/modules/watch_progress/application/event_handlers/on_movie_merged.py
@@ -36,7 +36,7 @@ class OnMovieMergedHandler(EventHandler):
             return
 
         async with self._uow_factory() as uow:
-            deleted = await uow.progress.delete_all_for_movie(event.loser_id.value)
+            deleted = await uow.progress.delete_all_for_movie(event.loser_id)
 
         if deleted:
             _logger.info(

--- a/src/modules/watch_progress/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/watch_progress/application/event_handlers/on_movie_promoted_to_series.py
@@ -38,7 +38,7 @@ class OnMoviePromotedToSeriesHandler(EventHandler):
             return
 
         async with self._uow_factory() as uow:
-            deleted = await uow.progress.delete_all_for_movie(event.movie_id.value)
+            deleted = await uow.progress.delete_all_for_movie(event.movie_id)
 
         if deleted:
             _logger.info(

--- a/src/modules/watch_progress/application/ports/media_lookup_port.py
+++ b/src/modules/watch_progress/application/ports/media_lookup_port.py
@@ -12,6 +12,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
+
 
 @dataclass(frozen=True)
 class MovieDisplayInfo:
@@ -73,14 +75,14 @@ class MediaLookupPort(ABC):
     """
 
     @abstractmethod
-    async def get_movie(self, media_id: str, lang: str) -> MovieDisplayInfo | None:
+    async def get_movie(self, movie_id: MovieId, lang: str) -> MovieDisplayInfo | None:
         """Resolve a single movie. Returns ``None`` when id is unknown."""
         ...
 
     @abstractmethod
     async def get_series_with_episodes(
         self,
-        series_id: str,
+        series_id: SeriesId,
         lang: str,
     ) -> SeriesWithEpisodesInfo | None:
         """Resolve a series including the sorted episode list."""

--- a/src/modules/watch_progress/application/use_cases/clear_progress.py
+++ b/src/modules/watch_progress/application/use_cases/clear_progress.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -26,7 +27,7 @@ class ClearProgressUseCase:
         """Soft-delete the row, returning ``True`` when one was found."""
         async with self._uow_factory() as uow:
             return await uow.progress.delete(
-                input_dto.media_id,
+                WatchableMediaId(input_dto.media_id),
                 ProfileId(input_dto.profile_id),
             )
 

--- a/src/modules/watch_progress/application/use_cases/clear_series_progress.py
+++ b/src/modules/watch_progress/application/use_cases/clear_series_progress.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.shared_kernel.value_objects.media_id import SeriesId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -33,7 +34,7 @@ class ClearSeriesProgressUseCase:
         """Soft-delete every episode-progress row for the series, return count."""
         async with self._uow_factory() as uow:
             return await uow.progress.delete_by_series(
-                input_dto.series_id,
+                SeriesId(input_dto.series_id),
                 ProfileId(input_dto.profile_id),
             )
 

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -16,7 +16,11 @@ from src.modules.watch_progress.domain.value_objects import (
     WatchableMediaType,
     WatchStatus,
 )
+from src.modules.watch_progress.domain.value_objects.watchable_media_id import (
+    WatchableMediaId,
+)
 from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
+from src.shared_kernel.value_objects.media_id import SeriesId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 if TYPE_CHECKING:
@@ -89,13 +93,13 @@ class GetContinueWatchingUseCase:
                     if item:
                         items.append(item)
                 elif progress.media_type == WatchableMediaType.EPISODE:
-                    parsed = EpisodeCompositeId.parse(progress.media_id)
-                    if not parsed or parsed.series_id in seen_series:
+                    parsed = progress.media_id.as_episode()
+                    if parsed.series_id in seen_series:
                         continue
                     seen_series.add(parsed.series_id)
                     item = await self._resolve_series_episode(
                         uow,
-                        parsed.series_id,
+                        SeriesId(parsed.series_id),
                         input_dto.lang,
                         profile_id,
                     )
@@ -107,7 +111,7 @@ class GetContinueWatchingUseCase:
     async def _resolve_series_episode(
         self,
         uow: WatchProgressUnitOfWork,
-        series_id: str,
+        series_id: SeriesId,
         lang: str,
         profile_id: ProfileId,
     ) -> ContinueWatchingItem | None:
@@ -129,7 +133,7 @@ class GetContinueWatchingUseCase:
     @staticmethod
     async def _build_candidates(
         uow: WatchProgressUnitOfWork,
-        series_id: str,
+        series_id: SeriesId,
         series: SeriesWithEpisodesInfo,
         profile_id: ProfileId,
     ) -> list[EpisodeCandidate]:
@@ -143,11 +147,13 @@ class GetContinueWatchingUseCase:
             return []
 
         media_ids = [
-            EpisodeCompositeId.build(
-                series_id,
-                ep.season_number,
-                ep.episode_number,
-            ).media_id
+            WatchableMediaId(
+                EpisodeCompositeId.build(
+                    series_id.value,
+                    ep.season_number,
+                    ep.episode_number,
+                ).media_id
+            )
             for ep in series.episodes
         ]
 
@@ -155,13 +161,13 @@ class GetContinueWatchingUseCase:
 
         return [
             EpisodeCandidate(
-                series_id=series_id,
+                series_id=series_id.value,
                 media_id=mid,
                 season_number=ep.season_number,
                 episode_number=ep.episode_number,
                 episode_title=ep.title,
                 duration_seconds=ep.duration_seconds,
-                progress=progress_map.get(mid),
+                progress=progress_map.get(mid.value),
             )
             for ep, mid in zip(series.episodes, media_ids, strict=True)
         ]
@@ -181,7 +187,7 @@ class GetContinueWatchingUseCase:
         )
 
         return ContinueWatchingItem(
-            media_id=candidate.media_id,
+            media_id=candidate.media_id.value,
             media_type=WatchableMediaType.EPISODE,
             title=candidate.episode_title,
             poster_path=series.poster_path,
@@ -204,11 +210,11 @@ class GetContinueWatchingUseCase:
         lang: str,
     ) -> ContinueWatchingItem | None:
         """Enrich a movie progress record with metadata."""
-        movie = await self._media_lookup.get_movie(progress.media_id, lang)
+        movie = await self._media_lookup.get_movie(progress.media_id.as_movie_id(), lang)
         if not movie:
             return None
         return ContinueWatchingItem(
-            media_id=progress.media_id,
+            media_id=progress.media_id.value,
             media_type=progress.media_type,
             title=movie.title,
             poster_path=movie.poster_path,

--- a/src/modules/watch_progress/application/use_cases/get_progress.py
+++ b/src/modules/watch_progress/application/use_cases/get_progress.py
@@ -2,6 +2,7 @@
 
 from src.modules.watch_progress.application.dtos import GetProgressInput, ProgressOutput
 from src.modules.watch_progress.application.unit_of_work import WatchProgressUnitOfWorkFactory
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -20,7 +21,7 @@ class GetProgressUseCase:
         """Return the caller's progress for the media, or ``None`` if absent."""
         async with self._uow_factory() as uow:
             progress = await uow.progress.find_by_media_id(
-                input_dto.media_id,
+                WatchableMediaId(input_dto.media_id),
                 ProfileId(input_dto.profile_id),
             )
         if progress is None:

--- a/src/modules/watch_progress/application/use_cases/save_progress.py
+++ b/src/modules/watch_progress/application/use_cases/save_progress.py
@@ -5,7 +5,10 @@ from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.modules.watch_progress.domain.value_objects import (
+    WatchableMediaId,
+    WatchableMediaType,
+)
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -18,8 +21,9 @@ class SaveProgressUseCase:
     async def execute(self, input_dto: SaveProgressInput) -> ProgressOutput:
         """Persist progress for the caller's profile."""
         profile_id = ProfileId(input_dto.profile_id)
+        media_id = WatchableMediaId(input_dto.media_id)
         async with self._uow_factory() as uow:
-            existing = await uow.progress.find_by_media_id(input_dto.media_id, profile_id)
+            existing = await uow.progress.find_by_media_id(media_id, profile_id)
 
             if existing:
                 progress = existing.update_position(
@@ -31,7 +35,7 @@ class SaveProgressUseCase:
             else:
                 progress = WatchProgress.create(
                     profile_id=profile_id,
-                    media_id=input_dto.media_id,
+                    media_id=media_id,
                     media_type=WatchableMediaType(input_dto.media_type),
                     position_seconds=input_dto.position_seconds,
                     duration_seconds=input_dto.duration_seconds,

--- a/src/modules/watch_progress/domain/entities/watch_progress.py
+++ b/src/modules/watch_progress/domain/entities/watch_progress.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from src.building_blocks.domain import AggregateRoot
 from src.modules.watch_progress.domain.value_objects import (
     ProgressId,
+    WatchableMediaId,
     WatchableMediaType,
     WatchStatus,
 )
@@ -41,8 +42,18 @@ class WatchProgress(AggregateRoot[ProgressId]):
     profile_id: ProfileId
 
     # What is being watched
-    media_id: str
+    media_id: WatchableMediaId
     media_type: WatchableMediaType
+
+    @model_validator(mode="after")
+    def _validate_media_id_matches_type(self) -> Self:
+        """Reject a movie id paired with episode type and vice versa."""
+        if self.media_id.is_movie != (self.media_type is WatchableMediaType.MOVIE):
+            raise ValueError(
+                f"media_id '{self.media_id.value}' does not match "
+                f"media_type '{self.media_type.value}'",
+            )
+        return self
 
     # Position tracking
     position_seconds: int = Field(ge=0)
@@ -129,7 +140,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
     def create(
         cls,
         profile_id: ProfileId,
-        media_id: str,
+        media_id: WatchableMediaId,
         media_type: WatchableMediaType,
         position_seconds: int,
         duration_seconds: int,
@@ -142,7 +153,8 @@ class WatchProgress(AggregateRoot[ProgressId]):
             profile_id: Owning profile (``prf_xxx``). Every progress
                 row is scoped to a single profile so multi-profile
                 households watch independently.
-            media_id: External ID of the media (mov_xxx or epi_xxx).
+            media_id: Typed watchable id (``mov_xxx`` or the composite
+                ``epi_ser_xxx_S_E``); must match ``media_type``.
             media_type: Type of media ("movie" or "episode").
             position_seconds: Current playback position in seconds.
             duration_seconds: Total duration of the media in seconds.

--- a/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/domain/repositories/watch_progress_repository.py
@@ -3,6 +3,8 @@
 from abc import ABC, abstractmethod
 
 from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -16,21 +18,21 @@ class WatchProgressRepository(ABC):
 
     Example:
         >>> progress = await repo.find_by_media_id(
-        ...     "mov_abc123def456", caller_profile_id
+        ...     WatchableMediaId("mov_abc123def456"), caller_profile_id
         ... )
     """
 
     @abstractmethod
     async def find_by_media_id(
         self,
-        media_id: str,
+        media_id: WatchableMediaId,
         profile_id: ProfileId,
     ) -> WatchProgress | None:
         """Find progress by media + profile.
 
         Args:
-            media_id: External ID of the media (``mov_xxx`` or
-                ``epi_xxx``).
+            media_id: Typed watchable id (``mov_xxx`` or composite
+                ``epi_ser_xxx_S_E``).
             profile_id: The caller's profile.
 
         Returns:
@@ -71,27 +73,27 @@ class WatchProgressRepository(ABC):
     @abstractmethod
     async def find_by_media_ids(
         self,
-        media_ids: list[str],
+        media_ids: list[WatchableMediaId],
         profile_id: ProfileId,
     ) -> dict[str, WatchProgress]:
         """Find progress for multiple media items in a single query.
 
         Args:
-            media_ids: List of external media IDs to look up.
+            media_ids: Typed watchable ids to look up.
             profile_id: The caller's profile — only their rows match.
 
         Returns:
-            Dict mapping ``media_id`` to ``WatchProgress`` for found
+            Dict mapping raw ``media_id`` strings to ``WatchProgress`` for found
             rows. Missing keys mean no progress exists for that
             media in this profile.
         """
 
     @abstractmethod
-    async def delete(self, media_id: str, profile_id: ProfileId) -> bool:
+    async def delete(self, media_id: WatchableMediaId, profile_id: ProfileId) -> bool:
         """Soft-delete progress for a media item in this profile.
 
         Args:
-            media_id: External ID of the media.
+            media_id: Typed watchable id of the media.
             profile_id: The caller's profile.
 
         Returns:
@@ -101,7 +103,7 @@ class WatchProgressRepository(ABC):
     @abstractmethod
     async def delete_by_series(
         self,
-        series_id: str,
+        series_id: SeriesId,
         profile_id: ProfileId,
     ) -> int:
         """Soft-delete every episode progress for a series in this profile.
@@ -141,7 +143,7 @@ class WatchProgressRepository(ABC):
         """
 
     @abstractmethod
-    async def delete_all_for_movie(self, movie_id: str) -> int:
+    async def delete_all_for_movie(self, movie_id: MovieId) -> int:
         """Soft-delete every progress row that points at a movie id.
 
         Cross-BC operation driven by ``MoviePromotedToSeriesEvent``:

--- a/src/modules/watch_progress/domain/value_objects/__init__.py
+++ b/src/modules/watch_progress/domain/value_objects/__init__.py
@@ -5,6 +5,9 @@ from src.modules.watch_progress.domain.value_objects.episode_candidate import (
 )
 from src.modules.watch_progress.domain.value_objects.progress_id import ProgressId
 from src.modules.watch_progress.domain.value_objects.watch_status import WatchStatus
+from src.modules.watch_progress.domain.value_objects.watchable_media_id import (
+    WatchableMediaId,
+)
 from src.modules.watch_progress.domain.value_objects.watchable_media_type import (
     WatchableMediaType,
 )
@@ -13,5 +16,6 @@ __all__ = [
     "EpisodeCandidate",
     "ProgressId",
     "WatchStatus",
+    "WatchableMediaId",
     "WatchableMediaType",
 ]

--- a/src/modules/watch_progress/domain/value_objects/episode_candidate.py
+++ b/src/modules/watch_progress/domain/value_objects/episode_candidate.py
@@ -19,6 +19,9 @@ from typing import TYPE_CHECKING, ClassVar
 from pydantic import ConfigDict
 
 from src.building_blocks.domain.value_objects import CompoundValueObject
+from src.modules.watch_progress.domain.value_objects.watchable_media_id import (  # noqa: TCH001 - Pydantic field type, needed at runtime
+    WatchableMediaId,
+)
 
 if TYPE_CHECKING:
     from src.modules.watch_progress.domain.entities import WatchProgress
@@ -29,7 +32,7 @@ class EpisodeCandidate(CompoundValueObject):
 
     Attributes:
         series_id: External series id (``ser_...``).
-        media_id: Composite episode id keyed by ``WatchProgressRepository``.
+        media_id: Typed composite episode id keyed by ``WatchProgressRepository``.
         season_number: One-based season number.
         episode_number: One-based episode number within the season.
         episode_title: Display title of the episode (already localized
@@ -52,7 +55,7 @@ class EpisodeCandidate(CompoundValueObject):
     )
 
     series_id: str
-    media_id: str
+    media_id: WatchableMediaId
     season_number: int
     episode_number: int
     episode_title: str

--- a/src/modules/watch_progress/domain/value_objects/watchable_media_id.py
+++ b/src/modules/watch_progress/domain/value_objects/watchable_media_id.py
@@ -1,0 +1,102 @@
+"""Watchable media identifier value object."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import model_validator
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.value_objects import StringValueObject
+from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
+
+
+class WatchableMediaId(StringValueObject):
+    """Identifier of something a profile can watch.
+
+    Watch progress rows point at exactly two shapes of identifier:
+
+    - ``mov_{base62_12chars}`` — a movie external id.
+    - ``epi_{ser_xxx}_{season}_{episode}`` — the composite episode id
+      built by :class:`EpisodeCompositeId` (the frontend contract for
+      episode playback). Plain ``epi_{base62}`` catalog episode ids are
+      **not** accepted — the player never sends them.
+
+    Anything else (empty strings, wrong prefixes, malformed composites)
+    fails on construction, so garbage can no longer round-trip to the
+    database and silently vanish from Continue Watching.
+
+    Example:
+        >>> WatchableMediaId("mov_2xK9mPqR7nL4").is_movie
+        True
+        >>> WatchableMediaId("epi_ser_3yL8nQsT9mK5_1_2").as_episode().episode_number
+        2
+    """
+
+    _RULE_CODE: ClassVar[str] = "WATCH_PROGRESS.MEDIA_ID.INVALID"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate(cls, value: str) -> str:
+        """Accept a movie id or a composite episode id, reject the rest."""
+        if not isinstance(value, str):
+            raise ValueError("Watchable media id must be a string")
+
+        value = value.strip()
+        if value.startswith("mov_"):
+            try:
+                MovieId(value)
+            except DomainValidationException as exc:
+                raise ValueError(
+                    f"Invalid movie id for watch progress: '{value}' [{cls._RULE_CODE}]"
+                ) from exc
+            return value
+
+        parsed = EpisodeCompositeId.parse(value)
+        if parsed is not None:
+            try:
+                SeriesId(parsed.series_id)
+            except DomainValidationException as exc:
+                raise ValueError(
+                    f"Invalid series id inside composite episode id: '{value}' "
+                    f"[{cls._RULE_CODE}]"
+                ) from exc
+            return value
+
+        raise ValueError(
+            f"Invalid watchable media id: '{value}'. Expected 'mov_xxx' or "
+            f"'epi_ser_xxx_S_E' [{cls._RULE_CODE}]"
+        )
+
+    @property
+    def is_movie(self) -> bool:
+        """``True`` when the id points at a movie (``mov_xxx``)."""
+        return self.value.startswith("mov_")
+
+    @property
+    def is_episode(self) -> bool:
+        """``True`` when the id is a composite episode id."""
+        return not self.is_movie
+
+    def as_movie_id(self) -> MovieId:
+        """Return the id as a typed :class:`MovieId`.
+
+        Raises:
+            DomainValidationException: When the id is an episode id.
+        """
+        return MovieId(self.value)
+
+    def as_episode(self) -> EpisodeCompositeId:
+        """Return the parsed :class:`EpisodeCompositeId`.
+
+        Raises:
+            ValueError: When the id is a movie id.
+        """
+        parsed = EpisodeCompositeId.parse(self.value)
+        if parsed is None:
+            raise ValueError(f"Not a composite episode id: '{self.value}'")
+        return parsed
+
+
+__all__ = ["WatchableMediaId"]

--- a/src/modules/watch_progress/infrastructure/acl/media_lookup_adapter.py
+++ b/src/modules/watch_progress/infrastructure/acl/media_lookup_adapter.py
@@ -6,13 +6,13 @@ Media BC. Above the adapter, the use cases only see
 """
 
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-from src.modules.media.domain.value_objects import MovieId, SeriesId
 from src.modules.watch_progress.application.ports.media_lookup_port import (
     EpisodeInfo,
     MediaLookupPort,
     MovieDisplayInfo,
     SeriesWithEpisodesInfo,
 )
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 
 
 class MediaLookupAdapter(MediaLookupPort):
@@ -21,14 +21,14 @@ class MediaLookupAdapter(MediaLookupPort):
     def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
         self._media_uow_factory = media_uow_factory
 
-    async def get_movie(self, media_id: str, lang: str) -> MovieDisplayInfo | None:
+    async def get_movie(self, movie_id: MovieId, lang: str) -> MovieDisplayInfo | None:
         """Map a ``Movie`` entity to a display DTO, or ``None`` when absent."""
         async with self._media_uow_factory() as uow:
-            movie = await uow.movies.find_by_id(MovieId(media_id))
+            movie = await uow.movies.find_by_id(movie_id)
         if movie is None:
             return None
         return MovieDisplayInfo(
-            media_id=media_id,
+            media_id=movie_id.value,
             title=movie.get_title(lang),
             poster_path=movie.poster_path.value if movie.poster_path else None,
             backdrop_path=movie.backdrop_path.value if movie.backdrop_path else None,
@@ -36,12 +36,12 @@ class MediaLookupAdapter(MediaLookupPort):
 
     async def get_series_with_episodes(
         self,
-        series_id: str,
+        series_id: SeriesId,
         lang: str,
     ) -> SeriesWithEpisodesInfo | None:
         """Flatten a ``Series`` into display + sorted-episode DTOs."""
         async with self._media_uow_factory() as uow:
-            series = await uow.series.find_by_id(SeriesId(series_id))
+            series = await uow.series.find_by_id(series_id)
         if series is None:
             return None
 
@@ -58,7 +58,7 @@ class MediaLookupAdapter(MediaLookupPort):
                 )
 
         return SeriesWithEpisodesInfo(
-            series_id=series_id,
+            series_id=series_id.value,
             title=series.get_title(lang),
             poster_path=series.poster_path.value if series.poster_path else None,
             backdrop_path=series.backdrop_path.value if series.backdrop_path else None,

--- a/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
+++ b/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
@@ -3,6 +3,7 @@
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import (
     ProgressId,
+    WatchableMediaId,
     WatchableMediaType,
     WatchStatus,
 )
@@ -34,7 +35,7 @@ class WatchProgressMapper:
         return WatchProgressModel(
             external_id=str(entity.id),
             profile_id=str(entity.profile_id),
-            media_id=entity.media_id,
+            media_id=entity.media_id.value,
             media_type=entity.media_type,
             position_seconds=entity.position_seconds,
             duration_seconds=entity.duration_seconds,
@@ -51,7 +52,7 @@ class WatchProgressMapper:
         return WatchProgress(
             id=ProgressId(model.external_id),
             profile_id=ProfileId(model.profile_id),
-            media_id=model.media_id,
+            media_id=WatchableMediaId(model.media_id),
             media_type=WatchableMediaType(model.media_type),
             position_seconds=model.position_seconds,
             duration_seconds=model.duration_seconds,

--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -1,17 +1,24 @@
 """SQLAlchemy implementation of WatchProgressRepository."""
 
+import logging
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.repositories import WatchProgressRepository
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId
 from src.modules.watch_progress.infrastructure.persistence.mappers import (
     WatchProgressMapper,
 )
 from src.modules.watch_progress.infrastructure.persistence.models import (
     WatchProgressModel,
 )
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_logger = logging.getLogger(__name__)
 
 
 class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
@@ -26,7 +33,7 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
     Example:
         >>> repo = SQLAlchemyWatchProgressRepository(session)
         >>> progress = await repo.find_by_media_id(
-        ...     "mov_abc123def456", caller_profile_id
+        ...     WatchableMediaId("mov_abc123def456"), caller_profile_id
         ... )
     """
 
@@ -35,12 +42,12 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
 
     async def find_by_media_id(
         self,
-        media_id: str,
+        media_id: WatchableMediaId,
         profile_id: ProfileId,
     ) -> WatchProgress | None:
         """Look up a non-deleted row scoped to ``(media_id, profile_id)``."""
         stmt = select(WatchProgressModel).where(
-            WatchProgressModel.media_id == media_id,
+            WatchProgressModel.media_id == media_id.value,
             WatchProgressModel.profile_id == str(profile_id),
             WatchProgressModel.deleted_at.is_(None),
         )
@@ -57,7 +64,7 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         index.
         """
         stmt = select(WatchProgressModel).where(
-            WatchProgressModel.media_id == progress.media_id,
+            WatchProgressModel.media_id == progress.media_id.value,
             WatchProgressModel.profile_id == str(progress.profile_id),
         )
         result = await self._session.execute(stmt)
@@ -93,7 +100,7 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
             .limit(limit)
         )
         result = await self._session.execute(stmt)
-        return [WatchProgressMapper.to_entity(m) for m in result.scalars().all()]
+        return self._to_entities_dropping_invalid(result.scalars().all())
 
     async def list_recently_watched(
         self,
@@ -112,11 +119,35 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
             .limit(limit)
         )
         result = await self._session.execute(stmt)
-        return [WatchProgressMapper.to_entity(m) for m in result.scalars().all()]
+        return self._to_entities_dropping_invalid(result.scalars().all())
+
+    @staticmethod
+    def _to_entities_dropping_invalid(
+        models: list[WatchProgressModel],
+    ) -> list[WatchProgress]:
+        """Map rows to entities, dropping (and logging) corrupt media ids.
+
+        Rows persisted before media-id validation existed may carry a
+        ``media_id`` that no longer parses as :class:`WatchableMediaId`.
+        Such rows were already invisible downstream (Continue Watching
+        silently skipped them); dropping them here with a WARNING makes
+        the corrupt state observable instead of silent.
+        """
+        entities: list[WatchProgress] = []
+        for model in models:
+            try:
+                entities.append(WatchProgressMapper.to_entity(model))
+            except DomainValidationException:
+                _logger.warning(
+                    "Dropping watch-progress row %s with invalid media_id %r",
+                    model.id,
+                    model.media_id,
+                )
+        return entities
 
     async def find_by_media_ids(
         self,
-        media_ids: list[str],
+        media_ids: list[WatchableMediaId],
         profile_id: ProfileId,
     ) -> dict[str, WatchProgress]:
         """Bulk-look-up rows for the profile, returned as ``{media_id: progress}``."""
@@ -124,16 +155,16 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
             return {}
         stmt = select(WatchProgressModel).where(
             WatchProgressModel.profile_id == str(profile_id),
-            WatchProgressModel.media_id.in_(media_ids),
+            WatchProgressModel.media_id.in_([media_id.value for media_id in media_ids]),
             WatchProgressModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
         return {m.media_id: WatchProgressMapper.to_entity(m) for m in result.scalars().all()}
 
-    async def delete(self, media_id: str, profile_id: ProfileId) -> bool:
+    async def delete(self, media_id: WatchableMediaId, profile_id: ProfileId) -> bool:
         """Soft-delete the row for (profile_id, media_id), if any."""
         stmt = select(WatchProgressModel).where(
-            WatchProgressModel.media_id == media_id,
+            WatchProgressModel.media_id == media_id.value,
             WatchProgressModel.profile_id == str(profile_id),
             WatchProgressModel.deleted_at.is_(None),
         )
@@ -149,11 +180,11 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
 
     async def delete_by_series(
         self,
-        series_id: str,
+        series_id: SeriesId,
         profile_id: ProfileId,
     ) -> int:
         """Soft-delete every episode-progress row for this series in the profile."""
-        prefix = f"epi_{series_id}_"
+        prefix = f"epi_{series_id.value}_"
         stmt = select(WatchProgressModel).where(
             WatchProgressModel.profile_id == str(profile_id),
             WatchProgressModel.media_id.startswith(prefix),
@@ -187,7 +218,7 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
             await self._session.flush()
         return len(models)
 
-    async def delete_all_for_movie(self, movie_id: str) -> int:
+    async def delete_all_for_movie(self, movie_id: MovieId) -> int:
         """Soft-delete every (cross-profile) progress row on a movie id.
 
         Driven by ``MoviePromotedToSeriesEvent`` — see the interface
@@ -196,7 +227,7 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         almost guaranteed to be wrong).
         """
         stmt = select(WatchProgressModel).where(
-            WatchProgressModel.media_id == movie_id,
+            WatchProgressModel.media_id == movie_id.value,
             WatchProgressModel.media_type == "movie",
             WatchProgressModel.deleted_at.is_(None),
         )

--- a/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
+++ b/tests/modules/media/integration/acl/test_progress_lookup_adapter.py
@@ -53,21 +53,21 @@ class TestProgressLookupAdapter:
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         progress_repo = SQLAlchemyWatchProgressRepository(db_session)
-        await progress_repo.save(_progress("epi_ser_ABC_1_1", position=900))
-        await progress_repo.save(_progress("epi_ser_ABC_1_2", position=3300))
+        await progress_repo.save(_progress("epi_ser_abc123def456_1_1", position=900))
+        await progress_repo.save(_progress("epi_ser_abc123def456_1_2", position=3300))
         await db_session.commit()
 
         adapter = _make_adapter(session_factory)
 
         result = await adapter.find_for_media_ids(
-            ["epi_ser_ABC_1_1", "epi_ser_ABC_1_2", "epi_ser_ABC_1_3"],
+            ["epi_ser_abc123def456_1_1", "epi_ser_abc123def456_1_2", "epi_ser_abc123def456_1_3"],
             profile_id=_PROFILE_ID.value,
         )
 
-        assert set(result.keys()) == {"epi_ser_ABC_1_1", "epi_ser_ABC_1_2"}
-        assert result["epi_ser_ABC_1_1"].position_seconds == 900
-        assert result["epi_ser_ABC_1_1"].percentage == pytest.approx(25.0)
-        assert result["epi_ser_ABC_1_2"].status == "completed"
+        assert set(result.keys()) == {"epi_ser_abc123def456_1_1", "epi_ser_abc123def456_1_2"}
+        assert result["epi_ser_abc123def456_1_1"].position_seconds == 900
+        assert result["epi_ser_abc123def456_1_1"].percentage == pytest.approx(25.0)
+        assert result["epi_ser_abc123def456_1_2"].status == "completed"
 
     async def test_find_for_media_ids_with_empty_input(
         self,
@@ -86,25 +86,25 @@ class TestProgressLookupAdapter:
         # never visible to another. Same media_id, two profiles, only
         # the caller's row comes back.
         progress_repo = SQLAlchemyWatchProgressRepository(db_session)
-        await progress_repo.save(_progress("epi_ser_ABC_1_1", position=900))
+        await progress_repo.save(_progress("epi_ser_abc123def456_1_1", position=900))
         await progress_repo.save(
-            _progress("epi_ser_ABC_1_1", position=3300, profile_id=_OTHER_PROFILE_ID),
+            _progress("epi_ser_abc123def456_1_1", position=3300, profile_id=_OTHER_PROFILE_ID),
         )
         await db_session.commit()
 
         adapter = _make_adapter(session_factory)
 
         mine = await adapter.find_for_media_ids(
-            ["epi_ser_ABC_1_1"],
+            ["epi_ser_abc123def456_1_1"],
             profile_id=_PROFILE_ID.value,
         )
         theirs = await adapter.find_for_media_ids(
-            ["epi_ser_ABC_1_1"],
+            ["epi_ser_abc123def456_1_1"],
             profile_id=_OTHER_PROFILE_ID.value,
         )
 
-        assert mine["epi_ser_ABC_1_1"].position_seconds == 900
-        assert theirs["epi_ser_ABC_1_1"].position_seconds == 3300
+        assert mine["epi_ser_abc123def456_1_1"].position_seconds == 900
+        assert theirs["epi_ser_abc123def456_1_1"].position_seconds == 3300
 
     async def test_progress_summary_includes_last_watched_at(
         self,
@@ -112,15 +112,15 @@ class TestProgressLookupAdapter:
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         progress_repo = SQLAlchemyWatchProgressRepository(db_session)
-        await progress_repo.save(_progress("epi_ser_ABC_1_1"))
+        await progress_repo.save(_progress("epi_ser_abc123def456_1_1"))
         await db_session.commit()
 
         adapter = _make_adapter(session_factory)
         result = await adapter.find_for_media_ids(
-            ["epi_ser_ABC_1_1"],
+            ["epi_ser_abc123def456_1_1"],
             profile_id=_PROFILE_ID.value,
         )
 
-        summary = result["epi_ser_ABC_1_1"]
+        summary = result["epi_ser_abc123def456_1_1"]
         assert summary.last_watched_at is not None
-        assert summary.media_id == "epi_ser_ABC_1_1"
+        assert summary.media_id == "epi_ser_abc123def456_1_1"

--- a/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
+++ b/tests/modules/watch_progress/integration/acl/test_watch_progress_media_lookup_adapter.py
@@ -112,7 +112,7 @@ class TestWatchProgressMediaLookupAdapter:
         await db_session.commit()
 
         adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
-        result = await adapter.get_movie(str(movie_id), "en")
+        result = await adapter.get_movie(movie_id, "en")
 
         assert result is not None
         assert result.media_id == str(movie_id)
@@ -126,7 +126,7 @@ class TestWatchProgressMediaLookupAdapter:
     ) -> None:
         adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
-        assert await adapter.get_movie("mov_missing00000", "en") is None
+        assert await adapter.get_movie(MovieId("mov_missing00000"), "en") is None
 
     async def test_get_series_with_episodes_returns_sorted_list(
         self,
@@ -143,7 +143,7 @@ class TestWatchProgressMediaLookupAdapter:
         await db_session.commit()
 
         adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
-        result = await adapter.get_series_with_episodes(str(series_id), "en")
+        result = await adapter.get_series_with_episodes(series_id, "en")
 
         assert result is not None
         assert result.title == "Breaking Bad"
@@ -161,4 +161,4 @@ class TestWatchProgressMediaLookupAdapter:
     ) -> None:
         adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
 
-        assert await adapter.get_series_with_episodes("ser_missing00000", "en") is None
+        assert await adapter.get_series_with_episodes(SeriesId("ser_missing00000"), "en") is None

--- a/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
+++ b/tests/modules/watch_progress/integration/persistence/repositories/test_watch_progress_repository.py
@@ -4,20 +4,23 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.modules.watch_progress.domain.value_objects import (
+    WatchableMediaId,
+    WatchableMediaType,
+)
 from src.modules.watch_progress.infrastructure.persistence.repositories import (
     SQLAlchemyWatchProgressRepository,
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
-SAMPLE_MOVIE_ID = "mov_abc123def456"
-SAMPLE_EPISODE_ID = "epi_xyz789abc123"
-MISSING_MEDIA_ID = "mov_missing00000"
+SAMPLE_MOVIE_ID = WatchableMediaId("mov_abc123def456")
+SAMPLE_EPISODE_ID = WatchableMediaId("epi_ser_xyz789abc123_1_2")
+MISSING_MEDIA_ID = WatchableMediaId("mov_missing00000")
 _PROFILE_ID = ProfileId("prf_test12345678")
 
 
 def _create_progress(
-    media_id: str = SAMPLE_MOVIE_ID,
+    media_id: WatchableMediaId | str = SAMPLE_MOVIE_ID,
     media_type: WatchableMediaType = WatchableMediaType.MOVIE,
     position: int = 1800,
     duration: int = 7200,
@@ -139,8 +142,8 @@ class TestSQLAlchemyWatchProgressRepositoryFind:
         result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, SAMPLE_EPISODE_ID], _PROFILE_ID)
 
         assert len(result) == 2
-        assert SAMPLE_MOVIE_ID in result
-        assert SAMPLE_EPISODE_ID in result
+        assert SAMPLE_MOVIE_ID.value in result
+        assert SAMPLE_EPISODE_ID.value in result
 
     async def test_find_by_media_ids_should_return_empty_for_empty_input(
         self, db_session: AsyncSession
@@ -157,7 +160,7 @@ class TestSQLAlchemyWatchProgressRepositoryFind:
 
         result = await repo.find_by_media_ids([SAMPLE_MOVIE_ID, MISSING_MEDIA_ID], _PROFILE_ID)
 
-        assert list(result.keys()) == [SAMPLE_MOVIE_ID]
+        assert list(result.keys()) == [SAMPLE_MOVIE_ID.value]
 
 
 @pytest.mark.integration
@@ -182,7 +185,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         result = await repo.list_in_progress(_PROFILE_ID)
 
         assert len(result) == 1
-        assert result[0].media_id == "mov_aaaaaaaaaaaa"
+        assert result[0].media_id.value == "mov_aaaaaaaaaaaa"
 
     async def test_list_in_progress_should_order_by_last_watched_desc(
         self, db_session: AsyncSession
@@ -194,7 +197,7 @@ class TestSQLAlchemyWatchProgressRepositoryList:
 
         result = await repo.list_in_progress(_PROFILE_ID)
 
-        assert [p.media_id for p in result] == [
+        assert [p.media_id.value for p in result] == [
             "mov_third0000000",
             "mov_second000000",
             "mov_first0000000",
@@ -220,8 +223,8 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         first_view = await repo.list_in_progress(_PROFILE_ID)
         other_view = await repo.list_in_progress(other_profile)
 
-        assert {p.media_id for p in first_view} == {"mov_aaaaaaaaaaaa"}
-        assert {p.media_id for p in other_view} == {"mov_bbbbbbbbbbbb"}
+        assert {p.media_id.value for p in first_view} == {"mov_aaaaaaaaaaaa"}
+        assert {p.media_id.value for p in other_view} == {"mov_bbbbbbbbbbbb"}
 
     async def test_list_recently_watched_should_include_completed(
         self, db_session: AsyncSession
@@ -246,14 +249,14 @@ class TestSQLAlchemyWatchProgressRepositoryList:
         self, db_session: AsyncSession
     ) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
-        await repo.save(_create_progress(media_id="mov_kept000000000"))
-        await repo.save(_create_progress(media_id="mov_deleted000000"))
-        await repo.delete("mov_deleted000000", _PROFILE_ID)
+        await repo.save(_create_progress(media_id="mov_kept00000000"))
+        await repo.save(_create_progress(media_id="mov_deleted00000"))
+        await repo.delete(WatchableMediaId("mov_deleted00000"), _PROFILE_ID)
 
         result = await repo.list_recently_watched(_PROFILE_ID)
 
         assert len(result) == 1
-        assert result[0].media_id == "mov_kept000000000"
+        assert result[0].media_id.value == "mov_kept00000000"
 
     async def test_list_recently_watched_should_respect_limit(
         self, db_session: AsyncSession
@@ -331,32 +334,16 @@ class TestDeleteAllForMovie:
         await repo.save(_create_progress())
         await repo.save(_create_progress(profile_id=other_profile))
 
-        deleted = await repo.delete_all_for_movie(SAMPLE_MOVIE_ID)
+        deleted = await repo.delete_all_for_movie(SAMPLE_MOVIE_ID.as_movie_id())
 
         assert deleted == 2
         assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)) is None
         assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, other_profile)) is None
 
-    async def test_should_only_delete_movie_progress_not_episode(
-        self, db_session: AsyncSession
-    ) -> None:
-        """``media_type`` filter prevents accidentally wiping episode
-        progress whose id happens to collide (won't happen with prefixed
-        ids, but defensive)."""
-        repo = SQLAlchemyWatchProgressRepository(db_session)
-        await repo.save(
-            _create_progress(media_id=SAMPLE_EPISODE_ID, media_type=WatchableMediaType.EPISODE),
-        )
-
-        deleted = await repo.delete_all_for_movie(SAMPLE_EPISODE_ID)
-
-        assert deleted == 0
-        assert (await repo.find_by_media_id(SAMPLE_EPISODE_ID, _PROFILE_ID)) is not None
-
     async def test_should_return_zero_when_nothing_matches(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchProgressRepository(db_session)
 
-        deleted = await repo.delete_all_for_movie(MISSING_MEDIA_ID)
+        deleted = await repo.delete_all_for_movie(MISSING_MEDIA_ID.as_movie_id())
 
         assert deleted == 0
 
@@ -400,3 +387,43 @@ class TestDeleteAllForProfiles:
 
         assert deleted == 0
         assert (await repo.find_by_media_id(SAMPLE_MOVIE_ID, _PROFILE_ID)) is not None
+
+
+@pytest.mark.integration
+class TestListDropsCorruptRows:
+    """Rows persisted before media-id validation may carry garbage ids;
+    list reads drop them with a WARNING instead of failing the request."""
+
+    async def test_list_recently_watched_drops_invalid_media_id_row(
+        self,
+        db_session: AsyncSession,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import logging
+        from datetime import UTC, datetime
+
+        from src.modules.watch_progress.infrastructure.persistence.models import (
+            WatchProgressModel,
+        )
+
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_create_progress())
+        db_session.add(
+            WatchProgressModel(
+                external_id="prg_corrupt00000",
+                profile_id=_PROFILE_ID.value,
+                media_id="epi_garbage",
+                media_type="episode",
+                position_seconds=10,
+                duration_seconds=100,
+                status="in_progress",
+                last_watched_at=datetime.now(UTC),
+            ),
+        )
+        await db_session.flush()
+
+        with caplog.at_level(logging.WARNING):
+            result = await repo.list_recently_watched(_PROFILE_ID)
+
+        assert [p.media_id for p in result] == [SAMPLE_MOVIE_ID]
+        assert any("invalid media_id" in record.message for record in caplog.records)

--- a/tests/modules/watch_progress/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/watch_progress/unit/application/event_handlers/test_on_movie_merged.py
@@ -40,7 +40,7 @@ class TestOnMovieMergedHandlerWatchProgress:
             ),
         )
 
-        progress.delete_all_for_movie.assert_awaited_once_with("mov_loserbbbbbbb")
+        progress.delete_all_for_movie.assert_awaited_once_with(MovieId("mov_loserbbbbbbb"))
 
     @pytest.mark.asyncio
     async def test_ignores_unrelated_events(self) -> None:

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -118,16 +118,6 @@ class TestEnrichEpisode:
         assert item.episode_number == 2
 
     @pytest.mark.asyncio
-    async def test_enrich_returns_none_for_standard_episode_id(self, repos):
-        mocks, _ = repos
-        mocks.progress.list_recently_watched.return_value = [
-            _make_progress("epi_03ZzYaQ77FaB"),
-        ]
-
-        result = await _make_use_case(repos).execute(_input())
-        assert len(result.items) == 0
-
-    @pytest.mark.asyncio
     async def test_enrich_returns_none_for_missing_series(self, repos):
         mocks, media_lookup = repos
         mocks.progress.list_recently_watched.return_value = [
@@ -162,16 +152,6 @@ class TestEnrichEpisode:
             "epi_ser_Hy9VjMfILYZe_3_99": progress,
         }
         media_lookup.get_series_with_episodes.return_value = series
-
-        result = await _make_use_case(repos).execute(_input())
-        assert len(result.items) == 0
-
-    @pytest.mark.asyncio
-    async def test_enrich_returns_none_for_malformed_media_id(self, repos):
-        mocks, _ = repos
-        mocks.progress.list_recently_watched.return_value = [
-            _make_progress("epi_ser_broken"),
-        ]
 
         result = await _make_use_case(repos).execute(_input())
         assert len(result.items) == 0
@@ -287,9 +267,9 @@ class TestSeriesDeduplication:
         series_b = _make_series_info("ser_BBBBBBBBBBBB", {1: [1]}, title="Series B")
 
         async def get_series_side_effect(sid, lang):
-            if sid == "ser_AAAAAAAAAAAA":
+            if sid.value == "ser_AAAAAAAAAAAA":
                 return series_a
-            if sid == "ser_BBBBBBBBBBBB":
+            if sid.value == "ser_BBBBBBBBBBBB":
                 return series_b
             return None
 
@@ -300,10 +280,11 @@ class TestSeriesDeduplication:
         mocks.progress.list_recently_watched.return_value = [pa, pb]
 
         def find_by_media_ids_side_effect(ids, profile_id):
+            id_values = [media_id.value for media_id in ids]
             result: dict[str, WatchProgress] = {}
-            if "epi_ser_AAAAAAAAAAAA_1_1" in ids:
+            if "epi_ser_AAAAAAAAAAAA_1_1" in id_values:
                 result["epi_ser_AAAAAAAAAAAA_1_1"] = pa
-            if "epi_ser_BBBBBBBBBBBB_1_1" in ids:
+            if "epi_ser_BBBBBBBBBBBB_1_1" in id_values:
                 result["epi_ser_BBBBBBBBBBBB_1_1"] = pb
             return result
 

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_progress.py
@@ -5,7 +5,7 @@ import pytest
 from src.modules.watch_progress.application.dtos import GetProgressInput, ProgressOutput
 from src.modules.watch_progress.application.use_cases import GetProgressUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId, WatchableMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from tests.modules.watch_progress.unit.conftest import make_watch_progress_uow_mock
 
@@ -38,7 +38,9 @@ class TestGetProgressUseCase:
         assert isinstance(result, ProgressOutput)
         assert result.position_seconds == 1800
         assert result.percentage == 25.0
-        mocks.progress.find_by_media_id.assert_called_once_with("mov_abc123def456", _PROFILE_ID)
+        mocks.progress.find_by_media_id.assert_called_once_with(
+            WatchableMediaId("mov_abc123def456"), _PROFILE_ID
+        )
 
     @pytest.mark.asyncio
     async def test_returns_none_when_not_found(self):

--- a/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
@@ -5,7 +5,7 @@ import pytest
 from src.modules.watch_progress.application.dtos import ProgressOutput, SaveProgressInput
 from src.modules.watch_progress.application.use_cases import SaveProgressUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId, WatchableMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from tests.modules.watch_progress.unit.conftest import make_watch_progress_uow_mock
 
@@ -39,7 +39,9 @@ class TestSaveProgressUseCase:
         assert result.status == "in_progress"
         mock_repo.save.assert_called_once()
         # The repo find lookup was scoped by profile.
-        mock_repo.find_by_media_id.assert_called_once_with("mov_abc123def456", _PROFILE_ID)
+        mock_repo.find_by_media_id.assert_called_once_with(
+            WatchableMediaId("mov_abc123def456"), _PROFILE_ID
+        )
 
     @pytest.mark.asyncio
     async def test_updates_existing_progress(self):

--- a/tests/modules/watch_progress/unit/domain/entities/test_watch_progress.py
+++ b/tests/modules/watch_progress/unit/domain/entities/test_watch_progress.py
@@ -89,10 +89,10 @@ class TestWatchProgress:
 
     def test_create_with_episode(self):
         progress = _create_progress(
-            media_id="epi_abc123def456",
+            media_id="epi_ser_abc123def456_1_2",
             media_type=WatchableMediaType.EPISODE,
             position_seconds=300,
             duration_seconds=2700,
         )
         assert progress.media_type == "episode"
-        assert progress.media_id == "epi_abc123def456"
+        assert progress.media_id.value == "epi_ser_abc123def456_1_2"

--- a/tests/modules/watch_progress/unit/domain/services/test_continue_watching_selector.py
+++ b/tests/modules/watch_progress/unit/domain/services/test_continue_watching_selector.py
@@ -41,7 +41,7 @@ def _candidate(
     episode: int,
     *,
     progress: WatchProgress | None = None,
-    series_id: str = "ser_ABC",
+    series_id: str = "ser_abc123def456",
 ) -> EpisodeCandidate:
     """Build an EpisodeCandidate with derived composite id."""
     media_id = f"epi_{series_id}_{season}_{episode}"
@@ -73,14 +73,14 @@ class TestContinueWatchingSelectorEmptyCases:
 @pytest.mark.unit
 class TestInProgressPriority:
     def test_single_in_progress_episode_is_selected(self) -> None:
-        cand = _candidate(2, 3, progress=_progress("epi_ser_ABC_2_3"))
+        cand = _candidate(2, 3, progress=_progress("epi_ser_abc123def456_2_3"))
         result = ContinueWatchingSelector().pick([cand])
         assert result.candidate is cand
 
     def test_highest_numbered_in_progress_wins_against_earlier_ones(self) -> None:
-        early = _candidate(1, 1, progress=_progress("epi_ser_ABC_1_1"))
-        mid = _candidate(1, 5, progress=_progress("epi_ser_ABC_1_5"))
-        later = _candidate(2, 1, progress=_progress("epi_ser_ABC_2_1"))
+        early = _candidate(1, 1, progress=_progress("epi_ser_abc123def456_1_1"))
+        mid = _candidate(1, 5, progress=_progress("epi_ser_abc123def456_1_5"))
+        later = _candidate(2, 1, progress=_progress("epi_ser_abc123def456_2_1"))
 
         result = ContinueWatchingSelector().pick([early, mid, later])
 
@@ -90,9 +90,9 @@ class TestInProgressPriority:
         completed = _candidate(
             2,
             5,
-            progress=_progress("epi_ser_ABC_2_5", status=WatchStatus.COMPLETED),
+            progress=_progress("epi_ser_abc123def456_2_5", status=WatchStatus.COMPLETED),
         )
-        in_progress = _candidate(1, 2, progress=_progress("epi_ser_ABC_1_2"))
+        in_progress = _candidate(1, 2, progress=_progress("epi_ser_abc123def456_1_2"))
 
         result = ContinueWatchingSelector().pick([in_progress, completed])
 
@@ -103,10 +103,10 @@ class TestInProgressPriority:
 class TestNextUnwatchedFallback:
     def test_first_unwatched_after_last_completed_is_selected(self) -> None:
         s01e01 = _candidate(
-            1, 1, progress=_progress("epi_ser_ABC_1_1", status=WatchStatus.COMPLETED)
+            1, 1, progress=_progress("epi_ser_abc123def456_1_1", status=WatchStatus.COMPLETED)
         )
         s01e02 = _candidate(
-            1, 2, progress=_progress("epi_ser_ABC_1_2", status=WatchStatus.COMPLETED)
+            1, 2, progress=_progress("epi_ser_abc123def456_1_2", status=WatchStatus.COMPLETED)
         )
         s01e03 = _candidate(1, 3)
         s01e04 = _candidate(1, 4)
@@ -117,10 +117,10 @@ class TestNextUnwatchedFallback:
 
     def test_completed_with_no_unwatched_after_returns_none(self) -> None:
         s01e01 = _candidate(
-            1, 1, progress=_progress("epi_ser_ABC_1_1", status=WatchStatus.COMPLETED)
+            1, 1, progress=_progress("epi_ser_abc123def456_1_1", status=WatchStatus.COMPLETED)
         )
         s01e02 = _candidate(
-            1, 2, progress=_progress("epi_ser_ABC_1_2", status=WatchStatus.COMPLETED)
+            1, 2, progress=_progress("epi_ser_abc123def456_1_2", status=WatchStatus.COMPLETED)
         )
 
         result = ContinueWatchingSelector().pick([s01e01, s01e02])
@@ -131,7 +131,7 @@ class TestNextUnwatchedFallback:
         """Gaps in the "watched" history don't force the user back to them."""
         s01e01 = _candidate(1, 1)  # skipped entirely
         s01e02 = _candidate(
-            1, 2, progress=_progress("epi_ser_ABC_1_2", status=WatchStatus.COMPLETED)
+            1, 2, progress=_progress("epi_ser_abc123def456_1_2", status=WatchStatus.COMPLETED)
         )
         s01e03 = _candidate(1, 3)
 
@@ -149,12 +149,12 @@ class TestLatestWatchedAt:
         s01e01 = _candidate(
             1,
             1,
-            progress=_progress("epi_ser_ABC_1_1", last_watched_at=older),
+            progress=_progress("epi_ser_abc123def456_1_1", last_watched_at=older),
         )
         s01e02 = _candidate(
             1,
             2,
-            progress=_progress("epi_ser_ABC_1_2", last_watched_at=newer),
+            progress=_progress("epi_ser_abc123def456_1_2", last_watched_at=newer),
         )
 
         result = ContinueWatchingSelector().pick([s01e01, s01e02])
@@ -169,12 +169,12 @@ class TestLatestWatchedAt:
         s01e01 = _candidate(
             1,
             1,
-            progress=_progress("epi_ser_ABC_1_1", WatchStatus.COMPLETED, older),
+            progress=_progress("epi_ser_abc123def456_1_1", WatchStatus.COMPLETED, older),
         )
         s01e02 = _candidate(
             1,
             2,
-            progress=_progress("epi_ser_ABC_1_2", WatchStatus.COMPLETED, newer),
+            progress=_progress("epi_ser_abc123def456_1_2", WatchStatus.COMPLETED, newer),
         )
 
         result = ContinueWatchingSelector().pick([s01e01, s01e02])

--- a/tests/modules/watch_progress/unit/domain/value_objects/test_watchable_media_id.py
+++ b/tests/modules/watch_progress/unit/domain/value_objects/test_watchable_media_id.py
@@ -1,0 +1,77 @@
+"""Tests for the WatchableMediaId value object."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId
+from src.shared_kernel.value_objects.media_id import MovieId
+
+
+class TestWatchableMediaIdMovie:
+    """Movie-shaped ids."""
+
+    def test_accepts_valid_movie_id(self):
+        media_id = WatchableMediaId("mov_2xK9mPqR7nL4")
+
+        assert media_id.value == "mov_2xK9mPqR7nL4"
+        assert media_id.is_movie is True
+        assert media_id.is_episode is False
+
+    def test_as_movie_id_returns_typed_id(self):
+        media_id = WatchableMediaId("mov_2xK9mPqR7nL4")
+
+        assert media_id.as_movie_id() == MovieId("mov_2xK9mPqR7nL4")
+
+    def test_rejects_malformed_movie_id(self):
+        with pytest.raises(DomainValidationException):
+            WatchableMediaId("mov_short")
+
+
+class TestWatchableMediaIdEpisode:
+    """Composite-episode-shaped ids."""
+
+    def test_accepts_valid_composite_id(self):
+        media_id = WatchableMediaId("epi_ser_3yL8nQsT9mK5_3_2")
+
+        assert media_id.is_episode is True
+        assert media_id.is_movie is False
+
+    def test_as_episode_parses_components(self):
+        parsed = WatchableMediaId("epi_ser_3yL8nQsT9mK5_3_2").as_episode()
+
+        assert parsed.series_id == "ser_3yL8nQsT9mK5"
+        assert parsed.season_number == 3
+        assert parsed.episode_number == 2
+
+    def test_rejects_plain_catalog_episode_id(self):
+        # The player only ever sends composite ids; a bare epi_xxx would
+        # be invisible to Continue Watching, so it fails at the boundary.
+        with pytest.raises(DomainValidationException):
+            WatchableMediaId("epi_5aH0pQuV1oM7")
+
+    def test_rejects_composite_with_invalid_series_id(self):
+        with pytest.raises(DomainValidationException):
+            WatchableMediaId("epi_ser_bad_1_2")
+
+    def test_as_episode_raises_for_movie_id(self):
+        with pytest.raises(ValueError, match="Not a composite episode id"):
+            WatchableMediaId("mov_2xK9mPqR7nL4").as_episode()
+
+
+class TestWatchableMediaIdRejections:
+    """Garbage shapes."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "garbage",
+            "ser_3yL8nQsT9mK5",
+            "ssn_4zM9oPtU0nL6",
+            "lib_2xK9mPqR7nL4",
+            "epi_ser_3yL8nQsT9mK5_x_y",
+        ],
+    )
+    def test_rejects_invalid_shapes(self, value: str):
+        with pytest.raises(DomainValidationException):
+            WatchableMediaId(value)

--- a/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
+++ b/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
@@ -111,7 +111,7 @@ class TestWatchProgressMapperToEntity:
         model = WatchProgressModel(
             external_id=str(progress_id),
             profile_id=str(_PROFILE_ID),
-            media_id="epi_xyz789abc123",
+            media_id="epi_ser_xyz789abc123_1_2",
             media_type="episode",
             position_seconds=900,
             duration_seconds=3600,
@@ -128,7 +128,7 @@ class TestWatchProgressMapperToEntity:
 
         assert entity.id == progress_id
         assert entity.profile_id == _PROFILE_ID
-        assert entity.media_id == "epi_xyz789abc123"
+        assert entity.media_id.value == "epi_ser_xyz789abc123_1_2"
         assert entity.media_type == "episode"
         assert entity.position_seconds == 900
         assert entity.status == "in_progress"


### PR DESCRIPTION
## Summary

- New `WatchableMediaId` VO in the watch_progress domain (ADR-018 deferred bucket): accepts exactly the two shapes progress rows store — `mov_xxx` and the composite `epi_ser_xxx_S_E` frontend contract. Plain `epi_xxx` and malformed composites are rejected at construction; helpers `is_movie`/`is_episode`/`as_movie_id()`/`as_episode()`
- `WatchProgress.media_id` typed + `model_validator` cross-checking `media_type ↔ id shape` (movie ⇔ `mov_`, episode ⇔ composite) — garbage now fails **on write** instead of round-tripping to the DB
- Repository typed: `find_by_media_id`/`find_by_media_ids`/`delete` take `WatchableMediaId`; `delete_by_series(SeriesId)`; `delete_all_for_movie(MovieId)` — cross-BC handlers pass the event VO directly again (drops the `.value` shim from #264)
- List reads (`list_in_progress`/`list_recently_watched`) **drop-and-warn** rows with corrupt legacy ids — previously Continue Watching skipped them silently (`if not parsed: continue`); the skip is now observable in logs and centralized at the read boundary
- `MediaLookupPort` typed (`get_movie(MovieId)`, `get_series_with_episodes(SeriesId)`); media's `ProgressLookupAdapter` (the sanctioned ACL file) converts `str → WatchableMediaId` at the boundary
- `EpisodeCandidate.media_id` typed; use cases convert DTO strings at entry

## Breaking changes

- `POST /progress` with a malformed `media_id` now returns a validation error instead of silently persisting garbage (same for GET/DELETE path params)
- Two tests removed because the scenarios became unrepresentable by the type system (plain-episode-id row reaching the selector; episode id passed to `delete_all_for_movie`)

## Test plan

- [x] Full suite: 2706 passed, 5 skipped
- [x] New VO unit tests (14 cases) + repository drop-and-warn integration test
- [x] `ruff check` + `ruff format` clean

## Related issues

- ADR-018 deferred bucket (media_id typing — step 2 of 4: events ✅ → **watch_progress** → collections → catalog_requests)

## Summary by Sourcery

Introduce a typed WatchableMediaId value object for watch progress and propagate it through the domain, repositories, ACLs, and use cases to validate media IDs and surface corrupt legacy rows.

New Features:
- Add WatchableMediaId value object to represent valid movie and composite episode identifiers in the watch_progress domain.

Bug Fixes:
- Reject malformed or unsupported media_id values at construction and via WatchProgress validation instead of letting them persist silently.
- Ensure list queries drop and log corrupt legacy watch_progress rows instead of failing or skipping them invisibly.

Enhancements:
- Type MediaLookupPort, repository interfaces, entities, DTOs, and use cases to use MovieId, SeriesId, and WatchableMediaId instead of raw strings.
- Simplify episode handling in continue-watching flows by using WatchableMediaId helpers and SeriesId rather than ad-hoc parsing.
- Align tests and ACL adapters with the new typed ID contracts and remove scenarios no longer representable with the stricter types.

Tests:
- Add unit tests for WatchableMediaId validation and episode parsing plus integration coverage for dropping corrupt rows in list queries.