### PR TITLE
feat(catalog-requests): admin queue counts + mark-as-included fanout (ADR-022 B4)

### DIFF
--- a/src/config/containers/catalog_requests.py
+++ b/src/config/containers/catalog_requests.py
@@ -4,6 +4,8 @@ from dependency_injector import containers, providers
 
 from src.modules.catalog_requests.application.use_cases import (
     DismissCatalogRequestUseCase,
+    IncludeCatalogRequestUseCase,
+    ListAdminCatalogRequestsUseCase,
     ListCatalogRequestFeedUseCase,
     ListCatalogRequestsUseCase,
     RequestCatalogInclusionUseCase,
@@ -29,6 +31,10 @@ class CatalogRequestsContainer(containers.DeclarativeContainer):  # type: ignore
     """
 
     session_factory = providers.Dependency()
+
+    # Cross-BC publisher (Notifications BC) — powers the arrival fanout
+    # on the manual "mark as included" action (ADR-022 / ADR-009).
+    notification_publisher = providers.Dependency()
 
     # =========================================================================
     # Unit of Work
@@ -77,7 +83,18 @@ class CatalogRequestsContainer(containers.DeclarativeContainer):  # type: ignore
         uow_factory=catalog_requests_unit_of_work_factory,
     )
 
+    list_admin_catalog_requests = providers.Factory(
+        ListAdminCatalogRequestsUseCase,
+        uow_factory=catalog_requests_unit_of_work_factory,
+    )
+
     dismiss_catalog_request = providers.Factory(
         DismissCatalogRequestUseCase,
         uow_factory=catalog_requests_unit_of_work_factory,
+    )
+
+    include_catalog_request = providers.Factory(
+        IncludeCatalogRequestUseCase,
+        uow_factory=catalog_requests_unit_of_work_factory,
+        notification_publisher=notification_publisher,
     )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -160,6 +160,16 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         session_factory=infrastructure.session_factory,
     )
 
+    # Notifications is built before Catalog Requests so its publisher
+    # adapter can be injected as the latter's ``NotificationPublisherPort``
+    # — used by both the OnMediaEnriched fanout and the manual
+    # "mark as included" action. Notifications takes no Catalog Requests
+    # dependency, so the ordering stays acyclic.
+    notifications = providers.Container(
+        NotificationsContainer,
+        session_factory=infrastructure.session_factory,
+    )
+
     # Catalog Requests is built before Media so its ACL adapter can be
     # plumbed into the Media container as the ``CatalogRequestLookupPort``
     # implementation. Catalog Requests itself takes no Media dependency,
@@ -167,6 +177,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
     catalog_requests = providers.Container(
         CatalogRequestsContainer,
         session_factory=infrastructure.session_factory,
+        notification_publisher=notifications.notification_publisher,
     )
 
     media = providers.Container(
@@ -216,15 +227,6 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         CollectionsContainer,
         session_factory=infrastructure.session_factory,
         media_uow_factory=media.media_unit_of_work_factory,
-    )
-
-    # Notifications BC: provides the cross-BC publisher adapter
-    # consumed by ``catalog_requests``' ``OnMediaEnrichedHandler``
-    # (wired in main.py's event subscription block, not here, so the
-    # container parse order stays acyclic).
-    notifications = providers.Container(
-        NotificationsContainer,
-        session_factory=infrastructure.session_factory,
     )
 
     # =========================================================================

--- a/src/modules/catalog_requests/application/dtos/__init__.py
+++ b/src/modules/catalog_requests/application/dtos/__init__.py
@@ -1,19 +1,23 @@
 """Catalog Requests application DTOs."""
 
 from src.modules.catalog_requests.application.dtos.catalog_request_dtos import (
+    AdminCatalogRequestItem,
     CatalogRequestFeedItem,
     CatalogRequestOutput,
     CreateCatalogRequestInput,
     DismissCatalogRequestInput,
+    IncludeCatalogRequestInput,
     SubscribeCatalogNotificationInput,
     UnsubscribeCatalogNotificationInput,
 )
 
 __all__ = [
+    "AdminCatalogRequestItem",
     "CatalogRequestFeedItem",
     "CatalogRequestOutput",
     "CreateCatalogRequestInput",
     "DismissCatalogRequestInput",
+    "IncludeCatalogRequestInput",
     "SubscribeCatalogNotificationInput",
     "UnsubscribeCatalogNotificationInput",
 ]

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -159,11 +159,41 @@ class CatalogRequestFeedItem:
     is_subscribed: bool
 
 
+@dataclass(frozen=True)
+class AdminCatalogRequestItem:
+    """A pending request enriched for the admin queue.
+
+    Like the member feed item but without the per-caller
+    ``is_subscribed`` flag — the admin sees the aggregate count, not
+    their own subscription state.
+
+    Attributes:
+        request: The underlying request DTO (carries source + status).
+        subscriber_count: Active subscribers — the "Inscritos" column.
+    """
+
+    request: CatalogRequestOutput
+    subscriber_count: int
+
+
+@dataclass(frozen=True)
+class IncludeCatalogRequestInput:
+    """Input for ``IncludeCatalogRequestUseCase`` — admin "mark as included".
+
+    Attributes:
+        request_id: External catalog-request id (``req_xxx``).
+    """
+
+    request_id: str
+
+
 __all__ = [
+    "AdminCatalogRequestItem",
     "CatalogRequestFeedItem",
     "CatalogRequestOutput",
     "CreateCatalogRequestInput",
     "DismissCatalogRequestInput",
+    "IncludeCatalogRequestInput",
     "SubscribeCatalogNotificationInput",
     "UnsubscribeCatalogNotificationInput",
 ]

--- a/src/modules/catalog_requests/application/ports/notification_publisher_port.py
+++ b/src/modules/catalog_requests/application/ports/notification_publisher_port.py
@@ -40,7 +40,10 @@ class CatalogArrivalNotification:
             link if the local media id is unavailable.
         media_id: Typed external id of the local media row
             (``MovieId`` / ``SeriesId``) the request was fulfilled
-            by. Used as the primary click-through target.
+            by. Used as the primary click-through target. ``None`` for
+            a manual "mark as included" with no resolved local title
+            (ADR-022) — the notification still fires, the renderer just
+            falls back to search instead of a precise deep-link.
         media_type: ``"movie"`` or ``"series"`` so the renderer
             picks the right deep-link path.
     """
@@ -48,7 +51,7 @@ class CatalogArrivalNotification:
     recipient_user_id: str
     title: str
     tmdb_id: int
-    media_id: MovieId | SeriesId
+    media_id: MovieId | SeriesId | None
     media_type: str
 
 

--- a/src/modules/catalog_requests/application/use_cases/__init__.py
+++ b/src/modules/catalog_requests/application/use_cases/__init__.py
@@ -3,6 +3,12 @@
 from src.modules.catalog_requests.application.use_cases.dismiss_catalog_request import (
     DismissCatalogRequestUseCase,
 )
+from src.modules.catalog_requests.application.use_cases.include_catalog_request import (
+    IncludeCatalogRequestUseCase,
+)
+from src.modules.catalog_requests.application.use_cases.list_admin_catalog_requests import (
+    ListAdminCatalogRequestsUseCase,
+)
 from src.modules.catalog_requests.application.use_cases.list_catalog_request_feed import (
     ListCatalogRequestFeedUseCase,
 )
@@ -21,6 +27,8 @@ from src.modules.catalog_requests.application.use_cases.unsubscribe_catalog_noti
 
 __all__ = [
     "DismissCatalogRequestUseCase",
+    "IncludeCatalogRequestUseCase",
+    "ListAdminCatalogRequestsUseCase",
     "ListCatalogRequestFeedUseCase",
     "ListCatalogRequestsUseCase",
     "RequestCatalogInclusionUseCase",

--- a/src/modules/catalog_requests/application/use_cases/include_catalog_request.py
+++ b/src/modules/catalog_requests/application/use_cases/include_catalog_request.py
@@ -1,0 +1,120 @@
+"""IncludeCatalogRequestUseCase — admin marks a request as available."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.catalog_requests.application.dtos import (
+    CatalogRequestOutput,
+    IncludeCatalogRequestInput,
+)
+from src.modules.catalog_requests.application.ports import CatalogArrivalNotification
+from src.modules.catalog_requests.domain.value_objects import CatalogRequestId
+
+if TYPE_CHECKING:
+    from src.modules.catalog_requests.application.ports import NotificationPublisherPort
+    from src.modules.catalog_requests.application.unit_of_work import (
+        CatalogRequestsUnitOfWorkFactory,
+    )
+    from src.modules.catalog_requests.domain.entities import CatalogRequest
+
+_logger = logging.getLogger(__name__)
+
+
+class IncludeCatalogRequestUseCase:
+    """Admin "Marcar como incluído": fulfill + fan out + archive (ADR-022).
+
+    The manual counterpart to the auto-fulfillment loop, for the
+    orphan-rescue case: the title is in the catalog but the request
+    never auto-matched (it landed under a different tmdb id). Marking
+    it included stamps ``fulfilled_at`` — so the request leaves the
+    pending queue — and pings every subscriber "já disponível".
+
+    No local media is resolved here, so the arrival notification
+    carries no ``media_id``; the renderer falls back to search instead
+    of a precise deep-link (the chosen trade-off for a plain
+    confirm-only admin action).
+
+    Idempotent: an already-fulfilled request is returned unchanged
+    without re-notifying.
+    """
+
+    def __init__(
+        self,
+        uow_factory: CatalogRequestsUnitOfWorkFactory,
+        notification_publisher: NotificationPublisherPort | None = None,
+    ) -> None:
+        """Initialize the use case.
+
+        Args:
+            uow_factory: Factory for the Catalog Requests UoW.
+            notification_publisher: Optional cross-BC publisher. ``None``
+                still fulfills the request (the queue closes); only the
+                user-facing fanout is skipped.
+        """
+        self._uow_factory = uow_factory
+        self._notification_publisher = notification_publisher
+
+    async def execute(
+        self,
+        input_dto: IncludeCatalogRequestInput,
+    ) -> CatalogRequestOutput:
+        """Mark the request fulfilled and fan out the arrival ping.
+
+        Raises:
+            ResourceNotFoundException: When no active request matches.
+        """
+        request_id = CatalogRequestId(input_dto.request_id)
+        subscriber_ids: list[str] = []
+        async with self._uow_factory() as uow:
+            request = await uow.catalog_requests.find_by_id(request_id)
+            if request is None:
+                raise ResourceNotFoundException.for_resource(
+                    "CatalogRequest",
+                    input_dto.request_id,
+                )
+            if request.is_fulfilled:
+                return CatalogRequestOutput.from_entity(request)
+
+            request = await uow.catalog_requests.update(request.mark_fulfilled())
+            if self._notification_publisher is not None:
+                subscriptions = await uow.catalog_subscriptions.list_for_request(
+                    request.id,
+                )
+                subscriber_ids = [sub.user_id for sub in subscriptions]
+
+        await self._fan_out(request, subscriber_ids)
+        return CatalogRequestOutput.from_entity(request)
+
+    async def _fan_out(
+        self,
+        request: CatalogRequest,
+        subscriber_ids: list[str],
+    ) -> None:
+        """Publish "já disponível" to each subscriber, isolated per recipient."""
+        if self._notification_publisher is None or not subscriber_ids:
+            return
+
+        title = request.title or f"tmdb/{request.media_type.value}/{request.tmdb_id}"
+        for user_id in subscriber_ids:
+            try:
+                await self._notification_publisher.publish_catalog_arrival(
+                    CatalogArrivalNotification(
+                        recipient_user_id=user_id,
+                        title=title,
+                        tmdb_id=request.tmdb_id,
+                        media_id=None,
+                        media_type=request.media_type.value,
+                    ),
+                )
+            except Exception:
+                _logger.exception(
+                    "Failed to publish manual-include notification for request %s to user %s",
+                    request.id,
+                    user_id,
+                )
+
+
+__all__ = ["IncludeCatalogRequestUseCase"]

--- a/src/modules/catalog_requests/application/use_cases/list_admin_catalog_requests.py
+++ b/src/modules/catalog_requests/application/use_cases/list_admin_catalog_requests.py
@@ -1,0 +1,46 @@
+"""List pending catalog requests enriched for the admin queue."""
+
+from src.modules.catalog_requests.application.dtos import (
+    AdminCatalogRequestItem,
+    CatalogRequestOutput,
+)
+from src.modules.catalog_requests.application.unit_of_work import (
+    CatalogRequestsUnitOfWorkFactory,
+)
+
+
+class ListAdminCatalogRequestsUseCase:
+    """Pending requests + subscriber counts for the admin queue (ADR-022).
+
+    The admin counterpart to the member feed: every pending request
+    with its ``subscriber_count`` ("Inscritos"). ``source`` and the
+    derived ``status`` already ride on the base DTO. Counts are
+    resolved in one batch query rather than N+1.
+    """
+
+    def __init__(self, uow_factory: CatalogRequestsUnitOfWorkFactory) -> None:
+        """Initialize the use case.
+
+        Args:
+            uow_factory: Factory that opens a fresh catalog-requests
+                Unit of Work.
+        """
+        self._uow_factory = uow_factory
+
+    async def execute(self) -> list[AdminCatalogRequestItem]:
+        """Return every pending request annotated with its subscriber count."""
+        async with self._uow_factory() as uow:
+            pending = await uow.catalog_requests.list_pending(None)
+            request_ids = [r.id for r in pending if r.id is not None]
+            counts = await uow.catalog_subscriptions.count_by_requests(request_ids)
+
+        return [
+            AdminCatalogRequestItem(
+                request=CatalogRequestOutput.from_entity(request),
+                subscriber_count=counts.get(request.id, 0),
+            )
+            for request in pending
+        ]
+
+
+__all__ = ["ListAdminCatalogRequestsUseCase"]

--- a/src/modules/catalog_requests/domain/repositories/catalog_request_repository.py
+++ b/src/modules/catalog_requests/domain/repositories/catalog_request_repository.py
@@ -38,6 +38,20 @@ class CatalogRequestRepository(ABC):
         """
 
     @abstractmethod
+    async def find_by_id(self, request_id: CatalogRequestId) -> CatalogRequest | None:
+        """Look up a single request by its external id.
+
+        Backs the admin per-row actions (the "mark as included" flow),
+        which carry the ``req_xxx`` id rather than the TMDB target.
+
+        Args:
+            request_id: External id (``req_xxx``).
+
+        Returns:
+            The matching ``CatalogRequest`` or ``None``.
+        """
+
+    @abstractmethod
     async def find_by_tmdb_ids(
         self,
         tmdb_ids: Sequence[int],

--- a/src/modules/catalog_requests/infrastructure/persistence/repositories/catalog_request_repository.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/repositories/catalog_request_repository.py
@@ -50,6 +50,16 @@ class SQLAlchemyCatalogRequestRepository(CatalogRequestRepository):
         model = result.scalar_one_or_none()
         return None if model is None else CatalogRequestMapper.to_entity(model)
 
+    async def find_by_id(self, request_id: CatalogRequestId) -> CatalogRequest | None:
+        """Look up a single request by its external id."""
+        stmt = select(CatalogRequestModel).where(
+            CatalogRequestModel.external_id == str(request_id),
+            CatalogRequestModel.deleted_at.is_(None),
+        )
+        result = await self._session.execute(stmt)
+        model = result.scalar_one_or_none()
+        return None if model is None else CatalogRequestMapper.to_entity(model)
+
     async def find_by_tmdb_ids(
         self,
         tmdb_ids: Sequence[int],

--- a/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
@@ -6,15 +6,16 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
-from src.building_blocks.presentation import api_list
+from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.catalog_requests.application.dtos import DismissCatalogRequestInput
+from src.modules.catalog_requests.application.dtos import (
+    DismissCatalogRequestInput,
+    IncludeCatalogRequestInput,
+)
 from src.modules.catalog_requests.application.use_cases import (
     DismissCatalogRequestUseCase,
-    ListCatalogRequestsUseCase,
-)
-from src.modules.catalog_requests.application.use_cases.list_catalog_requests import (
-    ListCatalogRequestsInput,
+    IncludeCatalogRequestUseCase,
+    ListAdminCatalogRequestsUseCase,
 )
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
@@ -26,19 +27,41 @@ router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Catalog Requests"])
 @inject  # type: ignore[misc]
 async def list_admin_catalog_requests(
     _admin: UserModel = Depends(current_admin_user),
-    use_case: ListCatalogRequestsUseCase = Depends(
-        Provide[ApplicationContainer.catalog_requests.list_catalog_requests],
+    use_case: ListAdminCatalogRequestsUseCase = Depends(
+        Provide[ApplicationContainer.catalog_requests.list_admin_catalog_requests],
     ),
 ) -> dict[str, Any]:
-    """List every pending catalog request across the household.
+    """List every pending catalog request with its subscriber count.
 
-    Same shape as the user-facing ``GET /api/v1/catalog-requests``
-    but admin-only; the admin endpoint exists so the panel page can
-    sit behind ``RequireAdmin`` even though the user-facing endpoint
-    is intentionally available to any authenticated profile.
+    Admin-only queue: each row carries the base request fields
+    (including ``source`` + derived ``status``) plus ``subscriber_count``
+    (the "Inscritos" column). Admin-gated via ``current_admin_user``.
     """
-    items = await use_case.execute(ListCatalogRequestsInput())
-    return api_list([asdict(item) for item in items])
+    items = await use_case.execute()
+    return api_list(
+        [{**asdict(item.request), "subscriber_count": item.subscriber_count} for item in items],
+    )
+
+
+@router.post("/catalog-requests/{request_id}/include", status_code=200)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def include_catalog_request(
+    request_id: str,
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: IncludeCatalogRequestUseCase = Depends(
+        Provide[ApplicationContainer.catalog_requests.include_catalog_request],
+    ),
+) -> dict[str, Any]:
+    """Mark a request as included — fulfill it and notify every subscriber.
+
+    The manual counterpart to auto-fulfillment, for the orphan-rescue
+    case (the title is in the catalog but the request never
+    auto-matched). The request leaves the pending queue and each
+    subscriber gets the "já disponível" ping. ``404`` when no active
+    request matches; idempotent on an already-fulfilled request.
+    """
+    result = await use_case.execute(IncludeCatalogRequestInput(request_id=request_id))
+    return api_single("catalog_request", asdict(result))
 
 
 @router.delete("/catalog-requests/{request_id}", status_code=204)  # type: ignore[misc]

--- a/src/modules/notifications/infrastructure/acl/notification_publisher_adapter.py
+++ b/src/modules/notifications/infrastructure/acl/notification_publisher_adapter.py
@@ -51,7 +51,7 @@ class NotificationPublisherAdapter(NotificationPublisherPort):
                 body=None,
                 payload={
                     "tmdb_id": notification.tmdb_id,
-                    "media_id": notification.media_id.value,
+                    "media_id": (notification.media_id.value if notification.media_id else None),
                     "media_type": notification.media_type,
                 },
             ),

--- a/tests/modules/catalog_requests/e2e/test_admin_catalog_request_routes.py
+++ b/tests/modules/catalog_requests/e2e/test_admin_catalog_request_routes.py
@@ -1,0 +1,81 @@
+"""End-to-end tests for the admin catalog-request routes (ADR-022 B4)."""
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+from httpx import AsyncClient
+
+from tests.modules.catalog_requests.e2e.conftest import SeededUser
+
+LOGIN_PATH = "/api/v1/auth/cookie/login"
+ROOT = "/api/v1/catalog-requests"
+ADMIN_ROOT = "/api/v1/admin/catalog-requests"
+_TMDB = 348
+
+
+async def _login(client: AsyncClient, user: SeededUser) -> None:
+    resp = await client.post(
+        LOGIN_PATH,
+        data={"username": user.email, "password": user.password},
+    )
+    assert resp.status_code == 204
+
+
+@pytest.mark.e2e
+class TestAdminCatalogRequestRoutes:
+    """The admin queue (subscriber counts) + the include action."""
+
+    async def test_member_cannot_access_admin_queue(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile()
+        await _login(client, member)
+
+        assert (await client.get(ADMIN_ROOT)).status_code == 403
+
+    async def test_queue_shows_count_then_include_archives(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        member = await seed_user_with_profile(email="member@example.com")
+        admin = await seed_user_with_profile(email="admin@example.com", is_admin=True)
+
+        # Member subscribes to a missing title.
+        await _login(client, member)
+        sub = await client.post(
+            f"{ROOT}/{_TMDB}/notify",
+            json={"media_type": "movie", "title": "Alien"},
+        )
+        assert sub.status_code == 200
+
+        # Admin sees it in the queue with the subscriber count.
+        await _login(client, admin)
+        queue = await client.get(ADMIN_ROOT)
+        item = next(i for i in queue.json()["data"] if i["tmdb_id"] == _TMDB)
+        assert item["subscriber_count"] == 1
+        assert item["status"] == "pending"
+        assert item["source"] == "user"
+        request_id = item["id"]
+
+        # Admin marks it included → fulfilled + dropped from the queue.
+        included = await client.post(f"{ADMIN_ROOT}/{request_id}/include")
+        assert included.status_code == 200
+        assert included.json()["data"]["is_fulfilled"] is True
+
+        after = await client.get(ADMIN_ROOT)
+        assert all(i["tmdb_id"] != _TMDB for i in after.json()["data"])
+
+    async def test_include_unknown_returns_404(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await seed_user_with_profile(is_admin=True)
+        await _login(client, admin)
+
+        resp = await client.post(f"{ADMIN_ROOT}/req_missing00000/include")
+
+        assert resp.status_code == 404

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_include_catalog_request.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_include_catalog_request.py
@@ -1,0 +1,94 @@
+"""Tests for ``IncludeCatalogRequestUseCase``."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.catalog_requests.application.dtos import IncludeCatalogRequestInput
+from src.modules.catalog_requests.application.ports import NotificationPublisherPort
+from src.modules.catalog_requests.application.use_cases import (
+    IncludeCatalogRequestUseCase,
+)
+from src.modules.catalog_requests.domain.entities import (
+    CatalogRequest,
+    CatalogSubscription,
+)
+from src.shared_kernel.value_objects import MediaType
+from tests.modules.catalog_requests.unit.conftest import (
+    make_catalog_requests_uow_mock,
+)
+
+
+def _pending() -> CatalogRequest:
+    return CatalogRequest.create(tmdb_id=348, media_type=MediaType.MOVIE, title="Alien")
+
+
+@pytest.mark.unit
+class TestIncludeCatalogRequestUseCase:
+    """Tests for the admin "mark as included" action."""
+
+    @pytest.mark.asyncio
+    async def test_fulfills_and_fans_out_without_media_id(self) -> None:
+        request = _pending()
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_id.return_value = request
+        mocks.catalog_requests.update.side_effect = lambda req: req
+        mocks.catalog_subscriptions.list_for_request.return_value = [
+            CatalogSubscription.create(request.id, "usr_alice"),
+            CatalogSubscription.create(request.id, "usr_bob"),
+        ]
+        publisher = AsyncMock(spec=NotificationPublisherPort)
+        use_case = IncludeCatalogRequestUseCase(
+            uow_factory=mocks.factory,
+            notification_publisher=publisher,
+        )
+
+        result = await use_case.execute(IncludeCatalogRequestInput(request_id=str(request.id)))
+
+        assert result.is_fulfilled is True
+        mocks.catalog_requests.update.assert_called_once()
+        assert publisher.publish_catalog_arrival.await_count == 2
+        payload = publisher.publish_catalog_arrival.await_args_list[0].args[0]
+        assert payload.media_id is None
+        assert payload.title == "Alien"
+
+    @pytest.mark.asyncio
+    async def test_raises_404_when_not_found(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_id.return_value = None
+        use_case = IncludeCatalogRequestUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(IncludeCatalogRequestInput(request_id="req_missing00000"))
+
+    @pytest.mark.asyncio
+    async def test_idempotent_when_already_fulfilled(self) -> None:
+        request = _pending().mark_fulfilled()
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_id.return_value = request
+        publisher = AsyncMock(spec=NotificationPublisherPort)
+        use_case = IncludeCatalogRequestUseCase(
+            uow_factory=mocks.factory,
+            notification_publisher=publisher,
+        )
+
+        result = await use_case.execute(IncludeCatalogRequestInput(request_id=str(request.id)))
+
+        assert result.is_fulfilled is True
+        mocks.catalog_requests.update.assert_not_called()
+        publisher.publish_catalog_arrival.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fulfills_without_publisher(self) -> None:
+        request = _pending()
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_id.return_value = request
+        mocks.catalog_requests.update.side_effect = lambda req: req
+        use_case = IncludeCatalogRequestUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(IncludeCatalogRequestInput(request_id=str(request.id)))
+
+        assert result.is_fulfilled is True
+        mocks.catalog_requests.update.assert_called_once()
+        mocks.catalog_subscriptions.list_for_request.assert_not_called()

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_list_admin_catalog_requests.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_list_admin_catalog_requests.py
@@ -1,0 +1,33 @@
+"""Tests for ``ListAdminCatalogRequestsUseCase``."""
+
+import pytest
+
+from src.modules.catalog_requests.application.use_cases import (
+    ListAdminCatalogRequestsUseCase,
+)
+from src.modules.catalog_requests.domain.entities import CatalogRequest
+from src.shared_kernel.value_objects import MediaType
+from tests.modules.catalog_requests.unit.conftest import (
+    make_catalog_requests_uow_mock,
+)
+
+
+@pytest.mark.unit
+class TestListAdminCatalogRequestsUseCase:
+    """Tests for the admin queue listing."""
+
+    @pytest.mark.asyncio
+    async def test_enriches_with_subscriber_count(self) -> None:
+        a = CatalogRequest.create(tmdb_id=1, media_type=MediaType.MOVIE)
+        b = CatalogRequest.create(tmdb_id=2, media_type=MediaType.MOVIE)
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.list_pending.return_value = [a, b]
+        mocks.catalog_subscriptions.count_by_requests.return_value = {a.id: 5}
+        use_case = ListAdminCatalogRequestsUseCase(uow_factory=mocks.factory)
+
+        items = await use_case.execute()
+
+        by_tmdb = {item.request.tmdb_id: item for item in items}
+        assert by_tmdb[1].subscriber_count == 5
+        assert by_tmdb[2].subscriber_count == 0
+        mocks.catalog_requests.list_pending.assert_awaited_once_with(None)


### PR DESCRIPTION
## Summary

Phase **B4** — the admin side of the Catalog Requests feature (builds on #297/#298/#299).

- **Admin queue enrichment** — `GET /admin/catalog-requests` now returns each pending request with its **`subscriber_count`** ("Inscritos"), alongside the `source` + derived `status` already on the base DTO (B2). One batch query, no N+1 (`ListAdminCatalogRequestsUseCase`).
- **`POST /admin/catalog-requests/{request_id}/include`** — the manual "Marcar como incluído". The counterpart to auto-fulfillment for the **orphan-rescue** case (the title is in the catalog but the request never auto-matched). Stamps `fulfilled_at` (drops it from the pending queue) and **fans the "já disponível" ping out to every subscriber**. Idempotent on an already-fulfilled request; `404` when none matches.

### Design notes (per the chosen approach)
- The arrival notification's **`media_id` is now optional**: the manual include resolves no local media, so the notification fires without a precise deep-link (the renderer falls back to search). This touches the `CatalogArrivalNotification` DTO + the Notifications adapter; the frontend guard for a missing `media_id` lands with the F-phase.
- The Notifications **publisher is wired into the catalog_requests container** (now composed *before* it in the composition root — acyclic). Added `CatalogRequestRepository.find_by_id`.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] Unit — include (fulfill + fanout with `media_id=None`, 404, idempotent, no-publisher) + admin list (subscriber count enrichment)
- [x] e2e — member 403 on the admin queue, queue shows `subscriber_count`/`status`/`source`, include archives + returns fulfilled (exercises the **cross-container publisher fanout** end-to-end), include 404
- [x] **Full suite green — 2956 passed, 5 skipped**

## Deploy
Restart only — no migration.

## Follow-ups
Backend for the feature is complete (B1–B4). Remaining: **F1** (admin page — Status/Origem columns + "Marcar como incluído" action) and **F2** (consumer "Em breve" page) in homeflix-web, plus the small NotificationBell guard for a missing `media_id`.