### PR TITLE
feat(media): link existing scrub previews during scan

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -147,6 +147,9 @@ from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import
 )
 from src.modules.media.infrastructure.streaming import HlsService, MediaProbeService
 from src.modules.media.infrastructure.streaming.file_streamer import LocalFileStreamer
+from src.modules.media.infrastructure.streaming.scrub_preview_locator import (
+    FilesystemScrubPreviewLocator,
+)
 from src.modules.media.infrastructure.streaming.thumbnail_service import (
     ThumbnailGenerationService,
 )
@@ -411,6 +414,14 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         runtime_settings=runtime_settings,
     )
 
+    # Re-links scrub previews that already exist on disk (e.g. after a DB
+    # reset) during a scan, so the scanner can populate scrub_preview_path
+    # without waiting for the backfill job to regenerate the sprites.
+    scrub_preview_locator = providers.Singleton(
+        FilesystemScrubPreviewLocator,
+        runtime_settings=runtime_settings,
+    )
+
     # Audio analysis primitives — shared by the periodic intro detection
     # job. Singletons because each wrapper is stateless apart from the
     # runtime config it reads per call, and the job runs them serially
@@ -502,6 +513,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         uow_factory=media_unit_of_work_factory,
         probe_service=media_probe_service,
         event_bus=event_bus,
+        scrub_preview_locator=scrub_preview_locator,
     )
 
     # =========================================================================

--- a/src/infrastructure/scheduling/thumbnail_backfill_job.py
+++ b/src/infrastructure/scheduling/thumbnail_backfill_job.py
@@ -21,6 +21,7 @@ from src.modules.media.domain.value_objects import EpisodeId, ImageUrl, MovieId
 from src.modules.media.infrastructure.streaming.thumbnail_service import (
     ThumbnailGenerationService,
     ThumbnailResult,
+    scrub_preview_output_dir,
 )
 
 if TYPE_CHECKING:
@@ -217,13 +218,7 @@ class ThumbnailBackfillJob:
                 file_path=file_path,
             )
             return None
-        # Per-stem subfolder so episodes that share a season directory
-        # do not overwrite each other's ``sprite.jpg`` / ``sprite.vtt``.
-        # Movies typically sit in their own folders so the change is a
-        # no-op for them in practice, but the consistent layout means a
-        # "Movies/" folder hosting multiple titles flat would survive
-        # the same overwrite hazard.
-        output_dir = source.parent / subdir / source.stem
+        output_dir = scrub_preview_output_dir(source, subdir)
         return await asyncio.to_thread(
             self._thumbnail_service.generate,
             file_path,

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -51,6 +51,9 @@ from src.modules.media.application.ports.progress_lookup_port import (
     ProgressLookupPort,
     ProgressSummary,
 )
+from src.modules.media.application.ports.scrub_preview_locator_port import (
+    ScrubPreviewLocatorPort,
+)
 from src.modules.media.application.ports.variant_detector_port import (
     VariantDetectorPort,
 )
@@ -87,6 +90,7 @@ __all__ = [
     "ProgressLookupPort",
     "ProgressSummary",
     "ScannedFile",
+    "ScrubPreviewLocatorPort",
     "SearchCandidate",
     "SeasonMetadata",
     "VariantDetectorPort",

--- a/src/modules/media/application/ports/scrub_preview_locator_port.py
+++ b/src/modules/media/application/ports/scrub_preview_locator_port.py
@@ -1,0 +1,34 @@
+"""Port for locating an already-generated scrub-preview on disk."""
+
+from abc import ABC, abstractmethod
+
+
+class ScrubPreviewLocatorPort(ABC):
+    """Resolve whether a media file's scrub-preview already exists on disk.
+
+    The scrub-preview (sprite + WebVTT) is generated next to the source
+    file at a deterministic, stem-based path. After a database reset the
+    sprites usually survive on disk while the ``scrub_preview_path``
+    column is cleared, so this port lets the scanner re-link an existing
+    preview instead of waiting for the backfill job to regenerate it.
+    """
+
+    @abstractmethod
+    async def locate(self, source_file_path: str) -> str | None:
+        """Return the VTT path when a complete preview exists, else ``None``.
+
+        A preview counts as complete only when BOTH the WebVTT cue file
+        and its sibling sprite image are present, since the player needs
+        both to render hover thumbnails.
+
+        Args:
+            source_file_path: Absolute path to the source media file.
+
+        Returns:
+            Absolute path to the ``sprite.vtt`` file, or ``None`` when no
+            complete preview is on disk.
+        """
+        raise NotImplementedError
+
+
+__all__ = ["ScrubPreviewLocatorPort"]

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -13,6 +13,7 @@ from src.modules.media.application.ports import (
     MediaType,
     ProbeResult,
     ScannedFile,
+    ScrubPreviewLocatorPort,
     VariantDetectorPort,
 )
 from src.modules.media.application.unit_of_work import (
@@ -31,6 +32,7 @@ from src.modules.media.domain.value_objects import (
     Title,
     Year,
 )
+from src.shared_kernel.value_objects.image_url import ImageUrl
 
 # Aliased to avoid colliding with the scanner port's ``MediaType``
 # (movie | episode, a file-classification enum). This is the catalog
@@ -60,6 +62,11 @@ class ScanMediaDirectoriesUseCase:
         uow_factory: Factory that opens a fresh media Unit of Work per group.
         probe_service: Optional probe port for track and resolution detection.
         event_bus: Optional event bus for domain events.
+        scrub_preview_locator: Optional port that re-links an already-generated
+            scrub-preview found on disk. When provided, newly-created and
+            preview-less existing media get their ``scrub_preview_path`` set
+            during the scan instead of waiting for the backfill job — useful
+            after a database reset where the sprites survived on disk.
     """
 
     def __init__(
@@ -69,12 +76,14 @@ class ScanMediaDirectoriesUseCase:
         uow_factory: MediaUnitOfWorkFactory,
         probe_service: MediaProbePort | None = None,
         event_bus: EventBus | None = None,
+        scrub_preview_locator: ScrubPreviewLocatorPort | None = None,
     ) -> None:
         self._file_scanner = file_scanner
         self._variant_detector = variant_detector
         self._uow_factory = uow_factory
         self._probe_service = probe_service
         self._event_bus = event_bus
+        self._scrub_preview_locator = scrub_preview_locator
 
     async def execute(self, input_dto: ScanMediaInput) -> ScanMediaOutput:
         """Execute the media scan.
@@ -126,6 +135,32 @@ class ScanMediaDirectoriesUseCase:
         if self._probe_service is None:
             return None
         return await asyncio.to_thread(self._probe_service.probe, file_path)
+
+    async def _locate_scrub_preview(self, source_file_path: str) -> ImageUrl | None:
+        """Resolve an already-generated scrub-preview for a source file.
+
+        Returns an ``ImageUrl`` pointing at the on-disk WebVTT when the
+        locator finds a complete preview, else ``None`` (no locator wired,
+        or nothing on disk yet — the backfill job handles that case).
+        """
+        if self._scrub_preview_locator is None:
+            return None
+        located = await self._scrub_preview_locator.locate(source_file_path)
+        return ImageUrl(located) if located else None
+
+    async def _maybe_link_scrub_preview(self, entity: Movie | Episode) -> ImageUrl | None:
+        """Locate a preview for an existing entity that has none yet.
+
+        Returns ``None`` when the entity already has a preview, has no
+        primary file, or nothing is on disk — so callers only set the
+        field when there's a fresh link to make, never overwriting one.
+        """
+        if entity.scrub_preview_path is not None:
+            return None
+        primary = entity.primary_file
+        if primary is None:
+            return None
+        return await self._locate_scrub_preview(primary.file_path.value)
 
     async def _build_new_media_file(
         self,
@@ -302,8 +337,15 @@ class ScanMediaDirectoriesUseCase:
                 files[existing_idx] = refreshed
                 changed = True
 
+        updates: dict[str, object] = {}
         if changed:
-            movie = movie.with_updates(files=files)
+            updates["files"] = files
+        scrub_preview = await self._maybe_link_scrub_preview(movie)
+        if scrub_preview is not None:
+            updates["scrub_preview_path"] = scrub_preview
+
+        if updates:
+            movie = movie.with_updates(**updates)
             events = movie.pull_events()
             await uow.movies.save(movie)
             return 0, 1, events
@@ -328,6 +370,7 @@ class ScanMediaDirectoriesUseCase:
             year=Year(first.year or _current_year()),
             duration=Duration(duration or 0),
             files=[primary_file],
+            scrub_preview_path=await self._locate_scrub_preview(first.file_path.value),
         )
         movie.add_event(MediaCreatedEvent(media_id=movie_id, media_type=CatalogMediaType.MOVIE))
         for path in paths[1:]:
@@ -463,6 +506,7 @@ class ScanMediaDirectoriesUseCase:
             title=Title(ep_title),
             duration=Duration(duration or 0),
             files=[primary_file],
+            scrub_preview_path=await self._locate_scrub_preview(first.file_path.value),
         )
         for f in ep_files[1:]:
             variant_file, _ = await self._build_new_media_file(f, is_primary=False)
@@ -494,9 +538,17 @@ class ScanMediaDirectoriesUseCase:
                 files[existing_idx] = refreshed
                 changed = True
 
+        updates: dict[str, object] = {}
         if changed:
-            episode = episode.with_updates(files=files)
-        return episode, changed
+            updates["files"] = files
+        scrub_preview = await self._maybe_link_scrub_preview(episode)
+        if scrub_preview is not None:
+            updates["scrub_preview_path"] = scrub_preview
+
+        if updates:
+            episode = episode.with_updates(**updates)
+            return episode, True
+        return episode, False
 
 
 def _upsert_episode_in_season(season: Season, episode: Episode) -> Season:

--- a/src/modules/media/infrastructure/streaming/scrub_preview_locator.py
+++ b/src/modules/media/infrastructure/streaming/scrub_preview_locator.py
@@ -1,0 +1,44 @@
+"""Filesystem implementation of :class:`ScrubPreviewLocatorPort`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.ports.scrub_preview_locator_port import (
+    ScrubPreviewLocatorPort,
+)
+from src.modules.media.infrastructure.streaming.thumbnail_service import (
+    SPRITE_FILENAME,
+    VTT_FILENAME,
+    scrub_preview_output_dir,
+)
+
+if TYPE_CHECKING:
+    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+
+
+class FilesystemScrubPreviewLocator(ScrubPreviewLocatorPort):
+    """Locate scrub previews on the local filesystem.
+
+    Reads the configured sprite ``subdir`` from runtime settings on each
+    call so an admin edit propagates without a restart, then checks the
+    deterministic per-stem location (see ``scrub_preview_output_dir``)
+    for both the VTT and its sprite.
+    """
+
+    def __init__(self, runtime_settings: RuntimeSettings) -> None:
+        self._runtime_settings = runtime_settings
+
+    async def locate(self, source_file_path: str) -> str | None:
+        """Return the VTT path when a complete preview is on disk, else ``None``."""
+        subdir = (await self._runtime_settings.thumbnail_backfill()).subdir
+        output_dir = scrub_preview_output_dir(Path(source_file_path), subdir)
+        vtt = output_dir / VTT_FILENAME
+        sprite = output_dir / SPRITE_FILENAME
+        if vtt.is_file() and sprite.is_file():
+            return str(vtt)
+        return None
+
+
+__all__ = ["FilesystemScrubPreviewLocator"]

--- a/src/modules/media/infrastructure/streaming/thumbnail_service.py
+++ b/src/modules/media/infrastructure/streaming/thumbnail_service.py
@@ -40,6 +40,27 @@ _logger = logging.getLogger(__name__)
 SPRITE_FILENAME = "sprite.jpg"
 VTT_FILENAME = "sprite.vtt"
 
+
+def scrub_preview_output_dir(source: Path, subdir: str) -> Path:
+    """Return the deterministic per-stem sprite directory for a source file.
+
+    Mirrors the layout the backfill job and HLS pipeline write to —
+    ``<source-dir>/<subdir>/<source-stem>/`` — one folder per media stem
+    so episodes sharing a season directory don't overwrite each other's
+    ``sprite.jpg`` / ``sprite.vtt``. Centralised here so the scanner can
+    predict an already-generated preview's location and re-link it
+    without re-running ffmpeg.
+
+    Args:
+        source: Absolute path to the source media file.
+        subdir: Configured sprite sub-directory (e.g. ``.homeflix/thumbnails``).
+
+    Returns:
+        The directory that holds (or would hold) this file's sprite + VTT.
+    """
+    return source.parent / subdir / source.stem
+
+
 # JPEG quality for the sprite: ffmpeg -q:v where 2 is near-lossless and
 # 31 is worst. 5 keeps previews sharp enough for hover without bloating
 # the sprite — each 160x90 tile lands around 5-8KB on real content.

--- a/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
+++ b/tests/modules/media/unit/application/use_cases/test_scan_media_directories.py
@@ -1,6 +1,6 @@
 """Tests for ScanMediaDirectoriesUseCase."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -25,6 +25,7 @@ from src.modules.media.domain.value_objects import (
 )
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
 from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.image_url import ImageUrl
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 from tests.modules.media.unit.conftest import MediaUoWMocks, make_media_uow_mock
@@ -93,6 +94,7 @@ def _make_use_case(
     scanner_results: list[ScannedFile] | None = None,
     mocks: MediaUoWMocks | None = None,
     probe_service: MediaProbePort | MagicMock | None = None,
+    scrub_preview_locator: MagicMock | None = None,
 ) -> tuple[ScanMediaDirectoriesUseCase, MediaUoWMocks]:
     """Build the scan use case wired to a mock Unit of Work factory."""
     file_scanner = MagicMock()
@@ -113,8 +115,16 @@ def _make_use_case(
         variant_detector=variant_detector,
         uow_factory=mocks.factory,
         probe_service=probe_service,
+        scrub_preview_locator=scrub_preview_locator,
     )
     return use_case, mocks
+
+
+def _locator(return_value: str | None) -> MagicMock:
+    """A ScrubPreviewLocatorPort mock whose ``locate`` returns a fixed value."""
+    locator = MagicMock()
+    locator.locate = AsyncMock(return_value=return_value)
+    return locator
 
 
 @pytest.mark.unit
@@ -814,3 +824,154 @@ class TestScanIdempotencyAndErrors:
         assert "INSERT INTO" not in joined
         assert "UNIQUE constraint" not in joined
         assert "SQL" not in joined
+
+
+@pytest.mark.unit
+class TestScanMediaScrubPreviewLinking:
+    """Linking already-generated scrub previews found on disk during a scan."""
+
+    @pytest.mark.asyncio
+    async def test_should_link_existing_scrub_preview_on_new_movie(self) -> None:
+        saved: list[Movie] = []
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.series.find_by_title.return_value = None
+        mocks.series.find_by_file_path.return_value = None
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
+
+        vtt = "/movies/.homeflix/thumbnails/Inception/sprite.vtt"
+        use_case, _ = _make_use_case(
+            scanner_results=[_movie_file("/movies/Inception.mkv", "Inception")],
+            mocks=mocks,
+            scrub_preview_locator=_locator(vtt),
+        )
+
+        await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert saved
+        assert saved[0].scrub_preview_path is not None
+        assert saved[0].scrub_preview_path.value == vtt
+
+    @pytest.mark.asyncio
+    async def test_should_leave_scrub_preview_none_when_not_on_disk(self) -> None:
+        saved: list[Movie] = []
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.series.find_by_title.return_value = None
+        mocks.series.find_by_file_path.return_value = None
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
+
+        use_case, _ = _make_use_case(
+            scanner_results=[_movie_file("/movies/Inception.mkv", "Inception")],
+            mocks=mocks,
+            scrub_preview_locator=_locator(None),
+        )
+
+        await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert saved
+        assert saved[0].scrub_preview_path is None
+
+    @pytest.mark.asyncio
+    async def test_should_leave_scrub_preview_none_without_locator(self) -> None:
+        saved: list[Movie] = []
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.return_value = None
+        mocks.series.find_by_title.return_value = None
+        mocks.series.find_by_file_path.return_value = None
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
+
+        use_case, _ = _make_use_case(
+            scanner_results=[_movie_file("/movies/Inception.mkv", "Inception")],
+            mocks=mocks,
+        )
+
+        await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert saved
+        assert saved[0].scrub_preview_path is None
+
+    @pytest.mark.asyncio
+    async def test_should_link_existing_scrub_preview_on_new_episode(self) -> None:
+        saved: list[Series] = []
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_title.return_value = None
+        mocks.series.find_by_file_path.return_value = None
+        mocks.series.save.side_effect = lambda s: saved.append(s) or s
+
+        vtt = "/series/Show/S01/.homeflix/thumbnails/S01E01/sprite.vtt"
+        use_case, _ = _make_use_case(
+            scanner_results=[_episode_file("/series/Show/S01/S01E01.mkv", series_name="Show")],
+            mocks=mocks,
+            scrub_preview_locator=_locator(vtt),
+        )
+
+        await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert saved
+        episode = saved[0].seasons[0].episodes[0]
+        assert episode.scrub_preview_path is not None
+        assert episode.scrub_preview_path.value == vtt
+
+    @pytest.mark.asyncio
+    async def test_should_link_scrub_preview_on_existing_movie_without_one(self) -> None:
+        existing = Movie.create(
+            library_id=_LIBRARY_ID,
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/Inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        saved: list[Movie] = []
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/Inception.mkv" else None
+        )
+        mocks.movies.save.side_effect = lambda m: saved.append(m) or m
+
+        vtt = "/movies/.homeflix/thumbnails/Inception/sprite.vtt"
+        use_case, _ = _make_use_case(
+            scanner_results=[_movie_file("/movies/Inception.mkv", "Inception", 2010, "1080p")],
+            mocks=mocks,
+            scrub_preview_locator=_locator(vtt),
+        )
+
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert result.movies_updated == 1
+        assert saved
+        assert saved[0].scrub_preview_path is not None
+        assert saved[0].scrub_preview_path.value == vtt
+
+    @pytest.mark.asyncio
+    async def test_should_not_overwrite_existing_scrub_preview(self) -> None:
+        existing = Movie.create(
+            library_id=_LIBRARY_ID,
+            title="Inception",
+            year=2010,
+            duration=8880,
+            file_path="/movies/Inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+            scrub_preview_path=ImageUrl("/movies/.homeflix/thumbnails/Inception/sprite.vtt"),
+        )
+        mocks = make_media_uow_mock()
+        mocks.movies.find_by_file_path.side_effect = lambda fp: (
+            existing if fp.value == "/movies/Inception.mkv" else None
+        )
+        mocks.movies.save.side_effect = lambda m: m
+
+        locator = _locator("/somewhere/else/sprite.vtt")
+        use_case, _ = _make_use_case(
+            scanner_results=[_movie_file("/movies/Inception.mkv", "Inception", 2010, "1080p")],
+            mocks=mocks,
+            scrub_preview_locator=locator,
+        )
+
+        result = await use_case.execute(ScanMediaInput(library_id=_LIBRARY_ID))
+
+        assert result.movies_updated == 0
+        mocks.movies.save.assert_not_called()
+        locator.locate.assert_not_awaited()

--- a/tests/modules/media/unit/infrastructure/streaming/test_scrub_preview_locator.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_scrub_preview_locator.py
@@ -1,0 +1,102 @@
+"""Tests for FilesystemScrubPreviewLocator."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.media.infrastructure.streaming.scrub_preview_locator import (
+    FilesystemScrubPreviewLocator,
+)
+from src.modules.media.infrastructure.streaming.thumbnail_service import (
+    SPRITE_FILENAME,
+    VTT_FILENAME,
+    scrub_preview_output_dir,
+)
+from src.modules.settings.domain.value_objects import ThumbnailBackfillConfig
+
+_SUBDIR = ".homeflix/thumbnails"
+
+
+def _locator(subdir: str = _SUBDIR) -> FilesystemScrubPreviewLocator:
+    runtime = MagicMock()
+    runtime.thumbnail_backfill = AsyncMock(
+        return_value=ThumbnailBackfillConfig(batch_size=10, subdir=subdir),
+    )
+    return FilesystemScrubPreviewLocator(runtime_settings=runtime)
+
+
+def _write_preview(
+    source: Path, subdir: str = _SUBDIR, *, vtt: bool = True, sprite: bool = True
+) -> Path:
+    output_dir = scrub_preview_output_dir(source, subdir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if vtt:
+        (output_dir / VTT_FILENAME).write_text("WEBVTT\n")
+    if sprite:
+        (output_dir / SPRITE_FILENAME).write_bytes(b"\xff\xd8\xff")
+    return output_dir / VTT_FILENAME
+
+
+@pytest.mark.unit
+class TestFilesystemScrubPreviewLocator:
+    @pytest.mark.asyncio
+    async def test_should_return_vtt_path_when_both_files_present(self, tmp_path: Path) -> None:
+        source = tmp_path / "movies" / "Inception.mkv"
+        source.parent.mkdir(parents=True)
+        source.write_bytes(b"\x00")
+        expected_vtt = _write_preview(source)
+
+        result = await _locator().locate(str(source))
+
+        assert result == str(expected_vtt)
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_when_sprite_missing(self, tmp_path: Path) -> None:
+        source = tmp_path / "movies" / "Inception.mkv"
+        source.parent.mkdir(parents=True)
+        _write_preview(source, sprite=False)
+
+        result = await _locator().locate(str(source))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_when_vtt_missing(self, tmp_path: Path) -> None:
+        source = tmp_path / "movies" / "Inception.mkv"
+        source.parent.mkdir(parents=True)
+        _write_preview(source, vtt=False)
+
+        result = await _locator().locate(str(source))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_return_none_when_nothing_on_disk(self, tmp_path: Path) -> None:
+        source = tmp_path / "movies" / "Inception.mkv"
+
+        result = await _locator().locate(str(source))
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_should_honour_configured_subdir(self, tmp_path: Path) -> None:
+        source = tmp_path / "movies" / "Inception.mkv"
+        source.parent.mkdir(parents=True)
+        expected_vtt = _write_preview(source, subdir="custom/previews")
+
+        result = await _locator(subdir="custom/previews").locate(str(source))
+
+        assert result == str(expected_vtt)
+
+
+@pytest.mark.unit
+class TestScrubPreviewOutputDir:
+    def test_should_build_per_stem_directory(self) -> None:
+        source = Path("/media/Show/S01/Show.S01E01.mkv")
+
+        output_dir = scrub_preview_output_dir(source, ".homeflix/thumbnails")
+
+        assert output_dir == Path(
+            "/media/Show/S01/.homeflix/thumbnails/Show.S01E01",
+        )


### PR DESCRIPTION
## Summary

- After a database reset the sprite/VTT files usually survive on disk while the `scrub_preview_path` column is cleared, so most titles show no scrub preview until the periodic backfill job regenerates them (re-running ffmpeg unnecessarily).
- The scan now resolves the **deterministic** per-stem preview location (`<source-dir>/<subdir>/<source-stem>/sprite.vtt` + sibling `sprite.jpg`) and re-links it when both files are present — for newly-created **and** preview-less existing movies and episodes. Never overwrites a preview that's already set.
- Adds `ScrubPreviewLocatorPort` (application port) with a filesystem adapter `FilesystemScrubPreviewLocator` that reads the configured `subdir` from runtime settings on each call.
- Centralises the sprite-directory path computation in `thumbnail_service.scrub_preview_output_dir` (previously inline in the backfill job) so the scanner and the job share one source of truth.
- The locator is optional on the use case (`None` → no-op), so non-wired call sites and tests behave exactly as before.

## Test plan

- [x] `pytest tests/modules/media/unit tests/infrastructure/scheduling` (1329 passed)
- [x] New unit tests: scan links preview on new movie/episode, leaves `None` when not on disk / no locator, links on a preview-less existing movie, never overwrites an existing preview
- [x] New adapter tests: returns VTT when both files present, `None` when either missing / nothing on disk, honours configured `subdir`; plus `scrub_preview_output_dir` layout
- [x] `ruff check` + `ruff format --check` clean; `MediaContainer` import/wiring smoke check
- [ ] Manual: run a real library scan and confirm titles whose sprites exist on disk get `scrub_preview_path` populated (no ffmpeg re-run)