### PR TITLE
feat(catalog-requests): poster snapshot + block already-hosted suggestions

### DIFF
--- a/migrations/versions/2026_06_24_add_poster_url_to_catalog_requests.py
+++ b/migrations/versions/2026_06_24_add_poster_url_to_catalog_requests.py
@@ -1,0 +1,41 @@
+"""Add poster_url snapshot to catalog_requests.
+
+A queued title has no local artwork, so the "Em breve" grid needs a
+poster to render. The request now snapshots the TMDB poster URL at
+creation (like ``title``). Existing rows are backfilled out-of-band by
+``specs/heal_catalog_request_posters.py`` (which calls TMDB) rather than
+here — migrations stay network-free.
+
+Revision ID: c4f7a2b9e1d3
+Revises: b3e8d1f6a04c
+Create Date: 2026-06-24 10:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "c4f7a2b9e1d3"
+down_revision: str | Sequence[str] | None = "b3e8d1f6a04c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the nullable ``poster_url`` column."""
+    op.add_column(
+        "catalog_requests",
+        sa.Column("poster_url", sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``poster_url`` column."""
+    op.drop_column("catalog_requests", "poster_url")

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -681,6 +681,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     search_tmdb_titles = providers.Factory(
         SearchTmdbTitlesUseCase,
         metadata_provider=tmdb_client,
+        uow_factory=media_unit_of_work_factory,
     )
 
     relink_movie = providers.Factory(

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -32,6 +32,7 @@ class CreateCatalogRequestInput:
     tmdb_id: int
     media_type: MediaType
     title: str | None = None
+    poster_url: str | None = None
     requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
     notify_on_arrival: bool = False
@@ -44,6 +45,7 @@ class SubscribeCatalogNotificationInput:
     tmdb_id: int
     media_type: MediaType
     title: str | None = None
+    poster_url: str | None = None
     requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
 
@@ -95,6 +97,8 @@ class CatalogRequestOutput:
         media_type: ``"movie"`` or ``"series"``.
         title: Snapshot of the title taken at request time. ``None``
             on legacy rows created before the column existed.
+        poster_url: Snapshot of the TMDB poster URL, or ``None`` when
+            not captured / not yet backfilled.
         requester_user_id: External id (``usr_xxx``) of the user who
             registered the request. ``None`` on legacy rows.
         collection_tmdb_id: Originating TMDB collection id, if any.
@@ -110,6 +114,7 @@ class CatalogRequestOutput:
     tmdb_id: int
     media_type: str
     title: str | None
+    poster_url: str | None
     requester_user_id: str | None
     collection_tmdb_id: int | None
     source: str
@@ -127,6 +132,7 @@ class CatalogRequestOutput:
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
             title=entity.title,
+            poster_url=entity.poster_url,
             requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
             source=entity.source.value,

--- a/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
+++ b/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
@@ -67,6 +67,7 @@ class RequestCatalogInclusionUseCase:
                 # ``None`` means nothing changed, so skip the write.
                 reconciled = existing.reconcile(
                     title=input_dto.title,
+                    poster_url=input_dto.poster_url,
                     requester_user_id=input_dto.requester_user_id,
                     notify=input_dto.notify_on_arrival,
                 )
@@ -79,6 +80,7 @@ class RequestCatalogInclusionUseCase:
                 tmdb_id=input_dto.tmdb_id,
                 media_type=input_dto.media_type,
                 title=input_dto.title,
+                poster_url=input_dto.poster_url,
                 requester_user_id=input_dto.requester_user_id,
                 collection_tmdb_id=input_dto.collection_tmdb_id,
                 notify_on_arrival=input_dto.notify_on_arrival,

--- a/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
+++ b/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
@@ -67,6 +67,7 @@ class SubscribeCatalogNotificationUseCase:
                 # entry point always wants the notification flag on.
                 reconciled = existing.reconcile(
                     title=input_dto.title,
+                    poster_url=input_dto.poster_url,
                     requester_user_id=input_dto.requester_user_id,
                     notify=True,
                 )
@@ -81,6 +82,7 @@ class SubscribeCatalogNotificationUseCase:
                         tmdb_id=input_dto.tmdb_id,
                         media_type=input_dto.media_type,
                         title=input_dto.title,
+                        poster_url=input_dto.poster_url,
                         requester_user_id=input_dto.requester_user_id,
                         collection_tmdb_id=input_dto.collection_tmdb_id,
                         notify_on_arrival=True,

--- a/src/modules/catalog_requests/domain/entities/catalog_request.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_request.py
@@ -76,6 +76,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
     tmdb_id: int
     media_type: MediaType
     title: str | None = None
+    poster_url: str | None = None
     requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
     source: CatalogRequestSource = CatalogRequestSource.HOUSEHOLD
@@ -89,6 +90,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         tmdb_id: int,
         media_type: MediaType,
         title: str | None = None,
+        poster_url: str | None = None,
         requester_user_id: str | None = None,
         collection_tmdb_id: int | None = None,
         notify_on_arrival: bool = False,
@@ -103,6 +105,8 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
                 (older clients, programmatic ingest), the field stays
                 ``None`` and the admin queue falls back to the bare
                 ``tmdb/<id>`` link.
+            poster_url: Snapshot of the TMDB poster URL at request
+                time, for the "Em breve" grid. ``None`` when unknown.
             requester_user_id: External id (``usr_xxx``) of the user
                 creating the request. Powers the per-user arrival
                 notification; ``None`` skips the ping (legacy or
@@ -120,6 +124,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
             tmdb_id=tmdb_id,
             media_type=media_type,
             title=title,
+            poster_url=poster_url,
             requester_user_id=requester_user_id,
             collection_tmdb_id=collection_tmdb_id,
             source=CatalogRequestSource.for_requester(requester_user_id),
@@ -164,6 +169,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         self,
         *,
         title: str | None = None,
+        poster_url: str | None = None,
         requester_user_id: str | None = None,
         notify: bool = False,
     ) -> CatalogRequest | None:
@@ -183,6 +189,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
 
         Args:
             title: Candidate title snapshot from the repeat request.
+            poster_url: Candidate poster URL from the repeat request.
             requester_user_id: Candidate requester from the repeat
                 request.
             notify: Whether this entry point wants the arrival
@@ -196,6 +203,8 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         updates: dict[str, object] = {}
         if self.title is None and title:
             updates["title"] = title
+        if self.poster_url is None and poster_url:
+            updates["poster_url"] = poster_url
         if self.requester_user_id is None and requester_user_id:
             updates["requester_user_id"] = requester_user_id
         if notify and not self.notify_on_arrival:

--- a/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
@@ -41,6 +41,7 @@ class CatalogRequestMapper:
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
             title=entity.title,
+            poster_url=entity.poster_url,
             requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
             source=entity.source.value,
@@ -57,6 +58,7 @@ class CatalogRequestMapper:
             tmdb_id=model.tmdb_id,
             media_type=MediaType(model.media_type),
             title=model.title,
+            poster_url=model.poster_url,
             requester_user_id=model.requester_user_id,
             collection_tmdb_id=model.collection_tmdb_id,
             source=CatalogRequestSource(model.source),
@@ -83,6 +85,7 @@ class CatalogRequestMapper:
         recipient on legacy rows.
         """
         model.title = entity.title
+        model.poster_url = entity.poster_url
         model.requester_user_id = entity.requester_user_id
         model.collection_tmdb_id = entity.collection_tmdb_id
         model.notify_on_arrival = entity.notify_on_arrival

--- a/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
@@ -47,6 +47,7 @@ class CatalogRequestModel(Base):
     tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     media_type: Mapped[str] = mapped_column(String(20), nullable=False)
     title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    poster_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     requester_user_id: Mapped[str | None] = mapped_column(
         String(50),
         nullable=True,

--- a/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
@@ -55,6 +55,7 @@ class CreateCatalogRequestRequest(BaseModel):
     tmdb_id: int = Field(..., ge=1)
     media_type: MediaType
     title: str | None = Field(default=None, max_length=500)
+    poster_url: str | None = Field(default=None, max_length=500)
     collection_tmdb_id: int | None = Field(default=None, ge=1)
     notify_on_arrival: bool = False
 
@@ -64,6 +65,7 @@ class SubscribeNotifyRequest(BaseModel):
 
     media_type: MediaType
     title: str | None = Field(default=None, max_length=500)
+    poster_url: str | None = Field(default=None, max_length=500)
     collection_tmdb_id: int | None = Field(default=None, ge=1)
 
 
@@ -93,6 +95,7 @@ async def create_catalog_request(
             tmdb_id=body.tmdb_id,
             media_type=body.media_type,
             title=body.title,
+            poster_url=body.poster_url,
             requester_user_id=user.external_id,
             collection_tmdb_id=body.collection_tmdb_id,
             notify_on_arrival=body.notify_on_arrival,
@@ -123,6 +126,7 @@ async def subscribe_catalog_notification(
             tmdb_id=tmdb_id,
             media_type=body.media_type,
             title=body.title,
+            poster_url=body.poster_url,
             requester_user_id=user.external_id,
             collection_tmdb_id=body.collection_tmdb_id,
         ),

--- a/src/modules/media/application/dtos/tmdb_lookup_dtos.py
+++ b/src/modules/media/application/dtos/tmdb_lookup_dtos.py
@@ -40,6 +40,9 @@ class TmdbLookupCandidate:
             lacks a usable date.
         overview: Synopsis (possibly empty).
         poster_url: Absolute poster URL, or ``None``.
+        in_catalog: ``True`` when the title is already hosted locally —
+            the request dialog disables "request" for these so a user
+            can't ask for something already available.
     """
 
     tmdb_id: int
@@ -48,6 +51,7 @@ class TmdbLookupCandidate:
     year: int | None
     overview: str | None
     poster_url: str | None
+    in_catalog: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/modules/media/application/use_cases/search_tmdb_titles.py
+++ b/src/modules/media/application/use_cases/search_tmdb_titles.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Literal
 
 from src.modules.media.application.dtos.tmdb_lookup_dtos import (
@@ -21,6 +21,7 @@ from src.modules.media.application.dtos.tmdb_lookup_dtos import (
 
 if TYPE_CHECKING:
     from src.modules.media.application.ports import MetadataProvider, SearchCandidate
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 
 
 # TMDB URL example: https://www.themoviedb.org/movie/603-the-matrix
@@ -101,8 +102,13 @@ class SearchTmdbTitlesUseCase:
             already wired into the rest of the media BC.
     """
 
-    def __init__(self, metadata_provider: MetadataProvider) -> None:
+    def __init__(
+        self,
+        metadata_provider: MetadataProvider,
+        uow_factory: MediaUnitOfWorkFactory,
+    ) -> None:
         self._provider = metadata_provider
+        self._uow_factory = uow_factory
 
     async def execute(self, input_dto: SearchTmdbTitlesInput) -> SearchTmdbTitlesOutput:
         """Parse ``input_dto.query`` and return the matching TMDB candidates."""
@@ -119,7 +125,7 @@ class SearchTmdbTitlesUseCase:
             return SearchTmdbTitlesOutput(
                 query=display,
                 kind="tmdb_id",
-                candidates=candidates,
+                candidates=await self._mark_in_catalog(candidates),
             )
 
         if parsed.kind == "imdb_id":
@@ -127,7 +133,7 @@ class SearchTmdbTitlesUseCase:
             return SearchTmdbTitlesOutput(
                 query=parsed.imdb_id or "",
                 kind="imdb_id",
-                candidates=[_to_dto(c) for c in results],
+                candidates=await self._mark_in_catalog([_to_dto(c) for c in results]),
             )
 
         # text branch
@@ -140,8 +146,37 @@ class SearchTmdbTitlesUseCase:
         return SearchTmdbTitlesOutput(
             query=text,
             kind="text",
-            candidates=[_to_dto(c) for c in (*movies, *series)],
+            candidates=await self._mark_in_catalog(
+                [_to_dto(c) for c in (*movies, *series)],
+            ),
         )
+
+    async def _mark_in_catalog(
+        self,
+        candidates: list[TmdbLookupCandidate],
+    ) -> list[TmdbLookupCandidate]:
+        """Flag candidates whose ``tmdb_id`` is already hosted locally.
+
+        One batch query per kind against the catalog, so the picker can
+        disable "request" for titles that are already available
+        (regardless of profile library access — "in the catalog" is a
+        household-level fact here).
+        """
+        if not candidates:
+            return candidates
+        movie_ids = [c.tmdb_id for c in candidates if c.media_type == "movie"]
+        series_ids = [c.tmdb_id for c in candidates if c.media_type == "tv"]
+        async with self._uow_factory() as uow:
+            movies = await uow.movies.find_by_tmdb_ids(movie_ids) if movie_ids else {}
+            series = await uow.series.find_by_tmdb_ids(series_ids) if series_ids else {}
+        return [
+            replace(
+                candidate,
+                in_catalog=candidate.tmdb_id
+                in (movies if candidate.media_type == "movie" else series),
+            )
+            for candidate in candidates
+        ]
 
     async def _fetch_by_tmdb_id(
         self,

--- a/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
+++ b/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
@@ -152,3 +152,21 @@ class TestCatalogRequest:
 
         assert request.status is CatalogRequestStatus.PENDING
         assert request.mark_fulfilled().status is CatalogRequestStatus.FULFILLED
+
+    def test_create_snapshots_poster(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            poster_url="https://image.tmdb.org/t/p/original/alien.jpg",
+        )
+
+        assert request.poster_url == "https://image.tmdb.org/t/p/original/alien.jpg"
+
+    def test_reconcile_backfills_poster_first_owner_wins(self) -> None:
+        without = CatalogRequest.create(tmdb_id=348, media_type=MediaType.MOVIE)
+        backfilled = without.reconcile(poster_url="https://img/poster.jpg")
+        assert backfilled is not None
+        assert backfilled.poster_url == "https://img/poster.jpg"
+
+        # A later poster never overwrites the first snapshot.
+        assert backfilled.reconcile(poster_url="https://img/other.jpg") is None

--- a/tests/modules/media/unit/application/use_cases/test_search_tmdb_titles.py
+++ b/tests/modules/media/unit/application/use_cases/test_search_tmdb_titles.py
@@ -1,6 +1,6 @@
 """Tests for SearchTmdbTitlesUseCase routing."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -11,6 +11,39 @@ from src.modules.media.application.ports import SearchCandidate
 from src.modules.media.application.use_cases.search_tmdb_titles import (
     SearchTmdbTitlesUseCase,
 )
+
+
+def _empty_uow_factory() -> MagicMock:
+    """A UoW factory whose catalog repos report nothing already hosted."""
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.movies.find_by_tmdb_ids.return_value = {}
+    uow.series.find_by_tmdb_ids.return_value = {}
+    return MagicMock(return_value=uow)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_marks_candidate_already_in_catalog() -> None:
+    """A candidate whose tmdb_id is hosted locally is flagged in_catalog."""
+    provider = AsyncMock()
+    provider.get_movie_summary_by_id.return_value = _movie_candidate(tmdb_id=603)
+    provider.get_series_summary_by_id.return_value = None
+
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.movies.find_by_tmdb_ids.return_value = {603: object()}  # already hosted
+    uow.series.find_by_tmdb_ids.return_value = {}
+    use_case = SearchTmdbTitlesUseCase(
+        metadata_provider=provider,
+        uow_factory=MagicMock(return_value=uow),
+    )
+
+    out = await use_case.execute(SearchTmdbTitlesInput(query="603", limit=5))
+
+    assert [c.in_catalog for c in out.candidates] == [True]
 
 
 def _movie_candidate(tmdb_id: int = 603, title: str = "The Matrix") -> SearchCandidate:
@@ -41,7 +74,9 @@ class TestTmdbUrlBranch:
         provider = AsyncMock()
         provider.get_movie_summary_by_id.return_value = _movie_candidate()
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         out = await use_case.execute(
             SearchTmdbTitlesInput(query="https://www.themoviedb.org/movie/603"),
         )
@@ -58,7 +93,9 @@ class TestTmdbUrlBranch:
         provider = AsyncMock()
         provider.get_series_summary_by_id.return_value = _series_candidate()
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         out = await use_case.execute(
             SearchTmdbTitlesInput(query="https://www.themoviedb.org/tv/1399"),
         )
@@ -76,7 +113,9 @@ class TestImdbBranch:
         provider = AsyncMock()
         provider.find_by_imdb_id.return_value = [_movie_candidate()]
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         out = await use_case.execute(
             SearchTmdbTitlesInput(query="https://www.imdb.com/title/tt0133093/"),
         )
@@ -93,7 +132,9 @@ class TestImdbBranch:
             _series_candidate(),
         ]
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         out = await use_case.execute(SearchTmdbTitlesInput(query="tt0133093"))
 
         assert out.kind == "imdb_id"
@@ -107,7 +148,9 @@ class TestBareNumericBranch:
         provider.get_movie_summary_by_id.return_value = _movie_candidate(603)
         provider.get_series_summary_by_id.return_value = _series_candidate(603)
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         out = await use_case.execute(SearchTmdbTitlesInput(query="603"))
 
         provider.get_movie_summary_by_id.assert_awaited_once_with(603)
@@ -121,7 +164,9 @@ class TestBareNumericBranch:
         provider.get_movie_summary_by_id.return_value = _movie_candidate(603)
         provider.get_series_summary_by_id.return_value = None
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         out = await use_case.execute(SearchTmdbTitlesInput(query="603"))
 
         assert len(out.candidates) == 1
@@ -135,7 +180,9 @@ class TestTextBranch:
         provider.find_movie_candidates.return_value = [_movie_candidate()]
         provider.find_series_candidates.return_value = [_series_candidate()]
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         out = await use_case.execute(
             SearchTmdbTitlesInput(query="  matrix  ", limit=3),
         )
@@ -153,7 +200,9 @@ class TestTextBranch:
         provider.find_movie_candidates.return_value = []
         provider.find_series_candidates.return_value = []
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         await use_case.execute(SearchTmdbTitlesInput(query="x", limit=1000))
 
         # Use case caps at 20 internally even if a misbehaving caller
@@ -166,7 +215,9 @@ class TestEmptyInput:
     async def test_whitespace_only_returns_empty_without_calling_provider(self) -> None:
         provider = AsyncMock()
 
-        use_case = SearchTmdbTitlesUseCase(metadata_provider=provider)
+        use_case = SearchTmdbTitlesUseCase(
+            metadata_provider=provider, uow_factory=_empty_uow_factory()
+        )
         out = await use_case.execute(SearchTmdbTitlesInput(query="   "))
 
         assert out.candidates == []


### PR DESCRIPTION
## Summary

Two polish fixes found while wiring the "Em breve" consumer page (on top of B1–B4 already on develop).

- **Poster snapshot** — `CatalogRequest` gains `poster_url`, snapshotted at request time (like `title`) and exposed on the member feed + admin DTOs, so the grid renders real artwork instead of a placeholder. Migration `c4f7a2b9e1d3` adds the nullable column; existing rows are backfilled out-of-band.
- **Block already-hosted suggestions** — the `/catalog/lookup` picker (Media BC, which owns both TMDB lookup *and* the catalog) now marks each candidate `in_catalog` via one batch query per kind. The "Suggest a title" dialog uses it to refuse titles already hosted locally (no cross-BC cycle, since the check lives where the data is).

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] Domain — poster snapshot + reconcile backfill (first-owner-wins); lookup marks `in_catalog`
- [x] Updated `search_tmdb_titles` unit tests for the new UoW dep
- [x] Migration validated on a temp DB (column add + downgrade)
- [x] **Full suite green — 2959 passed, 5 skipped**

## Deploy
`make migrate`, then run the local poster backfill one-shot (`specs/heal_catalog_request_posters.py`, gitignored by convention — calls TMDB to fill `poster_url` on existing rows), then restart.

## Notes
Pairs with the frontend "Em breve" page PR on `main`. Closes out the catalog-requests backend (B1–B5).

## Summary by Sourcery

Snapshot TMDB poster URLs on catalog requests and surface them through APIs while marking TMDB lookup suggestions that are already in the local catalog so they can’t be re-requested.

New Features:
- Capture and store a poster_url snapshot on catalog requests and expose it via request creation, subscription, persistence, and output DTOs.
- Extend TMDB lookup candidates with an in_catalog flag to indicate titles already hosted locally.

Enhancements:
- Update catalog request reconciliation logic so poster URLs are backfilled once and treated as first-owner-wins snapshots.
- Wire the media search use case to the catalog unit of work to batch-check existing movies and series and annotate lookup results with in_catalog.
- Adjust media container wiring and unit tests to support the new unit-of-work dependency in TMDB search.

Build:
- Add a database migration to introduce the nullable poster_url column on catalog_requests.

Tests:
- Add unit coverage for poster URL snapshot and reconcile behavior on catalog requests.
- Extend TMDB search tests to cover in_catalog marking and the new unit-of-work-backed search behavior.