### PR TITLE
refactor(media): consolidate movie/series Literal into MediaType

### DIFF
--- a/src/modules/media/application/dtos/catalog_dtos.py
+++ b/src/modules/media/application/dtos/catalog_dtos.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
 
-# Canonical media-type filter shared by the catalog inputs. ``None``
-# means "no filter — aggregate both movies and series". Kept as a
-# module-level alias so the use cases, the routes, and the tests all
-# agree on the exact literal values without copy-pasting the shape.
-MediaTypeFilter = Literal["movie", "series"]
+if TYPE_CHECKING:
+    from src.shared_kernel.value_objects import MediaType
 
 
 @dataclass(frozen=True)
@@ -54,7 +51,7 @@ class ListGenresInput:
 
     profile_id: str
     lang: str = "en"
-    media_type: MediaTypeFilter | None = None
+    media_type: MediaType | None = None
 
 
 @dataclass(frozen=True)
@@ -125,7 +122,7 @@ class ListByGenreInput:
     cursor: str | None = None
     limit: int = DEFAULT_PAGE_SIZE
     lang: str = "en"
-    media_type: MediaTypeFilter | None = None
+    media_type: MediaType | None = None
 
 
 @dataclass(frozen=True)
@@ -187,5 +184,4 @@ __all__ = [
     "ListGenresOutput",
     "ListRecentlyAddedCatalogInput",
     "ListRecentlyAddedCatalogOutput",
-    "MediaTypeFilter",
 ]

--- a/src/modules/media/application/dtos/conflict_dtos.py
+++ b/src/modules/media/application/dtos/conflict_dtos.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from src.shared_kernel.value_objects import MediaType
+
 
 @dataclass(frozen=True)
 class DetectMovieConflictsInput:
@@ -106,7 +108,7 @@ class ConflictCandidateSummary:
     """
 
     media_id: str
-    media_type: str
+    media_type: MediaType
     title: str | None
     year: int | None
     files: list[ConflictCandidateFile]

--- a/src/modules/media/application/dtos/search_dtos.py
+++ b/src/modules/media/application/dtos/search_dtos.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
+
+if TYPE_CHECKING:
+    from src.shared_kernel.value_objects import MediaType
 
 
 @dataclass(frozen=True)
@@ -31,7 +34,7 @@ class SearchInput:
 
     profile_id: str
     query: str
-    media_type: Literal["movie", "series"] | None = None
+    media_type: MediaType | None = None
     genre: str | None = None
     year_min: int | None = None
     year_max: int | None = None

--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal, TypeVar
+from typing import TypeVar
 
 from src.building_blocks.application.pagination import (
     DualCursorValue,
@@ -23,6 +23,7 @@ from src.modules.media.application.ports.profile_library_access_port import (
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
 from src.modules.media.domain.value_objects import Genre
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.library_id import LibraryId
 
 _T = TypeVar("_T")
@@ -55,7 +56,7 @@ class _MergedItem:
     this module — the public API still returns ``CatalogItemOutput``.
     """
 
-    kind: Literal["movie", "series"]
+    kind: MediaType
     source_index: int
     entity: Movie | Series
 
@@ -133,10 +134,10 @@ class ListByGenreUseCase:
         # Tag each entity with its source stream and its source-page
         # index so we can recover the per-item cursor after the merge.
         tagged: list[_MergedItem] = [
-            _MergedItem(kind="movie", source_index=index, entity=item)
+            _MergedItem(kind=MediaType.MOVIE, source_index=index, entity=item)
             for index, item in enumerate(movies_page.items)
         ] + [
-            _MergedItem(kind="series", source_index=index, entity=item)
+            _MergedItem(kind=MediaType.SERIES, source_index=index, entity=item)
             for index, item in enumerate(series_page.items)
         ]
         # Sort by (lowercase title, source index) — the source index
@@ -153,7 +154,7 @@ class ListByGenreUseCase:
         last_movie_index: int | None = None
         last_series_index: int | None = None
         for item in page_items:
-            if item.kind == "movie":
+            if item.kind is MediaType.MOVIE:
                 last_movie_index = item.source_index
             else:
                 last_series_index = item.source_index
@@ -188,7 +189,7 @@ class ListByGenreUseCase:
         genre: Genre,
         decoded: DualCursorValue,
         limit: int,
-        media_type: Literal["movie", "series"] | None,
+        media_type: MediaType | None,
         allowed_library_ids: Sequence[LibraryId],
     ) -> tuple[PaginatedResult[Movie], PaginatedResult[Series]]:
         """Fetch the movie and series pages, honoring the media-type filter.
@@ -203,7 +204,7 @@ class ListByGenreUseCase:
         shape and the "previous cursor stays put if nothing is consumed"
         semantics of the merge sort.
         """
-        if media_type == "movie":
+        if media_type is MediaType.MOVIE:
             async with self._uow_factory() as uow:
                 movies_page = await uow.movies.list_paginated_by_genre(
                     genre=genre,
@@ -212,7 +213,7 @@ class ListByGenreUseCase:
                     allowed_library_ids=allowed_library_ids,
                 )
             return movies_page, _empty_page(Series)
-        if media_type == "series":
+        if media_type is MediaType.SERIES:
             async with self._uow_factory() as uow:
                 series_page = await uow.series.list_paginated_by_genre(
                     genre=genre,
@@ -306,12 +307,12 @@ class ListByGenreUseCase:
         return encode_dual_cursor(next_movies_cursor, next_series_cursor)
 
     @staticmethod
-    def _to_output(kind: str, item: Movie | Series, lang: str) -> CatalogItemOutput:
+    def _to_output(kind: MediaType, item: Movie | Series, lang: str) -> CatalogItemOutput:
         """Convert a movie/series entity into the catalog row DTO."""
         if isinstance(item, Movie):
             return CatalogItemOutput(
                 id=str(item.id),
-                type=kind,
+                type=kind.value,
                 title=item.get_title(lang),
                 year=item.year.value,
                 synopsis=item.get_synopsis(lang),

--- a/src/modules/media/application/use_cases/list_conflicts.py
+++ b/src/modules/media/application/use_cases/list_conflicts.py
@@ -158,11 +158,11 @@ def _build_summary(
 
 def _build_candidate(
     media_id: str,
-    media_type: str,
+    media_type: MediaType,
     movies_by_id: dict[str, Movie],
 ) -> ConflictCandidateSummary:
     """Hydrate one side of the pair with the looked-up movie (when present)."""
-    if media_type == "movie":
+    if media_type is MediaType.MOVIE:
         movie = movies_by_id.get(media_id)
         if movie is not None:
             return ConflictCandidateSummary(

--- a/src/modules/media/application/use_cases/list_genres.py
+++ b/src/modules/media/application/use_cases/list_genres.py
@@ -10,6 +10,7 @@ from src.modules.media.application.ports.profile_library_access_port import (
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.repositories.movie_repository import GenreRow
+from src.shared_kernel.value_objects import MediaType
 
 
 class ListGenresUseCase:
@@ -84,7 +85,7 @@ class ListGenresUseCase:
                     input_dto.lang,
                     allowed_library_ids=allowed,
                 )
-                if input_dto.media_type != "series"
+                if input_dto.media_type is not MediaType.SERIES
                 else []
             )
             series_rows = (
@@ -92,7 +93,7 @@ class ListGenresUseCase:
                     input_dto.lang,
                     allowed_library_ids=allowed,
                 )
-                if input_dto.media_type != "movie"
+                if input_dto.media_type is not MediaType.MOVIE
                 else []
             )
 

--- a/src/modules/media/application/use_cases/search_catalog.py
+++ b/src/modules/media/application/use_cases/search_catalog.py
@@ -13,6 +13,7 @@ from src.modules.media.application.ports.profile_library_access_port import (
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
+from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.library_id import LibraryId
 
 
@@ -63,9 +64,9 @@ class SearchCatalogUseCase:
         movie_hits: list[tuple[Movie, float]] = []
         series_hits: list[tuple[Series, float]] = []
 
-        if input_dto.media_type == "movie":
+        if input_dto.media_type is MediaType.MOVIE:
             movie_hits = await self._search_movies(input_dto, allowed)
-        elif input_dto.media_type == "series":
+        elif input_dto.media_type is MediaType.SERIES:
             series_hits = await self._search_series(input_dto, allowed)
         else:
             movie_hits, series_hits = await asyncio.gather(

--- a/src/modules/media/presentation/routes/catalog_routes.py
+++ b/src/modules/media/presentation/routes/catalog_routes.py
@@ -1,7 +1,7 @@
 """Catalog (cross-cutting movies + series) REST API routes."""
 
 from dataclasses import asdict
-from typing import Any, Literal
+from typing import Any
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
@@ -13,7 +13,6 @@ from src.modules.media.application.dtos.catalog_dtos import (
     ListByGenreInput,
     ListGenresInput,
     ListRecentlyAddedCatalogInput,
-    MediaTypeFilter,
 )
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
@@ -25,13 +24,14 @@ from src.modules.media.application.use_cases.list_recently_added_catalog import 
     ListRecentlyAddedCatalogUseCase,
 )
 from src.modules.media.presentation.dependencies import resolve_profile_id
+from src.shared_kernel.value_objects import MediaType
 
 router = APIRouter(prefix="/api/v1/catalog", tags=["Catalog"])
 
 # Shared OpenAPI/validation config for the `?type=` query param. Kept
 # as a module-level constant so both routes stay identical and changes
 # to the description show up in a single place.
-_MEDIA_TYPE_QUERY: MediaTypeFilter | None = Query(
+_MEDIA_TYPE_QUERY: MediaType | None = Query(
     default=None,
     description=(
         "Optional filter — restrict the result to a single media type. "
@@ -44,7 +44,7 @@ _MEDIA_TYPE_QUERY: MediaTypeFilter | None = Query(
 @inject  # type: ignore[misc]
 async def list_genres(
     lang: str = "en",
-    type: Literal["movie", "series"] | None = _MEDIA_TYPE_QUERY,
+    type: MediaType | None = _MEDIA_TYPE_QUERY,
     profile_id: str = Depends(resolve_profile_id),
     use_case: ListGenresUseCase = Depends(
         Provide[ApplicationContainer.media.list_genres],
@@ -81,7 +81,7 @@ async def list_by_genre(
     cursor: str | None = None,
     limit: int = DEFAULT_PAGE_SIZE,
     lang: str = "en",
-    type: Literal["movie", "series"] | None = _MEDIA_TYPE_QUERY,
+    type: MediaType | None = _MEDIA_TYPE_QUERY,
     profile_id: str = Depends(resolve_profile_id),
     use_case: ListByGenreUseCase = Depends(
         Provide[ApplicationContainer.media.list_by_genre],

--- a/src/modules/media/presentation/routes/search_routes.py
+++ b/src/modules/media/presentation/routes/search_routes.py
@@ -1,7 +1,7 @@
 """Catalog search REST API route."""
 
 from dataclasses import asdict
-from typing import Any, Literal
+from typing import Any
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
@@ -12,6 +12,7 @@ from src.config.containers import ApplicationContainer
 from src.modules.media.application.dtos.search_dtos import SearchInput
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
 from src.modules.media.presentation.dependencies import resolve_profile_id
+from src.shared_kernel.value_objects import MediaType
 
 router = APIRouter(prefix="/api/v1", tags=["Search"])
 
@@ -20,7 +21,7 @@ router = APIRouter(prefix="/api/v1", tags=["Search"])
 @inject  # type: ignore[misc]
 async def search(
     q: str = Query(..., min_length=1, description="Full-text search query"),
-    type: Literal["movie", "series"] | None = Query(
+    type: MediaType | None = Query(
         default=None,
         description="Restrict to a single media type",
     ),

--- a/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
@@ -15,6 +15,7 @@ from src.modules.media.application.dtos.catalog_dtos import (
 )
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.domain.entities import Movie, Series
+from src.shared_kernel.value_objects import MediaType
 from tests.modules.media.unit.conftest import (
     FakeProfileLibraryAccessPort,
     make_media_uow_mock,
@@ -234,7 +235,7 @@ class TestListByGenreUseCase:
 
     @pytest.mark.asyncio
     async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
-        # media_type="movie" restricts the merge to the movie stream
+        # media_type=MediaType.MOVIE restricts the merge to the movie stream
         # — series repo stays silent so the output is a pure movies
         # listing for the Movies tab.
         mocks = make_media_uow_mock()
@@ -244,7 +245,7 @@ class TestListByGenreUseCase:
         use_case = _make_use_case(mocks)
 
         result = await use_case.execute(
-            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", media_type="movie")
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", media_type=MediaType.MOVIE)
         )
 
         mocks.movies.list_paginated_by_genre.assert_awaited_once()
@@ -261,7 +262,7 @@ class TestListByGenreUseCase:
         use_case = _make_use_case(mocks)
 
         result = await use_case.execute(
-            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", media_type="series")
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", media_type=MediaType.SERIES)
         )
 
         mocks.series.list_paginated_by_genre.assert_awaited_once()
@@ -293,7 +294,7 @@ class TestListByGenreUseCase:
                 genre="Action",
                 cursor=previous_cursor,
                 limit=2,
-                media_type="movie",
+                media_type=MediaType.MOVIE,
             )
         )
 

--- a/tests/modules/media/unit/application/use_cases/test_list_genres.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_genres.py
@@ -10,6 +10,7 @@ from src.modules.media.application.dtos.catalog_dtos import (
 )
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
 from src.modules.media.domain.repositories.movie_repository import GenreRow
+from src.shared_kernel.value_objects import MediaType
 from tests.modules.media.unit.conftest import (
     FakeProfileLibraryAccessPort,
     make_media_uow_mock,
@@ -161,7 +162,7 @@ class TestListGenresUseCase:
 
     @pytest.mark.asyncio
     async def test_should_skip_series_repo_when_filtered_to_movies(self) -> None:
-        # media_type="movie" restricts the aggregation to the movie
+        # media_type=MediaType.MOVIE restricts the aggregation to the movie
         # repo — the series repo must not be called at all so the
         # counts reflect movies only (and the Movies tab on the
         # frontend doesn't surface series-only genres).
@@ -173,7 +174,9 @@ class TestListGenresUseCase:
             profile_library_access=make_profile_library_access(),
         )
 
-        result = await use_case.execute(ListGenresInput(profile_id=_PROFILE_ID, media_type="movie"))
+        result = await use_case.execute(
+            ListGenresInput(profile_id=_PROFILE_ID, media_type=MediaType.MOVIE)
+        )
 
         mocks.movies.list_genre_rows.assert_awaited_once()
         mocks.series.list_genre_rows.assert_not_awaited()
@@ -192,7 +195,7 @@ class TestListGenresUseCase:
         )
 
         result = await use_case.execute(
-            ListGenresInput(profile_id=_PROFILE_ID, media_type="series")
+            ListGenresInput(profile_id=_PROFILE_ID, media_type=MediaType.SERIES)
         )
 
         mocks.series.list_genre_rows.assert_awaited_once()

--- a/tests/modules/media/unit/application/use_cases/test_search_catalog.py
+++ b/tests/modules/media/unit/application/use_cases/test_search_catalog.py
@@ -10,6 +10,7 @@ from src.modules.media.application.dtos.search_dtos import (
 )
 from src.modules.media.application.use_cases.search_catalog import SearchCatalogUseCase
 from src.modules.media.domain.entities import Movie, Series
+from src.shared_kernel.value_objects import MediaType
 from tests.modules.media.unit.conftest import (
     FakeProfileLibraryAccessPort,
     make_media_uow_mock,
@@ -69,7 +70,7 @@ class TestSearchCatalogUseCase:
         )
 
         result = await use_case.execute(
-            SearchInput(profile_id=_PROFILE_ID, query="avatar", media_type="movie")
+            SearchInput(profile_id=_PROFILE_ID, query="avatar", media_type=MediaType.MOVIE)
         )
 
         mocks.movies.search.assert_awaited_once()
@@ -87,7 +88,7 @@ class TestSearchCatalogUseCase:
         )
 
         result = await use_case.execute(
-            SearchInput(profile_id=_PROFILE_ID, query="dark", media_type="series")
+            SearchInput(profile_id=_PROFILE_ID, query="dark", media_type=MediaType.SERIES)
         )
 
         mocks.series.search.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Replace the internal `MediaTypeFilter = Literal["movie", "series"]` alias and the scattered `Literal["movie", "series"]` annotations with the canonical `MediaType` enum (ADR-016 deferred bucket, step 3 of 3 — final)
- Typed surfaces: catalog/search query params (`?type=`), `ListGenresInput`/`ListByGenreInput`/`SearchInput.media_type`, `ConflictCandidateSummary.media_type`, and the internal `_MergedItem.kind` discriminator in `list_by_genre`
- Literal comparisons replaced with enum identity: `== "movie"` → `is MediaType.MOVIE` in `list_genres`, `list_by_genre`, `search_catalog`, `list_conflicts`
- `MediaType` query params give FastAPI a real OpenAPI enum + 422 on bad values, instead of a bare Literal

## Out of scope (intentionally untouched)

- TMDB `tv` vocabulary at the edge (`search_tmdb_titles`, `get_movie_tmdb_suggestions`, admin relink/lookup DTOs) — mirrors `/search/tv`, correct as-is per ADR-016
- `WatchableMediaType` (movie/episode) — a different concept (playback granularity)
- `GetFeaturedInput.media_type` — three-valued (`all`/movie/series), doesn't map cleanly onto the two-member enum without an API change

## Test plan

- [x] Full suite: 2716 passed, 5 skipped
- [x] `ruff check` + `ruff format` clean
- [x] Response wire format unchanged (`CatalogItemOutput.type` stays `str` via `.value`; StrEnum serializes identically)

## Related issues

- ADR-016 deferred bucket — final step (RequestedMediaType ✅ → CollectionMediaType alias ✅ → **Literal consolidation**). Completes the ADR-016 MediaType consolidation.

## Summary by Sourcery

Consolidate media-type handling across catalog, search, genre, and conflict flows to use the shared MediaType enum instead of string Literals.

New Features:
- Expose catalog and search media-type query parameters as OpenAPI enums via MediaType, improving validation of ?type= filters.

Enhancements:
- Align DTOs, use cases, and internal discriminators on the canonical MediaType enum for movies and series.
- Update conflict and catalog outputs to carry MediaType while preserving existing wire-format strings via enum values.

Tests:
- Adjust catalog, genre, and search unit tests to assert behavior using MediaType enum filters instead of string literals.