### PR TITLE
fix(media): honour exact HLS start offset for forward seeks

### DIFF
--- a/src/modules/media/application/use_cases/generate_hls_playlist.py
+++ b/src/modules/media/application/use_cases/generate_hls_playlist.py
@@ -22,10 +22,10 @@ class GenerateHlsPlaylistInput:
             does not know its own mount point, so presentation passes
             it in.
         start: Source-time second the player wants playback to begin
-            from. ``0`` (the default) keeps the legacy single-bucket
-            cache. Non-zero values are rounded down to a coarser
-            bucket by the adapter so adjacent resume positions reuse
-            the same encode.
+            from, honoured exactly by the adapter so a forward seek
+            anchors a fresh encode on the target second. ``0`` (the
+            default) keeps the legacy single-bucket cache. The player
+            quantises resume positions itself when it wants cache reuse.
     """
 
     file_path: str

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -73,13 +73,6 @@ _BROWSER_SAFE_CODECS = {"h264"}
 # hls.js something to render; the rest stream in as they're written.
 _MIN_SEGMENTS_FRESH = 1
 
-# Granularity (in source-time seconds) for the cache key when a non-zero
-# ``start`` offset is requested. Adjacent resume positions inside the
-# same bucket reuse the same encode instead of spawning a fresh ffmpeg
-# per second; coarser buckets save disk at the cost of a longer wait
-# for ``video.currentTime`` to land on the exact saved point.
-_RESUME_BUCKET_SECONDS = 300
-
 # Idle eviction defaults: kill ffmpeg after this many seconds with no
 # segment requests. Trade-off: short timeout frees CPU faster after the
 # user navigates away, but a paused user beyond this window will see the
@@ -302,11 +295,14 @@ class HlsService(HlsPlaylistPort):
 
         Args:
             file_path: Absolute path to the source video file.
-            start: Source-time second the playback session starts from.
-                Rounded down to ``_RESUME_BUCKET_SECONDS`` so adjacent
-                resume positions share a cache bucket. ``0`` (the
-                default) hashes the file path alone, keeping
-                pre-existing cache directories valid after upgrade.
+            start: Source-time second the playback session starts from,
+                honoured exactly so a forward seek (e.g. Skip Intro) can
+                anchor a fresh encode at the target second instead of
+                snapping onto a coarser bucket. Callers that want cache
+                reuse across nearby positions (the resume flow) quantise
+                ``start`` themselves before calling. ``0`` (the default)
+                hashes the file path alone, keeping pre-existing cache
+                directories valid after upgrade.
 
         Returns:
             Hex MD5 digest uniquely identifying the cache bucket. The
@@ -314,8 +310,7 @@ class HlsService(HlsPlaylistPort):
             being deterministic so the same offset always re-attaches
             to the same on-disk bucket.
         """
-        bucket = (start // _RESUME_BUCKET_SECONDS) * _RESUME_BUCKET_SECONDS
-        key = file_path if bucket == 0 else f"{file_path}:{bucket}"
+        key = file_path if start == 0 else f"{file_path}:{start}"
         return hashlib.md5(key.encode()).hexdigest()
 
     def get_file_by_hash(self, path_hash: str, relative_path: str) -> Path | None:
@@ -423,10 +418,11 @@ class HlsService(HlsPlaylistPort):
 
         Args:
             file_path: Absolute path to the source video file.
-            start: Source-time second to begin transcoding at. Rounded
-                down to a 5-minute bucket via ``get_path_hash`` so a
-                small change in resume position reuses the same encode.
-                ``0`` is the legacy behaviour (single bucket per file).
+            start: Source-time second to begin transcoding at, honoured
+                exactly so a forward seek anchors a fresh encode on the
+                target second. Callers wanting cache reuse across nearby
+                positions quantise ``start`` before calling. ``0`` is the
+                legacy behaviour (single bucket per file).
 
         Returns:
             The path hash for the bucket — unique per ``(file_path,
@@ -601,12 +597,11 @@ class HlsService(HlsPlaylistPort):
     def _start_generation(self, file_path: str, start: int = 0) -> str:
         """Start all FFmpeg processes for multi-track HLS generation.
 
-        Transcodes from ``start`` seconds (rounded down to the cache
-        bucket) into a bucket keyed by ``(file_path, start_bucket)``.
-        Each ffmpeg invocation gets ``-ss N`` as an input seek so the
-        encode skips fast to the nearest preceding keyframe before
-        producing segments. ENDLIST sealing happens via the watcher
-        spawned in ``_spawn_ffmpeg``.
+        Transcodes from the exact ``start`` second into a bucket keyed
+        by ``(file_path, start)``. Each ffmpeg invocation gets ``-ss N``
+        as an input seek so the encode skips fast to the nearest
+        preceding keyframe before producing segments. ENDLIST sealing
+        happens via the watcher spawned in ``_spawn_ffmpeg``.
 
         Args:
             file_path: Absolute path to the source video file.
@@ -615,7 +610,12 @@ class HlsService(HlsPlaylistPort):
         source = self._validate_source(file_path)
         safe_path = str(source)
         path_hash = self.get_path_hash(file_path, start)
-        bucket_start = (start // _RESUME_BUCKET_SECONDS) * _RESUME_BUCKET_SECONDS
+        # The encode is anchored at the exact requested second so a
+        # forward seek lands on the first segment of a fresh manifest
+        # (no out-of-range seek on the live/event playlist). Cache reuse
+        # for nearby resume positions is the caller's responsibility —
+        # the resume flow quantises ``start`` before it gets here.
+        bucket_start = start
 
         if self.is_complete(path_hash):
             return path_hash

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -138,9 +138,9 @@ async def movie_hls_playlist(
         0,
         ge=0,
         description=(
-            "Source-time second to begin transcoding at. Rounded down "
-            "to a 5-minute bucket. Defaults to 0 for legacy single-bucket "
-            "caching."
+            "Source-time second to begin transcoding at, honoured "
+            "exactly so a forward seek starts a fresh encode at the "
+            "target. Defaults to 0 for legacy single-bucket caching."
         ),
     ),
     profile_id: str = Depends(resolve_profile_id),
@@ -177,9 +177,9 @@ async def episode_hls_playlist(
         0,
         ge=0,
         description=(
-            "Source-time second to begin transcoding at. Rounded down "
-            "to a 5-minute bucket. Defaults to 0 for legacy single-bucket "
-            "caching."
+            "Source-time second to begin transcoding at, honoured "
+            "exactly so a forward seek starts a fresh encode at the "
+            "target. Defaults to 0 for legacy single-bucket caching."
         ),
     ),
     profile_id: str = Depends(resolve_profile_id),

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -166,20 +166,19 @@ class TestHlsServiceGetPathHash:
         assert service.get_path_hash(path) == expected
         assert service.get_path_hash(path, start=0) == expected
 
-    def test_should_round_start_down_to_bucket(self, tmp_path: Path) -> None:
-        # Adjacent resume positions inside the same 5-minute window
-        # collapse onto the same bucket so a player resuming at t=302
-        # reuses the ffmpeg encode started at t=300.
+    def test_should_honour_exact_start_second(self, tmp_path: Path) -> None:
+        # The start offset is honoured exactly (not floored to a coarse
+        # bucket) so a forward seek — e.g. Skip Intro — anchors a fresh
+        # encode at the target second instead of snapping onto a shared
+        # bucket that transcodes from an earlier point.
         service = HlsService(
             runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "hls")
         )
         path = "/movies/test.mkv"
-        # 299s rounds down to bucket 0 — same as default
-        assert service.get_path_hash(path, start=299) == service.get_path_hash(path)
-        # 300s and 599s share the same bucket (300)
-        assert service.get_path_hash(path, start=300) == service.get_path_hash(path, start=599)
-        # 600s steps to the next bucket
-        assert service.get_path_hash(path, start=300) != service.get_path_hash(path, start=600)
+        # Every distinct non-zero second is its own bucket.
+        assert service.get_path_hash(path, start=90) != service.get_path_hash(path)
+        assert service.get_path_hash(path, start=90) != service.get_path_hash(path, start=91)
+        assert service.get_path_hash(path, start=302) != service.get_path_hash(path, start=300)
 
     def test_should_differ_across_buckets_for_same_file(self, tmp_path: Path) -> None:
         service = HlsService(


### PR DESCRIPTION
## Summary

- Skip Intro on a still-encoding file snapped back: the transcode is a live/`event` HLS playlist (no `#EXT-X-ENDLIST`), so the browser clamps any seek past the live edge and drops it once the encoder catches up. A reliable forward jump must mount a fresh encode anchored AT the target second.
- The adapter floored the `?start=` offset to a 5-minute bucket (`_RESUME_BUCKET_SECONDS`), collapsing early targets (e.g. an intro ending ~90s) onto the from-zero encode — so the player's clock advanced while the picture stayed at the start.
- `get_path_hash` and `_start_generation` now honour the **exact** `start` second: the cache key becomes `file_path:{start}` and ffmpeg seeks with `-ss {start}`. Removed the now-unused `_RESUME_BUCKET_SECONDS`.
- Resume still reuses cache because the player quantises saved positions to the 300s grid before requesting the playlist; only the legacy `start=0` single-bucket hash is preserved untouched.
- Trade-off: each cold forward seek spawns a fresh ffmpeg at that second (more cache buckets, LRU-evicted). Resume and within-buffer seeks are unaffected.

Pairs with homeflix-web `fix/player-skip-intro-exact-start`.

## Test plan

- [x] `pytest tests/modules/media/unit/infrastructure/streaming/test_hls_service.py` (122 passed)
- [x] `pytest tests/modules/media/unit/application/use_cases/ -k "hls or stream"` (21 passed)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] Manual smoke test: Skip Intro on a cold/still-encoding episode jumps to the intro end with clock and picture in sync; resume (continue watching) unchanged

## Summary by Sourcery

Honour exact HLS start offsets so forward seeks like Skip Intro start transcoding from the precise target second instead of a coarse bucketed position.

Bug Fixes:
- Fix forward seeks on still-encoding HLS playlists snapping back to earlier buckets by anchoring new encodes at the exact requested start second.

Enhancements:
- Simplify HLS cache bucketing to use the exact non-zero start second as part of the cache key while preserving legacy behaviour for start=0.

Documentation:
- Clarify API and use case documentation to describe that HLS start offsets are honoured exactly and that resume flows handle their own quantisation.

Tests:
- Update HlsService tests to assert exact start-second bucketing semantics instead of 5-minute bucket rounding.