### PR TITLE
refactor: remove CollectionMediaType alias for MediaType

### DIFF
--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.modules.collections.domain.entities import CustomList, CustomListItem
-    from src.shared_kernel.value_objects import CollectionMediaType
+    from src.shared_kernel.value_objects import MediaType
 
 
 @dataclass(frozen=True)
@@ -64,7 +64,7 @@ class AddItemToCustomListInput:
     profile_id: str
     list_id: str
     media_id: str
-    media_type: CollectionMediaType
+    media_type: MediaType
 
 
 @dataclass(frozen=True)
@@ -90,7 +90,7 @@ class CustomListItemOutput:
     """Output representing an item in a custom list with media metadata."""
 
     media_id: str
-    media_type: CollectionMediaType
+    media_type: MediaType
     title: str
     poster_path: str | None
     position: int

--- a/src/modules/collections/application/dtos/watchlist_dtos.py
+++ b/src/modules/collections/application/dtos/watchlist_dtos.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.modules.collections.domain.entities import WatchlistItem
-    from src.shared_kernel.value_objects import CollectionMediaType
+    from src.shared_kernel.value_objects import MediaType
 
 
 @dataclass(frozen=True)
@@ -16,7 +16,7 @@ class ToggleWatchlistInput:
 
     profile_id: str
     media_id: str
-    media_type: CollectionMediaType
+    media_type: MediaType
 
 
 @dataclass(frozen=True)
@@ -40,7 +40,7 @@ class WatchlistItemOutput:
     """Output representing a single watchlist item with media metadata."""
 
     media_id: str
-    media_type: CollectionMediaType
+    media_type: MediaType
     title: str
     poster_path: str | None
     added_at: str

--- a/src/modules/collections/application/event_handlers/on_movie_merged.py
+++ b/src/modules/collections/application/event_handlers/on_movie_merged.py
@@ -9,7 +9,7 @@ from src.modules.collections.application.unit_of_work import (
 )
 from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.media.domain.events import MovieMergedEvent
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -43,12 +43,12 @@ class OnMovieMergedHandler(EventHandler):
             watchlist_updated = await uow.watchlist.rewrite_media_id(
                 from_media_id=from_media_id,
                 to_media_id=to_media_id,
-                to_media_type=CollectionMediaType.MOVIE,
+                to_media_type=MediaType.MOVIE,
             )
             lists_updated = await uow.custom_lists.rewrite_item_media_id(
                 from_media_id=from_media_id,
                 to_media_id=to_media_id,
-                to_media_type=CollectionMediaType.MOVIE,
+                to_media_type=MediaType.MOVIE,
             )
 
         if watchlist_updated or lists_updated:

--- a/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
@@ -9,7 +9,7 @@ from src.modules.collections.application.unit_of_work import (
 )
 from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.media.domain.events import MoviePromotedToSeriesEvent
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 
 _logger = logging.getLogger(__name__)
 
@@ -43,12 +43,12 @@ class OnMoviePromotedToSeriesHandler(EventHandler):
             watchlist_updated = await uow.watchlist.rewrite_media_id(
                 from_media_id=from_media_id,
                 to_media_id=to_media_id,
-                to_media_type=CollectionMediaType.SERIES,
+                to_media_type=MediaType.SERIES,
             )
             lists_updated = await uow.custom_lists.rewrite_item_media_id(
                 from_media_id=from_media_id,
                 to_media_id=to_media_id,
-                to_media_type=CollectionMediaType.SERIES,
+                to_media_type=MediaType.SERIES,
             )
 
         if watchlist_updated or lists_updated:

--- a/src/modules/collections/application/ports/media_lookup_port.py
+++ b/src/modules/collections/application/ports/media_lookup_port.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 
 
@@ -30,7 +30,7 @@ class MediaSummary:
     """
 
     media_id: str
-    media_type: CollectionMediaType
+    media_type: MediaType
     title: str
     poster_path: str | None
 
@@ -50,7 +50,7 @@ class MediaLookupPort(ABC):
         movie_ids: Sequence[MovieId],
         series_ids: Sequence[SeriesId],
         lang: str,
-    ) -> dict[tuple[CollectionMediaType, str], MediaSummary]:
+    ) -> dict[tuple[MediaType, str], MediaSummary]:
         """Resolve metadata for the given movies and series.
 
         Args:

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -9,7 +9,7 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _logger = logging.getLogger(__name__)
@@ -69,12 +69,8 @@ class GetCustomListItemsUseCase:
         if not items:
             return []
 
-        movie_ids = [
-            i.media_id.as_movie_id() for i in items if i.media_type == CollectionMediaType.MOVIE
-        ]
-        series_ids = [
-            i.media_id.as_series_id() for i in items if i.media_type == CollectionMediaType.SERIES
-        ]
+        movie_ids = [i.media_id.as_movie_id() for i in items if i.media_type == MediaType.MOVIE]
+        series_ids = [i.media_id.as_series_id() for i in items if i.media_type == MediaType.SERIES]
 
         summaries = await self._media_lookup.get_many(movie_ids, series_ids, input_dto.lang)
 

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -8,7 +8,7 @@ from src.modules.collections.application.dtos import (
 )
 from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _logger = logging.getLogger(__name__)
@@ -58,12 +58,8 @@ class GetWatchlistUseCase:
         if not items:
             return []
 
-        movie_ids = [
-            i.media_id.as_movie_id() for i in items if i.media_type == CollectionMediaType.MOVIE
-        ]
-        series_ids = [
-            i.media_id.as_series_id() for i in items if i.media_type == CollectionMediaType.SERIES
-        ]
+        movie_ids = [i.media_id.as_movie_id() for i in items if i.media_type == MediaType.MOVIE]
+        series_ids = [i.media_id.as_series_id() for i in items if i.media_type == MediaType.SERIES]
 
         summaries = await self._media_lookup.get_many(movie_ids, series_ids, input_dto.lang)
 

--- a/src/modules/collections/domain/entities/custom_list.py
+++ b/src/modules/collections/domain/entities/custom_list.py
@@ -19,7 +19,7 @@ from src.modules.collections.domain.value_objects import (
     ListName,
 )
 from src.shared_kernel.value_objects import (
-    CollectionMediaType,  # — runtime for Pydantic
+    MediaType,  # — runtime for Pydantic
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
@@ -43,7 +43,7 @@ class CustomListItem(DomainEntity[CustomListItemId]):
     Example:
         >>> item = CustomListItem.create(
         ...     media_id=CollectionMediaId("mov_abc123def456"),
-        ...     media_type=CollectionMediaType.MOVIE,
+        ...     media_type=MediaType.MOVIE,
         ...     position=0,
         ... )
     """
@@ -51,14 +51,14 @@ class CustomListItem(DomainEntity[CustomListItemId]):
     id: CustomListItemId | None = Field(default=None)
 
     media_id: CollectionMediaId
-    media_type: CollectionMediaType
+    media_type: MediaType
     position: int = 0
     added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     @model_validator(mode="after")
     def _validate_media_id_matches_type(self) -> Self:
         """Reject a movie id paired with series type and vice versa."""
-        if self.media_id.is_movie != (self.media_type is CollectionMediaType.MOVIE):
+        if self.media_id.is_movie != (self.media_type is MediaType.MOVIE):
             raise ValueError(
                 f"media_id '{self.media_id.value}' does not match "
                 f"media_type '{self.media_type.value}'",
@@ -69,7 +69,7 @@ class CustomListItem(DomainEntity[CustomListItemId]):
     def create(
         cls,
         media_id: CollectionMediaId,
-        media_type: CollectionMediaType,
+        media_type: MediaType,
         position: int = 0,
     ) -> CustomListItem:
         """Factory method with automatic ID generation.

--- a/src/modules/collections/domain/entities/watchlist_item.py
+++ b/src/modules/collections/domain/entities/watchlist_item.py
@@ -13,7 +13,7 @@ from src.modules.collections.domain.value_objects import (
     ListId,
 )
 from src.shared_kernel.value_objects import (
-    CollectionMediaType,  # — runtime for Pydantic
+    MediaType,  # — runtime for Pydantic
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId  # noqa: TCH001
 
@@ -35,7 +35,7 @@ class WatchlistItem(AggregateRoot[ListId]):
         >>> item = WatchlistItem.create(
         ...     profile_id=caller_profile_id,
         ...     media_id=CollectionMediaId("mov_abc123def456"),
-        ...     media_type=CollectionMediaType.MOVIE,
+        ...     media_type=MediaType.MOVIE,
         ... )
     """
 
@@ -43,13 +43,13 @@ class WatchlistItem(AggregateRoot[ListId]):
 
     profile_id: ProfileId
     media_id: CollectionMediaId
-    media_type: CollectionMediaType
+    media_type: MediaType
     added_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     @model_validator(mode="after")
     def _validate_media_id_matches_type(self) -> Self:
         """Reject a movie id paired with series type and vice versa."""
-        if self.media_id.is_movie != (self.media_type is CollectionMediaType.MOVIE):
+        if self.media_id.is_movie != (self.media_type is MediaType.MOVIE):
             raise ValueError(
                 f"media_id '{self.media_id.value}' does not match "
                 f"media_type '{self.media_type.value}'",
@@ -61,7 +61,7 @@ class WatchlistItem(AggregateRoot[ListId]):
         cls,
         profile_id: ProfileId,
         media_id: CollectionMediaId,
-        media_type: CollectionMediaType,
+        media_type: MediaType,
     ) -> WatchlistItem:
         """Factory method with automatic ID generation."""
         return cls(

--- a/src/modules/collections/domain/repositories/custom_list_repository.py
+++ b/src/modules/collections/domain/repositories/custom_list_repository.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
 from src.modules.collections.domain.value_objects import CollectionMediaId
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -129,7 +129,7 @@ class CustomListRepository(ABC):
         self,
         from_media_id: CollectionMediaId,
         to_media_id: CollectionMediaId,
-        to_media_type: CollectionMediaType,
+        to_media_type: MediaType,
     ) -> int:
         """Repoint every custom-list item from one media id to another.
 

--- a/src/modules/collections/domain/repositories/watchlist_repository.py
+++ b/src/modules/collections/domain/repositories/watchlist_repository.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 
 from src.modules.collections.domain.entities import WatchlistItem
 from src.modules.collections.domain.value_objects import CollectionMediaId
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -70,7 +70,7 @@ class WatchlistRepository(ABC):
         self,
         from_media_id: CollectionMediaId,
         to_media_id: CollectionMediaId,
-        to_media_type: CollectionMediaType,
+        to_media_type: MediaType,
     ) -> int:
         """Repoint every row from one media id to another (cross-profile).
 

--- a/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
+++ b/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
@@ -11,7 +11,7 @@ from src.modules.collections.application.ports.media_lookup_port import (
     MediaSummary,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 
 
@@ -26,9 +26,9 @@ class MediaLookupAdapter(MediaLookupPort):
         movie_ids: Sequence[MovieId],
         series_ids: Sequence[SeriesId],
         lang: str,
-    ) -> dict[tuple[CollectionMediaType, str], MediaSummary]:
+    ) -> dict[tuple[MediaType, str], MediaSummary]:
         """Batch-resolve display metadata via a single Media UoW."""
-        result: dict[tuple[CollectionMediaType, str], MediaSummary] = {}
+        result: dict[tuple[MediaType, str], MediaSummary] = {}
 
         if not movie_ids and not series_ids:
             return result
@@ -37,9 +37,9 @@ class MediaLookupAdapter(MediaLookupPort):
             if movie_ids:
                 movies_map = await uow.movies.find_by_ids(list(movie_ids))
                 for media_id, movie in movies_map.items():
-                    result[(CollectionMediaType.MOVIE, media_id)] = MediaSummary(
+                    result[(MediaType.MOVIE, media_id)] = MediaSummary(
                         media_id=media_id,
-                        media_type=CollectionMediaType.MOVIE,
+                        media_type=MediaType.MOVIE,
                         title=movie.get_title(lang),
                         poster_path=movie.poster_path.value if movie.poster_path else None,
                     )
@@ -47,9 +47,9 @@ class MediaLookupAdapter(MediaLookupPort):
             if series_ids:
                 series_map = await uow.series.find_by_ids(list(series_ids))
                 for media_id, series in series_map.items():
-                    result[(CollectionMediaType.SERIES, media_id)] = MediaSummary(
+                    result[(MediaType.SERIES, media_id)] = MediaSummary(
                         media_id=media_id,
-                        media_type=CollectionMediaType.SERIES,
+                        media_type=MediaType.SERIES,
                         title=series.get_title(lang),
                         poster_path=series.poster_path.value if series.poster_path else None,
                     )

--- a/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
@@ -10,7 +10,7 @@ from src.modules.collections.infrastructure.persistence.models import (
     CustomListItemModel,
     CustomListModel,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -76,7 +76,7 @@ class CustomListItemMapper:
         return CustomListItem(
             id=CustomListItemId(model.external_id),
             media_id=CollectionMediaId(model.media_id),
-            media_type=CollectionMediaType(model.media_type),
+            media_type=MediaType(model.media_type),
             position=model.position,
             added_at=model.added_at,
             created_at=model.created_at,

--- a/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/watchlist_item_mapper.py
@@ -5,7 +5,7 @@ from src.modules.collections.domain.value_objects import CollectionMediaId, List
 from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -34,7 +34,7 @@ class WatchlistItemMapper:
             id=ListId(model.external_id),
             profile_id=ProfileId(model.profile_id),
             media_id=CollectionMediaId(model.media_id),
-            media_type=CollectionMediaType(model.media_type),
+            media_type=MediaType(model.media_type),
             added_at=model.added_at,
             created_at=model.created_at,
             updated_at=model.updated_at,

--- a/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
@@ -14,7 +14,7 @@ from src.modules.collections.infrastructure.persistence.models import (
     CustomListItemModel,
     CustomListModel,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -306,7 +306,7 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         self,
         from_media_id: CollectionMediaId,
         to_media_id: CollectionMediaId,
-        to_media_type: CollectionMediaType,
+        to_media_type: MediaType,
     ) -> int:
         """Repoint every list item (cross-list, cross-profile) to a new media id."""
         stmt = select(CustomListItemModel).where(

--- a/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/watchlist_repository.py
@@ -12,7 +12,7 @@ from src.modules.collections.infrastructure.persistence.mappers import (
 from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 
@@ -140,7 +140,7 @@ class SQLAlchemyWatchlistRepository(WatchlistRepository):
         self,
         from_media_id: CollectionMediaId,
         to_media_id: CollectionMediaId,
-        to_media_type: CollectionMediaType,
+        to_media_type: MediaType,
     ) -> int:
         """Repoint every watchlist row (across profiles) to a new media id."""
         stmt = select(WatchlistItemModel).where(

--- a/src/modules/collections/presentation/routes/watchlist_routes.py
+++ b/src/modules/collections/presentation/routes/watchlist_routes.py
@@ -20,7 +20,7 @@ from src.modules.collections.application.use_cases import (
     ToggleWatchlistUseCase,
 )
 from src.modules.collections.presentation.dependencies import resolve_profile_id
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 
 router = APIRouter(prefix="/api/v1/watchlist", tags=["Watchlist"])
 
@@ -32,7 +32,7 @@ class ToggleWatchlistRequest(BaseModel):
     """Request body for toggling a watchlist item."""
 
     media_id: str
-    media_type: CollectionMediaType
+    media_type: MediaType
 
 
 # -- Endpoints -----------------------------------------------------------------

--- a/src/modules/collections/presentation/schemas/custom_list_schemas.py
+++ b/src/modules/collections/presentation/schemas/custom_list_schemas.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field
 
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 
 
 class CreateCustomListRequest(BaseModel):
@@ -21,7 +21,7 @@ class AddItemToCustomListRequest(BaseModel):
     """Request body for adding an item to a custom list."""
 
     media_id: str
-    media_type: CollectionMediaType
+    media_type: MediaType
 
 
 __all__ = [

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -15,14 +15,13 @@ from src.shared_kernel.value_objects.media_id import (
     SeriesId,
     parse_media_id,
 )
-from src.shared_kernel.value_objects.media_type import CollectionMediaType, MediaType
+from src.shared_kernel.value_objects.media_type import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 from src.shared_kernel.value_objects.user_id import UserId
 
 __all__ = [
     "AudioTrack",
-    "CollectionMediaType",
     "EpisodeCompositeId",
     "EpisodeId",
     "FilePath",

--- a/src/shared_kernel/value_objects/media_type.py
+++ b/src/shared_kernel/value_objects/media_type.py
@@ -29,9 +29,4 @@ class MediaType(StrEnum):
     SERIES = "series"
 
 
-# Back-compat alias — collections still imports ``CollectionMediaType``.
-# Removed once collections migrates to ``MediaType`` (ADR-016, deferred).
-CollectionMediaType = MediaType
-
-
-__all__ = ["CollectionMediaType", "MediaType"]
+__all__ = ["MediaType"]

--- a/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
+++ b/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
@@ -23,7 +23,7 @@ from src.modules.media.infrastructure.persistence.repositories import (
 from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyMediaUnitOfWorkFactory,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 
 _LIBRARY_ID = "lib_test12345678"
 
@@ -80,11 +80,11 @@ class TestCollectionsMediaLookupAdapter:
 
         summaries = await adapter.get_many([str(movie_id)], [str(series_id)], "en")
 
-        movie_summary = summaries[(CollectionMediaType.MOVIE, str(movie_id))]
+        movie_summary = summaries[(MediaType.MOVIE, str(movie_id))]
         assert movie_summary.title == "Inception"
         assert movie_summary.poster_path == "/p/inception.jpg"
 
-        series_summary = summaries[(CollectionMediaType.SERIES, str(series_id))]
+        series_summary = summaries[(MediaType.SERIES, str(series_id))]
         assert series_summary.title == "Breaking Bad"
         assert series_summary.poster_path == "/p/bb.jpg"
 
@@ -117,5 +117,5 @@ class TestCollectionsMediaLookupAdapter:
         adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
         summaries = await adapter.get_many([str(movie_id)], [], "en")
 
-        summary = summaries[(CollectionMediaType.MOVIE, str(movie_id))]
+        summary = summaries[(MediaType.MOVIE, str(movie_id))]
         assert summary.poster_path is None

--- a/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
@@ -8,7 +8,7 @@ from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.collections.infrastructure.persistence.repositories import (
     SQLAlchemyCustomListRepository,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 SAMPLE_MOVIE_ID = CollectionMediaId("mov_abc123def456")
@@ -27,7 +27,7 @@ def _create_list(
 
 def _create_item(
     media_id: CollectionMediaId | str = SAMPLE_MOVIE_ID,
-    media_type: CollectionMediaType = CollectionMediaType.MOVIE,
+    media_type: MediaType = MediaType.MOVIE,
     position: int = 0,
 ) -> CustomListItem:
     return CustomListItem.create(

--- a/tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_watchlist_repository.py
@@ -8,7 +8,7 @@ from src.modules.collections.domain.value_objects import CollectionMediaId
 from src.modules.collections.infrastructure.persistence.repositories import (
     SQLAlchemyWatchlistRepository,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 SAMPLE_MOVIE_ID = CollectionMediaId("mov_abc123def456")
@@ -18,7 +18,7 @@ _OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
 
 def _create_item(
     media_id: CollectionMediaId | str = SAMPLE_MOVIE_ID,
-    media_type: CollectionMediaType = CollectionMediaType.MOVIE,
+    media_type: MediaType = MediaType.MOVIE,
     profile_id: ProfileId = _PROFILE_ID,
 ) -> WatchlistItem:
     return WatchlistItem.create(profile_id=profile_id, media_id=media_id, media_type=media_type)
@@ -196,12 +196,12 @@ class TestSQLAlchemyWatchlistRepository:
         repo = SQLAlchemyWatchlistRepository(db_session)
         item = _create_item(
             media_id="ser_abc123def456",
-            media_type=CollectionMediaType.SERIES,
+            media_type=MediaType.SERIES,
         )
 
         saved = await repo.add(item)
 
-        assert saved.media_type == CollectionMediaType.SERIES
+        assert saved.media_type == MediaType.SERIES
 
     async def test_rewrite_media_id_should_repoint_rows_across_profiles(
         self, db_session: AsyncSession
@@ -216,7 +216,7 @@ class TestSQLAlchemyWatchlistRepository:
         updated = await repo.rewrite_media_id(
             from_media_id=SAMPLE_MOVIE_ID,
             to_media_id=CollectionMediaId("ser_promotedxxxx"),
-            to_media_type=CollectionMediaType.SERIES,
+            to_media_type=MediaType.SERIES,
         )
 
         assert updated == 2
@@ -225,7 +225,7 @@ class TestSQLAlchemyWatchlistRepository:
             assert stale is None
             fresh = await repo.find_by_media_id(CollectionMediaId("ser_promotedxxxx"), profile)
             assert fresh is not None
-            assert fresh.media_type == CollectionMediaType.SERIES
+            assert fresh.media_type == MediaType.SERIES
 
     async def test_rewrite_media_id_should_return_zero_when_nothing_matches(
         self, db_session: AsyncSession
@@ -235,7 +235,7 @@ class TestSQLAlchemyWatchlistRepository:
         updated = await repo.rewrite_media_id(
             from_media_id=CollectionMediaId("mov_unknown00000"),
             to_media_id=CollectionMediaId("ser_promotedxxxx"),
-            to_media_type=CollectionMediaType.SERIES,
+            to_media_type=MediaType.SERIES,
         )
 
         assert updated == 0

--- a/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
@@ -12,7 +12,7 @@ from src.modules.media.domain.events import (
     MediaCreatedEvent,
     MovieMergedEvent,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.media_id import MovieId
 
 
@@ -48,12 +48,12 @@ class TestOnMovieMergedHandlerCollections:
         watchlist.rewrite_media_id.assert_awaited_once_with(
             from_media_id=CollectionMediaId("mov_loserbbbbbbb"),
             to_media_id=CollectionMediaId("mov_winneraaaaaa"),
-            to_media_type=CollectionMediaType.MOVIE,
+            to_media_type=MediaType.MOVIE,
         )
         custom_lists.rewrite_item_media_id.assert_awaited_once_with(
             from_media_id=CollectionMediaId("mov_loserbbbbbbb"),
             to_media_id=CollectionMediaId("mov_winneraaaaaa"),
-            to_media_type=CollectionMediaType.MOVIE,
+            to_media_type=MediaType.MOVIE,
         )
 
     @pytest.mark.asyncio

--- a/tests/modules/collections/unit/application/use_cases/conftest.py
+++ b/tests/modules/collections/unit/application/use_cases/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src.modules.collections.application.ports import MediaLookupPort, MediaSummary
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 
 MediaSummaryFactory = Callable[..., MediaSummary]
 
@@ -22,7 +22,7 @@ def movie_summary() -> MediaSummaryFactory:
     ) -> MediaSummary:
         return MediaSummary(
             media_id=media_id,
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
             title=title,
             poster_path=poster_path,
         )
@@ -41,7 +41,7 @@ def series_summary() -> MediaSummaryFactory:
     ) -> MediaSummary:
         return MediaSummary(
             media_id=media_id,
-            media_type=CollectionMediaType.SERIES,
+            media_type=MediaType.SERIES,
             title=title,
             poster_path=poster_path,
         )

--- a/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_add_item_to_custom_list.py
@@ -13,7 +13,7 @@ from src.modules.collections.domain.entities import (
     CustomList,
     CustomListItem,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -39,7 +39,7 @@ class TestAddItemToCustomListUseCase:
         mock_repo.get_next_position.return_value = 0
         mock_repo.add_item.return_value = CustomListItem.create(
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
             position=0,
         )
         mock_repo.update.return_value = custom_list.increment_item_count()
@@ -50,7 +50,7 @@ class TestAddItemToCustomListUseCase:
                 profile_id=_PROFILE_ID.value,
                 list_id=str(custom_list.id),
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
             )
         )
 
@@ -70,7 +70,7 @@ class TestAddItemToCustomListUseCase:
                     profile_id=_PROFILE_ID.value,
                     list_id="lst_nonexistent00",
                     media_id="mov_abc123def456",
-                    media_type=CollectionMediaType.MOVIE,
+                    media_type=MediaType.MOVIE,
                 )
             )
 
@@ -81,7 +81,7 @@ class TestAddItemToCustomListUseCase:
         custom_list = _create_list(item_count=1)
         existing_item = CustomListItem.create(
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists
@@ -95,7 +95,7 @@ class TestAddItemToCustomListUseCase:
                     profile_id=_PROFILE_ID.value,
                     list_id=str(custom_list.id),
                     media_id="mov_abc123def456",
-                    media_type=CollectionMediaType.MOVIE,
+                    media_type=MediaType.MOVIE,
                 )
             )
 
@@ -116,7 +116,7 @@ class TestAddItemToCustomListUseCase:
                     profile_id=_PROFILE_ID.value,
                     list_id=str(custom_list.id),
                     media_id="mov_abc123def456",
-                    media_type=CollectionMediaType.MOVIE,
+                    media_type=MediaType.MOVIE,
                 )
             )
 
@@ -132,7 +132,7 @@ class TestAddItemToCustomListUseCase:
         mock_repo.get_next_position.return_value = 3
         mock_repo.add_item.return_value = CustomListItem.create(
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
             position=3,
         )
         mock_repo.update.return_value = custom_list.increment_item_count()
@@ -143,7 +143,7 @@ class TestAddItemToCustomListUseCase:
                 profile_id=_PROFILE_ID.value,
                 list_id=str(custom_list.id),
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
             )
         )
 

--- a/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
@@ -19,7 +19,7 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetCustomListItemsUseCase
 from src.modules.collections.domain.entities import CustomList, CustomListItem
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.media_id import MovieId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
@@ -43,7 +43,7 @@ class TestGetCustomListItemsUseCase:
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
                 position=0,
             ),
         ]
@@ -117,7 +117,7 @@ class TestGetCustomListItemsUseCase:
         items = [
             CustomListItem.create(
                 media_id="mov_missing00000",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
                 position=0,
             ),
         ]
@@ -149,12 +149,12 @@ class TestGetCustomListItemsUseCase:
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
                 position=0,
             ),
             CustomListItem.create(
                 media_id="ser_xyz789abc123",
-                media_type=CollectionMediaType.SERIES,
+                media_type=MediaType.SERIES,
                 position=1,
             ),
         ]
@@ -191,7 +191,7 @@ class TestGetCustomListItemsUseCase:
         items = [
             CustomListItem.create(
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
                 position=0,
             ),
         ]

--- a/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
@@ -18,7 +18,7 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.ports import MediaLookupPort
 from src.modules.collections.application.use_cases import GetWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.media_id import MovieId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
@@ -42,7 +42,7 @@ class TestGetWatchlistUseCase:
             WatchlistItem.create(
                 profile_id=_PROFILE_ID,
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
             ),
         ]
         mocks = make_collections_uow_mock()
@@ -82,7 +82,7 @@ class TestGetWatchlistUseCase:
             WatchlistItem.create(
                 profile_id=_PROFILE_ID,
                 media_id="mov_missing00000",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
             ),
         ]
         mocks = make_collections_uow_mock()
@@ -107,12 +107,12 @@ class TestGetWatchlistUseCase:
             WatchlistItem.create(
                 profile_id=_PROFILE_ID,
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
             ),
             WatchlistItem.create(
                 profile_id=_PROFILE_ID,
                 media_id="ser_xyz789abc123",
-                media_type=CollectionMediaType.SERIES,
+                media_type=MediaType.SERIES,
             ),
         ]
         mocks = make_collections_uow_mock()
@@ -155,7 +155,7 @@ class TestGetWatchlistUseCase:
             WatchlistItem.create(
                 profile_id=_PROFILE_ID,
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
             ),
         ]
         mocks = make_collections_uow_mock()

--- a/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_toggle_watchlist.py
@@ -11,7 +11,7 @@ from src.modules.collections.application.dtos import (
 from src.modules.collections.application.use_cases import ToggleWatchlistUseCase
 from src.modules.collections.domain.entities import WatchlistItem
 from src.modules.collections.domain.value_objects import CollectionMediaId
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -29,7 +29,7 @@ class TestToggleWatchlistUseCase:
         mock_repo.add.return_value = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
         use_case = ToggleWatchlistUseCase(uow_factory=mocks.factory)
 
@@ -37,7 +37,7 @@ class TestToggleWatchlistUseCase:
             ToggleWatchlistInput(
                 profile_id=_PROFILE_ID.value,
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
             )
         )
 
@@ -58,7 +58,7 @@ class TestToggleWatchlistUseCase:
             ToggleWatchlistInput(
                 profile_id=_PROFILE_ID.value,
                 media_id="mov_abc123def456",
-                media_type=CollectionMediaType.MOVIE,
+                media_type=MediaType.MOVIE,
             )
         )
 
@@ -74,7 +74,7 @@ class TestToggleWatchlistUseCase:
         mock_repo.add.return_value = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="ser_abc123def456",
-            media_type=CollectionMediaType.SERIES,
+            media_type=MediaType.SERIES,
         )
         use_case = ToggleWatchlistUseCase(uow_factory=mocks.factory)
 
@@ -82,7 +82,7 @@ class TestToggleWatchlistUseCase:
             ToggleWatchlistInput(
                 profile_id=_PROFILE_ID.value,
                 media_id="ser_abc123def456",
-                media_type=CollectionMediaType.SERIES,
+                media_type=MediaType.SERIES,
             )
         )
 

--- a/tests/modules/collections/unit/domain/entities/test_custom_list.py
+++ b/tests/modules/collections/unit/domain/entities/test_custom_list.py
@@ -15,7 +15,7 @@ from src.modules.collections.domain.value_objects import (
     ListId,
     ListName,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -241,18 +241,18 @@ class TestCustomListItemCreation:
     def test_should_create_with_required_fields(self) -> None:
         item = CustomListItem(
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         assert item.id is None
         assert item.media_id.value == "mov_abc123def456"
-        assert item.media_type == CollectionMediaType.MOVIE
+        assert item.media_type == MediaType.MOVIE
         assert item.position == 0
 
     def test_should_create_via_factory_with_auto_id(self) -> None:
         item = CustomListItem.create(
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         assert item.id is not None
@@ -262,7 +262,7 @@ class TestCustomListItemCreation:
     def test_should_create_with_custom_position(self) -> None:
         item = CustomListItem.create(
             media_id="ser_abc123def456",
-            media_type=CollectionMediaType.SERIES,
+            media_type=MediaType.SERIES,
             position=5,
         )
 
@@ -271,7 +271,7 @@ class TestCustomListItemCreation:
     def test_should_have_added_at_timestamp(self) -> None:
         item = CustomListItem.create(
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         assert item.added_at is not None
@@ -279,15 +279,15 @@ class TestCustomListItemCreation:
     def test_should_accept_series_media_type(self) -> None:
         item = CustomListItem.create(
             media_id="ser_abc123def456",
-            media_type=CollectionMediaType.SERIES,
+            media_type=MediaType.SERIES,
         )
 
-        assert item.media_type == CollectionMediaType.SERIES
+        assert item.media_type == MediaType.SERIES
 
     def test_should_be_frozen(self) -> None:
         item = CustomListItem.create(
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         with pytest.raises(DomainValidationException):

--- a/tests/modules/collections/unit/domain/entities/test_watchlist_item.py
+++ b/tests/modules/collections/unit/domain/entities/test_watchlist_item.py
@@ -5,7 +5,7 @@ import pytest
 from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.collections.domain.entities import WatchlistItem
 from src.modules.collections.domain.value_objects import ListId
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -19,19 +19,19 @@ class TestWatchlistItemCreation:
         item = WatchlistItem(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         assert item.id is None
         assert item.media_id.value == "mov_abc123def456"
-        assert item.media_type == CollectionMediaType.MOVIE
+        assert item.media_type == MediaType.MOVIE
         assert item.profile_id == _PROFILE_ID
 
     def test_should_create_via_factory_with_auto_id(self) -> None:
         item = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         assert item.id is not None
@@ -42,16 +42,16 @@ class TestWatchlistItemCreation:
         item = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="ser_abc123def456",
-            media_type=CollectionMediaType.SERIES,
+            media_type=MediaType.SERIES,
         )
 
-        assert item.media_type == CollectionMediaType.SERIES
+        assert item.media_type == MediaType.SERIES
 
     def test_should_have_added_at_timestamp(self) -> None:
         item = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         assert item.added_at is not None
@@ -65,7 +65,7 @@ class TestWatchlistItemImmutability:
         item = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         with pytest.raises(DomainValidationException):
@@ -75,11 +75,11 @@ class TestWatchlistItemImmutability:
         item = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         with pytest.raises(DomainValidationException):
-            item.media_type = CollectionMediaType.SERIES  # type: ignore[misc]
+            item.media_type = MediaType.SERIES  # type: ignore[misc]
 
 
 @pytest.mark.unit
@@ -92,13 +92,13 @@ class TestWatchlistItemEquality:
             id=list_id,
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
         item_b = WatchlistItem(
             id=list_id,
             profile_id=_PROFILE_ID,
             media_id="ser_xyz789abc123",
-            media_type=CollectionMediaType.SERIES,
+            media_type=MediaType.SERIES,
         )
 
         assert item_a == item_b
@@ -107,12 +107,12 @@ class TestWatchlistItemEquality:
         item_a = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
         item_b = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         assert item_a != item_b
@@ -121,7 +121,7 @@ class TestWatchlistItemEquality:
         item = WatchlistItem.create(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         assert hash(item) is not None

--- a/tests/modules/collections/unit/infrastructure/persistence/mappers/test_custom_list_mapper.py
+++ b/tests/modules/collections/unit/infrastructure/persistence/mappers/test_custom_list_mapper.py
@@ -14,7 +14,7 @@ from src.modules.collections.infrastructure.persistence.models import (
     CustomListItemModel,
     CustomListModel,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -114,7 +114,7 @@ class TestCustomListItemMapper:
     def test_to_model_should_raise_when_id_is_none(self) -> None:
         item = CustomListItem(
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         with pytest.raises(ValueError, match="Cannot map entity without ID"):
@@ -126,7 +126,7 @@ class TestCustomListItemMapper:
         item = CustomListItem(
             id=item_id,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
             position=2,
             added_at=added_at,
         )
@@ -136,7 +136,7 @@ class TestCustomListItemMapper:
         assert model.external_id == str(item_id)
         assert model.custom_list_id == 42
         assert model.media_id == "mov_abc123def456"
-        assert model.media_type == CollectionMediaType.MOVIE
+        assert model.media_type == MediaType.MOVIE
         assert model.position == 2
         assert model.added_at == added_at
 
@@ -159,6 +159,6 @@ class TestCustomListItemMapper:
 
         assert entity.id == item_id
         assert entity.media_id.value == "ser_xyz789abc123"
-        assert entity.media_type == CollectionMediaType.SERIES
+        assert entity.media_type == MediaType.SERIES
         assert entity.position == 0
         assert entity.added_at == added_at

--- a/tests/modules/collections/unit/infrastructure/persistence/mappers/test_watchlist_item_mapper.py
+++ b/tests/modules/collections/unit/infrastructure/persistence/mappers/test_watchlist_item_mapper.py
@@ -12,7 +12,7 @@ from src.modules.collections.infrastructure.persistence.mappers import (
 from src.modules.collections.infrastructure.persistence.models import (
     WatchlistItemModel,
 )
-from src.shared_kernel.value_objects import CollectionMediaType
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -26,7 +26,7 @@ class TestWatchlistItemMapper:
         item = WatchlistItem(
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
         )
 
         with pytest.raises(ValueError, match="Cannot map entity without ID"):
@@ -39,7 +39,7 @@ class TestWatchlistItemMapper:
             id=list_id,
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
             added_at=added_at,
         )
 
@@ -48,7 +48,7 @@ class TestWatchlistItemMapper:
         assert model.external_id == str(list_id)
         assert model.profile_id == _PROFILE_ID.value
         assert model.media_id == "mov_abc123def456"
-        assert model.media_type == CollectionMediaType.MOVIE
+        assert model.media_type == MediaType.MOVIE
         assert model.added_at == added_at
 
     def test_to_entity_should_convert_model_correctly(self) -> None:
@@ -70,7 +70,7 @@ class TestWatchlistItemMapper:
         assert entity.id == list_id
         assert entity.profile_id == _PROFILE_ID
         assert entity.media_id.value == "ser_xyz789abc123"
-        assert entity.media_type == CollectionMediaType.SERIES
+        assert entity.media_type == MediaType.SERIES
         assert entity.added_at == added_at
 
     def test_round_trip_should_preserve_fields(self) -> None:
@@ -80,7 +80,7 @@ class TestWatchlistItemMapper:
             id=list_id,
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
             added_at=added_at,
         )
         model = WatchlistItemMapper.to_model(original)
@@ -116,7 +116,7 @@ class TestWatchlistItemMapper:
             id=list_id,
             profile_id=_PROFILE_ID,
             media_id="mov_old000000000",
-            media_type=CollectionMediaType.MOVIE,
+            media_type=MediaType.MOVIE,
             added_at=new_added_at,
         )
 
@@ -143,7 +143,7 @@ class TestWatchlistItemMapper:
             id=list_id,
             profile_id=_PROFILE_ID,
             media_id="ser_new000000000",
-            media_type=CollectionMediaType.SERIES,
+            media_type=MediaType.SERIES,
             added_at=datetime(2025, 6, 1, tzinfo=UTC),
         )
 


### PR DESCRIPTION
## Summary

- `CollectionMediaType` was already defined as `CollectionMediaType = MediaType` (the exact same object), kept as a back-compat alias by ADR-016 so collections didn't have to migrate at the time
- Rename every `CollectionMediaType` usage across collections (entities, repos, mappers, DTOs, ports, ACL adapter, routes, schemas, use cases) to the canonical `MediaType`
- Delete the alias line + its `__all__` entry in `shared_kernel/value_objects/media_type.py` and the re-export in `shared_kernel/value_objects/__init__.py`

## Notes

- Pure mechanical rename — `CollectionMediaType` and `MediaType` were the identical runtime object, so there is **zero behavior change** (persisted strings, serialization, comparisons all unchanged)
- 33 files, net −14 lines

## Test plan

- [x] Full suite: 2716 passed, 5 skipped
- [x] `ruff check` + `ruff format` clean
- [x] `grep` confirms zero `CollectionMediaType` references remain

## Related issues

- ADR-016 deferred bucket (MediaType alias migration — step 2 of 3: RequestedMediaType ✅ → **CollectionMediaType alias** → Literal consolidation)

## Summary by Sourcery

Standardize collections on the shared MediaType value object and remove the deprecated CollectionMediaType alias.

Enhancements:
- Replace all CollectionMediaType usages in collections domain, application, infrastructure, and tests with the canonical MediaType value object.
- Remove the CollectionMediaType alias and its re-exports from the shared kernel media_type module and package exports.