### PR TITLE
fix(media): software fallback when HW transcode fails

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -469,7 +469,55 @@ class HlsService(HlsPlaylistPort):
             msg = f"Source file not found: {file_path}"
             raise FileNotFoundError(msg)
 
-        await asyncio.to_thread(self._start_generation, file_path, start)
+        # Try the configured pipeline first; if a HW (NVENC/CUDA) attempt
+        # fails — transient GPU contention, a 10-bit profile NVDEC can't
+        # set up that moment — fall back to the proven libx264 path once
+        # instead of surfacing a 500/404 to the player. Purely additive:
+        # this only runs after the HW attempt already failed.
+        hw_eligible = self._would_use_hw_transcode(file_path, start)
+        try:
+            await self._generate_and_wait(file_path, start, path_hash, force_software=False)
+        except RuntimeError:
+            if not hw_eligible:
+                raise
+            _logger.warning(
+                "HW transcode failed for %s (start=%d) — retrying in software",
+                file_path,
+                start,
+            )
+            shutil.rmtree(self._cache_dir / path_hash, ignore_errors=True)
+            self._kill_processes(path_hash)
+            await self._generate_and_wait(file_path, start, path_hash, force_software=True)
+        return path_hash
+
+    def _would_use_hw_transcode(self, file_path: str, start: int) -> bool:
+        """Whether the NVENC/CUDA pipeline would be chosen for this request.
+
+        Drives the software-fallback decision: a HW-only failure (CUDA
+        init, NVDEC capability, transient GPU contention) recovers on the
+        libx264 path, whereas a software failure would just repeat.
+        """
+        if not self._use_nvenc():
+            return False
+        if start > 0:
+            return True
+        return self._probe_video_codec(file_path) not in _BROWSER_SAFE_CODECS
+
+    async def _generate_and_wait(
+        self,
+        file_path: str,
+        start: int,
+        path_hash: str,
+        *,
+        force_software: bool,
+    ) -> None:
+        """Start generation and block until the first segments are ready.
+
+        Raises:
+            RuntimeError: if the ffmpeg process fails or no segments
+                appear within the poll timeout.
+        """
+        await asyncio.to_thread(self._start_generation, file_path, start, force_software)
 
         video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
         attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
@@ -482,7 +530,7 @@ class HlsService(HlsPlaylistPort):
                     # so anything counted here is safe to serve.
                     extinf_count = content.count("#EXTINF:")
                     if extinf_count >= _MIN_SEGMENTS_FRESH:
-                        return path_hash
+                        return
                 except OSError:
                     pass
 
@@ -613,7 +661,9 @@ class HlsService(HlsPlaylistPort):
 
     # -- Private: generation ---------------------------------------------------
 
-    def _start_generation(self, file_path: str, start: int = 0) -> str:
+    def _start_generation(
+        self, file_path: str, start: int = 0, force_software: bool = False
+    ) -> str:
         """Start all FFmpeg processes for multi-track HLS generation.
 
         Transcodes from the exact ``start`` second into a bucket keyed
@@ -625,6 +675,8 @@ class HlsService(HlsPlaylistPort):
         Args:
             file_path: Absolute path to the source video file.
             start: Source-time second to begin the encode at.
+            force_software: Skip the NVENC pipeline and encode with
+                libx264 — the fallback used after a HW attempt fails.
         """
         source = self._validate_source(file_path)
         safe_path = str(source)
@@ -682,7 +734,9 @@ class HlsService(HlsPlaylistPort):
             video_dir = output_dir / _VIDEO_DIR
             video_dir.mkdir()
             cmd = with_ffmpeg_threads(
-                self._build_video_cmd(safe_path, video_dir, probe_result, bucket_start),
+                self._build_video_cmd(
+                    safe_path, video_dir, probe_result, bucket_start, force_software
+                ),
                 ffmpeg_threads,
             )
             _logger.info("Starting video HLS for %s (offset=%ds)", safe_path, bucket_start)
@@ -899,6 +953,7 @@ class HlsService(HlsPlaylistPort):
         output_dir: Path,
         probe: ProbeResult,
         start: int = 0,
+        force_software: bool = False,
     ) -> list[str]:
         """Build FFmpeg command for video + default audio.
 
@@ -941,7 +996,7 @@ class HlsService(HlsPlaylistPort):
         hwaccel_input_args: list[str] = []
         vf_args: list[str] = []
 
-        if needs_transcode and self._use_nvenc():
+        if needs_transcode and self._use_nvenc() and not force_software:
             _logger.info("Source codec %s — transcoding via NVENC (start=%d)", codec, start)
             # Full-GPU pipeline: NVDEC decode → scale_cuda (10→8 bit in
             # VRAM) → NVENC encode. ``spatial_aq`` redistributes bits to

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1720,3 +1720,72 @@ class TestHlsServiceSpawnFfmpegWatcher:
 
         # wait() must not have been called from a watcher — no watcher started.
         fake_proc.wait.assert_not_called()
+
+
+class TestEnsurePlaylistSoftwareFallback:
+    """ensure_playlist retries in software when a HW (NVENC) attempt fails."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_falls_back_to_software_on_hw_failure(self, tmp_path: Path) -> None:
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hw_accel=HardwareAccel.NVENC),
+            cache_dir=str(tmp_path / "hls"),
+        )
+        source = tmp_path / "movie.mkv"
+        source.write_bytes(b"data")
+
+        calls: list[bool] = []
+
+        def fake_generate(_file_path, _start, _path_hash, *, force_software):
+            calls.append(force_software)
+            if not force_software:
+                msg = "FFmpeg failed (hwaccel init)"
+                raise RuntimeError(msg)
+
+        with (
+            patch.object(service, "is_complete", return_value=False),
+            patch.object(service, "_would_use_hw_transcode", return_value=True),
+            patch.object(service, "_generate_and_wait", new=AsyncMock(side_effect=fake_generate)),
+            patch(
+                "src.modules.media.infrastructure.streaming.hls_service.shutil.which",
+                return_value="ffmpeg",
+            ),
+        ):
+            result = await service.ensure_playlist(str(source), start=300)
+
+        # HW attempt first, then the software retry.
+        assert calls == [False, True]
+        assert result == service.get_path_hash(str(source), 300)
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_no_software_retry_when_not_hw_eligible(self, tmp_path: Path) -> None:
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hw_accel=HardwareAccel.OFF),
+            cache_dir=str(tmp_path / "hls"),
+        )
+        source = tmp_path / "movie.mkv"
+        source.write_bytes(b"data")
+
+        calls: list[bool] = []
+
+        def fake_generate(_file_path, _start, _path_hash, *, force_software):
+            calls.append(force_software)
+            msg = "FFmpeg failed"
+            raise RuntimeError(msg)
+
+        with (
+            patch.object(service, "is_complete", return_value=False),
+            patch.object(service, "_would_use_hw_transcode", return_value=False),
+            patch.object(service, "_generate_and_wait", new=AsyncMock(side_effect=fake_generate)),
+            patch(
+                "src.modules.media.infrastructure.streaming.hls_service.shutil.which",
+                return_value="ffmpeg",
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await service.ensure_playlist(str(source), start=0)
+
+        # Software path failing is not retried.
+        assert calls == [False]


### PR DESCRIPTION
## Summary

Resuming or seeking **10-bit sources** intermittently broke playback: the NVENC/CUDA pipeline would fail to initialise — transient GPU contention (concurrent scrub-preview ffmpeg) or an NVDEC capability hiccup (`hwaccel initialisation returned error`, `Hardware is lacking required capabilities`, `src: yuv420p10le → dst: cuda`) — and produce no output, surfacing as a **500** (then a **404** on the next request since the cache was left empty). "Works most of the time" because the failure is transient.

`ensure_playlist` now **retries once on the software path** (`libx264`, no `-hwaccel cuda`) when a HW attempt fails, instead of giving up. Purely additive — the fallback only runs *after* the HW attempt already failed, reusing the exact libx264 path that already serves `hw_accel=off`. The failed bucket + orphan processes are cleaned before the retry.

- Extracts `_generate_and_wait` from `ensure_playlist`.
- `_would_use_hw_transcode` decides whether a failure is worth a software retry (HW-only failures self-heal on libx264; software failures would just repeat).
- `force_software` flag threaded through `_start_generation` → `_build_video_cmd`.
- **The segment/playlist model is untouched** — this is a fallback, not a refactor.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] 2 new unit tests: HW failure → software retry; software-path failure → no retry
- [x] **124 HlsService tests pass**
- [x] Manual smoke: the 10-bit episode that 500'd on resume now plays; normal playback (HW path) unchanged; log shows `HW transcode failed … retrying in software` when the fallback kicks in

## Deploy
No migration — restart the backend.

## Not in scope
The `PermissionError` on `sub.vtt.shift.tmp` (subtitle shift) seen in the same logs is a separate, non-fatal issue (already caught + logged) — not the cause of the playback break.