### PR TITLE
feat(media): expose intro_marked_count on series list

### DIFF
--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -157,6 +157,9 @@ class SeriesSummaryOutput:
         poster_path: Path to poster (optional).
         season_count: Number of seasons.
         total_episodes: Total episode count.
+        intro_marked_count: Number of episodes with an intro marker set
+            (auto-detected or manual). Drives the admin intro-coverage
+            progress shown per series.
         genres: List of genre strings.
         library_id: External library id (``lib_xxx``) owning the
             series. Used by the admin Catalog "Library" column.
@@ -175,6 +178,7 @@ class SeriesSummaryOutput:
     backdrop_path: str | None
     season_count: int
     total_episodes: int
+    intro_marked_count: int
     genres: list[str]
     library_id: str
     tmdb_id: int | None

--- a/src/modules/media/application/use_cases/_series_summary_helpers.py
+++ b/src/modules/media/application/use_cases/_series_summary_helpers.py
@@ -24,6 +24,7 @@ def to_series_summary(series: Series, lang: str = "en") -> SeriesSummaryOutput:
         backdrop_path=series.backdrop_path.value if series.backdrop_path else None,
         season_count=series.season_count,
         total_episodes=series.total_episodes,
+        intro_marked_count=series.intro_marked_count,
         genres=series.get_genres(lang),
         library_id=series.library_id,
         tmdb_id=series.tmdb_id.value if series.tmdb_id else None,

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -161,6 +161,22 @@ class Series(AggregateRoot[SeriesId]):
         return sum(s.episode_count for s in self.seasons)
 
     @property
+    def intro_marked_count(self) -> int:
+        """Return the number of episodes that have an intro marker set.
+
+        Counts episodes (across all seasons) whose intro span has been
+        recorded, whether auto-detected or set manually. Lets the admin
+        UI show per-series "skip intro" coverage without loading each
+        season's detail.
+
+        Returns:
+            The count of episodes with an intro marker.
+        """
+        return sum(
+            1 for season in self.seasons for episode in season.episodes if episode.intro is not None
+        )
+
+    @property
     def is_ongoing(self) -> bool:
         """Check if the series is still ongoing.
 

--- a/tests/modules/media/unit/application/use_cases/test_list_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series.py
@@ -179,6 +179,7 @@ class TestListSeriesUseCase:
 
         assert result.series[0].season_count == 0
         assert result.series[0].total_episodes == 0
+        assert result.series[0].intro_marked_count == 0
 
     @pytest.mark.asyncio
     async def test_should_request_total_when_include_total_is_true(self) -> None:

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -145,6 +145,85 @@ class TestSeriesSeasonManagement:
         assert found is None
 
 
+class TestSeriesIntroMarkedCount:
+    """Tests for Series.intro_marked_count."""
+
+    @staticmethod
+    def _episode(series_id, season_number, episode_number, *, with_intro):
+        from src.modules.media.domain.entities import Episode
+        from src.modules.media.domain.value_objects import (
+            Duration,
+            FilePath,
+            IntroMarker,
+            IntroMarkerSource,
+            MediaFile,
+            Resolution,
+            Title,
+        )
+
+        episode = Episode(
+            series_id=series_id,
+            season_number=season_number,
+            episode_number=episode_number,
+            title=Title(f"Ep {episode_number}"),
+            duration=Duration(2700),
+            files=[
+                MediaFile(
+                    file_path=FilePath(
+                        f"/series/show/s{season_number:02d}e{episode_number:02d}.mkv"
+                    ),
+                    file_size=1_000_000_000,
+                    resolution=Resolution("1080p"),
+                    is_primary=True,
+                )
+            ],
+        )
+        if with_intro:
+            episode = episode.with_intro_marker(
+                IntroMarker(start_seconds=10, end_seconds=80, source=IntroMarkerSource.MANUAL)
+            )
+        return episode
+
+    def _series_with(self, marked_flags_by_season):
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId
+
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
+        for season_number, flags in enumerate(marked_flags_by_season, start=1):
+            season = Season(
+                id=SeasonId.generate(),
+                series_id=series.id,
+                season_number=season_number,
+                episodes=[
+                    self._episode(series.id, season_number, n + 1, with_intro=flag)
+                    for n, flag in enumerate(flags)
+                ],
+            )
+            series = series.with_season(season)
+        return series
+
+    def test_should_return_zero_when_no_episodes(self):
+        series = self._series_with([])
+
+        assert series.intro_marked_count == 0
+
+    def test_should_return_zero_when_no_episode_has_intro(self):
+        series = self._series_with([[False, False, False]])
+
+        assert series.intro_marked_count == 0
+
+    def test_should_count_only_episodes_with_intro_marker(self):
+        series = self._series_with([[True, False, True]])
+
+        assert series.intro_marked_count == 2
+
+    def test_should_sum_marked_episodes_across_seasons(self):
+        series = self._series_with([[True, False], [True, True, False]])
+
+        assert series.intro_marked_count == 3
+        assert series.total_episodes == 5
+
+
 class TestSeriesEquality:
     """Tests for Series equality based on ID."""
 


### PR DESCRIPTION
## Summary

- Add `Series.intro_marked_count` domain property — counts episodes (across all seasons) that carry an intro marker, mirroring how `total_episodes` is derived.
- Expose `intro_marked_count` on the `SeriesSummaryOutput` list DTO and populate it in the shared `to_series_summary` mapper, so it ships on `GET /series` (serialized straight through `dataclasses.asdict`).
- Computed in-Python over the episode rows already eager-loaded by `list_paginated` — no extra SQL, no schema change, no migration.

Unblocks the admin intro picker's per-series "skip intro" coverage (progress bar + Pending/Done filter) without fetching each season's detail.

## Test plan

- [x] `pytest tests/modules/media/unit/domain/entities/test_series.py` — new `TestSeriesIntroMarkedCount` (empty, none-marked, partial, multi-season sum)
- [x] `pytest tests/modules/media/unit/application/use_cases/test_list_series.py` — asserts `intro_marked_count` flows through the list use case
- [x] `ruff check` + `ruff format` clean

## Summary by Sourcery

Expose a per-series intro-marked episode count on series summaries used by the list endpoint.

New Features:
- Add a Series.intro_marked_count domain property that counts episodes with intro markers across all seasons.
- Include intro_marked_count in the SeriesSummaryOutput DTO and populate it in the shared series summary mapper so it is returned by the series listing API.

Tests:
- Add unit tests for Series.intro_marked_count covering empty, unmarked, partial, and multi-season scenarios.
- Extend list-series use case tests to assert that intro_marked_count is present and correctly populated in series summaries.