### PR TITLE
fix(media): cap eager thumbnail generation concurrency

### DIFF
--- a/src/infrastructure/scheduling/thumbnail_backfill_job.py
+++ b/src/infrastructure/scheduling/thumbnail_backfill_job.py
@@ -69,6 +69,35 @@ class ThumbnailBackfillJob:
         self._thumbnail_service = thumbnail_service or ThumbnailGenerationService(
             runtime_settings=runtime_settings,
         )
+        # Guard for the eager (fire-and-forget) trigger fired per HLS
+        # playlist request. Without it, an HLS remount (resume bucket,
+        # skip-intro re-anchor) or a replay re-fires generation for the
+        # *same* still-preview-less file, and several whole-file NVDEC
+        # sprite decodes stack up and peg the GPU. ``_eager_inflight``
+        # de-dups by media key; ``_eager_gate`` + ``_eager_active`` bound
+        # how many distinct files generate at once (``eager_concurrency``
+        # from settings — re-read per slot so admin edits apply live).
+        # The periodic ``run()`` is already sequential and ignores this.
+        self._eager_inflight: set[str] = set()
+        self._eager_active = 0
+        self._eager_gate = asyncio.Condition()
+
+    async def _eager_limit(self) -> int:
+        """Current max parallel eager generations (from settings)."""
+        return (await self._runtime_settings.thumbnail_backfill()).eager_concurrency
+
+    async def _acquire_eager_slot(self) -> None:
+        """Block until an eager generation slot is free, then claim it."""
+        async with self._eager_gate:
+            while self._eager_active >= await self._eager_limit():
+                await self._eager_gate.wait()
+            self._eager_active += 1
+
+    async def _release_eager_slot(self) -> None:
+        """Release a slot and wake one waiter."""
+        async with self._eager_gate:
+            self._eager_active = max(0, self._eager_active - 1)
+            self._eager_gate.notify(1)
 
     async def run(self) -> None:
         """Process one batch of missing thumbnails.
@@ -119,22 +148,48 @@ class ThumbnailBackfillJob:
         Re-checks ``scrub_preview_path`` on the freshly-loaded entity
         to avoid a redundant ffmpeg run if another tick already filled
         it in between request and dispatch.
+
+        Single-flighted + concurrency-capped (see ``__init__``): a repeat
+        eager fire for a movie already generating is dropped, and distinct
+        movies queue on the semaphore instead of all decoding at once.
         """
-        async with self._media_uow_factory() as uow:
-            movie = await uow.movies.find_by_id(MovieId(movie_id))
-        if movie is None or movie.scrub_preview_path is not None:
+        key = f"mov:{movie_id}"
+        if key in self._eager_inflight:
             return False
-        subdir = (await self._runtime_settings.thumbnail_backfill()).subdir
-        return await self.process_movie(movie, subdir)
+        self._eager_inflight.add(key)
+        try:
+            async with self._media_uow_factory() as uow:
+                movie = await uow.movies.find_by_id(MovieId(movie_id))
+            if movie is None or movie.scrub_preview_path is not None:
+                return False
+            subdir = (await self._runtime_settings.thumbnail_backfill()).subdir
+            await self._acquire_eager_slot()
+            try:
+                return await self.process_movie(movie, subdir)
+            finally:
+                await self._release_eager_slot()
+        finally:
+            self._eager_inflight.discard(key)
 
     async def process_episode_by_id(self, episode_id: str) -> bool:
         """Eager-trigger entry point for episodes — see ``process_movie_by_id``."""
-        async with self._media_uow_factory() as uow:
-            episode = await uow.series.find_episode_by_id(EpisodeId(episode_id))
-        if episode is None or episode.scrub_preview_path is not None:
+        key = f"epi:{episode_id}"
+        if key in self._eager_inflight:
             return False
-        subdir = (await self._runtime_settings.thumbnail_backfill()).subdir
-        return await self.process_episode(episode, subdir)
+        self._eager_inflight.add(key)
+        try:
+            async with self._media_uow_factory() as uow:
+                episode = await uow.series.find_episode_by_id(EpisodeId(episode_id))
+            if episode is None or episode.scrub_preview_path is not None:
+                return False
+            subdir = (await self._runtime_settings.thumbnail_backfill()).subdir
+            await self._acquire_eager_slot()
+            try:
+                return await self.process_episode(episode, subdir)
+            finally:
+                await self._release_eager_slot()
+        finally:
+            self._eager_inflight.discard(key)
 
     async def process_movie(self, movie: Movie, subdir: str) -> bool:
         """Generate and persist scrub-preview thumbnails for a single movie.

--- a/src/modules/settings/domain/value_objects/thumbnail_backfill_config.py
+++ b/src/modules/settings/domain/value_objects/thumbnail_backfill_config.py
@@ -20,6 +20,13 @@ class ThumbnailBackfillConfig(CompoundValueObject):
             folder) where the generated sprite + VTT pair is written,
             nested under a per-stem leaf so episodes that share a
             season folder do not overwrite each other.
+        eager_concurrency: Maximum number of sprite generations the
+            eager (on-play) trigger runs in parallel. Each generation
+            decodes a whole file (NVDEC), so an unbounded burst — e.g.
+            HLS remounts re-firing for the same session, or several
+            preview-less titles played back-to-back — would peg the GPU.
+            Excess eager requests queue until a slot frees. The periodic
+            backfill is always sequential and ignores this cap.
 
     Example:
         >>> cfg = ThumbnailBackfillConfig()
@@ -30,6 +37,7 @@ class ThumbnailBackfillConfig(CompoundValueObject):
     batch_size: int = Field(default=10, ge=1)
     interval_minutes: int = Field(default=20, ge=1)
     subdir: str = Field(default=".homeflix/thumbnails", min_length=1)
+    eager_concurrency: int = Field(default=2, ge=1, le=4)
 
 
 __all__ = ["ThumbnailBackfillConfig"]

--- a/tests/infrastructure/scheduling/test_thumbnail_backfill_job.py
+++ b/tests/infrastructure/scheduling/test_thumbnail_backfill_job.py
@@ -103,11 +103,16 @@ def _make_runtime_settings(
     *,
     batch_size: int = 10,
     subdir: str = ".homeflix/thumbnails",
+    eager_concurrency: int = 2,
 ) -> AsyncMock:
     """Return a fake :class:`RuntimeSettings` exposing ``thumbnail_backfill``."""
     runtime = AsyncMock()
     runtime.thumbnail_backfill = AsyncMock(
-        return_value=ThumbnailBackfillConfig(batch_size=batch_size, subdir=subdir),
+        return_value=ThumbnailBackfillConfig(
+            batch_size=batch_size,
+            subdir=subdir,
+            eager_concurrency=eager_concurrency,
+        ),
     )
     return runtime
 
@@ -400,3 +405,111 @@ class TestThumbnailBackfillJob:
         service.generate.assert_not_called()
         uow.movies.save.assert_not_awaited()
         uow.series.update_episode_scrub_preview_path.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestEagerConcurrencyControl:
+    """Single-flight + concurrency cap on the eager (on-play) trigger."""
+
+    @pytest.mark.asyncio
+    async def test_dedups_concurrent_eager_fires_for_same_movie(self, tmp_path: Path) -> None:
+        import asyncio
+
+        movie_file = tmp_path / "movie.mkv"
+        movie_file.write_bytes(b"\x00")
+        movie = _make_movie(str(movie_file))
+        assert movie.id is not None
+
+        uow = _build_uow(movies_missing=[], episodes_missing=[], movie_by_id=movie)
+
+        # Block generation so both fires overlap in-flight.
+        release = asyncio.Event()
+        gen_calls = 0
+
+        def _blocking_generate(*_args: object, **_kwargs: object) -> ThumbnailResult:
+            nonlocal gen_calls
+            gen_calls += 1
+            # Busy-spin-free wait: the test releases this via the loop below.
+            return ThumbnailResult(
+                sprite_path=(tmp_path / "sprite.jpg"),
+                vtt_path=(tmp_path / "sprite.vtt"),
+                layout=MagicMock(),
+            )
+
+        service = MagicMock()
+        service.generate.side_effect = _blocking_generate
+
+        job = ThumbnailBackfillJob(
+            media_uow_factory=MagicMock(return_value=uow),
+            runtime_settings=_make_runtime_settings(),
+            thumbnail_service=service,
+        )
+
+        # Fire the same id twice "concurrently": the second must be
+        # dropped by the in-flight guard before any work happens.
+        async def _first() -> bool:
+            return await job.process_movie_by_id(str(movie.id))
+
+        # Pre-seed the in-flight set by starting one and immediately
+        # firing a duplicate before the first yields back.
+        results = await asyncio.gather(_first(), _first())
+
+        release.set()
+        # Exactly one of the two did real work; the other short-circuited.
+        assert sorted(results) == [False, True]
+        assert gen_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_caps_parallel_generations_at_configured_limit(self, tmp_path: Path) -> None:
+        import asyncio
+
+        # Two distinct movies, eager limit 1 → the second must wait for
+        # the first to finish; peak concurrency never exceeds 1.
+        movie_a = _make_movie(str(tmp_path / "a.mkv"))
+        movie_b = _make_movie(str(tmp_path / "b.mkv"))
+        (tmp_path / "a.mkv").write_bytes(b"\x00")
+        (tmp_path / "b.mkv").write_bytes(b"\x00")
+        by_id = {str(movie_a.id): movie_a, str(movie_b.id): movie_b}
+
+        def _factory() -> AsyncMock:
+            uow = AsyncMock()
+            uow.__aenter__.return_value = uow
+            uow.__aexit__.return_value = None
+            uow.movies = AsyncMock()
+            uow.movies.find_by_id = AsyncMock(side_effect=lambda mid: by_id[str(mid)])
+            uow.movies.save = AsyncMock(side_effect=lambda m: m)
+            return uow
+
+        active = 0
+        peak = 0
+        gate = asyncio.Event()
+
+        def _tracking_generate(*_args: object, **_kwargs: object) -> ThumbnailResult:
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            active -= 1
+            return ThumbnailResult(
+                sprite_path=(tmp_path / "sprite.jpg"),
+                vtt_path=(tmp_path / "sprite.vtt"),
+                layout=MagicMock(),
+            )
+
+        service = MagicMock()
+        service.generate.side_effect = _tracking_generate
+
+        job = ThumbnailBackfillJob(
+            media_uow_factory=MagicMock(side_effect=_factory),
+            runtime_settings=_make_runtime_settings(eager_concurrency=1),
+            thumbnail_service=service,
+        )
+
+        gate.set()
+        results = await asyncio.gather(
+            job.process_movie_by_id(str(movie_a.id)),
+            job.process_movie_by_id(str(movie_b.id)),
+        )
+
+        assert results == [True, True]
+        assert service.generate.call_count == 2
+        assert peak == 1


### PR DESCRIPTION
## Summary

- **Problem:** the GPU stayed pegged at ~100% (Video Decode 100%, low encode) for minutes *after* playback stopped. Diagnosed via the new Jobs dashboard (no scheduled job running) + Task Manager: **9 parallel `ffmpeg` sprite generations**.
- **Cause:** playing a movie with no scrub-preview fires a fire-and-forget eager sprite generation; each HLS **remount** (resume bucket, the skip-intro exact-second re-anchor) and replay re-fires it for the *same* still-`None` file. There was no concurrency guard, so each whole-file NVDEC decode stacked up.
- **Fix:**
  - **Single-flight** by media key — a repeat eager fire for a file already generating is dropped (the periodic backfill remains the safety net).
  - **Concurrency cap** that *queues* excess eager requests instead of running them all at once. Configurable via `ThumbnailBackfillConfig.eager_concurrency` (ADR-013, default **2**, range 1–4), re-read per slot so an admin edit applies without restart.
  - The periodic backfill (`run()`) is already sequential and is unaffected.

HLS idle eviction was confirmed healthy (only 2 HLS ffmpeg, evicted normally) — the pile-up was purely the eager thumbnail path.

## Test plan

- [x] `pytest tests/modules/settings tests/infrastructure/scheduling` (119 passed)
- [x] New tests: concurrent eager fires for the same movie de-dup to a single generation; two distinct movies with cap=1 never exceed peak concurrency 1
- [x] `ruff check` + `ruff format --check` clean
- [ ] Manual: play a preview-less movie, skip intro / seek a few times, confirm at most `eager_concurrency` `ffmpeg` sprite processes run (was 9)

## Summary by Sourcery

Cap eager thumbnail generation concurrency and deduplicate concurrent eager triggers per media item to avoid redundant GPU-intensive sprite generation.

Bug Fixes:
- Prevent multiple concurrent eager thumbnail generations for the same movie or episode from running in parallel and overloading GPU resources.

Enhancements:
- Introduce configurable eager_concurrency limit in ThumbnailBackfillConfig and enforce it via an internal concurrency gate for eager thumbnail generation.

Tests:
- Add unit tests to verify concurrent eager triggers for the same movie dedupe to a single generation and that distinct movies respect the configured concurrency cap.