### PR TITLE
fix(media): store real file duration from probe, not TMDB runtime

### DIFF
--- a/src/modules/media/application/ports/media_probe_port.py
+++ b/src/modules/media/application/ports/media_probe_port.py
@@ -22,12 +22,17 @@ class ProbeResult:
             discovered next to the probed video.
         resolution: Named resolution (``"1080p"``, ``"4K"``, …) or
             ``None`` when the video stream is missing or below 360p.
+        duration_seconds: Container duration in whole seconds, or ``None``
+            when ffprobe could not read it. This is the real file
+            duration (the source of truth for playback), distinct from a
+            metadata provider's nominal runtime.
     """
 
     audio_tracks: list[AudioTrack] = field(default_factory=list)
     subtitle_tracks: list[SubtitleTrack] = field(default_factory=list)
     external_subtitles: list[SubtitleTrack] = field(default_factory=list)
     resolution: str | None = None
+    duration_seconds: int | None = None
 
     @property
     def all_subtitles(self) -> list[SubtitleTrack]:

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -261,7 +261,10 @@ def _apply_movie_metadata(
         updates["imdb_id"] = ImdbId(metadata.imdb_id)
     if metadata.original_title:
         updates["original_title"] = Title(metadata.original_title)
-    if metadata.duration_seconds and (force or movie.duration.value == 0):
+    # Duration is the file's real (probed) length — the scanner stamps it.
+    # TMDB's nominal runtime is only a fallback when the probe failed
+    # (duration still 0); never overwrite a real duration, even on force.
+    if metadata.duration_seconds and movie.duration.value == 0:
         updates["duration"] = Duration(metadata.duration_seconds)
     if metadata.year:
         updates["year"] = Year(metadata.year)

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -382,9 +382,11 @@ def _apply_multi_episode_metadata(
     if synopses and (force or not episode.synopsis):
         updates["synopsis"] = " ◆ ".join(synopses)
 
-    # Sum durations from all segments
+    # Sum durations from all segments. Only a fallback — the scanner
+    # stamps the file's real probed duration; never overwrite it (even on
+    # force) with TMDB's nominal runtime.
     total_duration = sum(m.duration_seconds or 0 for m in present)
-    if total_duration and (force or episode.duration.value == 0):
+    if total_duration and episode.duration.value == 0:
         updates["duration"] = Duration(total_duration)
 
     # Thumbnail: first available
@@ -424,7 +426,8 @@ def _apply_episode_metadata(
         parsed = _parse_date(meta.air_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
-    if meta.duration_seconds and (force or episode.duration.value == 0):
+    # Fallback only — real duration comes from the file probe at scan time.
+    if meta.duration_seconds and episode.duration.value == 0:
         updates["duration"] = Duration(meta.duration_seconds)
     if meta.still_url and (force or not episode.thumbnail_path):
         updates["thumbnail_path"] = ImageUrl(meta.still_url)

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -129,15 +129,18 @@ class ScanMediaDirectoriesUseCase:
         scanned: ScannedFile,
         *,
         is_primary: bool,
-    ) -> MediaFile:
+    ) -> tuple[MediaFile, int | None]:
         """Build a MediaFile for a path being registered for the first time.
 
         Always probes the file so audio and subtitle tracks — including their
-        languages — are persisted on first registration.
+        languages — are persisted on first registration. Returns the probed
+        container ``duration_seconds`` alongside the file (the caller stamps
+        it on the entity for a primary file) so a single probe serves both;
+        ``None`` when the duration could not be read.
         """
         probed = await self._probe(scanned.file_path.value)
         resolution = scanned.resolution or (probed.resolution if probed else None) or "Unknown"
-        return MediaFile(
+        media_file = MediaFile(
             file_path=scanned.file_path,
             file_size=scanned.file_size,
             resolution=Resolution(resolution),
@@ -145,6 +148,7 @@ class ScanMediaDirectoriesUseCase:
             subtitle_tracks=list(probed.all_subtitles) if probed else [],
             is_primary=is_primary,
         )
+        return media_file, (probed.duration_seconds if probed else None)
 
     async def _maybe_refresh_media_file(
         self,
@@ -263,7 +267,8 @@ class ScanMediaDirectoriesUseCase:
                 None,
             )
             if existing_idx is None:
-                files.append(await self._build_new_media_file(scanned, is_primary=False))
+                variant_file, _ = await self._build_new_media_file(scanned, is_primary=False)
+                files.append(variant_file)
                 changed = True
                 continue
 
@@ -289,21 +294,20 @@ class ScanMediaDirectoriesUseCase:
     ) -> tuple[int, int, list[DomainEvent]]:
         """Create a new movie from a group of file variants."""
         first = by_path[paths[0]]
-        primary_file = await self._build_new_media_file(first, is_primary=True)
+        primary_file, duration = await self._build_new_media_file(first, is_primary=True)
         movie_id = MovieId.generate()
         movie = Movie(
             id=movie_id,
             library_id=library_id,
             title=Title(first.title),
             year=Year(first.year or _current_year()),
-            duration=Duration(0),
+            duration=Duration(duration or 0),
             files=[primary_file],
         )
         movie.add_event(MediaCreatedEvent(media_id=movie_id, media_type=CatalogMediaType.MOVIE))
         for path in paths[1:]:
-            movie = movie.with_file(
-                await self._build_new_media_file(by_path[path], is_primary=False)
-            )
+            variant_file, _ = await self._build_new_media_file(by_path[path], is_primary=False)
+            movie = movie.with_file(variant_file)
         events = movie.pull_events()
         await uow.movies.save(movie)
         return 1, 0, events
@@ -412,16 +416,18 @@ class ScanMediaDirectoriesUseCase:
         if series.id is None:
             raise RuntimeError("Series id must be assigned before creating episodes")
         ep_title = first.episode_title or f"Episode {episode_num}"
+        primary_file, duration = await self._build_new_media_file(first, is_primary=True)
         episode = Episode(
             series_id=series.id,
             season_number=SeasonNumber(season_num),
             episode_number=EpisodeNumber(episode_num),
             title=Title(ep_title),
-            duration=Duration(0),
-            files=[await self._build_new_media_file(first, is_primary=True)],
+            duration=Duration(duration or 0),
+            files=[primary_file],
         )
         for f in ep_files[1:]:
-            episode = episode.with_file(await self._build_new_media_file(f, is_primary=False))
+            variant_file, _ = await self._build_new_media_file(f, is_primary=False)
+            episode = episode.with_file(variant_file)
         return episode
 
     async def _refresh_episode(
@@ -439,7 +445,8 @@ class ScanMediaDirectoriesUseCase:
                 None,
             )
             if existing_idx is None:
-                files.append(await self._build_new_media_file(scanned, is_primary=False))
+                variant_file, _ = await self._build_new_media_file(scanned, is_primary=False)
+                files.append(variant_file)
                 changed = True
                 continue
 

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -4,6 +4,7 @@ Discovers audio tracks, subtitle tracks (embedded and external)
 from a media file, returning structured domain value objects.
 """
 
+import contextlib
 import functools
 import json
 import logging
@@ -182,18 +183,21 @@ class MediaProbeService(MediaProbePort):
             _logger.warning("Cannot probe non-existent file: %s", file_path)
             return ProbeResult()
 
-        streams = self._run_ffprobe(str(source))
+        data = self._run_ffprobe(str(source))
+        streams = list(data.get("streams", []))
         audio_tracks = self._parse_audio_tracks(streams)
         subtitle_tracks = self._parse_subtitle_tracks(streams)
         external_subs = self._scan_external_subtitles(source, len(subtitle_tracks))
         resolution = self._parse_resolution(streams)
+        duration = self._parse_duration(data)
 
         _logger.info(
-            "Probed %s: %d audio, %d embedded subs, %d external subs",
+            "Probed %s: %d audio, %d embedded subs, %d external subs, duration=%ss",
             source.name,
             len(audio_tracks),
             len(subtitle_tracks),
             len(external_subs),
+            duration if duration is not None else "?",
         )
 
         return ProbeResult(
@@ -201,7 +205,30 @@ class MediaProbeService(MediaProbePort):
             subtitle_tracks=subtitle_tracks,
             external_subtitles=external_subs,
             resolution=resolution,
+            duration_seconds=duration,
         )
+
+    @staticmethod
+    def _parse_duration(data: dict[str, Any]) -> int | None:
+        """Read the container duration (seconds) from the ffprobe payload.
+
+        Prefers ``format.duration`` (reliable across containers,
+        especially MKV where per-stream durations are often absent);
+        falls back to the longest stream duration. Returns whole seconds,
+        or ``None`` when no usable value is present.
+        """
+        candidates: list[float] = []
+        fmt_duration = data.get("format", {}).get("duration")
+        if fmt_duration is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                candidates.append(float(fmt_duration))
+        for stream in data.get("streams", []):
+            value = stream.get("duration")
+            if value is not None:
+                with contextlib.suppress(TypeError, ValueError):
+                    candidates.append(float(value))
+        usable = [c for c in candidates if c > 0]
+        return round(max(usable)) if usable else None
 
     @staticmethod
     def _run_ffprobe_video_dimensions(file_path: str) -> tuple[int, int] | None:
@@ -245,11 +272,16 @@ class MediaProbeService(MediaProbePort):
             return None
 
     @staticmethod
-    def _run_ffprobe(file_path: str) -> list[dict[str, Any]]:
-        """Run ffprobe and return stream data as JSON."""
+    def _run_ffprobe(file_path: str) -> dict[str, Any]:
+        """Run ffprobe and return the full JSON payload (streams + format).
+
+        ``format`` is requested alongside ``streams`` so callers can read
+        the container duration (``format.duration``) from the same single
+        invocation. Returns an empty dict on any failure.
+        """
         ffprobe = _ffprobe_path()
         if ffprobe is None:
-            return []
+            return {}
         try:
             result = subprocess.run(
                 [
@@ -257,6 +289,7 @@ class MediaProbeService(MediaProbePort):
                     "-v",
                     "error",
                     "-show_streams",
+                    "-show_format",
                     "-of",
                     "json",
                     file_path,
@@ -267,12 +300,12 @@ class MediaProbeService(MediaProbePort):
             )
             if result.returncode != 0:
                 _logger.error("ffprobe failed for %s: %s", file_path, result.stderr)
-                return []
+                return {}
             data: dict[str, Any] = json.loads(result.stdout)
-            return list(data.get("streams", []))
+            return data
         except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError) as e:
             _logger.error("ffprobe error for %s: %s", file_path, e)
-            return []
+            return {}
 
     @staticmethod
     def _parse_resolution(streams: list[dict[str, Any]]) -> str | None:

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -345,6 +345,22 @@ class TestRescanResolutionUpgrade:
         probe.probe.assert_called_once_with("/movies/inception.mkv")
 
     @pytest.mark.asyncio
+    async def test_should_stamp_probed_duration_on_new_movie(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda _fp: None
+        saved: list[Movie] = []
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
+        probe = MagicMock(spec=MediaProbePort)
+        probe.probe.return_value = ProbeResult(resolution="1080p", duration_seconds=7245)
+        files = [_movie_file("/movies/inception.mkv", "Inception", 2010, None)]
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks, probe_service=probe)
+
+        await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        # Real file duration is stamped at scan time (not left 0 for enrichment).
+        assert saved[0].duration.value == 7245
+
+    @pytest.mark.asyncio
     async def test_should_probe_when_existing_resolution_is_unknown(self) -> None:
         existing = Movie.create(
             library_id=_LIBRARY_ID,

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -413,7 +413,7 @@ class TestMediaProbeServiceRunFfprobe:
     )
     def test_should_return_empty_when_ffprobe_missing(self, _which: MagicMock) -> None:
         result = MediaProbeService._run_ffprobe("/path/to/movie.mkv")
-        assert result == []
+        assert result == {}
 
     @patch("src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run")
     @patch(
@@ -422,14 +422,15 @@ class TestMediaProbeServiceRunFfprobe:
     )
     def test_should_return_streams_on_success(self, _which: MagicMock, mock_run: MagicMock) -> None:
         streams = [{"codec_type": "audio", "codec_name": "aac"}]
+        payload = {"streams": streams, "format": {"duration": "120.5"}}
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = json.dumps({"streams": streams})
+        mock_result.stdout = json.dumps(payload)
         mock_run.return_value = mock_result
 
         result = MediaProbeService._run_ffprobe("/path/to/movie.mkv")
 
-        assert result == streams
+        assert result == payload
 
     @patch("src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run")
     @patch(
@@ -446,7 +447,7 @@ class TestMediaProbeServiceRunFfprobe:
 
         result = MediaProbeService._run_ffprobe("/path/to/movie.mkv")
 
-        assert result == []
+        assert result == {}
 
     @patch(
         "src.modules.media.infrastructure.streaming.media_probe_service.subprocess.run",
@@ -458,7 +459,27 @@ class TestMediaProbeServiceRunFfprobe:
     )
     def test_should_return_empty_on_os_error(self, _which: MagicMock, _run: MagicMock) -> None:
         result = MediaProbeService._run_ffprobe("/path/to/movie.mkv")
-        assert result == []
+        assert result == {}
+
+
+@pytest.mark.unit
+class TestMediaProbeServiceParseDuration:
+    """Tests for MediaProbeService._parse_duration."""
+
+    def test_prefers_format_duration(self) -> None:
+        data = {"format": {"duration": "5430.6"}, "streams": [{"duration": "10.0"}]}
+        assert MediaProbeService._parse_duration(data) == 5431
+
+    def test_falls_back_to_longest_stream(self) -> None:
+        data = {"streams": [{"duration": "100.0"}, {"duration": "2700.4"}]}
+        assert MediaProbeService._parse_duration(data) == 2700
+
+    def test_none_when_no_duration(self) -> None:
+        assert MediaProbeService._parse_duration({"streams": [{}]}) is None
+
+    def test_ignores_zero_and_garbage(self) -> None:
+        data = {"format": {"duration": "0"}, "streams": [{"duration": "N/A"}]}
+        assert MediaProbeService._parse_duration(data) is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- **Bug:** movie/episode duration never matched the actual file. The scanner created entities with ``duration=0`` and the probe read only tracks + resolution, so enrichment filled ``duration`` from TMDB's **nominal runtime** (rounded to whole minutes, reflecting the official cut — not this file). On force-enrich it would even overwrite a correct value.
- **Fix:**
  - ``ProbeResult`` gains ``duration_seconds``; ``MediaProbeService`` reads the container duration from ffprobe (``format.duration``, with a longest-stream fallback) in the same single invocation (``-show_format`` added).
  - The scanner stamps the probed duration on the movie/episode at creation (``_build_new_media_file`` now returns the duration so there's still **one** probe per new file — no extra ffprobe).
  - Enrichment demotes the TMDB runtime to a **fallback**: it only sets duration when the probe yielded nothing (``duration == 0``) and never overwrites a real duration, even on force.

## Test plan

- [x] New unit tests: ``_parse_duration`` (format preferred, longest-stream fallback, none, zero/garbage ignored); scanner stamps the probed duration on a new movie.
- [x] Updated the ``_run_ffprobe`` tests for the new dict (streams + format) return shape.
- [x] `pytest tests/modules/media tests/infrastructure` — 1599 passed.
- [x] `ruff check` + `ruff format --check` clean; mypy clean on touched files.

## Notes

- No schema change. New scans get the real duration automatically; **existing catalog** durations (already TMDB runtimes) are healed by a separate one-shot backfill that re-probes each file (run alongside this).

## Summary by Sourcery

Ensure media entities store the real probed file duration and treat metadata-provider runtimes as a fallback only.

Bug Fixes:
- Fix movies and episodes being created with incorrect durations sourced from TMDB runtimes instead of the actual file length.
- Prevent enrichment from overwriting an existing real file duration with TMDB’s nominal runtime, even on force enrich.

Enhancements:
- Extend the media probe to read and expose container duration from ffprobe in a single invocation and persist it on new primary media files at scan time.

Tests:
- Add and update unit tests for ffprobe payload handling, duration parsing, and stamping probed durations on newly scanned movies.