### PR TITLE
feat(media): add series enrichment-review listing and flag

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -33,6 +33,9 @@ from src.modules.media.application.use_cases.enrich_series_metadata import (
 from src.modules.media.application.use_cases.flag_movie_enrichment_review import (
     FlagMovieEnrichmentReviewUseCase,
 )
+from src.modules.media.application.use_cases.flag_series_enrichment_review import (
+    FlagSeriesEnrichmentReviewUseCase,
+)
 from src.modules.media.application.use_cases.generate_hls_playlist import (
     GenerateHlsPlaylistUseCase,
 )
@@ -76,6 +79,9 @@ from src.modules.media.application.use_cases.list_recently_added_series import (
 )
 from src.modules.media.application.use_cases.list_scan_runs import ListScanRunsUseCase
 from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
+from src.modules.media.application.use_cases.list_series_needing_review import (
+    ListSeriesNeedingReviewUseCase,
+)
 from src.modules.media.application.use_cases.promote_movie_to_series import (
     PromoteMovieToSeriesUseCase,
 )
@@ -562,6 +568,16 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     flag_movie_enrichment_review = providers.Factory(
         FlagMovieEnrichmentReviewUseCase,
+        uow_factory=media_unit_of_work_factory,
+    )
+
+    list_series_needing_review = providers.Factory(
+        ListSeriesNeedingReviewUseCase,
+        uow_factory=media_unit_of_work_factory,
+    )
+
+    flag_series_enrichment_review = providers.Factory(
+        FlagSeriesEnrichmentReviewUseCase,
         uow_factory=media_unit_of_work_factory,
     )
 

--- a/src/modules/media/application/dtos/admin_relink_dtos.py
+++ b/src/modules/media/application/dtos/admin_relink_dtos.py
@@ -138,6 +138,61 @@ class RelinkMovieOutput:
 
 
 @dataclass(frozen=True)
+class NeedsReviewSeriesOutput:
+    """One row on the admin series "needs review" list.
+
+    Slim by design — enough to identify the series and seed the TMDB
+    picker. ``tmdb_id`` is surfaced because a wrongly-enriched series
+    already has one (pointing at the wrong title), and showing it helps
+    the operator confirm the mismatch before relinking.
+
+    Attributes:
+        id: External series id (``ser_xxx``).
+        title: Title as currently stored.
+        year: Start year as currently stored.
+        tmdb_id: Current TMDB id, or ``None`` when enrichment never
+            resolved a match.
+    """
+
+    id: str
+    title: str
+    year: int
+    tmdb_id: int | None
+
+
+@dataclass(frozen=True)
+class ListSeriesNeedingReviewOutput:
+    """Top-level response for the series needs-review listing."""
+
+    series: list[NeedsReviewSeriesOutput] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class FlagSeriesEnrichmentReviewInput:
+    """Admin command: flag a series' enrichment as wrong.
+
+    Attributes:
+        series_id: External series id (``ser_xxx``) to flag.
+    """
+
+    series_id: str
+
+
+@dataclass(frozen=True)
+class FlagSeriesEnrichmentReviewOutput:
+    """Result of a series flag command.
+
+    Attributes:
+        series_id: External series id (echoed).
+        needs_enrichment_review: The flag state after the command —
+            always ``True`` on success.
+    """
+
+    series_id: str
+    needs_enrichment_review: bool
+
+
+@dataclass(frozen=True)
 class FlagMovieEnrichmentReviewInput:
     """Admin command: flag a movie's enrichment as wrong.
 
@@ -205,11 +260,15 @@ class PromoteMovieToSeriesOutput:
 __all__ = [
     "FlagMovieEnrichmentReviewInput",
     "FlagMovieEnrichmentReviewOutput",
+    "FlagSeriesEnrichmentReviewInput",
+    "FlagSeriesEnrichmentReviewOutput",
     "GetMovieTmdbSuggestionsInput",
     "GetMovieTmdbSuggestionsOutput",
     "ListMoviesNeedingReviewOutput",
+    "ListSeriesNeedingReviewOutput",
     "MediaType",
     "NeedsReviewMovieOutput",
+    "NeedsReviewSeriesOutput",
     "PromoteMovieToSeriesInput",
     "PromoteMovieToSeriesOutput",
     "RelinkMovieInput",

--- a/src/modules/media/application/use_cases/flag_series_enrichment_review.py
+++ b/src/modules/media/application/use_cases/flag_series_enrichment_review.py
@@ -1,0 +1,63 @@
+"""Use case: admin flags a series' enrichment as wrong."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    FlagSeriesEnrichmentReviewInput,
+    FlagSeriesEnrichmentReviewOutput,
+)
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.value_objects import SeriesId
+
+
+class FlagSeriesEnrichmentReviewUseCase:
+    """Put a wrongly-enriched series back on the review queue.
+
+    Unlike the automatic failure flag (set by
+    ``EnrichSeriesMetadataUseCase`` when no TMDB match is found), this
+    is an operator-driven command for series that *did* enrich but
+    matched the wrong title. Flagging surfaces the series on the admin
+    ``needs-review`` listing, from where the operator relinks to the
+    correct TMDB id. The flag is cleared on the next successful
+    enrichment.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+    """
+
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(
+        self,
+        input_dto: FlagSeriesEnrichmentReviewInput,
+    ) -> FlagSeriesEnrichmentReviewOutput:
+        """Flag the series for enrichment review.
+
+        Args:
+            input_dto: Input carrying the series id to flag.
+
+        Returns:
+            The flag state after the command.
+
+        Raises:
+            ResourceNotFoundException: When no series matches the id.
+        """
+        async with self._uow_factory() as uow:
+            series = await uow.series.find_by_id(SeriesId(input_dto.series_id))
+            if not series:
+                raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
+
+            flagged = series.with_enrichment_review_flagged()
+            # Idempotent: ``with_enrichment_review_flagged`` returns the
+            # same instance when already flagged, so only persist on a
+            # real state change.
+            if flagged is not series:
+                await uow.series.save(flagged)
+
+        return FlagSeriesEnrichmentReviewOutput(
+            series_id=input_dto.series_id,
+            needs_enrichment_review=True,
+        )
+
+
+__all__ = ["FlagSeriesEnrichmentReviewUseCase"]

--- a/src/modules/media/application/use_cases/list_series_needing_review.py
+++ b/src/modules/media/application/use_cases/list_series_needing_review.py
@@ -1,0 +1,46 @@
+"""Use case: list series the admin needs to relink manually."""
+
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    ListSeriesNeedingReviewOutput,
+    NeedsReviewSeriesOutput,
+)
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.entities import Series
+
+
+class ListSeriesNeedingReviewUseCase:
+    """Return series whose ``needs_enrichment_review`` flag is set.
+
+    Backs the admin series "review queue" — small set in practice, so
+    no pagination. Newest-flagged first comes from the repository's
+    ``updated_at DESC`` order.
+
+    The admin endpoint is global (no per-profile filter): the caller is
+    already gated by ``current_admin_user``.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+    """
+
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(self) -> ListSeriesNeedingReviewOutput:
+        """Return all series pending enrichment review."""
+        async with self._uow_factory() as uow:
+            series = await uow.series.find_needs_enrichment_review()
+            return ListSeriesNeedingReviewOutput(
+                series=[_to_output(s) for s in series],
+            )
+
+
+def _to_output(series: Series) -> NeedsReviewSeriesOutput:
+    return NeedsReviewSeriesOutput(
+        id=str(series.id),
+        title=series.title.value,
+        year=series.start_year.value,
+        tmdb_id=series.tmdb_id.value if series.tmdb_id else None,
+    )
+
+
+__all__ = ["ListSeriesNeedingReviewUseCase"]

--- a/src/modules/media/presentation/routes/admin_relink_routes.py
+++ b/src/modules/media/presentation/routes/admin_relink_routes.py
@@ -1,14 +1,23 @@
-"""Admin REST API routes for the TMDB relink workflow.
+"""Admin REST API routes for the TMDB relink / enrichment-review workflow.
 
-Three endpoints, all gated by ``current_admin_user``:
+All endpoints are gated by ``current_admin_user``. Movies:
 
 * ``GET  /admin/movies/needs-review`` — listing of movies whose
-  enrichment couldn't find a TMDB match.
+  enrichment couldn't find a TMDB match (or were flagged as wrong).
+* ``POST /admin/movies/{id}/flag-enrichment`` — flag an enriched movie
+  whose metadata matched the wrong title.
 * ``GET  /admin/movies/{id}/tmdb-suggestions`` — live TMDB picker
   payload (movie + TV candidates) seeded by the movie's title/year.
 * ``POST /admin/movies/{id}/relink`` — admin commits a pick. Movie
   picks refresh the enrichment in place; TV picks 422 with a
   pointer to the deferred promote-to-series flow.
+
+Series (listing + manual flag; the TMDB picker + relink land in a
+follow-up):
+
+* ``GET  /admin/series/needs-review`` — listing of series needing review.
+* ``POST /admin/series/{id}/flag-enrichment`` — flag a wrongly-enriched
+  series.
 """
 
 from dataclasses import asdict
@@ -23,6 +32,7 @@ from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.admin_relink_dtos import (
     FlagMovieEnrichmentReviewInput,
+    FlagSeriesEnrichmentReviewInput,
     GetMovieTmdbSuggestionsInput,
     PromoteMovieToSeriesInput,
     RelinkMovieInput,
@@ -30,11 +40,17 @@ from src.modules.media.application.dtos.admin_relink_dtos import (
 from src.modules.media.application.use_cases.flag_movie_enrichment_review import (
     FlagMovieEnrichmentReviewUseCase,
 )
+from src.modules.media.application.use_cases.flag_series_enrichment_review import (
+    FlagSeriesEnrichmentReviewUseCase,
+)
 from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
     GetMovieTmdbSuggestionsUseCase,
 )
 from src.modules.media.application.use_cases.list_movies_needing_review import (
     ListMoviesNeedingReviewUseCase,
+)
+from src.modules.media.application.use_cases.list_series_needing_review import (
+    ListSeriesNeedingReviewUseCase,
 )
 from src.modules.media.application.use_cases.promote_movie_to_series import (
     PromoteMovieToSeriesUseCase,
@@ -122,6 +138,33 @@ async def promote_movie_to_series(
         PromoteMovieToSeriesInput(movie_id=movie_id, tmdb_id=body.tmdb_id),
     )
     return api_single("promote_to_series", asdict(output))
+
+
+@router.get("/series/needs-review")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_series_needing_review(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: ListSeriesNeedingReviewUseCase = Depends(
+        Provide[ApplicationContainer.media.list_series_needing_review],
+    ),
+) -> dict[str, Any]:
+    """List series needing enrichment review (failed match or flagged)."""
+    output = await use_case.execute()
+    return api_list([asdict(s) for s in output.series])
+
+
+@router.post("/series/{series_id}/flag-enrichment")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def flag_series_enrichment(
+    series_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: FlagSeriesEnrichmentReviewUseCase = Depends(
+        Provide[ApplicationContainer.media.flag_series_enrichment_review],
+    ),
+) -> dict[str, Any]:
+    """Flag a wrongly-enriched series so it re-enters the review queue."""
+    output = await use_case.execute(FlagSeriesEnrichmentReviewInput(series_id=series_id))
+    return api_single("flag_enrichment", asdict(output))
 
 
 __all__ = ["router"]

--- a/tests/modules/media/unit/application/use_cases/test_flag_series_enrichment_review.py
+++ b/tests/modules/media/unit/application/use_cases/test_flag_series_enrichment_review.py
@@ -1,0 +1,70 @@
+"""Tests for FlagSeriesEnrichmentReviewUseCase."""
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    FlagSeriesEnrichmentReviewInput,
+)
+from src.modules.media.application.use_cases.flag_series_enrichment_review import (
+    FlagSeriesEnrichmentReviewUseCase,
+)
+from src.modules.media.domain.entities import Series
+from src.modules.media.domain.value_objects import SeriesId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_series() -> Series:
+    return Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
+
+
+@pytest.mark.unit
+class TestFlagSeriesEnrichmentReview:
+    @pytest.mark.asyncio
+    async def test_should_flag_and_persist_series(self) -> None:
+        series = _make_series()
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+
+        use_case = FlagSeriesEnrichmentReviewUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            FlagSeriesEnrichmentReviewInput(series_id=str(series.id)),
+        )
+
+        assert result.series_id == str(series.id)
+        assert result.needs_enrichment_review is True
+
+        mocks.series.save.assert_called_once()
+        saved = mocks.series.save.call_args.args[0]
+        assert saved.needs_enrichment_review is True
+
+    @pytest.mark.asyncio
+    async def test_should_not_persist_when_already_flagged(self) -> None:
+        """Idempotent: re-flagging must not write (avoids a spurious
+        ``updated_at`` bump)."""
+        series = _make_series().with_enrichment_review_flagged()
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+
+        use_case = FlagSeriesEnrichmentReviewUseCase(uow_factory=mocks.factory)
+        result = await use_case.execute(
+            FlagSeriesEnrichmentReviewInput(series_id=str(series.id)),
+        )
+
+        assert result.needs_enrichment_review is True
+        mocks.series.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_series_not_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = None
+
+        use_case = FlagSeriesEnrichmentReviewUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                FlagSeriesEnrichmentReviewInput(series_id=str(SeriesId.generate())),
+            )

--- a/tests/modules/media/unit/application/use_cases/test_list_series_needing_review.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series_needing_review.py
@@ -1,0 +1,62 @@
+"""Tests for ListSeriesNeedingReviewUseCase."""
+
+import pytest
+
+from src.modules.media.application.use_cases.list_series_needing_review import (
+    ListSeriesNeedingReviewUseCase,
+)
+from src.modules.media.domain.entities import Series
+from src.modules.media.domain.value_objects import TmdbId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_series(title: str, start_year: int, tmdb_id: int | None = None) -> Series:
+    series = Series.create(library_id=_LIBRARY_ID, title=title, start_year=start_year)
+    if tmdb_id is not None:
+        series = series.with_updates(tmdb_id=TmdbId(tmdb_id))
+    return series
+
+
+@pytest.mark.unit
+class TestListSeriesNeedingReview:
+    @pytest.mark.asyncio
+    async def test_should_return_flagged_series(self) -> None:
+        flagged = [
+            _make_series("Breaking Bad", 2008, tmdb_id=1396),
+            _make_series("The Wire", 2002),
+        ]
+        mocks = make_media_uow_mock()
+        mocks.series.find_needs_enrichment_review.return_value = flagged
+
+        use_case = ListSeriesNeedingReviewUseCase(uow_factory=mocks.factory)
+        output = await use_case.execute()
+
+        assert len(output.series) == 2
+        assert {s.title for s in output.series} == {"Breaking Bad", "The Wire"}
+        assert all(s.id.startswith("ser_") for s in output.series)
+
+    @pytest.mark.asyncio
+    async def test_should_surface_current_tmdb_id(self) -> None:
+        """The current (possibly wrong) tmdb_id helps the operator
+        confirm the mismatch before relinking."""
+        mocks = make_media_uow_mock()
+        mocks.series.find_needs_enrichment_review.return_value = [
+            _make_series("Breaking Bad", 2008, tmdb_id=1396),
+        ]
+
+        use_case = ListSeriesNeedingReviewUseCase(uow_factory=mocks.factory)
+        output = await use_case.execute()
+
+        assert output.series[0].tmdb_id == 1396
+
+    @pytest.mark.asyncio
+    async def test_should_return_empty_list_when_none_flagged(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_needs_enrichment_review.return_value = []
+
+        use_case = ListSeriesNeedingReviewUseCase(uow_factory=mocks.factory)
+        output = await use_case.execute()
+
+        assert output.series == []


### PR DESCRIPTION
## Summary

- Expose the series enrichment-review queue and a manual flag command (PR 3 of the flag-wrong-enrichment rollout; builds on #276).
- `GET /api/v1/admin/series/needs-review` — lists flagged series (admin-only), newest-first, surfacing the current (possibly wrong) `tmdb_id`.
- `POST /api/v1/admin/series/{id}/flag-enrichment` — flags a wrongly-enriched series so it re-enters the queue.
- Adds `ListSeriesNeedingReviewUseCase` + `FlagSeriesEnrichmentReviewUseCase`, their DTOs, routes (in `admin_relink_routes.py`), and container wiring — mirroring the movie equivalents.

The series TMDB picker + relink (closing the fix loop) land in the final follow-up (PR 4).

## Test plan

- [x] `ruff check` + `ruff format --check` on changed files
- [x] Unit: `ListSeriesNeedingReviewUseCase` (returns flagged, surfaces tmdb_id, empty case)
- [x] Unit: `FlagSeriesEnrichmentReviewUseCase` (flags & persists, idempotent no-write, not-found raises)
- [x] Container resolves + both series routes registered
- [x] Full media suite: 1466 passed, 5 skipped

## Summary by Sourcery

Introduce admin capabilities to list and flag TV series needing enrichment review, mirroring existing movie enrichment-review workflows.

New Features:
- Add admin API endpoint to list series flagged for enrichment review, returning basic series metadata and current tmdb_id.
- Add admin API endpoint to flag a series' enrichment as incorrect so it re-enters the review queue.

Enhancements:
- Wire new series enrichment-review use cases into the media DI container and admin relink routes alongside the existing movie flows.

Tests:
- Add unit tests for listing series needing enrichment review, including tmdb_id surfacing and empty-result handling.
- Add unit tests for flagging series enrichment for review, covering persistence, idempotency, and not-found behavior.