### PR TITLE
feat(media): add series TMDB picker and relink

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -60,6 +60,9 @@ from src.modules.media.application.use_cases.get_related_movies import GetRelate
 from src.modules.media.application.use_cases.get_related_series import GetRelatedSeriesUseCase
 from src.modules.media.application.use_cases.get_scan_run import GetScanRunUseCase
 from src.modules.media.application.use_cases.get_series_by_id import GetSeriesByIdUseCase
+from src.modules.media.application.use_cases.get_series_tmdb_suggestions import (
+    GetSeriesTmdbSuggestionsUseCase,
+)
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_conflicts import ListConflictsUseCase
 from src.modules.media.application.use_cases.list_genres import ListGenresUseCase
@@ -86,6 +89,7 @@ from src.modules.media.application.use_cases.promote_movie_to_series import (
     PromoteMovieToSeriesUseCase,
 )
 from src.modules.media.application.use_cases.relink_movie import RelinkMovieUseCase
+from src.modules.media.application.use_cases.relink_series import RelinkSeriesUseCase
 from src.modules.media.application.use_cases.remove_file_variant import RemoveFileVariantUseCase
 from src.modules.media.application.use_cases.resolve_media_conflict import (
     ResolveMediaConflictUseCase,
@@ -579,6 +583,18 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     flag_series_enrichment_review = providers.Factory(
         FlagSeriesEnrichmentReviewUseCase,
         uow_factory=media_unit_of_work_factory,
+    )
+
+    get_series_tmdb_suggestions = providers.Factory(
+        GetSeriesTmdbSuggestionsUseCase,
+        uow_factory=media_unit_of_work_factory,
+        metadata_provider=tmdb_client,
+    )
+
+    relink_series = providers.Factory(
+        RelinkSeriesUseCase,
+        uow_factory=media_unit_of_work_factory,
+        enrich_use_case=enrich_series_metadata,
     )
 
     promote_movie_to_series = providers.Factory(

--- a/src/modules/media/application/dtos/admin_relink_dtos.py
+++ b/src/modules/media/application/dtos/admin_relink_dtos.py
@@ -193,6 +193,65 @@ class FlagSeriesEnrichmentReviewOutput:
 
 
 @dataclass(frozen=True)
+class GetSeriesTmdbSuggestionsInput:
+    """Input for the series suggestion picker.
+
+    Attributes:
+        series_id: External series id whose title + start year are the
+            search seed.
+    """
+
+    series_id: str
+
+
+@dataclass(frozen=True)
+class GetSeriesTmdbSuggestionsOutput:
+    """Picker payload for a series — TV candidates only.
+
+    Unlike the movie picker (which also offers TV candidates for the
+    promote-to-series path), the series picker only lists ``/search/tv``
+    results: re-pointing a series at a *movie* would be the inverse
+    promotion, which isn't supported.
+    """
+
+    series_id: str
+    series: list[TmdbSuggestionOutput] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RelinkSeriesInput:
+    """Admin's TV pick from the series suggestion picker.
+
+    Attributes:
+        series_id: External series id to relink.
+        tmdb_id: TMDB *series* id the admin selected.
+        media_type: Must be ``"tv"``. ``"movie"`` is rejected by the
+            use case (series → movie conversion is not supported).
+    """
+
+    series_id: str
+    tmdb_id: int
+    media_type: MediaType
+
+
+@dataclass(frozen=True)
+class RelinkSeriesOutput:
+    """Result of a series relink command.
+
+    Attributes:
+        series_id: External series id (echoed).
+        enriched: ``True`` when the new TMDB metadata was written.
+        provider: Provider that resolved the new metadata.
+        error: Failure reason when ``enriched`` is ``False``.
+    """
+
+    series_id: str
+    enriched: bool
+    provider: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
 class FlagMovieEnrichmentReviewInput:
     """Admin command: flag a movie's enrichment as wrong.
 
@@ -264,6 +323,8 @@ __all__ = [
     "FlagSeriesEnrichmentReviewOutput",
     "GetMovieTmdbSuggestionsInput",
     "GetMovieTmdbSuggestionsOutput",
+    "GetSeriesTmdbSuggestionsInput",
+    "GetSeriesTmdbSuggestionsOutput",
     "ListMoviesNeedingReviewOutput",
     "ListSeriesNeedingReviewOutput",
     "MediaType",
@@ -273,5 +334,7 @@ __all__ = [
     "PromoteMovieToSeriesOutput",
     "RelinkMovieInput",
     "RelinkMovieOutput",
+    "RelinkSeriesInput",
+    "RelinkSeriesOutput",
     "TmdbSuggestionOutput",
 ]

--- a/src/modules/media/application/use_cases/get_series_tmdb_suggestions.py
+++ b/src/modules/media/application/use_cases/get_series_tmdb_suggestions.py
@@ -1,0 +1,83 @@
+"""Use case: live TMDB picker payload for the series relink flow."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    GetSeriesTmdbSuggestionsInput,
+    GetSeriesTmdbSuggestionsOutput,
+    TmdbSuggestionOutput,
+)
+from src.modules.media.application.ports import MetadataProvider, SearchCandidate
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.value_objects import SeriesId
+
+
+class GetSeriesTmdbSuggestionsUseCase:
+    """Return TMDB TV candidates for a series needing review.
+
+    Loads the series to seed the search with its stored title and
+    start year, then issues ``/search/tv``. When the year-hinted query
+    returns nothing, retries without the year so the picker still shows
+    something for the operator to pick visually.
+
+    Only TV candidates are returned — re-pointing a series at a movie
+    would be the inverse promotion, which isn't supported.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+        metadata_provider: TMDB-side metadata port.
+        candidates_limit: Maximum number of suggestions to return.
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        metadata_provider: MetadataProvider,
+        candidates_limit: int = 5,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._provider = metadata_provider
+        self._limit = candidates_limit
+
+    async def execute(
+        self,
+        input_dto: GetSeriesTmdbSuggestionsInput,
+    ) -> GetSeriesTmdbSuggestionsOutput:
+        """Return TMDB TV candidates for the picker UI."""
+        async with self._uow_factory() as uow:
+            series = await uow.series.find_by_id(SeriesId(input_dto.series_id))
+            if not series:
+                raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
+            title = series.title.value
+            year = series.start_year.value
+
+        candidates = await self._candidates_with_fallback(title, year)
+
+        return GetSeriesTmdbSuggestionsOutput(
+            series_id=input_dto.series_id,
+            series=[_to_output(c) for c in candidates],
+        )
+
+    async def _candidates_with_fallback(
+        self,
+        title: str,
+        year: int | None,
+    ) -> list[SearchCandidate]:
+        """Search with year first; if empty, drop the year hint."""
+        candidates = await self._provider.find_series_candidates(title, year, self._limit)
+        if not candidates and year is not None:
+            candidates = await self._provider.find_series_candidates(title, None, self._limit)
+        return candidates
+
+
+def _to_output(candidate: SearchCandidate) -> TmdbSuggestionOutput:
+    return TmdbSuggestionOutput(
+        tmdb_id=candidate.tmdb_id,
+        media_type=candidate.media_type,
+        title=candidate.title,
+        year=candidate.year,
+        overview=candidate.overview,
+        poster_url=candidate.poster_url,
+    )
+
+
+__all__ = ["GetSeriesTmdbSuggestionsUseCase"]

--- a/src/modules/media/application/use_cases/relink_series.py
+++ b/src/modules/media/application/use_cases/relink_series.py
@@ -1,0 +1,80 @@
+"""Use case: admin re-points a series at a specific TMDB id."""
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    RelinkSeriesInput,
+    RelinkSeriesOutput,
+)
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
+from src.modules.media.domain.value_objects import SeriesId, TmdbId
+
+
+class RelinkSeriesUseCase:
+    """Apply an admin-picked TMDB id to a series and re-enrich.
+
+    Flow:
+        1. Validate ``media_type``. ``"movie"`` is rejected with a
+           ``UseCaseValidationException`` — converting a series back
+           into a movie is not supported.
+        2. Load the series and stamp the picked ``tmdb_id``.
+        3. Force-enrich. ``EnrichSeriesMetadataUseCase`` resolves
+           ``get_series_by_id`` first when ``series.tmdb_id`` is set,
+           so the admin's pick wins over the title-based search, and
+           clears the review flag on success.
+        4. Surface the enrichment outcome to the caller.
+
+    Args:
+        uow_factory: Factory that opens a fresh media Unit of Work.
+        enrich_use_case: ``EnrichSeriesMetadataUseCase`` instance used
+            to refresh the entity after the new id is stamped.
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        enrich_use_case: EnrichSeriesMetadataUseCase,
+    ) -> None:
+        self._uow_factory = uow_factory
+        self._enrich = enrich_use_case
+
+    async def execute(self, input_dto: RelinkSeriesInput) -> RelinkSeriesOutput:
+        """Execute the relink command."""
+        if input_dto.media_type == "movie":
+            raise UseCaseValidationException(
+                message=(
+                    "Cross-type relink (series → movie) is not "
+                    "supported. Pick a TV candidate from the series "
+                    "suggestion picker."
+                ),
+                message_code="RELINK_CROSS_TYPE_NOT_SUPPORTED",
+            )
+
+        async with self._uow_factory() as uow:
+            series = await uow.series.find_by_id(SeriesId(input_dto.series_id))
+            if not series:
+                raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
+            # Stamp the picked id so the enrichment path resolves
+            # via ``get_series_by_id`` instead of the title search.
+            # The flag is cleared by the enrich use case on success.
+            series = series.with_updates(tmdb_id=TmdbId(input_dto.tmdb_id))
+            await uow.series.save(series)
+
+        result = await self._enrich.execute(
+            EnrichMediaInput(media_id=input_dto.series_id, force=True),
+        )
+        return RelinkSeriesOutput(
+            series_id=result.media_id,
+            enriched=result.enriched,
+            provider=result.provider,
+            error=result.error,
+        )
+
+
+__all__ = ["RelinkSeriesUseCase"]

--- a/src/modules/media/presentation/routes/admin_relink_routes.py
+++ b/src/modules/media/presentation/routes/admin_relink_routes.py
@@ -12,12 +12,15 @@ All endpoints are gated by ``current_admin_user``. Movies:
   picks refresh the enrichment in place; TV picks 422 with a
   pointer to the deferred promote-to-series flow.
 
-Series (listing + manual flag; the TMDB picker + relink land in a
-follow-up):
+Series (full review + relink workflow):
 
 * ``GET  /admin/series/needs-review`` — listing of series needing review.
 * ``POST /admin/series/{id}/flag-enrichment`` — flag a wrongly-enriched
   series.
+* ``GET  /admin/series/{id}/tmdb-suggestions`` — live TMDB picker
+  (TV candidates) seeded by the series' title/start year.
+* ``POST /admin/series/{id}/relink`` — admin commits a TV pick; the
+  series is re-pointed at the chosen TMDB id and force-enriched.
 """
 
 from dataclasses import asdict
@@ -34,8 +37,10 @@ from src.modules.media.application.dtos.admin_relink_dtos import (
     FlagMovieEnrichmentReviewInput,
     FlagSeriesEnrichmentReviewInput,
     GetMovieTmdbSuggestionsInput,
+    GetSeriesTmdbSuggestionsInput,
     PromoteMovieToSeriesInput,
     RelinkMovieInput,
+    RelinkSeriesInput,
 )
 from src.modules.media.application.use_cases.flag_movie_enrichment_review import (
     FlagMovieEnrichmentReviewUseCase,
@@ -45,6 +50,9 @@ from src.modules.media.application.use_cases.flag_series_enrichment_review impor
 )
 from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
     GetMovieTmdbSuggestionsUseCase,
+)
+from src.modules.media.application.use_cases.get_series_tmdb_suggestions import (
+    GetSeriesTmdbSuggestionsUseCase,
 )
 from src.modules.media.application.use_cases.list_movies_needing_review import (
     ListMoviesNeedingReviewUseCase,
@@ -56,7 +64,12 @@ from src.modules.media.application.use_cases.promote_movie_to_series import (
     PromoteMovieToSeriesUseCase,
 )
 from src.modules.media.application.use_cases.relink_movie import RelinkMovieUseCase
-from src.modules.media.presentation.schemas import PromoteMovieToSeriesRequest, RelinkMovieRequest
+from src.modules.media.application.use_cases.relink_series import RelinkSeriesUseCase
+from src.modules.media.presentation.schemas import (
+    PromoteMovieToSeriesRequest,
+    RelinkMovieRequest,
+    RelinkSeriesRequest,
+)
 
 router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Movie Relink"])
 
@@ -165,6 +178,41 @@ async def flag_series_enrichment(
     """Flag a wrongly-enriched series so it re-enters the review queue."""
     output = await use_case.execute(FlagSeriesEnrichmentReviewInput(series_id=series_id))
     return api_single("flag_enrichment", asdict(output))
+
+
+@router.get("/series/{series_id}/tmdb-suggestions")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_series_tmdb_suggestions(
+    series_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: GetSeriesTmdbSuggestionsUseCase = Depends(
+        Provide[ApplicationContainer.media.get_series_tmdb_suggestions],
+    ),
+) -> dict[str, Any]:
+    """Return TMDB TV candidates seeded by the series' title/start year."""
+    output = await use_case.execute(GetSeriesTmdbSuggestionsInput(series_id=series_id))
+    return api_single("tmdb_suggestions", asdict(output))
+
+
+@router.post("/series/{series_id}/relink")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def relink_series(
+    series_id: str,
+    body: RelinkSeriesRequest,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: RelinkSeriesUseCase = Depends(
+        Provide[ApplicationContainer.media.relink_series],
+    ),
+) -> dict[str, Any]:
+    """Stamp the picked TMDB id on the series and force-enrich."""
+    output = await use_case.execute(
+        RelinkSeriesInput(
+            series_id=series_id,
+            tmdb_id=body.tmdb_id,
+            media_type=body.media_type,
+        ),
+    )
+    return api_single("relink", asdict(output))
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/schemas/__init__.py
+++ b/src/modules/media/presentation/schemas/__init__.py
@@ -3,6 +3,7 @@
 from src.modules.media.presentation.schemas.admin_relink_schemas import (
     PromoteMovieToSeriesRequest,
     RelinkMovieRequest,
+    RelinkSeriesRequest,
 )
 from src.modules.media.presentation.schemas.enrichment_schemas import EnrichRequest
 from src.modules.media.presentation.schemas.file_variant_schemas import (
@@ -18,6 +19,7 @@ __all__ = [
     "EnrichRequest",
     "PromoteMovieToSeriesRequest",
     "RelinkMovieRequest",
+    "RelinkSeriesRequest",
     "RemoveFileVariantRequest",
     "ScanMediaRequest",
     "SetIntroRequest",

--- a/src/modules/media/presentation/schemas/admin_relink_schemas.py
+++ b/src/modules/media/presentation/schemas/admin_relink_schemas.py
@@ -26,6 +26,22 @@ class RelinkMovieRequest(BaseModel):
     )
 
 
+class RelinkSeriesRequest(BaseModel):
+    """Request body for ``POST /admin/series/{id}/relink``.
+
+    Only TV picks ride this endpoint. ``media_type`` is pinned to
+    ``"tv"`` by ``Literal`` so a ``"movie"`` payload is rejected at the
+    schema layer with a 422 — re-pointing a series at a movie (the
+    inverse promotion) is not supported.
+    """
+
+    tmdb_id: int = Field(..., ge=1, description="TMDB *series* id of the picked entry.")
+    media_type: Literal["tv"] = Field(
+        ...,
+        description="Must be 'tv'. Series can only relink to other TV entries.",
+    )
+
+
 class PromoteMovieToSeriesRequest(BaseModel):
     """Request body for ``POST /admin/movies/{id}/promote-to-series``.
 
@@ -43,4 +59,4 @@ class PromoteMovieToSeriesRequest(BaseModel):
     )
 
 
-__all__ = ["PromoteMovieToSeriesRequest", "RelinkMovieRequest"]
+__all__ = ["PromoteMovieToSeriesRequest", "RelinkMovieRequest", "RelinkSeriesRequest"]

--- a/tests/modules/media/unit/application/use_cases/test_get_series_tmdb_suggestions.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_series_tmdb_suggestions.py
@@ -1,0 +1,95 @@
+"""Tests for GetSeriesTmdbSuggestionsUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.admin_relink_dtos import (
+    GetSeriesTmdbSuggestionsInput,
+)
+from src.modules.media.application.ports import MetadataProvider, SearchCandidate
+from src.modules.media.application.use_cases.get_series_tmdb_suggestions import (
+    GetSeriesTmdbSuggestionsUseCase,
+)
+from src.modules.media.domain.entities import Series
+from src.modules.media.domain.value_objects import SeriesId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_series(title: str = "Breaking Bad", start_year: int = 2008) -> Series:
+    return Series.create(library_id=_LIBRARY_ID, title=title, start_year=start_year)
+
+
+def _series_candidate(tmdb_id: int, title: str, year: int | None = None) -> SearchCandidate:
+    return SearchCandidate(
+        tmdb_id=tmdb_id,
+        media_type="tv",
+        title=title,
+        year=year,
+        overview=None,
+        poster_url=None,
+    )
+
+
+@pytest.mark.unit
+class TestGetSeriesTmdbSuggestions:
+    @pytest.mark.asyncio
+    async def test_should_return_tv_candidates(self) -> None:
+        series = _make_series()
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.find_series_candidates.return_value = [
+            _series_candidate(1396, "Breaking Bad", 2008),
+        ]
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+
+        use_case = GetSeriesTmdbSuggestionsUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+        )
+        output = await use_case.execute(GetSeriesTmdbSuggestionsInput(series_id=str(series.id)))
+
+        assert output.series_id == str(series.id)
+        assert [s.tmdb_id for s in output.series] == [1396]
+        assert output.series[0].media_type == "tv"
+
+    @pytest.mark.asyncio
+    async def test_should_retry_without_year_when_empty(self) -> None:
+        series = _make_series()
+        provider = AsyncMock(spec=MetadataProvider)
+        # First (year-hinted) call empty, second (no year) returns a hit.
+        provider.find_series_candidates.side_effect = [
+            [],
+            [_series_candidate(1396, "Breaking Bad", 2008)],
+        ]
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+
+        use_case = GetSeriesTmdbSuggestionsUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+        )
+        output = await use_case.execute(GetSeriesTmdbSuggestionsInput(series_id=str(series.id)))
+
+        assert [s.tmdb_id for s in output.series] == [1396]
+        assert provider.find_series_candidates.await_count == 2
+        # Second call dropped the year hint.
+        assert provider.find_series_candidates.await_args_list[1].args[1] is None
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_series_not_found(self) -> None:
+        provider = AsyncMock(spec=MetadataProvider)
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = None
+
+        use_case = GetSeriesTmdbSuggestionsUseCase(
+            uow_factory=mocks.factory,
+            metadata_provider=provider,
+        )
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                GetSeriesTmdbSuggestionsInput(series_id=str(SeriesId.generate())),
+            )

--- a/tests/modules/media/unit/application/use_cases/test_relink_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_relink_series.py
@@ -1,0 +1,97 @@
+"""Tests for RelinkSeriesUseCase."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.modules.media.application.dtos.admin_relink_dtos import RelinkSeriesInput
+from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaOutput
+from src.modules.media.application.use_cases.enrich_series_metadata import (
+    EnrichSeriesMetadataUseCase,
+)
+from src.modules.media.application.use_cases.relink_series import RelinkSeriesUseCase
+from src.modules.media.domain.entities import Series
+from src.modules.media.domain.value_objects import SeriesId
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_series() -> Series:
+    return Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
+
+
+@pytest.mark.unit
+class TestRelinkSeries:
+    @pytest.mark.asyncio
+    async def test_should_stamp_tmdb_id_and_force_enrich_on_tv_pick(self) -> None:
+        series = _make_series()
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+        enrich.execute.return_value = EnrichMediaOutput(
+            media_id=str(series.id),
+            enriched=True,
+            provider="tmdb",
+        )
+
+        use_case = RelinkSeriesUseCase(uow_factory=mocks.factory, enrich_use_case=enrich)
+        result = await use_case.execute(
+            RelinkSeriesInput(series_id=str(series.id), tmdb_id=1396, media_type="tv"),
+        )
+
+        assert result.enriched is True
+        assert result.provider == "tmdb"
+
+        mocks.series.save.assert_called_once()
+        saved = mocks.series.save.call_args.args[0]
+        assert saved.tmdb_id is not None
+        assert saved.tmdb_id.value == 1396
+
+        enrich.execute.assert_awaited_once()
+        enrich_input = enrich.execute.await_args.args[0]
+        assert enrich_input.media_id == str(series.id)
+        assert enrich_input.force is True
+
+    @pytest.mark.asyncio
+    async def test_should_reject_movie_media_type_with_validation_error(self) -> None:
+        mocks = make_media_uow_mock()
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+
+        use_case = RelinkSeriesUseCase(uow_factory=mocks.factory, enrich_use_case=enrich)
+
+        with pytest.raises(UseCaseValidationException) as excinfo:
+            await use_case.execute(
+                RelinkSeriesInput(
+                    series_id=str(SeriesId.generate()),
+                    tmdb_id=603,
+                    media_type="movie",
+                ),
+            )
+
+        assert excinfo.value.message_code == "RELINK_CROSS_TYPE_NOT_SUPPORTED"
+        mocks.series.find_by_id.assert_not_called()
+        enrich.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_series_not_found(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = None
+        enrich = AsyncMock(spec=EnrichSeriesMetadataUseCase)
+
+        use_case = RelinkSeriesUseCase(uow_factory=mocks.factory, enrich_use_case=enrich)
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                RelinkSeriesInput(
+                    series_id=str(SeriesId.generate()),
+                    tmdb_id=1396,
+                    media_type="tv",
+                ),
+            )


### PR DESCRIPTION
## Summary

- Close the series enrichment-review loop (final backend PR of the rollout; builds on #277).
- `GET /api/v1/admin/series/{id}/tmdb-suggestions` — TMDB TV candidates seeded by the series' title/start year, with a no-year retry fallback (admin-only). TV-only by design: re-pointing a series at a movie (inverse promotion) isn't supported.
- `POST /api/v1/admin/series/{id}/relink` — stamps the picked TMDB id and force-enriches via `EnrichSeriesMetadataUseCase`, which clears the review flag on success. A `movie` pick is rejected (422 at the schema layer + defensive `UseCaseValidationException`).
- Adds `GetSeriesTmdbSuggestionsUseCase` + `RelinkSeriesUseCase`, DTOs, `RelinkSeriesRequest` schema, routes, and container wiring — mirroring the movie picker/relink.

With this, series reach full parity with movies: flag → needs-review listing → picker → relink (clears flag).

## Test plan

- [x] `ruff check` + `ruff format --check` on changed files
- [x] Unit: `GetSeriesTmdbSuggestionsUseCase` (returns TV candidates, no-year retry, not-found raises)
- [x] Unit: `RelinkSeriesUseCase` (stamps id + force-enrich, rejects movie pick, not-found raises)
- [x] Container resolves + both series routes registered
- [x] Full media suite: 1472 passed, 5 skipped

## Summary by Sourcery

Add admin series TMDB picker and relink flow to complete series enrichment review parity with movies.

New Features:
- Expose admin endpoint to fetch TMDB TV suggestions for a given series based on its title and start year.
- Expose admin endpoint to relink a series to a chosen TMDB TV id and trigger re-enrichment, disallowing series-to-movie conversions.

Enhancements:
- Introduce series-specific TMDB suggestion and relink DTOs, use cases, and container wiring aligned with the existing movie relink flow.

Tests:
- Add unit tests covering series TMDB suggestion lookup behavior and the series relink use case, including validation and not-found scenarios.