### PR TITLE
refactor(catalog_requests): type notification media_id as VO

### DIFF
--- a/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
+++ b/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
@@ -162,7 +162,7 @@ class OnMediaEnrichedHandler(EventHandler):
                     recipient_user_id=request.requester_user_id,
                     title=request.title or f"tmdb/{event.media_type}/{event.tmdb_id}",
                     tmdb_id=event.tmdb_id,
-                    media_id=event.media_id.value,
+                    media_id=event.media_id,
                     media_type=event.media_type,
                 ),
             )

--- a/src/modules/catalog_requests/application/ports/notification_publisher_port.py
+++ b/src/modules/catalog_requests/application/ports/notification_publisher_port.py
@@ -12,6 +12,8 @@ Notifications' domain types.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
+
 
 @dataclass(frozen=True)
 class CatalogArrivalNotification:
@@ -36,9 +38,9 @@ class CatalogArrivalNotification:
         tmdb_id: TMDB id of the fulfilled title — kept on the
             payload so the frontend can fall back to a TMDB
             link if the local media id is unavailable.
-        media_id: External id of the local media row (``mov_xxx``
-            / ``ser_xxx``) the request was fulfilled by. Used as
-            the primary click-through target.
+        media_id: Typed external id of the local media row
+            (``MovieId`` / ``SeriesId``) the request was fulfilled
+            by. Used as the primary click-through target.
         media_type: ``"movie"`` or ``"series"`` so the renderer
             picks the right deep-link path.
     """
@@ -46,7 +48,7 @@ class CatalogArrivalNotification:
     recipient_user_id: str
     title: str
     tmdb_id: int
-    media_id: str
+    media_id: MovieId | SeriesId
     media_type: str
 
 

--- a/src/modules/notifications/infrastructure/acl/notification_publisher_adapter.py
+++ b/src/modules/notifications/infrastructure/acl/notification_publisher_adapter.py
@@ -51,7 +51,7 @@ class NotificationPublisherAdapter(NotificationPublisherPort):
                 body=None,
                 payload={
                     "tmdb_id": notification.tmdb_id,
-                    "media_id": notification.media_id,
+                    "media_id": notification.media_id.value,
                     "media_type": notification.media_type,
                 },
             ),

--- a/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
+++ b/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
@@ -195,7 +195,7 @@ class TestOnMediaEnrichedHandler:
         assert payload.recipient_user_id == "usr_alice"
         assert payload.title == "Alien"
         assert payload.tmdb_id == 348
-        assert payload.media_id == "mov_abcabcabcabc"
+        assert payload.media_id == MovieId("mov_abcabcabcabc")
         assert payload.media_type == "movie"
 
     @pytest.mark.asyncio

--- a/tests/modules/notifications/unit/infrastructure/acl/test_notification_publisher_adapter.py
+++ b/tests/modules/notifications/unit/infrastructure/acl/test_notification_publisher_adapter.py
@@ -9,6 +9,7 @@ from src.modules.notifications.application.dtos import CreateNotificationInput
 from src.modules.notifications.application.use_cases import CreateNotificationUseCase
 from src.modules.notifications.domain.value_objects import NotificationKind
 from src.modules.notifications.infrastructure.acl import NotificationPublisherAdapter
+from src.shared_kernel.value_objects.media_id import MovieId
 
 
 @pytest.mark.unit
@@ -25,7 +26,7 @@ class TestNotificationPublisherAdapter:
                 recipient_user_id="usr_alice",
                 title="Alien",
                 tmdb_id=348,
-                media_id="mov_abc",
+                media_id=MovieId("mov_abcabcabcabc"),
                 media_type="movie",
             ),
         )
@@ -38,6 +39,6 @@ class TestNotificationPublisherAdapter:
         assert called_input.title == "Alien"
         assert called_input.payload == {
             "tmdb_id": 348,
-            "media_id": "mov_abc",
+            "media_id": "mov_abcabcabcabc",
             "media_type": "movie",
         }


### PR DESCRIPTION
## Summary

- `CatalogArrivalNotification.media_id` is now `MovieId | SeriesId` instead of `str` (ADR-018 deferred bucket) — it mirrors the already-typed `MediaEnrichedEvent.media_id` field it simply forwards, so the cross-BC notification contract is typed end to end
- The `OnMediaEnrichedHandler` passes `event.media_id` straight through (drops the `.value` shim added in #264)
- The notifications ACL adapter (`NotificationPublisherAdapter`) unwraps with `.value` at the JSON `payload` boundary — the wire format stays a plain string, so persisted notifications and frontend deep-links are unchanged
- `media_type` stays `str` here — that's the separate ADR-016 alias migration, out of scope for this bucket

## Notes

- catalog_requests has no other `media_id` surface: requests are keyed by `tmdb_id` + `requested_media_type`, never by a local media id, so this is the whole BC's exposure

## Test plan

- [x] Full suite: 2718 passed, 5 skipped
- [x] `ruff check` + `ruff format` clean
- [x] Notification payload JSON unchanged (adapter test asserts the same dict)

## Related issues

- ADR-018 deferred bucket (media_id typing — step 4 of 4: events ✅ → watch_progress ✅ → collections ✅ → **catalog_requests**). Remaining: drop the back-compat `MediaId` re-export once the ~100 legacy imports migrate.

## Summary by Sourcery

Type catalog arrival notification media identifiers as value objects while preserving the existing string wire format for outbound notifications.

Enhancements:
- Change CatalogArrivalNotification.media_id to use MovieId | SeriesId value objects end-to-end within the catalog_requests bounded context.
- Adjust the media enrichment event handler and notifications ACL adapter to pass and unwrap typed media_id values at the JSON payload boundary.

Tests:
- Update notification publisher adapter and media enrichment handler tests to assert correct handling of typed media_id while keeping the emitted JSON payload unchanged.