### PR TITLE
feat(media): add enrichment-review flag to series

### DIFF
--- a/migrations/versions/2026_06_14_add_needs_enrichment_review_to_series.py
+++ b/migrations/versions/2026_06_14_add_needs_enrichment_review_to_series.py
@@ -1,0 +1,57 @@
+"""Add needs_enrichment_review flag to series.
+
+Mirrors the ``movies`` flag (revision a6b7c8d9e0f1): surfaces series
+whose TMDB enrichment couldn't resolve a match, or that an operator
+flagged as wrongly enriched, on the admin "needs review" listing. Set
+by ``EnrichSeriesMetadataUseCase`` on failure / cleared on success, and
+toggled manually via the flag-enrichment command.
+
+``op.add_column`` is used directly (no ``batch_alter_table``) because
+rewriting the ``series`` table on SQLite would silently break the
+external-content FTS5 link — same discipline as the movies flag.
+
+Revision ID: b1c2d3e4f5a6
+Revises: 5f60718293a4
+Create Date: 2026-06-14 19:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: str | Sequence[str] | None = "5f60718293a4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add needs_enrichment_review column + supporting index."""
+    op.add_column(
+        "series",
+        sa.Column(
+            "needs_enrichment_review",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+    op.create_index(
+        "ix_series_needs_enrichment_review",
+        "series",
+        ["needs_enrichment_review"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the flag column and its index."""
+    op.drop_index("ix_series_needs_enrichment_review", table_name="series")
+    op.drop_column("series", "needs_enrichment_review")

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -82,6 +82,12 @@ class EnrichSeriesMetadataUseCase:
 
             metadata, provider_name = await self._fetch_metadata(series)
             if not metadata:
+                # Flag for admin review (cleared on the next successful
+                # enrichment) so the unresolved series surfaces on the
+                # needs-review queue instead of silently staying bare.
+                if not series.needs_enrichment_review:
+                    series = series.with_enrichment_review_flagged()
+                    await uow.series.save(series)
                 return EnrichMediaOutput(
                     media_id=input_dto.media_id,
                     enriched=False,
@@ -96,6 +102,8 @@ class EnrichSeriesMetadataUseCase:
                     metadata = localized_meta
 
             series = _apply_series_metadata(series, metadata)
+            if series.needs_enrichment_review:
+                series = series.with_updates(needs_enrichment_review=False)
             await uow.series.save(series)
             enriched_tmdb_id = series.tmdb_id.value if series.tmdb_id else None
 

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -81,6 +81,13 @@ class Series(AggregateRoot[SeriesId]):
     tmdb_id: TmdbId | None = None
     imdb_id: ImdbId | None = None
 
+    # Set true when the series needs an enrichment review — either an
+    # enrichment attempt couldn't resolve a TMDB match or an operator
+    # flagged the result as wrong (matched the wrong title). Read by
+    # the admin "needs review" listing so the operator can relink
+    # manually. Cleared on the next successful enrichment.
+    needs_enrichment_review: bool = False
+
     # Composition
     seasons: list[Season] = Field(default_factory=list)
 
@@ -161,6 +168,24 @@ class Series(AggregateRoot[SeriesId]):
             True if series has no end_year.
         """
         return self.end_year is None
+
+    def with_enrichment_review_flagged(self) -> Self:
+        """Return a copy flagged for manual enrichment review.
+
+        Used when an operator decides the current metadata is wrong
+        (the enrichment matched the wrong title) and wants the series
+        back in the admin review queue. Idempotent — returns ``self``
+        when the flag is already set so no spurious ``updated_at`` bump
+        happens. The flag is cleared on the next successful enrichment
+        (see ``EnrichSeriesMetadataUseCase``).
+
+        Returns:
+            A new Series with ``needs_enrichment_review=True``, or
+            ``self`` if it was already flagged.
+        """
+        if self.needs_enrichment_review:
+            return self
+        return self.with_updates(needs_enrichment_review=True)
 
     def with_season(self, season: Season) -> Self:
         """Return a copy with the season added.

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -54,6 +54,30 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_needs_enrichment_review(
+        self,
+        *,
+        allowed_library_ids: Sequence[LibraryId] | None = None,
+    ) -> Sequence[Series]:
+        """Return series flagged for admin enrichment review.
+
+        Backs the ``GET /admin/series/needs-review`` listing.
+        Soft-deleted rows are excluded. The set is expected to be
+        small so no pagination — caller orders by ``updated_at`` so
+        newest-flagged float up.
+
+        Args:
+            allowed_library_ids: Optional per-profile ACL filter. When
+                non-``None``, restricts to rows owned by libraries in
+                the set; ``None`` means no library filter (current
+                admin endpoint passes ``None``).
+
+        Returns:
+            Sequence of flagged series.
+        """
+        ...
+
+    @abstractmethod
     async def save(self, series: Series) -> Series:
         """Persist a series with all its seasons and episodes.
 

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -301,6 +301,7 @@ class SeriesMapper:
             else None,
             tmdb_id=entity.tmdb_id.value if entity.tmdb_id else None,
             imdb_id=entity.imdb_id.value if entity.imdb_id else None,
+            needs_enrichment_review=entity.needs_enrichment_review,
         )
 
     @staticmethod
@@ -340,6 +341,7 @@ class SeriesMapper:
             localized=json.loads(model.localized) if model.localized else {},
             tmdb_id=TmdbId(model.tmdb_id) if model.tmdb_id else None,
             imdb_id=ImdbId(model.imdb_id) if model.imdb_id else None,
+            needs_enrichment_review=bool(model.needs_enrichment_review),
             seasons=season_list,
             created_at=model.created_at,
             updated_at=model.updated_at,
@@ -376,6 +378,7 @@ class SeriesMapper:
         )
         model.tmdb_id = entity.tmdb_id.value if entity.tmdb_id else None
         model.imdb_id = entity.imdb_id.value if entity.imdb_id else None
+        model.needs_enrichment_review = entity.needs_enrichment_review
 
         return model
 

--- a/src/modules/media/infrastructure/persistence/models/series.py
+++ b/src/modules/media/infrastructure/persistence/models/series.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Integer, String, Text
+from sqlalchemy import Boolean, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.infrastructure.persistence.base import Base
@@ -62,6 +62,17 @@ class SeriesModel(Base):
     # External IDs
     tmdb_id: Mapped[int | None] = mapped_column(Integer, nullable=True, index=True)
     imdb_id: Mapped[str | None] = mapped_column(String(20), nullable=True, index=True)
+
+    # Flag set when enrichment couldn't resolve a TMDB match or an
+    # operator marked the result as wrong. Indexed so the admin "needs
+    # review" listing scans cheaply as the catalog grows.
+    needs_enrichment_review: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="0",
+        index=True,
+    )
 
     # Relationships
     seasons: Mapped[list["SeasonModel"]] = relationship(

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -165,6 +165,31 @@ class SQLAlchemySeriesRepository(SeriesRepository):
 
         return None if model is None else SeriesMapper.to_entity(model)
 
+    async def find_needs_enrichment_review(
+        self,
+        *,
+        allowed_library_ids: Sequence[LibraryId] | None = None,
+    ) -> Sequence[Series]:
+        """Return series with the review flag set, newest-first."""
+        conditions = [
+            SeriesModel.deleted_at.is_(None),
+            SeriesModel.needs_enrichment_review.is_(True),
+        ]
+        if allowed_library_ids is not None:
+            allowed = [library_id.value for library_id in allowed_library_ids]
+            if not allowed:
+                return []
+            conditions.append(SeriesModel.library_id.in_(allowed))
+
+        stmt = (
+            select(SeriesModel)
+            .where(*conditions)
+            .options(*self._series_load_options())
+            .order_by(SeriesModel.updated_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return [SeriesMapper.to_entity(model) for model in result.scalars().all()]
+
     async def save(self, series: Series) -> Series:
         """Persist a series with all its seasons and episodes.
 

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -218,6 +218,59 @@ class TestSQLAlchemySeriesRepository:
 
         assert found is None
 
+    async def test_find_needs_enrichment_review_returns_only_flagged(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """Only series with the flag set come back; others are excluded."""
+        repo = SQLAlchemySeriesRepository(db_session)
+        flagged = _create_series(title="Flagged", needs_enrichment_review=True)
+        clean = _create_series(title="Clean")
+        await repo.save(flagged)
+        await repo.save(clean)
+
+        result = await repo.find_needs_enrichment_review()
+
+        assert [s.title.value for s in result] == ["Flagged"]
+        assert result[0].needs_enrichment_review is True
+
+    async def test_find_needs_enrichment_review_excludes_soft_deleted(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """A flagged-then-deleted series must not surface on the queue."""
+        repo = SQLAlchemySeriesRepository(db_session)
+        flagged = _create_series(title="Flagged", needs_enrichment_review=True)
+        await repo.save(flagged)
+        await repo.delete(_id_of(flagged))
+
+        result = await repo.find_needs_enrichment_review()
+
+        assert result == []
+
+    async def test_find_needs_enrichment_review_honors_library_acl(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """The optional ACL filter restricts to allowed libraries."""
+        repo = SQLAlchemySeriesRepository(db_session)
+        mine = _create_series(title="Mine", needs_enrichment_review=True)
+        other = Series(
+            library_id=_LIBRARY_ID_OTHER,
+            id=SeriesId.generate(),
+            title=Title("Other"),
+            start_year=Year(2020),
+            needs_enrichment_review=True,
+        )
+        await repo.save(mine)
+        await repo.save(other)
+
+        result = await repo.find_needs_enrichment_review(
+            allowed_library_ids=[LibraryId(_LIBRARY_ID)],
+        )
+
+        assert [s.title.value for s in result] == ["Mine"]
+
     async def test_delete_removes_series_and_children(
         self,
         db_session: AsyncSession,

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -160,6 +160,43 @@ class TestEnrichSeriesMetadata:
             await use_case.execute(EnrichMediaInput(media_id=fake_id))
 
     @pytest.mark.asyncio
+    async def test_should_flag_for_review_when_no_metadata(self) -> None:
+        series = _make_series()
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = None
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        assert result.enriched is False
+        # The unresolved series is flagged + persisted for admin review.
+        saved = mocks.series.save.call_args[0][0]
+        assert saved.needs_enrichment_review is True
+
+    @pytest.mark.asyncio
+    async def test_should_clear_review_flag_on_success(self) -> None:
+        series = _make_series().with_enrichment_review_flagged()
+        assert series.needs_enrichment_review is True
+
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = _make_metadata()
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        result = await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        assert result.enriched is True
+        saved = mocks.series.save.call_args[0][0]
+        assert saved.needs_enrichment_review is False
+
+    @pytest.mark.asyncio
     async def test_should_enrich_double_episode(self) -> None:
         """Double episode file should merge metadata from two TMDB episodes."""
         series = _make_series()

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -310,3 +310,35 @@ class TestSeriesLogoLocalization:
     def test_returns_none_when_no_logo_anywhere(self):
         series = self._series(logo_path=None, localized={})
         assert series.get_logo_path("en") is None
+
+
+class TestSeriesEnrichmentReview:
+    """Tests for the enrichment-review flag transition."""
+
+    @staticmethod
+    def _series():
+        from src.modules.media.domain.entities import Series
+
+        return Series.create(
+            library_id=_LIBRARY_ID,
+            title="Breaking Bad",
+            start_year=2008,
+        )
+
+    def test_should_flag_for_review(self):
+        series = self._series()
+        assert series.needs_enrichment_review is False
+
+        flagged = series.with_enrichment_review_flagged()
+
+        assert flagged.needs_enrichment_review is True
+        # Immutability: the original is untouched.
+        assert series.needs_enrichment_review is False
+
+    def test_should_be_idempotent_when_already_flagged(self):
+        series = self._series().with_enrichment_review_flagged()
+
+        again = series.with_enrichment_review_flagged()
+
+        # Same instance — no spurious updated_at bump on re-flag.
+        assert again is series

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_series_mapper.py
@@ -333,6 +333,38 @@ class TestSeriesMapper:
         assert rebuilt.cast[1].profile_path is None
         assert rebuilt.cast[1].tmdb_id is None
 
+    def test_needs_enrichment_review_roundtrips(self) -> None:
+        """The review flag survives a ``to_model`` → ``to_entity`` cycle."""
+        series = _create_series(series_id=SeriesId.generate()).with_enrichment_review_flagged()
+
+        model = SeriesMapper.to_model(series)
+        now = datetime.now(UTC)
+        model.created_at = now
+        model.updated_at = now
+
+        assert model.needs_enrichment_review is True
+        rebuilt = SeriesMapper.to_entity(model, include_seasons=False)
+        assert rebuilt.needs_enrichment_review is True
+
+    def test_to_entity_coerces_null_review_flag_to_false(self) -> None:
+        """An un-flushed model (DB default not yet applied) has a
+        ``None`` flag column — to_entity must coerce it to ``False`` so
+        the ``bool`` domain field doesn't reject it."""
+        series_id = SeriesId.generate()
+        now = datetime.now(UTC)
+        model = SeriesModel(
+            library_id=_LIBRARY_ID,
+            external_id=str(series_id),
+            title="Flagless Series",
+            start_year=2020,
+            created_at=now,
+            updated_at=now,
+        )
+
+        entity = SeriesMapper.to_entity(model, include_seasons=False)
+
+        assert entity.needs_enrichment_review is False
+
     def test_update_model_overwrites_existing_cast(self) -> None:
         """``update_model`` replaces the persisted cast wholesale
         rather than merging — the new entity's list is the source of


### PR DESCRIPTION
## Summary

- Mirror the movies enrichment-review flag for **series** (PR 2 of the flag-wrong-enrichment rollout; follows #275).
- Domain: `Series.needs_enrichment_review` + idempotent `with_enrichment_review_flagged()` (ADR-007 `with_*`).
- Persistence: `SeriesModel` column + index, migration via `op.add_column` (no `batch_alter_table` — FTS5 triggers), mapper round-trip (`to_model`/`to_entity`/`update_model`, with `bool(...)` coercion for un-flushed rows).
- Repository: `SeriesRepository.find_needs_enrichment_review` (interface + impl) with optional per-profile ACL filter, newest-first, soft-deleted excluded — mirrors the movie finder.
- `EnrichSeriesMetadataUseCase` now flags on a no-match failure and clears the flag on success, reaching parity with movies.

This PR adds the domain + persistence foundation only. The admin needs-review listing, manual flag command, and series TMDB picker/relink land in follow-up PRs (3 and 4).

## Migration steps

- `make migrate` — adds `series.needs_enrichment_review` (default `0`) + `ix_series_needs_enrichment_review`. Verified `alembic upgrade head` and `downgrade -1` on a fresh SQLite DB.

## Test plan

- [x] `ruff check` + `ruff format --check` on changed files
- [x] Unit: series flag transition (flag + idempotency)
- [x] Unit: `EnrichSeriesMetadataUseCase` flags on no-match, clears on success
- [x] Unit: mapper round-trip + null-flag coercion
- [x] Integration: `find_needs_enrichment_review` (only-flagged, excludes soft-deleted, honors library ACL)
- [x] Full media suite: 1460 passed, 5 skipped
- [x] Migration upgrade + downgrade verified on a temp DB

## Summary by Sourcery

Add a needs_enrichment_review flag to series and ensure it is correctly persisted, queried, and managed by the series enrichment use case.

New Features:
- Introduce a needs_enrichment_review field on the Series domain entity and persistence model to track items requiring manual enrichment review.
- Expose a SeriesRepository.find_needs_enrichment_review method to retrieve flagged series with optional library ACL filtering.

Enhancements:
- Update EnrichSeriesMetadataUseCase to flag unresolved series for review and clear the flag after successful enrichment.
- Extend the series mapper to round-trip the enrichment-review flag and coerce null database values to False.

Tests:
- Add unit and integration tests covering the enrichment-review flag transitions, repository finder behavior, and mapper round-trips for series.

Chores:
- Add a database migration to create the needs_enrichment_review column and index on the series table.