### PR TITLE
feat(media): add GPU hardware transcoding via NVENC

### DIFF
--- a/docs/adr/ADR-019-hardware-accelerated-transcoding.md
+++ b/docs/adr/ADR-019-hardware-accelerated-transcoding.md
@@ -1,0 +1,122 @@
+# ADR-019: Transcodificação por Hardware (NVENC/NVDEC) com Seleção de Encoder Configurável
+
+**Status:** Aceito  
+**Data:** 2026-06-14  
+**Deciders:** Lucas Cristovam  
+**Technical Story:** Banding em gradientes suaves no player (WALL·E, fonte HEVC 10-bit 4K) + CPU saturada durante reprodução e geração de thumbnails. PRs homeflix#274 (backend) e homeflix-web#165 (admin).
+
+---
+
+## Contexto
+
+O pipeline de HLS re-encoda para H.264 toda fonte cujo codec de vídeo não é diretamente reproduzível no browser (qualquer coisa fora de `{"h264"}`), e remuxa (`-c:v copy`) quando já é H.264. Fontes modernas de filme — HEVC/H.265, frequentemente 10-bit e 4K — caem no caminho de re-encode.
+
+Esse re-encode rodava em **software** com `libx264 -preset ultrafast -crf 23`. Dois problemas concretos surgiram:
+
+1. **Qualidade.** `ultrafast` desliga CABAC e adaptive quantization, o que colapsa gradientes suaves (céu, névoa) em macroblocos visíveis. O mesmo conteúdo no VLC (que decodifica o HEVC original, sem re-encode) ficava liso.
+2. **Custo de CPU.** Encodar 4K HEVC→H.264 por software em tempo real satura a CPU (medido ~92% nos 24 threads de um Ryzen 9 7900X). A geração de **sprites de scrub-preview** agrava o quadro: decodifica o filme 4K HEVC *inteiro* por software, em passes concorrentes.
+
+A máquina-alvo tem uma GPU NVIDIA (RTX 4070 Ti SUPER) com NVENC/NVDEC dedicados, ociosa enquanto a CPU gargalava. Benchmark do pipeline full-GPU (`-hwaccel cuda` → `scale_cuda=format=nv12` → `h264_nvenc`) deu ~1,6× tempo real em 4K com CPU ≈ 0%.
+
+O HomeFlix já tem infraestrutura para tunables operacionais persistidos (ADR-013) com um aggregate por bucket (ADR-014); `StreamingConfig` já existia para `ffmpeg_threads` e `hls_cache_max_size_mb`.
+
+## Decisão
+
+**Vamos delegar à GPU todo trabalho de ffmpeg que seja decode/encode de vídeo, controlado por um único knob persistido `StreamingConfig.hw_accel`.**
+
+- **Novo Value Object** `HardwareAccel` (StrEnum: `auto` | `nvenc` | `off`), campo `hw_accel` em `StreamingConfig`, default `auto`. Persistido como JSON em `app_settings`; retrocompatível (chave ausente → `auto`, sem migration).
+  - `auto` — sonda funcionalmente o NVENC uma vez (encode sintético descartável via `lavfi`) e usa se funcionar; senão cai para software. Default seguro: host sem GPU NVIDIA fica em software sozinho.
+  - `nvenc` — força NVENC, pulando o probe. Encoder quebrado vira falha de transcode (sem fallback silencioso).
+  - `off` — força software, ignorando qualquer GPU (CI, containers sem `--gpus`, A/B).
+- **HLS transcode** (`hls_service.py`): caminho full-GPU para fontes que precisam de re-encode — `-hwaccel cuda -hwaccel_output_format cuda` (decode NVDEC) → `scale_cuda=format=nv12` (conversão 10→8 bit em VRAM) → `h264_nvenc -preset p5 -tune hq -rc vbr -cq 19 -spatial_aq 1`. O fallback de software sai do `ultrafast` para `superfast -crf 20 -pix_fmt yuv420p`.
+- **Sprites de scrub-preview** (`thumbnail_service.py`): o decode do filme inteiro vai para a NVDEC (`-hwaccel cuda`, decode-only — os filtros `scale`/`pad`/`tile` seguem na CPU sobre frames já baixados, pois `tile` não tem equivalente CUDA e o custo pós-downscale é pequeno). Com retry automático em software numa falha rápida de hwaccel e **sem** retry em timeout.
+- **Desacoplamento de módulo** (ADR-008): `media` é infraestrutura consumidora; compara `hw_accel` pelo valor do StrEnum (`"off"`/`"nvenc"`) sem importar o VO de `settings` em runtime — `media` só importa `settings` sob `TYPE_CHECKING`, seguindo o precedente existente.
+
+**Auditoria de delegação à GPU (escopo desta decisão).** Nem todo ffmpeg é candidato — só decode/encode de vídeo. O levantamento de todas as invocações:
+
+| Serviço | Trabalho ffmpeg | Candidato a GPU? | Estado |
+|---|---|---|---|
+| HLS — transcode de vídeo | decode + encode H.264 | **Sim** | ✅ NVDEC + NVENC |
+| Sprite de scrub-preview | decode do filme inteiro | **Sim** | ✅ NVDEC (decode) |
+| HLS — áudio primário/alternativo | decode de áudio + encode AAC | Não (áudio) | — |
+| Extração de legenda | remux de legenda de texto p/ WebVTT | Não (texto) | — |
+| Extração de áudio (intro detection) | janela de áudio → WAV | Não (áudio) | — |
+| Fingerprint de intro (fpcalc) | chromaprint | Não (áudio) | — |
+| Probe (`ffprobe`) | só metadados | Não | — |
+
+NVENC/NVDEC aceleram apenas vídeo; áudio, legenda de texto e fingerprinting são CPU-bound mas baratos. **Os dois únicos caminhos pesados de vídeo já estão na GPU; nenhum outro serviço se beneficia.**
+
+## Consequências
+
+### Positivas
+
+- CPU praticamente livre no transcode 4K do player e na geração de sprites (medido ~0% vs ~92%).
+- Banding resolvido na GPU (`spatial_aq`) e também no fallback de software (saída do `ultrafast`).
+- Comportamento controlável por host sem recompilar, via `/admin` → Settings → Streaming (admin control no homeflix-web#165).
+- Default `auto` é seguro e portável: degrada para software onde não há GPU.
+
+### Negativas
+
+- Acopla a qualidade/custo do streaming à presença de uma GPU NVIDIA + driver + build de ffmpeg com NVENC. Em outros vendors (Intel QSV, AMD AMF, VAAPI) o `auto` não detecta nada e fica em software.
+- O caminho HLS full-GPU **não tem fallback de software por-arquivo**: uma fonte que a NVDEC não decodifica falha aquele transcode (escape hatch: `hw_accel=off`).
+- Matriz de teste cresce: caminhos GPU não rodam em CI sem GPU (cobertos por testes que mockam o probe/detecção).
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Fonte não-decodável pela NVDEC quebra o transcode HLS | Baixa (biblioteca é codec mainstream) | Médio | `hw_accel=off`; fallback per-arquivo é follow-up |
+| Probe NVENC passa mas encode real falha sob contenção de sessões | Baixa | Médio | `nvenc` força sem probe; `off` como escape; falha vira erro de geração, não corrupção |
+| Limites de sessões NVENC concorrentes (cards consumer) | Baixa (uso pessoal, poucas sessões) | Baixo | Eviction de ffmpeg idle já existente (ADR de runtime settings) |
+
+## Alternativas Consideradas
+
+### 1. Continuar em software, só ajustando o preset
+
+Trocar `ultrafast` por `superfast`/`veryfast` e baixar o CRF.
+
+**Rejeitado porque:** resolve o banding mas não o custo de CPU — encode 4K por software em tempo real continua saturando a máquina, com risco de rebuffer. (Mantido apenas como *fallback* quando não há GPU.)
+
+### 2. Downscale para 1080p no caminho de software
+
+Escalar 4K→1080p para caber um preset melhor no mesmo orçamento de CPU.
+
+**Rejeitado porque:** degrada a resolução entregue e ainda gasta CPU; a GPU resolve sem abrir mão do 4K. Pode voltar como opção futura (`max_transcode_height`) ortogonal a esta decisão.
+
+### 3. Hardcode do NVENC, sem knob nem fallback
+
+Trocar o bloco de software direto por NVENC fixo.
+
+**Rejeitado porque:** quebra em qualquer ambiente sem GPU NVIDIA (CI, Docker, outra máquina) e foge da convenção de tunables persistidos (ADR-013/014).
+
+### 4. Pré-converter a biblioteca para H.264 offline
+
+Transcodar tudo uma vez para H.264 8-bit, deixando o playback como puro remux.
+
+**Rejeitado (por ora) porque:** custa disco (cópia duplicada) e descarta a fonte de maior qualidade; é um trade-off de produto diferente. Não conflita com esta decisão e pode coexistir no futuro.
+
+## Referências
+
+- PR backend: lucaschf/homeflix#274
+- PR admin (knob no frontend): lucaschf/homeflix-web#165
+- ADR-013 (Runtime Settings persistidos), ADR-014 (Aggregate por bucket), ADR-008 (direção de dependência entre módulos)
+- `docs/roadmap.md` — Phase 3.2 (Hardware transcoding VAAPI/NVENC)
+
+---
+
+## Notas de Implementação
+
+Seleção de encoder (decode-only para sprite, full-GPU para HLS):
+
+```python
+# HLS — full-GPU quando hw_accel resolve para NVENC
+hwaccel_input_args = ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
+vf_args = ["-vf", "scale_cuda=format=nv12"]               # 10->8 bit em VRAM
+video_args = ["-c:v", "h264_nvenc", "-preset", "p5", "-tune", "hq",
+              "-rc", "vbr", "-cq", "19", "-b:v", "0", "-spatial_aq", "1"]
+
+# Sprite — decode na NVDEC, filtros scale/pad/tile na CPU
+hwaccel_args = ["-hwaccel", "cuda"] if use_hwaccel else []
+```
+
+Extensão futura natural: trocar `HardwareAccel` por uma seleção mais rica (`qsv`, `amf`, `vaapi`) e/ou adicionar `max_transcode_height`, sem mudar a fronteira da decisão (encoder configurável + fallback de software).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-016](./ADR-016-media-type-value-object.md) | MediaType como Value Object compartilhado | ✅ Aceito | 2026-05-31 |
 | [ADR-017](./ADR-017-domain-invariants-in-domain-layer.md) | Invariantes de domínio na camada de domínio | ✅ Aceito | 2026-06-04 |
 | [ADR-018](./ADR-018-domain-identifiers-as-vos-at-boundaries.md) | Identificadores de domínio como Value Objects nas fronteiras | ✅ Aceito | 2026-06-04 |
+| [ADR-019](./ADR-019-hardware-accelerated-transcoding.md) | Transcodificação por Hardware (NVENC/NVDEC) com Seleção de Encoder Configurável | ✅ Aceito | 2026-06-14 |
 
 ## Como Criar um Novo ADR
 

--- a/src/modules/media/infrastructure/streaming/_subprocess.py
+++ b/src/modules/media/infrastructure/streaming/_subprocess.py
@@ -7,6 +7,15 @@ subprocess.run() call in the streaming package stays consistent.
 from types import MappingProxyType
 from typing import Any
 
+# HardwareAccel.* string values, compared by value (HardwareAccel is a
+# StrEnum) so the streaming infrastructure stays decoupled from the
+# settings domain — media imports settings only under TYPE_CHECKING
+# (ADR-008). Kept here, beside the other shared ffmpeg helpers, so the
+# HLS and thumbnail services read one source of truth instead of each
+# carrying its own copy.
+HW_ACCEL_OFF = "off"
+HW_ACCEL_NVENC = "nvenc"
+
 # Match against the binary's basename so absolute paths
 # (``/usr/bin/ffmpeg``) and the Windows executable suffix
 # (``ffmpeg.exe``) both flow through the cap. A bare ``cmd[0] ==

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -50,6 +50,8 @@ from src.modules.media.application.ports.hls_playlist_port import (
 )
 from src.modules.media.application.ports.media_probe_port import ProbeResult
 from src.modules.media.infrastructure.streaming._subprocess import (
+    HW_ACCEL_NVENC,
+    HW_ACCEL_OFF,
     SUBPROCESS_TEXT_KWARGS,
     with_ffmpeg_threads,
 )
@@ -88,11 +90,15 @@ _EVICTION_INTERVAL = 10.0
 
 _VIDEO_DIR = "video"
 
-# HardwareAccel.* string values. Compared by value (HardwareAccel is a
-# StrEnum) so this infrastructure stays decoupled from the settings
-# domain — media imports settings only under TYPE_CHECKING (ADR-008).
-_HW_ACCEL_OFF = "off"
-_HW_ACCEL_NVENC = "nvenc"
+# Wall-clock cap for the one-time NVENC functional probe. Deliberately
+# generous: the probe is the process's first CUDA call, so it absorbs the
+# cold driver / context init, which was measured at ~20s on a cold but
+# perfectly working GPU. Cutting this to a few seconds would time out
+# that cold init and make AUTO mode fall back to software on a host that
+# actually has a usable encoder — the exact false negative this feature
+# exists to avoid. The cost (a longer first play once per process on a
+# hung driver) fits inside the 120s first-segment budget.
+_NVENC_PROBE_TIMEOUT = 30
 
 # -- Module helpers -----------------------------------------------------------
 
@@ -835,7 +841,7 @@ class HlsService(HlsPlaylistPort):
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 check=False,
-                timeout=30,
+                timeout=_NVENC_PROBE_TIMEOUT,
             )
         except (OSError, subprocess.SubprocessError):
             return False
@@ -862,9 +868,9 @@ class HlsService(HlsPlaylistPort):
         back), and ``auto`` defers to the cached functional probe.
         """
         mode = self._runtime_settings.streaming_snapshot_sync().hw_accel
-        if mode == _HW_ACCEL_OFF:
+        if mode == HW_ACCEL_OFF:
             return False
-        if mode == _HW_ACCEL_NVENC:
+        if mode == HW_ACCEL_NVENC:
             return True
         return self._nvenc_available()
 

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -57,7 +57,7 @@ from src.modules.media.infrastructure.streaming.media_probe_service import Media
 
 if TYPE_CHECKING:
     from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
-    from src.shared_kernel.value_objects.tracks import SubtitleTrack
+    from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 _logger = logging.getLogger(__name__)
 
@@ -100,6 +100,39 @@ _HW_ACCEL_NVENC = "nvenc"
 def _primary_audio_index(probe: ProbeResult) -> int:
     """Get the index of the primary audio track (first one, always index 0)."""
     return probe.audio_tracks[0].index if probe.audio_tracks else 0
+
+
+def _audio_args_for(track: AudioTrack | None, start: int) -> list[str]:
+    """Pick the ffmpeg audio args for one HLS track: copy or re-encode.
+
+    Re-encoding every audio track to AAC stereo 48 kHz is wasted work
+    when the source already *is* browser-playable AAC. We remux with
+    ``-c:a copy`` only when the track is unambiguously safe to drop into
+    MPEG-TS untouched:
+
+    - **AAC-LC** — the one AAC profile MSE/hls.js decode everywhere;
+      HE-AAC (SBR/PS) is excluded because browser support is spotty.
+    - **stereo** — multichannel must be downmixed to 2.0 for the player.
+    - **48 kHz** — matches the rate the re-encode path normalises to, so
+      a copied stream is byte-for-byte what a transcode would have
+      targeted.
+    - **start == 0** — a non-zero resume offset re-encodes the video with
+      ``-accurate_seek``; copying the audio there would land it at the
+      nearest packet instead of the exact second and drift out of sync.
+
+    Anything else (unknown profile/rate, non-AAC, surround, mid-stream
+    seek) falls back to the safe AAC re-encode.
+    """
+    if (
+        track is not None
+        and start == 0
+        and track.codec == "aac"
+        and track.is_stereo
+        and track.sample_rate == 48000
+        and (track.profile or "").strip().upper() == "LC"
+    ):
+        return ["-c:a", "copy"]
+    return ["-c:a", "aac", "-ac", "2", "-ar", "48000"]
 
 
 class HlsService(HlsPlaylistPort):
@@ -640,7 +673,7 @@ class HlsService(HlsPlaylistPort):
                 audio_dir = output_dir / f"audio_{track.index}"
                 audio_dir.mkdir()
                 cmd = with_ffmpeg_threads(
-                    self._build_audio_cmd(safe_path, audio_dir, track.index, bucket_start),
+                    self._build_audio_cmd(safe_path, audio_dir, track, bucket_start),
                     ffmpeg_threads,
                 )
                 _logger.info(
@@ -941,6 +974,8 @@ class HlsService(HlsPlaylistPort):
 
         primary_idx = _primary_audio_index(probe)
         audio_map = f"0:a:{primary_idx}"
+        primary_track = probe.audio_tracks[0] if probe.audio_tracks else None
+        audio_args = _audio_args_for(primary_track, start)
 
         seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
         ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
@@ -958,12 +993,7 @@ class HlsService(HlsPlaylistPort):
             "-sn",
             *vf_args,
             *video_args,
-            "-c:a",
-            "aac",
-            "-ac",
-            "2",
-            "-ar",
-            "48000",
+            *audio_args,
             *ts_normalize_args,
             "-hls_time",
             str(_SEGMENT_DURATION),
@@ -988,7 +1018,7 @@ class HlsService(HlsPlaylistPort):
     def _build_audio_cmd(
         file_path: str,
         output_dir: Path,
-        audio_index: int,
+        track: AudioTrack,
         start: int = 0,
     ) -> list[str]:
         """Build FFmpeg command for audio-only HLS track.
@@ -1000,6 +1030,10 @@ class HlsService(HlsPlaylistPort):
         ``-accurate_seek`` / ``-avoid_negative_ts make_zero`` so a
         switch from primary to alternate audio at a non-zero bucket
         lands on the same source-time second.
+
+        Like the primary audio in ``_build_video_cmd``, a browser-ready
+        AAC-LC stereo 48 kHz source is remuxed with ``-c:a copy`` instead
+        of re-encoded; see :func:`_audio_args_for`.
         """
         seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
         ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
@@ -1009,15 +1043,10 @@ class HlsService(HlsPlaylistPort):
             "-i",
             file_path,
             "-map",
-            f"0:a:{audio_index}",
+            f"0:a:{track.index}",
             "-vn",
             "-sn",
-            "-c:a",
-            "aac",
-            "-ac",
-            "2",
-            "-ar",
-            "48000",
+            *_audio_args_for(track, start),
             *ts_normalize_args,
             "-hls_time",
             str(_SEGMENT_DURATION),
@@ -1221,6 +1250,8 @@ class HlsService(HlsPlaylistPort):
                     "title": t.title,
                     "is_default": t.is_default,
                     "bitrate": t.bitrate,
+                    "sample_rate": t.sample_rate,
+                    "profile": t.profile,
                 }
                 for t in probe.audio_tracks
             ],
@@ -1258,6 +1289,8 @@ class HlsService(HlsPlaylistPort):
                 title=t.get("title"),
                 is_default=t["is_default"],
                 bitrate=t.get("bitrate"),
+                sample_rate=t.get("sample_rate"),
+                profile=t.get("profile"),
             )
             for t in data.get("audio_tracks", [])
         ]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -88,6 +88,12 @@ _EVICTION_INTERVAL = 10.0
 
 _VIDEO_DIR = "video"
 
+# HardwareAccel.* string values. Compared by value (HardwareAccel is a
+# StrEnum) so this infrastructure stays decoupled from the settings
+# domain — media imports settings only under TYPE_CHECKING (ADR-008).
+_HW_ACCEL_OFF = "off"
+_HW_ACCEL_NVENC = "nvenc"
+
 # -- Module helpers -----------------------------------------------------------
 
 
@@ -138,6 +144,9 @@ class HlsService(HlsPlaylistPort):
         self._subtitle_events: dict[str, dict[int, threading.Event]] = {}
         self._lock = threading.Lock()
         self._idle_timeout = idle_timeout
+        # Memoised result of the one-time NVENC functional probe (None
+        # until first transcode in AUTO mode forces the check).
+        self._nvenc_probe: bool | None = None
         if enable_eviction:
             self._start_eviction_thread()
 
@@ -761,6 +770,71 @@ class HlsService(HlsPlaylistPort):
         except Exception:
             return None
 
+    @staticmethod
+    def _detect_nvenc() -> bool:
+        """Functionally probe whether ``h264_nvenc`` can actually encode.
+
+        The encoder being *listed* by ffmpeg is not enough — a host can
+        ship an ffmpeg with NVENC compiled in while lacking the GPU,
+        driver, or a free encode session. We run a sub-second throwaway
+        encode of a synthetic source through CUDA so AUTO mode only
+        commits to NVENC when the full decode→encode path works.
+
+        Returns ``True`` only on a clean (exit 0) probe encode.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-hide_banner",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=c=black:s=256x256:r=10",
+                    "-t",
+                    "0.2",
+                    "-c:v",
+                    "h264_nvenc",
+                    "-f",
+                    "null",
+                    "-",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return result.returncode == 0
+
+    def _nvenc_available(self) -> bool:
+        """Return the memoised NVENC functional-probe result.
+
+        Probed at most once per service instance — the first transcode
+        in AUTO mode pays the ~1s cold-start CUDA init, every later call
+        reads the cached boolean.
+        """
+        if self._nvenc_probe is None:
+            self._nvenc_probe = self._detect_nvenc()
+            _logger.info("NVENC functional probe result: %s", self._nvenc_probe)
+        return self._nvenc_probe
+
+    def _use_nvenc(self) -> bool:
+        """Decide whether this transcode should use NVENC.
+
+        Honours the persisted ``hw_accel`` knob: ``off`` forces
+        software, ``nvenc`` forces hardware (a broken encoder then
+        surfaces as a transcode failure rather than silently falling
+        back), and ``auto`` defers to the cached functional probe.
+        """
+        mode = self._runtime_settings.streaming_snapshot_sync().hw_accel
+        if mode == _HW_ACCEL_OFF:
+            return False
+        if mode == _HW_ACCEL_NVENC:
+            return True
+        return self._nvenc_available()
+
     def _build_video_cmd(
         self,
         file_path: str,
@@ -795,13 +869,64 @@ class HlsService(HlsPlaylistPort):
         copied video would land at the preceding keyframe while the
         re-encoded audio lands at the exact ``start``, recreating the
         same 1-3s gap the seek flag was meant to close.
+
+        When a transcode is required and ``hw_accel`` resolves to NVENC,
+        the whole pipeline runs on the GPU: ``-hwaccel cuda`` decodes
+        with NVDEC, ``scale_cuda=format=nv12`` does the 10-bit→8-bit
+        conversion in VRAM, and ``h264_nvenc`` encodes — keeping the CPU
+        almost idle and staying well above real-time on 4K HEVC. The
+        software ``libx264`` path is the fallback.
         """
         codec = self._probe_video_codec(file_path)
         needs_transcode = codec not in _BROWSER_SAFE_CODECS or start > 0
 
-        if needs_transcode:
-            _logger.info("Source codec %s — transcoding to H.264 (start=%d)", codec, start)
-            video_args = ["-c:v", "libx264", "-preset", "ultrafast", "-crf", "23"]
+        hwaccel_input_args: list[str] = []
+        vf_args: list[str] = []
+
+        if needs_transcode and self._use_nvenc():
+            _logger.info("Source codec %s — transcoding via NVENC (start=%d)", codec, start)
+            # Full-GPU pipeline: NVDEC decode → scale_cuda (10→8 bit in
+            # VRAM) → NVENC encode. ``spatial_aq`` redistributes bits to
+            # flat regions, which is what keeps sky/fog gradients from
+            # banding. ``-cq 19`` is constant-quality VBR (``-b:v 0``).
+            hwaccel_input_args = ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
+            vf_args = ["-vf", "scale_cuda=format=nv12"]
+            video_args = [
+                "-c:v",
+                "h264_nvenc",
+                "-preset",
+                "p5",
+                "-tune",
+                "hq",
+                "-rc",
+                "vbr",
+                "-cq",
+                "19",
+                "-b:v",
+                "0",
+                "-spatial_aq",
+                "1",
+            ]
+        elif needs_transcode:
+            _logger.info("Source codec %s — transcoding via libx264 (start=%d)", codec, start)
+            # ``superfast`` (not ``ultrafast``) is the floor here: ultrafast
+            # disables CABAC and adaptive quantization, which is exactly what
+            # collapses smooth gradients (sky, fog) into visible macroblocks
+            # on HEVC/10-bit sources re-encoded to H.264. superfast turns both
+            # back on for a moderate CPU cost while staying real-time on 4K.
+            # ``-pix_fmt yuv420p`` forces a clean 8-bit output so 10-bit
+            # sources (yuv420p10le) downconvert through swscale's dithering
+            # instead of producing an unplayable High 10 stream.
+            video_args = [
+                "-c:v",
+                "libx264",
+                "-preset",
+                "superfast",
+                "-crf",
+                "20",
+                "-pix_fmt",
+                "yuv420p",
+            ]
         else:
             _logger.info("Source codec %s — copying", codec)
             # H.264 inside MP4/MKV is AVCC (length-prefixed NALs) with
@@ -822,6 +947,7 @@ class HlsService(HlsPlaylistPort):
 
         return [
             "ffmpeg",
+            *hwaccel_input_args,
             *seek_args,
             "-i",
             file_path,
@@ -830,6 +956,7 @@ class HlsService(HlsPlaylistPort):
             "-map",
             audio_map,
             "-sn",
+            *vf_args,
             *video_args,
             "-c:a",
             "aac",

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -341,6 +341,9 @@ class MediaProbeService(MediaProbePort):
             title = tags.get("title", tags.get("TITLE"))
             is_default = bool(disposition.get("default", 0))
             bitrate = None
+            raw_rate = stream.get("sample_rate")
+            sample_rate = int(raw_rate) if raw_rate and str(raw_rate).isdigit() else None
+            profile = stream.get("profile")
 
             # Try to get bitrate from multiple sources
             for key in ("bit_rate", "BPS", "BPS-eng"):
@@ -358,21 +361,15 @@ class MediaProbeService(MediaProbePort):
                     title=title,
                     is_default=is_default,
                     bitrate=bitrate,
+                    sample_rate=sample_rate,
+                    profile=profile,
                 )
             )
             audio_index += 1
 
         # Ensure at least one track is default
         if tracks and not any(t.is_default for t in tracks):
-            tracks[0] = AudioTrack(
-                index=tracks[0].index,
-                language=tracks[0].language,
-                codec=tracks[0].codec,
-                channels=tracks[0].channels,
-                title=tracks[0].title,
-                is_default=True,
-                bitrate=tracks[0].bitrate,
-            )
+            tracks[0] = tracks[0].with_updates(is_default=True)
 
         return tracks
 

--- a/src/modules/media/infrastructure/streaming/thumbnail_service.py
+++ b/src/modules/media/infrastructure/streaming/thumbnail_service.py
@@ -25,6 +25,7 @@ from src.modules.media.application.streaming.thumbnail_vtt import (
     compute_layout,
 )
 from src.modules.media.infrastructure.streaming._subprocess import (
+    HW_ACCEL_OFF,
     SUBPROCESS_TEXT_KWARGS,
     with_ffmpeg_threads,
 )
@@ -47,11 +48,6 @@ _THUMBNAIL_JPEG_QUALITY = 5
 # if ffmpeg is still running at this point we kill it and move on.
 _THUMBNAIL_TIMEOUT = 300.0
 _PROBE_TIMEOUT = 10
-
-# HardwareAccel.OFF value. Compared by value (HardwareAccel is a StrEnum)
-# so this infrastructure stays decoupled from the settings domain — media
-# imports settings only under TYPE_CHECKING (ADR-008).
-_HW_ACCEL_OFF = "off"
 
 
 @dataclass(frozen=True)
@@ -137,7 +133,7 @@ class ThumbnailGenerationService:
 
         snapshot = self._runtime_settings.streaming_snapshot_sync()
         ffmpeg_threads = snapshot.ffmpeg_threads
-        use_hwaccel = snapshot.hw_accel != _HW_ACCEL_OFF
+        use_hwaccel = snapshot.hw_accel != HW_ACCEL_OFF
         if not self._render_sprite(
             file_path, sprite_path, layout, interval_seconds, ffmpeg_threads, use_hwaccel
         ):

--- a/src/modules/media/infrastructure/streaming/thumbnail_service.py
+++ b/src/modules/media/infrastructure/streaming/thumbnail_service.py
@@ -48,6 +48,11 @@ _THUMBNAIL_JPEG_QUALITY = 5
 _THUMBNAIL_TIMEOUT = 300.0
 _PROBE_TIMEOUT = 10
 
+# HardwareAccel.OFF value. Compared by value (HardwareAccel is a StrEnum)
+# so this infrastructure stays decoupled from the settings domain — media
+# imports settings only under TYPE_CHECKING (ADR-008).
+_HW_ACCEL_OFF = "off"
+
 
 @dataclass(frozen=True)
 class ThumbnailResult:
@@ -130,9 +135,11 @@ class ThumbnailGenerationService:
         sprite_path = output_dir / SPRITE_FILENAME
         vtt_path = output_dir / VTT_FILENAME
 
-        ffmpeg_threads = self._runtime_settings.streaming_snapshot_sync().ffmpeg_threads
+        snapshot = self._runtime_settings.streaming_snapshot_sync()
+        ffmpeg_threads = snapshot.ffmpeg_threads
+        use_hwaccel = snapshot.hw_accel != _HW_ACCEL_OFF
         if not self._render_sprite(
-            file_path, sprite_path, layout, interval_seconds, ffmpeg_threads
+            file_path, sprite_path, layout, interval_seconds, ffmpeg_threads, use_hwaccel
         ):
             return None
 
@@ -161,19 +168,66 @@ class ThumbnailGenerationService:
         layout: SpriteLayout,
         interval_seconds: int,
         max_threads: int | None,
+        use_hwaccel: bool,
     ) -> bool:
-        """Run ffmpeg to render the sprite JPEG. Returns ``False`` on any failure."""
+        """Run ffmpeg to render the sprite JPEG. Returns ``False`` on any failure.
+
+        A sprite decodes the *entire* film (one frame every
+        ``interval_seconds``), so on a 4K HEVC source the decode pass
+        dominates CPU. When ``use_hwaccel`` is set we offload that decode
+        to NVDEC (``-hwaccel cuda``); the CPU-side ``scale``/``pad``/
+        ``tile`` filters still run on downloaded frames, but the heavy
+        part moves to the GPU. Sprites are a nice-to-have, so a hardware
+        decode that fails fast (e.g. a codec NVDEC can't handle) falls
+        back to a software pass rather than dropping the sprite. A
+        *timeout* is not retried — software would be no faster.
+        """
         filter_expr = (
             f"fps=1/{interval_seconds},"
             f"scale={layout.tile_width}:{layout.tile_height}:force_original_aspect_ratio=decrease,"
             f"pad={layout.tile_width}:{layout.tile_height}:(ow-iw)/2:(oh-ih)/2,"
             f"tile={layout.columns}x{layout.rows}"
         )
+        if use_hwaccel:
+            outcome = ThumbnailGenerationService._run_sprite_ffmpeg(
+                file_path, sprite_path, filter_expr, max_threads, hwaccel=True
+            )
+            if outcome is True:
+                return True
+            if outcome is None:
+                # Timed out — a software pass would be no faster. Give up.
+                return False
+            _logger.info("Thumbnail hwaccel decode failed for %s — retrying on CPU", file_path)
+        return (
+            ThumbnailGenerationService._run_sprite_ffmpeg(
+                file_path, sprite_path, filter_expr, max_threads, hwaccel=False
+            )
+            is True
+        )
+
+    @staticmethod
+    def _run_sprite_ffmpeg(
+        file_path: str,
+        sprite_path: Path,
+        filter_expr: str,
+        max_threads: int | None,
+        *,
+        hwaccel: bool,
+    ) -> bool | None:
+        """Run one sprite ffmpeg pass.
+
+        Returns ``True`` on a clean render, ``False`` on a fast failure
+        (non-zero exit / missing output — safe to retry in software),
+        and ``None`` on a timeout (do *not* retry; software is no
+        faster on a stuck decode).
+        """
+        hwaccel_args = ["-hwaccel", "cuda"] if hwaccel else []
         try:
             result = subprocess.run(
                 with_ffmpeg_threads(
                     [
                         "ffmpeg",
+                        *hwaccel_args,
                         "-i",
                         file_path,
                         "-vf",
@@ -197,16 +251,17 @@ class ThumbnailGenerationService:
             )
         except subprocess.TimeoutExpired:
             _logger.warning("Thumbnail generation timed out for %s", file_path)
-            return False
+            return None
         except FileNotFoundError:
             _logger.warning("ffmpeg not available; skipping thumbnails for %s", file_path)
             return False
 
         if result.returncode != 0 or not sprite_path.is_file():
             _logger.warning(
-                "Thumbnail ffmpeg failed for %s (code %s): %s",
+                "Thumbnail ffmpeg failed for %s (code %s, hwaccel=%s): %s",
                 file_path,
                 result.returncode,
+                hwaccel,
                 result.stderr.strip() if result.stderr else "",
             )
             return False

--- a/src/modules/settings/domain/value_objects/__init__.py
+++ b/src/modules/settings/domain/value_objects/__init__.py
@@ -18,7 +18,10 @@ from src.modules.settings.domain.value_objects.setting_vo_registry import (
     SETTING_VO_TYPES,
     vo_type_for,
 )
-from src.modules.settings.domain.value_objects.streaming_config import StreamingConfig
+from src.modules.settings.domain.value_objects.streaming_config import (
+    HardwareAccel,
+    StreamingConfig,
+)
 from src.modules.settings.domain.value_objects.thumbnail_backfill_config import (
     ThumbnailBackfillConfig,
 )
@@ -37,6 +40,7 @@ __all__ = [
     "AvatarConfig",
     "ConfigVO",
     "SETTING_VO_TYPES",
+    "HardwareAccel",
     "IntroDetectionConfig",
     "ScanDedupConfig",
     "SchedulerConfig",

--- a/src/modules/settings/domain/value_objects/streaming_config.py
+++ b/src/modules/settings/domain/value_objects/streaming_config.py
@@ -1,8 +1,32 @@
-"""Streaming tunables — ffmpeg parallelism and HLS cache cap."""
+"""Streaming tunables — ffmpeg parallelism, HLS cache cap, and hardware accel."""
+
+from enum import StrEnum
 
 from pydantic import Field
 
 from src.building_blocks.domain.value_objects import CompoundValueObject
+
+
+class HardwareAccel(StrEnum):
+    """Video encoder selection for the HLS transcode path.
+
+    Members:
+        AUTO: Probe the host for a working NVENC encoder at runtime and
+            use it when present; fall back to software ``libx264``
+            otherwise. The safe default — a machine without an NVIDIA
+            GPU silently stays on software.
+        NVENC: Force NVIDIA NVENC (``h264_nvenc`` + CUDA decode). Use
+            on a known-good GPU host to skip the probe. A broken or
+            absent encoder surfaces as a transcode failure rather than
+            falling back.
+        OFF: Force software ``libx264``, ignoring any available GPU.
+            Useful for CI, containers without ``--gpus``, or to A/B the
+            two paths.
+    """
+
+    AUTO = "auto"
+    NVENC = "nvenc"
+    OFF = "off"
 
 
 class StreamingConfig(CompoundValueObject):
@@ -23,13 +47,22 @@ class StreamingConfig(CompoundValueObject):
             on large catalogs to avoid re-transcoding popular titles
             on every visit. Set to ``0`` to disable LRU eviction
             entirely (the cache will grow without bound).
+        hw_accel: Which video encoder the HLS transcode path uses.
+            ``AUTO`` (default) prefers NVENC when a functional GPU
+            encoder is detected and falls back to software libx264 —
+            decisive for 4K/HEVC sources where software encoding
+            bottlenecks the CPU. Has no effect on the H.264 ``copy``
+            fast path, which never re-encodes.
 
     Example:
         >>> cfg = StreamingConfig(ffmpeg_threads=4, hls_cache_max_size_mb=10240)
+        >>> cfg.hw_accel
+        <HardwareAccel.AUTO: 'auto'>
     """
 
     ffmpeg_threads: int | None = Field(default=None, ge=1)
     hls_cache_max_size_mb: int = Field(default=5120, ge=0)
+    hw_accel: HardwareAccel = Field(default=HardwareAccel.AUTO)
 
 
-__all__ = ["StreamingConfig"]
+__all__ = ["HardwareAccel", "StreamingConfig"]

--- a/src/shared_kernel/value_objects/tracks.py
+++ b/src/shared_kernel/value_objects/tracks.py
@@ -31,6 +31,10 @@ class AudioTrack(CompoundValueObject):
         title: Descriptive title from file metadata.
         is_default: Whether marked as default in the container.
         bitrate: Bitrate in kbps, if available.
+        sample_rate: Sample rate in Hz (e.g. 48000), if available.
+        profile: Codec profile from the container (e.g. "LC",
+            "HE-AAC"), if available. ``None`` when the prober did not
+            report one.
 
     Example:
         >>> track = AudioTrack(
@@ -52,6 +56,8 @@ class AudioTrack(CompoundValueObject):
     title: str | None = None
     is_default: bool = False
     bitrate: int | None = Field(default=None, ge=0)
+    sample_rate: int | None = Field(default=None, ge=1)
+    profile: str | None = None
 
     @property
     def is_stereo(self) -> bool:

--- a/tests/infrastructure/migrations/test_seed_streaming_avatar_settings.py
+++ b/tests/infrastructure/migrations/test_seed_streaming_avatar_settings.py
@@ -93,7 +93,11 @@ class TestSeedRows:
         assert key == "streaming"
         assert source == "migration_seed"
         payload = json.loads(value_json)
-        assert payload == {"ffmpeg_threads": 4, "hls_cache_max_size_mb": 20480}
+        assert payload == {
+            "ffmpeg_threads": 4,
+            "hls_cache_max_size_mb": 20480,
+            "hw_accel": "auto",
+        }
 
     def test_seeds_avatar_row_with_partial_overrides(self, connection: Connection) -> None:
         # Only ``size_pixels`` is overridden; the other two fields

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -18,7 +18,7 @@ from src.modules.media.infrastructure.streaming.hls_service import (
     _shift_webvtt_to_bucket_local,
 )
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
-from src.modules.settings.domain.value_objects import StreamingConfig
+from src.modules.settings.domain.value_objects import HardwareAccel, StreamingConfig
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
@@ -27,12 +27,18 @@ def _fake_runtime_settings(
     *,
     ffmpeg_threads: int | None = None,
     hls_cache_max_size_mb: int = 5120,
+    hw_accel: HardwareAccel = HardwareAccel.OFF,
 ) -> MagicMock:
-    """Build a fake :class:`RuntimeSettings` exposing the sync streaming snapshot."""
+    """Build a fake :class:`RuntimeSettings` exposing the sync streaming snapshot.
+
+    ``hw_accel`` defaults to ``OFF`` so command-building tests stay on
+    the deterministic software path and never spawn the NVENC probe.
+    """
     runtime = MagicMock()
     runtime.streaming_snapshot_sync.return_value = StreamingConfig(
         ffmpeg_threads=ffmpeg_threads,
         hls_cache_max_size_mb=hls_cache_max_size_mb,
+        hw_accel=hw_accel,
     )
     return runtime
 
@@ -444,6 +450,114 @@ class TestHlsServiceBuildVideoCmd:
             cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "libx264" in cmd
+
+    def test_should_use_nvenc_when_available(self, tmp_path: Path) -> None:
+        # AUTO + a passing functional probe → full-GPU NVENC pipeline.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hw_accel=HardwareAccel.AUTO),
+            cache_dir=str(tmp_path / "cache"),
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with (
+            patch.object(HlsService, "_probe_video_codec", return_value="hevc"),
+            patch.object(HlsService, "_detect_nvenc", return_value=True),
+        ):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "h264_nvenc" in cmd
+        assert "libx264" not in cmd
+        # Full-GPU: CUDA decode + in-VRAM 10→8 bit conversion.
+        assert cmd[cmd.index("-hwaccel") + 1] == "cuda"
+        assert "-hwaccel_output_format" in cmd
+        assert cmd[cmd.index("-vf") + 1] == "scale_cuda=format=nv12"
+        # hwaccel flags must precede the input.
+        assert cmd.index("-hwaccel") < cmd.index("-i")
+
+    def test_should_fallback_to_software_when_nvenc_probe_fails(self, tmp_path: Path) -> None:
+        # AUTO + a failing probe → libx264, no CUDA flags leak in.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hw_accel=HardwareAccel.AUTO),
+            cache_dir=str(tmp_path / "cache"),
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with (
+            patch.object(HlsService, "_probe_video_codec", return_value="hevc"),
+            patch.object(HlsService, "_detect_nvenc", return_value=False),
+        ):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "libx264" in cmd
+        assert "h264_nvenc" not in cmd
+        assert "-hwaccel" not in cmd
+
+    def test_should_force_software_when_hw_accel_off(self, tmp_path: Path) -> None:
+        # OFF must win even if NVENC would probe successfully.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hw_accel=HardwareAccel.OFF),
+            cache_dir=str(tmp_path / "cache"),
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with (
+            patch.object(HlsService, "_probe_video_codec", return_value="hevc"),
+            patch.object(HlsService, "_detect_nvenc", return_value=True) as detect,
+        ):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "libx264" in cmd
+        assert "h264_nvenc" not in cmd
+        detect.assert_not_called()
+
+    def test_should_force_nvenc_without_probing_when_mode_nvenc(self, tmp_path: Path) -> None:
+        # Explicit NVENC mode skips the probe entirely.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hw_accel=HardwareAccel.NVENC),
+            cache_dir=str(tmp_path / "cache"),
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with (
+            patch.object(HlsService, "_probe_video_codec", return_value="hevc"),
+            patch.object(HlsService, "_detect_nvenc", return_value=False) as detect,
+        ):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "h264_nvenc" in cmd
+        detect.assert_not_called()
+
+    def test_should_not_use_nvenc_on_h264_copy_path(self, tmp_path: Path) -> None:
+        # An already-H.264 source remuxes (copy); NVENC never enters even
+        # when available, because there is no encode to accelerate.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hw_accel=HardwareAccel.NVENC),
+            cache_dir=str(tmp_path / "cache"),
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with (
+            patch.object(HlsService, "_probe_video_codec", return_value="h264"),
+            patch.object(HlsService, "_detect_nvenc", return_value=True),
+        ):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "copy" in cmd
+        assert "h264_nvenc" not in cmd
+        assert "-hwaccel" not in cmd
+
+    def test_should_memoise_nvenc_probe(self, tmp_path: Path) -> None:
+        # The functional probe runs at most once per service instance.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hw_accel=HardwareAccel.AUTO),
+            cache_dir=str(tmp_path / "cache"),
+        )
+
+        with patch.object(HlsService, "_detect_nvenc", return_value=True) as detect:
+            assert service._nvenc_available() is True
+            assert service._nvenc_available() is True
+
+        detect.assert_called_once()
 
     def test_should_map_primary_audio_track(self, tmp_path: Path) -> None:
         service = HlsService(

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -50,6 +50,8 @@ def _make_audio_track(
     channels: int = 2,
     is_default: bool = True,
     title: str | None = None,
+    sample_rate: int | None = None,
+    profile: str | None = None,
 ) -> AudioTrack:
     return AudioTrack(
         index=index,
@@ -58,6 +60,20 @@ def _make_audio_track(
         channels=channels,
         is_default=is_default,
         title=title,
+        sample_rate=sample_rate,
+        profile=profile,
+    )
+
+
+def _aac_lc_stereo_48k(index: int = 0, **kwargs: object) -> AudioTrack:
+    """An AAC-LC stereo 48 kHz track — the one shape eligible for ``-c:a copy``."""
+    return _make_audio_track(
+        index=index,
+        codec="aac",
+        channels=2,
+        sample_rate=48000,
+        profile="LC",
+        **kwargs,  # type: ignore[arg-type]
     )
 
 
@@ -321,30 +337,30 @@ class TestHlsServiceBuildAudioCmd:
     """Tests for _build_audio_cmd."""
 
     def test_should_include_input_file(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=1)
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
 
         assert "-i" in cmd
         assert "/movies/test.mkv" in cmd
 
     def test_should_map_to_correct_audio_stream(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=2)
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=2))
 
         assert "0:a:2" in cmd
 
     def test_should_disable_video_and_subtitle(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
 
         assert "-vn" in cmd
         assert "-sn" in cmd
 
     def test_should_use_aac_codec(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
 
         assert "aac" in cmd
 
     def test_should_omit_seek_flag_when_start_is_zero(self, tmp_path: Path) -> None:
         # Default cold-cache transcode starts at t=0 — no ``-ss``.
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
 
         assert "-ss" not in cmd
 
@@ -352,7 +368,9 @@ class TestHlsServiceBuildAudioCmd:
         # ``-ss N`` must come BEFORE ``-i`` so ffmpeg does an input
         # seek (fast, keyframe-accurate) rather than decoding from 0
         # and dropping output.
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0, start=1800)
+        cmd = HlsService._build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=0), start=1800
+        )
 
         assert "-ss" in cmd
         ss_index = cmd.index("-ss")
@@ -364,7 +382,9 @@ class TestHlsServiceBuildAudioCmd:
         # Without ``-accurate_seek`` ffmpeg drops to the preceding
         # keyframe but audio starts at exactly ``start`` — the two
         # streams open out of sync by ``start - keyframe_pos``.
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0, start=1800)
+        cmd = HlsService._build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=0), start=1800
+        )
 
         assert "-accurate_seek" in cmd
         accurate_index = cmd.index("-accurate_seek")
@@ -375,7 +395,9 @@ class TestHlsServiceBuildAudioCmd:
         # ``-avoid_negative_ts make_zero`` clamps the per-stream PTS
         # minimum to zero so any residual offset surfaces as a tiny
         # leading silence instead of an audio-leads-video drift.
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0, start=1800)
+        cmd = HlsService._build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=0), start=1800
+        )
 
         assert "-avoid_negative_ts" in cmd
         idx = cmd.index("-avoid_negative_ts")
@@ -385,10 +407,44 @@ class TestHlsServiceBuildAudioCmd:
         # Sync hardening only kicks in for non-zero ``start`` since the
         # legacy cold-cache transcode never hits the keyframe-vs-audio
         # gap (it begins at t=0 of the source).
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, audio_index=0)
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
 
         assert "-accurate_seek" not in cmd
         assert "-avoid_negative_ts" not in cmd
+
+    def test_should_copy_aac_lc_stereo_48k_at_start_zero(self, tmp_path: Path) -> None:
+        # Already browser-ready audio is remuxed, not re-encoded.
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _aac_lc_stereo_48k(index=1))
+
+        assert cmd[cmd.index("-c:a") + 1] == "copy"
+        assert "-ar" not in cmd  # no encode params on the copy path
+
+    def test_should_reencode_when_seeking_even_if_aac_lc(self, tmp_path: Path) -> None:
+        # A non-zero start re-encodes audio so it lands at the exact
+        # second instead of the nearest packet (A/V sync).
+        cmd = HlsService._build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _aac_lc_stereo_48k(index=0), start=1800
+        )
+
+        assert "copy" not in cmd
+        assert cmd[cmd.index("-c:a") + 1] == "aac"
+
+    @pytest.mark.parametrize(
+        "track",
+        [
+            _make_audio_track(codec="ac3", channels=2, sample_rate=48000, profile="LC"),
+            _make_audio_track(codec="aac", channels=6, sample_rate=48000, profile="LC"),
+            _make_audio_track(codec="aac", channels=2, sample_rate=44100, profile="LC"),
+            _make_audio_track(codec="aac", channels=2, sample_rate=48000, profile="HE-AAC"),
+            _make_audio_track(codec="aac", channels=2, sample_rate=48000, profile=None),
+        ],
+        ids=["not-aac", "surround", "wrong-rate", "he-aac", "unknown-profile"],
+    )
+    def test_should_reencode_when_not_safe_to_copy(self, tmp_path: Path, track: AudioTrack) -> None:
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, track)
+
+        assert "copy" not in cmd
+        assert cmd[cmd.index("-c:a") + 1] == "aac"
 
 
 @pytest.mark.unit
@@ -450,6 +506,20 @@ class TestHlsServiceBuildVideoCmd:
             cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "libx264" in cmd
+
+    def test_should_copy_primary_audio_when_aac_lc_stereo_48k(self, tmp_path: Path) -> None:
+        # Video transcodes (hevc) but the AAC-LC stereo 48k primary
+        # audio is remuxed rather than re-encoded.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "cache")
+        )
+        probe = ProbeResult(audio_tracks=[_aac_lc_stereo_48k()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="hevc"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert cmd[cmd.index("-c:a") + 1] == "copy"
+        assert "libx264" in cmd  # video still re-encoded
 
     def test_should_use_nvenc_when_available(self, tmp_path: Path) -> None:
         # AUTO + a passing functional probe → full-GPU NVENC pipeline.

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -30,6 +30,8 @@ def _ffprobe_stream(
     forced: bool = False,
     title: str | None = None,
     bit_rate: str | None = None,
+    sample_rate: str | None = None,
+    profile: str | None = None,
 ) -> dict[str, Any]:
     stream: dict[str, Any] = {
         "codec_type": codec_type,
@@ -44,6 +46,10 @@ def _ffprobe_stream(
         stream["tags"]["title"] = title
     if bit_rate is not None:
         stream["bit_rate"] = bit_rate
+    if sample_rate is not None:
+        stream["sample_rate"] = sample_rate
+    if profile is not None:
+        stream["profile"] = profile
     return stream
 
 
@@ -167,6 +173,23 @@ class TestParseAudioTracks:
         tracks = MediaProbeService._parse_audio_tracks(streams)
 
         assert tracks[0].channels == 16
+
+    def test_should_parse_sample_rate_and_profile(self) -> None:
+        streams = [_ffprobe_stream(codec_name="aac", sample_rate="48000", profile="LC")]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        assert tracks[0].sample_rate == 48000
+        assert tracks[0].profile == "LC"
+
+    def test_should_default_sample_rate_and_profile_to_none(self) -> None:
+        # ffprobe omits these on some containers; absence must not crash.
+        streams = [_ffprobe_stream(codec_name="ac3")]
+
+        tracks = MediaProbeService._parse_audio_tracks(streams)
+
+        assert tracks[0].sample_rate is None
+        assert tracks[0].profile is None
 
     def test_should_return_empty_for_no_audio(self) -> None:
         tracks = MediaProbeService._parse_audio_tracks([])

--- a/tests/modules/media/unit/infrastructure/streaming/test_thumbnail_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_thumbnail_service.py
@@ -20,18 +20,28 @@ from src.modules.media.infrastructure.streaming.thumbnail_service import (
     VTT_FILENAME,
     ThumbnailGenerationService,
 )
-from src.modules.settings.domain.value_objects import StreamingConfig
+from src.modules.settings.domain.value_objects import HardwareAccel, StreamingConfig
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _fake_runtime_settings(*, ffmpeg_threads: int | None = None) -> MagicMock:
+def _fake_runtime_settings(
+    *,
+    ffmpeg_threads: int | None = None,
+    hw_accel: HardwareAccel = HardwareAccel.AUTO,
+) -> MagicMock:
     runtime = MagicMock()
     runtime.streaming_snapshot_sync.return_value = StreamingConfig(
         ffmpeg_threads=ffmpeg_threads,
+        hw_accel=hw_accel,
     )
     return runtime
+
+
+def _ffmpeg_cmds(mock_run: MagicMock) -> list[list[str]]:
+    """All ffmpeg argv lists captured by the mocked ``subprocess.run``."""
+    return [c.args[0] for c in mock_run.call_args_list if c.args[0][0] == "ffmpeg"]
 
 
 _SUBPROCESS_TARGET = "src.modules.media.infrastructure.streaming.thumbnail_service.subprocess.run"
@@ -188,3 +198,83 @@ class TestThumbnailGenerationService:
 
         ffmpeg_call = next(call for call in mock_run.call_args_list if call.args[0][0] == "ffmpeg")
         assert "-ss" not in ffmpeg_call.args[0]
+
+    def test_uses_cuda_hwaccel_decode_by_default(self, tmp_path: Path) -> None:
+        # hw_accel defaults to AUTO → the sprite decode runs on NVDEC,
+        # with the flag placed before -i so ffmpeg applies it to the input.
+        output_dir = tmp_path / "thumbs"
+        sprite_path = output_dir / SPRITE_FILENAME
+
+        service = ThumbnailGenerationService(_fake_runtime_settings())
+        with (
+            patch(_WHICH_TARGET, return_value="/usr/bin/ffprobe"),
+            patch(_SUBPROCESS_TARGET, side_effect=_ffmpeg_writes_sprite(sprite_path)) as mock_run,
+        ):
+            result = service.generate("/fake/movie.mkv", output_dir)
+
+        assert result is not None
+        (cmd,) = _ffmpeg_cmds(mock_run)
+        assert cmd[cmd.index("-hwaccel") + 1] == "cuda"
+        assert cmd.index("-hwaccel") < cmd.index("-i")
+
+    def test_no_hwaccel_when_hw_accel_off(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "thumbs"
+        sprite_path = output_dir / SPRITE_FILENAME
+
+        service = ThumbnailGenerationService(_fake_runtime_settings(hw_accel=HardwareAccel.OFF))
+        with (
+            patch(_WHICH_TARGET, return_value="/usr/bin/ffprobe"),
+            patch(_SUBPROCESS_TARGET, side_effect=_ffmpeg_writes_sprite(sprite_path)) as mock_run,
+        ):
+            result = service.generate("/fake/movie.mkv", output_dir)
+
+        assert result is not None
+        (cmd,) = _ffmpeg_cmds(mock_run)
+        assert "-hwaccel" not in cmd
+
+    def test_falls_back_to_software_when_hwaccel_decode_fails(self, tmp_path: Path) -> None:
+        # NVDEC can't decode this source: the hwaccel pass exits non-zero,
+        # but the software retry renders the sprite — it must not be lost.
+        output_dir = tmp_path / "thumbs"
+        sprite_path = output_dir / SPRITE_FILENAME
+
+        def run(cmd, *_, **__):  # type: ignore[no-untyped-def]
+            if cmd[0] == "ffprobe":
+                return subprocess.CompletedProcess(cmd, 0, stdout="120.0\n", stderr="")
+            if "-hwaccel" in cmd:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="no NVDEC")
+            sprite_path.parent.mkdir(parents=True, exist_ok=True)
+            sprite_path.write_bytes(b"\xff\xd8\xff\xe0")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        service = ThumbnailGenerationService(_fake_runtime_settings())
+        with (
+            patch(_WHICH_TARGET, return_value="/usr/bin/ffprobe"),
+            patch(_SUBPROCESS_TARGET, side_effect=run) as mock_run,
+        ):
+            result = service.generate("/fake/movie.mkv", output_dir)
+
+        assert result is not None
+        assert sprite_path.is_file()
+        hwaccel_flags = [("-hwaccel" in cmd) for cmd in _ffmpeg_cmds(mock_run)]
+        assert hwaccel_flags == [True, False]  # hwaccel attempt, then software retry
+
+    def test_does_not_retry_software_on_hwaccel_timeout(self, tmp_path: Path) -> None:
+        # A timeout is not a codec problem; software would be no faster, so
+        # the run gives up after the single hwaccel attempt.
+        output_dir = tmp_path / "thumbs"
+
+        def run(cmd, *_, **__):  # type: ignore[no-untyped-def]
+            if cmd[0] == "ffprobe":
+                return subprocess.CompletedProcess(cmd, 0, stdout="120.0\n", stderr="")
+            raise subprocess.TimeoutExpired(cmd, timeout=1)
+
+        service = ThumbnailGenerationService(_fake_runtime_settings())
+        with (
+            patch(_WHICH_TARGET, return_value="/usr/bin/ffprobe"),
+            patch(_SUBPROCESS_TARGET, side_effect=run) as mock_run,
+        ):
+            result = service.generate("/fake/movie.mkv", output_dir)
+
+        assert result is None
+        assert len(_ffmpeg_cmds(mock_run)) == 1

--- a/tests/modules/settings/unit/domain/value_objects/test_streaming_config.py
+++ b/tests/modules/settings/unit/domain/value_objects/test_streaming_config.py
@@ -1,0 +1,45 @@
+"""Unit tests for :class:`StreamingConfig` and :class:`HardwareAccel`."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.settings.domain.value_objects import HardwareAccel, StreamingConfig
+
+
+class TestStreamingConfig:
+    def test_default_values(self) -> None:
+        config = StreamingConfig()
+
+        assert config.ffmpeg_threads is None
+        assert config.hls_cache_max_size_mb == 5120
+        assert config.hw_accel is HardwareAccel.AUTO
+
+    def test_hw_accel_can_be_set(self) -> None:
+        config = StreamingConfig(hw_accel=HardwareAccel.NVENC)
+
+        assert config.hw_accel is HardwareAccel.NVENC
+
+    def test_hw_accel_accepts_string_value(self) -> None:
+        # The admin route binds the raw JSON body to the VO, so the enum
+        # must validate from its string form.
+        config = StreamingConfig.model_validate({"hw_accel": "off"})
+
+        assert config.hw_accel is HardwareAccel.OFF
+
+    def test_hw_accel_rejects_unknown_value(self) -> None:
+        with pytest.raises(DomainValidationException):
+            StreamingConfig(hw_accel="vaapi")  # type: ignore[arg-type]
+
+    def test_missing_hw_accel_key_defaults_to_auto(self) -> None:
+        # Backward compatibility: rows persisted before this field
+        # existed have no ``hw_accel`` key and must rehydrate to AUTO.
+        config = StreamingConfig.model_validate(
+            {"ffmpeg_threads": 4, "hls_cache_max_size_mb": 2048}
+        )
+
+        assert config.hw_accel is HardwareAccel.AUTO
+
+    def test_serialises_hw_accel_as_string(self) -> None:
+        dumped = StreamingConfig(hw_accel=HardwareAccel.NVENC).model_dump(mode="json")
+
+        assert dumped["hw_accel"] == "nvenc"


### PR DESCRIPTION
## Summary

- Add `hw_accel` to `StreamingConfig` (`HardwareAccel` StrEnum: `auto`/`nvenc`/`off`, default `auto`); JSON-persisted, backward-compatible (missing key → `auto`, no migration). Already exposed on `PATCH /admin/settings/streaming` since the route binds the VO directly.
- **HLS transcode**: non-H.264 sources now run a full-GPU pipeline (`-hwaccel cuda` NVDEC decode → `scale_cuda=format=nv12` 10→8 bit → `h264_nvenc -preset p5 -tune hq -rc vbr -cq 19 -spatial_aq 1`), cutting 4K HEVC transcode CPU to ~0. `auto` functionally probes NVENC once and memoises; `off` forces software; `nvenc` forces hardware.
- **Software fallback** also moves off `-preset ultrafast` to `superfast -crf 20 -pix_fmt yuv420p` — ultrafast disabled CABAC + AQ, which was collapsing smooth sky/fog gradients into visible macroblocks.
- **Thumbnail sprites**: the whole-film decode offloads to NVDEC (same `hw_accel` gate), with an automatic software retry on a fast hwaccel failure and **no** retry on timeout.
- `media` stays decoupled from `settings` — `hw_accel` compared by StrEnum value, no runtime import (ADR-008).

## Test plan

- [x] `pytest tests/modules/media tests/modules/settings tests/infrastructure/scheduling/test_thumbnail_backfill_job.py` — 1514 passed
- [x] New unit tests: NVENC select/fallback/off/forced/copy-path/memoise (HLS); cuda-default/off/software-fallback/no-retry-on-timeout (thumbnail); `StreamingConfig` field default + JSON round-trip
- [x] `ruff check` + `ruff format --check` clean
- [x] Manual smoke test on RTX 4070 Ti SUPER: WALL·E (4K HEVC 10-bit) — banding gone, CPU freed on both player transcode and sprite generation

## Notes

- Full-GPU HLS path has no per-file software fallback: a source NVDEC can't decode fails that transcode (escape hatch: set `hw_accel=off`). Mainstream codecs are fine.
- Frontend admin control for `hw_accel` lands separately in `homeflix-web`.

## Summary by Sourcery

Add configurable hardware-accelerated video processing for media streaming and thumbnails, defaulting safely and remaining backward compatible.

New Features:
- Introduce a HardwareAccel enum and hw_accel field on StreamingConfig to control hardware vs software video encoding.
- Enable NVENC-based GPU transcoding for HLS when configured or auto-detected, with software libx264 as a fallback.
- Offload thumbnail sprite generation decode to NVDEC when enabled, with controlled fallback behavior.

Enhancements:
- Improve default software HLS encoding settings to reduce banding artifacts on high-resolution sources.

Tests:
- Add unit tests covering HardwareAccel/StreamingConfig defaults and serialization, NVENC selection and memoization for HLS, and hwaccel usage and fallback behavior in thumbnail generation.

## Update — audio remux

- Probe now captures audio `sample_rate` + `profile`. HLS remuxes primary and alternate audio with `-c:a copy` when the source is already **AAC-LC stereo 48 kHz** at `start=0`, falling back to the AAC re-encode otherwise (non-AAC, surround, wrong rate, HE-AAC, or a mid-stream seek where copy would drift). Extra CPU win on top of the GPU video path.
- Suite now at 1663 passing.