### PR TITLE
feat(media): background-jobs execution log + admin endpoint

### DIFF
--- a/migrations/versions/2026_06_20_add_job_runs.py
+++ b/migrations/versions/2026_06_20_add_job_runs.py
@@ -1,0 +1,67 @@
+"""Add job_runs execution log.
+
+Generic per-tick execution record for every recurring scheduler job
+(thumbnail backfill, intro/credits detection, scheduled scans, dedup
+sweep). Backs the admin Jobs dashboard with a uniform "last run /
+status / duration / running now" view.
+
+Revision ID: aa11bb22cc33
+Revises: e9d8c7b6a5f4
+Create Date: 2026-06-20 18:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "aa11bb22cc33"
+down_revision: str | Sequence[str] | None = "e9d8c7b6a5f4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``job_runs`` table."""
+    op.create_table(
+        "job_runs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("external_id", sa.String(length=50), nullable=False),
+        sa.Column("job_id", sa.String(length=100), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error", sa.String(length=2000), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_job_runs_external_id", "job_runs", ["external_id"], unique=True)
+    op.create_index("ix_job_runs_job_id", "job_runs", ["job_id"])
+    op.create_index("ix_job_runs_status", "job_runs", ["status"])
+    op.create_index("ix_job_runs_deleted_at", "job_runs", ["deleted_at"])
+
+
+def downgrade() -> None:
+    """Drop the ``job_runs`` table."""
+    op.drop_index("ix_job_runs_deleted_at", table_name="job_runs")
+    op.drop_index("ix_job_runs_status", table_name="job_runs")
+    op.drop_index("ix_job_runs_job_id", table_name="job_runs")
+    op.drop_index("ix_job_runs_external_id", table_name="job_runs")
+    op.drop_table("job_runs")

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -33,10 +33,14 @@ from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work imp
 from src.modules.library.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyLibraryUnitOfWorkFactory,
 )
+from src.modules.media.application.use_cases.list_jobs import ListJobsUseCase
 from src.modules.media.infrastructure.acl import (
     LibraryHealthAdapter,
     ProfileLibraryAccessAdapter,
     ProgressLookupAdapter,
+)
+from src.modules.media.infrastructure.scheduling.scheduler_inspector import (
+    LibraryScanSchedulerInspector,
 )
 from src.modules.settings.domain.value_objects import IntroDetectionAlgorithm
 from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_work import (
@@ -230,6 +234,20 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         library_uow_factory=library.library_unit_of_work_factory,
         scan_run_service=media.scan_run_service,
         runtime_settings=settings.runtime_settings,
+        job_run_recorder=media.job_run_service,
+    )
+
+    # Read-only window into the live scheduler for the admin Jobs page.
+    # Shares the same scheduler singleton the lifespan starts.
+    scheduler_inspector = providers.Singleton(
+        LibraryScanSchedulerInspector,
+        scheduler=library_scan_scheduler,
+    )
+
+    list_jobs = providers.Factory(
+        ListJobsUseCase,
+        scheduler_inspector=scheduler_inspector,
+        media_uow_factory=media.media_unit_of_work_factory,
     )
 
     thumbnail_backfill_job = providers.Singleton(

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -6,6 +6,7 @@ Provides repositories and use cases for the Media module.
 from dependency_injector import containers, providers
 
 from src.modules.media.application.event_handlers import OnMediaCreatedHandler
+from src.modules.media.application.services.job_run_service import JobRunService
 from src.modules.media.application.services.scan_run_service import ScanRunService
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
 from src.modules.media.application.use_cases.bulk_enrich_metadata import (
@@ -78,6 +79,7 @@ from src.modules.media.application.use_cases.list_genres import ListGenresUseCas
 from src.modules.media.application.use_cases.list_intro_detection_runs import (
     ListIntroDetectionRunsUseCase,
 )
+from src.modules.media.application.use_cases.list_job_runs import ListJobRunsUseCase
 from src.modules.media.application.use_cases.list_movies import ListMoviesUseCase
 from src.modules.media.application.use_cases.list_movies_by_actor import ListMoviesByActorUseCase
 from src.modules.media.application.use_cases.list_movies_needing_review import (
@@ -124,6 +126,9 @@ from src.modules.media.application.use_cases.set_credits_marker import SetCredit
 from src.modules.media.application.use_cases.set_episode_intro import SetEpisodeIntroUseCase
 from src.modules.media.application.use_cases.set_primary_file import SetPrimaryFileUseCase
 from src.modules.media.application.use_cases.stream_file_range import StreamFileRangeUseCase
+from src.modules.media.application.use_cases.sweep_interrupted_job_runs import (
+    SweepInterruptedJobRunsUseCase,
+)
 from src.modules.media.application.use_cases.sweep_interrupted_scan_runs import (
     SweepInterruptedScanRunsUseCase,
 )
@@ -621,6 +626,23 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     sweep_interrupted_scan_runs = providers.Factory(
         SweepInterruptedScanRunsUseCase,
+        media_uow_factory=media_unit_of_work_factory,
+    )
+
+    # Background-jobs dashboard: a recorder the scheduler wraps every job
+    # with, plus read use cases for the history list.
+    job_run_service = providers.Singleton(
+        JobRunService,
+        media_uow_factory=media_unit_of_work_factory,
+    )
+
+    list_job_runs = providers.Factory(
+        ListJobRunsUseCase,
+        media_uow_factory=media_unit_of_work_factory,
+    )
+
+    sweep_interrupted_job_runs = providers.Factory(
+        SweepInterruptedJobRunsUseCase,
         media_uow_factory=media_unit_of_work_factory,
     )
 

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -10,6 +10,8 @@ background work never shares a request-scoped session.
 
 from __future__ import annotations
 
+import functools
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -25,6 +27,7 @@ if TYPE_CHECKING:
 
     from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
     from src.modules.library.domain.entities.library import Library
+    from src.modules.media.application.services.job_run_service import JobRunService
     from src.modules.media.application.services.scan_run_service import ScanRunService
     from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
@@ -36,6 +39,21 @@ _LIBRARY_JOB_PREFIX = "library-scan:"
 
 def _job_id_for(library_id: str) -> str:
     return f"{_LIBRARY_JOB_PREFIX}{library_id}"
+
+
+@dataclass(frozen=True)
+class ScheduledJobSnapshot:
+    """Live view of one registered APScheduler job (for admin introspection).
+
+    Attributes:
+        id: The job's stable id.
+        next_run_at: ISO-8601 of the next fire, or ``None`` when paused.
+        schedule: Human-readable trigger (interval/cron) string.
+    """
+
+    id: str
+    next_run_at: str | None
+    schedule: str
 
 
 class LibraryScanScheduler:
@@ -58,11 +76,50 @@ class LibraryScanScheduler:
         library_uow_factory: LibraryUnitOfWorkFactory,
         scan_run_service: ScanRunService,
         runtime_settings: RuntimeSettings,
+        job_run_recorder: JobRunService | None = None,
     ) -> None:
         self._library_uow_factory = library_uow_factory
         self._scan_run_service = scan_run_service
         self._runtime_settings = runtime_settings
+        self._job_run_recorder = job_run_recorder
         self._scheduler = AsyncIOScheduler(timezone="UTC")
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the scheduler is started and ticking."""
+        return self._scheduler.running
+
+    def list_jobs(self) -> list[ScheduledJobSnapshot]:
+        """Snapshot every currently-registered job (in-memory, no I/O)."""
+        snapshots: list[ScheduledJobSnapshot] = []
+        for job in self._scheduler.get_jobs():
+            next_run = getattr(job, "next_run_time", None)
+            snapshots.append(
+                ScheduledJobSnapshot(
+                    id=job.id,
+                    next_run_at=next_run.isoformat() if next_run else None,
+                    schedule=str(job.trigger),
+                ),
+            )
+        return snapshots
+
+    def _recorded(
+        self,
+        job_id: str,
+        func: Callable[[], Awaitable[None]],
+    ) -> Callable[[], Awaitable[None]]:
+        """Wrap ``func`` so each run is logged to ``job_runs``.
+
+        Returns ``func`` unchanged when no recorder is configured.
+        """
+        recorder = self._job_run_recorder
+        if recorder is None:
+            return func
+
+        async def _wrapped() -> None:
+            await recorder.record(job_id, func)
+
+        return _wrapped
 
     async def start(self) -> None:
         """Start the scheduler and register the reconcile + initial jobs."""
@@ -111,7 +168,7 @@ class LibraryScanScheduler:
                 stale jobs around.
         """
         self._scheduler.add_job(
-            func,
+            self._recorded(job_id, func),
             trigger="interval",
             minutes=minutes,
             id=job_id,
@@ -169,9 +226,8 @@ class LibraryScanScheduler:
                 continue
 
             self._scheduler.add_job(
-                self._run_scan,
+                self._recorded(job_id, functools.partial(self._run_scan, library_id)),
                 trigger=trigger,
-                args=[library_id],
                 id=job_id,
                 replace_existing=True,
                 max_instances=1,
@@ -240,4 +296,4 @@ class LibraryScanScheduler:
             await uow.libraries.save(updated)
 
 
-__all__ = ["LibraryScanScheduler"]
+__all__ = ["LibraryScanScheduler", "ScheduledJobSnapshot"]

--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,7 @@ from src.modules.media.presentation.routes import (
     admin_conflicts_router,
     admin_credits_router,
     admin_intro_detection_router,
+    admin_jobs_router,
     admin_overview_router,
     admin_relink_router,
     admin_scan_router,
@@ -67,6 +68,7 @@ WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.media.presentation.routes.admin_conflicts_routes",
     "src.modules.media.presentation.routes.admin_credits_routes",
     "src.modules.media.presentation.routes.admin_intro_detection_routes",
+    "src.modules.media.presentation.routes.admin_jobs_routes",
     "src.modules.media.presentation.routes.admin_overview_routes",
     "src.modules.media.presentation.routes.admin_relink_routes",
     "src.modules.media.presentation.routes.admin_scan_routes",
@@ -188,6 +190,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # must be awaited before ``.execute()``.
     sweep_scan_runs = await container.media.sweep_interrupted_scan_runs()
     await sweep_scan_runs.execute()
+
+    # Same repair for the generic job_runs log — any tick that was
+    # mid-flight at the previous shutdown is closed as ``interrupted``.
+    sweep_job_runs = await container.media.sweep_interrupted_job_runs()
+    await sweep_job_runs.execute()
 
     # Start background scheduler (library scans + thumbnail backfill +
     # intro detection). Scheduler-on/off + per-job intervals come from
@@ -447,6 +454,7 @@ def create_app() -> FastAPI:
     app.include_router(admin_relink_router)
     app.include_router(admin_scan_router)
     app.include_router(admin_intro_detection_router)
+    app.include_router(admin_jobs_router)
     app.include_router(admin_credits_router)
     app.include_router(admin_system_router)
     app.include_router(catalog_router)

--- a/src/modules/media/application/dtos/job_dtos.py
+++ b/src/modules/media/application/dtos/job_dtos.py
@@ -1,0 +1,64 @@
+"""DTOs for the admin Jobs dashboard."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class JobRunOutput:
+    """API-facing shape of a single recorded job execution."""
+
+    id: str
+    job_id: str
+    status: str
+    started_at: str
+    finished_at: str | None
+    duration_ms: int | None
+    error: str | None
+
+
+@dataclass(frozen=True)
+class JobOutput:
+    """One job on the dashboard: live schedule + its last execution.
+
+    Attributes:
+        job_id: Stable scheduler job id.
+        scheduled: Whether the job is currently registered with a
+            running scheduler (``False`` for a disabled job that only
+            shows up because it has history).
+        schedule: Human-readable trigger, or ``None`` when not scheduled.
+        next_run_at: ISO-8601 of the next fire, or ``None``.
+        running: Whether a run is in progress right now.
+        last_run: The most recent recorded execution, or ``None``.
+    """
+
+    job_id: str
+    scheduled: bool
+    schedule: str | None
+    next_run_at: str | None
+    running: bool
+    last_run: JobRunOutput | None
+
+
+@dataclass(frozen=True)
+class JobsOverviewOutput:
+    """Top-level dashboard payload."""
+
+    scheduler_running: bool
+    jobs: list[JobOutput]
+
+
+@dataclass(frozen=True)
+class ListJobRunsInput:
+    """Input for ``ListJobRunsUseCase``."""
+
+    job_id: str | None = None
+    limit: int = 50
+    offset: int = 0
+
+
+__all__ = [
+    "JobOutput",
+    "JobRunOutput",
+    "JobsOverviewOutput",
+    "ListJobRunsInput",
+]

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -51,6 +51,11 @@ from src.modules.media.application.ports.progress_lookup_port import (
     ProgressLookupPort,
     ProgressSummary,
 )
+from src.modules.media.application.ports.scheduler_inspector_port import (
+    ScheduledJob,
+    SchedulerInspectorPort,
+    SchedulerSnapshot,
+)
 from src.modules.media.application.ports.scrub_preview_locator_port import (
     ScrubPreviewLocatorPort,
 )
@@ -90,6 +95,9 @@ __all__ = [
     "ProgressLookupPort",
     "ProgressSummary",
     "ScannedFile",
+    "ScheduledJob",
+    "SchedulerInspectorPort",
+    "SchedulerSnapshot",
     "ScrubPreviewLocatorPort",
     "SearchCandidate",
     "SeasonMetadata",

--- a/src/modules/media/application/ports/scheduler_inspector_port.py
+++ b/src/modules/media/application/ports/scheduler_inspector_port.py
@@ -1,0 +1,46 @@
+"""Port exposing the live state of the background scheduler."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScheduledJob:
+    """A job currently registered with the scheduler.
+
+    Attributes:
+        job_id: Stable scheduler job id.
+        next_run_at: ISO-8601 timestamp of the next fire, or ``None``
+            when the job is paused / has no future run.
+        schedule: Human-readable trigger (e.g. ``interval[0:20:00]``
+            or a cron expression).
+    """
+
+    job_id: str
+    next_run_at: str | None
+    schedule: str
+
+
+@dataclass(frozen=True)
+class SchedulerSnapshot:
+    """Point-in-time view of the scheduler.
+
+    Attributes:
+        running: Whether the scheduler is started and ticking.
+        jobs: Every currently-registered job.
+    """
+
+    running: bool
+    jobs: list[ScheduledJob]
+
+
+class SchedulerInspectorPort(ABC):
+    """Read-only window into the live scheduler for the admin dashboard."""
+
+    @abstractmethod
+    def snapshot(self) -> SchedulerSnapshot:
+        """Return the current scheduler state (in-memory, no I/O)."""
+        ...
+
+
+__all__ = ["ScheduledJob", "SchedulerInspectorPort", "SchedulerSnapshot"]

--- a/src/modules/media/application/services/job_run_service.py
+++ b/src/modules/media/application/services/job_run_service.py
@@ -1,0 +1,80 @@
+"""Records scheduler-job executions to the ``job_runs`` log.
+
+A single seam the scheduler wraps every recurring job with: open a
+``running`` row, run the work, write the terminal state. This gives the
+admin Jobs dashboard a uniform "last run / outcome / duration / running
+now" view even for jobs (backfill, dedup) that keep no history of their
+own. Failures are caught, recorded as ``failed`` and swallowed — a job
+that raises must not take down the scheduler tick (APScheduler would
+only log it otherwise), and the row makes the failure visible.
+
+On process restart any rows still ``running`` are swept to
+``interrupted`` by the lifespan startup hook (see
+:class:`SweepInterruptedJobRunsUseCase`).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.modules.media.domain.entities.job_run import JobRun
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.domain.value_objects.job_run_id import JobRunId
+
+_logger = logging.getLogger(__name__)
+
+# Bound the per-job history so high-frequency jobs (e.g. backfill every
+# 20 min) can't grow the table without limit. Older rows are soft-deleted
+# after each finished run.
+_HISTORY_RETAINED_PER_JOB = 100
+
+
+class JobRunService:
+    """Wrap a job's execution with ``job_runs`` lifecycle bookkeeping."""
+
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
+
+    async def record(self, job_id: str, func: Callable[[], Awaitable[None]]) -> None:
+        """Run ``func`` while recording a ``job_runs`` row for ``job_id``."""
+        run_id = await self._open(job_id)
+        try:
+            await func()
+        except Exception as exc:  # must not break the scheduler tick
+            _logger.exception("Job %s crashed", job_id)
+            message = str(exc)
+            await self._finalize(run_id, lambda run: run.fail(message))
+        else:
+            await self._finalize(run_id, lambda run: run.succeed())
+        await self._prune(job_id)
+
+    async def _open(self, job_id: str) -> JobRunId:
+        async with self._media_uow_factory() as uow:
+            saved = await uow.job_runs.save(JobRun.start(job_id))
+        if saved.id is None:  # pragma: no cover — repo always assigns
+            raise RuntimeError("JobRun id was not assigned on open")
+        return saved.id
+
+    async def _finalize(
+        self,
+        run_id: JobRunId,
+        transition: Callable[[JobRun], JobRun],
+    ) -> None:
+        async with self._media_uow_factory() as uow:
+            run = await uow.job_runs.find_by_id(run_id)
+            if run is None:  # pragma: no cover — defensive, deleted mid-run
+                _logger.warning("job_run %s disappeared before finalize", run_id)
+                return
+            await uow.job_runs.save(transition(run))
+
+    async def _prune(self, job_id: str) -> None:
+        async with self._media_uow_factory() as uow:
+            await uow.job_runs.prune(job_id, keep=_HISTORY_RETAINED_PER_JOB)
+
+
+__all__ = ["JobRunService"]

--- a/src/modules/media/application/unit_of_work.py
+++ b/src/modules/media/application/unit_of_work.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from src.building_blocks.application.unit_of_work import UnitOfWork
 from src.modules.media.domain.repositories import (
     IntroDetectionRunRepository,
+    JobRunRepository,
     MediaConflictRepository,
     MovieRepository,
     ScanRunRepository,
@@ -34,6 +35,7 @@ class MediaUnitOfWork(UnitOfWork):
     scan_runs: ScanRunRepository
     intro_detection_runs: IntroDetectionRunRepository
     media_conflicts: MediaConflictRepository
+    job_runs: JobRunRepository
 
 
 class MediaUnitOfWorkFactory(ABC):

--- a/src/modules/media/application/use_cases/_to_job_run_output.py
+++ b/src/modules/media/application/use_cases/_to_job_run_output.py
@@ -1,0 +1,22 @@
+"""Internal helper projecting a ``JobRun`` aggregate into the API DTO."""
+
+from src.modules.media.application.dtos.job_dtos import JobRunOutput
+from src.modules.media.domain.entities.job_run import JobRun
+
+
+def job_run_to_output(run: JobRun) -> JobRunOutput:
+    """Convert a ``JobRun`` to ``JobRunOutput`` (timestamps as ISO-8601)."""
+    if run.id is None:
+        raise ValueError("Cannot project an unpersisted JobRun to output")
+    return JobRunOutput(
+        id=str(run.id),
+        job_id=run.job_id,
+        status=run.status.value,
+        started_at=run.started_at.isoformat(),
+        finished_at=run.finished_at.isoformat() if run.finished_at else None,
+        duration_ms=run.duration_ms,
+        error=run.error,
+    )
+
+
+__all__ = ["job_run_to_output"]

--- a/src/modules/media/application/use_cases/list_job_runs.py
+++ b/src/modules/media/application/use_cases/list_job_runs.py
@@ -1,0 +1,31 @@
+"""ListJobRunsUseCase — paginated job execution history."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.use_cases._to_job_run_output import job_run_to_output
+
+if TYPE_CHECKING:
+    from src.modules.media.application.dtos.job_dtos import JobRunOutput, ListJobRunsInput
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+
+class ListJobRunsUseCase:
+    """List recorded job executions newest-first, optionally per job."""
+
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
+
+    async def execute(self, input_dto: ListJobRunsInput) -> list[JobRunOutput]:
+        """Return a page of job runs."""
+        async with self._media_uow_factory() as uow:
+            runs = await uow.job_runs.list_paginated(
+                job_id=input_dto.job_id,
+                limit=input_dto.limit,
+                offset=input_dto.offset,
+            )
+        return [job_run_to_output(run) for run in runs]
+
+
+__all__ = ["ListJobRunsUseCase"]

--- a/src/modules/media/application/use_cases/list_jobs.py
+++ b/src/modules/media/application/use_cases/list_jobs.py
@@ -1,0 +1,64 @@
+"""ListJobsUseCase — the admin Jobs dashboard overview."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.dtos.job_dtos import (
+    JobOutput,
+    JobsOverviewOutput,
+)
+from src.modules.media.application.use_cases._to_job_run_output import job_run_to_output
+from src.modules.media.domain.entities.job_run import JobRunStatus
+
+if TYPE_CHECKING:
+    from src.modules.media.application.ports import SchedulerInspectorPort
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+
+class ListJobsUseCase:
+    """Merge the live scheduler state with each job's last recorded run.
+
+    The result is the union of jobs currently registered with the
+    scheduler and jobs that have history but are no longer scheduled
+    (e.g. one that was disabled), so the operator sees both "what will
+    run" and "what last ran".
+    """
+
+    def __init__(
+        self,
+        scheduler_inspector: SchedulerInspectorPort,
+        media_uow_factory: MediaUnitOfWorkFactory,
+    ) -> None:
+        self._inspector = scheduler_inspector
+        self._media_uow_factory = media_uow_factory
+
+    async def execute(self) -> JobsOverviewOutput:
+        """Return the dashboard overview (live schedule + last run per job)."""
+        snapshot = self._inspector.snapshot()
+
+        async with self._media_uow_factory() as uow:
+            latest = await uow.job_runs.latest_per_job()
+
+        last_by_job = {run.job_id: run for run in latest}
+        live_by_job = {job.job_id: job for job in snapshot.jobs}
+
+        jobs = [
+            JobOutput(
+                job_id=job_id,
+                scheduled=job_id in live_by_job,
+                schedule=live_by_job[job_id].schedule if job_id in live_by_job else None,
+                next_run_at=live_by_job[job_id].next_run_at if job_id in live_by_job else None,
+                running=(
+                    job_id in last_by_job and last_by_job[job_id].status == JobRunStatus.RUNNING
+                ),
+                last_run=(
+                    job_run_to_output(last_by_job[job_id]) if job_id in last_by_job else None
+                ),
+            )
+            for job_id in sorted(set(live_by_job) | set(last_by_job))
+        ]
+        return JobsOverviewOutput(scheduler_running=snapshot.running, jobs=jobs)
+
+
+__all__ = ["ListJobsUseCase"]

--- a/src/modules/media/application/use_cases/sweep_interrupted_job_runs.py
+++ b/src/modules/media/application/use_cases/sweep_interrupted_job_runs.py
@@ -1,0 +1,42 @@
+"""SweepInterruptedJobRunsUseCase — startup repair for orphan ``running`` rows."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.modules.media.domain.entities.job_run import JobRunStatus
+
+if TYPE_CHECKING:
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+_logger = logging.getLogger(__name__)
+
+
+class SweepInterruptedJobRunsUseCase:
+    """Mark every ``running`` ``job_runs`` row as ``interrupted``.
+
+    Runs once during ``lifespan`` startup. A job tick that was in
+    flight when the process died would otherwise leave a row stuck in
+    ``running``, making the dashboard show a job as perpetually active.
+    """
+
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
+
+    async def execute(self) -> int:
+        """Sweep + return the number of rows transitioned."""
+        async with self._media_uow_factory() as uow:
+            running = await uow.job_runs.list_by_status(JobRunStatus.RUNNING)
+            for run in running:
+                await uow.job_runs.save(run.mark_interrupted())
+
+        if running:
+            _logger.warning(
+                "Marked %d orphan job_runs as 'interrupted' on startup.",
+                len(running),
+            )
+        return len(running)
+
+
+__all__ = ["SweepInterruptedJobRunsUseCase"]

--- a/src/modules/media/domain/entities/job_run.py
+++ b/src/modules/media/domain/entities/job_run.py
@@ -1,0 +1,96 @@
+"""JobRun aggregate — one recorded execution of a scheduler job."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Self
+
+from pydantic import Field
+
+from src.building_blocks.domain import AggregateRoot
+from src.modules.media.domain.value_objects.job_run_id import JobRunId
+
+_MAX_ERROR_LEN = 2000
+
+
+class JobRunStatus(str, Enum):
+    """Lifecycle state of a recorded job execution."""
+
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+class JobRun(AggregateRoot[JobRunId]):
+    """A single execution of a background scheduler job.
+
+    Generic execution log shared by every recurring job (thumbnail
+    backfill, intro/credits detection, scheduled scans, dedup sweep).
+    Each tick writes a ``running`` row up front and transitions to a
+    terminal state when the work finishes, so the admin Jobs page can
+    show "last run / outcome / duration" and "running now" uniformly —
+    even for jobs that keep no domain-specific history of their own.
+
+    Attributes:
+        id: External id (``job_xxx``).
+        job_id: Stable scheduler job identifier (e.g.
+            ``homeflix:thumbnail-backfill`` or ``library-scan:lib_x``).
+        status: Current lifecycle state.
+        started_at: When the tick began.
+        finished_at: ``None`` while ``running``; set on terminal states.
+        error: Failure message when ``status == failed`` (truncated),
+            else ``None``.
+    """
+
+    id: JobRunId | None = Field(default=None)
+
+    job_id: str
+    status: JobRunStatus = JobRunStatus.RUNNING
+    started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    finished_at: datetime | None = None
+    error: str | None = None
+
+    @classmethod
+    def start(cls, job_id: str) -> Self:
+        """Open a new run row in the ``running`` state."""
+        return cls(
+            job_id=job_id,
+            status=JobRunStatus.RUNNING,
+            started_at=datetime.now(UTC),
+        )
+
+    def succeed(self) -> Self:
+        """Return a copy stamped ``succeeded`` with a finish timestamp."""
+        return self.with_updates(
+            status=JobRunStatus.SUCCEEDED,
+            finished_at=datetime.now(UTC),
+            error=None,
+        )
+
+    def fail(self, error_message: str) -> Self:
+        """Return a copy stamped ``failed`` with the truncated error."""
+        return self.with_updates(
+            status=JobRunStatus.FAILED,
+            finished_at=datetime.now(UTC),
+            error=error_message[:_MAX_ERROR_LEN],
+        )
+
+    def mark_interrupted(self) -> Self:
+        """Mark a ``running`` row as interrupted by a process restart."""
+        return self.with_updates(
+            status=JobRunStatus.INTERRUPTED,
+            finished_at=datetime.now(UTC),
+            error="Process restarted while the job was in progress.",
+        )
+
+    @property
+    def duration_ms(self) -> int | None:
+        """Elapsed milliseconds, or ``None`` while still running."""
+        if self.finished_at is None:
+            return None
+        return int((self.finished_at - self.started_at).total_seconds() * 1000)
+
+
+__all__ = ["JobRun", "JobRunStatus"]

--- a/src/modules/media/domain/repositories/__init__.py
+++ b/src/modules/media/domain/repositories/__init__.py
@@ -3,6 +3,7 @@
 from src.modules.media.domain.repositories.intro_detection_run_repository import (
     IntroDetectionRunRepository,
 )
+from src.modules.media.domain.repositories.job_run_repository import JobRunRepository
 from src.modules.media.domain.repositories.media_conflict_repository import (
     MediaConflictRepository,
 )
@@ -12,6 +13,7 @@ from src.modules.media.domain.repositories.series_repository import SeriesReposi
 
 __all__ = [
     "IntroDetectionRunRepository",
+    "JobRunRepository",
     "MediaConflictRepository",
     "MovieRepository",
     "ScanRunRepository",

--- a/src/modules/media/domain/repositories/job_run_repository.py
+++ b/src/modules/media/domain/repositories/job_run_repository.py
@@ -1,0 +1,68 @@
+"""JobRun repository interface."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from src.modules.media.domain.entities.job_run import JobRun, JobRunStatus
+from src.modules.media.domain.value_objects.job_run_id import JobRunId
+
+
+class JobRunRepository(ABC):
+    """Repository for the ``JobRun`` execution log.
+
+    Backs the admin Jobs dashboard. Writes are cheap (one insert +
+    one update per tick); reads are bounded by ``limit`` for the
+    history list and by job for the "last run per job" summary.
+    """
+
+    @abstractmethod
+    async def save(self, run: JobRun) -> JobRun:
+        """Insert when id-less, update when known; re-read and return it."""
+        ...
+
+    @abstractmethod
+    async def find_by_id(self, run_id: JobRunId) -> JobRun | None:
+        """Look up a non-deleted run by external id."""
+        ...
+
+    @abstractmethod
+    async def list_paginated(
+        self,
+        *,
+        job_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Sequence[JobRun]:
+        """List runs newest-first, optionally narrowed to one ``job_id``."""
+        ...
+
+    @abstractmethod
+    async def count(self, *, job_id: str | None = None) -> int:
+        """Count matching non-deleted runs."""
+        ...
+
+    @abstractmethod
+    async def latest_per_job(self) -> Sequence[JobRun]:
+        """Return the most recent run for each distinct ``job_id``.
+
+        Powers the dashboard's per-job "last run / status / duration"
+        column without loading the full history.
+        """
+        ...
+
+    @abstractmethod
+    async def list_by_status(self, status: JobRunStatus) -> Sequence[JobRun]:
+        """List every run in a given status (used by the startup sweep)."""
+        ...
+
+    @abstractmethod
+    async def prune(self, job_id: str, *, keep: int) -> int:
+        """Soft-delete all but the newest ``keep`` runs of ``job_id``.
+
+        Keeps the append-only log bounded for high-frequency jobs.
+        Returns the number of rows pruned.
+        """
+        ...
+
+
+__all__ = ["JobRunRepository"]

--- a/src/modules/media/domain/value_objects/job_run_id.py
+++ b/src/modules/media/domain/value_objects/job_run_id.py
@@ -1,0 +1,18 @@
+"""JobRunId external id."""
+
+from typing import ClassVar
+
+from src.building_blocks.domain.external_id import ExternalId
+
+
+class JobRunId(ExternalId):
+    """External ID for a recorded scheduler job execution.
+
+    One ``job_runs`` row per tick of any background job (backfill,
+    detection, scans, etc.). Format: ``job_{base62_12chars}``.
+    """
+
+    EXPECTED_PREFIX: ClassVar[str] = "job"
+
+
+__all__ = ["JobRunId"]

--- a/src/modules/media/infrastructure/persistence/mappers/job_run_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/job_run_mapper.py
@@ -1,0 +1,49 @@
+"""Translate between :class:`JobRun` aggregates and the ORM row."""
+
+from src.modules.media.domain.entities.job_run import JobRun, JobRunStatus
+from src.modules.media.domain.value_objects.job_run_id import JobRunId
+from src.modules.media.infrastructure.persistence.models.job_run import JobRunModel
+
+
+class JobRunMapper:
+    """Pure functions converting entity ↔ ``JobRunModel``."""
+
+    @staticmethod
+    def to_entity(model: JobRunModel) -> JobRun:
+        """Hydrate the aggregate from a row."""
+        return JobRun(
+            id=JobRunId(model.external_id),
+            job_id=model.job_id,
+            status=JobRunStatus(model.status),
+            started_at=model.started_at,
+            finished_at=model.finished_at,
+            error=model.error,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    @staticmethod
+    def to_model(entity: JobRun) -> JobRunModel:
+        """Build a fresh ``JobRunModel`` from a brand-new aggregate."""
+        if entity.id is None:
+            raise ValueError("JobRun must have an id before mapping to model")
+        return JobRunModel(
+            external_id=str(entity.id),
+            job_id=entity.job_id,
+            status=entity.status.value,
+            started_at=entity.started_at,
+            finished_at=entity.finished_at,
+            error=entity.error,
+        )
+
+    @staticmethod
+    def update_model(model: JobRunModel, entity: JobRun) -> None:
+        """Copy mutable fields from the entity onto an existing row."""
+        model.job_id = entity.job_id
+        model.status = entity.status.value
+        model.started_at = entity.started_at
+        model.finished_at = entity.finished_at
+        model.error = entity.error
+
+
+__all__ = ["JobRunMapper"]

--- a/src/modules/media/infrastructure/persistence/models/__init__.py
+++ b/src/modules/media/infrastructure/persistence/models/__init__.py
@@ -4,6 +4,7 @@ from src.modules.media.infrastructure.persistence.models.episode import EpisodeM
 from src.modules.media.infrastructure.persistence.models.intro_detection_run import (
     IntroDetectionRunModel,
 )
+from src.modules.media.infrastructure.persistence.models.job_run import JobRunModel
 from src.modules.media.infrastructure.persistence.models.media_conflict import (
     MediaConflictModel,
 )
@@ -16,6 +17,7 @@ from src.modules.media.infrastructure.persistence.models.series import SeriesMod
 __all__ = [
     "EpisodeModel",
     "IntroDetectionRunModel",
+    "JobRunModel",
     "MediaConflictModel",
     "MediaFileModel",
     "MovieModel",

--- a/src/modules/media/infrastructure/persistence/models/job_run.py
+++ b/src/modules/media/infrastructure/persistence/models/job_run.py
@@ -1,0 +1,35 @@
+"""JobRun ORM model — generic scheduler-job execution log."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.base import Base
+
+
+class JobRunModel(Base):
+    """SQLAlchemy model for the ``job_runs`` table.
+
+    One row per execution of any recurring scheduler job. The
+    ``job_id`` matches the APScheduler job identifier so the admin
+    dashboard can line each live job up with its execution history.
+
+    Attributes:
+        job_id: Stable scheduler job id (e.g.
+            ``homeflix:thumbnail-backfill``).
+        status: ``running`` | ``succeeded`` | ``failed`` |
+            ``interrupted`` (the post-restart sweep value).
+        started_at: When the tick began.
+        finished_at: ``None`` while ``running``; set on terminal states.
+        error: Failure message when failed, else ``None``.
+    """
+
+    job_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    error: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+
+
+__all__ = ["JobRunModel"]

--- a/src/modules/media/infrastructure/persistence/repositories/job_run_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/job_run_repository.py
@@ -1,0 +1,129 @@
+"""SQLAlchemy implementation of ``JobRunRepository``."""
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.domain.entities.job_run import JobRun, JobRunStatus
+from src.modules.media.domain.repositories.job_run_repository import JobRunRepository
+from src.modules.media.domain.value_objects.job_run_id import JobRunId
+from src.modules.media.infrastructure.persistence.mappers.job_run_mapper import JobRunMapper
+from src.modules.media.infrastructure.persistence.models.job_run import JobRunModel
+
+
+class SqlAlchemyJobRunRepository(JobRunRepository):
+    """Async SQLAlchemy repository for the ``JobRun`` log."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def save(self, run: JobRun) -> JobRun:
+        """Insert when id-less, update when known."""
+        run = run.with_updates(id=JobRunId.generate_if_absent(run.id))
+
+        stmt = select(JobRunModel).where(JobRunModel.external_id == str(run.id))
+        existing = (await self._session.execute(stmt)).scalar_one_or_none()
+
+        if existing is not None:
+            JobRunMapper.update_model(existing, run)
+        else:
+            self._session.add(JobRunMapper.to_model(run))
+        await self._session.flush()
+
+        if run.id is None:  # pragma: no cover — generate_if_absent assigns one
+            raise RuntimeError("JobRun id was not assigned before save")
+        saved = await self.find_by_id(run.id)
+        if saved is None:  # pragma: no cover — row was just written
+            raise RuntimeError(f"JobRun {run.id} disappeared between flush and reload")
+        return saved
+
+    async def find_by_id(self, run_id: JobRunId) -> JobRun | None:
+        """Look up a non-deleted run by external id."""
+        stmt = select(JobRunModel).where(
+            JobRunModel.external_id == str(run_id),
+            JobRunModel.deleted_at.is_(None),
+        )
+        model = (await self._session.execute(stmt)).scalar_one_or_none()
+        return None if model is None else JobRunMapper.to_entity(model)
+
+    async def list_paginated(
+        self,
+        *,
+        job_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Sequence[JobRun]:
+        """List non-deleted runs newest-first, optionally for one job."""
+        stmt = select(JobRunModel).where(JobRunModel.deleted_at.is_(None))
+        if job_id is not None:
+            stmt = stmt.where(JobRunModel.job_id == job_id)
+        stmt = stmt.order_by(JobRunModel.started_at.desc()).limit(limit).offset(offset)
+        result = await self._session.execute(stmt)
+        return [JobRunMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def count(self, *, job_id: str | None = None) -> int:
+        """Count non-deleted runs matching the filter."""
+        stmt = select(func.count(JobRunModel.id)).where(JobRunModel.deleted_at.is_(None))
+        if job_id is not None:
+            stmt = stmt.where(JobRunModel.job_id == job_id)
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
+    async def latest_per_job(self) -> Sequence[JobRun]:
+        """Return the newest non-deleted run per distinct ``job_id``."""
+        row_number = (
+            func.row_number()
+            .over(
+                partition_by=JobRunModel.job_id,
+                order_by=(JobRunModel.started_at.desc(), JobRunModel.id.desc()),
+            )
+            .label("rn")
+        )
+        ranked = (
+            select(JobRunModel.id, row_number).where(JobRunModel.deleted_at.is_(None)).subquery()
+        )
+        stmt = (
+            select(JobRunModel)
+            .join(ranked, JobRunModel.id == ranked.c.id)
+            .where(ranked.c.rn == 1)
+            .order_by(JobRunModel.job_id.asc())
+        )
+        result = await self._session.execute(stmt)
+        return [JobRunMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def list_by_status(self, status: JobRunStatus) -> Sequence[JobRun]:
+        """List non-deleted runs in a given status."""
+        stmt = (
+            select(JobRunModel)
+            .where(
+                JobRunModel.deleted_at.is_(None),
+                JobRunModel.status == status.value,
+            )
+            .order_by(JobRunModel.started_at.desc())
+        )
+        result = await self._session.execute(stmt)
+        return [JobRunMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def prune(self, job_id: str, *, keep: int) -> int:
+        """Soft-delete all but the newest ``keep`` runs of ``job_id``."""
+        stale = (
+            select(JobRunModel.id)
+            .where(
+                JobRunModel.job_id == job_id,
+                JobRunModel.deleted_at.is_(None),
+            )
+            .order_by(JobRunModel.started_at.desc(), JobRunModel.id.desc())
+            .offset(keep)
+        )
+        result = await self._session.execute(
+            update(JobRunModel)
+            .where(JobRunModel.id.in_(stale.scalar_subquery()))
+            .values(deleted_at=datetime.now(UTC)),
+        )
+        await self._session.flush()
+        return int(result.rowcount or 0)
+
+
+__all__ = ["SqlAlchemyJobRunRepository"]

--- a/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -10,6 +10,9 @@ from src.modules.media.application.unit_of_work import (
 from src.modules.media.infrastructure.persistence.repositories.intro_detection_run_repository import (
     SqlAlchemyIntroDetectionRunRepository,
 )
+from src.modules.media.infrastructure.persistence.repositories.job_run_repository import (
+    SqlAlchemyJobRunRepository,
+)
 from src.modules.media.infrastructure.persistence.repositories.media_conflict_repository import (
     SqlAlchemyMediaConflictRepository,
 )
@@ -39,6 +42,7 @@ class SqlAlchemyMediaUnitOfWork(SqlAlchemyUnitOfWork, MediaUnitOfWork):
         self.scan_runs = SqlAlchemyScanRunRepository(session)
         self.intro_detection_runs = SqlAlchemyIntroDetectionRunRepository(session)
         self.media_conflicts = SqlAlchemyMediaConflictRepository(session)
+        self.job_runs = SqlAlchemyJobRunRepository(session)
 
 
 class SqlAlchemyMediaUnitOfWorkFactory(MediaUnitOfWorkFactory):

--- a/src/modules/media/infrastructure/scheduling/__init__.py
+++ b/src/modules/media/infrastructure/scheduling/__init__.py
@@ -1,0 +1,1 @@
+"""Media scheduling adapters."""

--- a/src/modules/media/infrastructure/scheduling/scheduler_inspector.py
+++ b/src/modules/media/infrastructure/scheduling/scheduler_inspector.py
@@ -1,0 +1,42 @@
+"""Adapter exposing the live ``LibraryScanScheduler`` via the port."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.ports import (
+    ScheduledJob,
+    SchedulerInspectorPort,
+    SchedulerSnapshot,
+)
+
+if TYPE_CHECKING:
+    from src.infrastructure.scheduling.scheduler_service import LibraryScanScheduler
+
+
+class LibraryScanSchedulerInspector(SchedulerInspectorPort):
+    """Maps the APScheduler-backed scheduler to the read-only port.
+
+    Holds the same ``LibraryScanScheduler`` singleton the lifespan
+    starts, so its snapshot reflects the jobs actually registered and
+    running. When the scheduler is disabled (never started) the
+    snapshot reports ``running=False`` with no jobs.
+    """
+
+    def __init__(self, scheduler: LibraryScanScheduler) -> None:
+        self._scheduler = scheduler
+
+    def snapshot(self) -> SchedulerSnapshot:
+        """Return the current scheduler state."""
+        jobs = [
+            ScheduledJob(
+                job_id=job.id,
+                next_run_at=job.next_run_at,
+                schedule=job.schedule,
+            )
+            for job in self._scheduler.list_jobs()
+        ]
+        return SchedulerSnapshot(running=self._scheduler.is_running, jobs=jobs)
+
+
+__all__ = ["LibraryScanSchedulerInspector"]

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -9,6 +9,9 @@ from src.modules.media.presentation.routes.admin_credits_routes import (
 from src.modules.media.presentation.routes.admin_intro_detection_routes import (
     router as admin_intro_detection_router,
 )
+from src.modules.media.presentation.routes.admin_jobs_routes import (
+    router as admin_jobs_router,
+)
 from src.modules.media.presentation.routes.admin_overview_routes import (
     router as admin_overview_router,
 )
@@ -39,6 +42,7 @@ __all__ = [
     "admin_conflicts_router",
     "admin_credits_router",
     "admin_intro_detection_router",
+    "admin_jobs_router",
     "admin_overview_router",
     "admin_relink_router",
     "admin_scan_router",

--- a/src/modules/media/presentation/routes/admin_jobs_routes.py
+++ b/src/modules/media/presentation/routes/admin_jobs_routes.py
@@ -1,0 +1,54 @@
+"""Admin REST API routes for the background-jobs dashboard."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.presentation import api_list, api_single
+from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import current_admin_user
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.media.application.dtos.job_dtos import ListJobRunsInput
+from src.modules.media.application.use_cases.list_job_runs import ListJobRunsUseCase
+from src.modules.media.application.use_cases.list_jobs import ListJobsUseCase
+
+router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Jobs"])
+
+
+@router.get("/jobs")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_admin_jobs(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: ListJobsUseCase = Depends(Provide[ApplicationContainer.list_jobs]),
+) -> dict[str, Any]:
+    """Overview of every background job: live schedule + last run + running-now.
+
+    Merges the scheduler's live registry (next run, schedule) with each
+    job's most recent recorded execution, so a single call drives the
+    admin Jobs dashboard.
+    """
+    overview = await use_case.execute()
+    return api_single("jobs_overview", asdict(overview))
+
+
+@router.get("/jobs/runs")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def list_admin_job_runs(
+    job_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: ListJobRunsUseCase = Depends(
+        Provide[ApplicationContainer.media.list_job_runs],
+    ),
+) -> dict[str, Any]:
+    """Paginated job-execution history, newest-first, optionally per job."""
+    rows = await use_case.execute(
+        ListJobRunsInput(job_id=job_id, limit=limit, offset=offset),
+    )
+    return api_list([asdict(r) for r in rows])
+
+
+__all__ = ["router"]

--- a/tests/modules/media/e2e/test_admin_jobs_routes.py
+++ b/tests/modules/media/e2e/test_admin_jobs_routes.py
@@ -1,0 +1,126 @@
+"""End-to-end tests for the admin Jobs dashboard endpoints."""
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.modules.media.domain.entities.job_run import JobRun
+from src.modules.media.infrastructure.persistence.repositories.job_run_repository import (
+    SqlAlchemyJobRunRepository,
+)
+from tests.modules.media.e2e.conftest import SeededUser
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+JOBS_PATH = "/api/v1/admin/jobs"
+JOB_RUNS_PATH = "/api/v1/admin/jobs/runs"
+
+
+async def _login(client: AsyncClient, user: SeededUser) -> None:
+    resp = await client.post(
+        LOGIN_PATH,
+        data={"username": user.email, "password": user.password},
+    )
+    assert resp.status_code == 204
+
+
+async def _login_as_admin(
+    client: AsyncClient,
+    seed: Callable[..., Awaitable[SeededUser]],
+) -> None:
+    admin = await seed(email="admin@example.com", is_admin=True)
+    await _login(client, admin)
+
+
+async def _seed_job_run(session_factory: async_sessionmaker[AsyncSession], job_id: str) -> None:
+    async with session_factory() as session:
+        repo = SqlAlchemyJobRunRepository(session)
+        await repo.save(JobRun.start(job_id).succeed())
+        await session.commit()
+
+
+@pytest.mark.e2e
+class TestAdminJobsAuth:
+    async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        assert (await client.get(JOBS_PATH)).status_code == 401
+        assert (await client.get(JOB_RUNS_PATH)).status_code == 401
+
+    async def test_member_returns_403(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile(email="member@example.com", is_admin=False)
+        await _login(client, member)
+        assert (await client.get(JOBS_PATH)).status_code == 403
+
+
+@pytest.mark.e2e
+class TestAdminJobsOverview:
+    async def test_overview_shape_with_no_history(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+
+        response = await client.get(JOBS_PATH)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["type"] == "jobs_overview"
+        assert body["data"]["scheduler_running"] is False
+        assert body["data"]["jobs"] == []
+
+    async def test_overview_surfaces_recorded_job_as_last_run(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        await _seed_job_run(session_factory, "homeflix:thumbnail-backfill")
+
+        body = (await client.get(JOBS_PATH)).json()
+
+        (job,) = body["data"]["jobs"]
+        assert job["job_id"] == "homeflix:thumbnail-backfill"
+        assert job["scheduled"] is False  # scheduler not started in e2e
+        assert job["running"] is False
+        assert job["last_run"]["status"] == "succeeded"
+
+
+@pytest.mark.e2e
+class TestAdminJobRunsHistory:
+    async def test_empty_history_returns_empty_list(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+
+        response = await client.get(JOB_RUNS_PATH)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["type"] == "list"
+        assert body["data"] == []
+
+    async def test_history_returns_seeded_run(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+        await _seed_job_run(session_factory, "homeflix:credits-detection")
+
+        body = (
+            await client.get(JOB_RUNS_PATH, params={"job_id": "homeflix:credits-detection"})
+        ).json()
+
+        assert len(body["data"]) == 1
+        assert body["data"][0]["job_id"] == "homeflix:credits-detection"
+        assert body["data"][0]["status"] == "succeeded"
+        assert body["data"][0]["duration_ms"] is not None

--- a/tests/modules/media/integration/persistence/repositories/test_job_run_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_job_run_repository.py
@@ -1,0 +1,87 @@
+"""Integration tests for SqlAlchemyJobRunRepository."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.domain.entities.job_run import JobRun, JobRunStatus
+from src.modules.media.infrastructure.persistence.repositories.job_run_repository import (
+    SqlAlchemyJobRunRepository,
+)
+
+
+@pytest.mark.integration
+class TestSaveAndFind:
+    async def test_save_assigns_external_id(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        saved = await repo.save(JobRun.start("homeflix:thumbnail-backfill"))
+
+        assert saved.id is not None
+        assert str(saved.id).startswith("job_")
+        assert saved.status == JobRunStatus.RUNNING
+
+    async def test_save_updates_in_place_on_terminal(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        opened = await repo.save(JobRun.start("job-x"))
+
+        await repo.save(opened.succeed())
+        again = await repo.find_by_id(opened.id)  # type: ignore[arg-type]
+
+        assert again is not None
+        assert again.status == JobRunStatus.SUCCEEDED
+        assert again.finished_at is not None
+        assert again.duration_ms is not None
+
+
+@pytest.mark.integration
+class TestLatestPerJob:
+    async def test_returns_most_recent_run_per_job(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        # Two jobs; job-a runs twice, the second finishing failed.
+        await repo.save(JobRun.start("job-a").succeed())
+        await repo.save(JobRun.start("job-a").fail("boom"))
+        await repo.save(JobRun.start("job-b").succeed())
+
+        latest = await repo.latest_per_job()
+        by_job = {r.job_id: r for r in latest}
+
+        assert set(by_job) == {"job-a", "job-b"}
+        assert by_job["job-a"].status == JobRunStatus.FAILED
+        assert by_job["job-b"].status == JobRunStatus.SUCCEEDED
+
+
+@pytest.mark.integration
+class TestListAndStatus:
+    async def test_list_paginated_filters_by_job_id(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        await repo.save(JobRun.start("job-a").succeed())
+        await repo.save(JobRun.start("job-b").succeed())
+
+        only_a = await repo.list_paginated(job_id="job-a")
+
+        assert len(only_a) == 1
+        assert only_a[0].job_id == "job-a"
+
+    async def test_list_by_status_returns_running(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        await repo.save(JobRun.start("job-a"))  # running
+        await repo.save(JobRun.start("job-b").succeed())
+
+        running = await repo.list_by_status(JobRunStatus.RUNNING)
+
+        assert len(running) == 1
+        assert running[0].job_id == "job-a"
+
+
+@pytest.mark.integration
+class TestPrune:
+    async def test_prune_soft_deletes_all_but_newest(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        for _ in range(5):
+            await repo.save(JobRun.start("job-a").succeed())
+
+        pruned = await repo.prune("job-a", keep=2)
+
+        assert pruned == 3
+        remaining = await repo.list_paginated(job_id="job-a", limit=100)
+        assert len(remaining) == 2
+        assert await repo.count(job_id="job-a") == 2

--- a/tests/modules/media/unit/application/services/test_job_run_service.py
+++ b/tests/modules/media/unit/application/services/test_job_run_service.py
@@ -1,0 +1,78 @@
+"""Tests for JobRunService (the scheduler job recorder)."""
+
+import pytest
+
+from src.modules.media.application.services.job_run_service import JobRunService
+from src.modules.media.domain.entities.job_run import JobRun, JobRunStatus
+from src.modules.media.domain.value_objects.job_run_id import JobRunId
+
+
+class _FakeJobRuns:
+    def __init__(self) -> None:
+        self.saved: list[JobRun] = []
+        self.pruned: list[tuple[str, int]] = []
+
+    async def save(self, run: JobRun) -> JobRun:
+        if run.id is None:
+            run = run.with_updates(id=JobRunId.generate())
+        self.saved.append(run)
+        return run
+
+    async def find_by_id(self, run_id: JobRunId) -> JobRun | None:
+        for run in reversed(self.saved):
+            if run.id == run_id:
+                return run
+        return None
+
+    async def prune(self, job_id: str, *, keep: int) -> int:
+        self.pruned.append((job_id, keep))
+        return 0
+
+
+class _FakeUoW:
+    def __init__(self, job_runs: _FakeJobRuns) -> None:
+        self.job_runs = job_runs
+
+    async def __aenter__(self) -> "_FakeUoW":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+def _service() -> tuple[JobRunService, _FakeJobRuns]:
+    repo = _FakeJobRuns()
+    service = JobRunService(media_uow_factory=lambda: _FakeUoW(repo))  # type: ignore[arg-type]
+    return service, repo
+
+
+@pytest.mark.unit
+class TestJobRunService:
+    @pytest.mark.asyncio
+    async def test_records_running_then_succeeded(self) -> None:
+        service, repo = _service()
+        calls: list[str] = []
+
+        async def work() -> None:
+            calls.append("ran")
+
+        await service.record("homeflix:thumbnail-backfill", work)
+
+        assert calls == ["ran"]
+        assert repo.saved[0].status == JobRunStatus.RUNNING
+        assert repo.saved[-1].status == JobRunStatus.SUCCEEDED
+        assert repo.pruned == [("homeflix:thumbnail-backfill", 100)]
+
+    @pytest.mark.asyncio
+    async def test_records_failure_without_propagating(self) -> None:
+        service, repo = _service()
+
+        async def boom() -> None:
+            raise RuntimeError("kaboom")
+
+        # Must not raise — a crashing job cannot take down the scheduler.
+        await service.record("homeflix:intro-detection", boom)
+
+        assert repo.saved[-1].status == JobRunStatus.FAILED
+        assert repo.saved[-1].error == "kaboom"
+        assert repo.pruned == [("homeflix:intro-detection", 100)]

--- a/tests/modules/media/unit/application/use_cases/test_list_jobs.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_jobs.py
@@ -1,0 +1,99 @@
+"""Tests for ListJobsUseCase (Jobs dashboard overview)."""
+
+import pytest
+
+from src.modules.media.application.ports import (
+    ScheduledJob,
+    SchedulerInspectorPort,
+    SchedulerSnapshot,
+)
+from src.modules.media.application.use_cases.list_jobs import ListJobsUseCase
+from src.modules.media.domain.entities.job_run import JobRun, JobRunStatus
+from src.modules.media.domain.value_objects.job_run_id import JobRunId
+
+
+class _FakeInspector(SchedulerInspectorPort):
+    def __init__(self, snapshot: SchedulerSnapshot) -> None:
+        self._snapshot = snapshot
+
+    def snapshot(self) -> SchedulerSnapshot:
+        return self._snapshot
+
+
+class _FakeJobRuns:
+    def __init__(self, latest: list[JobRun]) -> None:
+        self._latest = latest
+
+    async def latest_per_job(self) -> list[JobRun]:
+        return self._latest
+
+
+class _FakeUoW:
+    def __init__(self, job_runs: _FakeJobRuns) -> None:
+        self.job_runs = job_runs
+
+    async def __aenter__(self) -> "_FakeUoW":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+def _run(job_id: str, status: JobRunStatus) -> JobRun:
+    run = JobRun.start(job_id).with_updates(id=JobRunId.generate())
+    return run if status == JobRunStatus.RUNNING else run.with_updates(status=status)
+
+
+def _use_case(snapshot: SchedulerSnapshot, latest: list[JobRun]) -> ListJobsUseCase:
+    return ListJobsUseCase(
+        scheduler_inspector=_FakeInspector(snapshot),
+        media_uow_factory=lambda: _FakeUoW(_FakeJobRuns(latest)),  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.unit
+class TestListJobs:
+    @pytest.mark.asyncio
+    async def test_merges_live_schedule_with_last_run(self) -> None:
+        snapshot = SchedulerSnapshot(
+            running=True,
+            jobs=[ScheduledJob(job_id="job-a", next_run_at="2026-06-20T10:00:00", schedule="i")],
+        )
+        use_case = _use_case(snapshot, [_run("job-a", JobRunStatus.SUCCEEDED)])
+
+        out = await use_case.execute()
+
+        assert out.scheduler_running is True
+        (job,) = out.jobs
+        assert job.job_id == "job-a"
+        assert job.scheduled is True
+        assert job.next_run_at == "2026-06-20T10:00:00"
+        assert job.running is False
+        assert job.last_run is not None
+        assert job.last_run.status == "succeeded"
+
+    @pytest.mark.asyncio
+    async def test_flags_running_from_last_run_status(self) -> None:
+        snapshot = SchedulerSnapshot(
+            running=True,
+            jobs=[ScheduledJob(job_id="job-a", next_run_at=None, schedule="i")],
+        )
+        use_case = _use_case(snapshot, [_run("job-a", JobRunStatus.RUNNING)])
+
+        out = await use_case.execute()
+
+        assert out.jobs[0].running is True
+
+    @pytest.mark.asyncio
+    async def test_includes_unscheduled_jobs_that_have_history(self) -> None:
+        # A job with history but no live registration (e.g. now disabled).
+        snapshot = SchedulerSnapshot(running=True, jobs=[])
+        use_case = _use_case(snapshot, [_run("retired-job", JobRunStatus.SUCCEEDED)])
+
+        out = await use_case.execute()
+
+        (job,) = out.jobs
+        assert job.job_id == "retired-job"
+        assert job.scheduled is False
+        assert job.schedule is None
+        assert job.last_run is not None

--- a/tests/modules/media/unit/domain/entities/test_job_run.py
+++ b/tests/modules/media/unit/domain/entities/test_job_run.py
@@ -1,0 +1,40 @@
+"""Tests for the JobRun aggregate."""
+
+import pytest
+
+from src.modules.media.domain.entities.job_run import JobRun, JobRunStatus
+
+
+@pytest.mark.unit
+class TestJobRunLifecycle:
+    def test_start_opens_running_row(self) -> None:
+        run = JobRun.start("homeflix:thumbnail-backfill")
+
+        assert run.job_id == "homeflix:thumbnail-backfill"
+        assert run.status == JobRunStatus.RUNNING
+        assert run.finished_at is None
+        assert run.duration_ms is None
+
+    def test_succeed_sets_finished_and_status(self) -> None:
+        run = JobRun.start("job").succeed()
+
+        assert run.status == JobRunStatus.SUCCEEDED
+        assert run.finished_at is not None
+        assert run.error is None
+        assert run.duration_ms is not None
+        assert run.duration_ms >= 0
+
+    def test_fail_records_truncated_error(self) -> None:
+        run = JobRun.start("job").fail("x" * 5000)
+
+        assert run.status == JobRunStatus.FAILED
+        assert run.finished_at is not None
+        assert run.error is not None
+        assert len(run.error) == 2000
+
+    def test_mark_interrupted_closes_row(self) -> None:
+        run = JobRun.start("job").mark_interrupted()
+
+        assert run.status == JobRunStatus.INTERRUPTED
+        assert run.finished_at is not None
+        assert run.error is not None


### PR DESCRIPTION
## Summary

PR 1 of 2 for the admin **Jobs dashboard** ("see all jobs that are running"). This is the backend; the `/admin/system/jobs` page follows in homeflix-web.

- New generic **`job_runs`** execution log (table + `JobRun` aggregate + repo + migration), written for **every** recurring scheduler job — so the dashboard can show *last run / status / duration* and *running now* uniformly, even for jobs that previously kept no history (thumbnail backfill, scan-dedup sweep).
- A **`JobRunService` recorder** wraps each job at the single scheduler registration seam (`add_interval_job` + the cron library-scans), opening a `running` row and writing the terminal state. A crashing job is recorded as `failed` and swallowed so it can't take down the scheduler tick. The high-frequency reconcile job is intentionally not recorded (it still shows live).
- A **`SchedulerInspector`** port + adapter expose the live APScheduler state (next run, schedule, scheduler-running) — in-memory, no DB cost.
- Read endpoints (admin-gated): **`GET /api/v1/admin/jobs`** (overview merging live schedule with each job's last run) and **`GET /api/v1/admin/jobs/runs`** (paginated history, optional `job_id`).
- Orphan `running` rows are swept to `interrupted` on startup (mirrors the scan-runs sweep); per-job history is pruned to the latest 100 to bound growth.

Placement follows the existing `scan_runs` / `intro_detection_runs` precedent in the media module; cross-BC wiring (recorder → scheduler, inspector → use case) lives at the composition root.

## Test plan

- [x] `pytest tests/modules/media tests/infrastructure/scheduling` (1623 passed) + 21 new tests
- [x] Unit: `JobRun` lifecycle, `JobRunService` (records success/failure, prunes, never propagates), `ListJobsUseCase` (live+history merge, running flag, unscheduled-with-history)
- [x] Integration: repo save/find, `latest_per_job`, `prune`, `list_by_status`, filters
- [x] E2E: `/admin/jobs` + `/admin/jobs/runs` auth gate (401/403) + admin response shape + seeded run surfaced
- [x] Migration `upgrade`/`downgrade` clean on a scratch DB; single alembic head
- [x] `ruff check` + `ruff format --check` clean; app builds with both routes registered + DI wired