### PR TITLE
refactor(collections): type media_id as CollectionMediaId VO

### DIFF
--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -105,7 +105,7 @@ class CustomListItemOutput:
     ) -> CustomListItemOutput:
         """Create output DTO from a CustomListItem entity with metadata."""
         return cls(
-            media_id=entity.media_id,
+            media_id=entity.media_id.value,
             media_type=entity.media_type,
             title=title,
             poster_path=poster_path,

--- a/src/modules/collections/application/dtos/watchlist_dtos.py
+++ b/src/modules/collections/application/dtos/watchlist_dtos.py
@@ -54,7 +54,7 @@ class WatchlistItemOutput:
     ) -> WatchlistItemOutput:
         """Create output DTO from a WatchlistItem entity with metadata."""
         return cls(
-            media_id=entity.media_id,
+            media_id=entity.media_id.value,
             media_type=entity.media_type,
             title=title,
             poster_path=poster_path,

--- a/src/modules/collections/application/event_handlers/on_movie_merged.py
+++ b/src/modules/collections/application/event_handlers/on_movie_merged.py
@@ -7,7 +7,9 @@ from src.building_blocks.domain.events import DomainEvent
 from src.modules.collections.application.unit_of_work import (
     CollectionsUnitOfWorkFactory,
 )
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.media.domain.events import MovieMergedEvent
+from src.shared_kernel.value_objects import CollectionMediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -36,15 +38,17 @@ class OnMovieMergedHandler(EventHandler):
             return
 
         async with self._uow_factory() as uow:
+            from_media_id = CollectionMediaId(event.loser_id.value)
+            to_media_id = CollectionMediaId(event.winner_id.value)
             watchlist_updated = await uow.watchlist.rewrite_media_id(
-                from_media_id=event.loser_id.value,
-                to_media_id=event.winner_id.value,
-                to_media_type="movie",
+                from_media_id=from_media_id,
+                to_media_id=to_media_id,
+                to_media_type=CollectionMediaType.MOVIE,
             )
             lists_updated = await uow.custom_lists.rewrite_item_media_id(
-                from_media_id=event.loser_id.value,
-                to_media_id=event.winner_id.value,
-                to_media_type="movie",
+                from_media_id=from_media_id,
+                to_media_id=to_media_id,
+                to_media_type=CollectionMediaType.MOVIE,
             )
 
         if watchlist_updated or lists_updated:

--- a/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
@@ -7,7 +7,9 @@ from src.building_blocks.domain.events import DomainEvent
 from src.modules.collections.application.unit_of_work import (
     CollectionsUnitOfWorkFactory,
 )
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.media.domain.events import MoviePromotedToSeriesEvent
+from src.shared_kernel.value_objects import CollectionMediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -36,15 +38,17 @@ class OnMoviePromotedToSeriesHandler(EventHandler):
             return
 
         async with self._uow_factory() as uow:
+            from_media_id = CollectionMediaId(event.movie_id.value)
+            to_media_id = CollectionMediaId(event.series_id.value)
             watchlist_updated = await uow.watchlist.rewrite_media_id(
-                from_media_id=event.movie_id.value,
-                to_media_id=event.series_id.value,
-                to_media_type="series",
+                from_media_id=from_media_id,
+                to_media_id=to_media_id,
+                to_media_type=CollectionMediaType.SERIES,
             )
             lists_updated = await uow.custom_lists.rewrite_item_media_id(
-                from_media_id=event.movie_id.value,
-                to_media_id=event.series_id.value,
-                to_media_type="series",
+                from_media_id=from_media_id,
+                to_media_id=to_media_id,
+                to_media_type=CollectionMediaType.SERIES,
             )
 
         if watchlist_updated or lists_updated:

--- a/src/modules/collections/application/ports/media_lookup_port.py
+++ b/src/modules/collections/application/ports/media_lookup_port.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 
 
 @dataclass(frozen=True)
@@ -46,15 +47,15 @@ class MediaLookupPort(ABC):
     @abstractmethod
     async def get_many(
         self,
-        movie_ids: Sequence[str],
-        series_ids: Sequence[str],
+        movie_ids: Sequence[MovieId],
+        series_ids: Sequence[SeriesId],
         lang: str,
     ) -> dict[tuple[CollectionMediaType, str], MediaSummary]:
         """Resolve metadata for the given movies and series.
 
         Args:
-            movie_ids: External movie ids (``mov_xxx``).
-            series_ids: External series ids (``ser_xxx``).
+            movie_ids: Typed external movie ids.
+            series_ids: Typed external series ids.
             lang: Language code used to localize titles.
 
         Returns:

--- a/src/modules/collections/application/use_cases/add_item_to_custom_list.py
+++ b/src/modules/collections/application/use_cases/add_item_to_custom_list.py
@@ -5,6 +5,7 @@ from src.building_blocks.domain import BusinessRuleViolationException
 from src.modules.collections.application.dtos import AddItemToCustomListInput
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.modules.collections.domain.entities import CustomListItem
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -21,13 +22,14 @@ class AddItemToCustomListUseCase:
     async def execute(self, input_dto: AddItemToCustomListInput) -> None:
         """Add the item, enforcing list ownership + limits."""
         profile_id = ProfileId(input_dto.profile_id)
+        media_id = CollectionMediaId(input_dto.media_id)
         async with self._uow_factory() as uow:
             custom_list = await uow.custom_lists.find_by_id(input_dto.list_id, profile_id)
             if not custom_list:
                 raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
             existing_item = await uow.custom_lists.find_item(
-                input_dto.list_id, input_dto.media_id, profile_id
+                input_dto.list_id, media_id, profile_id
             )
             if existing_item:
                 raise BusinessRuleViolationException(
@@ -42,7 +44,7 @@ class AddItemToCustomListUseCase:
             next_position = await uow.custom_lists.get_next_position(input_dto.list_id, profile_id)
 
             item = CustomListItem.create(
-                media_id=input_dto.media_id,
+                media_id=media_id,
                 media_type=input_dto.media_type,
                 position=next_position,
             )

--- a/src/modules/collections/application/use_cases/check_watchlist.py
+++ b/src/modules/collections/application/use_cases/check_watchlist.py
@@ -2,6 +2,7 @@
 
 from src.modules.collections.application.dtos import CheckWatchlistInput
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -14,7 +15,9 @@ class CheckWatchlistUseCase:
     async def execute(self, input_dto: CheckWatchlistInput) -> bool:
         """Return True if the profile has the item on its watchlist."""
         async with self._uow_factory() as uow:
-            return await uow.watchlist.exists(input_dto.media_id, ProfileId(input_dto.profile_id))
+            return await uow.watchlist.exists(
+                CollectionMediaId(input_dto.media_id), ProfileId(input_dto.profile_id)
+            )
 
 
 __all__ = ["CheckWatchlistUseCase"]

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -69,14 +69,18 @@ class GetCustomListItemsUseCase:
         if not items:
             return []
 
-        movie_ids = [i.media_id for i in items if i.media_type == CollectionMediaType.MOVIE]
-        series_ids = [i.media_id for i in items if i.media_type == CollectionMediaType.SERIES]
+        movie_ids = [
+            i.media_id.as_movie_id() for i in items if i.media_type == CollectionMediaType.MOVIE
+        ]
+        series_ids = [
+            i.media_id.as_series_id() for i in items if i.media_type == CollectionMediaType.SERIES
+        ]
 
         summaries = await self._media_lookup.get_many(movie_ids, series_ids, input_dto.lang)
 
         result: list[CustomListItemOutput] = []
         for item in items:
-            summary = summaries.get((item.media_type, item.media_id))
+            summary = summaries.get((item.media_type, item.media_id.value))
             if summary is None:
                 _logger.warning(
                     "Could not find media for custom list item: %s",

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -58,14 +58,18 @@ class GetWatchlistUseCase:
         if not items:
             return []
 
-        movie_ids = [i.media_id for i in items if i.media_type == CollectionMediaType.MOVIE]
-        series_ids = [i.media_id for i in items if i.media_type == CollectionMediaType.SERIES]
+        movie_ids = [
+            i.media_id.as_movie_id() for i in items if i.media_type == CollectionMediaType.MOVIE
+        ]
+        series_ids = [
+            i.media_id.as_series_id() for i in items if i.media_type == CollectionMediaType.SERIES
+        ]
 
         summaries = await self._media_lookup.get_many(movie_ids, series_ids, input_dto.lang)
 
         result: list[WatchlistItemOutput] = []
         for item in items:
-            summary = summaries.get((item.media_type, item.media_id))
+            summary = summaries.get((item.media_type, item.media_id.value))
             if summary is None:
                 _logger.warning("Could not find media for watchlist item: %s", item.media_id)
                 continue

--- a/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
+++ b/src/modules/collections/application/use_cases/remove_item_from_custom_list.py
@@ -3,6 +3,7 @@
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.collections.application.dtos import RemoveItemFromCustomListInput
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -21,7 +22,7 @@ class RemoveItemFromCustomListUseCase:
                 raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
 
             removed = await uow.custom_lists.remove_item(
-                input_dto.list_id, input_dto.media_id, profile_id
+                input_dto.list_id, CollectionMediaId(input_dto.media_id), profile_id
             )
             if not removed:
                 raise ResourceNotFoundException.for_resource("CustomListItem", input_dto.media_id)

--- a/src/modules/collections/application/use_cases/toggle_watchlist.py
+++ b/src/modules/collections/application/use_cases/toggle_watchlist.py
@@ -6,6 +6,7 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.modules.collections.domain.entities import WatchlistItem
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -22,16 +23,17 @@ class ToggleWatchlistUseCase:
     async def execute(self, input_dto: ToggleWatchlistInput) -> ToggleWatchlistOutput:
         """Toggle the entry, scoped to the caller's profile."""
         profile_id = ProfileId(input_dto.profile_id)
+        media_id = CollectionMediaId(input_dto.media_id)
         async with self._uow_factory() as uow:
-            exists = await uow.watchlist.exists(input_dto.media_id, profile_id)
+            exists = await uow.watchlist.exists(media_id, profile_id)
 
             if exists:
-                await uow.watchlist.remove(input_dto.media_id, profile_id)
+                await uow.watchlist.remove(media_id, profile_id)
                 return ToggleWatchlistOutput(media_id=input_dto.media_id, added=False)
 
             item = WatchlistItem.create(
                 profile_id=profile_id,
-                media_id=input_dto.media_id,
+                media_id=media_id,
                 media_type=input_dto.media_type,
             )
             await uow.watchlist.add(item)

--- a/src/modules/collections/domain/entities/custom_list.py
+++ b/src/modules/collections/domain/entities/custom_list.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Self
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from src.building_blocks.domain import (
     AggregateRoot,
@@ -12,12 +13,13 @@ from src.building_blocks.domain import (
     DomainEntity,
 )
 from src.modules.collections.domain.value_objects import (
+    CollectionMediaId,  # — runtime for Pydantic
     CustomListItemId,
     ListId,
     ListName,
 )
 from src.shared_kernel.value_objects import (
-    CollectionMediaType,  # noqa: TCH001 — runtime for Pydantic
+    CollectionMediaType,  # — runtime for Pydantic
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
@@ -32,14 +34,15 @@ class CustomListItem(DomainEntity[CustomListItemId]):
 
     Attributes:
         id: External ID (cli_xxx format).
-        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_id: Typed catalog id (``mov_xxx`` or ``ser_xxx``); must
+            match ``media_type``.
         media_type: Type of media (movie or series).
         position: Ordering position within the list.
         added_at: Timestamp when the item was added.
 
     Example:
         >>> item = CustomListItem.create(
-        ...     media_id="mov_abc123def456",
+        ...     media_id=CollectionMediaId("mov_abc123def456"),
         ...     media_type=CollectionMediaType.MOVIE,
         ...     position=0,
         ... )
@@ -47,22 +50,32 @@ class CustomListItem(DomainEntity[CustomListItemId]):
 
     id: CustomListItemId | None = Field(default=None)
 
-    media_id: str
+    media_id: CollectionMediaId
     media_type: CollectionMediaType
     position: int = 0
     added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
+    @model_validator(mode="after")
+    def _validate_media_id_matches_type(self) -> Self:
+        """Reject a movie id paired with series type and vice versa."""
+        if self.media_id.is_movie != (self.media_type is CollectionMediaType.MOVIE):
+            raise ValueError(
+                f"media_id '{self.media_id.value}' does not match "
+                f"media_type '{self.media_type.value}'",
+            )
+        return self
+
     @classmethod
     def create(
         cls,
-        media_id: str,
+        media_id: CollectionMediaId,
         media_type: CollectionMediaType,
         position: int = 0,
     ) -> CustomListItem:
         """Factory method with automatic ID generation.
 
         Args:
-            media_id: External ID of the media (mov_xxx or ser_xxx).
+            media_id: Typed catalog id (``mov_xxx`` or ``ser_xxx``).
             media_type: Type of media (movie or series).
             position: Ordering position within the list.
 

--- a/src/modules/collections/domain/entities/watchlist_item.py
+++ b/src/modules/collections/domain/entities/watchlist_item.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from src.building_blocks.domain import AggregateRoot
-from src.modules.collections.domain.value_objects import ListId
+from src.modules.collections.domain.value_objects import (
+    CollectionMediaId,  # — runtime for Pydantic
+    ListId,
+)
 from src.shared_kernel.value_objects import (
-    CollectionMediaType,  # noqa: TCH001 — runtime for Pydantic
+    CollectionMediaType,  # — runtime for Pydantic
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
@@ -22,14 +26,15 @@ class WatchlistItem(AggregateRoot[ListId]):
     Attributes:
         id: External ID (lst_xxx format).
         profile_id: Owning profile (``prf_xxx``).
-        media_id: External ID of the media (mov_xxx or ser_xxx).
+        media_id: Typed catalog id (``mov_xxx`` or ``ser_xxx``); must
+            match ``media_type``.
         media_type: Type of media (movie or series).
         added_at: Timestamp when the item was added.
 
     Example:
         >>> item = WatchlistItem.create(
         ...     profile_id=caller_profile_id,
-        ...     media_id="mov_abc123def456",
+        ...     media_id=CollectionMediaId("mov_abc123def456"),
         ...     media_type=CollectionMediaType.MOVIE,
         ... )
     """
@@ -37,15 +42,25 @@ class WatchlistItem(AggregateRoot[ListId]):
     id: ListId | None = Field(default=None)
 
     profile_id: ProfileId
-    media_id: str
+    media_id: CollectionMediaId
     media_type: CollectionMediaType
     added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @model_validator(mode="after")
+    def _validate_media_id_matches_type(self) -> Self:
+        """Reject a movie id paired with series type and vice versa."""
+        if self.media_id.is_movie != (self.media_type is CollectionMediaType.MOVIE):
+            raise ValueError(
+                f"media_id '{self.media_id.value}' does not match "
+                f"media_type '{self.media_type.value}'",
+            )
+        return self
 
     @classmethod
     def create(
         cls,
         profile_id: ProfileId,
-        media_id: str,
+        media_id: CollectionMediaId,
         media_type: CollectionMediaType,
     ) -> WatchlistItem:
         """Factory method with automatic ID generation."""

--- a/src/modules/collections/domain/repositories/custom_list_repository.py
+++ b/src/modules/collections/domain/repositories/custom_list_repository.py
@@ -3,6 +3,8 @@
 from abc import ABC, abstractmethod
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
+from src.modules.collections.domain.value_objects import CollectionMediaId
+from src.shared_kernel.value_objects import CollectionMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -62,7 +64,7 @@ class CustomListRepository(ABC):
     async def find_item(
         self,
         list_id: str,
-        media_id: str,
+        media_id: CollectionMediaId,
         profile_id: ProfileId,
     ) -> CustomListItem | None:
         """Find an item in a list, scoped to the profile owning that list."""
@@ -80,7 +82,7 @@ class CustomListRepository(ABC):
     async def remove_item(
         self,
         list_id: str,
-        media_id: str,
+        media_id: CollectionMediaId,
         profile_id: ProfileId,
     ) -> bool:
         """Remove an item from a list owned by ``profile_id``."""
@@ -125,9 +127,9 @@ class CustomListRepository(ABC):
     @abstractmethod
     async def rewrite_item_media_id(
         self,
-        from_media_id: str,
-        to_media_id: str,
-        to_media_type: str,
+        from_media_id: CollectionMediaId,
+        to_media_id: CollectionMediaId,
+        to_media_type: CollectionMediaType,
     ) -> int:
         """Repoint every custom-list item from one media id to another.
 

--- a/src/modules/collections/domain/repositories/watchlist_repository.py
+++ b/src/modules/collections/domain/repositories/watchlist_repository.py
@@ -3,6 +3,8 @@
 from abc import ABC, abstractmethod
 
 from src.modules.collections.domain.entities import WatchlistItem
+from src.modules.collections.domain.value_objects import CollectionMediaId
+from src.shared_kernel.value_objects import CollectionMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -14,14 +16,14 @@ class WatchlistRepository(ABC):
 
     Example:
         >>> item = await repo.find_by_media_id(
-        ...     "mov_abc123def456", caller_profile_id
+        ...     CollectionMediaId("mov_abc123def456"), caller_profile_id
         ... )
     """
 
     @abstractmethod
     async def find_by_media_id(
         self,
-        media_id: str,
+        media_id: CollectionMediaId,
         profile_id: ProfileId,
     ) -> WatchlistItem | None:
         """Find an entry for ``media_id`` in ``profile_id``'s watchlist."""
@@ -31,7 +33,7 @@ class WatchlistRepository(ABC):
         """Add an item (profile is read from the entity)."""
 
     @abstractmethod
-    async def remove(self, media_id: str, profile_id: ProfileId) -> bool:
+    async def remove(self, media_id: CollectionMediaId, profile_id: ProfileId) -> bool:
         """Soft-delete an item from ``profile_id``'s watchlist."""
 
     @abstractmethod
@@ -43,7 +45,7 @@ class WatchlistRepository(ABC):
         """List the profile's watchlist items, most recently added first."""
 
     @abstractmethod
-    async def exists(self, media_id: str, profile_id: ProfileId) -> bool:
+    async def exists(self, media_id: CollectionMediaId, profile_id: ProfileId) -> bool:
         """Check whether ``media_id`` is on ``profile_id``'s watchlist."""
 
     @abstractmethod
@@ -66,9 +68,9 @@ class WatchlistRepository(ABC):
     @abstractmethod
     async def rewrite_media_id(
         self,
-        from_media_id: str,
-        to_media_id: str,
-        to_media_type: str,
+        from_media_id: CollectionMediaId,
+        to_media_id: CollectionMediaId,
+        to_media_type: CollectionMediaType,
     ) -> int:
         """Repoint every row from one media id to another (cross-profile).
 

--- a/src/modules/collections/domain/value_objects/__init__.py
+++ b/src/modules/collections/domain/value_objects/__init__.py
@@ -1,9 +1,12 @@
 """Collections value objects."""
 
+from src.modules.collections.domain.value_objects.collection_media_id import (
+    CollectionMediaId,
+)
 from src.modules.collections.domain.value_objects.custom_list_item_id import (
     CustomListItemId,
 )
 from src.modules.collections.domain.value_objects.list_id import ListId
 from src.modules.collections.domain.value_objects.list_name import ListName
 
-__all__ = ["CustomListItemId", "ListId", "ListName"]
+__all__ = ["CollectionMediaId", "CustomListItemId", "ListId", "ListName"]

--- a/src/modules/collections/domain/value_objects/collection_media_id.py
+++ b/src/modules/collections/domain/value_objects/collection_media_id.py
@@ -1,0 +1,87 @@
+"""Collection media identifier value object."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import model_validator
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.value_objects import StringValueObject
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
+
+
+class CollectionMediaId(StringValueObject):
+    """Identifier of a catalog entry that can be saved to a collection.
+
+    Watchlist entries and custom-list items reference whole catalog
+    titles — a movie (``mov_xxx``) or a series (``ser_xxx``) — never a
+    season or an episode. Anything else (empty strings, season/episode
+    prefixes, malformed ids) fails on construction so garbage can no
+    longer round-trip to the database.
+
+    Example:
+        >>> CollectionMediaId("mov_2xK9mPqR7nL4").is_movie
+        True
+        >>> CollectionMediaId("ser_3yL8nQsT9mK5").as_series_id().value
+        'ser_3yL8nQsT9mK5'
+    """
+
+    _RULE_CODE: ClassVar[str] = "COLLECTIONS.MEDIA_ID.INVALID"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate(cls, value: str) -> str:
+        """Accept a movie or series id, reject everything else."""
+        if not isinstance(value, str):
+            raise ValueError("Collection media id must be a string")
+
+        value = value.strip()
+        if value.startswith("mov_"):
+            cls._ensure_valid(MovieId, value)
+        elif value.startswith("ser_"):
+            cls._ensure_valid(SeriesId, value)
+        else:
+            raise ValueError(
+                f"Invalid collection media id: '{value}'. Expected 'mov_xxx' or "
+                f"'ser_xxx' [{cls._RULE_CODE}]"
+            )
+        return value
+
+    @classmethod
+    def _ensure_valid(cls, id_type: type[MovieId | SeriesId], value: str) -> None:
+        try:
+            id_type(value)
+        except DomainValidationException as exc:
+            raise ValueError(
+                f"Invalid {id_type.__name__} for collection: '{value}' [{cls._RULE_CODE}]"
+            ) from exc
+
+    @property
+    def is_movie(self) -> bool:
+        """``True`` when the id points at a movie (``mov_xxx``)."""
+        return self.value.startswith("mov_")
+
+    @property
+    def is_series(self) -> bool:
+        """``True`` when the id points at a series (``ser_xxx``)."""
+        return self.value.startswith("ser_")
+
+    def as_movie_id(self) -> MovieId:
+        """Return the id as a typed :class:`MovieId`.
+
+        Raises:
+            DomainValidationException: When the id is a series id.
+        """
+        return MovieId(self.value)
+
+    def as_series_id(self) -> SeriesId:
+        """Return the id as a typed :class:`SeriesId`.
+
+        Raises:
+            DomainValidationException: When the id is a movie id.
+        """
+        return SeriesId(self.value)
+
+
+__all__ = ["CollectionMediaId"]

--- a/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
+++ b/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
@@ -11,8 +11,8 @@ from src.modules.collections.application.ports.media_lookup_port import (
     MediaSummary,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-from src.modules.media.domain.value_objects import MovieId, SeriesId
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 
 
 class MediaLookupAdapter(MediaLookupPort):
@@ -23,8 +23,8 @@ class MediaLookupAdapter(MediaLookupPort):
 
     async def get_many(
         self,
-        movie_ids: Sequence[str],
-        series_ids: Sequence[str],
+        movie_ids: Sequence[MovieId],
+        series_ids: Sequence[SeriesId],
         lang: str,
     ) -> dict[tuple[CollectionMediaType, str], MediaSummary]:
         """Batch-resolve display metadata via a single Media UoW."""
@@ -35,9 +35,7 @@ class MediaLookupAdapter(MediaLookupPort):
 
         async with self._media_uow_factory() as uow:
             if movie_ids:
-                movies_map = await uow.movies.find_by_ids(
-                    [MovieId(mid) for mid in movie_ids],
-                )
+                movies_map = await uow.movies.find_by_ids(list(movie_ids))
                 for media_id, movie in movies_map.items():
                     result[(CollectionMediaType.MOVIE, media_id)] = MediaSummary(
                         media_id=media_id,
@@ -47,9 +45,7 @@ class MediaLookupAdapter(MediaLookupPort):
                     )
 
             if series_ids:
-                series_map = await uow.series.find_by_ids(
-                    [SeriesId(sid) for sid in series_ids],
-                )
+                series_map = await uow.series.find_by_ids(list(series_ids))
                 for media_id, series in series_map.items():
                     result[(CollectionMediaType.SERIES, media_id)] = MediaSummary(
                         media_id=media_id,

--- a/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
@@ -1,7 +1,11 @@
 """Mapper between CustomList/CustomListItem entities and ORM models."""
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
-from src.modules.collections.domain.value_objects import CustomListItemId, ListId
+from src.modules.collections.domain.value_objects import (
+    CollectionMediaId,
+    CustomListItemId,
+    ListId,
+)
 from src.modules.collections.infrastructure.persistence.models import (
     CustomListItemModel,
     CustomListModel,
@@ -60,7 +64,7 @@ class CustomListItemMapper:
         return CustomListItemModel(
             external_id=str(entity.id),
             custom_list_id=list_internal_id,
-            media_id=entity.media_id,
+            media_id=entity.media_id.value,
             media_type=entity.media_type,
             position=entity.position,
             added_at=entity.added_at,
@@ -71,7 +75,7 @@ class CustomListItemMapper:
         """Convert ORM model to CustomListItem entity."""
         return CustomListItem(
             id=CustomListItemId(model.external_id),
-            media_id=model.media_id,
+            media_id=CollectionMediaId(model.media_id),
             media_type=CollectionMediaType(model.media_type),
             position=model.position,
             added_at=model.added_at,

--- a/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
@@ -1,7 +1,7 @@
 """Mapper between WatchlistItem entity and WatchlistItemModel."""
 
 from src.modules.collections.domain.entities import WatchlistItem
-from src.modules.collections.domain.value_objects import ListId
+from src.modules.collections.domain.value_objects import CollectionMediaId, ListId
 from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
@@ -22,7 +22,7 @@ class WatchlistItemMapper:
         return WatchlistItemModel(
             external_id=str(entity.id),
             profile_id=str(entity.profile_id),
-            media_id=entity.media_id,
+            media_id=entity.media_id.value,
             media_type=entity.media_type,
             added_at=entity.added_at,
         )
@@ -33,7 +33,7 @@ class WatchlistItemMapper:
         return WatchlistItem(
             id=ListId(model.external_id),
             profile_id=ProfileId(model.profile_id),
-            media_id=model.media_id,
+            media_id=CollectionMediaId(model.media_id),
             media_type=CollectionMediaType(model.media_type),
             added_at=model.added_at,
             created_at=model.created_at,

--- a/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
 from src.modules.collections.domain.repositories import CustomListRepository
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.collections.infrastructure.persistence.mappers import (
     CustomListItemMapper,
     CustomListMapper,
@@ -13,6 +14,7 @@ from src.modules.collections.infrastructure.persistence.models import (
     CustomListItemModel,
     CustomListModel,
 )
+from src.shared_kernel.value_objects import CollectionMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -158,7 +160,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
     async def find_item(
         self,
         list_id: str,
-        media_id: str,
+        media_id: CollectionMediaId,
         profile_id: ProfileId,
     ) -> CustomListItem | None:
         """Find an item, only if the parent list belongs to the profile."""
@@ -168,7 +170,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
 
         stmt = select(CustomListItemModel).where(
             CustomListItemModel.custom_list_id == internal_id,
-            CustomListItemModel.media_id == media_id,
+            CustomListItemModel.media_id == media_id.value,
             CustomListItemModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -190,7 +192,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         # Check for soft-deleted record to restore
         stmt = select(CustomListItemModel).where(
             CustomListItemModel.custom_list_id == internal_id,
-            CustomListItemModel.media_id == item.media_id,
+            CustomListItemModel.media_id == item.media_id.value,
             CustomListItemModel.deleted_at.is_not(None),
         )
         result = await self._session.execute(stmt)
@@ -213,7 +215,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
     async def remove_item(
         self,
         list_id: str,
-        media_id: str,
+        media_id: CollectionMediaId,
         profile_id: ProfileId,
     ) -> bool:
         """Soft-delete an item from a list owned by ``profile_id``."""
@@ -223,7 +225,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
 
         stmt = select(CustomListItemModel).where(
             CustomListItemModel.custom_list_id == internal_id,
-            CustomListItemModel.media_id == media_id,
+            CustomListItemModel.media_id == media_id.value,
             CustomListItemModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
@@ -302,20 +304,20 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
 
     async def rewrite_item_media_id(
         self,
-        from_media_id: str,
-        to_media_id: str,
-        to_media_type: str,
+        from_media_id: CollectionMediaId,
+        to_media_id: CollectionMediaId,
+        to_media_type: CollectionMediaType,
     ) -> int:
         """Repoint every list item (cross-list, cross-profile) to a new media id."""
         stmt = select(CustomListItemModel).where(
-            CustomListItemModel.media_id == from_media_id,
+            CustomListItemModel.media_id == from_media_id.value,
             CustomListItemModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
         models = result.scalars().all()
         for model in models:
-            model.media_id = to_media_id
-            model.media_type = to_media_type
+            model.media_id = to_media_id.value
+            model.media_type = to_media_type.value
         if models:
             await self._session.flush()
         return len(models)

--- a/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
@@ -5,12 +5,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.collections.domain.entities import WatchlistItem
 from src.modules.collections.domain.repositories import WatchlistRepository
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.collections.infrastructure.persistence.mappers import (
     WatchlistItemMapper,
 )
 from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
+from src.shared_kernel.value_objects import CollectionMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -27,12 +29,12 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
 
     async def find_by_media_id(
         self,
-        media_id: str,
+        media_id: CollectionMediaId,
         profile_id: ProfileId,
     ) -> WatchlistItem | None:
         """Find a row scoped to ``(media_id, profile_id)``."""
         stmt = select(WatchlistItemModel).where(
-            WatchlistItemModel.media_id == media_id,
+            WatchlistItemModel.media_id == media_id.value,
             WatchlistItemModel.profile_id == str(profile_id),
             WatchlistItemModel.deleted_at.is_(None),
         )
@@ -49,7 +51,7 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         constraint would refuse the insert).
         """
         stmt = select(WatchlistItemModel).where(
-            WatchlistItemModel.media_id == item.media_id,
+            WatchlistItemModel.media_id == item.media_id.value,
             WatchlistItemModel.profile_id == str(item.profile_id),
             WatchlistItemModel.deleted_at.is_not(None),
         )
@@ -69,10 +71,10 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         await self._session.refresh(model)
         return WatchlistItemMapper.to_entity(model)
 
-    async def remove(self, media_id: str, profile_id: ProfileId) -> bool:
+    async def remove(self, media_id: CollectionMediaId, profile_id: ProfileId) -> bool:
         """Soft-delete the row for (media_id, profile_id)."""
         stmt = select(WatchlistItemModel).where(
-            WatchlistItemModel.media_id == media_id,
+            WatchlistItemModel.media_id == media_id.value,
             WatchlistItemModel.profile_id == str(profile_id),
             WatchlistItemModel.deleted_at.is_(None),
         )
@@ -104,13 +106,13 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         result = await self._session.execute(stmt)
         return [WatchlistItemMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def exists(self, media_id: str, profile_id: ProfileId) -> bool:
+    async def exists(self, media_id: CollectionMediaId, profile_id: ProfileId) -> bool:
         """Check whether ``media_id`` is on ``profile_id``'s watchlist."""
         stmt = (
             select(func.count())
             .select_from(WatchlistItemModel)
             .where(
-                WatchlistItemModel.media_id == media_id,
+                WatchlistItemModel.media_id == media_id.value,
                 WatchlistItemModel.profile_id == str(profile_id),
                 WatchlistItemModel.deleted_at.is_(None),
             )
@@ -136,20 +138,20 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
 
     async def rewrite_media_id(
         self,
-        from_media_id: str,
-        to_media_id: str,
-        to_media_type: str,
+        from_media_id: CollectionMediaId,
+        to_media_id: CollectionMediaId,
+        to_media_type: CollectionMediaType,
     ) -> int:
         """Repoint every watchlist row (across profiles) to a new media id."""
         stmt = select(WatchlistItemModel).where(
-            WatchlistItemModel.media_id == from_media_id,
+            WatchlistItemModel.media_id == from_media_id.value,
             WatchlistItemModel.deleted_at.is_(None),
         )
         result = await self._session.execute(stmt)
         models = result.scalars().all()
         for model in models:
-            model.media_id = to_media_id
-            model.media_type = to_media_type
+            model.media_id = to_media_id.value
+            model.media_type = to_media_type.value
         if models:
             await self._session.flush()
         return len(models)

--- a/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
@@ -4,15 +4,16 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.collections.infrastructure.persistence.repositories import (
     SQLAlchemyCustomListRepository,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
-SAMPLE_MOVIE_ID = "mov_abc123def456"
+SAMPLE_MOVIE_ID = CollectionMediaId("mov_abc123def456")
 MISSING_LIST_ID = "lst_nonexistent00"
-MISSING_ITEM_ID = "mov_notinlist0000"
+MISSING_ITEM_ID = CollectionMediaId("mov_notinlist000")
 _PROFILE_ID = ProfileId("prf_test12345678")
 _OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
 
@@ -25,7 +26,7 @@ def _create_list(
 
 
 def _create_item(
-    media_id: str = SAMPLE_MOVIE_ID,
+    media_id: CollectionMediaId | str = SAMPLE_MOVIE_ID,
     media_type: CollectionMediaType = CollectionMediaType.MOVIE,
     position: int = 0,
 ) -> CustomListItem:
@@ -386,7 +387,7 @@ class TestSQLAlchemyCustomListRepositoryItems:
 
         items = await repo.list_items(str(custom_list.id), _PROFILE_ID)
 
-        assert [item.media_id for item in items] == [
+        assert [item.media_id.value for item in items] == [
             "mov_first0000000",
             "mov_second000000",
             "mov_third0000000",

--- a/tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py
@@ -4,19 +4,20 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.collections.domain.entities import WatchlistItem
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.collections.infrastructure.persistence.repositories import (
     SQLAlchemyWatchlistRepository,
 )
 from src.shared_kernel.value_objects import CollectionMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
-SAMPLE_MOVIE_ID = "mov_abc123def456"
+SAMPLE_MOVIE_ID = CollectionMediaId("mov_abc123def456")
 _PROFILE_ID = ProfileId("prf_test12345678")
 _OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
 
 
 def _create_item(
-    media_id: str = SAMPLE_MOVIE_ID,
+    media_id: CollectionMediaId | str = SAMPLE_MOVIE_ID,
     media_type: CollectionMediaType = CollectionMediaType.MOVIE,
     profile_id: ProfileId = _PROFILE_ID,
 ) -> WatchlistItem:
@@ -148,14 +149,14 @@ class TestSQLAlchemyWatchlistRepository:
 
     async def test_list_all_should_exclude_deleted(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
-        await repo.add(_create_item(media_id="mov_kept000000000"))
+        await repo.add(_create_item(media_id="mov_kept00000000"))
         await repo.add(_create_item(media_id="mov_removed00000"))
-        await repo.remove("mov_removed00000", _PROFILE_ID)
+        await repo.remove(CollectionMediaId("mov_removed00000"), _PROFILE_ID)
 
         result = await repo.list_all(_PROFILE_ID)
 
         assert len(result) == 1
-        assert result[0].media_id == "mov_kept000000000"
+        assert result[0].media_id.value == "mov_kept00000000"
 
     async def test_list_all_should_respect_limit(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
@@ -175,8 +176,8 @@ class TestSQLAlchemyWatchlistRepository:
         owner_view = await repo.list_all(_PROFILE_ID)
         other_view = await repo.list_all(_OTHER_PROFILE_ID)
 
-        assert {i.media_id for i in owner_view} == {"mov_aaaaaaaaaaaa"}
-        assert {i.media_id for i in other_view} == {"mov_bbbbbbbbbbbb"}
+        assert {i.media_id.value for i in owner_view} == {"mov_aaaaaaaaaaaa"}
+        assert {i.media_id.value for i in other_view} == {"mov_bbbbbbbbbbbb"}
 
     async def test_add_should_restore_soft_deleted(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyWatchlistRepository(db_session)
@@ -214,15 +215,15 @@ class TestSQLAlchemyWatchlistRepository:
 
         updated = await repo.rewrite_media_id(
             from_media_id=SAMPLE_MOVIE_ID,
-            to_media_id="ser_promotedxxxx",
-            to_media_type="series",
+            to_media_id=CollectionMediaId("ser_promotedxxxx"),
+            to_media_type=CollectionMediaType.SERIES,
         )
 
         assert updated == 2
         for profile in (_PROFILE_ID, _OTHER_PROFILE_ID):
             stale = await repo.find_by_media_id(SAMPLE_MOVIE_ID, profile)
             assert stale is None
-            fresh = await repo.find_by_media_id("ser_promotedxxxx", profile)
+            fresh = await repo.find_by_media_id(CollectionMediaId("ser_promotedxxxx"), profile)
             assert fresh is not None
             assert fresh.media_type == CollectionMediaType.SERIES
 
@@ -232,9 +233,9 @@ class TestSQLAlchemyWatchlistRepository:
         repo = SQLAlchemyWatchlistRepository(db_session)
 
         updated = await repo.rewrite_media_id(
-            from_media_id="mov_unknown00000",
-            to_media_id="ser_promotedxxxx",
-            to_media_type="series",
+            from_media_id=CollectionMediaId("mov_unknown00000"),
+            to_media_id=CollectionMediaId("ser_promotedxxxx"),
+            to_media_type=CollectionMediaType.SERIES,
         )
 
         assert updated == 0

--- a/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
@@ -7,10 +7,12 @@ import pytest
 from src.modules.collections.application.event_handlers.on_movie_merged import (
     OnMovieMergedHandler,
 )
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.media.domain.events import (
     MediaCreatedEvent,
     MovieMergedEvent,
 )
+from src.shared_kernel.value_objects import CollectionMediaType
 from src.shared_kernel.value_objects.media_id import MovieId
 
 
@@ -44,14 +46,14 @@ class TestOnMovieMergedHandlerCollections:
         )
 
         watchlist.rewrite_media_id.assert_awaited_once_with(
-            from_media_id="mov_loserbbbbbbb",
-            to_media_id="mov_winneraaaaaa",
-            to_media_type="movie",
+            from_media_id=CollectionMediaId("mov_loserbbbbbbb"),
+            to_media_id=CollectionMediaId("mov_winneraaaaaa"),
+            to_media_type=CollectionMediaType.MOVIE,
         )
         custom_lists.rewrite_item_media_id.assert_awaited_once_with(
-            from_media_id="mov_loserbbbbbbb",
-            to_media_id="mov_winneraaaaaa",
-            to_media_type="movie",
+            from_media_id=CollectionMediaId("mov_loserbbbbbbb"),
+            to_media_id=CollectionMediaId("mov_winneraaaaaa"),
+            to_media_type=CollectionMediaType.MOVIE,
         )
 
     @pytest.mark.asyncio

--- a/tests/modules/collections/unit/application/use_cases/test_check_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_check_watchlist.py
@@ -6,6 +6,7 @@ from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
 from src.modules.collections.application.dtos import CheckWatchlistInput
 from src.modules.collections.application.use_cases import CheckWatchlistUseCase
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -29,7 +30,9 @@ class TestCheckWatchlistUseCase:
         )
 
         assert result is True
-        mocks.watchlist.exists.assert_called_once_with("mov_abc123def456", _PROFILE_ID)
+        mocks.watchlist.exists.assert_called_once_with(
+            CollectionMediaId("mov_abc123def456"), _PROFILE_ID
+        )
 
     @pytest.mark.asyncio
     async def test_should_return_false_when_not_in_watchlist(self) -> None:

--- a/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
@@ -20,6 +20,7 @@ from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetCustomListItemsUseCase
 from src.modules.collections.domain.entities import CustomList, CustomListItem
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.media_id import MovieId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 if TYPE_CHECKING:
@@ -214,7 +215,7 @@ class TestGetCustomListItemsUseCase:
         )
 
         media_lookup.get_many.assert_awaited_once_with(
-            ["mov_abc123def456"],
+            [MovieId("mov_abc123def456")],
             [],
             "pt-BR",
         )

--- a/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
@@ -19,6 +19,7 @@ from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
 from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects.media_id import MovieId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 if TYPE_CHECKING:
@@ -170,7 +171,7 @@ class TestGetWatchlistUseCase:
         await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value, lang="pt-BR"))
 
         media_lookup.get_many.assert_awaited_once_with(
-            ["mov_abc123def456"],
+            [MovieId("mov_abc123def456")],
             [],
             "pt-BR",
         )

--- a/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_remove_item_from_custom_list.py
@@ -10,6 +10,7 @@ from src.modules.collections.application.use_cases import (
     RemoveItemFromCustomListUseCase,
 )
 from src.modules.collections.domain.entities import CustomList
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -40,7 +41,7 @@ class TestRemoveItemFromCustomListUseCase:
         )
 
         mock_repo.remove_item.assert_called_once_with(
-            str(custom_list.id), "mov_abc123def456", _PROFILE_ID
+            str(custom_list.id), CollectionMediaId("mov_abc123def456"), _PROFILE_ID
         )
         mock_repo.update.assert_called_once()
 
@@ -76,7 +77,7 @@ class TestRemoveItemFromCustomListUseCase:
                 RemoveItemFromCustomListInput(
                     profile_id=_PROFILE_ID.value,
                     list_id=str(custom_list.id),
-                    media_id="mov_notinlist0000",
+                    media_id="mov_notinlist000",
                 )
             )
 

--- a/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
@@ -10,6 +10,7 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.use_cases import ToggleWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
+from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.shared_kernel.value_objects import CollectionMediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
@@ -63,7 +64,7 @@ class TestToggleWatchlistUseCase:
 
         assert result.added is False
         assert result.media_id == "mov_abc123def456"
-        mock_repo.remove.assert_called_once_with("mov_abc123def456", _PROFILE_ID)
+        mock_repo.remove.assert_called_once_with(CollectionMediaId("mov_abc123def456"), _PROFILE_ID)
 
     @pytest.mark.asyncio
     async def test_should_toggle_series(self) -> None:

--- a/tests/modules/collections/unit/domain/entities/test_custom_list.py
+++ b/tests/modules/collections/unit/domain/entities/test_custom_list.py
@@ -245,7 +245,7 @@ class TestCustomListItemCreation:
         )
 
         assert item.id is None
-        assert item.media_id == "mov_abc123def456"
+        assert item.media_id.value == "mov_abc123def456"
         assert item.media_type == CollectionMediaType.MOVIE
         assert item.position == 0
 

--- a/tests/modules/collections/unit/domain/entities/test_watchlist_item.py
+++ b/tests/modules/collections/unit/domain/entities/test_watchlist_item.py
@@ -23,7 +23,7 @@ class TestWatchlistItemCreation:
         )
 
         assert item.id is None
-        assert item.media_id == "mov_abc123def456"
+        assert item.media_id.value == "mov_abc123def456"
         assert item.media_type == CollectionMediaType.MOVIE
         assert item.profile_id == _PROFILE_ID
 

--- a/tests/modules/collections/unit/domain/value_objects/test_collection_media_id.py
+++ b/tests/modules/collections/unit/domain/value_objects/test_collection_media_id.py
@@ -1,0 +1,61 @@
+"""Tests for the CollectionMediaId value object."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.collections.domain.value_objects import CollectionMediaId
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
+
+
+class TestCollectionMediaIdMovie:
+    """Movie-shaped ids."""
+
+    def test_accepts_valid_movie_id(self):
+        media_id = CollectionMediaId("mov_2xK9mPqR7nL4")
+
+        assert media_id.value == "mov_2xK9mPqR7nL4"
+        assert media_id.is_movie is True
+        assert media_id.is_series is False
+
+    def test_as_movie_id_returns_typed_id(self):
+        assert CollectionMediaId("mov_2xK9mPqR7nL4").as_movie_id() == MovieId("mov_2xK9mPqR7nL4")
+
+    def test_rejects_malformed_movie_id(self):
+        with pytest.raises(DomainValidationException):
+            CollectionMediaId("mov_short")
+
+
+class TestCollectionMediaIdSeries:
+    """Series-shaped ids."""
+
+    def test_accepts_valid_series_id(self):
+        media_id = CollectionMediaId("ser_3yL8nQsT9mK5")
+
+        assert media_id.is_series is True
+        assert media_id.is_movie is False
+
+    def test_as_series_id_returns_typed_id(self):
+        assert CollectionMediaId("ser_3yL8nQsT9mK5").as_series_id() == SeriesId("ser_3yL8nQsT9mK5")
+
+    def test_rejects_malformed_series_id(self):
+        with pytest.raises(DomainValidationException):
+            CollectionMediaId("ser_bad")
+
+
+class TestCollectionMediaIdRejections:
+    """Shapes that don't belong in a collection."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "garbage",
+            "ssn_4zM9oPtU0nL6",  # season — not a whole title
+            "epi_5aH0pQuV1oM7",  # episode — not a whole title
+            "epi_ser_3yL8nQsT9mK5_1_2",  # composite episode id
+            "lib_2xK9mPqR7nL4",
+        ],
+    )
+    def test_rejects_invalid_shapes(self, value: str):
+        with pytest.raises(DomainValidationException):
+            CollectionMediaId(value)

--- a/tests/modules/collections/unit/infrastructure/persistence/mappers/test_custom_list_mapper.py
+++ b/tests/modules/collections/unit/infrastructure/persistence/mappers/test_custom_list_mapper.py
@@ -158,7 +158,7 @@ class TestCustomListItemMapper:
         entity = CustomListItemMapper.to_entity(model)
 
         assert entity.id == item_id
-        assert entity.media_id == "ser_xyz789abc123"
+        assert entity.media_id.value == "ser_xyz789abc123"
         assert entity.media_type == CollectionMediaType.SERIES
         assert entity.position == 0
         assert entity.added_at == added_at

--- a/tests/modules/collections/unit/infrastructure/persistence/mappers/test_watchlist_item_mapper.py
+++ b/tests/modules/collections/unit/infrastructure/persistence/mappers/test_watchlist_item_mapper.py
@@ -69,7 +69,7 @@ class TestWatchlistItemMapper:
 
         assert entity.id == list_id
         assert entity.profile_id == _PROFILE_ID
-        assert entity.media_id == "ser_xyz789abc123"
+        assert entity.media_id.value == "ser_xyz789abc123"
         assert entity.media_type == CollectionMediaType.SERIES
         assert entity.added_at == added_at
 
@@ -108,14 +108,14 @@ class TestWatchlistItemMapper:
         model = WatchlistItemModel(
             external_id=str(list_id),
             profile_id=_PROFILE_ID.value,
-            media_id="mov_old00000000",
+            media_id="mov_old000000000",
             media_type="movie",
             added_at=old_added_at,
         )
         same_key_entity = WatchlistItem(
             id=list_id,
             profile_id=_PROFILE_ID,
-            media_id="mov_old00000000",
+            media_id="mov_old000000000",
             media_type=CollectionMediaType.MOVIE,
             added_at=new_added_at,
         )
@@ -123,7 +123,7 @@ class TestWatchlistItemMapper:
         result = WatchlistItemMapper.update_model(model, same_key_entity)
 
         assert result.added_at == new_added_at
-        assert result.media_id == "mov_old00000000"
+        assert result.media_id == "mov_old000000000"
         assert result.media_type == "movie"
 
     def test_update_model_does_not_overwrite_identity_fields(self) -> None:
@@ -135,19 +135,19 @@ class TestWatchlistItemMapper:
         model = WatchlistItemModel(
             external_id=str(list_id),
             profile_id=_PROFILE_ID.value,
-            media_id="mov_old00000000",
+            media_id="mov_old000000000",
             media_type="movie",
             added_at=datetime(2024, 1, 1, tzinfo=UTC),
         )
         mismatched_entity = WatchlistItem(
             id=list_id,
             profile_id=_PROFILE_ID,
-            media_id="ser_new00000000",
+            media_id="ser_new000000000",
             media_type=CollectionMediaType.SERIES,
             added_at=datetime(2025, 6, 1, tzinfo=UTC),
         )
 
         result = WatchlistItemMapper.update_model(model, mismatched_entity)
 
-        assert result.media_id == "mov_old00000000"
+        assert result.media_id == "mov_old000000000"
         assert result.media_type == "movie"


### PR DESCRIPTION
## Summary

- New `CollectionMediaId` VO in the collections domain (ADR-018 deferred bucket): accepts exactly the two catalog shapes a collection references — `mov_xxx` and `ser_xxx`. Seasons, episodes, composite ids and garbage are rejected at construction; helpers `is_movie`/`is_series`/`as_movie_id()`/`as_series_id()`
- `WatchlistItem.media_id` and `CustomListItem.media_id` typed + `model_validator` cross-checking `media_type ↔ id prefix` (movie ⇔ `mov_`, series ⇔ `ser_`) — garbage now fails **on write**
- Both repositories typed: `find_by_media_id`/`remove`/`exists`/`find_item`/`remove_item` take `CollectionMediaId`; the cross-BC `rewrite_media_id`/`rewrite_item_media_id` take `CollectionMediaId` + `CollectionMediaType` (no more bare `str` discriminator) — handlers drop the `.value` shim from #264
- `MediaLookupPort.get_many` typed (`Sequence[MovieId]`/`Sequence[SeriesId]`); the ACL adapter drops its `MovieId(...)`/`SeriesId(...)` re-wrap and imports from shared_kernel
- Use cases convert DTO strings to the VO at entry; output DTOs unwrap with `.value` (presentation stays `str`)

## Breaking changes

- Watchlist/custom-list mutations with a malformed or wrong-shaped `media_id` (e.g. an episode id) now return a validation error instead of silently persisting it

## Test plan

- [x] Full suite: 2718 passed, 5 skipped
- [x] New VO unit tests (13 cases) covering movie/series accept + season/episode/composite/garbage reject
- [x] `ruff check` + `ruff format` clean

## Related issues

- ADR-018 deferred bucket (media_id typing — step 3 of 4: events ✅ → watch_progress ✅ → **collections** → catalog_requests)

## Summary by Sourcery

Introduce a typed CollectionMediaId value object for collection entries and propagate it through collections domain, repositories, use cases, and adapters to enforce valid movie/series IDs.

New Features:
- Add CollectionMediaId value object to represent valid movie and series catalog identifiers for collections.

Bug Fixes:
- Prevent watchlist and custom list items from persisting malformed or non-title media_ids by validating shape and type at construction and use case level.

Enhancements:
- Type watchlist and custom list repositories and use cases to use CollectionMediaId instead of raw strings, including media rewrite handlers.
- Adjust media lookup port and adapter to operate on typed MovieId and SeriesId sequences, removing ad-hoc wrapping.
- Update mappers, DTOs, event handlers, and tests to work with the new typed media identifiers and maintain consistent serialization.

Tests:
- Add unit tests for CollectionMediaId covering valid movie/series IDs and rejection of invalid shapes.
- Update existing unit and integration tests for collections to assert on the new value object semantics and typed media lookup behavior.