### PR TITLE
feat(catalog-requests): member 'Em breve' feed + unsubscribe (ADR-022 B3)

### DIFF
--- a/src/config/containers/catalog_requests.py
+++ b/src/config/containers/catalog_requests.py
@@ -4,6 +4,7 @@ from dependency_injector import containers, providers
 
 from src.modules.catalog_requests.application.use_cases import (
     DismissCatalogRequestUseCase,
+    ListCatalogRequestFeedUseCase,
     ListCatalogRequestsUseCase,
     RequestCatalogInclusionUseCase,
     SubscribeCatalogNotificationUseCase,
@@ -68,6 +69,11 @@ class CatalogRequestsContainer(containers.DeclarativeContainer):  # type: ignore
 
     list_catalog_requests = providers.Factory(
         ListCatalogRequestsUseCase,
+        uow_factory=catalog_requests_unit_of_work_factory,
+    )
+
+    list_catalog_request_feed = providers.Factory(
+        ListCatalogRequestFeedUseCase,
         uow_factory=catalog_requests_unit_of_work_factory,
     )
 

--- a/src/modules/catalog_requests/application/dtos/__init__.py
+++ b/src/modules/catalog_requests/application/dtos/__init__.py
@@ -1,6 +1,7 @@
 """Catalog Requests application DTOs."""
 
 from src.modules.catalog_requests.application.dtos.catalog_request_dtos import (
+    CatalogRequestFeedItem,
     CatalogRequestOutput,
     CreateCatalogRequestInput,
     DismissCatalogRequestInput,
@@ -9,6 +10,7 @@ from src.modules.catalog_requests.application.dtos.catalog_request_dtos import (
 )
 
 __all__ = [
+    "CatalogRequestFeedItem",
     "CatalogRequestOutput",
     "CreateCatalogRequestInput",
     "DismissCatalogRequestInput",

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -138,9 +138,32 @@ class CatalogRequestOutput:
         )
 
 
+@dataclass(frozen=True)
+class CatalogRequestFeedItem:
+    """A pending request enriched for the member "Em breve" feed.
+
+    Wraps the base request DTO with the two per-view extras the
+    consumer page needs (ADR-022): how many people are waiting and
+    whether the caller is one of them. The route flattens this onto
+    the base fields for the wire.
+
+    Attributes:
+        request: The underlying request DTO (id, title, status, …).
+        subscriber_count: Active subscribers — the "{N} pessoas
+            aguardando" figure.
+        is_subscribed: Whether the calling user follows this title.
+    """
+
+    request: CatalogRequestOutput
+    subscriber_count: int
+    is_subscribed: bool
+
+
 __all__ = [
+    "CatalogRequestFeedItem",
     "CatalogRequestOutput",
     "CreateCatalogRequestInput",
     "DismissCatalogRequestInput",
     "SubscribeCatalogNotificationInput",
+    "UnsubscribeCatalogNotificationInput",
 ]

--- a/src/modules/catalog_requests/application/use_cases/__init__.py
+++ b/src/modules/catalog_requests/application/use_cases/__init__.py
@@ -3,6 +3,9 @@
 from src.modules.catalog_requests.application.use_cases.dismiss_catalog_request import (
     DismissCatalogRequestUseCase,
 )
+from src.modules.catalog_requests.application.use_cases.list_catalog_request_feed import (
+    ListCatalogRequestFeedUseCase,
+)
 from src.modules.catalog_requests.application.use_cases.list_catalog_requests import (
     ListCatalogRequestsUseCase,
 )
@@ -18,6 +21,7 @@ from src.modules.catalog_requests.application.use_cases.unsubscribe_catalog_noti
 
 __all__ = [
     "DismissCatalogRequestUseCase",
+    "ListCatalogRequestFeedUseCase",
     "ListCatalogRequestsUseCase",
     "RequestCatalogInclusionUseCase",
     "SubscribeCatalogNotificationUseCase",

--- a/src/modules/catalog_requests/application/use_cases/list_catalog_request_feed.py
+++ b/src/modules/catalog_requests/application/use_cases/list_catalog_request_feed.py
@@ -1,0 +1,77 @@
+"""List pending catalog requests enriched for the member 'Em breve' feed."""
+
+from dataclasses import dataclass
+
+from src.modules.catalog_requests.application.dtos import (
+    CatalogRequestFeedItem,
+    CatalogRequestOutput,
+)
+from src.modules.catalog_requests.application.unit_of_work import (
+    CatalogRequestsUnitOfWorkFactory,
+)
+
+
+@dataclass(frozen=True)
+class ListCatalogRequestFeedInput:
+    """Input for ``ListCatalogRequestFeedUseCase``.
+
+    Attributes:
+        user_id: External id (``usr_xxx``) of the caller, so each item
+            can carry whether *this* user is subscribed.
+        collection_tmdb_id: Optional franchise scope (same filter as
+            the plain listing).
+    """
+
+    user_id: str
+    collection_tmdb_id: int | None = None
+
+
+class ListCatalogRequestFeedUseCase:
+    """Pending requests + per-caller subscription state for "Em breve".
+
+    The member-facing view behind the consumer page: every pending
+    title, each annotated with its active subscriber count and whether
+    the calling user follows it (ADR-022). Counts and the caller's
+    subscriptions are resolved in two batch queries rather than N+1.
+    """
+
+    def __init__(self, uow_factory: CatalogRequestsUnitOfWorkFactory) -> None:
+        """Initialize the use case.
+
+        Args:
+            uow_factory: Factory that opens a fresh catalog-requests
+                Unit of Work.
+        """
+        self._uow_factory = uow_factory
+
+    async def execute(
+        self,
+        input_dto: ListCatalogRequestFeedInput,
+    ) -> list[CatalogRequestFeedItem]:
+        """Execute the use case.
+
+        Returns:
+            Pending requests enriched with ``subscriber_count`` and the
+            caller's ``is_subscribed`` flag, newest first.
+        """
+        async with self._uow_factory() as uow:
+            pending = await uow.catalog_requests.list_pending(
+                input_dto.collection_tmdb_id,
+            )
+            request_ids = [r.id for r in pending if r.id is not None]
+            counts = await uow.catalog_subscriptions.count_by_requests(request_ids)
+            subscribed = await uow.catalog_subscriptions.request_ids_for_user(
+                input_dto.user_id,
+            )
+
+        return [
+            CatalogRequestFeedItem(
+                request=CatalogRequestOutput.from_entity(request),
+                subscriber_count=counts.get(request.id, 0),
+                is_subscribed=request.id in subscribed,
+            )
+            for request in pending
+        ]
+
+
+__all__ = ["ListCatalogRequestFeedInput", "ListCatalogRequestFeedUseCase"]

--- a/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
@@ -7,19 +7,22 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
+from src.building_blocks.application.errors import ResourceNotFoundException
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.modules.catalog_requests.application.dtos import (
     CreateCatalogRequestInput,
     SubscribeCatalogNotificationInput,
+    UnsubscribeCatalogNotificationInput,
 )
 from src.modules.catalog_requests.application.use_cases import (
-    ListCatalogRequestsUseCase,
+    ListCatalogRequestFeedUseCase,
     RequestCatalogInclusionUseCase,
     SubscribeCatalogNotificationUseCase,
+    UnsubscribeCatalogNotificationUseCase,
 )
-from src.modules.catalog_requests.application.use_cases.list_catalog_requests import (
-    ListCatalogRequestsInput,
+from src.modules.catalog_requests.application.use_cases.list_catalog_request_feed import (
+    ListCatalogRequestFeedInput,
 )
 from src.modules.identity.infrastructure.auth import current_active_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
@@ -127,19 +130,69 @@ async def subscribe_catalog_notification(
     return api_single("catalog_request", asdict(result))
 
 
+@router.delete("/{tmdb_id}/notify", status_code=200)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def unsubscribe_catalog_notification(
+    tmdb_id: int,
+    media_type: MediaType = Query(...),
+    user: UserModel = Depends(current_active_user),
+    use_case: UnsubscribeCatalogNotificationUseCase = Depends(
+        Provide[ApplicationContainer.catalog_requests.unsubscribe_catalog_notification],
+    ),
+) -> dict[str, Any]:
+    """Turn the arrival notification off for the calling user.
+
+    Drops only this user's subscription; the request and every other
+    subscriber stay put. Idempotent — unsubscribing when not
+    subscribed still returns the request. ``404`` only when no request
+    exists for the title at all.
+    """
+    result = await use_case.execute(
+        UnsubscribeCatalogNotificationInput(
+            tmdb_id=tmdb_id,
+            media_type=media_type,
+            user_id=user.external_id,
+        ),
+    )
+    if result is None:
+        raise ResourceNotFoundException.for_resource(
+            "CatalogRequest",
+            f"tmdb/{media_type.value}/{tmdb_id}",
+        )
+    return api_single("catalog_request", asdict(result))
+
+
 @router.get("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_catalog_requests(
     collection_tmdb_id: int | None = Query(default=None, ge=1),
-    use_case: ListCatalogRequestsUseCase = Depends(
-        Provide[ApplicationContainer.catalog_requests.list_catalog_requests],
+    user: UserModel = Depends(current_active_user),
+    use_case: ListCatalogRequestFeedUseCase = Depends(
+        Provide[ApplicationContainer.catalog_requests.list_catalog_request_feed],
     ),
 ) -> dict[str, Any]:
-    """List all pending (unfulfilled) catalog requests."""
+    """List pending requests for the "Em breve" feed.
+
+    Each item carries the base request fields plus ``subscriber_count``
+    and the caller's ``is_subscribed`` flag (ADR-022). Optionally
+    scoped to a single franchise via ``collection_tmdb_id``.
+    """
     items = await use_case.execute(
-        ListCatalogRequestsInput(collection_tmdb_id=collection_tmdb_id),
+        ListCatalogRequestFeedInput(
+            user_id=user.external_id,
+            collection_tmdb_id=collection_tmdb_id,
+        ),
     )
-    return api_list([asdict(item) for item in items])
+    return api_list(
+        [
+            {
+                **asdict(item.request),
+                "subscriber_count": item.subscriber_count,
+                "is_subscribed": item.is_subscribed,
+            }
+            for item in items
+        ],
+    )
 
 
 __all__ = ["router"]

--- a/tests/modules/catalog_requests/e2e/__init__.py
+++ b/tests/modules/catalog_requests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Catalog Requests end-to-end tests."""

--- a/tests/modules/catalog_requests/e2e/conftest.py
+++ b/tests/modules/catalog_requests/e2e/conftest.py
@@ -1,0 +1,142 @@
+"""End-to-end test scaffolding for the catalog_requests BC.
+
+Mirrors the settings/identity e2e setup: in-memory SQLite shared via
+``StaticPool`` so seeds and HTTP-driven use cases see the same rows;
+``ApplicationContainer`` wired by hand so the lifespan handler does not
+run (no real scheduler boot under test).
+"""
+
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from dataclasses import dataclass
+
+import pytest
+from dependency_injector import providers
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pwdlib import PasswordHash
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+# Register identity + catalog_requests models on ``Base.metadata`` so
+# ``create_all`` discovers users / profiles / access_tokens /
+# catalog_requests / catalog_subscriptions.
+import src.modules.catalog_requests.infrastructure.persistence.models
+import src.modules.identity.infrastructure.persistence.models  # noqa: F401
+from src.config.containers import ApplicationContainer
+from src.infrastructure.persistence import Base
+from src.main import WIRED_ROUTE_MODULES, create_app
+from src.modules.identity.infrastructure.persistence.models.profile_model import (
+    ProfileModel,
+)
+from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.shared_kernel.value_objects.profile_id import ProfileId
+from src.shared_kernel.value_objects.user_id import UserId
+
+
+@pytest.fixture(scope="function")
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    """In-memory SQLite session factory bound to a shared connection."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+    yield factory
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def app(session_factory: async_sessionmaker[AsyncSession]) -> FastAPI:
+    """FastAPI app wired against the in-memory test session factory."""
+    container = ApplicationContainer()
+    container.wire(modules=list(WIRED_ROUTE_MODULES))
+    container.infrastructure.session_factory.override(
+        providers.Object(session_factory),
+    )
+
+    fastapi_app = create_app()
+    fastapi_app.state.container = container
+    return fastapi_app
+
+
+@pytest.fixture(scope="function")
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient, None]:
+    """In-process ``httpx`` client driving the test app."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        yield c
+
+
+@dataclass(frozen=True)
+class SeededUser:
+    """Convenience handle for the member seed fixture."""
+
+    email: str
+    password: str
+    user_external_id: str
+    profile_external_id: str
+
+
+_password_hash = PasswordHash.recommended()
+
+
+@pytest.fixture(scope="function")
+def seed_user_with_profile(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> Callable[..., Awaitable[SeededUser]]:
+    """Factory fixture: insert a verified user + default profile."""
+
+    async def _seed(
+        *,
+        email: str = "alice@example.com",
+        password: str = "password-strong",
+        profile_name: str = "Alice",
+        is_admin: bool = False,
+    ) -> SeededUser:
+        user_external = UserId.generate().value
+        profile_external = ProfileId.generate().value
+
+        async with session_factory() as session:
+            user = UserModel(
+                external_id=user_external,
+                email=email,
+                hashed_password=_password_hash.hash(password),
+                is_active=True,
+                is_verified=True,
+                is_superuser=is_admin,
+                role="admin" if is_admin else "member",
+            )
+            session.add(user)
+            await session.flush()
+
+            profile = ProfileModel(
+                external_id=profile_external,
+                user_id=user.id,
+                name=profile_name,
+                is_kids=False,
+            )
+            session.add(profile)
+            await session.commit()
+
+        return SeededUser(
+            email=email,
+            password=password,
+            user_external_id=user_external,
+            profile_external_id=profile_external,
+        )
+
+    return _seed

--- a/tests/modules/catalog_requests/e2e/test_catalog_request_routes.py
+++ b/tests/modules/catalog_requests/e2e/test_catalog_request_routes.py
@@ -1,0 +1,85 @@
+"""End-to-end tests for the member catalog-request routes (ADR-022 B3)."""
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from httpx import AsyncClient
+
+from tests.modules.catalog_requests.e2e.conftest import SeededUser
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+ROOT = "/api/v1/catalog-requests"
+_TMDB = 348
+
+
+async def _login(client: AsyncClient, user: SeededUser) -> None:
+    resp = await client.post(
+        LOGIN_PATH,
+        data={"username": user.email, "password": user.password},
+    )
+    assert resp.status_code == 204
+
+
+async def _subscribe(client: AsyncClient, tmdb_id: int = _TMDB) -> None:
+    resp = await client.post(
+        f"{ROOT}/{tmdb_id}/notify",
+        json={"media_type": "movie", "title": "Alien"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.e2e
+class TestCatalogRequestMemberRoutes:
+    """The "Em breve" feed + the unsubscribe toggle."""
+
+    async def test_unauthenticated_feed_returns_401(self, client: AsyncClient) -> None:
+        response = await client.get(ROOT)
+        assert response.status_code == 401
+
+    async def test_feed_shows_count_and_subscription(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile()
+        await _login(client, member)
+        await _subscribe(client)
+
+        response = await client.get(ROOT)
+
+        assert response.status_code == 200
+        items = response.json()["data"]
+        item = next(i for i in items if i["tmdb_id"] == _TMDB)
+        assert item["subscriber_count"] == 1
+        assert item["is_subscribed"] is True
+        assert item["status"] == "pending"
+        assert item["source"] == "user"
+
+    async def test_unsubscribe_drops_the_caller(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile()
+        await _login(client, member)
+        await _subscribe(client)
+
+        resp = await client.delete(f"{ROOT}/{_TMDB}/notify", params={"media_type": "movie"})
+        assert resp.status_code == 200
+
+        feed = await client.get(ROOT)
+        item = next(i for i in feed.json()["data"] if i["tmdb_id"] == _TMDB)
+        assert item["is_subscribed"] is False
+        assert item["subscriber_count"] == 0
+
+    async def test_unsubscribe_unknown_returns_404(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile()
+        await _login(client, member)
+
+        resp = await client.delete(f"{ROOT}/999999/notify", params={"media_type": "movie"})
+
+        assert resp.status_code == 404

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_list_catalog_request_feed.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_list_catalog_request_feed.py
@@ -1,0 +1,52 @@
+"""Tests for ``ListCatalogRequestFeedUseCase``."""
+
+import pytest
+
+from src.modules.catalog_requests.application.use_cases import (
+    ListCatalogRequestFeedUseCase,
+)
+from src.modules.catalog_requests.application.use_cases.list_catalog_request_feed import (
+    ListCatalogRequestFeedInput,
+)
+from src.modules.catalog_requests.domain.entities import CatalogRequest
+from src.shared_kernel.value_objects import MediaType
+from tests.modules.catalog_requests.unit.conftest import (
+    make_catalog_requests_uow_mock,
+)
+
+
+@pytest.mark.unit
+class TestListCatalogRequestFeedUseCase:
+    """Tests for the member 'Em breve' feed."""
+
+    @pytest.mark.asyncio
+    async def test_enriches_with_count_and_subscription(self) -> None:
+        followed = CatalogRequest.create(tmdb_id=1, media_type=MediaType.MOVIE)
+        other = CatalogRequest.create(tmdb_id=2, media_type=MediaType.MOVIE)
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.list_pending.return_value = [followed, other]
+        mocks.catalog_subscriptions.count_by_requests.return_value = {followed.id: 3}
+        mocks.catalog_subscriptions.request_ids_for_user.return_value = {followed.id}
+        use_case = ListCatalogRequestFeedUseCase(uow_factory=mocks.factory)
+
+        items = await use_case.execute(ListCatalogRequestFeedInput(user_id="usr_me"))
+
+        by_tmdb = {item.request.tmdb_id: item for item in items}
+        assert by_tmdb[1].subscriber_count == 3
+        assert by_tmdb[1].is_subscribed is True
+        # Absent from the count map → 0; not in the caller's set → False.
+        assert by_tmdb[2].subscriber_count == 0
+        assert by_tmdb[2].is_subscribed is False
+
+    @pytest.mark.asyncio
+    async def test_passes_collection_scope_through(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.list_pending.return_value = []
+        use_case = ListCatalogRequestFeedUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            ListCatalogRequestFeedInput(user_id="usr_me", collection_tmdb_id=8091),
+        )
+
+        assert result == []
+        mocks.catalog_requests.list_pending.assert_awaited_once_with(8091)

--- a/tests/modules/catalog_requests/unit/conftest.py
+++ b/tests/modules/catalog_requests/unit/conftest.py
@@ -33,6 +33,8 @@ def make_catalog_requests_uow_mock() -> CatalogRequestsUoWMocks:
     catalog_subscriptions.find.return_value = None
     catalog_subscriptions.list_for_request.return_value = []
     catalog_subscriptions.count_for_request.return_value = 0
+    catalog_subscriptions.count_by_requests.return_value = {}
+    catalog_subscriptions.request_ids_for_user.return_value = set()
     catalog_subscriptions.remove.return_value = False
 
     uow: CatalogRequestsUnitOfWork = AsyncMock()


### PR DESCRIPTION
## Summary

Phase **B3** of the Catalog Requests feature (builds on #297/#298). Wires the member-facing backend for the "Em breve" page.

- **`GET /catalog-requests`** becomes the member feed: each pending request carries the base fields plus **`subscriber_count`** and the caller's **`is_subscribed`** flag (resolved via two batch queries from B1 — `count_by_requests` + `request_ids_for_user`, no N+1). Now behind `current_active_user`.
- **`DELETE /catalog-requests/{tmdb_id}/notify?media_type=`** — turns the arrival notification off for the calling user, wiring the `UnsubscribeCatalogNotificationUseCase` from B1. Idempotent; `404` only when no request exists for the title.

### ⚠️ Contract change
`GET /catalog-requests` now **requires auth** and returns the **enriched feed shape** instead of the plain request list. Verified no backend consumer depends on the old shape (only the test conftest referenced it) and the frontend doesn't call it (the Collection page reads request state from the collection payload). The **admin** `GET /admin/catalog-requests` is unchanged — it stays the plain list and gets enriched separately in B4.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] Unit — feed enrichment (count + subscription, absent→0/False) + collection scope passthrough
- [x] **New e2e harness** for the BC (in-memory app + cookie login) — 401 unauthenticated, feed shows `subscriber_count`/`is_subscribed`/`status`/`source`, unsubscribe drops the caller, 404 on unknown title
- [x] **Full suite green — 2948 passed, 5 skipped**

## Deploy
Restart only — no migration.

## Follow-ups
- **B4** — admin endpoints: expose `status`/`source` + subscriber counts on the queue, `POST /admin/catalog-requests/{id}/include` (manual fulfill + fanout + archive).
- **F1/F2** — admin + consumer frontends.