### PR TITLE
feat(collections): enrich watchlist + list-item DTOs with media metadata

### DIFF
--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from src.modules.collections.application.ports.media_lookup_port import MediaSummary
     from src.modules.collections.domain.entities import CustomList, CustomListItem
     from src.shared_kernel.value_objects import MediaType
 
@@ -95,20 +96,29 @@ class CustomListItemOutput:
     poster_path: str | None
     position: int
     added_at: str
+    year: int | None = None
+    runtime_seconds: int | None = None
+    genres: tuple[str, ...] = ()
+    resolution: str | None = None
+    hdr: bool = False
 
     @classmethod
     def from_entity(
         cls,
         entity: CustomListItem,
-        title: str,
-        poster_path: str | None,
+        summary: MediaSummary,
     ) -> CustomListItemOutput:
-        """Create output DTO from a CustomListItem entity with metadata."""
+        """Create output DTO from a CustomListItem entity + media summary."""
         return cls(
             media_id=entity.media_id.value,
             media_type=entity.media_type,
-            title=title,
-            poster_path=poster_path,
+            title=summary.title,
+            poster_path=summary.poster_path,
             position=entity.position,
             added_at=entity.added_at.isoformat(),
+            year=summary.year,
+            runtime_seconds=summary.runtime_seconds,
+            genres=summary.genres,
+            resolution=summary.resolution,
+            hdr=summary.hdr,
         )

--- a/src/modules/collections/application/dtos/watchlist_dtos.py
+++ b/src/modules/collections/application/dtos/watchlist_dtos.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from src.modules.collections.application.ports.media_lookup_port import MediaSummary
     from src.modules.collections.domain.entities import WatchlistItem
     from src.shared_kernel.value_objects import MediaType
 
@@ -44,21 +45,30 @@ class WatchlistItemOutput:
     title: str
     poster_path: str | None
     added_at: str
+    year: int | None = None
+    runtime_seconds: int | None = None
+    genres: tuple[str, ...] = ()
+    resolution: str | None = None
+    hdr: bool = False
 
     @classmethod
     def from_entity(
         cls,
         entity: WatchlistItem,
-        title: str,
-        poster_path: str | None,
+        summary: MediaSummary,
     ) -> WatchlistItemOutput:
-        """Create output DTO from a WatchlistItem entity with metadata."""
+        """Create output DTO from a WatchlistItem entity + media summary."""
         return cls(
             media_id=entity.media_id.value,
             media_type=entity.media_type,
-            title=title,
-            poster_path=poster_path,
+            title=summary.title,
+            poster_path=summary.poster_path,
             added_at=entity.added_at.isoformat(),
+            year=summary.year,
+            runtime_seconds=summary.runtime_seconds,
+            genres=summary.genres,
+            resolution=summary.resolution,
+            hdr=summary.hdr,
         )
 
 

--- a/src/modules/collections/application/ports/media_lookup_port.py
+++ b/src/modules/collections/application/ports/media_lookup_port.py
@@ -27,12 +27,27 @@ class MediaSummary:
             ``lang`` argument passed to ``get_many``).
         poster_path: Absolute or relative poster URL, or ``None`` when
             the source has no poster.
+        year: Release year (movie) or first-air year (series), or
+            ``None`` when unknown.
+        runtime_seconds: Runtime in seconds. Set for movies; ``None``
+            for series (their runtime is per-episode and not surfaced
+            here yet).
+        genres: Localized genre names, ordered. Empty when none.
+        resolution: Best available resolution label (e.g. ``"4K"``,
+            ``"1080p"``). Set for movies with files; ``None`` for series
+            (episode-derived, deferred).
+        hdr: Whether the best file carries an HDR format. Movies only.
     """
 
     media_id: str
     media_type: MediaType
     title: str
     poster_path: str | None
+    year: int | None = None
+    runtime_seconds: int | None = None
+    genres: tuple[str, ...] = ()
+    resolution: str | None = None
+    hdr: bool = False
 
 
 class MediaLookupPort(ABC):

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -83,13 +83,7 @@ class GetCustomListItemsUseCase:
                     item.media_id,
                 )
                 continue
-            result.append(
-                CustomListItemOutput.from_entity(
-                    entity=item,
-                    title=summary.title,
-                    poster_path=summary.poster_path,
-                )
-            )
+            result.append(CustomListItemOutput.from_entity(entity=item, summary=summary))
 
         return result
 

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -69,13 +69,7 @@ class GetWatchlistUseCase:
             if summary is None:
                 _logger.warning("Could not find media for watchlist item: %s", item.media_id)
                 continue
-            result.append(
-                WatchlistItemOutput.from_entity(
-                    entity=item,
-                    title=summary.title,
-                    poster_path=summary.poster_path,
-                )
-            )
+            result.append(WatchlistItemOutput.from_entity(entity=item, summary=summary))
 
         return result
 

--- a/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
+++ b/src/modules/collections/infrastructure/acl/media_lookup_adapter.py
@@ -37,21 +37,32 @@ class MediaLookupAdapter(MediaLookupPort):
             if movie_ids:
                 movies_map = await uow.movies.find_by_ids(list(movie_ids))
                 for media_id, movie in movies_map.items():
+                    best = movie.best_file
                     result[(MediaType.MOVIE, media_id)] = MediaSummary(
                         media_id=media_id,
                         media_type=MediaType.MOVIE,
                         title=movie.get_title(lang),
                         poster_path=movie.poster_path.value if movie.poster_path else None,
+                        year=movie.year.value,
+                        runtime_seconds=movie.duration.value or None,
+                        genres=tuple(movie.get_genres(lang)),
+                        resolution=best.resolution.value if best else None,
+                        hdr=best.hdr_format is not None if best else False,
                     )
 
             if series_ids:
                 series_map = await uow.series.find_by_ids(list(series_ids))
                 for media_id, series in series_map.items():
+                    # Runtime/resolution/HDR live on the series' episodes,
+                    # which the batch lookup doesn't hydrate — left null
+                    # (the client hides those fields when absent).
                     result[(MediaType.SERIES, media_id)] = MediaSummary(
                         media_id=media_id,
                         media_type=MediaType.SERIES,
                         title=series.get_title(lang),
                         poster_path=series.poster_path.value if series.poster_path else None,
+                        year=series.start_year.value,
+                        genres=tuple(series.get_genres(lang)),
                     )
 
         return result

--- a/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
+++ b/tests/modules/collections/integration/acl/test_collections_media_lookup_adapter.py
@@ -8,6 +8,8 @@ from src.modules.media.domain.entities import Movie, Series
 from src.modules.media.domain.value_objects import (
     Duration,
     FilePath,
+    Genre,
+    HdrFormat,
     ImageUrl,
     MediaFile,
     MovieId,
@@ -83,10 +85,59 @@ class TestCollectionsMediaLookupAdapter:
         movie_summary = summaries[(MediaType.MOVIE, str(movie_id))]
         assert movie_summary.title == "Inception"
         assert movie_summary.poster_path == "/p/inception.jpg"
+        assert movie_summary.year == 2024
+        assert movie_summary.runtime_seconds == 7200
+        assert movie_summary.resolution == "1080p"
+        assert movie_summary.hdr is False
 
         series_summary = summaries[(MediaType.SERIES, str(series_id))]
         assert series_summary.title == "Breaking Bad"
         assert series_summary.poster_path == "/p/bb.jpg"
+        assert series_summary.year == 2024
+        # Runtime/resolution/HDR are episode-derived → not surfaced for series.
+        assert series_summary.runtime_seconds is None
+        assert series_summary.resolution is None
+        assert series_summary.hdr is False
+
+    async def test_movie_enrichment_derives_genres_and_best_quality(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        movie_id = MovieId.generate()
+        movie = Movie(
+            library_id=_LIBRARY_ID,
+            id=movie_id,
+            title=Title("Dune"),
+            year=Year(2021),
+            duration=Duration(9300),
+            genres=[Genre("Science Fiction"), Genre("Adventure")],
+            files=[
+                MediaFile(
+                    file_path=FilePath("/movies/dune-1080.mkv"),
+                    file_size=1_000_000,
+                    resolution=Resolution("1080p"),
+                    is_primary=True,
+                ),
+                MediaFile(
+                    file_path=FilePath("/movies/dune-4k.mkv"),
+                    file_size=4_000_000,
+                    resolution=Resolution("4K"),
+                    hdr_format=HdrFormat.DOLBY_VISION,
+                ),
+            ],
+        )
+        await SQLAlchemyMovieRepository(db_session).save(movie)
+        await db_session.commit()
+
+        adapter = MediaLookupAdapter(SqlAlchemyMediaUnitOfWorkFactory(session_factory))
+        summaries = await adapter.get_many([str(movie_id)], [], "en")
+
+        summary = summaries[(MediaType.MOVIE, str(movie_id))]
+        assert summary.genres == ("Science Fiction", "Adventure")
+        # best_file is the highest-resolution variant → 4K + its HDR.
+        assert summary.resolution == "4K"
+        assert summary.hdr is True
 
     async def test_get_many_omits_missing_ids(
         self,

--- a/tests/modules/collections/unit/application/use_cases/conftest.py
+++ b/tests/modules/collections/unit/application/use_cases/conftest.py
@@ -19,12 +19,22 @@ def movie_summary() -> MediaSummaryFactory:
         media_id: str,
         title: str = "Test Movie",
         poster_path: str | None = "https://image.tmdb.org/poster.jpg",
+        year: int | None = 2010,
+        runtime_seconds: int | None = 8880,
+        genres: tuple[str, ...] = ("Action", "Sci-Fi"),
+        resolution: str | None = "4K",
+        hdr: bool = True,
     ) -> MediaSummary:
         return MediaSummary(
             media_id=media_id,
             media_type=MediaType.MOVIE,
             title=title,
             poster_path=poster_path,
+            year=year,
+            runtime_seconds=runtime_seconds,
+            genres=genres,
+            resolution=resolution,
+            hdr=hdr,
         )
 
     return _factory
@@ -38,12 +48,16 @@ def series_summary() -> MediaSummaryFactory:
         media_id: str,
         title: str = "Test Series",
         poster_path: str | None = "https://image.tmdb.org/series.jpg",
+        year: int | None = 2008,
+        genres: tuple[str, ...] = ("Drama",),
     ) -> MediaSummary:
         return MediaSummary(
             media_id=media_id,
             media_type=MediaType.SERIES,
             title=title,
             poster_path=poster_path,
+            year=year,
+            genres=genres,
         )
 
     return _factory

--- a/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
@@ -71,6 +71,13 @@ class TestGetCustomListItemsUseCase:
         assert isinstance(result[0], CustomListItemOutput)
         assert result[0].title == "Inception"
         assert result[0].media_id == "mov_abc123def456"
+        assert result[0].position == 0
+        # Enrichment fields flow through from the media summary.
+        assert result[0].year == 2010
+        assert result[0].runtime_seconds == 8880
+        assert result[0].genres == ("Action", "Sci-Fi")
+        assert result[0].resolution == "4K"
+        assert result[0].hdr is True
 
     @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:

--- a/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
@@ -64,6 +64,31 @@ class TestGetWatchlistUseCase:
         assert result[0].title == "Inception"
 
     @pytest.mark.asyncio
+    async def test_should_carry_enrichment_fields_from_summary(
+        self, movie_summary: MediaSummaryFactory
+    ) -> None:
+        items = [
+            WatchlistItem.create(
+                profile_id=_PROFILE_ID,
+                media_id="mov_abc123def456",
+                media_type=MediaType.MOVIE,
+            ),
+        ]
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.list_all.return_value = items
+        media_lookup = make_media_lookup_mock(movie_summary("mov_abc123def456"))
+
+        use_case = GetWatchlistUseCase(uow_factory=mocks.factory, media_lookup=media_lookup)
+
+        out = (await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value)))[0]
+
+        assert out.year == 2010
+        assert out.runtime_seconds == 8880
+        assert out.genres == ("Action", "Sci-Fi")
+        assert out.resolution == "4K"
+        assert out.hdr is True
+
+    @pytest.mark.asyncio
     async def test_should_return_empty_list_when_no_items(self) -> None:
         mocks = make_collections_uow_mock()
         mocks.watchlist.list_all.return_value = []


### PR DESCRIPTION
## Summary

- Extends `MediaSummary` (the Collections → Media cross-BC read DTO, ADR-009) with `year`, `runtime_seconds`, `genres`, `resolution` and `hdr`, populated in the `MediaLookupAdapter` from the already-loaded `Movie`/`Series` aggregates — no new Media-owned port, no extra query.
- Surfaces those fields on `WatchlistItemOutput` and `CustomListItemOutput` (the GET `/watchlist` and `/custom-lists/{id}/items` responses), so the redesigned **My Lists** cards can show a meta line + quality chip.
- `from_entity` now takes the whole `MediaSummary` instead of loose title/poster args.
- **Movies** carry full metadata (`year`, `duration`, localized `genres`, best-file `resolution` + HDR). **Series** expose `year` (start year) + `genres` only — runtime/quality are episode-derived and intentionally left null (the client hides absent fields).

All fields are additive and optional; existing consumers are unaffected. No schema change / no migration.

## Part of

My Lists redesign — backend phase B1. Frontend F1 already merged (web#194). Follow-ups: B2 (collections progress port + list poster collage), list `description` field, reorder.

## Test plan

- [x] `pytest tests/modules/collections` — 201 passed (incl. 2 new: use-case enrichment flow-through + adapter derives genres/best-quality/HDR)
- [x] `ruff check` + `ruff format` clean on changed files
- [x] `mypy` clean on the edited files (pre-existing unused-ignore/no-any-return noise in untouched route/VO files is a local-vs-CI env difference)