### PR TITLE
docs(adr): mark ADR-016 as Aceito

### DIFF
--- a/docs/adr/ADR-016-media-type-value-object.md
+++ b/docs/adr/ADR-016-media-type-value-object.md
@@ -1,6 +1,6 @@
 # ADR-016: MediaType como Value Object compartilhado
 
-**Status:** Proposto
+**Status:** Aceito
 **Data:** 2026-05-31
 **Deciders:** Lucas Cristovam
 **Technical Story:** Revisão de code smells (Fase 1) — o discriminador "movie | series" é stringly-typed em estado persistido e em eventos de domínio.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-013](./ADR-013-runtime-settings-db-backed.md) | Runtime Settings Persistidos em Banco para Tunables Operacionais | ✅ Aceito | 2026-05-21 |
 | [ADR-014](./ADR-014-settings-per-bucket-aggregate.md) | Settings — Aggregate por Bucket (não Mega-Aggregate) | ✅ Aceito | 2026-05-21 |
 | [ADR-015](./ADR-015-scanner-deduplication-by-content-identity.md) | Scanner Deduplication by Content Identity | 🟡 Proposto | 2026-05-23 |
-| [ADR-016](./ADR-016-media-type-value-object.md) | MediaType como Value Object compartilhado | 🟡 Proposto | 2026-05-31 |
+| [ADR-016](./ADR-016-media-type-value-object.md) | MediaType como Value Object compartilhado | ✅ Aceito | 2026-05-31 |
 | [ADR-017](./ADR-017-domain-invariants-in-domain-layer.md) | Invariantes de domínio na camada de domínio | ✅ Aceito | 2026-06-04 |
 | [ADR-018](./ADR-018-domain-identifiers-as-vos-at-boundaries.md) | Identificadores de domínio como Value Objects nas fronteiras | ✅ Aceito | 2026-06-04 |
 


### PR DESCRIPTION
## Summary

- Promote ADR-016 (MediaType como Value Object compartilhado) from **Proposto** to **Aceito** — the decision is fully implemented: the canonical `MediaType` shipped in Fase 1 (#246-250) and the deferred consolidation bucket just completed (#269 RequestedMediaType collapse, #270 CollectionMediaType alias removal, #271 Literal consolidation)
- Sync the status badge in `docs/adr/README.md`

## Notes

- ADR-018 was already `Aceito`, so no change needed there
- Docs-only; original `Data` (2026-05-31) kept, matching the ADR-017/018 convention

## Test plan

- [x] N/A — documentation-only change

## Summary by Sourcery

Documentation:
- Mark ADR-016 as accepted in its ADR document and update the ADR index table to show ADR-016 as accepted.