### PR TITLE
feat(media): flag movie enrichment as wrong for review

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -30,6 +30,9 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
 from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
 )
+from src.modules.media.application.use_cases.flag_movie_enrichment_review import (
+    FlagMovieEnrichmentReviewUseCase,
+)
 from src.modules.media.application.use_cases.generate_hls_playlist import (
     GenerateHlsPlaylistUseCase,
 )
@@ -555,6 +558,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         RelinkMovieUseCase,
         uow_factory=media_unit_of_work_factory,
         enrich_use_case=enrich_movie_metadata,
+    )
+
+    flag_movie_enrichment_review = providers.Factory(
+        FlagMovieEnrichmentReviewUseCase,
+        uow_factory=media_unit_of_work_factory,
     )
 
     promote_movie_to_series = providers.Factory(

--- a/src/modules/media/application/dtos/admin_relink_dtos.py
+++ b/src/modules/media/application/dtos/admin_relink_dtos.py
@@ -138,6 +138,35 @@ class RelinkMovieOutput:
 
 
 @dataclass(frozen=True)
+class FlagMovieEnrichmentReviewInput:
+    """Admin command: flag a movie's enrichment as wrong.
+
+    Used when the metadata looks enriched but matched the wrong title.
+    Setting the flag puts the movie back on the admin "needs review"
+    listing so the operator can relink it to the correct TMDB id.
+
+    Attributes:
+        movie_id: External movie id (``mov_xxx``) to flag.
+    """
+
+    movie_id: str
+
+
+@dataclass(frozen=True)
+class FlagMovieEnrichmentReviewOutput:
+    """Result of a flag command.
+
+    Attributes:
+        movie_id: External movie id (echoed).
+        needs_enrichment_review: The flag state after the command —
+            always ``True`` on success.
+    """
+
+    movie_id: str
+    needs_enrichment_review: bool
+
+
+@dataclass(frozen=True)
 class PromoteMovieToSeriesInput:
     """Input for the cross-type promotion endpoint.
 
@@ -174,6 +203,8 @@ class PromoteMovieToSeriesOutput:
 
 
 __all__ = [
+    "FlagMovieEnrichmentReviewInput",
+    "FlagMovieEnrichmentReviewOutput",
     "GetMovieTmdbSuggestionsInput",
     "GetMovieTmdbSuggestionsOutput",
     "ListMoviesNeedingReviewOutput",

--- a/src/modules/media/application/dtos/movie_dtos.py
+++ b/src/modules/media/application/dtos/movie_dtos.py
@@ -111,6 +111,10 @@ class MovieOutput:
         resolution: Video resolution (None if no primary file).
         tmdb_id: TMDB external ID (optional).
         imdb_id: IMDB external ID (optional).
+        needs_enrichment_review: ``True`` when the movie is flagged for
+            enrichment review (enrichment failed or an operator marked
+            the result as wrong). Lets the admin detail UI show a
+            persistent "flagged" badge.
         created_at: ISO timestamp of creation.
         updated_at: ISO timestamp of last update.
     """
@@ -140,6 +144,7 @@ class MovieOutput:
     files: list[MediaFileOutput]
     tmdb_id: int | None
     imdb_id: str | None
+    needs_enrichment_review: bool
     created_at: str
     updated_at: str
 

--- a/src/modules/media/application/use_cases/flag_movie_enrichment_review.py
+++ b/src/modules/media/application/use_cases/flag_movie_enrichment_review.py
@@ -1,0 +1,63 @@
+"""Use case: admin flags a movie's enrichment as wrong."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    FlagMovieEnrichmentReviewInput,
+    FlagMovieEnrichmentReviewOutput,
+)
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.value_objects import MovieId
+
+
+class FlagMovieEnrichmentReviewUseCase:
+    """Put a wrongly-enriched movie back on the review queue.
+
+    Unlike the automatic failure flag (set by
+    ``EnrichMovieMetadataUseCase`` when no TMDB match is found), this
+    is an operator-driven command for movies that *did* enrich but
+    matched the wrong title. Flagging surfaces the movie on the admin
+    ``needs-review`` listing, from where the operator picks the correct
+    TMDB id via the suggestions picker and relinks. The flag is cleared
+    on the next successful enrichment.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+    """
+
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(
+        self,
+        input_dto: FlagMovieEnrichmentReviewInput,
+    ) -> FlagMovieEnrichmentReviewOutput:
+        """Flag the movie for enrichment review.
+
+        Args:
+            input_dto: Input carrying the movie id to flag.
+
+        Returns:
+            The flag state after the command.
+
+        Raises:
+            ResourceNotFoundException: When no movie matches the id.
+        """
+        async with self._uow_factory() as uow:
+            movie = await uow.movies.find_by_id(MovieId(input_dto.movie_id))
+            if not movie:
+                raise ResourceNotFoundException.for_resource("Movie", input_dto.movie_id)
+
+            flagged = movie.with_enrichment_review_flagged()
+            # Idempotent: ``with_enrichment_review_flagged`` returns the
+            # same instance when already flagged, so only persist on a
+            # real state change.
+            if flagged is not movie:
+                await uow.movies.save(flagged)
+
+        return FlagMovieEnrichmentReviewOutput(
+            movie_id=input_dto.movie_id,
+            needs_enrichment_review=True,
+        )
+
+
+__all__ = ["FlagMovieEnrichmentReviewUseCase"]

--- a/src/modules/media/application/use_cases/get_movie_by_id.py
+++ b/src/modules/media/application/use_cases/get_movie_by_id.py
@@ -133,6 +133,7 @@ class GetMovieByIdUseCase:
             files=[to_media_file_output(f) for f in movie.files],
             tmdb_id=movie.tmdb_id.value if movie.tmdb_id else None,
             imdb_id=movie.imdb_id.value if movie.imdb_id else None,
+            needs_enrichment_review=movie.needs_enrichment_review,
             created_at=movie.created_at.isoformat(),
             updated_at=movie.updated_at.isoformat(),
         )

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -94,10 +94,12 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
     tmdb_id: TmdbId | None = None
     imdb_id: ImdbId | None = None
 
-    # Set true when an enrichment attempt could not resolve a TMDB
-    # match (off-year movie, cross-type miss, ambiguous title, …).
-    # Read by the admin "needs review" listing so the operator can
-    # relink manually. Cleared on successful enrichment.
+    # Set true when the movie needs an enrichment review — either an
+    # enrichment attempt couldn't resolve a TMDB match (off-year movie,
+    # cross-type miss, ambiguous title, …) or an operator flagged the
+    # result as wrong (matched the wrong title). Read by the admin
+    # "needs review" listing so the operator can relink manually.
+    # Cleared on the next successful enrichment.
     needs_enrichment_review: bool = False
 
     # noinspection PyNestedDecorators
@@ -171,6 +173,26 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
         if genre in self.genres:
             return self
         return self.with_updates(genres=[*self.genres, genre])
+
+    # ── enrichment review ─────────────────────────────────────────────
+
+    def with_enrichment_review_flagged(self) -> Self:
+        """Return a copy flagged for manual enrichment review.
+
+        Used when an operator decides the current metadata is wrong
+        (the enrichment matched the wrong title) and wants the movie
+        back in the admin review queue. Idempotent — returns ``self``
+        when the flag is already set so no spurious ``updated_at`` bump
+        happens. The flag is cleared on the next successful enrichment
+        (see ``EnrichMovieMetadataUseCase``).
+
+        Returns:
+            A new Movie with ``needs_enrichment_review=True``, or
+            ``self`` if it was already flagged.
+        """
+        if self.needs_enrichment_review:
+            return self
+        return self.with_updates(needs_enrichment_review=True)
 
     # ── factory ───────────────────────────────────────────────────────
 

--- a/src/modules/media/presentation/routes/admin_relink_routes.py
+++ b/src/modules/media/presentation/routes/admin_relink_routes.py
@@ -22,9 +22,13 @@ from src.config.containers import ApplicationContainer
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.admin_relink_dtos import (
+    FlagMovieEnrichmentReviewInput,
     GetMovieTmdbSuggestionsInput,
     PromoteMovieToSeriesInput,
     RelinkMovieInput,
+)
+from src.modules.media.application.use_cases.flag_movie_enrichment_review import (
+    FlagMovieEnrichmentReviewUseCase,
 )
 from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
     GetMovieTmdbSuggestionsUseCase,
@@ -52,6 +56,20 @@ async def list_movies_needing_review(
     """List movies whose enrichment couldn't resolve a TMDB match."""
     output = await use_case.execute()
     return api_list([asdict(m) for m in output.movies])
+
+
+@router.post("/movies/{movie_id}/flag-enrichment")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def flag_movie_enrichment(
+    movie_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: FlagMovieEnrichmentReviewUseCase = Depends(
+        Provide[ApplicationContainer.media.flag_movie_enrichment_review],
+    ),
+) -> dict[str, Any]:
+    """Flag a wrongly-enriched movie so it re-enters the review queue."""
+    output = await use_case.execute(FlagMovieEnrichmentReviewInput(movie_id=movie_id))
+    return api_single("flag_enrichment", asdict(output))
 
 
 @router.get("/movies/{movie_id}/tmdb-suggestions")  # type: ignore[misc]

--- a/tests/modules/media/unit/application/use_cases/test_flag_movie_enrichment_review.py
+++ b/tests/modules/media/unit/application/use_cases/test_flag_movie_enrichment_review.py
@@ -1,0 +1,78 @@
+"""Tests for FlagMovieEnrichmentReviewUseCase."""
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    FlagMovieEnrichmentReviewInput,
+)
+from src.modules.media.application.use_cases.flag_movie_enrichment_review import (
+    FlagMovieEnrichmentReviewUseCase,
+)
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects import MovieId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_movie() -> Movie:
+    return Movie.create(
+        library_id=_LIBRARY_ID,
+        title="Salem's Lot",
+        year=1979,
+        duration=0,
+        file_path="/movies/file.mkv",
+        file_size=1,
+        resolution="1080p",
+    )
+
+
+@pytest.mark.unit
+class TestFlagMovieEnrichmentReview:
+    @pytest.mark.asyncio
+    async def test_should_flag_and_persist_movie(self) -> None:
+        movie = _make_movie()
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+        mocks.movies.save.side_effect = lambda m: m
+
+        use_case = FlagMovieEnrichmentReviewUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            FlagMovieEnrichmentReviewInput(movie_id=str(movie.id)),
+        )
+
+        assert result.movie_id == str(movie.id)
+        assert result.needs_enrichment_review is True
+
+        mocks.movies.save.assert_called_once()
+        saved = mocks.movies.save.call_args.args[0]
+        assert saved.needs_enrichment_review is True
+
+    @pytest.mark.asyncio
+    async def test_should_not_persist_when_already_flagged(self) -> None:
+        """Idempotent: re-flagging an already-flagged movie must not
+        write (avoids a spurious ``updated_at`` bump)."""
+        movie = _make_movie().with_enrichment_review_flagged()
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = movie
+
+        use_case = FlagMovieEnrichmentReviewUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            FlagMovieEnrichmentReviewInput(movie_id=str(movie.id)),
+        )
+
+        assert result.needs_enrichment_review is True
+        mocks.movies.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_movie_not_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_id.return_value = None
+
+        use_case = FlagMovieEnrichmentReviewUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                FlagMovieEnrichmentReviewInput(movie_id=str(MovieId.generate())),
+            )

--- a/tests/modules/media/unit/domain/entities/test_movie.py
+++ b/tests/modules/media/unit/domain/entities/test_movie.py
@@ -650,3 +650,39 @@ class TestMovieLogoLocalization:
     def test_returns_none_when_no_logo_anywhere(self):
         movie = self._movie(logo_path=None, localized={})
         assert movie.get_logo_path("en") is None
+
+
+class TestMovieEnrichmentReview:
+    """Tests for the enrichment-review flag transition."""
+
+    @staticmethod
+    def _movie():
+        from src.modules.media.domain.entities import Movie
+
+        return Movie.create(
+            library_id=_LIBRARY_ID,
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+
+    def test_should_flag_for_review(self):
+        movie = self._movie()
+        assert movie.needs_enrichment_review is False
+
+        flagged = movie.with_enrichment_review_flagged()
+
+        assert flagged.needs_enrichment_review is True
+        # Immutability: the original is untouched.
+        assert movie.needs_enrichment_review is False
+
+    def test_should_be_idempotent_when_already_flagged(self):
+        movie = self._movie().with_enrichment_review_flagged()
+
+        again = movie.with_enrichment_review_flagged()
+
+        # Same instance — no spurious updated_at bump on re-flag.
+        assert again is movie


### PR DESCRIPTION
## Summary

- Add an admin-only command to flag an already-enriched movie whose metadata matched the **wrong** title, so it re-enters the needs-review queue for relinking (the automatic flag only covered enrichment *failures*).
- New domain transition `Movie.with_enrichment_review_flagged()` (idempotent, follows the `with_*` convention of ADR-007); broadens the `needs_enrichment_review` meaning to "failed OR flagged as wrong".
- New `FlagMovieEnrichmentReviewUseCase` + `POST /api/v1/admin/movies/{id}/flag-enrichment` (gated by `current_admin_user`), wired in `MediaContainer`.
- Surface `needs_enrichment_review` on the movie **detail** payload (`MovieOutput`) so the admin UI can show a persistent "flagged" badge.

The fix path itself reuses the existing review flow: flagged movies show on `GET /admin/movies/needs-review`, and the operator relinks to the correct TMDB id via the existing suggestions picker + `relink` (which force-enriches and clears the flag).

## Test plan

- [x] `ruff check` + `ruff format --check` on changed files
- [x] Unit: `Movie.with_enrichment_review_flagged()` (flag + idempotency)
- [x] Unit: `FlagMovieEnrichmentReviewUseCase` (flags & persists, idempotent no-write, not-found raises)
- [x] Unit: `GetMovieByIdUseCase` populates `needs_enrichment_review`
- [x] Full media unit suite (1201 passed) + media e2e suite (31 passed)
- [ ] Manual smoke: flag an enriched movie as admin → appears in `/admin` review queue → relink clears the flag

## Summary by Sourcery

Add support for flagging wrongly enriched movies for manual review and expose the review flag via the admin API and movie detail output.

New Features:
- Introduce admin-only endpoint to flag a movie's enrichment as wrong, returning it to the needs-review queue.
- Add a use case and DTOs for flagging movie enrichment review and exposing the resulting flag state.
- Expose the needs_enrichment_review flag on the movie detail output for admin UI display.

Enhancements:
- Extend the Movie domain model with an idempotent transition to flag movies for enrichment review, covering both failed and operator-flagged enrichments.

Tests:
- Add unit tests for the movie enrichment review flag transition and the new flag-enrichment use case, including idempotency and not-found behavior.