### PR TITLE
feat(media): per-library catalog disk usage for the admin Overview

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -55,6 +55,9 @@ from src.modules.media.application.use_cases.get_hls_cache_stats import (
 from src.modules.media.application.use_cases.get_intro_detection_run import (
     GetIntroDetectionRunUseCase,
 )
+from src.modules.media.application.use_cases.get_library_usage import (
+    GetLibraryUsageUseCase,
+)
 from src.modules.media.application.use_cases.get_movie_by_id import GetMovieByIdUseCase
 from src.modules.media.application.use_cases.get_movie_tmdb_suggestions import (
     GetMovieTmdbSuggestionsUseCase,
@@ -507,6 +510,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         GetNowPlayingUseCase,
         now_playing=now_playing_registry,
         profile_summary=profile_summary,
+    )
+
+    get_library_usage = providers.Factory(
+        GetLibraryUsageUseCase,
+        uow_factory=media_unit_of_work_factory,
     )
 
     get_file_tracks = providers.Factory(

--- a/src/modules/media/application/dtos/library_usage_dtos.py
+++ b/src/modules/media/application/dtos/library_usage_dtos.py
@@ -1,0 +1,29 @@
+"""DTOs for the admin per-library disk-usage panel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LibraryUsageEntry:
+    """Catalog size for one library.
+
+    Attributes:
+        library_id: Owning library id.
+        size_bytes: Sum of primary-file bytes for the library's movies +
+            episodes. This is catalog size (primary variant only), not a
+            ``du`` of the library folders — it ranks libraries against
+            each other cheaply without touching disk.
+    """
+
+    library_id: str
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class LibraryUsageOutput:
+    """Per-library usage, sorted largest-first, plus the grand total."""
+
+    libraries: list[LibraryUsageEntry]
+    total_bytes: int

--- a/src/modules/media/application/use_cases/get_library_usage.py
+++ b/src/modules/media/application/use_cases/get_library_usage.py
@@ -1,0 +1,47 @@
+"""Use case: per-library catalog disk usage for the admin Overview.
+
+Sums primary-file bytes for movies and episodes grouped by library — a
+cheap SQL aggregation (no disk walk). The result ranks libraries against
+each other on the "Uso de disco por library" panel.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.modules.media.application.dtos.library_usage_dtos import (
+    LibraryUsageEntry,
+    LibraryUsageOutput,
+)
+
+if TYPE_CHECKING:
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+
+class GetLibraryUsageUseCase:
+    """Aggregate catalog size per library."""
+
+    def __init__(self, uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(self) -> LibraryUsageOutput:
+        """Return per-library catalog size, largest first, plus the total."""
+        async with self._uow_factory() as uow:
+            movie_sizes = await uow.movies.total_file_size_by_library()
+            episode_sizes = await uow.series.episode_file_size_by_library()
+
+        merged: dict[str, int] = {}
+        for sizes in (movie_sizes, episode_sizes):
+            for library_id, size in sizes.items():
+                merged[library_id] = merged.get(library_id, 0) + size
+
+        entries = sorted(
+            (
+                LibraryUsageEntry(library_id=library_id, size_bytes=size)
+                for library_id, size in merged.items()
+            ),
+            key=lambda entry: entry.size_bytes,
+            reverse=True,
+        )
+        total = sum(entry.size_bytes for entry in entries)
+        return LibraryUsageOutput(libraries=entries, total_bytes=total)

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -593,6 +593,11 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
+    async def total_file_size_by_library(self) -> dict[str, int]:
+        """Return ``{library_id: total primary-file bytes}`` over movies."""
+        ...
+
+    @abstractmethod
     async def list_credits_status(
         self, state: str | None, limit: int, offset: int
     ) -> tuple[Sequence[CreditsStatusRow], int]:

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -534,6 +534,11 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
+    async def episode_file_size_by_library(self) -> dict[str, int]:
+        """Return ``{library_id: total episode primary-file bytes}``."""
+        ...
+
+    @abstractmethod
     async def list_episode_credits_status(
         self, state: str | None, limit: int, offset: int
     ) -> tuple[Sequence[CreditsStatusRow], int]:

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -755,6 +755,19 @@ class SQLAlchemyMovieRepository(MovieRepository):
         result = await self._session.execute(stmt)
         return dict(result.all())
 
+    async def total_file_size_by_library(self) -> dict[str, int]:
+        """Sum primary-file bytes per library over non-deleted movies."""
+        stmt = (
+            select(
+                MovieModel.library_id,
+                func.coalesce(func.sum(MovieModel.file_size), 0),
+            )
+            .where(MovieModel.deleted_at.is_(None))
+            .group_by(MovieModel.library_id)
+        )
+        result = await self._session.execute(stmt)
+        return {library_id: int(total) for library_id, total in result.all()}
+
     async def list_credits_status(
         self, state: str | None, limit: int, offset: int
     ) -> tuple[Sequence[CreditsStatusRow], int]:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -836,6 +836,21 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         result = await self._session.execute(stmt)
         return dict(result.all())
 
+    async def episode_file_size_by_library(self) -> dict[str, int]:
+        """Sum episode primary-file bytes per library, via the parent series."""
+        stmt = (
+            select(
+                SeriesModel.library_id,
+                func.coalesce(func.sum(EpisodeModel.file_size), 0),
+            )
+            .join(SeasonModel, EpisodeModel.season_id == SeasonModel.id)
+            .join(SeriesModel, SeasonModel.series_id == SeriesModel.id)
+            .where(EpisodeModel.deleted_at.is_(None))
+            .group_by(SeriesModel.library_id)
+        )
+        result = await self._session.execute(stmt)
+        return {library_id: int(total) for library_id, total in result.all()}
+
     async def list_episode_credits_status(
         self, state: str | None, limit: int, offset: int
     ) -> tuple[Sequence[CreditsStatusRow], int]:

--- a/src/modules/media/presentation/routes/admin_overview_routes.py
+++ b/src/modules/media/presentation/routes/admin_overview_routes.py
@@ -10,6 +10,9 @@ from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.media.application.use_cases.get_library_usage import (
+    GetLibraryUsageUseCase,
+)
 from src.modules.media.application.use_cases.get_now_playing import GetNowPlayingUseCase
 from src.modules.media.application.use_cases.get_overview_stats import (
     GetOverviewStatsUseCase,
@@ -54,6 +57,24 @@ async def get_admin_now_playing(
     """
     snapshot = await use_case.execute()
     return api_single("now_playing", asdict(snapshot))
+
+
+@router.get("/library-usage")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_admin_library_usage(
+    _admin: UserModel = Depends(current_admin_user),
+    use_case: GetLibraryUsageUseCase = Depends(
+        Provide[ApplicationContainer.media.get_library_usage],
+    ),
+) -> dict[str, Any]:
+    """Per-library catalog size (sum of primary-file bytes), largest first.
+
+    Cheap SQL aggregation, not a disk ``du`` — it ranks libraries
+    against each other for the "Uso de disco por library" panel. The
+    frontend joins ``library_id`` with the libraries list for names.
+    """
+    usage = await use_case.execute()
+    return api_single("library_usage", asdict(usage))
 
 
 __all__ = ["router"]

--- a/tests/modules/media/unit/application/use_cases/test_get_library_usage.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_library_usage.py
@@ -1,0 +1,50 @@
+"""Tests for GetLibraryUsageUseCase."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.modules.media.application.use_cases.get_library_usage import (
+    GetLibraryUsageUseCase,
+)
+
+
+def _uow_factory(
+    movie_sizes: dict[str, int],
+    episode_sizes: dict[str, int],
+) -> MagicMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.movies.total_file_size_by_library.return_value = movie_sizes
+    uow.series.episode_file_size_by_library.return_value = episode_sizes
+    return MagicMock(return_value=uow)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_merges_movie_and_episode_sizes_sorted_desc() -> None:
+    use_case = GetLibraryUsageUseCase(
+        uow_factory=_uow_factory({"a": 100, "b": 50}, {"b": 200, "c": 30}),
+    )
+
+    out = await use_case.execute()
+
+    # b = 50 + 200, a = 100, c = 30 — largest first.
+    assert [(e.library_id, e.size_bytes) for e in out.libraries] == [
+        ("b", 250),
+        ("a", 100),
+        ("c", 30),
+    ]
+    assert out.total_bytes == 380
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_catalog_yields_no_libraries() -> None:
+    use_case = GetLibraryUsageUseCase(uow_factory=_uow_factory({}, {}))
+
+    out = await use_case.execute()
+
+    assert out.libraries == []
+    assert out.total_bytes == 0


### PR DESCRIPTION
## Summary

Backs the **"Uso de disco por library"** panel (PR3 of the Overview redesign) with a cheap, disk-free aggregation.

- **`GET /admin/library-usage`** → `GetLibraryUsageUseCase` sums **primary-file bytes** for movies + episodes grouped by library, returns per-library sizes **largest-first** plus the grand `total_bytes`.
- New repo aggregations: `MovieRepository.total_file_size_by_library` (movies) and `SeriesRepository.episode_file_size_by_library` (episodes via the parent series). Both pure `SUM ... GROUP BY` — no disk walk.

## Honest limitation
This is **catalog size** (primary variant only) — it undercounts multi-variant titles and ignores non-catalog files. It's perfect for ranking libraries against each other on the panel, but it is **not** a `du` of the library folders. Upgrading to a sum over all `media_files` variants is a cheap follow-up if true fidelity is wanted.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] Unit tests for the use case (merge + sort-desc + total; empty catalog)
- [x] **Full suite green — 2970 passed**

## Deploy
No migration — read-only aggregation. Just restart the backend.

## Notes
Pairs with the frontend panel PR on `main`.