### PR TITLE
fix(media): align HLS subtitles to the video clock

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -1075,6 +1075,13 @@ class HlsService(HlsPlaylistPort):
             *video_args,
             *audio_args,
             *ts_normalize_args,
+            # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
+            # segment PTS starts at ~0, keeping the video / audio / subtitle
+            # timelines aligned (the WebVTT X-TIMESTAMP-MAP anchors to MPEGTS:0).
+            "-muxdelay",
+            "0",
+            "-muxpreload",
+            "0",
             "-hls_time",
             str(_SEGMENT_DURATION),
             "-hls_list_size",
@@ -1128,6 +1135,13 @@ class HlsService(HlsPlaylistPort):
             "-sn",
             *_audio_args_for(track, start),
             *ts_normalize_args,
+            # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
+            # segment PTS starts at ~0, keeping the video / audio / subtitle
+            # timelines aligned (the WebVTT X-TIMESTAMP-MAP anchors to MPEGTS:0).
+            "-muxdelay",
+            "0",
+            "-muxpreload",
+            "0",
             "-hls_time",
             str(_SEGMENT_DURATION),
             "-hls_list_size",
@@ -1188,6 +1202,7 @@ class HlsService(HlsPlaylistPort):
             if vtt_path.is_file():
                 if start > 0:
                     _shift_webvtt_to_bucket_local(vtt_path, start)
+                _ensure_vtt_timestamp_map(vtt_path)
                 _write_subtitle_playlist(sub_dir)
                 _logger.info("Extracted %s to %s (start=%d)", log_label, vtt_path, start)
             else:
@@ -1522,6 +1537,42 @@ def _shift_webvtt_to_bucket_local(vtt_path: Path, shift_seconds: int) -> None:
         tmp_path.replace(vtt_path)
     except OSError:
         _logger.exception("Failed to write shifted VTT: %s", vtt_path)
+
+
+_VTT_TIMESTAMP_MAP = "X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000"
+
+
+def _ensure_vtt_timestamp_map(vtt_path: Path) -> None:
+    """Insert the HLS ``X-TIMESTAMP-MAP`` header into a standalone WebVTT.
+
+    The video segments start at MPEG-TS PTS 0 (muxdelay/muxpreload
+    zeroed), so cues anchored to ``LOCAL`` 0 line up with the video
+    clock. Without this header hls.js falls back to the muxer's old
+    ~1.4 s start offset and renders subtitles a second or two early.
+    Idempotent and best-effort — runs after any bucket-local shift so it
+    never rewrites the map's own ``00:00:00.000``.
+    """
+    if not vtt_path.is_file():
+        return
+    try:
+        content = vtt_path.read_text(encoding="utf-8")
+    except OSError:
+        _logger.exception("Failed to read VTT for timestamp map: %s", vtt_path)
+        return
+    if "X-TIMESTAMP-MAP" in content:
+        return
+    # ffmpeg writes "WEBVTT\n\n<cues>"; the map must sit on the line
+    # right after the WEBVTT signature, before the blank line + cues.
+    head, _, rest = content.partition("\n")
+    if "WEBVTT" not in head:
+        return
+    new_content = f"{head}\n{_VTT_TIMESTAMP_MAP}\n{rest}"
+    tmp_path = vtt_path.with_name(vtt_path.name + ".tsmap.tmp")
+    try:
+        tmp_path.write_text(new_content, encoding="utf-8")
+        tmp_path.replace(vtt_path)
+    except OSError:
+        _logger.exception("Failed to write VTT timestamp map: %s", vtt_path)
 
 
 __all__ = ["HlsService"]

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -13,6 +13,7 @@ from src.modules.media.application.ports import ProbeResult
 from src.modules.media.infrastructure.streaming.hls_service import (
     HlsService,
     _append_endlist_atomic,
+    _ensure_vtt_timestamp_map,
     _has_endlist,
     _primary_audio_index,
     _shift_webvtt_to_bucket_local,
@@ -1235,7 +1236,12 @@ class TestHlsServiceExtractOneSubtitle:
         assert "-ss" not in captured["cmd"]
         assert "-accurate_seek" not in captured["cmd"]
         assert "-avoid_negative_ts" not in captured["cmd"]
-        assert (output_dir / "sub_0" / "sub.vtt").read_text(encoding="utf-8") == original_vtt
+        result_vtt = (output_dir / "sub_0" / "sub.vtt").read_text(encoding="utf-8")
+        # No shift at start=0: cues keep their source timestamps...
+        assert "00:00:05.000 --> 00:00:07.000" in result_vtt
+        # ...but the HLS timestamp-map header is added so hls.js aligns
+        # cues to the (now zero-based) video clock.
+        assert "X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000" in result_vtt
 
     def test_should_post_shift_embedded_subtitle_cues_when_start_positive(
         self, tmp_path: Path
@@ -1789,3 +1795,54 @@ class TestEnsurePlaylistSoftwareFallback:
 
         # Software path failing is not retried.
         assert calls == [False]
+
+
+class TestMpegtsZeroStart:
+    """Video + audio commands zero the MPEG-TS muxer's initial offset."""
+
+    @pytest.mark.unit
+    def test_video_cmd_zeroes_muxer_offset(self, tmp_path: Path) -> None:
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "cache")
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        assert cmd[cmd.index("-muxdelay") + 1] == "0"
+        assert cmd[cmd.index("-muxpreload") + 1] == "0"
+
+    @pytest.mark.unit
+    def test_audio_cmd_zeroes_muxer_offset(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        assert cmd[cmd.index("-muxdelay") + 1] == "0"
+        assert cmd[cmd.index("-muxpreload") + 1] == "0"
+
+
+class TestVttTimestampMap:
+    """``_ensure_vtt_timestamp_map`` anchors cues to the zero-based clock."""
+
+    @pytest.mark.unit
+    def test_injects_map_after_webvtt_signature(self, tmp_path: Path) -> None:
+        vtt = tmp_path / "sub.vtt"
+        vtt.write_text("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nhi\n", encoding="utf-8")
+
+        _ensure_vtt_timestamp_map(vtt)
+
+        content = vtt.read_text(encoding="utf-8")
+        assert content.startswith("WEBVTT\nX-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000\n\n")
+        # Cue timestamps are untouched.
+        assert "00:00:01.000 --> 00:00:02.000" in content
+
+    @pytest.mark.unit
+    def test_is_idempotent(self, tmp_path: Path) -> None:
+        vtt = tmp_path / "sub.vtt"
+        vtt.write_text(
+            "WEBVTT\nX-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000\n\n"
+            "00:00:01.000 --> 00:00:02.000\nhi\n",
+            encoding="utf-8",
+        )
+        before = vtt.read_text(encoding="utf-8")
+
+        _ensure_vtt_timestamp_map(vtt)
+
+        assert vtt.read_text(encoding="utf-8") == before


### PR DESCRIPTION
## Summary

Subtitles rendered **~1-2s early** on every playback. Root cause: the MPEG-TS muxer adds its default ~1.4s start offset to the video segments, while the standalone WebVTT was served with **LOCAL-0 cues and no `X-TIMESTAMP-MAP`** — so hls.js had nothing to align the subtitle clock to the video clock. The per-bucket shift we added for seek/resume only ever corrected the *seek* offset, never this base muxer offset, so subs drifted even on a fresh play. Long-standing — not a recent regression.

Approach (2), as chosen:

- **Zero the muxer offset** (`-muxdelay 0 -muxpreload 0`) on the video **and** audio commands, so segment PTS starts at ~0. Applied to audio too so switching audio tracks stays aligned.
- **Inject `X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000`** into the served VTT (after any bucket-local shift, so it never rewrites the map's own `00:00:00.000`). hls.js then anchors cues to the now zero-based video clock.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] New unit tests: muxdelay/muxpreload on both video + audio commands; VTT map injection (placement + idempotence); start=0 keeps cue timestamps but gains the map
- [x] **128 HlsService tests pass**
- [x] Manual smoke (after clearing the HLS cache): subtitles in sync with speech on fresh play **and** after seek/resume; audio/video stay in sync

## Deploy
No migration. Restart the backend, and **clear the HLS cache** once — buckets cached before this change still carry the old offset / map-less VTT.