### PR TITLE
feat(media): now-playing live sessions for the admin Overview

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -59,6 +59,7 @@ from src.modules.media.application.use_cases.get_movie_by_id import GetMovieById
 from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
     GetMovieTmdbSuggestionsUseCase,
 )
+from src.modules.media.application.use_cases.get_now_playing import GetNowPlayingUseCase
 from src.modules.media.application.use_cases.get_overview_stats import (
     GetOverviewStatsUseCase,
 )
@@ -139,6 +140,9 @@ from src.modules.media.application.use_cases.trigger_bulk_enrich import (
     TriggerBulkEnrichUseCase,
 )
 from src.modules.media.application.use_cases.trigger_scan import TriggerScanUseCase
+from src.modules.media.infrastructure.acl.profile_summary_adapter import (
+    ProfileSummaryAdapter,
+)
 from src.modules.media.infrastructure.audio import (
     AudioExtractor,
     ChromaprintIntroDetector,
@@ -152,6 +156,9 @@ from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import
 )
 from src.modules.media.infrastructure.streaming import HlsService, MediaProbeService
 from src.modules.media.infrastructure.streaming.file_streamer import LocalFileStreamer
+from src.modules.media.infrastructure.streaming.now_playing_registry import (
+    NowPlayingRegistry,
+)
 from src.modules.media.infrastructure.streaming.scrub_preview_locator import (
     FilesystemScrubPreviewLocator,
 )
@@ -410,6 +417,18 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         enable_eviction=True,
     )
 
+    # In-memory registry of active playback sessions (admin now-playing).
+    # Singleton — one ffmpeg fleet / cache, one source of truth. Written
+    # by the streaming use cases (observationally), read by GetNowPlaying.
+    now_playing_registry = providers.Singleton(NowPlayingRegistry)
+
+    # Resolves watching profiles' display names via the identity UoW
+    # (ADR-009 ACL), for the now-playing "who" column.
+    profile_summary = providers.Singleton(
+        ProfileSummaryAdapter,
+        identity_uow_factory=identity_uow_factory,
+    )
+
     # Singleton because ``ThumbnailGenerationService`` is stateless apart
     # from the runtime config it reads per call; sharing one instance
     # across the eager fire-and-forget path (``stream_routes``) and the
@@ -475,11 +494,19 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     generate_hls_playlist = providers.Factory(
         GenerateHlsPlaylistUseCase,
         hls=hls_service,
+        now_playing=now_playing_registry,
     )
 
     serve_hls_file = providers.Factory(
         ServeHlsFileUseCase,
         hls=hls_service,
+        now_playing=now_playing_registry,
+    )
+
+    get_now_playing = providers.Factory(
+        GetNowPlayingUseCase,
+        now_playing=now_playing_registry,
+        profile_summary=profile_summary,
     )
 
     get_file_tracks = providers.Factory(

--- a/src/modules/media/application/dtos/now_playing_dtos.py
+++ b/src/modules/media/application/dtos/now_playing_dtos.py
@@ -1,0 +1,35 @@
+"""Output DTOs for the admin now-playing endpoint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NowPlayingSessionOutput:
+    """One active playback session as surfaced to the admin dashboard."""
+
+    profile_id: str | None
+    profile_name: str | None
+    media_id: str | None
+    media_kind: str | None
+    title: str | None
+    year: int | None
+    meta: str | None
+    poster_url: str | None
+    ip: str | None
+    device: str | None
+    mode: str | None
+    detail: str | None
+    position_seconds: int
+    duration_seconds: int | None
+    pct: int
+    mbps: float
+
+
+@dataclass(frozen=True)
+class NowPlayingOutput:
+    """The full now-playing snapshot: sessions + aggregate uplink."""
+
+    sessions: list[NowPlayingSessionOutput]
+    total_mbps: float

--- a/src/modules/media/application/ports/now_playing_port.py
+++ b/src/modules/media/application/ports/now_playing_port.py
@@ -1,0 +1,119 @@
+"""Port for the in-memory now-playing session registry.
+
+The streaming use cases write to it (a playlist request notes who/what,
+a segment request notes liveness + bytes); the admin read use case
+lists active sessions. The implementation lives in
+``media.infrastructure.streaming.now_playing_registry`` and is purely
+observational — it never alters what the player receives.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NowPlayingViewContext:
+    """Identity + media context captured when a playlist is generated.
+
+    Built by the streaming routes (which know the caller's profile,
+    client IP/device and the resolved title) and threaded into the
+    playlist use case, which owns the ``path_hash`` the registry keys on.
+    """
+
+    profile_id: str | None = None
+    media_id: str | None = None
+    media_kind: str | None = None
+    title: str | None = None
+    year: int | None = None
+    meta: str | None = None
+    poster_url: str | None = None
+    ip: str | None = None
+    device: str | None = None
+    duration_seconds: int | None = None
+
+
+@dataclass(frozen=True)
+class NowPlayingSession:
+    """Immutable snapshot of one live playback session.
+
+    Attributes:
+        profile_id: Watching profile (``prf_xxx``), or ``None`` if the
+            view note never carried one.
+        media_id: Movie / series id behind the stream.
+        media_kind: ``"movie"`` or ``"episode"``.
+        title: Display title captured at playlist time.
+        year: Release year, when known.
+        meta: Secondary line — resolution for movies, ``"T1 · E3"`` for
+            episodes.
+        poster_url: Poster path, reused as-is by the client.
+        ip: Client IP seen on the playlist request.
+        device: Shortened User-Agent of the player.
+        mode: ``"direct"`` / ``"transcode"`` once the service stamps it;
+            ``None`` until then.
+        detail: Optional technical detail (e.g. source→target codec).
+        position_seconds: Approximate playhead, derived from the newest
+            requested segment (leans slightly ahead of the real
+            position because the player buffers).
+        duration_seconds: Total runtime, when known.
+        mbps: Rolling-window estimate of the current uplink in Mbps.
+    """
+
+    profile_id: str | None
+    media_id: str | None
+    media_kind: str | None
+    title: str | None
+    year: int | None
+    meta: str | None
+    poster_url: str | None
+    ip: str | None
+    device: str | None
+    mode: str | None
+    detail: str | None
+    position_seconds: int
+    duration_seconds: int | None
+    mbps: float
+
+
+class NowPlayingPort(ABC):
+    """Records and reports active HLS playback sessions."""
+
+    @abstractmethod
+    def note_view(
+        self,
+        path_hash: str,
+        *,
+        profile_id: str | None = None,
+        media_id: str | None = None,
+        media_kind: str | None = None,
+        title: str | None = None,
+        year: int | None = None,
+        meta: str | None = None,
+        poster_url: str | None = None,
+        ip: str | None = None,
+        device: str | None = None,
+        duration_seconds: int | None = None,
+        start_offset: int = 0,
+    ) -> None:
+        """Record the identity + media context for a playlist request."""
+
+    @abstractmethod
+    def note_mode(self, path_hash: str, mode: str, detail: str | None = None) -> None:
+        """Stamp the decided playback mode for a session."""
+
+    @abstractmethod
+    def note_segment(
+        self,
+        path_hash: str,
+        byte_count: int,
+        segment_index: int | None = None,
+    ) -> None:
+        """Record a served segment (liveness + bytes + progress)."""
+
+    @abstractmethod
+    def active(self) -> list[NowPlayingSession]:
+        """Return live sessions, pruning any past the freshness window."""
+
+
+__all__ = ["NowPlayingPort", "NowPlayingSession", "NowPlayingViewContext"]

--- a/src/modules/media/application/ports/profile_summary_port.py
+++ b/src/modules/media/application/ports/profile_summary_port.py
@@ -1,0 +1,28 @@
+"""Cross-BC read port resolving profile display names from identity.
+
+For the admin now-playing panel's "who is watching" column. The adapter
+lives in ``media.infrastructure.acl`` and reads the identity UoW
+(ADR-009 — media never imports identity domain directly).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+class ProfileSummaryPort(ABC):
+    """Resolves profile ids to their display names."""
+
+    @abstractmethod
+    async def names_for(self, profile_ids: Sequence[str]) -> dict[str, str]:
+        """Map each known profile id to its display name.
+
+        Ids with no matching profile are omitted from the result.
+        """
+
+
+__all__ = ["ProfileSummaryPort"]

--- a/src/modules/media/application/use_cases/generate_hls_playlist.py
+++ b/src/modules/media/application/use_cases/generate_hls_playlist.py
@@ -1,10 +1,15 @@
 """GenerateHlsPlaylistUseCase — build (or reuse) the HLS master playlist."""
 
+import contextlib
 from dataclasses import dataclass
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.stream_dtos import HlsPlaylistOutput
 from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.ports.now_playing_port import (
+    NowPlayingPort,
+    NowPlayingViewContext,
+)
 from src.modules.media.application.streaming.playlist_rewriter import rewrite_m3u8
 
 
@@ -31,13 +36,19 @@ class GenerateHlsPlaylistInput:
     file_path: str
     base_url_template: str
     start: int = 0
+    view: NowPlayingViewContext | None = None
 
 
 class GenerateHlsPlaylistUseCase:
     """Ensure the HLS cache is warm and return a ready-to-serve m3u8."""
 
-    def __init__(self, hls: HlsPlaylistPort) -> None:
+    def __init__(
+        self,
+        hls: HlsPlaylistPort,
+        now_playing: NowPlayingPort | None = None,
+    ) -> None:
         self._hls = hls
+        self._now_playing = now_playing
 
     async def execute(self, input_dto: GenerateHlsPlaylistInput) -> HlsPlaylistOutput:
         """Generate (or reuse) the cache and return the rewritten master playlist.
@@ -53,6 +64,27 @@ class GenerateHlsPlaylistUseCase:
                 from the cache after ``ensure_playlist`` returns.
         """
         path_hash = await self._hls.ensure_playlist(input_dto.file_path, input_dto.start)
+
+        # Best-effort: record who/what for the admin now-playing panel.
+        # Strictly observational — a failure here must never break the
+        # stream, hence the blanket suppress.
+        if self._now_playing is not None and input_dto.view is not None:
+            view = input_dto.view
+            with contextlib.suppress(Exception):
+                self._now_playing.note_view(
+                    path_hash,
+                    profile_id=view.profile_id,
+                    media_id=view.media_id,
+                    media_kind=view.media_kind,
+                    title=view.title,
+                    year=view.year,
+                    meta=view.meta,
+                    poster_url=view.poster_url,
+                    ip=view.ip,
+                    device=view.device,
+                    duration_seconds=view.duration_seconds,
+                    start_offset=input_dto.start,
+                )
 
         content = self._hls.get_master_playlist(path_hash)
         if content is None:

--- a/src/modules/media/application/use_cases/get_now_playing.py
+++ b/src/modules/media/application/use_cases/get_now_playing.py
@@ -1,0 +1,70 @@
+"""Use case: list active HLS playback sessions for the admin dashboard.
+
+Reads the in-memory now-playing registry, resolves the watching
+profiles' display names via the identity ACL, and derives a percent
+progress per session plus the aggregate uplink.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.dtos.now_playing_dtos import (
+    NowPlayingOutput,
+    NowPlayingSessionOutput,
+)
+
+if TYPE_CHECKING:
+    from src.modules.media.application.ports.now_playing_port import NowPlayingPort
+    from src.modules.media.application.ports.profile_summary_port import (
+        ProfileSummaryPort,
+    )
+
+
+class GetNowPlayingUseCase:
+    """Snapshot of what's playing on the server right now."""
+
+    def __init__(
+        self,
+        now_playing: NowPlayingPort,
+        profile_summary: ProfileSummaryPort,
+    ) -> None:
+        self._now_playing = now_playing
+        self._profiles = profile_summary
+
+    async def execute(self) -> NowPlayingOutput:
+        """Return the live sessions enriched with profile names + pct."""
+        sessions = self._now_playing.active()
+        names = await self._profiles.names_for(
+            [s.profile_id for s in sessions if s.profile_id],
+        )
+
+        rows: list[NowPlayingSessionOutput] = []
+        for session in sessions:
+            pct = 0
+            if session.duration_seconds and session.duration_seconds > 0:
+                ratio = session.position_seconds / session.duration_seconds
+                pct = max(0, min(100, round(ratio * 100)))
+            rows.append(
+                NowPlayingSessionOutput(
+                    profile_id=session.profile_id,
+                    profile_name=names.get(session.profile_id) if session.profile_id else None,
+                    media_id=session.media_id,
+                    media_kind=session.media_kind,
+                    title=session.title,
+                    year=session.year,
+                    meta=session.meta,
+                    poster_url=session.poster_url,
+                    ip=session.ip,
+                    device=session.device,
+                    mode=session.mode,
+                    detail=session.detail,
+                    position_seconds=session.position_seconds,
+                    duration_seconds=session.duration_seconds,
+                    pct=pct,
+                    mbps=session.mbps,
+                ),
+            )
+
+        total_mbps = round(sum(session.mbps for session in sessions), 1)
+        return NowPlayingOutput(sessions=rows, total_mbps=total_mbps)

--- a/src/modules/media/application/use_cases/serve_hls_file.py
+++ b/src/modules/media/application/use_cases/serve_hls_file.py
@@ -1,17 +1,24 @@
 """ServeHlsFileUseCase — resolve a cached HLS file (segment/playlist/VTT)."""
 
 import asyncio
+import contextlib
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.stream_dtos import HlsFileOutput
 from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.ports.now_playing_port import NowPlayingPort
 from src.modules.media.application.streaming.playlist_rewriter import (
     SUB_PATH_RE,
     media_type_for,
     rewrite_m3u8,
 )
+
+# Matches the ffmpeg segment naming (``segment_0007.ts``) to recover the
+# index for the now-playing progress estimate.
+_SEGMENT_INDEX_RE = re.compile(r"segment_(\d+)\.ts$")
 
 # Hard cap on how long the use case will park a request waiting for a
 # background subtitle extraction. Must comfortably exceed the per-track
@@ -43,8 +50,13 @@ class ServeHlsFileInput:
 class ServeHlsFileUseCase:
     """Resolve a cached HLS file, rewriting nested playlists inline."""
 
-    def __init__(self, hls: HlsPlaylistPort) -> None:
+    def __init__(
+        self,
+        hls: HlsPlaylistPort,
+        now_playing: NowPlayingPort | None = None,
+    ) -> None:
         self._hls = hls
+        self._now_playing = now_playing
 
     async def execute(self, input_dto: ServeHlsFileInput) -> HlsFileOutput:
         """Return the requested file (or rewritten playlist).
@@ -64,11 +76,27 @@ class ServeHlsFileUseCase:
         if resolved.suffix == ".m3u8":
             return self._build_playlist_output(resolved, input_dto)
 
+        self._note_segment(input_dto.path_hash, resolved, input_dto.relative_path)
+
         return HlsFileOutput(
             kind="file",
             media_type=media_type_for(input_dto.relative_path),
             path=resolved,
         )
+
+    def _note_segment(self, path_hash: str, resolved: Path, relative_path: str) -> None:
+        """Feed the now-playing registry a served ``.ts`` segment.
+
+        Best-effort + observational: byte size for the rolling bitrate
+        and the segment index for the progress estimate. Wrapped so a
+        bookkeeping error can never fail the segment response.
+        """
+        if self._now_playing is None or resolved.suffix != ".ts":
+            return
+        with contextlib.suppress(Exception):
+            match = _SEGMENT_INDEX_RE.search(relative_path)
+            index = int(match.group(1)) if match else None
+            self._now_playing.note_segment(path_hash, resolved.stat().st_size, index)
 
     async def _maybe_wait_for_subtitle(self, path_hash: str, relative_path: str) -> None:
         """Block on subtitle extraction when the request targets ``sub_<idx>``."""

--- a/src/modules/media/infrastructure/acl/profile_summary_adapter.py
+++ b/src/modules/media/infrastructure/acl/profile_summary_adapter.py
@@ -1,0 +1,46 @@
+"""Adapter implementing ``ProfileSummaryPort`` via the identity UoW.
+
+Resolves the display name for the profiles behind active playback
+sessions. One small ``find_by_id`` per distinct profile — the session
+count is tiny (a household), so a batch query isn't worth the extra
+repo surface.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.ports.profile_summary_port import (
+    ProfileSummaryPort,
+)
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from src.modules.identity.application.unit_of_work import (
+        IdentityUnitOfWorkFactory,
+    )
+
+
+class ProfileSummaryAdapter(ProfileSummaryPort):
+    """Reads profile names from the identity bounded context."""
+
+    def __init__(self, identity_uow_factory: IdentityUnitOfWorkFactory) -> None:
+        self._identity_uow_factory = identity_uow_factory
+
+    async def names_for(self, profile_ids: Sequence[str]) -> dict[str, str]:
+        """Resolve each distinct profile id to its display name."""
+        unique = {pid for pid in profile_ids if pid}
+        if not unique:
+            return {}
+        names: dict[str, str] = {}
+        async with self._identity_uow_factory() as uow:
+            for pid in unique:
+                profile = await uow.profiles.find_by_id(ProfileId(pid))
+                if profile is not None:
+                    names[pid] = str(profile.name)
+        return names
+
+
+__all__ = ["ProfileSummaryAdapter"]

--- a/src/modules/media/infrastructure/streaming/now_playing_registry.py
+++ b/src/modules/media/infrastructure/streaming/now_playing_registry.py
@@ -1,0 +1,216 @@
+"""In-memory registry of active HLS playback sessions.
+
+Powers the admin "Reproduzindo agora" (now playing) dashboard. The
+registry is fed by *purely observational* hooks bolted onto the
+streaming path — generating a playlist and serving a segment each emit
+a note here, but neither the playlist bytes nor the segment bytes nor
+the ffmpeg pipeline change in any way. Every write is best-effort:
+callers wrap notes so a bug in dashboard bookkeeping can never break a
+stream.
+
+Sessions are keyed by ``path_hash`` (the same hash the HLS cache uses),
+so two viewers of the byte-identical file at the same ``start`` collapse
+into one row — an accepted limitation for a household server, where
+concurrent identical-file playback is rare. Different files (or a seek,
+which mints a new ``start`` bucket) get their own rows.
+
+State is in-memory and ephemeral: a backend restart clears it, which is
+correct for a "right now" view. Liveness is driven by segment requests
+(roughly one every ``_SEGMENT_DURATION`` seconds during playback); a
+session with no segment activity within ``_FRESHNESS_WINDOW`` is
+considered ended and pruned on the next read.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from threading import Lock
+
+from src.modules.media.application.ports.now_playing_port import (
+    NowPlayingPort,
+    NowPlayingSession,
+)
+
+# A session counts as live while its newest segment request is within
+# this window. Kept comfortably above the 10 s segment cadence so a
+# brief network stall doesn't flap a steady stream out of the list.
+_FRESHNESS_WINDOW = 25.0
+# Seconds of wall-clock playback each segment represents. Mirrors
+# ``HlsService._SEGMENT_DURATION`` — keep the two in sync.
+_SEGMENT_DURATION = 10
+# Rolling window (seconds) used to estimate the *current* bitrate from
+# recently-served segment bytes, rather than a whole-session average.
+_BITRATE_WINDOW = 12.0
+
+
+@dataclass
+class _LiveSession:
+    """Mutable bookkeeping for one in-flight playback session."""
+
+    path_hash: str
+    started_at: float
+    last_seen: float
+    # Identity + media context, captured when the playlist is built.
+    profile_id: str | None = None
+    media_id: str | None = None
+    media_kind: str | None = None  # "movie" | "episode"
+    title: str | None = None
+    year: int | None = None
+    meta: str | None = None
+    poster_url: str | None = None
+    ip: str | None = None
+    device: str | None = None
+    duration_seconds: int | None = None
+    start_offset: int = 0
+    # Technical mode, stamped by the HLS service when it decides.
+    mode: str | None = None  # "direct" | "transcode"
+    detail: str | None = None
+    # Progress + bitrate signals, driven by segment requests.
+    max_segment_index: int = 0
+    # (monotonic_ts, bytes) samples for the rolling bitrate estimate.
+    byte_samples: list[tuple[float, int]] = field(default_factory=list)
+
+
+class NowPlayingRegistry(NowPlayingPort):
+    """Thread-safe, in-memory store of active playback sessions.
+
+    A process-wide singleton (one ffmpeg fleet, one cache) shared by
+    the streaming routes and the HLS service. All public methods are
+    cheap and lock-guarded; the write methods never raise on bad input
+    (callers still wrap them defensively).
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, _LiveSession] = {}
+        self._lock = Lock()
+
+    @staticmethod
+    def _now() -> float:
+        return time.monotonic()
+
+    def _ensure(self, path_hash: str) -> _LiveSession:
+        session = self._sessions.get(path_hash)
+        if session is None:
+            now = self._now()
+            session = _LiveSession(path_hash=path_hash, started_at=now, last_seen=now)
+            self._sessions[path_hash] = session
+        return session
+
+    def note_view(
+        self,
+        path_hash: str,
+        *,
+        profile_id: str | None = None,
+        media_id: str | None = None,
+        media_kind: str | None = None,
+        title: str | None = None,
+        year: int | None = None,
+        meta: str | None = None,
+        poster_url: str | None = None,
+        ip: str | None = None,
+        device: str | None = None,
+        duration_seconds: int | None = None,
+        start_offset: int = 0,
+    ) -> None:
+        """Record the identity + media context for a playlist request.
+
+        Called when a master playlist is generated, where the caller
+        knows who is watching and what. Refreshes ``last_seen`` so the
+        session is live from the moment playback starts, before the
+        first segment lands.
+        """
+        with self._lock:
+            session = self._ensure(path_hash)
+            session.last_seen = self._now()
+            session.profile_id = profile_id
+            session.media_id = media_id
+            session.media_kind = media_kind
+            session.title = title
+            session.year = year
+            session.meta = meta
+            session.poster_url = poster_url
+            session.ip = ip
+            session.device = device
+            session.duration_seconds = duration_seconds
+            session.start_offset = start_offset
+
+    def note_mode(self, path_hash: str, mode: str, detail: str | None = None) -> None:
+        """Stamp the decided playback mode (``direct``/``transcode``)."""
+        with self._lock:
+            session = self._ensure(path_hash)
+            session.mode = mode
+            session.detail = detail
+
+    def note_segment(
+        self,
+        path_hash: str,
+        byte_count: int,
+        segment_index: int | None = None,
+    ) -> None:
+        """Record a served segment — liveness, bitrate bytes, progress."""
+        with self._lock:
+            session = self._ensure(path_hash)
+            now = self._now()
+            session.last_seen = now
+            if byte_count > 0:
+                session.byte_samples.append((now, byte_count))
+            if segment_index is not None and segment_index > session.max_segment_index:
+                session.max_segment_index = segment_index
+
+    def _rolling_mbps(self, session: _LiveSession, now: float) -> float:
+        cutoff = now - _BITRATE_WINDOW
+        recent = [(ts, n) for ts, n in session.byte_samples if ts >= cutoff]
+        session.byte_samples = recent
+        if not recent:
+            return 0.0
+        total_bytes = sum(n for _, n in recent)
+        span = max(now - recent[0][0], 1.0)
+        return round((total_bytes * 8) / (span * 1_000_000), 1)
+
+    def active(self) -> list[NowPlayingSession]:
+        """Return live sessions, pruning any past the freshness window.
+
+        Computes a rolling bitrate and a segment-derived playback
+        position per session. Position is approximate — the player
+        buffers ahead, so it leans slightly optimistic — and is clamped
+        to the media duration.
+        """
+        now = self._now()
+        snapshots: list[NowPlayingSession] = []
+        with self._lock:
+            stale = [h for h, s in self._sessions.items() if now - s.last_seen > _FRESHNESS_WINDOW]
+            for path_hash in stale:
+                del self._sessions[path_hash]
+
+            for session in self._sessions.values():
+                # Skip sessions that only ever saw segment requests (no
+                # playlist note): e.g. a stream that survived a backend
+                # restart keeps fetching segments but never re-requests
+                # the playlist, so we have bytes but no identity. Better
+                # to hide the ghost row than show a "—" with no watcher.
+                if session.media_id is None:
+                    continue
+                position = session.start_offset + session.max_segment_index * _SEGMENT_DURATION
+                if session.duration_seconds is not None:
+                    position = min(position, session.duration_seconds)
+                snapshots.append(
+                    NowPlayingSession(
+                        profile_id=session.profile_id,
+                        media_id=session.media_id,
+                        media_kind=session.media_kind,
+                        title=session.title,
+                        year=session.year,
+                        meta=session.meta,
+                        poster_url=session.poster_url,
+                        ip=session.ip,
+                        device=session.device,
+                        mode=session.mode,
+                        detail=session.detail,
+                        position_seconds=position,
+                        duration_seconds=session.duration_seconds,
+                        mbps=self._rolling_mbps(session, now),
+                    )
+                )
+        snapshots.sort(key=lambda s: (s.title or "").lower())
+        return snapshots

--- a/src/modules/media/presentation/routes/admin_overview_routes.py
+++ b/src/modules/media/presentation/routes/admin_overview_routes.py
@@ -10,6 +10,7 @@ from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.media.application.use_cases.get_now_playing import GetNowPlayingUseCase
 from src.modules.media.application.use_cases.get_overview_stats import (
     GetOverviewStatsUseCase,
 )
@@ -34,6 +35,25 @@ async def get_admin_overview_stats(
     """
     stats = await use_case.execute()
     return api_single("overview_stats", asdict(stats))
+
+
+@router.get("/now-playing")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_admin_now_playing(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: GetNowPlayingUseCase = Depends(
+        Provide[ApplicationContainer.media.get_now_playing],
+    ),
+) -> dict[str, Any]:
+    """List the playback sessions active on the server right now.
+
+    An in-memory snapshot fed observationally by the streaming path:
+    one row per live HLS session with watcher, progress and uplink,
+    plus the aggregate ``total_mbps``. An idle server returns an empty
+    list — the expected resting state.
+    """
+    snapshot = await use_case.execute()
+    return api_single("now_playing", asdict(snapshot))
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -25,7 +25,12 @@ from src.infrastructure.scheduling import ThumbnailBackfillJob
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
-from src.modules.media.application.dtos.series_dtos import EpisodeOutput, GetSeriesByIdInput
+from src.modules.media.application.dtos.series_dtos import (
+    EpisodeOutput,
+    GetSeriesByIdInput,
+    SeriesOutput,
+)
+from src.modules.media.application.ports.now_playing_port import NowPlayingViewContext
 from src.modules.media.application.use_cases.clear_hls_cache import (
     ClearHlsCacheInput,
     ClearHlsCacheUseCase,
@@ -134,6 +139,7 @@ async def hls_file(
 @inject  # type: ignore[misc]
 async def movie_hls_playlist(
     movie_id: str,
+    request: Request,
     start: int = Query(
         0,
         ge=0,
@@ -164,7 +170,19 @@ async def movie_hls_playlist(
     file_path = _require_file(movie.file_path)
     if movie.scrub_preview_path is None:
         _fire_eager_movie(backfill_job, movie_id)
-    return await _serve_master(hls_uc, file_path, start=start)
+    view = NowPlayingViewContext(
+        profile_id=profile_id,
+        media_id=movie_id,
+        media_kind="movie",
+        title=movie.title,
+        year=movie.year,
+        meta=movie.resolution,
+        poster_url=movie.poster_path,
+        ip=_client_ip(request),
+        device=_device_label(request),
+        duration_seconds=movie.duration_seconds,
+    )
+    return await _serve_master(hls_uc, file_path, start=start, view=view)
 
 
 @router.get("/episode/{series_id}/{season_number}/{episode_number}/hls/playlist.m3u8")  # type: ignore[misc]
@@ -173,6 +191,7 @@ async def episode_hls_playlist(
     series_id: str,
     season_number: int,
     episode_number: int,
+    request: Request,
     start: int = Query(
         0,
         ge=0,
@@ -194,13 +213,25 @@ async def episode_hls_playlist(
     ),
 ) -> Response:
     """Generate and serve HLS master playlist for an episode."""
-    episode = await _find_episode(series_uc, profile_id, series_id, season_number, episode_number)
+    series, episode = await _find_series_and_episode(
+        series_uc, profile_id, series_id, season_number, episode_number
+    )
     if episode is None:
         raise HTTPException(status_code=404, detail="Episode not found")
     file_path = _require_file(episode.file_path)
     if episode.scrub_preview_path is None and episode.id is not None:
         _fire_eager_episode(backfill_job, episode.id)
-    return await _serve_master(hls_uc, file_path, start=start)
+    view = NowPlayingViewContext(
+        profile_id=profile_id,
+        media_id=series_id,
+        media_kind="episode",
+        title=series.title if series else episode.title,
+        meta=f"T{season_number} · E{episode_number} · {episode.title}",
+        ip=_client_ip(request),
+        device=_device_label(request),
+        duration_seconds=episode.duration_seconds,
+    )
+    return await _serve_master(hls_uc, file_path, start=start, view=view)
 
 
 # -- Track info ----------------------------------------------------------------
@@ -417,10 +448,22 @@ async def stream_episode(
 # -- Helpers -------------------------------------------------------------------
 
 
+def _client_ip(request: Request) -> str | None:
+    """Best-effort client IP for the now-playing row."""
+    return request.client.host if request.client else None
+
+
+def _device_label(request: Request) -> str | None:
+    """Truncated User-Agent as the device label (no friendly names yet)."""
+    ua = request.headers.get("user-agent")
+    return ua[:120] if ua else None
+
+
 async def _serve_master(
     use_case: GenerateHlsPlaylistUseCase,
     file_path: str,
     start: int = 0,
+    view: NowPlayingViewContext | None = None,
 ) -> Response:
     """Run the generate-playlist use case and wrap its DTO in a Response."""
     output = await use_case.execute(
@@ -428,6 +471,7 @@ async def _serve_master(
             file_path=file_path,
             base_url_template=_MASTER_BASE_URL,
             start=start,
+            view=view,
         )
     )
     return Response(
@@ -466,6 +510,24 @@ async def _find_episode_file(
     return episode.file_path if episode else None
 
 
+async def _find_series_and_episode(
+    use_case: GetSeriesByIdUseCase,
+    profile_id: str,
+    series_id: str,
+    season_number: int,
+    episode_number: int,
+) -> tuple[SeriesOutput | None, EpisodeOutput | None]:
+    """Resolve the series aggregate plus a single episode within it."""
+    series = await use_case.execute(GetSeriesByIdInput(profile_id=profile_id, series_id=series_id))
+    for season in series.seasons:
+        if season.season_number == season_number:
+            for episode in season.episodes:
+                if episode.episode_number == episode_number:
+                    return series, episode
+            break
+    return series, None
+
+
 async def _find_episode(
     use_case: GetSeriesByIdUseCase,
     profile_id: str,
@@ -474,14 +536,10 @@ async def _find_episode(
     episode_number: int,
 ) -> EpisodeOutput | None:
     """Resolve a single ``EpisodeOutput`` from the series aggregate."""
-    series = await use_case.execute(GetSeriesByIdInput(profile_id=profile_id, series_id=series_id))
-    for season in series.seasons:
-        if season.season_number == season_number:
-            for episode in season.episodes:
-                if episode.episode_number == episode_number:
-                    return episode
-            break
-    return None
+    _, episode = await _find_series_and_episode(
+        use_case, profile_id, series_id, season_number, episode_number
+    )
+    return episode
 
 
 __all__ = ["router"]

--- a/tests/modules/media/unit/application/use_cases/test_get_now_playing.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_now_playing.py
@@ -1,0 +1,81 @@
+"""Tests for GetNowPlayingUseCase."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.media.application.ports.now_playing_port import NowPlayingSession
+from src.modules.media.application.use_cases.get_now_playing import (
+    GetNowPlayingUseCase,
+)
+
+
+def _session(**overrides: Any) -> NowPlayingSession:
+    base: dict[str, Any] = {
+        "profile_id": "prf_1",
+        "media_id": "mov_1",
+        "media_kind": "movie",
+        "title": "Inception",
+        "year": 2010,
+        "meta": "2160p",
+        "poster_url": None,
+        "ip": "192.168.0.2",
+        "device": "Chrome",
+        "mode": None,
+        "detail": None,
+        "position_seconds": 500,
+        "duration_seconds": 1000,
+        "mbps": 8.0,
+    }
+    base.update(overrides)
+    return NowPlayingSession(**base)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_enriches_name_pct_and_total() -> None:
+    now_playing = MagicMock()
+    now_playing.active.return_value = [_session(mbps=8.0), _session(mbps=2.0)]
+    profiles = AsyncMock()
+    profiles.names_for.return_value = {"prf_1": "Lucas"}
+
+    use_case = GetNowPlayingUseCase(now_playing=now_playing, profile_summary=profiles)
+    out = await use_case.execute()
+
+    assert out.total_mbps == 10.0
+    assert out.sessions[0].profile_name == "Lucas"
+    assert out.sessions[0].pct == 50  # 500 / 1000
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_when_nobody_watching() -> None:
+    now_playing = MagicMock()
+    now_playing.active.return_value = []
+    profiles = AsyncMock()
+    profiles.names_for.return_value = {}
+
+    out = await GetNowPlayingUseCase(
+        now_playing=now_playing,
+        profile_summary=profiles,
+    ).execute()
+
+    assert out.sessions == []
+    assert out.total_mbps == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_pct_zero_without_duration() -> None:
+    now_playing = MagicMock()
+    now_playing.active.return_value = [_session(duration_seconds=None)]
+    profiles = AsyncMock()
+    profiles.names_for.return_value = {"prf_1": "Lucas"}
+
+    out = await GetNowPlayingUseCase(
+        now_playing=now_playing,
+        profile_summary=profiles,
+    ).execute()
+
+    assert out.sessions[0].pct == 0

--- a/tests/modules/media/unit/infrastructure/test_now_playing_registry.py
+++ b/tests/modules/media/unit/infrastructure/test_now_playing_registry.py
@@ -1,0 +1,75 @@
+"""Tests for the in-memory now-playing registry."""
+
+import pytest
+
+from src.modules.media.infrastructure.streaming.now_playing_registry import (
+    NowPlayingRegistry,
+)
+
+
+@pytest.mark.unit
+def test_empty_registry_has_no_sessions() -> None:
+    assert NowPlayingRegistry().active() == []
+
+
+@pytest.mark.unit
+def test_note_view_and_segment_surface_a_live_session() -> None:
+    registry = NowPlayingRegistry()
+    registry.note_view(
+        "h1",
+        profile_id="prf_1",
+        media_id="mov_1",
+        media_kind="movie",
+        title="Inception",
+        year=2010,
+        duration_seconds=1000,
+    )
+    registry.note_segment("h1", byte_count=5_000_000, segment_index=3)
+
+    sessions = registry.active()
+
+    assert len(sessions) == 1
+    session = sessions[0]
+    assert session.title == "Inception"
+    assert session.profile_id == "prf_1"
+    assert session.position_seconds == 30  # segment 3 x 10s
+    assert session.duration_seconds == 1000
+    assert session.mbps > 0
+
+
+@pytest.mark.unit
+def test_position_is_clamped_to_duration() -> None:
+    registry = NowPlayingRegistry()
+    registry.note_view("h", media_id="m", duration_seconds=25)
+    registry.note_segment("h", byte_count=1, segment_index=100)
+
+    assert registry.active()[0].position_seconds == 25
+
+
+@pytest.mark.unit
+def test_start_offset_is_added_to_position() -> None:
+    registry = NowPlayingRegistry()
+    registry.note_view("h", media_id="m", duration_seconds=10_000, start_offset=300)
+    registry.note_segment("h", byte_count=1, segment_index=2)
+
+    assert registry.active()[0].position_seconds == 320  # 300 + 2 x 10s
+
+
+@pytest.mark.unit
+def test_separate_path_hashes_are_separate_sessions() -> None:
+    registry = NowPlayingRegistry()
+    registry.note_view("a", media_id="a", title="A", duration_seconds=100)
+    registry.note_view("b", media_id="b", title="B", duration_seconds=100)
+
+    assert {s.title for s in registry.active()} == {"A", "B"}
+
+
+@pytest.mark.unit
+def test_segment_only_session_is_hidden() -> None:
+    # A stream that only ever hit segment endpoints (e.g. survived a
+    # backend restart) has bytes but no identity — it must not surface
+    # as a ghost "—" row.
+    registry = NowPlayingRegistry()
+    registry.note_segment("orphan", byte_count=5_000_000, segment_index=4)
+
+    assert registry.active() == []


### PR DESCRIPTION
## Summary

Lights up the **"Reproduzindo agora"** panel on the admin Overview (PR2 of the Overview redesign) — what's playing on the server right now. Built the **observational** way: the streaming path only *notes* activity into an in-memory registry; it never alters the playlist bytes, segment bytes, or the ffmpeg pipeline, and every note is best-effort + suppressed so a bookkeeping bug can't break a stream.

- **`NowPlayingRegistry`** — in-memory, keyed by `path_hash`, lazy freshness-window eviction, rolling-window bitrate, segment-index-derived progress. Thread-safe singleton.
- **Capture hooks** (additive): the playlist use case notes profile / media / title / device / IP / duration; the segment use case notes liveness + bytes + segment index. Both wrapped in `contextlib.suppress`.
- **`GET /admin/now-playing`** → `GetNowPlayingUseCase` returns live sessions (watcher, progress %, uplink) + aggregate `total_mbps`. Profile names resolved via a new identity ACL (`ProfileSummaryPort` / `ProfileSummaryAdapter`).
- Episodes surface the **series name** + `T1 · E3 · <episode title>`.
- Segment-only sessions (e.g. a stream surviving a backend restart, fetching segments but not re-requesting the playlist) are hidden until identity is known — no ghost "—" rows.

## Honest limitations (by design / deferred)
- Position is segment-index based → leans slightly ahead of the real playhead (player buffers).
- Two viewers of the byte-identical file at the same offset collapse into one row (household-acceptable).
- In-memory + ephemeral — a restart clears it (correct for "right now").
- `mode` (direct/transcode) ships `null` for now — stamping it touches the HLS transcode decision, deferred to a careful follow-up. Per-library disk usage is a separate PR.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] New unit tests: registry (progress/clamp/offset/orphan-hidden) + GetNowPlaying (name/pct/total/empty)
- [x] **Full suite green — 2967 passed**
- [x] Manual smoke: playback **unchanged** (movie + episode, direct + transcode, forward seek); panel populates live and clears ~25s after stopping

## Deploy
No migration — in-memory registry. Just restart the backend.

## Notes
Pairs with the frontend panel PR on `main`.