### PR TITLE
feat(media): normalize track display names and version dubs

### DIFF
--- a/src/modules/media/application/dtos/stream_dtos.py
+++ b/src/modules/media/application/dtos/stream_dtos.py
@@ -9,6 +9,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
+from src.modules.media.domain.services.track_naming import (
+    TrackVersion,
+    audio_version_labels,
+    subtitle_version_labels,
+)
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
@@ -71,8 +77,25 @@ class RangeStreamOutput:
     body: AsyncIterator[bytes]
 
 
+def _version_dict(version: TrackVersion | None) -> dict[str, str] | None:
+    """Project a structured ``TrackVersion`` into a JSON-friendly dict."""
+    if version is None:
+        return None
+    return {"kind": version.kind, "value": version.value}
+
+
 def serialize_tracks(probe: ProbeResult) -> TrackListOutput:
-    """Project a ``ProbeResult`` into the flat track DTO."""
+    """Project a ``ProbeResult`` into the flat track DTO.
+
+    Each track carries a structured ``version`` differentiating it from
+    same-language siblings (e.g. a dub studio, channel layout, or an
+    ordinal), or ``None`` when the language alone is unambiguous. The
+    raw ``title`` is kept for reference; the player should prefer the
+    language + ``version`` and localize them.
+    """
+    audio_versions = audio_version_labels(probe.audio_tracks)
+    text_subs = [t for t in probe.all_subtitles if t.is_text_based]
+    sub_versions = subtitle_version_labels(text_subs)
     return TrackListOutput(
         audio_tracks=[
             {
@@ -82,6 +105,7 @@ def serialize_tracks(probe: ProbeResult) -> TrackListOutput:
                 "channels": t.channels,
                 "channel_layout": t.channel_layout,
                 "title": t.title,
+                "version": _version_dict(audio_versions.get(t.index)),
                 "is_default": t.is_default,
             }
             for t in probe.audio_tracks
@@ -92,13 +116,13 @@ def serialize_tracks(probe: ProbeResult) -> TrackListOutput:
                 "language": t.language.value,
                 "format": t.format,
                 "title": t.title,
+                "version": _version_dict(sub_versions.get(t.index)),
                 "is_default": t.is_default,
                 "is_forced": t.is_forced,
                 "is_external": t.is_external,
                 "is_image_based": t.is_image_based,
             }
-            for t in probe.all_subtitles
-            if t.is_text_based
+            for t in text_subs
         ],
     )
 

--- a/src/modules/media/domain/services/__init__.py
+++ b/src/modules/media/domain/services/__init__.py
@@ -1,0 +1,17 @@
+"""Media domain services."""
+
+from src.modules.media.domain.services.track_naming import (
+    TrackVersion,
+    audio_version_labels,
+    detect_studio,
+    render_version_token,
+    subtitle_version_labels,
+)
+
+__all__ = [
+    "TrackVersion",
+    "audio_version_labels",
+    "detect_studio",
+    "render_version_token",
+    "subtitle_version_labels",
+]

--- a/src/modules/media/domain/services/track_naming.py
+++ b/src/modules/media/domain/services/track_naming.py
@@ -1,0 +1,243 @@
+"""Display-name normalization for audio and subtitle tracks.
+
+Source files frequently carry noisy re-encode titles on their audio
+tracks (release-group tags, codec dumps, site URLs). The player only
+needs the *language*; what actually has to be disambiguated is the case
+where several tracks share one language — typically multiple dubs.
+
+There is no authoritative service that maps an audio track to its
+dubbing studio, so detection is best-effort from the raw ``title``
+text: we match it against a curated list of known studios. When that
+fails we fall back to the channel layout, and finally to a plain
+ordinal — which always guarantees a unique, sensible label.
+
+The result is a structured :class:`TrackVersion` (kind + value) rather
+than a finished string, so the presentation layer stays in charge of
+localization (e.g. rendering an ``ordinal`` as "Versão 2" / "Version 2").
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+VersionKind = Literal["studio", "channel_layout", "ordinal", "sdh"]
+
+
+@dataclass(frozen=True)
+class TrackVersion:
+    """A structured, language-agnostic differentiator for a track.
+
+    Attributes:
+        kind: How the track was disambiguated from same-language siblings:
+            ``studio`` (a dubbing studio detected in the raw title),
+            ``channel_layout`` (e.g. "5.1" vs "Stereo"), ``ordinal``
+            (a 1-based position when nothing else separates them), or
+            ``sdh`` (a subtitle for the deaf/hard-of-hearing).
+        value: The kind's payload — the studio name, the layout string,
+            the ordinal as a string, or "" for ``sdh``. ``ordinal`` and
+            ``sdh`` are meant to be localized by the presentation layer.
+    """
+
+    kind: VersionKind
+    value: str = ""
+
+
+# Curated dubbing studios → normalized aliases (lowercase, accent-stripped).
+# Matched against the raw track title on alphanumeric boundaries. There is
+# no public registry for this, so the list is intentionally conservative:
+# a false positive shows a wrong studio, whereas the ordinal fallback is
+# always safe. Add studios here (or promote to a runtime setting) as needed.
+_STUDIO_ALIASES: dict[str, tuple[str, ...]] = {
+    "Herbert Richers": ("herbert richers", "richers"),
+    "Álamo": ("alamo",),
+    "VTI": ("vti rio", "vti"),
+    "Delart": ("delart",),
+    "Dublavídeo": ("dublavideo",),
+    "Drei Marc": ("drei marc",),
+    "Som de Vera Cruz": ("som de vera cruz", "vera cruz"),
+    "Cinevídeo": ("cinevideo",),
+    "Centauro": ("centauro",),
+    "Unidub": ("unidub",),
+    "BKS": ("bks",),
+    "Marsh Mallow": ("marsh mallow", "marshmallow"),
+    "Wan Macher": ("wan macher",),
+    "TV Group": ("tv group", "tvgroup"),
+    "Rio Sound": ("rio sound",),
+    "Double Sound": ("double sound",),
+    "MG Estúdio": ("mg estudio", "mg studio"),
+    "Dublasom": ("dublasom",),
+    "Vox Mundi": ("vox mundi",),
+    "Studio Gábia": ("studio gabia",),
+    "Sincrocine": ("sincrocine",),
+    "Audio News": ("audio news",),
+    "Som Livre": ("som livre",),
+    "Master Sound": ("master sound",),
+    "Netflix": ("netflix",),
+    "Disney": ("disney+", "disney"),
+    "Amazon": ("prime video", "amazon"),
+    "HBO Max": ("hbo max", "hbomax"),
+    "Star+": ("star+",),
+    "Crunchyroll": ("crunchyroll",),
+    "Funimation": ("funimation",),
+    "Globo": ("globoplay", "tv globo"),
+    "Paramount": ("paramount",),
+}
+
+# Markers that a subtitle is for the deaf / hard-of-hearing.
+_SDH_MARKERS: tuple[str, ...] = ("sdh", "hearing impaired", "surdos")
+
+
+def _normalize(text: str) -> str:
+    """Lowercase and strip accents for tolerant alias matching."""
+    decomposed = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in decomposed if not unicodedata.combining(c)).lower()
+
+
+def _contains_token(haystack: str, token: str) -> bool:
+    """Whether ``token`` appears in ``haystack`` on alphanumeric boundaries."""
+    pattern = rf"(?<![a-z0-9]){re.escape(token)}(?![a-z0-9])"
+    return re.search(pattern, haystack) is not None
+
+
+def detect_studio(title: str | None) -> str | None:
+    """Return the canonical studio name found in ``title``, else ``None``."""
+    if not title:
+        return None
+    normalized = _normalize(title)
+    for canonical, aliases in _STUDIO_ALIASES.items():
+        if any(_contains_token(normalized, alias) for alias in aliases):
+            return canonical
+    return None
+
+
+def _is_sdh(title: str | None) -> bool:
+    """Whether ``title`` marks a deaf/hard-of-hearing subtitle."""
+    if not title:
+        return False
+    normalized = _normalize(title)
+    return any(_contains_token(normalized, marker) for marker in _SDH_MARKERS)
+
+
+def _render(version: TrackVersion) -> str:
+    """A collision key for a version, namespaced by kind."""
+    return f"{version.kind}:{version.value}"
+
+
+def render_version_token(version: TrackVersion | None) -> str | None:
+    """Render a version as a short, language-neutral token, or ``None``.
+
+    Used for the HLS ``NAME=`` fallback (which can't carry structured
+    data and isn't localized). Clients that read the structured
+    ``TrackVersion`` should compose and localize it themselves instead.
+    """
+    if version is None:
+        return None
+    if version.kind == "ordinal":
+        return f"v{version.value}"
+    if version.kind == "sdh":
+        return "SDH"
+    return version.value
+
+
+def _group_by_language(tracks: Iterable[object]) -> list[list]:
+    """Group tracks by language code, preserving first-seen order."""
+    groups: dict[str, list] = defaultdict(list)
+    for track in tracks:
+        groups[track.language.value].append(track)  # type: ignore[attr-defined]
+    return list(groups.values())
+
+
+def _ordinal_labels(group: list) -> dict[int, TrackVersion]:
+    """Assign 1-based ordinals to every track in a group — the safe fallback."""
+    return {t.index: TrackVersion("ordinal", str(i)) for i, t in enumerate(group, start=1)}
+
+
+def audio_version_labels(tracks: Iterable[AudioTrack]) -> dict[int, TrackVersion | None]:
+    """Compute a version label per audio track, keyed by track index.
+
+    A language with a single track gets ``None`` (just show the language).
+    Within a same-language group the chain is: detected studio → channel
+    layout (when it uniquely separates the rest) → ordinal. A final guard
+    falls the whole group back to ordinals if any label would collide, so
+    every track in a group always renders distinctly.
+    """
+    result: dict[int, TrackVersion | None] = {}
+    for group in _group_by_language(tracks):
+        if len(group) == 1:
+            result[group[0].index] = None
+            continue
+
+        labels: dict[int, TrackVersion] = {}
+        for track in group:
+            studio = detect_studio(track.title)
+            if studio is not None:
+                labels[track.index] = TrackVersion("studio", studio)
+
+        remaining = [t for t in group if t.index not in labels]
+        if remaining:
+            layouts = [t.channel_layout for t in remaining]
+            taken = {_render(v) for v in labels.values()}
+            layouts_unique = len(set(layouts)) == len(layouts)
+            if layouts_unique and taken.isdisjoint(f"channel_layout:{x}" for x in layouts):
+                for track in remaining:
+                    labels[track.index] = TrackVersion("channel_layout", track.channel_layout)
+            else:
+                for ordinal, track in enumerate(remaining, start=1):
+                    labels[track.index] = TrackVersion("ordinal", str(ordinal))
+
+        if len({_render(labels[t.index]) for t in group}) != len(group):
+            labels = _ordinal_labels(group)
+
+        result.update(labels)
+    return result
+
+
+def subtitle_version_labels(
+    subtitles: Iterable[SubtitleTrack],
+) -> dict[int, TrackVersion | None]:
+    """Compute a version label per subtitle track, keyed by track index.
+
+    Subtitles mostly only need the language; forced tracks are already
+    flagged separately. This adds an ``sdh`` label for deaf/hard-of-hearing
+    tracks and disambiguates genuine duplicates — tracks sharing language,
+    forced-flag and SDH-status — with an ordinal.
+    """
+    result: dict[int, TrackVersion | None] = {}
+    for group in _group_by_language(subtitles):
+        sdh = {t.index for t in group if _is_sdh(t.title)}
+
+        # Genuine duplicates share (is_forced, is_sdh); only those need an
+        # ordinal. Everything else is distinguishable by language + forced.
+        buckets: dict[tuple[bool, bool], list] = defaultdict(list)
+        for track in group:
+            buckets[(track.is_forced, track.index in sdh)].append(track)
+
+        for track in group:
+            is_sdh = track.index in sdh
+            bucket = buckets[(track.is_forced, is_sdh)]
+            if len(bucket) > 1:
+                result[track.index] = TrackVersion("ordinal", str(bucket.index(track) + 1))
+            elif is_sdh:
+                result[track.index] = TrackVersion("sdh")
+            else:
+                result[track.index] = None
+    return result
+
+
+__all__ = [
+    "TrackVersion",
+    "VersionKind",
+    "audio_version_labels",
+    "detect_studio",
+    "render_version_token",
+    "subtitle_version_labels",
+]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -49,6 +49,12 @@ from src.modules.media.application.ports.hls_playlist_port import (
     HlsPlaylistPort,
 )
 from src.modules.media.application.ports.media_probe_port import ProbeResult
+from src.modules.media.domain.services.track_naming import (
+    TrackVersion,
+    audio_version_labels,
+    render_version_token,
+    subtitle_version_labels,
+)
 from src.modules.media.infrastructure.streaming._subprocess import (
     HW_ACCEL_NVENC,
     HW_ACCEL_OFF,
@@ -99,6 +105,19 @@ _NVENC_PROBE_TIMEOUT = 30
 def _primary_audio_index(probe: ProbeResult) -> int:
     """Get the index of the primary audio track (first one, always index 0)."""
     return probe.audio_tracks[0].index if probe.audio_tracks else 0
+
+
+def _manifest_track_name(language: str, version: TrackVersion | None) -> str:
+    """Compose a fallback ``NAME=`` for a manifest rendition.
+
+    The manifest can't carry structured data and isn't localized, so we
+    use the language code plus a short version token (e.g. "PT",
+    "PT · Herbert Richers", "PT · 5.1"). Clients should prefer the
+    structured ``/tracks`` payload and localize it themselves.
+    """
+    base = language.upper()
+    token = render_version_token(version)
+    return f"{base} · {token}" if token else base
 
 
 def _audio_args_for(track: AudioTrack | None, start: int) -> list[str]:
@@ -1200,11 +1219,14 @@ class HlsService(HlsPlaylistPort):
         text_subs = [s for s in probe.all_subtitles if s.is_text_based]
         sub_group = 'SUBTITLES="subs"' if text_subs else ""
 
+        audio_versions = audio_version_labels(probe.audio_tracks)
+        sub_versions = subtitle_version_labels(text_subs)
+
         primary_idx = _primary_audio_index(probe)
         if has_alt_audio:
             for track in probe.audio_tracks:
                 is_primary = track.index == primary_idx
-                name = track.title or f"{track.language.value.upper()} ({track.channel_layout})"
+                name = _manifest_track_name(track.language.value, audio_versions.get(track.index))
                 if is_primary:
                     lines.append(
                         f'#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",'
@@ -1220,7 +1242,7 @@ class HlsService(HlsPlaylistPort):
                     )
 
         for sub in text_subs:
-            sub_name = sub.title or f"{sub.language.value.upper()}"
+            sub_name = _manifest_track_name(sub.language.value, sub_versions.get(sub.index))
             is_forced = "YES" if sub.is_forced else "NO"
             lines.append(
                 f'#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",'

--- a/tests/modules/media/unit/domain/services/test_track_naming.py
+++ b/tests/modules/media/unit/domain/services/test_track_naming.py
@@ -1,0 +1,172 @@
+"""Tests for the track display-name domain service."""
+
+import pytest
+
+from src.modules.media.domain.services.track_naming import (
+    TrackVersion,
+    audio_version_labels,
+    detect_studio,
+    subtitle_version_labels,
+)
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+
+def _audio(index: int, lang: str, *, title: str | None = None, channels: int = 2) -> AudioTrack:
+    return AudioTrack(
+        index=index,
+        language=LanguageCode(lang),
+        codec="aac",
+        channels=channels,
+        title=title,
+    )
+
+
+def _sub(
+    index: int,
+    lang: str,
+    *,
+    title: str | None = None,
+    forced: bool = False,
+) -> SubtitleTrack:
+    return SubtitleTrack(
+        index=index,
+        language=LanguageCode(lang),
+        format="srt",
+        title=title,
+        is_forced=forced,
+    )
+
+
+@pytest.mark.unit
+class TestDetectStudio:
+    def test_should_detect_studio_inside_noisy_title(self) -> None:
+        assert detect_studio("PT-BR Dublagem Herbert Richers AAC 5.1") == "Herbert Richers"
+
+    def test_should_match_accent_insensitively(self) -> None:
+        assert detect_studio("Áudio Dublavídeo") == "Dublavídeo"
+        assert detect_studio("audio dublavideo") == "Dublavídeo"
+
+    def test_should_match_streaming_studio_with_plus(self) -> None:
+        assert detect_studio("Dublagem Disney+") == "Disney"
+
+    def test_should_return_none_for_no_match(self) -> None:
+        assert detect_studio("English DTS-HD MA 7.1") is None
+
+    def test_should_return_none_for_missing_title(self) -> None:
+        assert detect_studio(None) is None
+        assert detect_studio("") is None
+
+    def test_should_respect_token_boundaries(self) -> None:
+        # "bks" must not match inside a larger word.
+        assert detect_studio("playbkster") is None
+
+
+@pytest.mark.unit
+class TestAudioVersionLabels:
+    def test_should_not_label_single_track_languages(self) -> None:
+        tracks = [_audio(0, "en"), _audio(1, "pt")]
+
+        labels = audio_version_labels(tracks)
+
+        assert labels == {0: None, 1: None}
+
+    def test_should_label_same_language_dubs_by_studio(self) -> None:
+        tracks = [
+            _audio(0, "pt", title="Dublagem Herbert Richers"),
+            _audio(1, "pt", title="Redublagem Álamo"),
+        ]
+
+        labels = audio_version_labels(tracks)
+
+        assert labels[0] == TrackVersion("studio", "Herbert Richers")
+        assert labels[1] == TrackVersion("studio", "Álamo")
+
+    def test_should_fall_back_to_channel_layout(self) -> None:
+        tracks = [
+            _audio(0, "pt", title="AAC", channels=6),
+            _audio(1, "pt", title="AAC", channels=2),
+        ]
+
+        labels = audio_version_labels(tracks)
+
+        assert labels[0] == TrackVersion("channel_layout", "5.1")
+        assert labels[1] == TrackVersion("channel_layout", "Stereo")
+
+    def test_should_fall_back_to_ordinal_when_indistinguishable(self) -> None:
+        tracks = [
+            _audio(0, "pt", title="AAC", channels=2),
+            _audio(1, "pt", title="Stereo", channels=2),
+        ]
+
+        labels = audio_version_labels(tracks)
+
+        assert labels[0] == TrackVersion("ordinal", "1")
+        assert labels[1] == TrackVersion("ordinal", "2")
+
+    def test_should_mix_studio_and_layout_within_a_group(self) -> None:
+        tracks = [
+            _audio(0, "pt", title="Herbert Richers", channels=6),
+            _audio(1, "pt", title="AAC", channels=2),
+        ]
+
+        labels = audio_version_labels(tracks)
+
+        assert labels[0] == TrackVersion("studio", "Herbert Richers")
+        assert labels[1] == TrackVersion("channel_layout", "Stereo")
+
+    def test_should_guard_against_duplicate_studio_names(self) -> None:
+        tracks = [
+            _audio(0, "pt", title="Netflix", channels=2),
+            _audio(1, "pt", title="Netflix", channels=2),
+        ]
+
+        labels = audio_version_labels(tracks)
+
+        assert labels[0] == TrackVersion("ordinal", "1")
+        assert labels[1] == TrackVersion("ordinal", "2")
+
+    def test_should_label_each_language_group_independently(self) -> None:
+        tracks = [
+            _audio(0, "en"),
+            _audio(1, "pt", title="Herbert Richers"),
+            _audio(2, "pt", title="Álamo"),
+        ]
+
+        labels = audio_version_labels(tracks)
+
+        assert labels[0] is None
+        assert labels[1] == TrackVersion("studio", "Herbert Richers")
+        assert labels[2] == TrackVersion("studio", "Álamo")
+
+
+@pytest.mark.unit
+class TestSubtitleVersionLabels:
+    def test_should_not_label_single_track_languages(self) -> None:
+        labels = subtitle_version_labels([_sub(0, "en"), _sub(1, "pt")])
+
+        assert labels == {0: None, 1: None}
+
+    def test_should_not_label_forced_vs_full_same_language(self) -> None:
+        # Forced is surfaced separately, so neither needs a version label.
+        labels = subtitle_version_labels(
+            [_sub(0, "pt"), _sub(1, "pt", forced=True)],
+        )
+
+        assert labels == {0: None, 1: None}
+
+    def test_should_label_sdh_subtitles(self) -> None:
+        labels = subtitle_version_labels(
+            [_sub(0, "pt"), _sub(1, "pt", title="Português SDH")],
+        )
+
+        assert labels[0] is None
+        assert labels[1] == TrackVersion("sdh")
+
+    def test_should_ordinal_genuine_duplicates(self) -> None:
+        labels = subtitle_version_labels(
+            [_sub(0, "pt", title="Full"), _sub(1, "pt", title="Completa")],
+        )
+
+        assert labels[0] == TrackVersion("ordinal", "1")
+        assert labels[1] == TrackVersion("ordinal", "2")


### PR DESCRIPTION
## Summary

- Audio/subtitle tracks carried raw re-encode titles (release-group tags, codec dumps, URLs) straight through to the player. This normalizes the display: the **language** is the name, and a differentiator is only added when several tracks share one language.
- New domain service `track_naming` (in `modules/media/domain/services/`) computes a structured `TrackVersion` per track within each language group:
  - **audio**: detected dubbing studio → distinguishing channel layout → ordinal (`Versão N`). A uniqueness guard falls a whole group back to ordinals if any label would collide.
  - **subtitles**: an `SDH` label, and ordinals only for genuine duplicates (same language + forced-flag + SDH); forced stays surfaced separately.
- Studio detection is **best-effort** against the raw title (accent/case-insensitive, token-boundary matched) using a curated, conservative list — there is no public registry, so the list errs toward fewer false positives and the ordinal fallback is always safe. Easy to extend; can graduate to a runtime setting later.
- The structured `version` (`{kind, value}` | null) is now exposed per track on the `/tracks` API, and the HLS master playlist `NAME=` is composed from the **same** service so both surfaces stay consistent. Version labels are derived (not cached), so they recompute from cached probe data with no schema change.

Backend half of the two-PR plan. The frontend (player composing the localized language + version, reading `/tracks`) follows in a separate `homeflix-web` PR. This PR already improves the manifest `NAME=` (drops junk, shows language + version) for the current player.

## Test plan

- [x] `pytest tests/modules/media/unit` (1295 passed) — incl. new `test_track_naming` (17), master-playlist and `/tracks` serializer tests
- [x] Domain service unit tests: studio detection (accent/boundary/None), audio studio→layout→ordinal chain, uniqueness guard, per-language grouping, subtitle SDH/forced/duplicate handling
- [x] `ruff check` + `ruff format --check` clean
- [ ] Manual: a title with multiple same-language dubs shows distinct labels (studio when named, else layout/version) in the player audio menu

## Summary by Sourcery

Normalize media track display names by deriving structured version metadata for audio and subtitle tracks and using it consistently in APIs and HLS manifests.

New Features:
- Expose a structured track version descriptor on audio and subtitle tracks in the `/tracks` API to differentiate same-language variants.
- Introduce a media domain service that infers audio and subtitle version labels (e.g., studio, channel layout, SDH, ordinal) from raw track metadata.
- Apply normalized language-plus-version naming to HLS master playlist entries for audio and subtitle renditions.

Tests:
- Add unit tests for the track naming domain service, including studio detection, audio version labeling, and subtitle version labeling.