### PR TITLE
feat(media): enrich jobs dashboard data + run-now trigger

### DIFF
--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -34,10 +34,14 @@ from src.modules.library.infrastructure.persistence.sqlalchemy_unit_of_work impo
     SqlAlchemyLibraryUnitOfWorkFactory,
 )
 from src.modules.media.application.use_cases.list_jobs import ListJobsUseCase
+from src.modules.media.application.use_cases.trigger_job import TriggerJobUseCase
 from src.modules.media.infrastructure.acl import (
     LibraryHealthAdapter,
     ProfileLibraryAccessAdapter,
     ProgressLookupAdapter,
+)
+from src.modules.media.infrastructure.scheduling.scheduler_controller import (
+    LibraryScanSchedulerController,
 )
 from src.modules.media.infrastructure.scheduling.scheduler_inspector import (
     LibraryScanSchedulerInspector,
@@ -248,6 +252,18 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         ListJobsUseCase,
         scheduler_inspector=scheduler_inspector,
         media_uow_factory=media.media_unit_of_work_factory,
+    )
+
+    # Write-side control of the same scheduler singleton for the admin
+    # "run now" action.
+    scheduler_controller = providers.Singleton(
+        LibraryScanSchedulerController,
+        scheduler=library_scan_scheduler,
+    )
+
+    trigger_job = providers.Factory(
+        TriggerJobUseCase,
+        scheduler_control=scheduler_controller,
     )
 
     thumbnail_backfill_job = providers.Singleton(

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -89,6 +89,28 @@ class LibraryScanScheduler:
         """Whether the scheduler is started and ticking."""
         return self._scheduler.running
 
+    def trigger_now(self, job_id: str) -> bool:
+        """Reschedule a registered job to fire immediately.
+
+        Sets the job's next run time to "now" so APScheduler dispatches
+        it on the next tick; the regular cadence resumes afterwards
+        (the trigger recomputes the following run as usual). Used by the
+        admin "run now" action.
+
+        Args:
+            job_id: Stable scheduler job id to run immediately.
+
+        Returns:
+            ``True`` when the job exists and was rescheduled; ``False``
+            when no job with that id is currently registered.
+        """
+        job = self._scheduler.get_job(job_id)
+        if job is None:
+            return False
+        job.modify(next_run_time=datetime.now(UTC))
+        _logger.info("[scheduler] Triggered job to run now", job_id=job_id)
+        return True
+
     def list_jobs(self) -> list[ScheduledJobSnapshot]:
         """Snapshot every currently-registered job (in-memory, no I/O)."""
         snapshots: list[ScheduledJobSnapshot] = []

--- a/src/modules/media/application/dtos/job_dtos.py
+++ b/src/modules/media/application/dtos/job_dtos.py
@@ -1,6 +1,6 @@
 """DTOs for the admin Jobs dashboard."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -29,6 +29,9 @@ class JobOutput:
         next_run_at: ISO-8601 of the next fire, or ``None``.
         running: Whether a run is in progress right now.
         last_run: The most recent recorded execution, or ``None``.
+        recent_runs: Status codes of the newest runs, oldest-first, so
+            the dashboard can render a left-to-right run-health strip
+            (the most recent outcome is the last element).
     """
 
     job_id: str
@@ -37,14 +40,25 @@ class JobOutput:
     next_run_at: str | None
     running: bool
     last_run: JobRunOutput | None
+    recent_runs: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class JobsOverviewOutput:
-    """Top-level dashboard payload."""
+    """Top-level dashboard payload.
+
+    Attributes:
+        scheduler_running: Whether the scheduler is started and ticking.
+        jobs: Every job (live or with history), one row each.
+        executions_24h: Total runs started in the last 24 hours.
+        failures_24h: Runs that failed or were interrupted in the last
+            24 hours.
+    """
 
     scheduler_running: bool
     jobs: list[JobOutput]
+    executions_24h: int = 0
+    failures_24h: int = 0
 
 
 @dataclass(frozen=True)
@@ -56,9 +70,17 @@ class ListJobRunsInput:
     offset: int = 0
 
 
+@dataclass(frozen=True)
+class TriggerJobInput:
+    """Input for ``TriggerJobUseCase``."""
+
+    job_id: str
+
+
 __all__ = [
     "JobOutput",
     "JobRunOutput",
     "JobsOverviewOutput",
     "ListJobRunsInput",
+    "TriggerJobInput",
 ]

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -51,6 +51,9 @@ from src.modules.media.application.ports.progress_lookup_port import (
     ProgressLookupPort,
     ProgressSummary,
 )
+from src.modules.media.application.ports.scheduler_control_port import (
+    SchedulerControlPort,
+)
 from src.modules.media.application.ports.scheduler_inspector_port import (
     ScheduledJob,
     SchedulerInspectorPort,
@@ -96,6 +99,7 @@ __all__ = [
     "ProgressSummary",
     "ScannedFile",
     "ScheduledJob",
+    "SchedulerControlPort",
     "SchedulerInspectorPort",
     "SchedulerSnapshot",
     "ScrubPreviewLocatorPort",

--- a/src/modules/media/application/ports/scheduler_control_port.py
+++ b/src/modules/media/application/ports/scheduler_control_port.py
@@ -1,0 +1,28 @@
+"""Port for issuing control commands to the background scheduler."""
+
+from abc import ABC, abstractmethod
+
+
+class SchedulerControlPort(ABC):
+    """Write-side window into the live scheduler for admin actions.
+
+    Kept separate from :class:`SchedulerInspectorPort` so the read path
+    (the Jobs dashboard) stays side-effect free while admin "run now"
+    actions go through an explicitly mutating contract.
+    """
+
+    @abstractmethod
+    def trigger(self, job_id: str) -> bool:
+        """Schedule ``job_id`` to fire as soon as possible.
+
+        Args:
+            job_id: Stable scheduler job id to run immediately.
+
+        Returns:
+            ``True`` when the job was registered and rescheduled to run
+            now; ``False`` when no such job is currently registered.
+        """
+        ...
+
+
+__all__ = ["SchedulerControlPort"]

--- a/src/modules/media/application/use_cases/list_jobs.py
+++ b/src/modules/media/application/use_cases/list_jobs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from src.modules.media.application.dtos.job_dtos import (
@@ -14,6 +16,15 @@ from src.modules.media.domain.entities.job_run import JobRunStatus
 if TYPE_CHECKING:
     from src.modules.media.application.ports import SchedulerInspectorPort
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+# How many recent outcomes feed each job's run-health strip.
+_RUN_STRIP_DEPTH = 8
+
+# Window for the dashboard's "executions / failures (24 h)" tiles.
+_RECENT_WINDOW = timedelta(hours=24)
+
+# Outcomes that count as a failure on the dashboard.
+_FAILURE_STATUSES = (JobRunStatus.FAILED, JobRunStatus.INTERRUPTED)
 
 
 class ListJobsUseCase:
@@ -36,11 +47,22 @@ class ListJobsUseCase:
     async def execute(self) -> JobsOverviewOutput:
         """Return the dashboard overview (live schedule + last run per job)."""
         snapshot = self._inspector.snapshot()
+        cutoff = datetime.now(UTC) - _RECENT_WINDOW
 
         async with self._media_uow_factory() as uow:
-            latest = await uow.job_runs.latest_per_job()
+            recent = await uow.job_runs.recent_per_job(limit=_RUN_STRIP_DEPTH)
+            executions_24h = await uow.job_runs.count(since=cutoff)
+            failures_24h = await uow.job_runs.count(
+                since=cutoff,
+                statuses=_FAILURE_STATUSES,
+            )
 
-        last_by_job = {run.job_id: run for run in latest}
+        # ``recent_per_job`` returns newest-first within each job; the
+        # first row per job is therefore its last run.
+        recent_by_job: dict[str, list] = defaultdict(list)
+        for run in recent:
+            recent_by_job[run.job_id].append(run)
+        last_by_job = {job_id: runs[0] for job_id, runs in recent_by_job.items()}
         live_by_job = {job.job_id: job for job in snapshot.jobs}
 
         jobs = [
@@ -55,10 +77,17 @@ class ListJobsUseCase:
                 last_run=(
                     job_run_to_output(last_by_job[job_id]) if job_id in last_by_job else None
                 ),
+                # Oldest-first so the strip reads left (old) to right (new).
+                recent_runs=[run.status.value for run in reversed(recent_by_job.get(job_id, []))],
             )
             for job_id in sorted(set(live_by_job) | set(last_by_job))
         ]
-        return JobsOverviewOutput(scheduler_running=snapshot.running, jobs=jobs)
+        return JobsOverviewOutput(
+            scheduler_running=snapshot.running,
+            jobs=jobs,
+            executions_24h=executions_24h,
+            failures_24h=failures_24h,
+        )
 
 
 __all__ = ["ListJobsUseCase"]

--- a/src/modules/media/application/use_cases/trigger_job.py
+++ b/src/modules/media/application/use_cases/trigger_job.py
@@ -1,0 +1,43 @@
+"""TriggerJobUseCase — admin runs a scheduled background job now."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.modules.media.application.dtos.job_dtos import TriggerJobInput
+    from src.modules.media.application.ports import SchedulerControlPort
+
+
+class JobNotScheduledError(Exception):
+    """Admin asked to run a job that isn't currently registered.
+
+    Either the job id is unknown, or it only exists in history (e.g. a
+    library whose schedule was removed). Such jobs cannot be triggered
+    because the scheduler has nothing registered to fire.
+    """
+
+    def __init__(self, job_id: str) -> None:
+        super().__init__(f"Job {job_id} is not currently scheduled")
+        self.job_id = job_id
+
+
+class TriggerJobUseCase:
+    """Reschedule a registered scheduler job to run immediately.
+
+    The job runs through its normal recorded wrapper, so the manual run
+    shows up in the Jobs dashboard (running → succeeded/failed) exactly
+    like a scheduled tick. The cadence is unaffected: APScheduler
+    recomputes the next scheduled run after the manual fire.
+    """
+
+    def __init__(self, scheduler_control: SchedulerControlPort) -> None:
+        self._control = scheduler_control
+
+    async def execute(self, input_dto: TriggerJobInput) -> None:
+        """Trigger ``job_id`` now, or raise if it isn't scheduled."""
+        if not self._control.trigger(input_dto.job_id):
+            raise JobNotScheduledError(input_dto.job_id)
+
+
+__all__ = ["JobNotScheduledError", "TriggerJobUseCase"]

--- a/src/modules/media/domain/repositories/job_run_repository.py
+++ b/src/modules/media/domain/repositories/job_run_repository.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from datetime import datetime
 
 from src.modules.media.domain.entities.job_run import JobRun, JobRunStatus
 from src.modules.media.domain.value_objects.job_run_id import JobRunId
@@ -37,8 +38,21 @@ class JobRunRepository(ABC):
         ...
 
     @abstractmethod
-    async def count(self, *, job_id: str | None = None) -> int:
-        """Count matching non-deleted runs."""
+    async def count(
+        self,
+        *,
+        job_id: str | None = None,
+        since: datetime | None = None,
+        statuses: Sequence[JobRunStatus] | None = None,
+    ) -> int:
+        """Count matching non-deleted runs.
+
+        Args:
+            job_id: Restrict to a single job when given.
+            since: Only count runs that started at or after this instant
+                (used for the dashboard's 24 h execution/failure tiles).
+            statuses: Only count runs in one of these terminal states.
+        """
         ...
 
     @abstractmethod
@@ -47,6 +61,16 @@ class JobRunRepository(ABC):
 
         Powers the dashboard's per-job "last run / status / duration"
         column without loading the full history.
+        """
+        ...
+
+    @abstractmethod
+    async def recent_per_job(self, *, limit: int) -> Sequence[JobRun]:
+        """Return up to ``limit`` newest runs for each distinct ``job_id``.
+
+        Powers the dashboard's per-job "run-health strip" — a short
+        sparkline of recent outcomes — without loading the full history.
+        Ordered by ``job_id`` then newest-first within each job.
         """
         ...
 

--- a/src/modules/media/infrastructure/persistence/repositories/job_run_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/job_run_repository.py
@@ -63,11 +63,21 @@ class SqlAlchemyJobRunRepository(JobRunRepository):
         result = await self._session.execute(stmt)
         return [JobRunMapper.to_entity(m) for m in result.scalars().all()]
 
-    async def count(self, *, job_id: str | None = None) -> int:
-        """Count non-deleted runs matching the filter."""
+    async def count(
+        self,
+        *,
+        job_id: str | None = None,
+        since: datetime | None = None,
+        statuses: Sequence[JobRunStatus] | None = None,
+    ) -> int:
+        """Count non-deleted runs matching the filters."""
         stmt = select(func.count(JobRunModel.id)).where(JobRunModel.deleted_at.is_(None))
         if job_id is not None:
             stmt = stmt.where(JobRunModel.job_id == job_id)
+        if since is not None:
+            stmt = stmt.where(JobRunModel.started_at >= since)
+        if statuses is not None:
+            stmt = stmt.where(JobRunModel.status.in_([s.value for s in statuses]))
         result = await self._session.execute(stmt)
         return int(result.scalar_one())
 
@@ -89,6 +99,32 @@ class SqlAlchemyJobRunRepository(JobRunRepository):
             .join(ranked, JobRunModel.id == ranked.c.id)
             .where(ranked.c.rn == 1)
             .order_by(JobRunModel.job_id.asc())
+        )
+        result = await self._session.execute(stmt)
+        return [JobRunMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def recent_per_job(self, *, limit: int) -> Sequence[JobRun]:
+        """Return up to ``limit`` newest non-deleted runs per distinct job."""
+        row_number = (
+            func.row_number()
+            .over(
+                partition_by=JobRunModel.job_id,
+                order_by=(JobRunModel.started_at.desc(), JobRunModel.id.desc()),
+            )
+            .label("rn")
+        )
+        ranked = (
+            select(JobRunModel.id, row_number).where(JobRunModel.deleted_at.is_(None)).subquery()
+        )
+        stmt = (
+            select(JobRunModel)
+            .join(ranked, JobRunModel.id == ranked.c.id)
+            .where(ranked.c.rn <= limit)
+            .order_by(
+                JobRunModel.job_id.asc(),
+                JobRunModel.started_at.desc(),
+                JobRunModel.id.desc(),
+            )
         )
         result = await self._session.execute(stmt)
         return [JobRunMapper.to_entity(m) for m in result.scalars().all()]

--- a/src/modules/media/infrastructure/scheduling/scheduler_controller.py
+++ b/src/modules/media/infrastructure/scheduling/scheduler_controller.py
@@ -1,0 +1,30 @@
+"""Adapter exposing the live ``LibraryScanScheduler`` control surface."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.ports import SchedulerControlPort
+
+if TYPE_CHECKING:
+    from src.infrastructure.scheduling.scheduler_service import LibraryScanScheduler
+
+
+class LibraryScanSchedulerController(SchedulerControlPort):
+    """Maps the APScheduler-backed scheduler to the control port.
+
+    Holds the same ``LibraryScanScheduler`` singleton the lifespan
+    starts, so triggering acts on the jobs actually registered. When the
+    scheduler is disabled (never started) no jobs are registered and
+    ``trigger`` reports ``False``.
+    """
+
+    def __init__(self, scheduler: LibraryScanScheduler) -> None:
+        self._scheduler = scheduler
+
+    def trigger(self, job_id: str) -> bool:
+        """Reschedule ``job_id`` to run immediately."""
+        return self._scheduler.trigger_now(job_id)
+
+
+__all__ = ["LibraryScanSchedulerController"]

--- a/src/modules/media/presentation/routes/admin_jobs_routes.py
+++ b/src/modules/media/presentation/routes/admin_jobs_routes.py
@@ -4,15 +4,19 @@ from dataclasses import asdict
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
-from src.modules.media.application.dtos.job_dtos import ListJobRunsInput
+from src.modules.media.application.dtos.job_dtos import ListJobRunsInput, TriggerJobInput
 from src.modules.media.application.use_cases.list_job_runs import ListJobRunsUseCase
 from src.modules.media.application.use_cases.list_jobs import ListJobsUseCase
+from src.modules.media.application.use_cases.trigger_job import (
+    JobNotScheduledError,
+    TriggerJobUseCase,
+)
 
 router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Jobs"])
 
@@ -49,6 +53,32 @@ async def list_admin_job_runs(
         ListJobRunsInput(job_id=job_id, limit=limit, offset=offset),
     )
     return api_list([asdict(r) for r in rows])
+
+
+@router.post("/jobs/{job_id}/run", status_code=202)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def trigger_admin_job(
+    job_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: TriggerJobUseCase = Depends(
+        Provide[ApplicationContainer.trigger_job],
+    ),
+) -> dict[str, Any]:
+    """Run a scheduled job immediately ("run now").
+
+    Reschedules the registered job to fire on the next scheduler tick;
+    its execution is recorded in ``job_runs`` like any scheduled run, so
+    the dashboard reflects it within a poll cycle. Returns 202 with the
+    job id; 404 when the job isn't currently scheduled.
+    """
+    try:
+        await use_case.execute(TriggerJobInput(job_id=job_id))
+    except JobNotScheduledError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    return api_single("job_trigger", {"job_id": job_id, "triggered": True})
 
 
 __all__ = ["router"]

--- a/tests/infrastructure/scheduling/test_scheduler_service.py
+++ b/tests/infrastructure/scheduling/test_scheduler_service.py
@@ -35,6 +35,11 @@ from src.shared_kernel.value_objects.library_id import LibraryId
 class _FakeJob:
     def __init__(self, job_id: str) -> None:
         self.id = job_id
+        self.next_run_time: datetime | None = None
+
+    def modify(self, **changes: object) -> None:
+        if "next_run_time" in changes:
+            self.next_run_time = changes["next_run_time"]  # type: ignore[assignment]
 
 
 class _FakeScheduler:
@@ -60,6 +65,15 @@ class _FakeScheduler:
 
     def get_jobs(self) -> list[_FakeJob]:
         return [_FakeJob(jid) for jid in self.jobs]
+
+    def get_job(self, job_id: str) -> _FakeJob | None:
+        if job_id not in self.jobs:
+            return None
+        existing = self.jobs[job_id].get("_job")
+        if not isinstance(existing, _FakeJob):
+            existing = _FakeJob(job_id)
+            self.jobs[job_id]["_job"] = existing
+        return existing
 
 
 def _make_library(name: str = "Test", schedule: str | None = "0 * * * *") -> Library:
@@ -187,6 +201,23 @@ class TestReconcile:
 
         fake: _FakeScheduler = scheduler._scheduler
         assert _job_id_for(str(lib.id)) not in fake.jobs
+
+
+class TestTriggerNow:
+    def test_reschedules_registered_job_to_now(self, scheduler: LibraryScanScheduler) -> None:
+        fake: _FakeScheduler = scheduler._scheduler
+        fake.jobs["homeflix:thumbnail-backfill"] = {}
+
+        result = scheduler.trigger_now("homeflix:thumbnail-backfill")
+
+        assert result is True
+        job = fake.get_job("homeflix:thumbnail-backfill")
+        assert job is not None
+        assert job.next_run_time is not None
+        assert job.next_run_time <= datetime.now(UTC)
+
+    def test_returns_false_for_unknown_job(self, scheduler: LibraryScanScheduler) -> None:
+        assert scheduler.trigger_now("does-not-exist") is False
 
 
 class TestRunScan:

--- a/tests/modules/media/e2e/test_admin_jobs_routes.py
+++ b/tests/modules/media/e2e/test_admin_jobs_routes.py
@@ -15,6 +15,7 @@ from tests.modules.media.e2e.conftest import SeededUser
 LOGIN_PATH = "/api/v1/auth/cookie/login"
 JOBS_PATH = "/api/v1/admin/jobs"
 JOB_RUNS_PATH = "/api/v1/admin/jobs/runs"
+JOB_RUN_NOW_PATH = "/api/v1/admin/jobs/homeflix:thumbnail-backfill/run"
 
 
 async def _login(client: AsyncClient, user: SeededUser) -> None:
@@ -45,6 +46,7 @@ class TestAdminJobsAuth:
     async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
         assert (await client.get(JOBS_PATH)).status_code == 401
         assert (await client.get(JOB_RUNS_PATH)).status_code == 401
+        assert (await client.post(JOB_RUN_NOW_PATH)).status_code == 401
 
     async def test_member_returns_403(
         self,
@@ -54,6 +56,7 @@ class TestAdminJobsAuth:
         member = await seed_user_with_profile(email="member@example.com", is_admin=False)
         await _login(client, member)
         assert (await client.get(JOBS_PATH)).status_code == 403
+        assert (await client.post(JOB_RUN_NOW_PATH)).status_code == 403
 
 
 @pytest.mark.e2e
@@ -72,6 +75,8 @@ class TestAdminJobsOverview:
         assert body["type"] == "jobs_overview"
         assert body["data"]["scheduler_running"] is False
         assert body["data"]["jobs"] == []
+        assert body["data"]["executions_24h"] == 0
+        assert body["data"]["failures_24h"] == 0
 
     async def test_overview_surfaces_recorded_job_as_last_run(
         self,
@@ -89,6 +94,25 @@ class TestAdminJobsOverview:
         assert job["scheduled"] is False  # scheduler not started in e2e
         assert job["running"] is False
         assert job["last_run"]["status"] == "succeeded"
+        assert job["recent_runs"] == ["succeeded"]
+        assert body["data"]["executions_24h"] == 1
+        assert body["data"]["failures_24h"] == 0
+
+
+@pytest.mark.e2e
+class TestAdminJobTrigger:
+    async def test_run_now_unscheduled_job_returns_404(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        # The scheduler isn't started in e2e, so nothing is registered
+        # and "run now" reports the job as not scheduled.
+        await _login_as_admin(client, seed_user_with_profile)
+
+        response = await client.post(JOB_RUN_NOW_PATH)
+
+        assert response.status_code == 404
 
 
 @pytest.mark.e2e

--- a/tests/modules/media/integration/persistence/repositories/test_job_run_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_job_run_repository.py
@@ -1,5 +1,7 @@
 """Integration tests for SqlAlchemyJobRunRepository."""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -47,6 +49,52 @@ class TestLatestPerJob:
         assert set(by_job) == {"job-a", "job-b"}
         assert by_job["job-a"].status == JobRunStatus.FAILED
         assert by_job["job-b"].status == JobRunStatus.SUCCEEDED
+
+
+@pytest.mark.integration
+class TestRecentPerJob:
+    async def test_returns_up_to_limit_newest_per_job(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        for _ in range(5):
+            await repo.save(JobRun.start("job-a").succeed())
+        await repo.save(JobRun.start("job-a").fail("boom"))  # newest for job-a
+        await repo.save(JobRun.start("job-b").succeed())
+
+        recent = await repo.recent_per_job(limit=3)
+        by_job: dict[str, list[JobRun]] = {}
+        for run in recent:
+            by_job.setdefault(run.job_id, []).append(run)
+
+        assert len(by_job["job-a"]) == 3
+        assert len(by_job["job-b"]) == 1
+        # Newest-first within each job: the failed run leads job-a.
+        assert by_job["job-a"][0].status == JobRunStatus.FAILED
+
+
+@pytest.mark.integration
+class TestCountFilters:
+    async def test_count_since_excludes_older_runs(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        old = JobRun.start("job-a").with_updates(
+            started_at=datetime.now(UTC) - timedelta(days=2),
+        )
+        await repo.save(old.succeed())
+        await repo.save(JobRun.start("job-a").succeed())  # now
+
+        cutoff = datetime.now(UTC) - timedelta(hours=24)
+        assert await repo.count(since=cutoff) == 1
+        assert await repo.count() == 2
+
+    async def test_count_filters_by_statuses(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemyJobRunRepository(db_session)
+        await repo.save(JobRun.start("job-a").succeed())
+        await repo.save(JobRun.start("job-a").fail("boom"))
+        await repo.save(JobRun.start("job-b").mark_interrupted())
+
+        failures = await repo.count(
+            statuses=[JobRunStatus.FAILED, JobRunStatus.INTERRUPTED],
+        )
+        assert failures == 2
 
 
 @pytest.mark.integration

--- a/tests/modules/media/unit/application/use_cases/test_list_jobs.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_jobs.py
@@ -21,11 +21,25 @@ class _FakeInspector(SchedulerInspectorPort):
 
 
 class _FakeJobRuns:
-    def __init__(self, latest: list[JobRun]) -> None:
-        self._latest = latest
+    def __init__(self, recent: list[JobRun]) -> None:
+        # Stored newest-first within each job, matching the real repo.
+        self._recent = recent
 
-    async def latest_per_job(self) -> list[JobRun]:
-        return self._latest
+    async def recent_per_job(self, *, limit: int) -> list[JobRun]:
+        by_job: dict[str, list[JobRun]] = {}
+        for run in self._recent:
+            by_job.setdefault(run.job_id, []).append(run)
+        out: list[JobRun] = []
+        for runs in by_job.values():
+            out.extend(runs[:limit])
+        return out
+
+    async def count(self, *, job_id=None, since=None, statuses=None) -> int:
+        runs = self._recent
+        if statuses is not None:
+            allowed = set(statuses)
+            runs = [r for r in runs if r.status in allowed]
+        return len(runs)
 
 
 class _FakeUoW:
@@ -44,10 +58,10 @@ def _run(job_id: str, status: JobRunStatus) -> JobRun:
     return run if status == JobRunStatus.RUNNING else run.with_updates(status=status)
 
 
-def _use_case(snapshot: SchedulerSnapshot, latest: list[JobRun]) -> ListJobsUseCase:
+def _use_case(snapshot: SchedulerSnapshot, recent: list[JobRun]) -> ListJobsUseCase:
     return ListJobsUseCase(
         scheduler_inspector=_FakeInspector(snapshot),
-        media_uow_factory=lambda: _FakeUoW(_FakeJobRuns(latest)),  # type: ignore[arg-type]
+        media_uow_factory=lambda: _FakeUoW(_FakeJobRuns(recent)),  # type: ignore[arg-type]
     )
 
 
@@ -97,3 +111,38 @@ class TestListJobs:
         assert job.scheduled is False
         assert job.schedule is None
         assert job.last_run is not None
+
+    @pytest.mark.asyncio
+    async def test_recent_runs_are_oldest_first(self) -> None:
+        snapshot = SchedulerSnapshot(
+            running=True,
+            jobs=[ScheduledJob(job_id="job-a", next_run_at=None, schedule="i")],
+        )
+        # Repo order is newest-first: failed (newest) then succeeded.
+        recent = [
+            _run("job-a", JobRunStatus.FAILED),
+            _run("job-a", JobRunStatus.SUCCEEDED),
+        ]
+        use_case = _use_case(snapshot, recent)
+
+        out = await use_case.execute()
+
+        # Strip reads left (old) to right (new): the failure is last.
+        assert out.jobs[0].recent_runs == ["succeeded", "failed"]
+        assert out.jobs[0].last_run is not None
+        assert out.jobs[0].last_run.status == "failed"
+
+    @pytest.mark.asyncio
+    async def test_aggregates_executions_and_failures(self) -> None:
+        snapshot = SchedulerSnapshot(running=True, jobs=[])
+        recent = [
+            _run("job-a", JobRunStatus.SUCCEEDED),
+            _run("job-a", JobRunStatus.FAILED),
+            _run("job-b", JobRunStatus.INTERRUPTED),
+        ]
+        use_case = _use_case(snapshot, recent)
+
+        out = await use_case.execute()
+
+        assert out.executions_24h == 3
+        assert out.failures_24h == 2

--- a/tests/modules/media/unit/application/use_cases/test_trigger_job.py
+++ b/tests/modules/media/unit/application/use_cases/test_trigger_job.py
@@ -1,0 +1,42 @@
+"""Tests for TriggerJobUseCase (admin "run now")."""
+
+import pytest
+
+from src.modules.media.application.dtos.job_dtos import TriggerJobInput
+from src.modules.media.application.ports import SchedulerControlPort
+from src.modules.media.application.use_cases.trigger_job import (
+    JobNotScheduledError,
+    TriggerJobUseCase,
+)
+
+
+class _FakeControl(SchedulerControlPort):
+    def __init__(self, *, found: bool) -> None:
+        self._found = found
+        self.triggered: list[str] = []
+
+    def trigger(self, job_id: str) -> bool:
+        self.triggered.append(job_id)
+        return self._found
+
+
+@pytest.mark.unit
+class TestTriggerJob:
+    @pytest.mark.asyncio
+    async def test_triggers_registered_job(self) -> None:
+        control = _FakeControl(found=True)
+        use_case = TriggerJobUseCase(scheduler_control=control)
+
+        await use_case.execute(TriggerJobInput(job_id="homeflix:thumbnail-backfill"))
+
+        assert control.triggered == ["homeflix:thumbnail-backfill"]
+
+    @pytest.mark.asyncio
+    async def test_raises_when_job_not_scheduled(self) -> None:
+        control = _FakeControl(found=False)
+        use_case = TriggerJobUseCase(scheduler_control=control)
+
+        with pytest.raises(JobNotScheduledError) as excinfo:
+            await use_case.execute(TriggerJobInput(job_id="ghost"))
+
+        assert excinfo.value.job_id == "ghost"


### PR DESCRIPTION
## Summary

- Expose **recent run outcomes per job** (`recent_runs`) on `GET /admin/jobs` to drive the dashboard's run-health strip — backed by a new `JobRunRepository.recent_per_job(limit)` (newest-first per job via window function).
- Expose **24h aggregates** (`executions_24h`, `failures_24h`) on the overview, via an extended `count(..., since=, statuses=)`.
- Add **run now**: `POST /admin/jobs/{job_id}/run` reschedules a registered job to fire immediately (`next_run_time=now`, regular cadence preserved). New `SchedulerControlPort` + `LibraryScanSchedulerController` keep the read-only inspector path side-effect free; `TriggerJobUseCase` raises `JobNotScheduledError` → 404 when the job isn't currently registered.
- The manual run flows through the existing recorded wrapper, so it shows up in `job_runs` (running → succeeded/failed) like a scheduled tick.

No schema changes — `make migrate` not required.

## Test plan

- [x] `pytest tests/modules/media` — 1602 passed
- [x] Repo: `recent_per_job` limit/ordering, `count` `since`/`statuses`
- [x] Use case: `recent_runs` ordering (oldest-first), 24h aggregates
- [x] Use case: `TriggerJobUseCase` triggers / raises when not scheduled
- [x] Scheduler: `trigger_now` reschedules / returns False for unknown job
- [x] e2e: auth (401/403), overview shape with new fields, run-now 404 when unscheduled
- [x] `ruff check` + `ruff format`

## Summary by Sourcery

Enrich the media admin jobs dashboard with recent run history, 24-hour aggregates, and a "run now" capability for scheduled jobs.

New Features:
- Expose recent run outcomes per job and 24-hour execution/failure aggregates on the admin jobs overview payload.
- Add an authenticated admin endpoint to trigger an individual scheduled job to run immediately while preserving its existing schedule.

Enhancements:
- Extend the job run repository and domain port to support time/status-filtered counts and fetching multiple recent runs per job for dashboard use.
- Introduce a scheduler control port and concrete controller to safely issue write-side commands to the live scheduler without affecting read-only inspection paths.

Tests:
- Add unit, integration, and end-to-end tests covering recent job runs ordering, 24-hour aggregates, repository filtering, scheduler trigger behavior, auth for the new endpoint, and error handling when triggering unscheduled jobs.