### PR TITLE
fix(media): apply h264_mp4toannexb on HLS copy path

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -804,7 +804,15 @@ class HlsService(HlsPlaylistPort):
             video_args = ["-c:v", "libx264", "-preset", "ultrafast", "-crf", "23"]
         else:
             _logger.info("Source codec %s — copying", codec)
-            video_args = ["-c:v", "copy"]
+            # H.264 inside MP4/MKV is AVCC (length-prefixed NALs) with
+            # SPS/PPS only in container extradata. The HLS muxer does not
+            # reliably auto-insert the Annex-B conversion the bare mpegts
+            # muxer applies, so sources that don't repeat parameter sets
+            # in-band lose them in the .ts segments — the browser decodes
+            # zero frames (black video, audio fine). h264_mp4toannexb
+            # converts to Annex-B and writes SPS/PPS in-band; it is a
+            # no-op for streams already in Annex-B form.
+            video_args = ["-c:v", "copy", "-bsf:v", "h264_mp4toannexb"]
 
         primary_idx = _primary_audio_index(probe)
         audio_map = f"0:a:{primary_idx}"

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -401,6 +401,22 @@ class TestHlsServiceBuildVideoCmd:
         assert "copy" in cmd
         assert "libx264" not in cmd
 
+    def test_should_annexb_bitstream_filter_on_h264_copy(self, tmp_path: Path) -> None:
+        # AVCC-packaged H.264 (SPS/PPS only in container extradata) loses
+        # its parameter sets when copied into MPEG-TS because the HLS muxer
+        # does not auto-insert the Annex-B conversion. Without the filter
+        # the browser decodes zero frames — black video, audio fine.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "cache")
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "-bsf:v" in cmd
+        assert cmd[cmd.index("-bsf:v") + 1] == "h264_mp4toannexb"
+
     def test_should_transcode_h264_when_start_positive(self, tmp_path: Path) -> None:
         # ``-c:v copy`` is the fast path for cold cache but it skips
         # the decode pass that ``-accurate_seek`` depends on. With a


### PR DESCRIPTION
## Summary

- Fixes black-video-with-working-audio on certain movies (e.g. *Whistle (2026)*, *Greenland 2 Migration (2026)*).
- Root cause: AVCC-packaged H.264 stores SPS/PPS only in container extradata. The ffmpeg **HLS muxer does not auto-insert** the Annex-B conversion the bare `mpegts` muxer applies, so the `-c:v copy` path emits `.ts` segments without parameter sets — the browser decodes **zero frames** (black video; audio plays because it is always re-encoded to AAC). Only "few" titles break: files whose encoder repeats SPS/PPS in-band survive without the filter.
- Fix: add `-bsf:v h264_mp4toannexb` to the copy path in `hls_service.py::_build_video_cmd`. The copy path only runs for H.264, and the filter is a no-op for sources already in Annex-B form, so working titles are unaffected.

## Test plan

- [x] Reproduced with ffmpeg: segment 0 of affected titles had `nb_read_frames=N/A` (no decodable video) before, `250`/`249` after the filter.
- [x] Regression check: a title that already worked (*Ace Ventura (1994)*) still produces `250` frames with the filter.
- [x] Manual smoke test in the player after clearing the HLS cache — affected movies now play video.
- [x] `pytest tests/modules/media/unit/infrastructure/streaming/test_hls_service.py` — 108 passed (incl. new `test_should_annexb_bitstream_filter_on_h264_copy`).
- [x] `ruff check` + `ruff format --check` clean.

> Note: existing broken `.ts` segments must be cleared from the HLS cache for affected titles so they regenerate.

## Summary by Sourcery

Ensure HLS video copy pipeline correctly preserves H.264 parameter sets for browser playback.

Bug Fixes:
- Apply the h264_mp4toannexb bitstream filter when copying H.264 video in the HLS pipeline to prevent black video with audio-only playback for affected sources.

Tests:
- Add a unit test verifying that the HLS H.264 copy path includes the h264_mp4toannexb bitstream filter.