### PR TITLE
feat(media): expose needs_enrichment_review on series detail

### DIFF
--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -101,6 +101,10 @@ class SeriesOutput:
         genres: List of genre strings.
         tmdb_id: TMDB external ID (optional).
         imdb_id: IMDB external ID (optional).
+        needs_enrichment_review: ``True`` when the series is flagged for
+            enrichment review (enrichment failed or an operator marked
+            the result as wrong). Lets the admin detail UI show a
+            persistent "flagged" badge.
         season_count: Number of seasons.
         total_episodes: Total episode count.
         seasons: List of seasons with episodes.
@@ -123,6 +127,7 @@ class SeriesOutput:
     trailer_url: str | None
     tmdb_id: int | None
     imdb_id: str | None
+    needs_enrichment_review: bool
     season_count: int
     total_episodes: int
     seasons: list[SeasonOutput]

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -131,6 +131,7 @@ class GetSeriesByIdUseCase:
             trailer_url=series.trailer_url,
             tmdb_id=series.tmdb_id.value if series.tmdb_id else None,
             imdb_id=series.imdb_id.value if series.imdb_id else None,
+            needs_enrichment_review=series.needs_enrichment_review,
             season_count=series.season_count,
             total_episodes=series.total_episodes,
             seasons=[self._to_season_output(s, series_id, progress_map) for s in series.seasons],

--- a/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_series_by_id.py
@@ -103,6 +103,24 @@ class TestGetSeriesByIdUseCase:
         assert result.title == "Breaking Bad"
         assert result.start_year == 2008
         assert result.is_ongoing is True
+        assert result.needs_enrichment_review is False
+
+    @pytest.mark.asyncio
+    async def test_should_expose_needs_enrichment_review_flag(self, mock_progress_lookup):
+        mocks = make_media_uow_mock()
+        series = Series.create(
+            library_id=_LIBRARY_ID,
+            title="Breaking Bad",
+            start_year=2008,
+        ).with_enrichment_review_flagged()
+        mocks.series.find_by_id.return_value = series
+        use_case = _make_use_case(mocks, mock_progress_lookup)
+
+        result = await use_case.execute(
+            GetSeriesByIdInput(profile_id=_PROFILE_ID, series_id=str(series.id))
+        )
+
+        assert result.needs_enrichment_review is True
 
     @pytest.mark.asyncio
     async def test_should_return_series_with_seasons(self, mock_progress_lookup):


### PR DESCRIPTION
## Summary

- Surface `needs_enrichment_review` on the series detail payload (`SeriesOutput`), mirroring the movie detail (#275).
- Lets the admin series detail UI render a persistent "flagged" badge that survives reloads (the frontend series flag button consumes this).

## Test plan

- [x] `ruff check` on changed files
- [x] Unit: `GetSeriesByIdUseCase` exposes the flag (default false + flagged true)
- [x] Full media suite: 1472 passed, 5 skipped

## Summary by Sourcery

Expose the enrichment review flag on series detail responses and cover it with tests.

New Features:
- Include the needs_enrichment_review flag in the SeriesOutput DTO and populate it in the GetSeriesById use case.

Tests:
- Add unit coverage to verify the needs_enrichment_review flag is present and correctly reflects flagged and unflagged series.