### PR TITLE
fix(media): make scan idempotent and stop infra leak on errors

### DIFF
--- a/migrations/versions/2026_06_20_partial_unique_file_path.py
+++ b/migrations/versions/2026_06_20_partial_unique_file_path.py
@@ -1,0 +1,50 @@
+"""Make movies/episodes file_path unique only among live rows.
+
+A global UNIQUE(file_path) counted soft-deleted rows, so a soft-deleted
+movie (e.g. one promoted to a series) or episode kept its path locked and
+a rescan that tried to re-register the same file blew up with an
+IntegrityError. Replace the full unique indexes with partial ones scoped
+to ``deleted_at IS NULL``.
+
+Uses drop_index/create_index (no table rebuild) so the FTS5 search tables
+and their triggers are left untouched.
+
+Revision ID: e9d8c7b6a5f4
+Revises: c3d4e5f6a7b8
+Create Date: 2026-06-20
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "e9d8c7b6a5f4"
+down_revision: str | None = "c3d4e5f6a7b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_LIVE = text("deleted_at IS NULL")
+
+
+def upgrade() -> None:
+    """Swap full unique indexes on file_path for partial (live-only) ones."""
+    for table in ("movies", "episodes"):
+        index = f"ix_{table}_file_path"
+        op.drop_index(index, table_name=table)
+        op.create_index(
+            index,
+            table,
+            ["file_path"],
+            unique=True,
+            sqlite_where=_LIVE,
+            postgresql_where=_LIVE,
+        )
+
+
+def downgrade() -> None:
+    """Restore the full (all-rows) unique indexes on file_path."""
+    for table in ("movies", "episodes"):
+        index = f"ix_{table}_file_path"
+        op.drop_index(index, table_name=table)
+        op.create_index(index, table, ["file_path"], unique=True)

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -1,6 +1,7 @@
 """Use case for scanning media directories and registering discovered files."""
 
 import asyncio
+import logging
 from collections import defaultdict
 
 from src.building_blocks.application.event_bus import EventBus
@@ -35,6 +36,8 @@ from src.modules.media.domain.value_objects import (
 # (movie | episode, a file-classification enum). This is the catalog
 # discriminator (movie | series) carried on domain events (ADR-016).
 from src.shared_kernel.value_objects.media_type import MediaType as CatalogMediaType
+
+_logger = logging.getLogger(__name__)
 
 
 class ScanMediaDirectoriesUseCase:
@@ -212,8 +215,11 @@ class ScanMediaDirectoriesUseCase:
                 c, u = await self._process_movie_group(paths, by_path, library_id=library_id)
                 created += c
                 updated += u
-            except Exception as e:
-                errors.append(f"Error processing movie files {paths}: {e}")
+            except Exception:
+                # Log the full exception (it may carry SQL / driver detail)
+                # but keep the user-facing message free of infrastructure.
+                _logger.exception("Failed to process movie file group: %s", paths)
+                errors.append(f"Failed to process movie: {_base_name}")
 
         return created, updated, errors
 
@@ -229,12 +235,31 @@ class ScanMediaDirectoriesUseCase:
             existing = await self._find_existing_movie(uow, paths, by_path)
             if existing:
                 created, updated, events = await self._update_movie(uow, existing, paths, by_path)
+            elif await self._path_owned_by_series(uow, paths, by_path):
+                # A path already registered to a series episode (e.g. a
+                # movie that was promoted to a series) must not be
+                # re-registered as a movie — that would duplicate the file
+                # and collide on the unique file_path. Skip it.
+                _logger.info("Skipping movie create; path belongs to a series episode: %s", paths)
+                return 0, 0
             else:
                 created, updated, events = await self._create_movie(
                     uow, paths, by_path, library_id=library_id
                 )
         await self._dispatch_events(events)
         return created, updated
+
+    @staticmethod
+    async def _path_owned_by_series(
+        uow: MediaUnitOfWork,
+        paths: list[str],
+        by_path: dict[str, ScannedFile],
+    ) -> bool:
+        """Return True if any path is already an episode of some series."""
+        for path in paths:
+            if await uow.series.find_by_file_path(by_path[path].file_path):
+                return True
+        return False
 
     @staticmethod
     async def _find_existing_movie(
@@ -337,8 +362,11 @@ class ScanMediaDirectoriesUseCase:
                 c, u = await self._process_series(series_name, series_files, library_id=library_id)
                 created += c
                 updated += u
-            except Exception as e:
-                errors.append(f"Error processing series '{series_name}': {e}")
+            except Exception:
+                # Log the full exception (it may carry SQL / driver detail)
+                # but keep the user-facing message free of infrastructure.
+                _logger.exception("Failed to process series '%s'", series_name)
+                errors.append(f"Failed to process series: {series_name}")
 
         return created, updated, errors
 
@@ -355,6 +383,17 @@ class ScanMediaDirectoriesUseCase:
 
         async with self._uow_factory() as uow:
             series = await uow.series.find_by_title(Title(series_name))
+            if not series:
+                # Enrichment may have rewritten the title (the folder name
+                # no longer matches the canonical title), so a title lookup
+                # misses an existing series. Fall back to matching any of
+                # its episode files by path before creating a new series —
+                # otherwise we'd re-create the series and collide on the
+                # globally-unique episode file_path.
+                for f in files:
+                    series = await uow.series.find_by_file_path(f.file_path)
+                    if series:
+                        break
             if not series:
                 year = min((f.year for f in files if f.year), default=_current_year())
                 series = Series.create(title=series_name, start_year=year, library_id=library_id)

--- a/src/modules/media/infrastructure/persistence/models/episode.py
+++ b/src/modules/media/infrastructure/persistence/models/episode.py
@@ -9,10 +9,12 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -51,6 +53,16 @@ class EpisodeModel(Base):
             "episode_number",
             name="uq_episode_season_number",
         ),
+        # Partial unique index: file_path is unique only among live rows.
+        # Soft-deleted episodes keep their path (audit/undo) but must not
+        # block a rescan from re-registering the same file.
+        Index(
+            "ix_episodes_file_path",
+            "file_path",
+            unique=True,
+            sqlite_where=text("deleted_at IS NULL"),
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
     )
 
     # Relationships
@@ -79,8 +91,6 @@ class EpisodeModel(Base):
     file_path: Mapped[str | None] = mapped_column(
         String(2000),
         nullable=True,
-        unique=True,
-        index=True,
     )
     file_size: Mapped[int | None] = mapped_column(BigInteger, nullable=True)  # bytes
     resolution: Mapped[str | None] = mapped_column(String(20), nullable=True)

--- a/src/modules/media/infrastructure/persistence/models/movie.py
+++ b/src/modules/media/infrastructure/persistence/models/movie.py
@@ -3,7 +3,17 @@
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import BigInteger, Boolean, DateTime, Float, Integer, String, Text
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    Float,
+    Index,
+    Integer,
+    String,
+    Text,
+    text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.infrastructure.persistence.base import Base
@@ -33,6 +43,19 @@ class MovieModel(Base):
         imdb_id: IMDb ID (e.g., "tt1234567").
     """
 
+    __table_args__ = (
+        # Partial unique index: file_path is unique only among live rows.
+        # A soft-deleted movie (e.g. one promoted to a series) keeps its
+        # path but must not block a rescan from registering the same file.
+        Index(
+            "ix_movies_file_path",
+            "file_path",
+            unique=True,
+            sqlite_where=text("deleted_at IS NULL"),
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
+
     # Library scoping (lib_xxx prefixed external id; cross-BC string
     # reference, no FK because the catalog and library tables live in
     # different bounded contexts).
@@ -59,8 +82,6 @@ class MovieModel(Base):
     file_path: Mapped[str | None] = mapped_column(
         String(2000),
         nullable=True,
-        unique=True,
-        index=True,
     )
     file_size: Mapped[int | None] = mapped_column(BigInteger, nullable=True)  # bytes
     resolution: Mapped[str | None] = mapped_column(String(20), nullable=True)

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -105,6 +105,7 @@ def _make_use_case(
         mocks.movies.find_by_file_path.return_value = None
         mocks.movies.save.side_effect = lambda m: m
         mocks.series.find_by_title.return_value = None
+        mocks.series.find_by_file_path.return_value = None
         mocks.series.save.side_effect = lambda s: s
 
     use_case = ScanMediaDirectoriesUseCase(
@@ -726,3 +727,90 @@ class TestScanLibraryIdPropagation:
 
         assert len(saved) == 1
         assert saved[0].library_id == other_library
+
+
+@pytest.mark.unit
+class TestScanIdempotencyAndErrors:
+    """Scanner must not re-create promoted/renamed media nor leak infra."""
+
+    @pytest.mark.asyncio
+    async def test_should_skip_movie_when_path_owned_by_series(self) -> None:
+        # A movie promoted to a series leaves its flat file behind; on a
+        # rescan that file must not be re-registered as a movie.
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.series.find_by_file_path.return_value = Series.create(
+            library_id=_LIBRARY_ID, title="Promoted", start_year=1994
+        )
+        saved: list[Movie] = []
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
+
+        files = [_movie_file("/series/The Stand (1994)/The Stand (1994).mkv", "The Stand", 1994)]
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
+
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert result.movies_created == 0
+        assert saved == []
+
+    @pytest.mark.asyncio
+    async def test_should_find_series_by_path_when_title_changed(self) -> None:
+        # Enrichment renamed the series, so find_by_title misses; the
+        # scanner must locate it by an episode file path and update it
+        # instead of creating a duplicate series.
+        series = Series.create(library_id=_LIBRARY_ID, title="Canonical", start_year=2016)
+        assert series.id is not None
+        path = "/series/Folder Name (2016)/S01/S01E01.mkv"
+        episode = Episode(
+            series_id=series.id,
+            season_number=SeasonNumber(1),
+            episode_number=EpisodeNumber(1),
+            title=Title("Pilot"),
+            duration=Duration(0),
+            files=[
+                MediaFile(
+                    file_path=FilePath(path),
+                    file_size=500_000,
+                    resolution=Resolution("Unknown"),
+                    is_primary=True,
+                )
+            ],
+        )
+        series = series.with_updates(
+            seasons=[Season(series_id=series.id, season_number=SeasonNumber(1), episodes=[episode])]
+        )
+
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_title.return_value = None
+        mocks.series.find_by_file_path.return_value = series
+        saved: list[Series] = []
+        mocks.series.save.side_effect = lambda s: saved.append(s) or s
+
+        files = [_episode_file(path, series_name="Folder Name (2016)", season=1, episode=1)]
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
+
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert result.episodes_created == 0
+        assert saved and saved[0].id == series.id  # existing series reused, not duplicated
+
+    @pytest.mark.asyncio
+    async def test_error_message_does_not_leak_infrastructure(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_title.return_value = None
+        mocks.series.find_by_file_path.return_value = None
+        mocks.series.save.side_effect = Exception(
+            "UNIQUE constraint failed: episodes.file_path "
+            "[SQL: INSERT INTO episodes (season_id, series_external_id, ...) VALUES (?, ?)]"
+        )
+
+        files = [_episode_file("/series/Show/S01/S01E01.mkv", series_name="Show")]
+        use_case, _ = _make_use_case(scanner_results=files, mocks=mocks)
+
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert result.errors == ["Failed to process series: Show"]
+        joined = " ".join(result.errors)
+        assert "INSERT INTO" not in joined
+        assert "UNIQUE constraint" not in joined
+        assert "SQL" not in joined

--- a/tests/modules/media/unit/conftest.py
+++ b/tests/modules/media/unit/conftest.py
@@ -55,6 +55,13 @@ def make_media_uow_mock() -> MediaUoWMocks:
     series = AsyncMock(spec=SeriesRepository)
     media_conflicts = AsyncMock(spec=MediaConflictRepository)
 
+    # Empty-catalog defaults: path lookups miss unless a test wires them.
+    # Without this, AsyncMock returns a truthy Mock and the scanner's
+    # idempotency guard / title-fallback would treat every path as already
+    # owned.
+    movies.find_by_file_path.return_value = None
+    series.find_by_file_path.return_value = None
+
     uow: MediaUnitOfWork = AsyncMock()
     uow.__aenter__.return_value = uow  # type: ignore[attr-defined]
     uow.__aexit__.return_value = None  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Promoting a movie to a series and then rescanning raised `UNIQUE constraint failed: movies.file_path` / `episodes.file_path` `IntegrityError`s — and the scan error list **leaked the raw SQL statement** to the user. Two root causes + a leak:

1. **Soft-deleted rows kept their `file_path` under a global unique index.** A movie promoted to a series is soft-deleted but keeps `file_path`; `find_by_file_path` filters soft-deleted, so a rescan re-registers the file → collides with the soft-deleted row.
2. **Enrichment rewrites a series title.** The scanner finds series by `find_by_title(folder_name)`, but the folder is `American Gothic (2016)` while the enriched title is `American Gothic` → miss → it recreates the series and collides on the globally-unique episode `file_path`.
3. **Leak:** the `except` blocks did `errors.append(f"... {e}")` where `e` was the SQLAlchemy error including the full `INSERT INTO ...` SQL.

## Changes

- **Partial unique indexes** on `movies.file_path` and `episodes.file_path` scoped to `deleted_at IS NULL` (migration via `drop_index`/`create_index` — no table rebuild, so the FTS5 tables and triggers are untouched). Models updated to match (partial `Index` in `__table_args__`).
- **Scanner idempotency:** skips creating a movie when the path already belongs to a series episode (promoted-movie leftovers), and falls back to `series.find_by_file_path` when the title lookup misses (enriched/renamed series) so it updates the existing series instead of duplicating.
- **No infra leak:** scan errors `logger.exception(...)` the full detail server-side but the user-facing message is generic (`Failed to process series: <name>`).

## Test plan

- [x] New unit tests: movie-create skipped when path owned by a series; series found by episode path when title changed; error message contains no SQL/`UNIQUE`/`INSERT`.
- [x] Updated mock defaults (empty-catalog `find_by_file_path` → None).
- [x] `pytest tests/modules/media tests/infrastructure` — 1606 passed.
- [x] Migration verified on a DB copy: partial indexes created, FTS untouched; `ruff`/`mypy` clean.

## Migration / data heal

- Run `make migrate` for the partial indexes.
- Existing leftovers (5 soft-deleted movies still holding a `file_path`, all promoted-to-series) are cleaned out-of-band by a one-shot that nulls their stale `file_path` (no longer blocking after the partial index, just cleanup).