### PR TITLE
fix(media): recover stale intro claims, gate insufficient retries

### DIFF
--- a/migrations/versions/2026_06_25_add_intro_attempted_episode_count.py
+++ b/migrations/versions/2026_06_25_add_intro_attempted_episode_count.py
@@ -1,0 +1,44 @@
+"""Add intro_detection_attempted_episode_count to seasons.
+
+Records how many (non-deleted) episodes a season had the last time the
+intro-detection job stamped its state. The job re-arms an
+``INSUFFICIENT_EPISODES`` season only once its episode count grows past
+this value, so a season that can never satisfy the detector (e.g. a
+2-part miniseries) stops being retried on every tick instead of
+monopolising the queue. Nullable so existing rows are treated as
+"unknown count" (re-eligible exactly once on the next tick, after which
+the count is stamped).
+
+Revision ID: 7c2f9a1b3e4d
+Revises: c4f7a2b9e1d3
+Create Date: 2026-06-25 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "7c2f9a1b3e4d"
+down_revision: str | Sequence[str] | None = "c4f7a2b9e1d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``intro_detection_attempted_episode_count`` to ``seasons``."""
+    with op.batch_alter_table("seasons", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "intro_detection_attempted_episode_count",
+                sa.Integer(),
+                nullable=True,
+            )
+        )
+
+
+def downgrade() -> None:
+    """Drop ``intro_detection_attempted_episode_count`` from ``seasons``."""
+    with op.batch_alter_table("seasons", schema=None) as batch_op:
+        batch_op.drop_column("intro_detection_attempted_episode_count")

--- a/src/infrastructure/scheduling/intro_detection_job.py
+++ b/src/infrastructure/scheduling/intro_detection_job.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from src.config.logging import get_logger
@@ -116,8 +116,13 @@ class IntroDetectionJob:
     async def run(self) -> None:
         """Process one batch of pending seasons."""
         config = await self._runtime_settings.intro_detection()
+        stale_before = datetime.now(UTC) - timedelta(minutes=config.stale_claim_timeout_minutes)
         async with self._media_uow_factory() as uow:
-            seasons = list(await uow.series.find_seasons_pending_intro_detection(config.batch_size))
+            seasons = list(
+                await uow.series.find_seasons_pending_intro_detection(
+                    config.batch_size, stale_before=stale_before
+                )
+            )
 
         if not seasons:
             return
@@ -219,10 +224,15 @@ class IntroDetectionJob:
         log_ctx: dict[str, str | int],
         config: IntroDetectionConfig,
     ) -> _RunMetrics:
+        episode_count = len(season.episodes)
         candidates = [ep for ep in season.episodes if not _has_manual_marker(ep)]
         candidate_count = len(candidates)
         if candidate_count < _MIN_EPISODES_FOR_DETECTION:
-            await self._mark_state(season_id, IntroDetectionState.INSUFFICIENT_EPISODES)
+            await self._mark_state(
+                season_id,
+                IntroDetectionState.INSUFFICIENT_EPISODES,
+                attempted_episode_count=episode_count,
+            )
             _logger.info(
                 "[intro-detection] season skipped: not enough non-MANUAL episodes",
                 **log_ctx,
@@ -233,7 +243,11 @@ class IntroDetectionJob:
 
         refs = _build_media_refs(candidates)
         if len(refs) < _MIN_EPISODES_FOR_DETECTION:
-            await self._mark_state(season_id, IntroDetectionState.INSUFFICIENT_EPISODES)
+            await self._mark_state(
+                season_id,
+                IntroDetectionState.INSUFFICIENT_EPISODES,
+                attempted_episode_count=episode_count,
+            )
             _logger.info(
                 "[intro-detection] season skipped: not enough episodes with a primary file",
                 **log_ctx,
@@ -255,7 +269,11 @@ class IntroDetectionJob:
         result = await asyncio.to_thread(detector.detect, refs, tuning)
 
         if result.analyzed_count < _MIN_EPISODES_FOR_DETECTION:
-            await self._mark_state(season_id, IntroDetectionState.INSUFFICIENT_EPISODES)
+            await self._mark_state(
+                season_id,
+                IntroDetectionState.INSUFFICIENT_EPISODES,
+                attempted_episode_count=episode_count,
+            )
             _logger.info(
                 "[intro-detection] season skipped: not enough analysable episodes",
                 **log_ctx,
@@ -270,7 +288,11 @@ class IntroDetectionJob:
 
         episode_results = _build_episode_results(result.markers, candidates, config.min_confidence)
         persisted_count = await self._persist_detections(result.markers, config.min_confidence)
-        await self._mark_state(season_id, IntroDetectionState.COMPLETED)
+        await self._mark_state(
+            season_id,
+            IntroDetectionState.COMPLETED,
+            attempted_episode_count=episode_count,
+        )
         _logger.info(
             "[intro-detection] season completed",
             **log_ctx,
@@ -374,6 +396,7 @@ class IntroDetectionJob:
         season_id: SeasonId,
         state: IntroDetectionState,
         *,
+        attempted_episode_count: int | None = None,
         error: str | None = None,
     ) -> None:
         async with self._media_uow_factory() as uow:
@@ -381,6 +404,7 @@ class IntroDetectionJob:
                 season_id,
                 state,
                 attempted_at=datetime.now(UTC),
+                attempted_episode_count=attempted_episode_count,
                 error=error,
             )
 

--- a/src/modules/media/domain/entities/season.py
+++ b/src/modules/media/domain/entities/season.py
@@ -61,6 +61,9 @@ class Season(DomainEntity[SeasonId]):
     # individual episodes are independent of this state)
     intro_detection_state: IntroDetectionState = IntroDetectionState.NOT_STARTED
     intro_detection_attempted_at: datetime | None = None
+    # Episodes present at the last attempt; the job re-arms an
+    # INSUFFICIENT_EPISODES season only once its count grows past this.
+    intro_detection_attempted_episode_count: int | None = None
     intro_detection_error: str | None = Field(default=None, max_length=2000)
 
     # noinspection PyNestedDecorators

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -429,15 +429,33 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_seasons_pending_intro_detection(self, limit: int) -> Sequence[Season]:
+    async def find_seasons_pending_intro_detection(
+        self,
+        limit: int,
+        *,
+        stale_before: datetime,
+    ) -> Sequence[Season]:
         """Return seasons whose intro-detection job has not converged yet.
 
-        Filters for seasons in ``NOT_STARTED`` or ``INSUFFICIENT_EPISODES``
-        state (the second so seasons that previously had too few
-        episodes get retried automatically once more land). ``COMPLETED``,
-        ``IN_PROGRESS``, ``FAILED``, and ``DISABLED`` are excluded —
-        ``FAILED`` and ``DISABLED`` require an explicit operator reset
-        before being retried.
+        A season is eligible when it is:
+
+        * ``NOT_STARTED`` — never attempted; or
+        * ``INSUFFICIENT_EPISODES`` *and* its current (non-deleted)
+          episode count exceeds ``intro_detection_attempted_episode_count``
+          — i.e. new episodes landed since the last attempt, so the
+          outcome could now differ. A season whose episode set hasn't
+          grown is NOT retried, so a permanently-small season (e.g. a
+          2-part miniseries) stops monopolising the queue; or
+        * ``IN_PROGRESS`` with ``intro_detection_attempted_at`` older than
+          ``stale_before`` — an orphaned claim (the worker died
+          mid-detection), reclaimed so it self-heals.
+
+        ``COMPLETED``, ``FAILED``, and ``DISABLED`` are excluded;
+        ``FAILED`` and ``DISABLED`` require an explicit operator reset.
+
+        Ordered by ``intro_detection_attempted_at`` ascending with NULLs
+        first, then ``id``, so never-attempted seasons run before any
+        already-attempted one.
 
         Returned ``Season`` entities have their ``episodes`` collection
         eagerly loaded (with file variants) so the detection job can
@@ -446,6 +464,9 @@ class SeriesRepository(ABC):
 
         Args:
             limit: Maximum number of seasons to return.
+            stale_before: Cutoff for reclaiming orphaned ``IN_PROGRESS``
+                seasons — those last attempted before this instant are
+                considered abandoned and made eligible again.
 
         Returns:
             Sequence of seasons eligible for the next detection tick.
@@ -459,6 +480,7 @@ class SeriesRepository(ABC):
         state: IntroDetectionState,
         *,
         attempted_at: datetime | None = None,
+        attempted_episode_count: int | None = None,
         error: str | None = None,
     ) -> bool:
         """Persist intro-detection job state for a season.
@@ -477,6 +499,10 @@ class SeriesRepository(ABC):
             attempted_at: When the job ran. Pass ``None`` to leave the
                 column unchanged for transient transitions like
                 ``IN_PROGRESS``.
+            attempted_episode_count: Episode count observed this attempt,
+                used to decide whether an ``INSUFFICIENT_EPISODES`` season
+                is worth retrying later. Pass ``None`` to leave it
+                unchanged (e.g. on the ``IN_PROGRESS`` claim).
             error: Diagnostic message for ``FAILED`` runs, or ``None`` to
                 clear.
 

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -218,6 +218,7 @@ class SeasonMapper:
             air_date=entity.air_date.value if entity.air_date else None,
             intro_detection_state=entity.intro_detection_state.value,
             intro_detection_attempted_at=entity.intro_detection_attempted_at,
+            intro_detection_attempted_episode_count=entity.intro_detection_attempted_episode_count,
             intro_detection_error=entity.intro_detection_error,
         )
 
@@ -249,6 +250,7 @@ class SeasonMapper:
             episodes=episode_list,
             intro_detection_state=IntroDetectionState(model.intro_detection_state),
             intro_detection_attempted_at=model.intro_detection_attempted_at,
+            intro_detection_attempted_episode_count=model.intro_detection_attempted_episode_count,
             intro_detection_error=model.intro_detection_error,
             created_at=model.created_at,
             updated_at=model.updated_at,
@@ -272,6 +274,9 @@ class SeasonMapper:
         model.air_date = entity.air_date.value if entity.air_date else None
         model.intro_detection_state = entity.intro_detection_state.value
         model.intro_detection_attempted_at = entity.intro_detection_attempted_at
+        model.intro_detection_attempted_episode_count = (
+            entity.intro_detection_attempted_episode_count
+        )
         model.intro_detection_error = entity.intro_detection_error
 
         return model

--- a/src/modules/media/infrastructure/persistence/models/season.py
+++ b/src/modules/media/infrastructure/persistence/models/season.py
@@ -77,6 +77,13 @@ class SeasonModel(Base):
     intro_detection_attempted_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # Episode count (non-deleted) at the last attempt. An
+    # INSUFFICIENT_EPISODES season is only re-attempted once its current
+    # count grows past this, so a permanently-small season stops being
+    # retried every tick. NULL means "never stamped" (re-eligible once).
+    intro_detection_attempted_episode_count: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
     intro_detection_error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Relationships

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import distinct, func, or_, select, text, update
+from sqlalchemy import and_, distinct, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -692,33 +692,62 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         result = await self._session.execute(stmt)
         return bool(result.rowcount)
 
-    async def find_seasons_pending_intro_detection(self, limit: int) -> Sequence[Season]:
-        """Return seasons in NOT_STARTED/INSUFFICIENT_EPISODES with episodes loaded.
+    async def find_seasons_pending_intro_detection(
+        self,
+        limit: int,
+        *,
+        stale_before: datetime,
+    ) -> Sequence[Season]:
+        """Return seasons eligible for the next intro-detection tick.
 
         Episodes (and their file_variants) are eager-loaded so the
         detection job can iterate file paths without N+1 queries.
         Soft-deleted rows are filtered out at both levels.
 
+        Eligibility (see the interface for the rationale):
+
+        * ``NOT_STARTED`` — never attempted.
+        * ``INSUFFICIENT_EPISODES`` whose live episode count now exceeds
+          ``intro_detection_attempted_episode_count`` (NULL counts as 0,
+          so legacy rows get exactly one more pass before the count is
+          stamped). A season whose episode set hasn't grown is skipped,
+          so a permanently-small season stops monopolising the queue.
+        * ``IN_PROGRESS`` last touched before ``stale_before`` — an
+          orphaned claim, reclaimed so a crash/restart self-heals.
+
         Ordered by ``intro_detection_attempted_at`` ascending with NULLs
-        first, then ``id``. NULL means never attempted (a fresh
-        ``NOT_STARTED`` season), so brand-new seasons run first; a season
-        that keeps landing in ``INSUFFICIENT_EPISODES`` (e.g. an extras
-        season with too few playable episodes) has its ``attempted_at``
-        stamped on each pass and so rotates to the BACK of the queue
-        instead of monopolizing every tick — without this a permanently
-        insufficient season starves all others when ``batch_size`` is
-        small. ``nullsfirst`` is explicit because SQLite (NULLs first on
-        ASC) and PostgreSQL (NULLs last) disagree on the default.
+        first, then ``id``: a never-attempted season (NULL) always runs
+        before any already-attempted one. ``nullsfirst`` is explicit
+        because SQLite (NULLs first on ASC) and PostgreSQL (NULLs last)
+        disagree on the default.
         """
-        eligible_states = (
-            IntroDetectionState.NOT_STARTED.value,
-            IntroDetectionState.INSUFFICIENT_EPISODES.value,
+        live_episode_count = (
+            select(func.count(EpisodeModel.id))
+            .where(
+                EpisodeModel.season_id == SeasonModel.id,
+                EpisodeModel.deleted_at.is_(None),
+            )
+            .correlate(SeasonModel)
+            .scalar_subquery()
         )
         stmt = (
             select(SeasonModel)
             .where(
                 SeasonModel.deleted_at.is_(None),
-                SeasonModel.intro_detection_state.in_(eligible_states),
+                or_(
+                    SeasonModel.intro_detection_state == IntroDetectionState.NOT_STARTED.value,
+                    and_(
+                        SeasonModel.intro_detection_state
+                        == IntroDetectionState.INSUFFICIENT_EPISODES.value,
+                        live_episode_count
+                        > func.coalesce(SeasonModel.intro_detection_attempted_episode_count, 0),
+                    ),
+                    and_(
+                        SeasonModel.intro_detection_state == IntroDetectionState.IN_PROGRESS.value,
+                        SeasonModel.intro_detection_attempted_at.is_not(None),
+                        SeasonModel.intro_detection_attempted_at < stale_before,
+                    ),
+                ),
             )
             .options(selectinload(SeasonModel.episodes).selectinload(EpisodeModel.file_variants))
             .order_by(
@@ -736,14 +765,16 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         state: IntroDetectionState,
         *,
         attempted_at: datetime | None = None,
+        attempted_episode_count: int | None = None,
         error: str | None = None,
     ) -> bool:
         """Direct UPDATE of intro-detection columns on the seasons row.
 
-        ``attempted_at`` is left untouched when ``None`` so transient
-        transitions (e.g. claiming a season as IN_PROGRESS) do not
-        overwrite the timestamp from the previous successful run.
-        ``error`` is always written through — pass ``None`` to clear.
+        ``attempted_at`` and ``attempted_episode_count`` are left
+        untouched when ``None`` so transient transitions (e.g. claiming a
+        season as IN_PROGRESS) do not overwrite the values from the
+        previous terminal run. ``error`` is always written through —
+        pass ``None`` to clear.
         """
         values: dict[str, Any] = {
             "intro_detection_state": state.value,
@@ -751,6 +782,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         }
         if attempted_at is not None:
             values["intro_detection_attempted_at"] = attempted_at
+        if attempted_episode_count is not None:
+            values["intro_detection_attempted_episode_count"] = attempted_episode_count
 
         stmt = (
             update(SeasonModel)

--- a/src/modules/settings/domain/value_objects/intro_detection_config.py
+++ b/src/modules/settings/domain/value_objects/intro_detection_config.py
@@ -78,6 +78,13 @@ class IntroDetectionConfig(CompoundValueObject):
             season decodes/fingerprints every episode, so values above
             2 can saturate the host on large seasons.
         interval_minutes: How often the detection job runs.
+        stale_claim_timeout_minutes: How long a season may sit in the
+            transient ``IN_PROGRESS`` state before the job treats the
+            claim as orphaned (e.g. a restart killed the worker
+            mid-detection) and re-picks it. Without this, a crashed
+            claim would never be retried because ``IN_PROGRESS`` is
+            excluded from the pending query. Must comfortably exceed the
+            time to process one season.
         analysis_window_seconds: Leading media (in seconds) analysed per
             episode. 600s (10 min) covers long cold opens plus the title
             sequence; trimming it speeds up the job at the cost of
@@ -100,6 +107,7 @@ class IntroDetectionConfig(CompoundValueObject):
     algorithm: IntroDetectionAlgorithm = Field(default=IntroDetectionAlgorithm.FRAME_HASH)
     batch_size: int = Field(default=1, ge=1)
     interval_minutes: int = Field(default=30, ge=1)
+    stale_claim_timeout_minutes: int = Field(default=120, ge=1)
     analysis_window_seconds: int = Field(default=600, ge=60)
     min_confidence: float = Field(default=0.65, ge=0.0, le=1.0)
     min_intro_seconds: float = Field(default=5.0, ge=0.0)

--- a/tests/infrastructure/scheduling/test_intro_detection_job.py
+++ b/tests/infrastructure/scheduling/test_intro_detection_job.py
@@ -10,6 +10,7 @@ job only sees its :class:`IntroDetectionResult`.
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -278,8 +279,11 @@ class TestIntroDetectionJob:
         await job.run()
 
         uow.series.update_episode_intro.assert_not_awaited()
-        terminal_state = uow.series.update_season_intro_detection.await_args_list[-1].args[1]
-        assert terminal_state == IntroDetectionState.INSUFFICIENT_EPISODES
+        terminal_call = uow.series.update_season_intro_detection.await_args_list[-1]
+        assert terminal_call.args[1] == IntroDetectionState.INSUFFICIENT_EPISODES
+        # The episode count is stamped so the season is only re-armed once
+        # more episodes land, instead of being retried every tick.
+        assert terminal_call.kwargs["attempted_episode_count"] == 3
 
     @pytest.mark.asyncio
     async def test_marks_failed_when_detector_raises(self) -> None:
@@ -412,6 +416,9 @@ class TestIntroDetectionJob:
 
         called_with = uow.series.find_seasons_pending_intro_detection.await_args
         assert called_with.args[0] == 1
+        # A stale-claim cutoff is passed so orphaned IN_PROGRESS seasons
+        # become reclaimable instead of stuck forever.
+        assert isinstance(called_with.kwargs["stale_before"], datetime)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -1210,6 +1210,7 @@ def _series_with_intro(
     intro: IntroMarker | None = None,
     detection_state: IntroDetectionState = IntroDetectionState.NOT_STARTED,
     detection_attempted_at: datetime | None = None,
+    detection_attempted_episode_count: int | None = None,
     detection_error: str | None = None,
     series_title: str = "Intro Series",
 ) -> Series:
@@ -1232,6 +1233,7 @@ def _series_with_intro(
         episodes=[episode],
         intro_detection_state=detection_state,
         intro_detection_attempted_at=detection_attempted_at,
+        intro_detection_attempted_episode_count=detection_attempted_episode_count,
         intro_detection_error=detection_error,
     )
     return Series(
@@ -1470,7 +1472,9 @@ class TestFindSeasonsPendingIntroDetection:
             )
         )
 
-        pending = await repo.find_seasons_pending_intro_detection(limit=10)
+        pending = await repo.find_seasons_pending_intro_detection(
+            limit=10, stale_before=datetime.now(UTC)
+        )
 
         states = sorted(s.intro_detection_state.value for s in pending)
         assert states == ["INSUFFICIENT_EPISODES", "NOT_STARTED"]
@@ -1482,7 +1486,9 @@ class TestFindSeasonsPendingIntroDetection:
         repo = SQLAlchemySeriesRepository(db_session)
         await repo.save(_series_with_intro(detection_state=IntroDetectionState.NOT_STARTED))
 
-        pending = await repo.find_seasons_pending_intro_detection(limit=10)
+        pending = await repo.find_seasons_pending_intro_detection(
+            limit=10, stale_before=datetime.now(UTC)
+        )
 
         assert len(pending) == 1
         season = pending[0]
@@ -1499,7 +1505,9 @@ class TestFindSeasonsPendingIntroDetection:
                 )
             )
 
-        pending = await repo.find_seasons_pending_intro_detection(limit=2)
+        pending = await repo.find_seasons_pending_intro_detection(
+            limit=2, stale_before=datetime.now(UTC)
+        )
 
         assert len(pending) == 2
 
@@ -1538,7 +1546,9 @@ class TestFindSeasonsPendingIntroDetection:
             )
         )
 
-        pending = await repo.find_seasons_pending_intro_detection(limit=10)
+        pending = await repo.find_seasons_pending_intro_detection(
+            limit=10, stale_before=datetime.now(UTC)
+        )
         attempted = [s.intro_detection_attempted_at for s in pending]
 
         assert len(attempted) == 3
@@ -1546,6 +1556,108 @@ class TestFindSeasonsPendingIntroDetection:
         assert attempted[1] is not None
         assert attempted[2] is not None
         assert attempted[1] <= attempted[2]  # then oldest-attempted before newest
+
+    async def test_insufficient_not_retried_until_episode_count_grows(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """An INSUFFICIENT season with an unchanged episode count is skipped.
+
+        The helper builds a single-episode season; stamping
+        ``attempted_episode_count`` at that same count means nothing has
+        grown, so the season must not resurface and burn a tick.
+        """
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.INSUFFICIENT_EPISODES,
+                detection_attempted_at=datetime(2020, 1, 1, tzinfo=UTC),
+                detection_attempted_episode_count=1,  # == live episode count
+                series_title="stuck-insufficient",
+            )
+        )
+
+        pending = await repo.find_seasons_pending_intro_detection(
+            limit=10, stale_before=datetime.now(UTC)
+        )
+
+        assert pending == []
+
+    async def test_insufficient_retried_when_episode_count_grew(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """An INSUFFICIENT season re-qualifies once new episodes land.
+
+        Stamped count 0 vs a live count of 1 stands in for "an episode
+        was added since the last attempt", which is the only thing that
+        could change the detector's verdict.
+        """
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.INSUFFICIENT_EPISODES,
+                detection_attempted_at=datetime(2020, 1, 1, tzinfo=UTC),
+                detection_attempted_episode_count=0,  # < live episode count
+                series_title="grew-since-attempt",
+            )
+        )
+
+        pending = await repo.find_seasons_pending_intro_detection(
+            limit=10, stale_before=datetime.now(UTC)
+        )
+
+        assert len(pending) == 1
+        assert pending[0].intro_detection_state == IntroDetectionState.INSUFFICIENT_EPISODES
+
+    async def test_stale_in_progress_claim_is_reclaimed(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """An IN_PROGRESS season older than ``stale_before`` self-heals.
+
+        Orphaned claims (a restart killed the worker mid-detection) would
+        otherwise be excluded forever; the cutoff makes them eligible.
+        """
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.IN_PROGRESS,
+                detection_attempted_at=datetime(2020, 1, 1, tzinfo=UTC),
+                series_title="orphaned-claim",
+            )
+        )
+
+        pending = await repo.find_seasons_pending_intro_detection(
+            limit=10, stale_before=datetime(2020, 6, 1, tzinfo=UTC)
+        )
+
+        assert len(pending) == 1
+        assert pending[0].intro_detection_state == IntroDetectionState.IN_PROGRESS
+
+    async def test_fresh_in_progress_claim_is_left_alone(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """An IN_PROGRESS season newer than ``stale_before`` is not reclaimed.
+
+        Guards against double-claiming a season that another tick is
+        legitimately processing right now.
+        """
+        repo = SQLAlchemySeriesRepository(db_session)
+        await repo.save(
+            _series_with_intro(
+                detection_state=IntroDetectionState.IN_PROGRESS,
+                detection_attempted_at=datetime(2020, 6, 1, tzinfo=UTC),
+                series_title="active-claim",
+            )
+        )
+
+        pending = await repo.find_seasons_pending_intro_detection(
+            limit=10, stale_before=datetime(2020, 1, 1, tzinfo=UTC)
+        )
+
+        assert pending == []
 
 
 @pytest.mark.integration
@@ -1613,6 +1725,50 @@ class TestUpdateSeasonIntroDetection:
         found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
         assert found is not None
         assert found.seasons[0].intro_detection_attempted_at is not None
+
+    async def test_stamps_attempted_episode_count(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _series_with_intro(detection_state=IntroDetectionState.NOT_STARTED)
+        await repo.save(series)
+        season_id = series.seasons[0].id
+        assert season_id is not None
+
+        await repo.update_season_intro_detection(
+            season_id,
+            IntroDetectionState.INSUFFICIENT_EPISODES,
+            attempted_at=datetime(2026, 6, 25, 12, 0, tzinfo=UTC),
+            attempted_episode_count=7,
+        )
+        await db_session.commit()
+
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert found is not None
+        assert found.seasons[0].intro_detection_attempted_episode_count == 7
+
+    async def test_leaves_attempted_episode_count_untouched_when_none(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _series_with_intro(
+            detection_state=IntroDetectionState.INSUFFICIENT_EPISODES,
+            detection_attempted_episode_count=3,
+        )
+        await repo.save(series)
+        season_id = series.seasons[0].id
+        assert season_id is not None
+
+        # Transient IN_PROGRESS claim passes no count — the previous
+        # stamp must survive so re-arm logic still compares correctly.
+        await repo.update_season_intro_detection(
+            season_id,
+            IntroDetectionState.IN_PROGRESS,
+        )
+        await db_session.commit()
+
+        found = await repo.find_by_id(series.id)  # type: ignore[arg-type]
+        assert found is not None
+        assert found.seasons[0].intro_detection_attempted_episode_count == 3
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

- The intro-detection job claimed each season as `IN_PROGRESS` before running detection; a restart that killed the worker mid-detection left the season orphaned in `IN_PROGRESS`, which the pending query **excludes forever**. On a real library this stranded 13 large seasons (e.g. 52/50/26-episode seasons) and left the job spinning only on 4 permanently-insufficient miniseries.
- The pending query now also reclaims `IN_PROGRESS` seasons whose `intro_detection_attempted_at` predates a configurable stale-claim cutoff (`stale_claim_timeout_minutes`, default 120), so a crash/restart self-heals.
- An `INSUFFICIENT_EPISODES` season is now re-attempted only once its live (non-deleted) episode count grows past the count stamped at the last attempt — a new `intro_detection_attempted_episode_count` column. A structurally-small season (e.g. a 2-part miniseries) stops monopolising every tick instead of being retried forever.
- Never-attempted (`NOT_STARTED`) seasons still sort first (`NULLS FIRST`), so genuinely-new work keeps priority.

## Changes

- New nullable column `seasons.intro_detection_attempted_episode_count` (migration `7c2f9a1b3e4d`) + entity/model/mapper plumbing.
- `find_seasons_pending_intro_detection(limit, *, stale_before)` rewritten with the three-way eligibility (NOT_STARTED / re-armed INSUFFICIENT / stale IN_PROGRESS).
- `update_season_intro_detection` accepts `attempted_episode_count`; the job stamps it on INSUFFICIENT/COMPLETED transitions and computes `stale_before` per tick from settings.
- New `IntroDetectionConfig.stale_claim_timeout_minutes` (live-tunable per ADR-013).

## Test plan

- [x] `pytest tests/modules/media tests/infrastructure/scheduling` — 1674 passed
- [x] 6 new repository integration tests (re-arm grew/unchanged, stale/fresh IN_PROGRESS reclaim, count stamping) + 2 job assertions
- [x] `ruff check` + `ruff format` clean on changed files
- [x] Migration `upgrade head` / `downgrade -1` verified on a DB copy; single alembic head
- [x] Read-only selection check against the real dev DB: query now yields the 13 stranded `IN_PROGRESS` seasons (oldest-first) + 4 miniseries for one final pass, vs only the 4 before the fix
- [ ] End-to-end: enable detection, run the job, confirm stranded seasons get intros and miniseries go dormant

## Migration steps

- Run `make migrate` before starting the server (adds the new column; `create_all` does not alter existing tables).