### PR TITLE
fix(media): clear stale end_year on relink; serialize error details

### DIFF
--- a/src/building_blocks/presentation/exception_handlers.py
+++ b/src/building_blocks/presentation/exception_handlers.py
@@ -13,6 +13,7 @@ serialize a category of errors. The envelope format comes from
 from typing import Any, cast
 
 from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -62,7 +63,12 @@ async def core_exception_handler(request: Request, exc: Exception) -> JSONRespon
     )
     _log_with_severity(logger, exc)
 
-    content = {**exc.to_dict(), "type": error_type}
+    # ``jsonable_encoder`` so non-primitive values that can legitimately
+    # appear in ``details`` (e.g. a ``datetime`` carried in a Pydantic
+    # error's ``input`` from a model-level validator) serialize cleanly
+    # instead of crashing ``JSONResponse`` and degrading a clean 4xx into
+    # an opaque 500.
+    content = jsonable_encoder({**exc.to_dict(), "type": error_type})
     return JSONResponse(status_code=http_status, content=content)
 
 

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -211,6 +211,12 @@ def _apply_series_metadata(
         updates["start_year"] = Year(metadata.year)
     if metadata.end_year:
         updates["end_year"] = Year(metadata.end_year)
+    elif force:
+        # On a relink the new match may be ongoing (no end_year) while a
+        # stale end_year lingers from the wrong match. Left in place it
+        # can fall before the new start_year and trip the
+        # ``end_year >= start_year`` invariant — clear it.
+        updates["end_year"] = None
     # The base title normally stays scanner-derived, but on a forced
     # refresh it may belong to a wrong match — overwrite it so the
     # canonical title tracks the newly-picked TMDB entry.

--- a/tests/building_blocks/unit/presentation/test_exception_handlers.py
+++ b/tests/building_blocks/unit/presentation/test_exception_handlers.py
@@ -117,6 +117,36 @@ class TestCoreExceptionTranslation:
         assert body["type"] == "gateway_timeout_error"
         assert "internal_message" not in body  # never leaked to client
 
+    def test_should_serialize_non_primitive_detail_values(self) -> None:
+        """A ``datetime`` carried in a Pydantic error's ``input`` (e.g. a
+        model-level validator firing on an entity dict) must not crash
+        ``JSONResponse``. Regression: it degraded a clean 422 into a 500."""
+        from datetime import UTC, datetime
+
+        app = _make_app()
+
+        @app.get("/foo")
+        async def _route() -> None:
+            raise DomainValidationException.from_pydantic_errors(
+                object_type="Series",
+                pydantic_errors=[
+                    {
+                        "type": "value_error",
+                        "msg": "end_year cannot be before start_year",
+                        "loc": (),
+                        "input": {"created_at": datetime(2026, 1, 1, tzinfo=UTC)},
+                    }
+                ],
+            )
+
+        response = TestClient(app).get("/foo")
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["type"] == "validation_error"
+        # The datetime survived as an ISO string instead of crashing.
+        assert "2026" in body["details"][0]["metadata"]["input"]["created_at"]
+
 
 @pytest.mark.unit
 class TestRequestValidation:

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -30,6 +30,7 @@ from src.modules.media.domain.value_objects import (
     Resolution,
     Title,
     TmdbId,
+    Year,
 )
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
@@ -242,6 +243,36 @@ class TestEnrichSeriesMetadata:
         # stale "es" entry from the wrong match is dropped.
         assert saved.get_title("pt-BR") == "From (Correto)"
         assert "es" not in saved.localized
+
+    @pytest.mark.asyncio
+    async def test_force_clears_stale_end_year_when_new_match_has_none(self) -> None:
+        """Relinking a 1995→2016 series must not trip the
+        ``end_year >= start_year`` invariant: the stale end_year from the
+        wrong (older, ended) match is cleared when the new match has none.
+        Regression for the American Gothic relink 500."""
+        series = _make_series().with_updates(
+            tmdb_id=TmdbId(999),
+            start_year=Year(1995),
+            end_year=Year(1998),  # wrong match was an ended 90s series
+        )
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+
+        # New match: a 2016 series with no end_year (start_year alone).
+        metadata = MediaMetadata(title="American Gothic", year=2016, tmdb_id=1234)
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.get_series_by_id.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        result = await use_case.execute(
+            EnrichMediaInput(media_id=str(series.id), force=True),
+        )
+
+        assert result.enriched is True
+        saved = mocks.series.save.call_args[0][0]
+        assert saved.start_year.value == 2016
+        assert saved.end_year is None
 
     @pytest.mark.asyncio
     async def test_non_force_keeps_existing_fields_and_merges_localized(self) -> None:


### PR DESCRIPTION
## Summary

Two fixes surfaced relinking "American Gothic" (detected as the 1995 series) to the 2016 one.

- **Stale `end_year` trips the domain invariant.** On a forced re-enrich (relink), `start_year` is overwritten by the new match but `end_year` was only set when the new match provided one. Re-pointing an ended 90s series (1995–1998) at a 2016 match left `end_year=1998` < `start_year=2016`, raising `end_year cannot be before start_year`. Now a forced refresh clears the stale `end_year` when the new match has none.
- **Error handler 500 instead of 422.** The domain validation error above *was* mapped to 422, but `core_exception_handler` then crashed rendering the body: a `datetime` carried in the Pydantic error's `input` (a model-level validator fires on the whole entity dict, incl. `created_at`) isn't JSON-serializable by `JSONResponse`'s plain `json.dumps`. Now the body is run through `jsonable_encoder`, so any non-primitive detail value serializes cleanly and a 4xx stays a 4xx.

No API/schema changes.

## Test plan

- [x] `ruff check` + `ruff format --check`
- [x] Unit: forced relink clears stale `end_year` (no invariant error)
- [x] Unit: `core_exception_handler` serializes a `datetime` in error details → 422, not 500
- [x] building_blocks + media suites: 1804 passed, 5 skipped

## Summary by Sourcery

Handle domain validation errors safely and ensure series relinking does not violate year invariants when re-enriching metadata.

Bug Fixes:
- Clear stale series end_year on forced metadata relink when the new match has no end year to avoid violating the end_year >= start_year invariant.
- Encode exception payloads with jsonable_encoder so non-primitive values in error details no longer cause JSONResponse to return a 500 instead of the intended 4xx.

Tests:
- Add a unit test ensuring forced series relink clears an outdated end_year when the new match is ongoing.
- Add a unit test verifying core_exception_handler correctly serializes datetime values in error details and returns a 422 response.