### PR TITLE
feat(catalog-requests): per-user subscriptions + arrival fanout (ADR-022)

### DIFF
--- a/docs/adr/ADR-022-catalog-requests-subscriptions-fanout.md
+++ b/docs/adr/ADR-022-catalog-requests-subscriptions-fanout.md
@@ -19,7 +19,7 @@ O redesign de UI (handoff) pressupõe um sistema multi-inscrito: contagem de "{N
 
 Vamos **separar "o título está na fila" de "quem quer ser avisado"**, introduzindo subscriptions por-usuário com fanout.
 
-1. **`CatalogSubscription` como agregado próprio** (id `csub_xxx`), referenciando `request_id` + `user_id`, com invariante de unicidade por `(request_id, user_id)`. **Não** é coleção dentro do `CatalogRequest` — manter o agregado-raiz pequeno e a relação um-para-muitos como query de repositório (`count_by_request`, `list_for_user`, `exists`, `add`, `remove`).
+1. **`CatalogSubscription` como agregado próprio** (id `sub_xxx`), referenciando `request_id` + `user_id`, com invariante de unicidade por `(request_id, user_id)`. **Não** é coleção dentro do `CatalogRequest` — manter o agregado-raiz pequeno e a relação um-para-muitos como query de repositório (`count_by_request`, `list_for_user`, `exists`, `add`, `remove`).
 
 2. **`CatalogRequest` continua sendo "o título na fila"** (a peça que o admin gerencia). O campo `requester_user_id` muda de semântica: deixa de ser o alvo da notificação e passa a ser **atribuição de origem** (quem primeiro colocou na fila) — alimenta `source` e `requestedBy`.
 
@@ -85,7 +85,7 @@ Cada (usuário, título) é uma linha; a fila é o group-by.
 - Handoff de design: `specs/design_handoff_catalog_requests/README.md`
 - ADR-009 Cross-BC Read Ports + ACL (padrão do `NotificationPublisherPort` usado no fanout)
 - ADR-018 Identificadores de Domínio como Value Objects nas Fronteiras (id do novo agregado)
-- ADR-002 Prefixed External IDs (`csub_xxx`)
+- ADR-002 Prefixed External IDs (`sub_xxx`, prefixo de 3 chars como a convenção)
 
 ---
 
@@ -94,7 +94,7 @@ Cada (usuário, título) é uma linha; a fila é o group-by.
 ```
 Tabela catalog_subscriptions:
   id            INTEGER PK
-  external_id   VARCHAR  ("csub_xxx")
+  external_id   VARCHAR  ("sub_xxx")
   request_id    VARCHAR  FK → catalog_requests.external_id  (index)
   user_id       VARCHAR  (index)
   created_at    DateTime(tz)

--- a/docs/adr/ADR-022-catalog-requests-subscriptions-fanout.md
+++ b/docs/adr/ADR-022-catalog-requests-subscriptions-fanout.md
@@ -1,0 +1,118 @@
+# ADR-022: Subscriptions Multi-Usuário + Fanout em Catalog Requests
+
+**Status:** Aceito
+**Data:** 2026-06-23
+**Deciders:** Lucas Cristovam
+**Technical Story:** Feature "Catalog requests / Avisar quando chegar / Em breve" (handoff em `specs/design_handoff_catalog_requests/`). Habilitar página consumer "Em breve", contagem de inscritos, e o aviso "já disponível" para todos. Branch `feat/catalog-requests-subscriptions`.
+
+---
+
+## Contexto
+
+O bounded context `catalog_requests` modela hoje **uma linha por título**: `CatalogRequest` é keyed por `(tmdb_id, media_type)` e carrega um **único** `requester_user_id` + um booleano `notify_on_arrival`. Quando o título entra no catálogo, o `OnMediaEnrichedHandler` reage ao `MediaEnrichedEvent`, casa o pedido pendente por `(tmdb_id, media_type)` exato, marca `fulfilled_at` e — **só** se `notify_on_arrival` e `requester_user_id` estiverem setados — publica **uma** notificação `catalog_request_fulfilled` para esse único usuário.
+
+A regra `reconcile` é "first-owner-wins": se um segundo usuário pede o mesmo título, o pedido existente é reconciliado mas o `requester_user_id` **continua sendo o primeiro**. Consequência: num household multi-usuário, **apenas o primeiro solicitante é avisado quando o título chega** — os demais interessados ficam de fora silenciosamente. É um bug latente do modelo single-owner.
+
+O redesign de UI (handoff) pressupõe um sistema multi-inscrito: contagem de "{N} pessoas aguardando", coluna "Inscritos" no admin, e a ação "Marcar como incluído" que "notifica todos os inscritos de uma vez". Nenhuma dessas três coisas é representável no modelo atual de 1-linha-com-1-dono.
+
+## Decisão
+
+Vamos **separar "o título está na fila" de "quem quer ser avisado"**, introduzindo subscriptions por-usuário com fanout.
+
+1. **`CatalogSubscription` como agregado próprio** (id `csub_xxx`), referenciando `request_id` + `user_id`, com invariante de unicidade por `(request_id, user_id)`. **Não** é coleção dentro do `CatalogRequest` — manter o agregado-raiz pequeno e a relação um-para-muitos como query de repositório (`count_by_request`, `list_for_user`, `exists`, `add`, `remove`).
+
+2. **`CatalogRequest` continua sendo "o título na fila"** (a peça que o admin gerencia). O campo `requester_user_id` muda de semântica: deixa de ser o alvo da notificação e passa a ser **atribuição de origem** (quem primeiro colocou na fila) — alimenta `source` e `requestedBy`.
+
+3. **Fanout:** tanto o `OnMediaEnrichedHandler` (chegada automática) quanto o "Marcar como incluído" manual iteram as subscriptions do request e publicam **uma notificação por inscrito**.
+
+4. **`source: user | household`** vira campo do `CatalogRequest`, derivado na criação: pedido iniciado por um membro = `user` (com `requester_user_id`); criado pelo sistema/flag da casa = `household`.
+
+5. **Status honesto/fino:** o status exposto é **derivado de `fulfilled_at`** (`pendente` / `disponível`), não um enum de pipeline. Os estados `processing`/`waiting_file`/`matching` do handoff descrevem um pipeline que o sistema **não rastreia** — seriam fictícios e enganosos. Ficam de fora; há espaço para um `preso` derivado no futuro (pendente + título já no catálogo sob outro tmdb_id).
+
+6. **Unsubscribe** passa a existir (remover a subscription). O `CatalogRequest` **persiste mesmo com zero subscriptions** — a fila é sobre títulos a caminho, independente de interesse de aviso. O booleano `notify_on_arrival` é aposentado: "estar inscrito" = existir uma subscription.
+
+## Consequências
+
+### Positivas
+
+- Corrige o bug latente: **todos** os interessados num household são avisados quando o título chega.
+- Habilita contagem de inscritos, social proof e "notificar todos" — base para a página "Em breve" e a página admin redesenhada.
+- Unsubscribe possível (o modelo one-way atual não permitia desligar o aviso).
+- Separação limpa título-vs-interesse: agregados pequenos, queries diretas por `user_id`/`request_id`, sem agregado ilimitado.
+- Status derivado é honesto — a UI não promete granularidade de pipeline que o backend não tem.
+
+### Negativas
+
+- Nova tabela `catalog_subscriptions` + migration **com backfill** (cada request existente com `notify_on_arrival=true` + `requester_user_id` vira 1 subscription).
+- Fanout gera N notificações por chegada (N pequeno no contexto doméstico — custo desprezível, mas é mais trabalho que 1).
+- Mais superfície: novos use cases (subscribe/unsubscribe/include/contagens), novos endpoints, novo agregado e repositório.
+- A coluna "Status" do admin fica de baixo valor no v1 (quase tudo "pendente") — aceito conscientemente em troca de honestidade.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Backfill perder/duplicar subscriptions na migração | Média | Médio | Migration idempotente derivando 1 sub por request elegível; teste de integração do backfill |
+| Pedido órfão (tmdb_id diferente no enrich) nunca casa → inscritos nunca avisados | Média | Médio | Ação manual "Marcar como incluído" como resgate; futuro: re-tentar casar pendências no relink |
+| Volume de notificações no fanout | Baixa | Baixo | Contexto doméstico (poucos usuários); publish já é fire-and-forget |
+
+## Alternativas Consideradas
+
+### 1. Manter single-owner (não fazer nada)
+
+Continuar com 1 `requester_user_id` por título.
+
+**Rejeitado porque:** mantém o bug multi-usuário e não suporta contagens/fanout/"notificar todos" que o redesign exige.
+
+### 2. Subscriptions como coleção dentro do agregado `CatalogRequest`
+
+Carregar todas as subscriptions junto com o request.
+
+**Rejeitado porque:** vira agregado **ilimitado** — um título popular força carregar todas as subscriptions só pra adicionar/remover uma, e contagem exige materializar a coleção inteira. Viola "agregados pequenos".
+
+### 3. Reshape em linhas por-`(user, título)` (sem entidade de request separada)
+
+Cada (usuário, título) é uma linha; a fila é o group-by.
+
+**Rejeitado porque:** os metadados do título (`source`, `fulfilled_at`, status) ficam duplicados/ambíguos entre linhas, e a fila admin é inerentemente por-título — o group-by complica leitura e arquivamento.
+
+### 4. Status de pipeline completo (`processing`/`waiting_file`/`matching`)
+
+**Rejeitado porque:** nada no backend rastreia esses estados; exporiam granularidade fictícia. Status derivado de `fulfilled_at` é o que o sistema honestamente sabe.
+
+## Referências
+
+- Handoff de design: `specs/design_handoff_catalog_requests/README.md`
+- ADR-009 Cross-BC Read Ports + ACL (padrão do `NotificationPublisherPort` usado no fanout)
+- ADR-018 Identificadores de Domínio como Value Objects nas Fronteiras (id do novo agregado)
+- ADR-002 Prefixed External IDs (`csub_xxx`)
+
+---
+
+## Notas de Implementação
+
+```
+Tabela catalog_subscriptions:
+  id            INTEGER PK
+  external_id   VARCHAR  ("csub_xxx")
+  request_id    VARCHAR  FK → catalog_requests.external_id  (index)
+  user_id       VARCHAR  (index)
+  created_at    DateTime(tz)
+  deleted_at    DateTime(tz) NULL
+  UNIQUE(request_id, user_id) WHERE deleted_at IS NULL   -- parcial (convenção do projeto)
+
+Fanout (OnMediaEnrichedHandler + IncludeCatalogRequestUseCase):
+  subs = subscription_repo.list_for_request(request_id)
+  for sub in subs:
+      publisher.publish(CatalogArrivalNotification(recipient_user_id=sub.user_id, ...))
+
+Backfill (migration):
+  para cada catalog_request com notify_on_arrival = TRUE e requester_user_id IS NOT NULL:
+      INSERT catalog_subscriptions(request_id, user_id=requester_user_id, ...)
+```
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-06-23 | Lucas Cristovam | Criação inicial |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-019](./ADR-019-hardware-accelerated-transcoding.md) | Transcodificação por Hardware (NVENC/NVDEC) com Seleção de Encoder Configurável | ✅ Aceito | 2026-06-14 |
 | [ADR-020](./ADR-020-pluggable-intro-detector-frame-hash.md) | Detector de Intro Plugável + Algoritmo por Frame-Hash de Vídeo | ✅ Aceito | 2026-06-15 |
 | [ADR-021](./ADR-021-credits-detector-per-file-visual.md) | Detector de Créditos Per-Arquivo por Sinais Visuais (Borda + Movimento) | ✅ Aceito | 2026-06-19 |
+| [ADR-022](./ADR-022-catalog-requests-subscriptions-fanout.md) | Subscriptions Multi-Usuário + Fanout em Catalog Requests | ✅ Aceito | 2026-06-23 |
 
 ## Como Criar um Novo ADR
 

--- a/migrations/versions/2026_06_23_add_catalog_subscriptions.py
+++ b/migrations/versions/2026_06_23_add_catalog_subscriptions.py
@@ -1,0 +1,161 @@
+"""Create catalog_subscriptions table + backfill from catalog_requests.
+
+ADR-022 splits "the title is in the queue" (``catalog_requests``)
+from "who wants to be notified" (this table). Each row is one user's
+opt-in to a queued title's arrival ping — the per-user fanout layer
+the single-owner model lacked.
+
+``(request_id, user_id)`` is unique among live rows so a repeat
+"Avisar quando chegar" stays idempotent. The backfill turns every
+existing request that had ``notify_on_arrival = TRUE`` and a known
+``requester_user_id`` into one subscription, so nobody who was
+already waiting loses their notification when the model flips.
+
+Revision ID: 7a1c93b5e2d8
+Revises: aa11bb22cc33
+Create Date: 2026-06-23 18:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+import secrets
+import string
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "7a1c93b5e2d8"
+down_revision: str | Sequence[str] | None = "aa11bb22cc33"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_LIVE = text("deleted_at IS NULL")
+
+# Base62 id generation, inlined so the migration stays independent of
+# the app's domain code (avoids schema-vs-code drift). Mirrors
+# ``ExternalId.generate()``: ``sub_`` + 12 base62 chars.
+_BASE62 = string.ascii_letters + string.digits
+
+
+def _gen_subscription_id() -> str:
+    return "sub_" + "".join(secrets.choice(_BASE62) for _ in range(12))
+
+
+def upgrade() -> None:
+    """Create ``catalog_subscriptions`` and backfill existing opt-ins."""
+    op.create_table(
+        "catalog_subscriptions",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("external_id", sa.String(length=50), nullable=False),
+        sa.Column("request_id", sa.String(length=50), nullable=False),
+        sa.Column("user_id", sa.String(length=50), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_catalog_subscriptions_external_id",
+        "catalog_subscriptions",
+        ["external_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_catalog_subscriptions_request_id",
+        "catalog_subscriptions",
+        ["request_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_subscriptions_user_id",
+        "catalog_subscriptions",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_catalog_subscriptions_deleted_at",
+        "catalog_subscriptions",
+        ["deleted_at"],
+        unique=False,
+    )
+    # One live subscription per (request, user) — partial so a
+    # soft-deleted unsubscribe doesn't block re-subscribing.
+    op.create_index(
+        "uq_catalog_subscriptions_request_user",
+        "catalog_subscriptions",
+        ["request_id", "user_id"],
+        unique=True,
+        sqlite_where=_LIVE,
+        postgresql_where=_LIVE,
+    )
+
+    _backfill_from_requests()
+
+
+def _backfill_from_requests() -> None:
+    """Seed one subscription per already-opted-in request."""
+    connection = op.get_bind()
+    rows = connection.execute(
+        text(
+            "SELECT external_id, requester_user_id "
+            "FROM catalog_requests "
+            "WHERE notify_on_arrival = :flag "
+            "AND requester_user_id IS NOT NULL "
+            "AND deleted_at IS NULL"
+        ),
+        {"flag": True},
+    ).fetchall()
+
+    for request_external_id, requester_user_id in rows:
+        connection.execute(
+            text(
+                "INSERT INTO catalog_subscriptions "
+                "(external_id, request_id, user_id) "
+                "VALUES (:eid, :rid, :uid)"
+            ),
+            {
+                "eid": _gen_subscription_id(),
+                "rid": request_external_id,
+                "uid": requester_user_id,
+            },
+        )
+
+
+def downgrade() -> None:
+    """Drop the ``catalog_subscriptions`` table."""
+    op.drop_index(
+        "uq_catalog_subscriptions_request_user",
+        table_name="catalog_subscriptions",
+    )
+    op.drop_index(
+        "ix_catalog_subscriptions_deleted_at",
+        table_name="catalog_subscriptions",
+    )
+    op.drop_index(
+        "ix_catalog_subscriptions_user_id",
+        table_name="catalog_subscriptions",
+    )
+    op.drop_index(
+        "ix_catalog_subscriptions_request_id",
+        table_name="catalog_subscriptions",
+    )
+    op.drop_index(
+        "ix_catalog_subscriptions_external_id",
+        table_name="catalog_subscriptions",
+    )
+    op.drop_table("catalog_subscriptions")

--- a/src/config/containers/catalog_requests.py
+++ b/src/config/containers/catalog_requests.py
@@ -7,6 +7,7 @@ from src.modules.catalog_requests.application.use_cases import (
     ListCatalogRequestsUseCase,
     RequestCatalogInclusionUseCase,
     SubscribeCatalogNotificationUseCase,
+    UnsubscribeCatalogNotificationUseCase,
 )
 from src.modules.catalog_requests.infrastructure.acl import CatalogRequestLookupAdapter
 from src.modules.catalog_requests.infrastructure.persistence.sqlalchemy_unit_of_work import (
@@ -57,6 +58,11 @@ class CatalogRequestsContainer(containers.DeclarativeContainer):  # type: ignore
 
     subscribe_catalog_notification = providers.Factory(
         SubscribeCatalogNotificationUseCase,
+        uow_factory=catalog_requests_unit_of_work_factory,
+    )
+
+    unsubscribe_catalog_notification = providers.Factory(
+        UnsubscribeCatalogNotificationUseCase,
         uow_factory=catalog_requests_unit_of_work_factory,
     )
 

--- a/src/modules/catalog_requests/application/dtos/__init__.py
+++ b/src/modules/catalog_requests/application/dtos/__init__.py
@@ -5,6 +5,7 @@ from src.modules.catalog_requests.application.dtos.catalog_request_dtos import (
     CreateCatalogRequestInput,
     DismissCatalogRequestInput,
     SubscribeCatalogNotificationInput,
+    UnsubscribeCatalogNotificationInput,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "CreateCatalogRequestInput",
     "DismissCatalogRequestInput",
     "SubscribeCatalogNotificationInput",
+    "UnsubscribeCatalogNotificationInput",
 ]

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -49,6 +49,27 @@ class SubscribeCatalogNotificationInput:
 
 
 @dataclass(frozen=True)
+class UnsubscribeCatalogNotificationInput:
+    """Input for ``UnsubscribeCatalogNotificationUseCase``.
+
+    The "Você será avisado → desligar" toggle on the consumer side.
+    Identifies the title by its TMDB target (every member entry point
+    speaks TMDB ids) plus the acting user, so we drop only that user's
+    subscription and leave the request — and everyone else's
+    subscriptions — in place.
+
+    Attributes:
+        tmdb_id: TMDB numeric id of the title to stop following.
+        media_type: Whether the target is a movie or a series.
+        user_id: External id (``usr_xxx``) of the user unsubscribing.
+    """
+
+    tmdb_id: int
+    media_type: MediaType
+    user_id: str
+
+
+@dataclass(frozen=True)
 class DismissCatalogRequestInput:
     """Input for ``DismissCatalogRequestUseCase``.
 

--- a/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
+++ b/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
@@ -34,13 +34,14 @@ class OnMediaEnrichedHandler(EventHandler):
     title). Already-fulfilled request → no-op (the event fired
     again after a force-refresh).
 
-    When fulfillment succeeds AND the requester opted in to
-    arrival notifications AND we know who they are, the handler
-    pings them through the optional ``NotificationPublisherPort``.
-    The publisher is optional so tests / earlier slices of the
-    rollout can run without the Notifications BC wired in —
-    fulfillment still closes the loop on the admin queue either
-    way.
+    When fulfillment succeeds, the handler fans a "title now
+    available" ping out to every active ``CatalogSubscription`` on
+    the request (ADR-022) through the optional
+    ``NotificationPublisherPort`` — one notification per subscriber,
+    not just the original requester. The publisher is optional so
+    tests / earlier slices of the rollout can run without the
+    Notifications BC wired in — fulfillment still closes the loop on
+    the admin queue either way.
 
     Runs out of the event bus, which is fire-and-forget — failures
     here don't roll back the enrichment that just succeeded. A
@@ -75,6 +76,7 @@ class OnMediaEnrichedHandler(EventHandler):
         if media_type is None:
             return
 
+        subscriber_ids: list[str] = []
         async with self._uow_factory() as uow:
             existing = await uow.catalog_requests.find_by_tmdb_id(
                 event.tmdb_id,
@@ -84,16 +86,25 @@ class OnMediaEnrichedHandler(EventHandler):
                 return
             fulfilled = existing.mark_fulfilled()
             await uow.catalog_requests.update(fulfilled)
+            # Collect subscribers inside the UoW so the fanout has the
+            # list once the session closes. Skip the query entirely when
+            # there's no publisher wired (earlier rollout slices / tests).
+            if self._notification_publisher is not None:
+                subscriptions = await uow.catalog_subscriptions.list_for_request(
+                    existing.id,
+                )
+                subscriber_ids = [sub.user_id for sub in subscriptions]
 
         _logger.info(
-            "Fulfilled catalog request %s (tmdb/%s/%s → media %s)",
+            "Fulfilled catalog request %s (tmdb/%s/%s → media %s); %d subscriber(s)",
             existing.id,
             event.media_type,
             event.tmdb_id,
             event.media_id,
+            len(subscriber_ids),
         )
 
-        await self._maybe_publish_arrival(existing, event)
+        await self._publish_arrivals(existing, event, subscriber_ids)
 
     @staticmethod
     def _normalize_media_type(raw: str) -> MediaType | None:
@@ -117,45 +128,43 @@ class OnMediaEnrichedHandler(EventHandler):
             )
             return None
 
-    async def _maybe_publish_arrival(
+    async def _publish_arrivals(
         self,
         request: CatalogRequest,
         event: MediaEnrichedEvent,
+        subscriber_ids: list[str],
     ) -> None:
-        """Dispatch the user-facing notification when conditions allow.
+        """Fan the "title now available" notification out to every subscriber.
 
-        Conditions: publisher wired, the requester opted in, the
-        requester is known, and we have a title to show. The
-        title falls back to the bare TMDB id when no snapshot
-        exists on the request, so legacy rows still produce a
-        readable row instead of a blank.
+        One ping per ``CatalogSubscription`` on the request (ADR-022),
+        replacing the old single-requester path. The title falls back
+        to the bare TMDB id when no snapshot exists on the request, so
+        legacy rows still produce a readable row instead of a blank.
+        Each publish is isolated: a failure for one subscriber is
+        logged and swallowed so it can't block the others or roll back
+        the fulfillment already committed.
         """
-        if self._notification_publisher is None:
-            return
-        if not request.notify_on_arrival:
-            return
-        if request.requester_user_id is None:
+        if self._notification_publisher is None or not subscriber_ids:
             return
 
-        try:
-            await self._notification_publisher.publish_catalog_arrival(
-                CatalogArrivalNotification(
-                    recipient_user_id=request.requester_user_id,
-                    title=request.title or f"tmdb/{event.media_type}/{event.tmdb_id}",
-                    tmdb_id=event.tmdb_id,
-                    media_id=event.media_id,
-                    media_type=event.media_type,
-                ),
-            )
-        except Exception:
-            # Fire-and-forget: a publisher failure can't roll back
-            # the catalog-request update we already committed. Log
-            # and move on — the worst case is the user doesn't see
-            # the badge for this title.
-            _logger.exception(
-                "Failed to publish catalog-arrival notification for request %s",
-                request.id,
-            )
+        title = request.title or f"tmdb/{event.media_type}/{event.tmdb_id}"
+        for user_id in subscriber_ids:
+            try:
+                await self._notification_publisher.publish_catalog_arrival(
+                    CatalogArrivalNotification(
+                        recipient_user_id=user_id,
+                        title=title,
+                        tmdb_id=event.tmdb_id,
+                        media_id=event.media_id,
+                        media_type=event.media_type,
+                    ),
+                )
+            except Exception:
+                _logger.exception(
+                    "Failed to publish catalog-arrival notification for request %s to user %s",
+                    request.id,
+                    user_id,
+                )
 
 
 __all__ = ["OnMediaEnrichedHandler"]

--- a/src/modules/catalog_requests/application/unit_of_work.py
+++ b/src/modules/catalog_requests/application/unit_of_work.py
@@ -3,13 +3,17 @@
 from abc import ABC, abstractmethod
 
 from src.building_blocks.application.unit_of_work import UnitOfWork
-from src.modules.catalog_requests.domain.repositories import CatalogRequestRepository
+from src.modules.catalog_requests.domain.repositories import (
+    CatalogRequestRepository,
+    CatalogSubscriptionRepository,
+)
 
 
 class CatalogRequestsUnitOfWork(UnitOfWork):
     """Transactional boundary for catalog-request writes."""
 
     catalog_requests: CatalogRequestRepository
+    catalog_subscriptions: CatalogSubscriptionRepository
 
 
 class CatalogRequestsUnitOfWorkFactory(ABC):

--- a/src/modules/catalog_requests/application/use_cases/__init__.py
+++ b/src/modules/catalog_requests/application/use_cases/__init__.py
@@ -12,10 +12,14 @@ from src.modules.catalog_requests.application.use_cases.request_catalog_inclusio
 from src.modules.catalog_requests.application.use_cases.subscribe_catalog_notification import (
     SubscribeCatalogNotificationUseCase,
 )
+from src.modules.catalog_requests.application.use_cases.unsubscribe_catalog_notification import (
+    UnsubscribeCatalogNotificationUseCase,
+)
 
 __all__ = [
     "DismissCatalogRequestUseCase",
     "ListCatalogRequestsUseCase",
     "RequestCatalogInclusionUseCase",
     "SubscribeCatalogNotificationUseCase",
+    "UnsubscribeCatalogNotificationUseCase",
 ]

--- a/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
+++ b/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
@@ -5,20 +5,29 @@ from src.modules.catalog_requests.application.dtos import (
     SubscribeCatalogNotificationInput,
 )
 from src.modules.catalog_requests.application.unit_of_work import (
+    CatalogRequestsUnitOfWork,
     CatalogRequestsUnitOfWorkFactory,
 )
-from src.modules.catalog_requests.domain.entities import CatalogRequest
+from src.modules.catalog_requests.domain.entities import (
+    CatalogRequest,
+    CatalogSubscription,
+)
+from src.modules.catalog_requests.domain.value_objects import CatalogRequestId
 
 
 class SubscribeCatalogNotificationUseCase:
     """Idempotent "Avisar quando chegar" handler.
 
-    Sets ``notify_on_arrival=True`` on an existing request, or
-    creates one in the same call when the user clicks "Avisar
-    quando chegar" without having clicked "Solicitar inclusão"
-    first. Either entry point produces the same end state, which
-    is what the UI assumes when it renders the two buttons side
-    by side on the missing-from-catalog FilmRow.
+    Ensures the title's request row exists (creating it in the same
+    call when the user clicks "Avisar quando chegar" without having
+    clicked "Solicitar inclusão" first), then records a per-user
+    ``CatalogSubscription`` so the arrival fanout reaches this user
+    (ADR-022). ``notify_on_arrival`` is kept as a denormalized
+    "has ≥1 subscriber" flag for the read-side CTA.
+
+    Idempotent on both halves: a repeat call neither duplicates the
+    request (keyed on ``(tmdb_id, media_type)``) nor the subscription
+    (keyed on ``(request, user)``).
 
     Example:
         >>> uc = SubscribeCatalogNotificationUseCase(uow_factory)
@@ -55,27 +64,50 @@ class SubscribeCatalogNotificationUseCase:
             )
             if existing is not None:
                 # Same merge as the "Solicitar inclusão" path, but this
-                # entry point always wants the notification on.
+                # entry point always wants the notification flag on.
                 reconciled = existing.reconcile(
                     title=input_dto.title,
                     requester_user_id=input_dto.requester_user_id,
                     notify=True,
                 )
-                if reconciled is None:
-                    return CatalogRequestOutput.from_entity(existing)
-                persisted = await uow.catalog_requests.update(reconciled)
-                return CatalogRequestOutput.from_entity(persisted)
+                request = (
+                    existing
+                    if reconciled is None
+                    else await uow.catalog_requests.update(reconciled)
+                )
+            else:
+                request = await uow.catalog_requests.add(
+                    CatalogRequest.create(
+                        tmdb_id=input_dto.tmdb_id,
+                        media_type=input_dto.media_type,
+                        title=input_dto.title,
+                        requester_user_id=input_dto.requester_user_id,
+                        collection_tmdb_id=input_dto.collection_tmdb_id,
+                        notify_on_arrival=True,
+                    ),
+                )
 
-            request = CatalogRequest.create(
-                tmdb_id=input_dto.tmdb_id,
-                media_type=input_dto.media_type,
-                title=input_dto.title,
-                requester_user_id=input_dto.requester_user_id,
-                collection_tmdb_id=input_dto.collection_tmdb_id,
-                notify_on_arrival=True,
+            await self._ensure_subscription(uow, request.id, input_dto.requester_user_id)
+            return CatalogRequestOutput.from_entity(request)
+
+    @staticmethod
+    async def _ensure_subscription(
+        uow: CatalogRequestsUnitOfWork,
+        request_id: CatalogRequestId | None,
+        user_id: str | None,
+    ) -> None:
+        """Add a subscription for ``user_id`` unless one already exists.
+
+        No-op for an anonymous call (``user_id`` is ``None``) — there
+        is no inbox to fan out to, so only the denormalized
+        ``notify_on_arrival`` flag carries that legacy intent.
+        """
+        if user_id is None or request_id is None:
+            return
+        if await uow.catalog_subscriptions.find(request_id, user_id) is None:
+            await uow.catalog_subscriptions.add(
+                CatalogSubscription.create(request_id=request_id, user_id=user_id),
             )
-            persisted = await uow.catalog_requests.add(request)
-            return CatalogRequestOutput.from_entity(persisted)
 
 
 __all__ = ["SubscribeCatalogNotificationUseCase"]

--- a/src/modules/catalog_requests/application/use_cases/unsubscribe_catalog_notification.py
+++ b/src/modules/catalog_requests/application/use_cases/unsubscribe_catalog_notification.py
@@ -1,0 +1,78 @@
+"""Unsubscribe a user from a TMDB title's arrival notification."""
+
+from src.modules.catalog_requests.application.dtos import (
+    CatalogRequestOutput,
+    UnsubscribeCatalogNotificationInput,
+)
+from src.modules.catalog_requests.application.unit_of_work import (
+    CatalogRequestsUnitOfWorkFactory,
+)
+
+
+class UnsubscribeCatalogNotificationUseCase:
+    """Idempotent "desligar o aviso" handler (ADR-022).
+
+    Drops the acting user's ``CatalogSubscription`` for a title and
+    leaves the request — and every other subscriber — untouched: the
+    queue tracks titles, not interest, so it survives with zero
+    subscribers. The denormalized ``notify_on_arrival`` flag on the
+    request is recomputed from the remaining live subscriber count so
+    the read-side CTA stays accurate.
+
+    No request for the title, or no subscription for the user, is not
+    an error — both return the current state (or ``None``) so a
+    double-tap on "desligar" is harmless.
+
+    Example:
+        >>> uc = UnsubscribeCatalogNotificationUseCase(uow_factory)
+        >>> await uc.execute(UnsubscribeCatalogNotificationInput(
+        ...     tmdb_id=348,
+        ...     media_type=MediaType.MOVIE,
+        ...     user_id="usr_alice",
+        ... ))
+    """
+
+    def __init__(self, uow_factory: CatalogRequestsUnitOfWorkFactory) -> None:
+        """Initialize the use case.
+
+        Args:
+            uow_factory: Factory that opens a fresh catalog-requests
+                Unit of Work.
+        """
+        self._uow_factory = uow_factory
+
+    async def execute(
+        self,
+        input_dto: UnsubscribeCatalogNotificationInput,
+    ) -> CatalogRequestOutput | None:
+        """Execute the use case.
+
+        Returns:
+            The request with its refreshed ``notify_on_arrival`` flag,
+            or ``None`` when no request exists for the title.
+        """
+        async with self._uow_factory() as uow:
+            request = await uow.catalog_requests.find_by_tmdb_id(
+                input_dto.tmdb_id,
+                input_dto.media_type,
+            )
+            if request is None or request.id is None:
+                return None
+
+            await uow.catalog_subscriptions.remove(request.id, input_dto.user_id)
+
+            # Re-derive the "has ≥1 subscriber" flag from the live count
+            # so the read-side CTA reflects reality after the drop.
+            remaining = await uow.catalog_subscriptions.count_for_request(request.id)
+            has_subscribers = remaining > 0
+            if request.notify_on_arrival != has_subscribers:
+                request = await uow.catalog_requests.update(
+                    request.enable_notification()
+                    if has_subscribers
+                    else request.disable_notification(),
+                )
+
+            return CatalogRequestOutput.from_entity(request)
+
+
+__all__ = ["UnsubscribeCatalogNotificationUseCase"]

--- a/src/modules/catalog_requests/domain/entities/__init__.py
+++ b/src/modules/catalog_requests/domain/entities/__init__.py
@@ -1,5 +1,8 @@
 """Catalog Requests domain entities."""
 
 from src.modules.catalog_requests.domain.entities.catalog_request import CatalogRequest
+from src.modules.catalog_requests.domain.entities.catalog_subscription import (
+    CatalogSubscription,
+)
 
-__all__ = ["CatalogRequest"]
+__all__ = ["CatalogRequest", "CatalogSubscription"]

--- a/src/modules/catalog_requests/domain/entities/catalog_request.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_request.py
@@ -134,6 +134,18 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         """
         return self.with_updates(notify_on_arrival=True)
 
+    def disable_notification(self) -> CatalogRequest:
+        """Return a copy with ``notify_on_arrival=False``.
+
+        The mirror of :meth:`enable_notification`. Since ADR-022 the
+        flag is a denormalized "has at least one active subscriber"
+        cache (the precise fanout list lives in ``CatalogSubscription``
+        rows): the unsubscribe use case calls this once the last
+        subscriber drops off so the read-side CTA flips back to
+        "Avisar quando chegar".
+        """
+        return self.with_updates(notify_on_arrival=False)
+
     def reconcile(
         self,
         *,

--- a/src/modules/catalog_requests/domain/entities/catalog_subscription.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_subscription.py
@@ -1,0 +1,76 @@
+"""CatalogSubscription aggregate root."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from src.building_blocks.domain import AggregateRoot
+from src.modules.catalog_requests.domain.value_objects import (
+    CatalogRequestId,
+    CatalogSubscriptionId,
+)
+
+
+class CatalogSubscription(AggregateRoot[CatalogSubscriptionId]):
+    """One user's opt-in to be notified when a queued title arrives.
+
+    ADR-022 splits "the title is in the queue" (``CatalogRequest``)
+    from "who wants to be notified" (this aggregate). A subscription
+    is a small, standalone aggregate — one row per
+    ``(request_id, user_id)`` — rather than a collection nested inside
+    ``CatalogRequest``, so a popular title doesn't force loading every
+    subscriber just to add or count one.
+
+    Fanout reads all subscriptions of a request and pings each
+    ``user_id`` when the title lands (auto via ``MediaEnrichedEvent``
+    or the admin "mark as included" action). Unsubscribing soft-deletes
+    the row; the parent ``CatalogRequest`` survives with zero
+    subscriptions because the queue tracks titles, not interest.
+
+    The subscribe timestamp is the inherited ``created_at`` (from
+    ``DomainEntity``) — no dedicated field, matching how
+    ``CatalogRequest`` leans on the base timestamps.
+
+    Attributes:
+        id: External ID (``sub_xxx`` format).
+        request_id: The ``CatalogRequest`` (queued title) this
+            subscription belongs to.
+        user_id: External id (``usr_xxx``) of the subscriber to notify
+            on arrival. Stored as a string to match the requester
+            anchor on ``CatalogRequest`` (no per-user VO in this BC).
+
+    Example:
+        >>> sub = CatalogSubscription.create(
+        ...     request_id=request.id,
+        ...     user_id="usr_3yL8nQsT9mK5",
+        ... )
+    """
+
+    id: CatalogSubscriptionId | None = Field(default=None)
+
+    request_id: CatalogRequestId
+    user_id: str
+
+    @classmethod
+    def create(
+        cls,
+        request_id: CatalogRequestId,
+        user_id: str,
+    ) -> CatalogSubscription:
+        """Factory method with automatic ID generation.
+
+        Args:
+            request_id: External id of the parent ``CatalogRequest``.
+            user_id: External id (``usr_xxx``) of the subscribing user.
+
+        Returns:
+            A new ``CatalogSubscription`` instance.
+        """
+        return cls(
+            id=CatalogSubscriptionId.generate(),
+            request_id=request_id,
+            user_id=user_id,
+        )
+
+
+__all__ = ["CatalogSubscription"]

--- a/src/modules/catalog_requests/domain/repositories/__init__.py
+++ b/src/modules/catalog_requests/domain/repositories/__init__.py
@@ -3,5 +3,8 @@
 from src.modules.catalog_requests.domain.repositories.catalog_request_repository import (
     CatalogRequestRepository,
 )
+from src.modules.catalog_requests.domain.repositories.catalog_subscription_repository import (
+    CatalogSubscriptionRepository,
+)
 
-__all__ = ["CatalogRequestRepository"]
+__all__ = ["CatalogRequestRepository", "CatalogSubscriptionRepository"]

--- a/src/modules/catalog_requests/domain/repositories/catalog_subscription_repository.py
+++ b/src/modules/catalog_requests/domain/repositories/catalog_subscription_repository.py
@@ -1,0 +1,139 @@
+"""Repository interface for ``CatalogSubscription`` aggregates."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from src.modules.catalog_requests.domain.entities import CatalogSubscription
+from src.modules.catalog_requests.domain.value_objects import CatalogRequestId
+
+
+class CatalogSubscriptionRepository(ABC):
+    """Abstract repository for ``CatalogSubscription`` persistence.
+
+    A subscription is keyed naturally by ``(request_id, user_id)`` —
+    "this user wants this title's arrival ping". The
+    ``CatalogSubscriptionId`` exists for soft-delete bookkeeping and
+    cross-references, but every interesting query is by request, by
+    user, or by the pair (ADR-022).
+    """
+
+    @abstractmethod
+    async def add(self, subscription: CatalogSubscription) -> CatalogSubscription:
+        """Persist a new subscription.
+
+        Args:
+            subscription: The aggregate to persist. Must have an ``id``.
+
+        Returns:
+            The persisted aggregate, refreshed from the database.
+        """
+
+    @abstractmethod
+    async def find(
+        self,
+        request_id: CatalogRequestId,
+        user_id: str,
+    ) -> CatalogSubscription | None:
+        """Look up a single subscription by its natural key.
+
+        Backs the idempotent subscribe path: a repeat "Avisar quando
+        chegar" on a title the user already follows must not create a
+        duplicate row.
+
+        Args:
+            request_id: External id of the parent ``CatalogRequest``.
+            user_id: External id (``usr_xxx``) of the subscriber.
+
+        Returns:
+            The matching ``CatalogSubscription`` or ``None``.
+        """
+
+    @abstractmethod
+    async def list_for_request(
+        self,
+        request_id: CatalogRequestId,
+    ) -> list[CatalogSubscription]:
+        """List every active subscription for a request.
+
+        The fanout read: when a title lands (auto via
+        ``MediaEnrichedEvent`` or the admin "mark as included"
+        action), each returned subscriber gets the "it arrived"
+        notification.
+
+        Args:
+            request_id: External id of the parent ``CatalogRequest``.
+
+        Returns:
+            Active subscriptions for the request (empty when none).
+        """
+
+    @abstractmethod
+    async def remove(
+        self,
+        request_id: CatalogRequestId,
+        user_id: str,
+    ) -> bool:
+        """Soft-delete a subscription by its natural key (unsubscribe).
+
+        Idempotent: removing a subscription that isn't there is not an
+        error. The parent ``CatalogRequest`` is left untouched — the
+        title stays in the queue even with zero subscribers.
+
+        Args:
+            request_id: External id of the parent ``CatalogRequest``.
+            user_id: External id (``usr_xxx``) of the subscriber.
+
+        Returns:
+            ``True`` when a row was soft-deleted, ``False`` when no
+            active subscription matched.
+        """
+
+    @abstractmethod
+    async def count_for_request(self, request_id: CatalogRequestId) -> int:
+        """Count active subscribers for a single request.
+
+        Args:
+            request_id: External id of the parent ``CatalogRequest``.
+
+        Returns:
+            Number of active subscriptions (the "N people waiting"
+            figure).
+        """
+
+    @abstractmethod
+    async def count_by_requests(
+        self,
+        request_ids: Sequence[CatalogRequestId],
+    ) -> dict[CatalogRequestId, int]:
+        """Batch subscriber counts keyed by request.
+
+        Lets the admin queue and the "Em breve" grid render their
+        subscriber counts in one round-trip instead of N+1 per-row
+        lookups. Empty input returns an empty dict; requests with zero
+        subscribers are simply absent from the mapping.
+
+        Args:
+            request_ids: Requests to count subscribers for.
+
+        Returns:
+            Mapping of ``request_id`` to its active subscriber count.
+        """
+
+    @abstractmethod
+    async def request_ids_for_user(self, user_id: str) -> set[CatalogRequestId]:
+        """Return the set of requests a user currently subscribes to.
+
+        Powers the "is the caller subscribed?" flag on the member
+        listing and the "só os que eu acompanho" filter without a
+        per-row check.
+
+        Args:
+            user_id: External id (``usr_xxx``) of the subscriber.
+
+        Returns:
+            Set of ``request_id`` the user has an active subscription
+            for (empty when none).
+        """
+
+
+__all__ = ["CatalogSubscriptionRepository"]

--- a/src/modules/catalog_requests/domain/value_objects/__init__.py
+++ b/src/modules/catalog_requests/domain/value_objects/__init__.py
@@ -3,5 +3,8 @@
 from src.modules.catalog_requests.domain.value_objects.catalog_request_id import (
     CatalogRequestId,
 )
+from src.modules.catalog_requests.domain.value_objects.catalog_subscription_id import (
+    CatalogSubscriptionId,
+)
 
-__all__ = ["CatalogRequestId"]
+__all__ = ["CatalogRequestId", "CatalogSubscriptionId"]

--- a/src/modules/catalog_requests/domain/value_objects/catalog_subscription_id.py
+++ b/src/modules/catalog_requests/domain/value_objects/catalog_subscription_id.py
@@ -1,0 +1,23 @@
+"""CatalogSubscriptionId external ID value object."""
+
+from typing import ClassVar
+
+from src.building_blocks.domain.external_id import ExternalId
+
+
+class CatalogSubscriptionId(ExternalId):
+    """External ID for a per-user catalog-request subscription.
+
+    Each row is one user's opt-in to be notified when a queued title
+    arrives (ADR-022). Distinct from ``CatalogRequestId`` (``req_``),
+    which identifies the title in the queue rather than an interested
+    user.
+
+    Format: ``sub_{base62_12chars}``
+    Example: ``sub_7pK2nQsT9mK5``
+    """
+
+    EXPECTED_PREFIX: ClassVar[str] = "sub"
+
+
+__all__ = ["CatalogSubscriptionId"]

--- a/src/modules/catalog_requests/infrastructure/persistence/mappers/__init__.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/mappers/__init__.py
@@ -3,5 +3,8 @@
 from src.modules.catalog_requests.infrastructure.persistence.mappers.catalog_request_mapper import (
     CatalogRequestMapper,
 )
+from src.modules.catalog_requests.infrastructure.persistence.mappers.catalog_subscription_mapper import (
+    CatalogSubscriptionMapper,
+)
 
-__all__ = ["CatalogRequestMapper"]
+__all__ = ["CatalogRequestMapper", "CatalogSubscriptionMapper"]

--- a/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_subscription_mapper.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_subscription_mapper.py
@@ -1,0 +1,63 @@
+"""Mapper between ``CatalogSubscription`` entity and ``CatalogSubscriptionModel``."""
+
+from src.modules.catalog_requests.domain.entities import CatalogSubscription
+from src.modules.catalog_requests.domain.value_objects import (
+    CatalogRequestId,
+    CatalogSubscriptionId,
+)
+from src.modules.catalog_requests.infrastructure.persistence.models import (
+    CatalogSubscriptionModel,
+)
+
+
+class CatalogSubscriptionMapper:
+    """Bidirectional mapper between domain aggregate and ORM model.
+
+    There is no ``update_model``: a subscription is immutable once
+    created — it is added or soft-deleted (unsubscribe), never
+    mutated.
+
+    Example:
+        >>> model = CatalogSubscriptionMapper.to_model(entity)
+        >>> entity = CatalogSubscriptionMapper.to_entity(model)
+    """
+
+    @staticmethod
+    def to_model(entity: CatalogSubscription) -> CatalogSubscriptionModel:
+        """Convert ``CatalogSubscription`` entity to ORM model.
+
+        ``created_at`` is left to the DB server default (the inherited
+        base timestamp), matching ``CatalogRequestMapper``.
+
+        Args:
+            entity: The domain aggregate. Must have an ``id``.
+
+        Returns:
+            SQLAlchemy model ready for persistence.
+
+        Raises:
+            ValueError: When ``entity.id`` is ``None``.
+        """
+        if entity.id is None:
+            msg = "Cannot map entity without ID to model"
+            raise ValueError(msg)
+
+        return CatalogSubscriptionModel(
+            external_id=str(entity.id),
+            request_id=str(entity.request_id),
+            user_id=entity.user_id,
+        )
+
+    @staticmethod
+    def to_entity(model: CatalogSubscriptionModel) -> CatalogSubscription:
+        """Convert ORM model to domain aggregate."""
+        return CatalogSubscription(
+            id=CatalogSubscriptionId(model.external_id),
+            request_id=CatalogRequestId(model.request_id),
+            user_id=model.user_id,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+
+__all__ = ["CatalogSubscriptionMapper"]

--- a/src/modules/catalog_requests/infrastructure/persistence/models/__init__.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/models/__init__.py
@@ -3,5 +3,8 @@
 from src.modules.catalog_requests.infrastructure.persistence.models.catalog_request_model import (
     CatalogRequestModel,
 )
+from src.modules.catalog_requests.infrastructure.persistence.models.catalog_subscription_model import (
+    CatalogSubscriptionModel,
+)
 
-__all__ = ["CatalogRequestModel"]
+__all__ = ["CatalogRequestModel", "CatalogSubscriptionModel"]

--- a/src/modules/catalog_requests/infrastructure/persistence/models/catalog_subscription_model.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/models/catalog_subscription_model.py
@@ -1,0 +1,43 @@
+"""CatalogSubscription ORM model."""
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.base import Base
+
+
+class CatalogSubscriptionModel(Base):
+    """SQLAlchemy model for ``CatalogSubscription``.
+
+    Maps to the ``catalog_subscriptions`` table. Each row is one
+    user's opt-in to be notified when a queued title arrives
+    (ADR-022) — the per-user fanout layer that ``CatalogRequest``
+    (one row per title) deliberately doesn't carry.
+
+    ``(request_id, user_id)`` is unique among non-deleted rows so a
+    repeat "Avisar quando chegar" stays idempotent; that partial
+    unique index lives in the alembic migration only (the dev
+    auto-create path covers the per-column lookups via the indexes
+    below).
+
+    Attributes:
+        request_id: External id (``req_xxx``) of the parent
+            ``CatalogRequest`` this subscription belongs to. Plain
+            indexed string, mirroring how the BC references user /
+            collection ids — no cross-table foreign key.
+        user_id: External id (``usr_xxx``) of the subscriber to ping
+            on arrival.
+    """
+
+    request_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"<CatalogSubscriptionModel(id={self.id}, "
+            f"request_id={self.request_id!r}, user_id={self.user_id!r})>"
+        )
+
+
+__all__ = ["CatalogSubscriptionModel"]

--- a/src/modules/catalog_requests/infrastructure/persistence/repositories/__init__.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/repositories/__init__.py
@@ -3,5 +3,11 @@
 from src.modules.catalog_requests.infrastructure.persistence.repositories.catalog_request_repository import (
     SQLAlchemyCatalogRequestRepository,
 )
+from src.modules.catalog_requests.infrastructure.persistence.repositories.catalog_subscription_repository import (
+    SQLAlchemyCatalogSubscriptionRepository,
+)
 
-__all__ = ["SQLAlchemyCatalogRequestRepository"]
+__all__ = [
+    "SQLAlchemyCatalogRequestRepository",
+    "SQLAlchemyCatalogSubscriptionRepository",
+]

--- a/src/modules/catalog_requests/infrastructure/persistence/repositories/catalog_subscription_repository.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/repositories/catalog_subscription_repository.py
@@ -1,0 +1,140 @@
+"""SQLAlchemy implementation of ``CatalogSubscriptionRepository``."""
+
+from collections.abc import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.catalog_requests.domain.entities import CatalogSubscription
+from src.modules.catalog_requests.domain.repositories import (
+    CatalogSubscriptionRepository,
+)
+from src.modules.catalog_requests.domain.value_objects import CatalogRequestId
+from src.modules.catalog_requests.infrastructure.persistence.mappers import (
+    CatalogSubscriptionMapper,
+)
+from src.modules.catalog_requests.infrastructure.persistence.models import (
+    CatalogSubscriptionModel,
+)
+
+
+class SQLAlchemyCatalogSubscriptionRepository(CatalogSubscriptionRepository):
+    """SQLAlchemy implementation of ``CatalogSubscriptionRepository``.
+
+    Example:
+        >>> repo = SQLAlchemyCatalogSubscriptionRepository(session)
+        >>> subs = await repo.list_for_request(request_id)
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize repository with database session.
+
+        Args:
+            session: SQLAlchemy async session.
+        """
+        self._session = session
+
+    async def add(self, subscription: CatalogSubscription) -> CatalogSubscription:
+        """Persist a new subscription."""
+        model = CatalogSubscriptionMapper.to_model(subscription)
+        self._session.add(model)
+        await self._session.flush()
+        await self._session.refresh(model)
+        return CatalogSubscriptionMapper.to_entity(model)
+
+    async def find(
+        self,
+        request_id: CatalogRequestId,
+        user_id: str,
+    ) -> CatalogSubscription | None:
+        """Look up a single subscription by its natural key."""
+        stmt = select(CatalogSubscriptionModel).where(
+            CatalogSubscriptionModel.request_id == str(request_id),
+            CatalogSubscriptionModel.user_id == user_id,
+            CatalogSubscriptionModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else CatalogSubscriptionMapper.to_entity(model)
+
+    async def list_for_request(
+        self,
+        request_id: CatalogRequestId,
+    ) -> list[CatalogSubscription]:
+        """List every active subscription for a request (the fanout read)."""
+        stmt = select(CatalogSubscriptionModel).where(
+            CatalogSubscriptionModel.request_id == str(request_id),
+            CatalogSubscriptionModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        return [CatalogSubscriptionMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def remove(
+        self,
+        request_id: CatalogRequestId,
+        user_id: str,
+    ) -> bool:
+        """Soft-delete a subscription by its natural key (unsubscribe)."""
+        stmt = select(CatalogSubscriptionModel).where(
+            CatalogSubscriptionModel.request_id == str(request_id),
+            CatalogSubscriptionModel.user_id == user_id,
+            CatalogSubscriptionModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        if model is None:
+            return False
+        model.soft_delete()
+        await self._session.flush()
+        return True
+
+    async def count_for_request(self, request_id: CatalogRequestId) -> int:
+        """Count active subscribers for a single request."""
+        stmt = (
+            select(func.count())
+            .select_from(CatalogSubscriptionModel)
+            .where(
+                CatalogSubscriptionModel.request_id == str(request_id),
+                CatalogSubscriptionModel.deleted_at.is_(None),
+            )
+        )
+        result = await self._session.execute(stmt)
+        return result.scalar_one()
+
+    async def count_by_requests(
+        self,
+        request_ids: Sequence[CatalogRequestId],
+    ) -> dict[CatalogRequestId, int]:
+        """Batch subscriber counts keyed by request."""
+        if not request_ids:
+            return {}
+        keys = [str(rid) for rid in request_ids]
+        stmt = (
+            select(
+                CatalogSubscriptionModel.request_id,
+                func.count().label("n"),
+            )
+            .where(
+                CatalogSubscriptionModel.request_id.in_(keys),
+                CatalogSubscriptionModel.deleted_at.is_(None),
+            )
+            .group_by(CatalogSubscriptionModel.request_id)
+        )
+        result = await self._session.execute(stmt)
+        return {CatalogRequestId(row.request_id): row.n for row in result.all()}
+
+    async def request_ids_for_user(self, user_id: str) -> set[CatalogRequestId]:
+        """Return the set of requests a user currently subscribes to."""
+        stmt = (
+            select(CatalogSubscriptionModel.request_id)
+            .where(
+                CatalogSubscriptionModel.user_id == user_id,
+                CatalogSubscriptionModel.deleted_at.is_(None),
+            )
+            .distinct()
+        )
+        result = await self._session.execute(stmt)
+        return {CatalogRequestId(rid) for rid in result.scalars().all()}
+
+
+__all__ = ["SQLAlchemyCatalogSubscriptionRepository"]

--- a/src/modules/catalog_requests/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -9,6 +9,7 @@ from src.modules.catalog_requests.application.unit_of_work import (
 )
 from src.modules.catalog_requests.infrastructure.persistence.repositories import (
     SQLAlchemyCatalogRequestRepository,
+    SQLAlchemyCatalogSubscriptionRepository,
 )
 
 
@@ -17,6 +18,7 @@ class SqlAlchemyCatalogRequestsUnitOfWork(SqlAlchemyUnitOfWork, CatalogRequestsU
 
     def _build_repositories(self, session: AsyncSession) -> None:
         self.catalog_requests = SQLAlchemyCatalogRequestRepository(session)
+        self.catalog_subscriptions = SQLAlchemyCatalogSubscriptionRepository(session)
 
 
 class SqlAlchemyCatalogRequestsUnitOfWorkFactory(CatalogRequestsUnitOfWorkFactory):

--- a/tests/modules/catalog_requests/integration/conftest.py
+++ b/tests/modules/catalog_requests/integration/conftest.py
@@ -1,0 +1,58 @@
+"""Integration test fixtures for catalog-requests database operations."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from src.infrastructure.persistence import Base
+
+# Import the BC models so they register on ``Base.metadata`` before
+# ``create_all`` runs (otherwise the tables wouldn't be created).
+from src.modules.catalog_requests.infrastructure.persistence.models import (  # noqa: F401
+    CatalogRequestModel,
+    CatalogSubscriptionModel,
+)
+
+
+@pytest.fixture(scope="function")
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """Expose an ``async_sessionmaker`` bound to an in-memory SQLite database.
+
+    ``StaticPool`` pins every connection to the same underlying SQLite
+    instance so seed-time sessions and UoW-opened sessions see the
+    same schema and rows.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+    yield factory
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+async def db_session(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> AsyncGenerator[AsyncSession, None]:
+    """Seed-time session sharing the ``session_factory`` engine."""
+    async with session_factory() as session:
+        yield session

--- a/tests/modules/catalog_requests/integration/persistence/__init__.py
+++ b/tests/modules/catalog_requests/integration/persistence/__init__.py
@@ -1,0 +1,1 @@
+"""catalog_requests integration tests."""

--- a/tests/modules/catalog_requests/integration/persistence/repositories/__init__.py
+++ b/tests/modules/catalog_requests/integration/persistence/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""catalog_requests integration tests."""

--- a/tests/modules/catalog_requests/integration/persistence/repositories/test_catalog_subscription_repository.py
+++ b/tests/modules/catalog_requests/integration/persistence/repositories/test_catalog_subscription_repository.py
@@ -1,0 +1,102 @@
+"""Integration tests for ``SQLAlchemyCatalogSubscriptionRepository``."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.catalog_requests.domain.entities import CatalogSubscription
+from src.modules.catalog_requests.domain.value_objects import CatalogRequestId
+from src.modules.catalog_requests.infrastructure.persistence.repositories import (
+    SQLAlchemyCatalogSubscriptionRepository,
+)
+
+_REQ_A = CatalogRequestId("req_aaaaaaaaaaaa")
+_REQ_B = CatalogRequestId("req_bbbbbbbbbbbb")
+_USER_1 = "usr_111111111111"
+_USER_2 = "usr_222222222222"
+
+
+def _repo(session: AsyncSession) -> SQLAlchemyCatalogSubscriptionRepository:
+    return SQLAlchemyCatalogSubscriptionRepository(session)
+
+
+class TestAddAndFind:
+    async def test_add_then_find_round_trips(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        saved = await repo.add(CatalogSubscription.create(_REQ_A, _USER_1))
+
+        assert saved.id is not None
+        assert str(saved.id).startswith("sub_")
+
+        found = await repo.find(_REQ_A, _USER_1)
+        assert found is not None
+        assert found.request_id == _REQ_A
+        assert found.user_id == _USER_1
+
+    async def test_find_misses_on_wrong_user(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_1))
+
+        assert await repo.find(_REQ_A, _USER_2) is None
+
+    async def test_find_ignores_soft_deleted(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_1))
+        await repo.remove(_REQ_A, _USER_1)
+
+        assert await repo.find(_REQ_A, _USER_1) is None
+
+
+class TestListForRequest:
+    async def test_lists_active_only_for_the_request(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_1))
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_2))
+        await repo.add(CatalogSubscription.create(_REQ_B, _USER_1))
+        await repo.remove(_REQ_A, _USER_2)
+
+        subs = await repo.list_for_request(_REQ_A)
+
+        assert {s.user_id for s in subs} == {_USER_1}
+
+
+class TestRemove:
+    async def test_remove_is_idempotent(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_1))
+
+        assert await repo.remove(_REQ_A, _USER_1) is True
+        assert await repo.remove(_REQ_A, _USER_1) is False
+
+
+class TestCounts:
+    async def test_count_for_request_excludes_deleted(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_1))
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_2))
+        await repo.remove(_REQ_A, _USER_2)
+
+        assert await repo.count_for_request(_REQ_A) == 1
+
+    async def test_count_by_requests_batches(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_1))
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_2))
+        await repo.add(CatalogSubscription.create(_REQ_B, _USER_1))
+
+        counts = await repo.count_by_requests([_REQ_A, _REQ_B])
+
+        assert counts == {_REQ_A: 2, _REQ_B: 1}
+
+    async def test_count_by_requests_empty_input(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        assert await repo.count_by_requests([]) == {}
+
+
+class TestRequestIdsForUser:
+    async def test_returns_active_request_ids(self, db_session: AsyncSession) -> None:
+        repo = _repo(db_session)
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_1))
+        await repo.add(CatalogSubscription.create(_REQ_B, _USER_1))
+        await repo.add(CatalogSubscription.create(_REQ_A, _USER_2))
+        await repo.remove(_REQ_B, _USER_1)
+
+        assert await repo.request_ids_for_user(_USER_1) == {_REQ_A}

--- a/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
+++ b/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
@@ -12,12 +12,21 @@ from src.modules.catalog_requests.application.ports import (
     CatalogArrivalNotification,
     NotificationPublisherPort,
 )
-from src.modules.catalog_requests.domain.entities import CatalogRequest
+from src.modules.catalog_requests.domain.entities import (
+    CatalogRequest,
+    CatalogSubscription,
+)
 from src.modules.media.domain.events import MediaCreatedEvent, MediaEnrichedEvent
 from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 from src.shared_kernel.value_objects.media_type import MediaType
 from tests.modules.catalog_requests.unit.conftest import (
     make_catalog_requests_uow_mock,
+)
+
+_MOVIE_EVENT = MediaEnrichedEvent(
+    media_id=MovieId("mov_abcabcabcabc"),
+    media_type="movie",
+    tmdb_id=348,
 )
 
 
@@ -43,13 +52,7 @@ class TestOnMediaEnrichedHandler:
         mocks.catalog_requests.update.side_effect = capture_update
         handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
 
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
+        await handler.handle(_MOVIE_EVENT)
 
         assert captured["req"].is_fulfilled is True
         assert captured["req"].fulfilled_at is not None
@@ -64,13 +67,7 @@ class TestOnMediaEnrichedHandler:
         mocks.catalog_requests.find_by_tmdb_id.return_value = None
         handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
 
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
+        await handler.handle(_MOVIE_EVENT)
 
         mocks.catalog_requests.update.assert_not_called()
 
@@ -86,13 +83,7 @@ class TestOnMediaEnrichedHandler:
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
 
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
+        await handler.handle(_MOVIE_EVENT)
 
         mocks.catalog_requests.update.assert_not_called()
 
@@ -157,160 +148,109 @@ class TestOnMediaEnrichedHandler:
         mocks.catalog_requests.update.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_publishes_notification_when_user_opted_in(self) -> None:
-        """When the requester opted in and we know who they are, the
-        handler dispatches a ``CatalogArrivalNotification`` to the
-        publisher port after committing the fulfillment."""
+    async def test_fans_out_to_every_subscriber(self) -> None:
+        """One arrival notification per active subscription (ADR-022),
+        not just the original requester."""
         existing = CatalogRequest.create(
             tmdb_id=348,
             media_type=MediaType.MOVIE,
             title="Alien",
-            requester_user_id="usr_alice",
-            notify_on_arrival=True,
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
+        mocks.catalog_subscriptions.list_for_request.return_value = [
+            CatalogSubscription.create(existing.id, "usr_alice"),
+            CatalogSubscription.create(existing.id, "usr_bob"),
+        ]
         publisher = AsyncMock(spec=NotificationPublisherPort)
         handler = OnMediaEnrichedHandler(
             uow_factory=mocks.factory,
             notification_publisher=publisher,
         )
 
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
+        await handler.handle(_MOVIE_EVENT)
 
-        publisher.publish_catalog_arrival.assert_awaited_once()
-        payload = publisher.publish_catalog_arrival.await_args.args[0]
+        assert publisher.publish_catalog_arrival.await_count == 2
+        recipients = {
+            call.args[0].recipient_user_id
+            for call in publisher.publish_catalog_arrival.await_args_list
+        }
+        assert recipients == {"usr_alice", "usr_bob"}
+        payload = publisher.publish_catalog_arrival.await_args_list[0].args[0]
         assert isinstance(payload, CatalogArrivalNotification)
-        assert payload.recipient_user_id == "usr_alice"
         assert payload.title == "Alien"
         assert payload.tmdb_id == 348
         assert payload.media_id == MovieId("mov_abcabcabcabc")
         assert payload.media_type == "movie"
 
     @pytest.mark.asyncio
-    async def test_no_notification_when_user_did_not_opt_in(self) -> None:
+    async def test_no_notification_when_no_subscribers(self) -> None:
         existing = CatalogRequest.create(
             tmdb_id=348,
             media_type=MediaType.MOVIE,
             title="Alien",
-            requester_user_id="usr_alice",
-            notify_on_arrival=False,
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
+        mocks.catalog_subscriptions.list_for_request.return_value = []
         publisher = AsyncMock(spec=NotificationPublisherPort)
         handler = OnMediaEnrichedHandler(
             uow_factory=mocks.factory,
             notification_publisher=publisher,
         )
 
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
-
-        publisher.publish_catalog_arrival.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_no_notification_when_requester_anonymous(self) -> None:
-        """Legacy rows without a ``requester_user_id`` skip the ping
-        even when ``notify_on_arrival=True`` (we have no inbox to
-        target)."""
-        existing = CatalogRequest.create(
-            tmdb_id=348,
-            media_type=MediaType.MOVIE,
-            title="Alien",
-            notify_on_arrival=True,
-        )
-        mocks = make_catalog_requests_uow_mock()
-        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
-        mocks.catalog_requests.update.side_effect = lambda req: req
-        publisher = AsyncMock(spec=NotificationPublisherPort)
-        handler = OnMediaEnrichedHandler(
-            uow_factory=mocks.factory,
-            notification_publisher=publisher,
-        )
-
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
+        await handler.handle(_MOVIE_EVENT)
 
         publisher.publish_catalog_arrival.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_notification_without_publisher(self) -> None:
-        """The handler stays usable without the Notifications BC
-        wired in — fulfillment still happens, publisher path stays
-        a no-op."""
+        """The handler stays usable without the Notifications BC wired
+        in — fulfillment still happens and the subscriber query is
+        skipped entirely."""
         existing = CatalogRequest.create(
             tmdb_id=348,
             media_type=MediaType.MOVIE,
             title="Alien",
-            requester_user_id="usr_alice",
-            notify_on_arrival=True,
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
         handler = OnMediaEnrichedHandler(uow_factory=mocks.factory)
 
-        # No publisher injected: should not raise, fulfillment still happens.
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
+        await handler.handle(_MOVIE_EVENT)
 
         mocks.catalog_requests.update.assert_called_once()
+        mocks.catalog_subscriptions.list_for_request.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_publisher_failure_swallowed(self) -> None:
-        """A publisher exception must not leak out — it would
-        otherwise propagate into the event bus and short-circuit
-        other subscribers of the same event."""
+    async def test_one_subscriber_failure_does_not_block_others(self) -> None:
+        """A publish failure for one subscriber is swallowed; the rest
+        still get pinged and fulfillment stays committed."""
         existing = CatalogRequest.create(
             tmdb_id=348,
             media_type=MediaType.MOVIE,
             title="Alien",
-            requester_user_id="usr_alice",
-            notify_on_arrival=True,
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
+        mocks.catalog_subscriptions.list_for_request.return_value = [
+            CatalogSubscription.create(existing.id, "usr_alice"),
+            CatalogSubscription.create(existing.id, "usr_bob"),
+        ]
         publisher = AsyncMock(spec=NotificationPublisherPort)
-        publisher.publish_catalog_arrival.side_effect = RuntimeError("boom")
+        publisher.publish_catalog_arrival.side_effect = [RuntimeError("boom"), None]
         handler = OnMediaEnrichedHandler(
             uow_factory=mocks.factory,
             notification_publisher=publisher,
         )
 
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
+        await handler.handle(_MOVIE_EVENT)
 
-        # No exception bubbled up; fulfillment still committed.
+        assert publisher.publish_catalog_arrival.await_count == 2
         mocks.catalog_requests.update.assert_called_once()
 
     @pytest.mark.asyncio
@@ -320,25 +260,20 @@ class TestOnMediaEnrichedHandler:
         existing = CatalogRequest.create(
             tmdb_id=348,
             media_type=MediaType.MOVIE,
-            requester_user_id="usr_alice",
-            notify_on_arrival=True,
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
+        mocks.catalog_subscriptions.list_for_request.return_value = [
+            CatalogSubscription.create(existing.id, "usr_alice"),
+        ]
         publisher = AsyncMock(spec=NotificationPublisherPort)
         handler = OnMediaEnrichedHandler(
             uow_factory=mocks.factory,
             notification_publisher=publisher,
         )
 
-        await handler.handle(
-            MediaEnrichedEvent(
-                media_id=MovieId("mov_abcabcabcabc"),
-                media_type="movie",
-                tmdb_id=348,
-            ),
-        )
+        await handler.handle(_MOVIE_EVENT)
 
         payload = publisher.publish_catalog_arrival.await_args.args[0]
         assert payload.title == "tmdb/movie/348"

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_subscribe_catalog_notification.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_subscribe_catalog_notification.py
@@ -8,7 +8,10 @@ from src.modules.catalog_requests.application.dtos import (
 from src.modules.catalog_requests.application.use_cases import (
     SubscribeCatalogNotificationUseCase,
 )
-from src.modules.catalog_requests.domain.entities import CatalogRequest
+from src.modules.catalog_requests.domain.entities import (
+    CatalogRequest,
+    CatalogSubscription,
+)
 from src.shared_kernel.value_objects import MediaType
 from tests.modules.catalog_requests.unit.conftest import (
     make_catalog_requests_uow_mock,
@@ -79,3 +82,56 @@ class TestSubscribeCatalogNotificationUseCase:
         assert result.notify_on_arrival is True
         mocks.catalog_requests.update.assert_not_called()
         mocks.catalog_requests.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_creates_subscription_for_the_requester(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            requester_user_id="usr_alice",
+            notify_on_arrival=True,
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_requests.update.side_effect = lambda req: req
+        mocks.catalog_subscriptions.find.return_value = None
+        use_case = SubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+
+        await use_case.execute(
+            SubscribeCatalogNotificationInput(
+                tmdb_id=348,
+                media_type=MediaType.MOVIE,
+                requester_user_id="usr_alice",
+            ),
+        )
+
+        mocks.catalog_subscriptions.add.assert_awaited_once()
+        added = mocks.catalog_subscriptions.add.await_args.args[0]
+        assert added.user_id == "usr_alice"
+        assert added.request_id == existing.id
+
+    @pytest.mark.asyncio
+    async def test_subscription_is_idempotent(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            requester_user_id="usr_alice",
+            notify_on_arrival=True,
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_subscriptions.find.return_value = CatalogSubscription.create(
+            existing.id,
+            "usr_alice",
+        )
+        use_case = SubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+
+        await use_case.execute(
+            SubscribeCatalogNotificationInput(
+                tmdb_id=348,
+                media_type=MediaType.MOVIE,
+                requester_user_id="usr_alice",
+            ),
+        )
+
+        mocks.catalog_subscriptions.add.assert_not_called()

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_unsubscribe_catalog_notification.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_unsubscribe_catalog_notification.py
@@ -1,0 +1,98 @@
+"""Tests for ``UnsubscribeCatalogNotificationUseCase``."""
+
+import pytest
+
+from src.modules.catalog_requests.application.dtos import (
+    UnsubscribeCatalogNotificationInput,
+)
+from src.modules.catalog_requests.application.use_cases import (
+    UnsubscribeCatalogNotificationUseCase,
+)
+from src.modules.catalog_requests.domain.entities import CatalogRequest
+from src.shared_kernel.value_objects import MediaType
+from tests.modules.catalog_requests.unit.conftest import (
+    make_catalog_requests_uow_mock,
+)
+
+
+def _input(user_id: str = "usr_alice") -> UnsubscribeCatalogNotificationInput:
+    return UnsubscribeCatalogNotificationInput(
+        tmdb_id=348,
+        media_type=MediaType.MOVIE,
+        user_id=user_id,
+    )
+
+
+@pytest.mark.unit
+class TestUnsubscribeCatalogNotificationUseCase:
+    """Tests for the "desligar o aviso" handler."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_request(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = None
+        use_case = UnsubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(_input())
+
+        assert result is None
+        mocks.catalog_subscriptions.remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_removes_the_callers_subscription(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            notify_on_arrival=True,
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_subscriptions.count_for_request.return_value = 1  # others remain
+        use_case = UnsubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+
+        await use_case.execute(_input("usr_alice"))
+
+        mocks.catalog_subscriptions.remove.assert_awaited_once_with(
+            existing.id,
+            "usr_alice",
+        )
+
+    @pytest.mark.asyncio
+    async def test_keeps_flag_on_when_other_subscribers_remain(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            notify_on_arrival=True,
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_subscriptions.count_for_request.return_value = 2
+        use_case = UnsubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(_input())
+
+        # Flag already matches reality (has subscribers) → no rewrite.
+        mocks.catalog_requests.update.assert_not_called()
+        assert result is not None
+        assert result.notify_on_arrival is True
+
+    @pytest.mark.asyncio
+    async def test_clears_flag_when_last_subscriber_leaves(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            notify_on_arrival=True,
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_requests.update.side_effect = lambda req: req
+        mocks.catalog_subscriptions.count_for_request.return_value = 0
+        use_case = UnsubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(_input())
+
+        mocks.catalog_requests.update.assert_called_once()
+        updated = mocks.catalog_requests.update.await_args.args[0]
+        assert updated.notify_on_arrival is False
+        assert result is not None
+        assert result.notify_on_arrival is False

--- a/tests/modules/catalog_requests/unit/conftest.py
+++ b/tests/modules/catalog_requests/unit/conftest.py
@@ -7,7 +7,10 @@ from src.modules.catalog_requests.application.unit_of_work import (
     CatalogRequestsUnitOfWork,
     CatalogRequestsUnitOfWorkFactory,
 )
-from src.modules.catalog_requests.domain.repositories import CatalogRequestRepository
+from src.modules.catalog_requests.domain.repositories import (
+    CatalogRequestRepository,
+    CatalogSubscriptionRepository,
+)
 
 
 @dataclass
@@ -17,20 +20,31 @@ class CatalogRequestsUoWMocks:
     factory: CatalogRequestsUnitOfWorkFactory
     uow: CatalogRequestsUnitOfWork
     catalog_requests: AsyncMock
+    catalog_subscriptions: AsyncMock
 
 
 def make_catalog_requests_uow_mock() -> CatalogRequestsUoWMocks:
     """Build a mock :class:`CatalogRequestsUnitOfWork` factory."""
     catalog_requests = AsyncMock(spec=CatalogRequestRepository)
 
+    catalog_subscriptions = AsyncMock(spec=CatalogSubscriptionRepository)
+    # Sensible "nobody subscribed yet" defaults so the common paths
+    # don't have to wire these up explicitly.
+    catalog_subscriptions.find.return_value = None
+    catalog_subscriptions.list_for_request.return_value = []
+    catalog_subscriptions.count_for_request.return_value = 0
+    catalog_subscriptions.remove.return_value = False
+
     uow: CatalogRequestsUnitOfWork = AsyncMock()
     uow.__aenter__.return_value = uow  # type: ignore[attr-defined]
     uow.__aexit__.return_value = None  # type: ignore[attr-defined]
     uow.catalog_requests = catalog_requests
+    uow.catalog_subscriptions = catalog_subscriptions
 
     factory = MagicMock(return_value=uow)
     return CatalogRequestsUoWMocks(
         factory=factory,
         uow=uow,
         catalog_requests=catalog_requests,
+        catalog_subscriptions=catalog_subscriptions,
     )


### PR DESCRIPTION
## Summary

Phase **B1** of the Catalog Requests / "Em breve" two-sided feature. Splits *"the title is in the queue"* (`CatalogRequest`, one row per title) from *"who wants to be notified"* (new `CatalogSubscription`), so a title's arrival pings **every subscriber** instead of only the first requester. See **ADR-022** (included in this PR).

This fixes a latent multi-user bug: today a second user who clicks "Avisar quando chegar" reconciles into the existing row (`first-owner-wins`), so only the original requester ever got the arrival notification.

### What's in here
- **ADR-022** — Subscriptions Multi-Usuário + Fanout em Catalog Requests (separate aggregate over collection-in-aggregate; honest status; `notify_on_arrival` becomes a denormalized flag).
- **Domain** — `CatalogSubscription` aggregate (`sub_` id, `request_id` + `user_id`) + repository interface (`add`/`find`/`list_for_request`/`remove`/`count_for_request`/`count_by_requests`/`request_ids_for_user`); `CatalogRequest.disable_notification()`.
- **Infra** — model/mapper/repo + UoW wiring + migration `2026_06_23_add_catalog_subscriptions` (table, partial-unique `(request_id, user_id) WHERE deleted_at IS NULL`, **backfill** of existing `notify_on_arrival` opt-ins → one subscription each).
- **Application** — subscribe now records a `CatalogSubscription` (idempotent); new `UnsubscribeCatalogNotificationUseCase`; `OnMediaEnrichedHandler` fans out one notification per subscriber, with per-recipient failure isolation.

### Design notes
- `notify_on_arrival` is kept as a **denormalized "has ≥1 subscriber"** flag maintained by subscribe/unsubscribe, so the cross-BC read port + Collection FilmRow CTA keep working unchanged. Per-user precision ("is *this* user subscribed?") lands in B3 (member view).
- `RequestCatalogInclusion` ("Solicitar inclusão") is intentionally left untouched — only the explicit "Avisar quando chegar" creates a subscription. The combined request+notify path (unused by the frontend) doesn't fan out; the suggest→auto-subscribe flow is formalized in B3.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] Repo integration tests (in-memory SQLite) — 9 cases across the 7 repo methods
- [x] Reworked handler/use-case unit tests (fanout to N subscribers, per-recipient failure isolation, subscribe idempotency, unsubscribe flag recompute)
- [x] Migration validated on a temp DB: upgrade + backfill seeds exactly the eligible request's subscription; downgrade drops the table
- [x] **Full suite green — 2938 passed, 5 skipped**

## Deploy

`make migrate` (creates `catalog_subscriptions` + backfills) then restart. No data loss; `notify_on_arrival` column retained.

## Follow-ups (next phases)
- **B2** — `source` (user/household) + honest derived status.
- **B3** — member endpoints (GET list w/ `is_subscribed` + counts, `DELETE .../subscribe`).
- **B4** — admin endpoints (status/source columns, `POST .../include` fanout).