### PR TITLE
feat(catalog-requests): source + honest derived status (ADR-022 B2)

### DIFF
--- a/migrations/versions/2026_06_23_add_source_to_catalog_requests.py
+++ b/migrations/versions/2026_06_23_add_source_to_catalog_requests.py
@@ -1,0 +1,56 @@
+"""Add source (user/household) to catalog_requests + backfill.
+
+ADR-022 records where a request originated: a member asking for the
+title (``user``) vs. the household/system seeding it (``household``).
+The backfill derives it from the existing requester anchor — a known
+``requester_user_id`` means a member asked, so those rows become
+``user``; the rest stay ``household``.
+
+Revision ID: b3e8d1f6a04c
+Revises: 7a1c93b5e2d8
+Create Date: 2026-06-23 19:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "b3e8d1f6a04c"
+down_revision: str | Sequence[str] | None = "7a1c93b5e2d8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the ``source`` column and backfill from ``requester_user_id``."""
+    # Plain add_column (no batch) — catalog_requests isn't an FTS table,
+    # so there are no triggers to preserve. NOT NULL with a server
+    # default so existing rows land on ``household`` before the backfill
+    # promotes the member-originated ones.
+    op.add_column(
+        "catalog_requests",
+        sa.Column(
+            "source",
+            sa.String(length=20),
+            nullable=False,
+            server_default="household",
+        ),
+    )
+    op.get_bind().execute(
+        text(
+            "UPDATE catalog_requests " "SET source = 'user' " "WHERE requester_user_id IS NOT NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``source`` column."""
+    op.drop_column("catalog_requests", "source")

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -98,8 +98,10 @@ class CatalogRequestOutput:
         requester_user_id: External id (``usr_xxx``) of the user who
             registered the request. ``None`` on legacy rows.
         collection_tmdb_id: Originating TMDB collection id, if any.
+        source: ``"user"`` or ``"household"`` — who put it in the queue.
         notify_on_arrival: Whether the user opted in to a notification.
         is_fulfilled: ``True`` when the title is already in the catalog.
+        status: Derived ``"pending"`` / ``"fulfilled"`` (honest, thin).
         requested_at: ISO-8601 creation timestamp.
         fulfilled_at: ISO-8601 fulfillment timestamp, or ``None``.
     """
@@ -110,8 +112,10 @@ class CatalogRequestOutput:
     title: str | None
     requester_user_id: str | None
     collection_tmdb_id: int | None
+    source: str
     notify_on_arrival: bool
     is_fulfilled: bool
+    status: str
     requested_at: str
     fulfilled_at: str | None
 
@@ -125,8 +129,10 @@ class CatalogRequestOutput:
             title=entity.title,
             requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
+            source=entity.source.value,
             notify_on_arrival=entity.notify_on_arrival,
             is_fulfilled=entity.is_fulfilled,
+            status=entity.status.value,
             requested_at=entity.requested_at.isoformat(),
             fulfilled_at=entity.fulfilled_at.isoformat() if entity.fulfilled_at else None,
         )

--- a/src/modules/catalog_requests/domain/entities/catalog_request.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_request.py
@@ -9,6 +9,8 @@ from pydantic import Field
 from src.building_blocks.domain import AggregateRoot
 from src.modules.catalog_requests.domain.value_objects import (
     CatalogRequestId,
+    CatalogRequestSource,
+    CatalogRequestStatus,
 )
 from src.shared_kernel.value_objects import (
     MediaType,  # noqa: TCH001 — runtime for Pydantic
@@ -45,6 +47,11 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
             request, if any. Lets us scope listings to a single
             franchise (e.g. "all pending requests in the Alien
             Anthology").
+        source: Where the request originated — :attr:`USER` when a
+            member asked for it, :attr:`HOUSEHOLD` when the system
+            seeded it (ADR-022). Derived from ``requester_user_id`` at
+            creation and fixed thereafter. See also the derived
+            :attr:`status` property (pending vs. fulfilled).
         notify_on_arrival: ``True`` when the user has opted in to a
             notification once the title enters the catalog. Defaults
             to ``False`` — "Solicitar inclusão" alone does not
@@ -71,6 +78,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
     title: str | None = None
     requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
+    source: CatalogRequestSource = CatalogRequestSource.HOUSEHOLD
     notify_on_arrival: bool = False
     requested_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     fulfilled_at: datetime | None = None
@@ -114,6 +122,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
             title=title,
             requester_user_id=requester_user_id,
             collection_tmdb_id=collection_tmdb_id,
+            source=CatalogRequestSource.for_requester(requester_user_id),
             notify_on_arrival=notify_on_arrival,
             requested_at=datetime.now(UTC),
             fulfilled_at=None,
@@ -123,6 +132,11 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
     def is_fulfilled(self) -> bool:
         """``True`` once the requested title has reached the catalog."""
         return self.fulfilled_at is not None
+
+    @property
+    def status(self) -> CatalogRequestStatus:
+        """Honest, derived status (pending vs. fulfilled) — never stored."""
+        return CatalogRequestStatus.FULFILLED if self.is_fulfilled else CatalogRequestStatus.PENDING
 
     def enable_notification(self) -> CatalogRequest:
         """Return a copy with ``notify_on_arrival=True``.

--- a/src/modules/catalog_requests/domain/value_objects/__init__.py
+++ b/src/modules/catalog_requests/domain/value_objects/__init__.py
@@ -3,8 +3,19 @@
 from src.modules.catalog_requests.domain.value_objects.catalog_request_id import (
     CatalogRequestId,
 )
+from src.modules.catalog_requests.domain.value_objects.catalog_request_source import (
+    CatalogRequestSource,
+)
+from src.modules.catalog_requests.domain.value_objects.catalog_request_status import (
+    CatalogRequestStatus,
+)
 from src.modules.catalog_requests.domain.value_objects.catalog_subscription_id import (
     CatalogSubscriptionId,
 )
 
-__all__ = ["CatalogRequestId", "CatalogSubscriptionId"]
+__all__ = [
+    "CatalogRequestId",
+    "CatalogRequestSource",
+    "CatalogRequestStatus",
+    "CatalogSubscriptionId",
+]

--- a/src/modules/catalog_requests/domain/value_objects/catalog_request_source.py
+++ b/src/modules/catalog_requests/domain/value_objects/catalog_request_source.py
@@ -1,0 +1,41 @@
+"""Origin of a catalog request — who put the title in the queue."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class CatalogRequestSource(StrEnum):
+    """Where a ``CatalogRequest`` came from (ADR-022).
+
+    Distinguishes a title a member explicitly asked for from one the
+    household surfaced on its own (e.g. a needs-review flag that seeds
+    a request). Fixed at creation — it records the *origin*, so a later
+    subscriber expressing interest doesn't change it (their interest is
+    a ``CatalogSubscription``, not the source).
+
+    Uses ``StrEnum`` so the value serializes straight to the DTO and
+    the database column.
+
+    Example:
+        >>> CatalogRequestSource.for_requester("usr_alice")
+        <CatalogRequestSource.USER: 'user'>
+        >>> CatalogRequestSource.for_requester(None)
+        <CatalogRequestSource.HOUSEHOLD: 'household'>
+    """
+
+    USER = "user"
+    HOUSEHOLD = "household"
+
+    @classmethod
+    def for_requester(cls, requester_user_id: str | None) -> CatalogRequestSource:
+        """Derive the source from whether a member initiated the request.
+
+        A known requester means a member asked for the title
+        (:attr:`USER`); its absence means the household/system seeded
+        it (:attr:`HOUSEHOLD`).
+        """
+        return cls.USER if requester_user_id else cls.HOUSEHOLD
+
+
+__all__ = ["CatalogRequestSource"]

--- a/src/modules/catalog_requests/domain/value_objects/catalog_request_status.py
+++ b/src/modules/catalog_requests/domain/value_objects/catalog_request_status.py
@@ -1,0 +1,29 @@
+"""Honest, derived status of a catalog request."""
+
+from enum import StrEnum
+
+
+class CatalogRequestStatus(StrEnum):
+    """Where a ``CatalogRequest`` stands, derived from ``fulfilled_at``.
+
+    Deliberately thin (ADR-022): the system only honestly knows
+    "still waiting" vs "the title landed". The richer pipeline states
+    the design mock imagined (processing / waiting_file / matching)
+    describe machinery that doesn't exist, so they're left out. A
+    future ``STALLED`` (pending but the title is already in the catalog
+    under a different tmdb id) can slot in here when there's a real
+    signal for it.
+
+    Not stored — computed on read from ``fulfilled_at`` so it can never
+    drift from the source of truth.
+
+    Example:
+        >>> CatalogRequestStatus.PENDING.value
+        'pending'
+    """
+
+    PENDING = "pending"
+    FULFILLED = "fulfilled"
+
+
+__all__ = ["CatalogRequestStatus"]

--- a/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
@@ -3,6 +3,7 @@
 from src.modules.catalog_requests.domain.entities import CatalogRequest
 from src.modules.catalog_requests.domain.value_objects import (
     CatalogRequestId,
+    CatalogRequestSource,
 )
 from src.modules.catalog_requests.infrastructure.persistence.models import (
     CatalogRequestModel,
@@ -42,6 +43,7 @@ class CatalogRequestMapper:
             title=entity.title,
             requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
+            source=entity.source.value,
             notify_on_arrival=entity.notify_on_arrival,
             requested_at=entity.requested_at,
             fulfilled_at=entity.fulfilled_at,
@@ -57,6 +59,7 @@ class CatalogRequestMapper:
             title=model.title,
             requester_user_id=model.requester_user_id,
             collection_tmdb_id=model.collection_tmdb_id,
+            source=CatalogRequestSource(model.source),
             notify_on_arrival=model.notify_on_arrival,
             requested_at=model.requested_at,
             fulfilled_at=model.fulfilled_at,

--- a/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
@@ -33,6 +33,8 @@ class CatalogRequestModel(Base):
             rows or programmatic seeds — those stay anonymous and
             never produce a notification.
         collection_tmdb_id: Originating TMDB collection id, if any.
+        source: ``"user"`` when a member asked for the title,
+            ``"household"`` when the system seeded it (ADR-022).
         notify_on_arrival: Whether the user opted in to a "title
             now available" notification.
         requested_at: First-time creation timestamp (separate from
@@ -54,6 +56,12 @@ class CatalogRequestModel(Base):
         Integer,
         nullable=True,
         index=True,
+    )
+    source: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="household",
+        server_default="household",
     )
     notify_on_arrival: Mapped[bool] = mapped_column(
         Boolean,

--- a/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
+++ b/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
@@ -7,6 +7,8 @@ import pytest
 from src.modules.catalog_requests.domain.entities import CatalogRequest
 from src.modules.catalog_requests.domain.value_objects import (
     CatalogRequestId,
+    CatalogRequestSource,
+    CatalogRequestStatus,
 )
 from src.shared_kernel.value_objects import MediaType
 
@@ -110,3 +112,43 @@ class TestCatalogRequest:
         )
 
         assert request.reconcile() is None
+
+    def test_source_is_user_when_a_member_requested(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            requester_user_id="usr_aaaaaaaaaaaa",
+        )
+
+        assert request.source is CatalogRequestSource.USER
+
+    def test_source_is_household_without_requester(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+        )
+
+        assert request.source is CatalogRequestSource.HOUSEHOLD
+
+    def test_source_is_fixed_at_creation(self) -> None:
+        # A later requester backfill (first-owner) records the notify
+        # anchor but must not rewrite the household origin.
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+        )
+
+        reconciled = request.reconcile(requester_user_id="usr_aaaaaaaaaaaa")
+
+        assert reconciled is not None
+        assert reconciled.requester_user_id == "usr_aaaaaaaaaaaa"
+        assert reconciled.source is CatalogRequestSource.HOUSEHOLD
+
+    def test_status_tracks_fulfillment(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+        )
+
+        assert request.status is CatalogRequestStatus.PENDING
+        assert request.mark_fulfilled().status is CatalogRequestStatus.FULFILLED


### PR DESCRIPTION
## Summary

Phase **B2** of the Catalog Requests / "Em breve" feature (builds on #297). Adds the two read-side attributes the redesign needs, modelled honestly per ADR-022.

- **`source`** (`CatalogRequestSource`: `user` / `household`) — where the request came from. Derived from the requester anchor at creation (`for_requester`) and **fixed thereafter**: a later requester backfill records the notify anchor but doesn't rewrite the origin.
- **`status`** (`CatalogRequestStatus`: `pending` / `fulfilled`) — **derived** from `fulfilled_at`, never stored, so it can't drift. The mock's richer pipeline states (`processing`/`waiting_file`/`matching`) describe machinery that doesn't exist and are intentionally left out; a real `STALLED` can slot in later.

### What's in here
- **Domain** — `CatalogRequestSource` + `CatalogRequestStatus` value objects; `source` field on `CatalogRequest` (derived in `create`) + derived `status` property.
- **Infra** — `source` column on the model + mapper (immutable, so it stays out of `update_model`) + migration `2026_06_23_add_source_to_catalog_requests` (add column, backfill `requester_user_id IS NOT NULL → user`, else `household`).
- **DTO** — `CatalogRequestOutput` carries `source` + `status`, ready for the admin/member views (routes are wired in B3/B4).

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] Domain tests — source derivation (user/household), source fixed at creation across a reconcile, status pending→fulfilled
- [x] Migration validated on a temp DB: backfill sets `user` for the requester row and `household` for the anonymous one; downgrade drops the column
- [x] **Full suite green — 2942 passed, 5 skipped**

## Deploy

`make migrate` (adds `source` + backfills) then restart.

## Follow-ups
- **B3** — member endpoints (GET list with `is_subscribed` + subscriber counts + status, `DELETE .../subscribe`).
- **B4** — admin endpoints (status/source columns, `POST .../include` fanout).