### PR TITLE
fix(media): rotate intro-detection queue by attempt time

### DIFF
--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -698,6 +698,17 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         Episodes (and their file_variants) are eager-loaded so the
         detection job can iterate file paths without N+1 queries.
         Soft-deleted rows are filtered out at both levels.
+
+        Ordered by ``intro_detection_attempted_at`` ascending with NULLs
+        first, then ``id``. NULL means never attempted (a fresh
+        ``NOT_STARTED`` season), so brand-new seasons run first; a season
+        that keeps landing in ``INSUFFICIENT_EPISODES`` (e.g. an extras
+        season with too few playable episodes) has its ``attempted_at``
+        stamped on each pass and so rotates to the BACK of the queue
+        instead of monopolizing every tick — without this a permanently
+        insufficient season starves all others when ``batch_size`` is
+        small. ``nullsfirst`` is explicit because SQLite (NULLs first on
+        ASC) and PostgreSQL (NULLs last) disagree on the default.
         """
         eligible_states = (
             IntroDetectionState.NOT_STARTED.value,
@@ -710,7 +721,10 @@ class SQLAlchemySeriesRepository(SeriesRepository):
                 SeasonModel.intro_detection_state.in_(eligible_states),
             )
             .options(selectinload(SeasonModel.episodes).selectinload(EpisodeModel.file_variants))
-            .order_by(SeasonModel.id.asc())
+            .order_by(
+                SeasonModel.intro_detection_attempted_at.asc().nullsfirst(),
+                SeasonModel.id.asc(),
+            )
             .limit(limit)
         )
         result = await self._session.execute(stmt)

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -1503,6 +1503,50 @@ class TestFindSeasonsPendingIntroDetection:
 
         assert len(pending) == 2
 
+    async def test_orders_never_attempted_first_then_oldest_attempted(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """Fresh seasons run before retried ones; retried rotate oldest-first.
+
+        Guards against a permanently-INSUFFICIENT season (recent
+        ``attempted_at``) starving never-attempted ones under a small
+        ``batch_size``.
+        """
+        repo = SQLAlchemySeriesRepository(db_session)
+        older = datetime(2020, 1, 1, tzinfo=UTC)
+        newer = datetime(2020, 6, 1, tzinfo=UTC)
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.INSUFFICIENT_EPISODES,
+                detection_attempted_at=newer,
+                series_title="newer-retry",
+            )
+        )
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.INSUFFICIENT_EPISODES,
+                detection_attempted_at=older,
+                series_title="older-retry",
+            )
+        )
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.NOT_STARTED,
+                detection_attempted_at=None,
+                series_title="never-attempted",
+            )
+        )
+
+        pending = await repo.find_seasons_pending_intro_detection(limit=10)
+        attempted = [s.intro_detection_attempted_at for s in pending]
+
+        assert len(attempted) == 3
+        assert attempted[0] is None  # never-attempted first
+        assert attempted[1] is not None
+        assert attempted[2] is not None
+        assert attempted[1] <= attempted[2]  # then oldest-attempted before newest
+
 
 @pytest.mark.integration
 class TestUpdateSeasonIntroDetection:


### PR DESCRIPTION
## Summary

- The intro-detection job re-queues seasons in ``INSUFFICIENT_EPISODES`` every tick (so they retry when more episodes land). Combined with the ``id ASC`` ordering and the default ``batch_size=1``, a season that can *never* become sufficient — e.g. an extras/"Season 0" with fewer than 2 playable episodes — sat at the front of the queue forever and **starved every other series** (observed on "The Stand", whose specials season has 1 file, manually marked → 0 analyzable refs → permanent ``INSUFFICIENT_EPISODES``).
- Fix: order ``find_seasons_pending_intro_detection`` by ``intro_detection_attempted_at`` ascending **NULLs first**, then ``id``. Never-attempted (``NOT_STARTED``) seasons have a NULL timestamp and run first; a retried season gets ``attempted_at`` stamped each pass and rotates to the **back**, so the queue round-robins and nothing starves. ``nullsfirst`` is explicit because SQLite and PostgreSQL disagree on the default NULL ordering.

## Test plan

- [x] New integration test: never-attempted season first, then retried seasons oldest-attempted first.
- [x] `pytest tests/modules/media/integration/persistence/repositories/test_series_repository.py tests/infrastructure/scheduling/test_intro_detection_job.py` — 109 passed.
- [x] `ruff check` + `ruff format` clean.

## Notes

- No schema change — the column already exists and the job already stamps ``attempted_at`` on every transition.
- A permanently-insufficient season is still retried (cheaply — the job bails before ffmpeg when there are <2 refs), just no longer at the expense of the rest.

## Summary by Sourcery

Adjust intro-detection season selection to prioritize never-attempted seasons and fairly rotate retried ones based on attempt time.

Bug Fixes:
- Prevent permanently-insufficient seasons from monopolizing the intro-detection queue when batch size is small.

Tests:
- Add an integration test verifying that seasons pending intro detection are ordered with never-attempted first, then oldest attempted.