### PR TITLE
fix(media): keep distinct dub studios, number repeats

### DIFF
--- a/src/modules/media/domain/services/track_naming.py
+++ b/src/modules/media/domain/services/track_naming.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -166,9 +166,11 @@ def audio_version_labels(tracks: Iterable[AudioTrack]) -> dict[int, TrackVersion
 
     A language with a single track gets ``None`` (just show the language).
     Within a same-language group the chain is: detected studio → channel
-    layout (when it uniquely separates the rest) → ordinal. A final guard
-    falls the whole group back to ordinals if any label would collide, so
-    every track in a group always renders distinctly.
+    layout (when it uniquely separates the rest) → ordinal. Multiple takes
+    from the *same* studio are numbered ("Herbert Richers 1/2/3") so they
+    stay distinct without dragging other studios in the group down to bare
+    ordinals. A final guard falls the whole group back to ordinals only if
+    a label would still collide, so every track always renders distinctly.
     """
     result: dict[int, TrackVersion | None] = {}
     for group in _group_by_language(tracks):
@@ -176,10 +178,20 @@ def audio_version_labels(tracks: Iterable[AudioTrack]) -> dict[int, TrackVersion
             result[group[0].index] = None
             continue
 
+        # Studio pass — number repeats so several takes from one studio
+        # remain distinct while other studios keep their plain name.
+        detected = {track.index: detect_studio(track.title) for track in group}
+        studio_totals = Counter(s for s in detected.values() if s is not None)
+        studio_seen: Counter[str] = Counter()
         labels: dict[int, TrackVersion] = {}
         for track in group:
-            studio = detect_studio(track.title)
-            if studio is not None:
+            studio = detected[track.index]
+            if studio is None:
+                continue
+            if studio_totals[studio] > 1:
+                studio_seen[studio] += 1
+                labels[track.index] = TrackVersion("studio", f"{studio} {studio_seen[studio]}")
+            else:
                 labels[track.index] = TrackVersion("studio", studio)
 
         remaining = [t for t in group if t.index not in labels]

--- a/tests/modules/media/unit/domain/services/test_track_naming.py
+++ b/tests/modules/media/unit/domain/services/test_track_naming.py
@@ -115,7 +115,7 @@ class TestAudioVersionLabels:
         assert labels[0] == TrackVersion("studio", "Herbert Richers")
         assert labels[1] == TrackVersion("channel_layout", "Stereo")
 
-    def test_should_guard_against_duplicate_studio_names(self) -> None:
+    def test_should_number_repeated_studio_names(self) -> None:
         tracks = [
             _audio(0, "pt", title="Netflix", channels=2),
             _audio(1, "pt", title="Netflix", channels=2),
@@ -123,8 +123,30 @@ class TestAudioVersionLabels:
 
         labels = audio_version_labels(tracks)
 
-        assert labels[0] == TrackVersion("ordinal", "1")
-        assert labels[1] == TrackVersion("ordinal", "2")
+        assert labels[0] == TrackVersion("studio", "Netflix 1")
+        assert labels[1] == TrackVersion("studio", "Netflix 2")
+
+    def test_should_keep_distinct_studios_while_numbering_repeats(self) -> None:
+        # Real-world case: 3 Herbert Richers takes + DublaVídeo + Centauro,
+        # all pt-BR. Repeats are numbered; the other studios keep their name
+        # (previously the whole group collapsed to plain ordinals).
+        tracks = [
+            _audio(0, "pt", title="1ª Dublagem Clássica - Herbert Richers - Completa"),
+            _audio(1, "pt", title="2ª Dublagem Clássica - Herbert Richers - Fonte 2 - 2.0"),
+            _audio(2, "pt", title="2ª Dublagem Clássica - Herbert Richers - 2.0"),
+            _audio(3, "pt", title="3ª Redublagem - DublaVideo SP"),
+            _audio(4, "pt", title="4ª Redublagem - Centauro"),
+            _audio(5, "en", title="Inglês - 5.1", channels=6),
+        ]
+
+        labels = audio_version_labels(tracks)
+
+        assert labels[0] == TrackVersion("studio", "Herbert Richers 1")
+        assert labels[1] == TrackVersion("studio", "Herbert Richers 2")
+        assert labels[2] == TrackVersion("studio", "Herbert Richers 3")
+        assert labels[3] == TrackVersion("studio", "Dublavídeo")
+        assert labels[4] == TrackVersion("studio", "Centauro")
+        assert labels[5] is None  # single English track → just the language
 
     def test_should_label_each_language_group_independently(self) -> None:
         tracks = [


### PR DESCRIPTION
## Summary

- A file with several audio tracks from the same dubbing studio (e.g. 3× "Herbert Richers" + "DublaVídeo" + "Centauro", all pt-BR) collapsed the **whole** language group to plain ordinals — the menu showed "Português · Versão 1…5" and the studio info was lost.
- Cause: the uniqueness guard saw the duplicate "Herbert Richers" labels and fell the entire group back to ordinals, dragging the distinct studios down with it.
- Fix: number repeated studios in the studio pass ("Herbert Richers 1/2/3") so duplicates stay distinct while other studios in the group keep their plain name. The whole-group ordinal fallback now only fires as a true last resort.

Follow-up to homeflix#290. Backend-only — the player already renders the `version.value` verbatim, so no frontend change is needed.

## Test plan

- [x] `pytest tests/modules/media/unit/domain/services/test_track_naming.py` (18 passed)
- [x] New test reproducing the reported file (3 Herbert Richers + DublaVídeo + Centauro + single English) → `Herbert Richers 1/2/3`, `Dublavídeo`, `Centauro`, English unlabeled
- [x] `pytest` on HLS master-playlist + `/tracks` serializer (124 passed)
- [x] `ruff check` + `ruff format --check` clean

## Summary by Sourcery

Ensure audio track labels keep distinct dubbing studios while still guaranteeing unique labels within each language group.

Bug Fixes:
- Prevent distinct dubbing studios in the same language group from collapsing to generic ordinal labels when some studios repeat.

Enhancements:
- Number repeated studio names within a language group so multiple takes from the same studio remain distinguishable without affecting other studios' labels.

Tests:
- Add and update unit tests covering numbering of repeated studio names and preservation of distinct studio labels alongside unique-label guarantees.