### PR TITLE
fix(media): tolerate transient lock when writing subtitle VTT

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -40,6 +40,7 @@ import shutil
 import subprocess
 import threading
 import time
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -1508,6 +1509,46 @@ def _shift_one_timestamp(match: re.Match[str], shift_seconds: int) -> str:
     return f"{new_h:02d}:{new_m:02d}:{new_s:02d}.{new_ms:03d}"
 
 
+# Windows refuses os.replace onto a file another handle has open (a
+# player fetching the .vtt, or an AV/indexer scanning a fresh write),
+# raising PermissionError. The lock is transient, so retry briefly.
+_VTT_REPLACE_ATTEMPTS = 5
+_VTT_REPLACE_BACKOFF = 0.1  # seconds, scaled by attempt number
+
+
+def _atomic_write_text(dest: Path, content: str) -> None:
+    """Atomically write ``content`` onto ``dest``, retrying a locked replace.
+
+    The unique temp name keeps two concurrent writers from clobbering
+    each other's temp (``WinError 2``); the retry rides out a momentary
+    open handle on the destination (``WinError 5``). Best-effort — gives
+    up and cleans the temp after a few attempts.
+    """
+    tmp_path = dest.with_name(f"{dest.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        tmp_path.write_text(content, encoding="utf-8")
+    except OSError:
+        _logger.exception("Failed to write temp for %s", dest)
+        return
+    for attempt in range(_VTT_REPLACE_ATTEMPTS):
+        try:
+            tmp_path.replace(dest)
+            return
+        except PermissionError:
+            if attempt == _VTT_REPLACE_ATTEMPTS - 1:
+                _logger.warning(
+                    "Could not replace %s after %d tries (file locked)",
+                    dest,
+                    _VTT_REPLACE_ATTEMPTS,
+                )
+            else:
+                time.sleep(_VTT_REPLACE_BACKOFF * (attempt + 1))
+        except OSError:
+            _logger.exception("Failed to replace %s", dest)
+            break
+    tmp_path.unlink(missing_ok=True)
+
+
 def _shift_webvtt_to_bucket_local(vtt_path: Path, shift_seconds: int) -> None:
     """Subtract ``shift_seconds`` from every cue timestamp in the VTT.
 
@@ -1531,12 +1572,7 @@ def _shift_webvtt_to_bucket_local(vtt_path: Path, shift_seconds: int) -> None:
         return _shift_one_timestamp(m, shift_seconds)
 
     new_content = _VTT_TIMESTAMP_RE.sub(_replace, content)
-    tmp_path = vtt_path.with_name(vtt_path.name + ".shift.tmp")
-    try:
-        tmp_path.write_text(new_content, encoding="utf-8")
-        tmp_path.replace(vtt_path)
-    except OSError:
-        _logger.exception("Failed to write shifted VTT: %s", vtt_path)
+    _atomic_write_text(vtt_path, new_content)
 
 
 _VTT_TIMESTAMP_MAP = "X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000"
@@ -1567,12 +1603,7 @@ def _ensure_vtt_timestamp_map(vtt_path: Path) -> None:
     if "WEBVTT" not in head:
         return
     new_content = f"{head}\n{_VTT_TIMESTAMP_MAP}\n{rest}"
-    tmp_path = vtt_path.with_name(vtt_path.name + ".tsmap.tmp")
-    try:
-        tmp_path.write_text(new_content, encoding="utf-8")
-        tmp_path.replace(vtt_path)
-    except OSError:
-        _logger.exception("Failed to write VTT timestamp map: %s", vtt_path)
+    _atomic_write_text(vtt_path, new_content)
 
 
 __all__ = ["HlsService"]

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -13,6 +13,7 @@ from src.modules.media.application.ports import ProbeResult
 from src.modules.media.infrastructure.streaming.hls_service import (
     HlsService,
     _append_endlist_atomic,
+    _atomic_write_text,
     _ensure_vtt_timestamp_map,
     _has_endlist,
     _primary_audio_index,
@@ -1846,3 +1847,47 @@ class TestVttTimestampMap:
         _ensure_vtt_timestamp_map(vtt)
 
         assert vtt.read_text(encoding="utf-8") == before
+
+
+class TestAtomicWriteText:
+    """``_atomic_write_text`` survives the Windows replace-while-open lock."""
+
+    @pytest.mark.unit
+    def test_writes_content(self, tmp_path: Path) -> None:
+        dest = tmp_path / "sub.vtt"
+        _atomic_write_text(dest, "hello")
+        assert dest.read_text(encoding="utf-8") == "hello"
+
+    @pytest.mark.unit
+    def test_retries_replace_on_permission_error(self, tmp_path: Path) -> None:
+        dest = tmp_path / "sub.vtt"
+        dest.write_text("old", encoding="utf-8")
+        real_replace = Path.replace
+        calls = {"n": 0}
+
+        def flaky_replace(self: Path, target: Path) -> None:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise PermissionError(5, "locked")
+            real_replace(self, target)
+
+        with patch.object(Path, "replace", flaky_replace), patch("time.sleep"):
+            _atomic_write_text(dest, "new")
+
+        assert dest.read_text(encoding="utf-8") == "new"
+        assert calls["n"] == 3
+
+    @pytest.mark.unit
+    def test_gives_up_and_cleans_temp_after_attempts(self, tmp_path: Path) -> None:
+        dest = tmp_path / "sub.vtt"
+        dest.write_text("old", encoding="utf-8")
+
+        def always_locked(self: Path, target: Path) -> None:
+            raise PermissionError(5, "locked")
+
+        with patch.object(Path, "replace", always_locked), patch("time.sleep"):
+            _atomic_write_text(dest, "new")
+
+        # Destination untouched; no orphaned temp left behind.
+        assert dest.read_text(encoding="utf-8") == "old"
+        assert list(tmp_path.glob("sub.vtt.*.tmp")) == []


### PR DESCRIPTION
## Summary

The post-extraction VTT rewrite (bucket-local shift + `X-TIMESTAMP-MAP` injection from #305) intermittently failed on Windows:

- **WinError 5** (Access denied) — `os.replace` onto `sub.vtt` while a player or AV/indexer briefly held the file open (Windows won't replace an open file).
- **WinError 2** (Not found) — two concurrent writers used the same `.shift.tmp` name; one renamed it before the other's `replace`.

On failure the shift/map was dropped — noisy logs **plus** a possibly-misaligned cue track for that subtitle.

- New `_atomic_write_text(dest, content)`: writes to a **uniquely-named temp** (`<name>.<uuid>.tmp` — no cross-writer clobber) and **retries the replace with backoff** (5 tries, ~0.1–0.5s — rides out the transient lock), giving up with a single warning + temp cleanup if it stays locked.
- `_shift_webvtt_to_bucket_local` and `_ensure_vtt_timestamp_map` now use it.

No change to served content — only how the VTT is written.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] New unit tests: writes content; retries on `PermissionError` then succeeds; gives up + cleans the temp after exhausting attempts
- [x] **131 HlsService tests pass**
- [x] Manual smoke: played an episode with subtitles — the `Failed to write shifted VTT … PermissionError` log spam is gone, subtitles stay in sync, playback (incl. the #304 software fallback) unaffected

## Deploy
No migration — restart the backend.