### PR TITLE
fix(media): force series relink to overwrite stale metadata

### DIFF
--- a/src/modules/media/application/use_cases/_localized_metadata_helpers.py
+++ b/src/modules/media/application/use_cases/_localized_metadata_helpers.py
@@ -14,6 +14,8 @@ def merge_localized_metadata(
     updates: dict[str, object],
     existing: dict[str, dict[str, object]],
     metadata: MediaMetadata,
+    *,
+    force: bool = False,
 ) -> None:
     """Merge per-language overrides from ``metadata`` into ``updates``.
 
@@ -29,6 +31,11 @@ def merge_localized_metadata(
             to merge.
         existing: The entity's current ``localized`` mapping.
         metadata: Provider metadata carrying the ``localized`` overrides.
+        force: When ``True`` (a relink / forced refresh) the entity's
+            current ``localized`` is **replaced** by the provider's,
+            dropping stale language entries left over from a wrong
+            match. When ``False`` the new entries are merged over the
+            existing ones (the default fill-and-update behavior).
     """
     if not metadata.localized:
         return
@@ -47,7 +54,7 @@ def merge_localized_metadata(
             localized[lang] = loc_entry
 
     if localized:
-        updates["localized"] = {**existing, **localized}
+        updates["localized"] = localized if force else {**existing, **localized}
 
 
 __all__ = ["merge_localized_metadata"]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -338,7 +338,7 @@ def _apply_credits(
         updates["content_rating"] = ContentRating(metadata.content_rating)
     if metadata.trailer_url and (force or not movie.trailer_url):
         updates["trailer_url"] = metadata.trailer_url
-    merge_localized_metadata(updates, movie.localized, metadata)
+    merge_localized_metadata(updates, movie.localized, metadata, force=force)
 
 
 __all__ = ["EnrichMovieMetadataUseCase"]

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -101,7 +101,7 @@ class EnrichSeriesMetadataUseCase:
                 if localized_meta is not None:
                     metadata = localized_meta
 
-            series = _apply_series_metadata(series, metadata)
+            series = _apply_series_metadata(series, metadata, force=input_dto.force)
             if series.needs_enrichment_review:
                 series = series.with_updates(needs_enrichment_review=False)
             await uow.series.save(series)
@@ -166,17 +166,38 @@ def _set_if_missing(
     metadata: MediaMetadata,
     entity: Series,
     field_map: dict[str, tuple[str, Callable[[Any], Any] | None]],
+    *,
+    force: bool = False,
 ) -> None:
-    """Set fields in updates only if metadata has a value and entity doesn't."""
+    """Set fields in updates, respecting the fill-if-empty guard.
+
+    A field is written when metadata has a value and either ``force``
+    is set or the entity field is empty. The fill-if-empty guard
+    protects user edits on a routine re-enrichment; ``force`` (a relink
+    / forced refresh) bypasses it so metadata from the newly-picked
+    match overwrites stale values left by a wrong match.
+    """
     for meta_attr, (entity_attr, converter) in field_map.items():
         meta_val = getattr(metadata, meta_attr, None)
         entity_val = getattr(entity, entity_attr, None)
-        if meta_val and not entity_val:
+        if meta_val and (force or not entity_val):
             updates[entity_attr] = converter(meta_val) if converter is not None else meta_val
 
 
-def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
-    """Apply metadata fields to a series entity."""
+def _apply_series_metadata(
+    series: Series,
+    metadata: MediaMetadata,
+    *,
+    force: bool = False,
+) -> Series:
+    """Apply metadata fields to a series entity.
+
+    Each "don't-overwrite" field has a fill-if-empty guard by default so
+    a routine re-enrichment doesn't clobber user edits. When ``force``
+    is set (a relink, where the existing data belongs to a wrong match)
+    every guard is bypassed and the provider payload wins — including a
+    full replace of the ``localized`` overrides and the base title.
+    """
     updates: dict[str, object] = {}
 
     # Always-overwrite fields
@@ -190,8 +211,13 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
         updates["start_year"] = Year(metadata.year)
     if metadata.end_year:
         updates["end_year"] = Year(metadata.end_year)
+    # The base title normally stays scanner-derived, but on a forced
+    # refresh it may belong to a wrong match — overwrite it so the
+    # canonical title tracks the newly-picked TMDB entry.
+    if metadata.title and force:
+        updates["title"] = Title(metadata.title)
 
-    # Don't-overwrite fields (only set if not already present)
+    # Don't-overwrite fields (only set if empty, unless ``force``)
     _set_if_missing(
         updates,
         metadata,
@@ -205,6 +231,7 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
             "content_rating": ("content_rating", ContentRating),
             "trailer_url": ("trailer_url", None),
         },
+        force=force,
     )
 
     # Cast: same fill-if-empty rule as the rest of the don't-overwrite
@@ -212,7 +239,7 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
     # provider DTO uses a different field name (``cast`` ↔ ``cast``)
     # AND a per-element converter from ``CreditPerson`` to the
     # domain ``CastMember`` VO.
-    if metadata.cast and not series.cast:
+    if metadata.cast and (force or not series.cast):
         updates["cast"] = [
             CastMember(
                 name=p.name,
@@ -223,40 +250,45 @@ def _apply_series_metadata(series: Series, metadata: MediaMetadata) -> Series:
             for p in metadata.cast
         ]
 
-    merge_localized_metadata(updates, series.localized, metadata)
+    merge_localized_metadata(updates, series.localized, metadata, force=force)
 
     if updates:
         series = series.with_updates(**updates)
 
     # Enrich seasons and episodes
     if metadata.seasons:
-        series = _enrich_seasons(series, metadata.seasons)
+        series = _enrich_seasons(series, metadata.seasons, force=force)
 
     return series
 
 
-def _enrich_seasons(series: Series, season_metas: list[SeasonMetadata]) -> Series:
+def _enrich_seasons(
+    series: Series,
+    season_metas: list[SeasonMetadata],
+    *,
+    force: bool = False,
+) -> Series:
     """Enrich existing seasons with metadata."""
     meta_by_num = {s.season_number: s for s in season_metas}  # int keys from API
 
     new_seasons = []
     for season in series.seasons:
         meta = meta_by_num.get(season.season_number.value)
-        enriched = _apply_season_metadata(season, meta) if meta else season
+        enriched = _apply_season_metadata(season, meta, force=force) if meta else season
         new_seasons.append(enriched)
 
     return series.with_updates(seasons=new_seasons)
 
 
-def _apply_season_metadata(season: Season, meta: SeasonMetadata) -> Season:
+def _apply_season_metadata(season: Season, meta: SeasonMetadata, *, force: bool = False) -> Season:
     """Apply metadata to a season and its episodes."""
     updates: dict[str, object] = {}
 
-    if meta.title and not season.title:
+    if meta.title and (force or not season.title):
         updates["title"] = Title(meta.title)
-    if meta.synopsis and not season.synopsis:
+    if meta.synopsis and (force or not season.synopsis):
         updates["synopsis"] = meta.synopsis
-    if meta.air_date and not season.air_date:
+    if meta.air_date and (force or not season.air_date):
         parsed = _parse_date(meta.air_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
@@ -274,11 +306,11 @@ def _apply_season_metadata(season: Season, meta: SeasonMetadata) -> Season:
             segment_count = _detect_multi_episode(ep.title.value)
             if segment_count > 1:
                 enriched_ep = _apply_multi_episode_metadata(
-                    ep, ep_by_num, segment_count, tmdb_start=tmdb_idx
+                    ep, ep_by_num, segment_count, tmdb_start=tmdb_idx, force=force
                 )
             else:
                 ep_meta = ep_by_num.get(tmdb_idx)
-                enriched_ep = _apply_episode_metadata(ep, ep_meta) if ep_meta else ep
+                enriched_ep = _apply_episode_metadata(ep, ep_meta, force=force) if ep_meta else ep
             new_episodes.append(enriched_ep)
             tmdb_idx += segment_count
         season = season.with_updates(episodes=new_episodes)
@@ -308,6 +340,8 @@ def _apply_multi_episode_metadata(
     ep_by_num: dict[int, EpisodeMetadata],
     segment_count: int,
     tmdb_start: int | None = None,
+    *,
+    force: bool = False,
 ) -> Episode:
     """Apply combined metadata from multiple TMDB episodes to a multi-segment file.
 
@@ -319,6 +353,8 @@ def _apply_multi_episode_metadata(
         ep_by_num: TMDB episodes keyed by episode number.
         segment_count: Number of TMDB episodes in this file.
         tmdb_start: Starting TMDB episode number (if None, uses episode.episode_number).
+        force: When ``True`` (a relink) the fill-if-empty guards are
+            bypassed so a wrong match's episode data is replaced.
     """
     start = tmdb_start if tmdb_start is not None else episode.episode_number.value
     metas = [ep_by_num.get(start + i) for i in range(segment_count)]
@@ -329,29 +365,30 @@ def _apply_multi_episode_metadata(
 
     updates: dict[str, object] = {}
 
-    # Concatenate titles from all segments (only if local title is from scanner)
+    # Concatenate titles from all segments (only if local title is from
+    # scanner, or on a forced refresh where the stored title may be wrong)
     titles = [m.title for m in present if m.title]
-    if titles and " / " not in episode.title.value:
+    if titles and (force or " / " not in episode.title.value):
         updates["title"] = Title(" / ".join(titles))
 
     # Synopsis: combine with separator
     synopses = [m.synopsis for m in present if m.synopsis]
-    if synopses and not episode.synopsis:
+    if synopses and (force or not episode.synopsis):
         updates["synopsis"] = " ◆ ".join(synopses)
 
     # Sum durations from all segments
     total_duration = sum(m.duration_seconds or 0 for m in present)
-    if total_duration and episode.duration.value == 0:
+    if total_duration and (force or episode.duration.value == 0):
         updates["duration"] = Duration(total_duration)
 
     # Thumbnail: first available
     first_still = next((m.still_url for m in present if m.still_url), None)
-    if first_still and not episode.thumbnail_path:
+    if first_still and (force or not episode.thumbnail_path):
         updates["thumbnail_path"] = ImageUrl(first_still)
 
     # Air date: first available
     first_date = next((m.air_date for m in present if m.air_date), None)
-    if first_date and not episode.air_date:
+    if first_date and (force or not episode.air_date):
         parsed = _parse_date(first_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
@@ -362,21 +399,28 @@ def _apply_multi_episode_metadata(
     return episode
 
 
-def _apply_episode_metadata(episode: Episode, meta: EpisodeMetadata) -> Episode:
-    """Apply metadata from a single TMDB episode."""
+def _apply_episode_metadata(
+    episode: Episode, meta: EpisodeMetadata, *, force: bool = False
+) -> Episode:
+    """Apply metadata from a single TMDB episode.
+
+    Each field is fill-if-empty by default (and the title only replaces
+    a generic scanner ``Episode N`` placeholder). ``force`` (a relink)
+    bypasses both guards so a wrong match's episode data is replaced.
+    """
     updates: dict[str, object] = {}
 
-    if meta.title and episode.title.value.startswith("Episode "):
+    if meta.title and (force or episode.title.value.startswith("Episode ")):
         updates["title"] = Title(meta.title)
-    if meta.synopsis and not episode.synopsis:
+    if meta.synopsis and (force or not episode.synopsis):
         updates["synopsis"] = meta.synopsis
-    if meta.air_date and not episode.air_date:
+    if meta.air_date and (force or not episode.air_date):
         parsed = _parse_date(meta.air_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
-    if meta.duration_seconds and episode.duration.value == 0:
+    if meta.duration_seconds and (force or episode.duration.value == 0):
         updates["duration"] = Duration(meta.duration_seconds)
-    if meta.still_url and not episode.thumbnail_path:
+    if meta.still_url and (force or not episode.thumbnail_path):
         updates["thumbnail_path"] = ImageUrl(meta.still_url)
 
     if updates:

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -25,6 +25,7 @@ from src.modules.media.domain.value_objects import (
     ContentRating,
     Duration,
     FilePath,
+    ImageUrl,
     MediaFile,
     Resolution,
     Title,
@@ -195,6 +196,88 @@ class TestEnrichSeriesMetadata:
         assert result.enriched is True
         saved = mocks.series.save.call_args[0][0]
         assert saved.needs_enrichment_review is False
+
+    @pytest.mark.asyncio
+    async def test_force_overwrites_stale_fields_and_replaces_localized(self) -> None:
+        """A relink (force=True) must overwrite series-level fields left
+        by a wrong match — the bug where backdrop/localized title stuck."""
+        series = _make_series().with_updates(
+            tmdb_id=TmdbId(999),  # wrong match already stamped
+            synopsis="Wrong synopsis",
+            poster_path=ImageUrl("https://img.example/wrong-poster.jpg"),
+            backdrop_path=ImageUrl("https://img.example/wrong-backdrop.jpg"),
+            localized={
+                "pt-BR": {"title": "Título Errado"},
+                "es": {"title": "Título Viejo"},  # stale lang absent from new match
+            },
+        )
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+
+        metadata = MediaMetadata(
+            title="From",
+            year=2022,
+            synopsis="Correct synopsis",
+            tmdb_id=1234,
+            poster_url="https://img.example/right-poster.jpg",
+            backdrop_url="https://img.example/right-backdrop.jpg",
+            localized={"pt-BR": LocalizedFields(title="From (Correto)")},
+        )
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_by_id.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        result = await use_case.execute(
+            EnrichMediaInput(media_id=str(series.id), force=True),
+        )
+
+        assert result.enriched is True
+        saved = mocks.series.save.call_args[0][0]
+        assert saved.synopsis == "Correct synopsis"
+        assert saved.poster_path.value == "https://img.example/right-poster.jpg"
+        assert saved.backdrop_path.value == "https://img.example/right-backdrop.jpg"
+        assert saved.title.value == "From"
+        # localized is replaced, not merged: new pt-BR wins and the
+        # stale "es" entry from the wrong match is dropped.
+        assert saved.get_title("pt-BR") == "From (Correto)"
+        assert "es" not in saved.localized
+
+    @pytest.mark.asyncio
+    async def test_non_force_keeps_existing_fields_and_merges_localized(self) -> None:
+        """A routine (non-force) re-enrichment preserves user/existing
+        data: filled fields stay, and localized merges rather than
+        replaces (stale-but-untouched langs survive)."""
+        series = _make_series().with_updates(
+            synopsis="Existing synopsis",
+            backdrop_path=ImageUrl("https://img.example/existing-backdrop.jpg"),
+            localized={"es": {"title": "Título Existente"}},
+        )
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+
+        metadata = MediaMetadata(
+            title="From",
+            year=2022,
+            synopsis="New synopsis",
+            tmdb_id=1234,
+            backdrop_url="https://img.example/new-backdrop.jpg",
+            localized={"pt-BR": LocalizedFields(title="From pt")},
+        )
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        saved = mocks.series.save.call_args[0][0]
+        # Fill-if-empty: existing values are preserved.
+        assert saved.synopsis == "Existing synopsis"
+        assert saved.backdrop_path.value == "https://img.example/existing-backdrop.jpg"
+        # Merge: new lang added, existing lang kept.
+        assert saved.get_title("pt-BR") == "From pt"
+        assert saved.localized["es"]["title"] == "Título Existente"
 
     @pytest.mark.asyncio
     async def test_should_enrich_double_episode(self) -> None:


### PR DESCRIPTION
## Summary

- Fix a partial series relink: re-pointing a series at the correct TMDB id kept the **wrong match's backdrop** and **localized title**.
- Root cause: `force=True` reached `EnrichSeriesMetadataUseCase` but was never threaded into `_apply_series_metadata` (unlike the movie path), so the fill-if-empty guards kept stale poster/backdrop/synopsis/genres/logo/cast and the localized overrides. Only id/title-original/years were overwritten.
- Fix: thread `force` through the whole series enrichment chain — series → seasons → episodes → localized. Under `force`:
  - every "don't-overwrite" field is overwritten by the new match;
  - the base title is refreshed (normally scanner-derived, but wrong on a bad match);
  - `merge_localized_metadata` **replaces** the localized map instead of merging, dropping stale language entries left by the wrong match.
- Also threaded `force` into the movie path's localized merge for parity (movie field overwrites already worked; this fixes stale-language localized on a movie relink too).

No API/schema changes. Routine (non-force) enrichment behavior is unchanged — guards still protect user edits.

## Test plan

- [x] `ruff check` + `ruff format --check` on changed files
- [x] New unit: force relink overwrites synopsis/poster/backdrop/title and replaces localized (stale lang dropped)
- [x] New unit: non-force enrichment preserves existing fields and merges localized
- [x] Full media suite: 1475 passed, 5 skipped

## Summary by Sourcery

Ensure forced media relinks fully refresh provider metadata instead of preserving stale values from a previous wrong match.

Bug Fixes:
- Fix series relink so forced enrichment overwrites stale metadata fields and replaces outdated localized entries instead of keeping them.
- Align movie localized metadata updates under forced enrichment to prevent stale language entries after a relink.

Enhancements:
- Thread the force flag through series, season, and episode enrichment logic so fill-if-empty guards can be bypassed when explicitly requested.
- Adjust localized metadata merging to support full replacement on forced refresh while preserving merge behavior for routine updates.

Tests:
- Add unit tests covering forced series relink behavior and non-force re-enrichment to verify overwrites, merges, and localized replacement semantics.