### PR TITLE
feat(collections): expose watch progress on watchlist + list items

### DIFF
--- a/src/config/containers/collections.py
+++ b/src/config/containers/collections.py
@@ -14,7 +14,7 @@ from src.modules.collections.application.use_cases import (
     RenameCustomListUseCase,
     ToggleWatchlistUseCase,
 )
-from src.modules.collections.infrastructure.acl import MediaLookupAdapter
+from src.modules.collections.infrastructure.acl import MediaLookupAdapter, ProgressLookupAdapter
 from src.modules.collections.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyCollectionsUnitOfWorkFactory,
 )
@@ -23,8 +23,9 @@ from src.modules.collections.infrastructure.persistence.sqlalchemy_unit_of_work 
 class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     """Container for Collections bounded context dependencies.
 
-    The ``session_factory`` and ``media_uow_factory`` dependencies must
-    be wired from the parent container.
+    The ``session_factory``, ``media_uow_factory`` and
+    ``watch_progress_uow_factory`` dependencies must be wired from the
+    parent container.
     """
 
     session_factory = providers.Dependency()
@@ -32,6 +33,10 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
     # short-lived Media transactions. Use cases only see
     # ``MediaLookupPort``.
     media_uow_factory = providers.Dependency()
+    # Watch Progress UoW factory — the progress ACL adapter opens its
+    # own short-lived transactions. Use cases only see
+    # ``ProgressLookupPort``.
+    watch_progress_uow_factory = providers.Dependency()
 
     # =========================================================================
     # Unit of Work
@@ -51,6 +56,11 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
         media_uow_factory=media_uow_factory,
     )
 
+    progress_lookup = providers.Factory(
+        ProgressLookupAdapter,
+        watch_progress_uow_factory=watch_progress_uow_factory,
+    )
+
     # =========================================================================
     # Watchlist Use Cases
     # =========================================================================
@@ -64,6 +74,7 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
         GetWatchlistUseCase,
         uow_factory=collections_unit_of_work_factory,
         media_lookup=media_lookup,
+        progress_lookup=progress_lookup,
     )
 
     check_watchlist = providers.Factory(
@@ -109,4 +120,5 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
         GetCustomListItemsUseCase,
         uow_factory=collections_unit_of_work_factory,
         media_lookup=media_lookup,
+        progress_lookup=progress_lookup,
     )

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -227,6 +227,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         CollectionsContainer,
         session_factory=infrastructure.session_factory,
         media_uow_factory=media.media_unit_of_work_factory,
+        watch_progress_uow_factory=watch_progress.watch_progress_unit_of_work_factory,
     )
 
     # =========================================================================

--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -101,12 +101,15 @@ class CustomListItemOutput:
     genres: tuple[str, ...] = ()
     resolution: str | None = None
     hdr: bool = False
+    # Watched fraction in [0, 1], or None when there's no progress.
+    progress: float | None = None
 
     @classmethod
     def from_entity(
         cls,
         entity: CustomListItem,
         summary: MediaSummary,
+        progress: float | None = None,
     ) -> CustomListItemOutput:
         """Create output DTO from a CustomListItem entity + media summary."""
         return cls(
@@ -121,4 +124,5 @@ class CustomListItemOutput:
             genres=summary.genres,
             resolution=summary.resolution,
             hdr=summary.hdr,
+            progress=progress,
         )

--- a/src/modules/collections/application/dtos/watchlist_dtos.py
+++ b/src/modules/collections/application/dtos/watchlist_dtos.py
@@ -50,12 +50,15 @@ class WatchlistItemOutput:
     genres: tuple[str, ...] = ()
     resolution: str | None = None
     hdr: bool = False
+    # Watched fraction in [0, 1], or None when there's no progress.
+    progress: float | None = None
 
     @classmethod
     def from_entity(
         cls,
         entity: WatchlistItem,
         summary: MediaSummary,
+        progress: float | None = None,
     ) -> WatchlistItemOutput:
         """Create output DTO from a WatchlistItem entity + media summary."""
         return cls(
@@ -69,6 +72,7 @@ class WatchlistItemOutput:
             genres=summary.genres,
             resolution=summary.resolution,
             hdr=summary.hdr,
+            progress=progress,
         )
 
 

--- a/src/modules/collections/application/ports/__init__.py
+++ b/src/modules/collections/application/ports/__init__.py
@@ -4,5 +4,8 @@ from src.modules.collections.application.ports.media_lookup_port import (
     MediaLookupPort,
     MediaSummary,
 )
+from src.modules.collections.application.ports.progress_lookup_port import (
+    ProgressLookupPort,
+)
 
-__all__ = ["MediaLookupPort", "MediaSummary"]
+__all__ = ["MediaLookupPort", "MediaSummary", "ProgressLookupPort"]

--- a/src/modules/collections/application/ports/progress_lookup_port.py
+++ b/src/modules/collections/application/ports/progress_lookup_port.py
@@ -1,0 +1,44 @@
+"""Port for reading watch-progress fractions for collection items.
+
+Watchlist and custom-list responses surface how far the caller has
+watched each movie so the UI can draw a progress bar / "watched" badge.
+Collections doesn't own progress data — this port is the only surface
+through which it reaches into the Watch Progress BC. The adapter lives
+in ``collections.infrastructure.acl``.
+
+See ADR-009 for the cross-BC read port pattern.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+
+class ProgressLookupPort(ABC):
+    """Batch lookup of watch-progress fractions, scoped to a profile."""
+
+    @abstractmethod
+    async def get_progress(
+        self,
+        media_ids: Sequence[str],
+        *,
+        profile_id: str,
+    ) -> dict[str, float]:
+        """Return the watched fraction in ``[0, 1]`` per media id.
+
+        Only ids with a progress row for the given profile are present;
+        absent ids simply have no progress. Series progress lives on
+        episodes (not surfaced here yet), so callers should pass movie
+        ids only — a series id would resolve to nothing.
+
+        Args:
+            media_ids: Standalone media ids (``mov_xxx``) to look up.
+            profile_id: Prefixed external id (``prf_xxx``) of the
+                profile whose progress to read.
+
+        Returns:
+            Map keyed by ``media_id`` → watched fraction in ``[0, 1]``.
+        """
+        ...
+
+
+__all__ = ["ProgressLookupPort"]

--- a/src/modules/collections/application/use_cases/get_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/get_custom_list_items.py
@@ -7,7 +7,7 @@ from src.modules.collections.application.dtos import (
     CustomListItemOutput,
     GetCustomListItemsInput,
 )
-from src.modules.collections.application.ports import MediaLookupPort
+from src.modules.collections.application.ports import MediaLookupPort, ProgressLookupPort
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
@@ -32,15 +32,18 @@ class GetCustomListItemsUseCase:
         self,
         uow_factory: CollectionsUnitOfWorkFactory,
         media_lookup: MediaLookupPort,
+        progress_lookup: ProgressLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh collections Unit of Work.
             media_lookup: Port for resolving media display metadata.
+            progress_lookup: Port for resolving the caller's watch progress.
         """
         self._uow_factory = uow_factory
         self._media_lookup = media_lookup
+        self._progress_lookup = progress_lookup
 
     async def execute(
         self,
@@ -74,6 +77,13 @@ class GetCustomListItemsUseCase:
 
         summaries = await self._media_lookup.get_many(movie_ids, series_ids, input_dto.lang)
 
+        # Progress only exists for movies (series progress lives on
+        # episodes — deferred), so look up movie ids only.
+        movie_id_strs = [i.media_id.value for i in items if i.media_type == MediaType.MOVIE]
+        progress = await self._progress_lookup.get_progress(
+            movie_id_strs, profile_id=input_dto.profile_id
+        )
+
         result: list[CustomListItemOutput] = []
         for item in items:
             summary = summaries.get((item.media_type, item.media_id.value))
@@ -83,7 +93,13 @@ class GetCustomListItemsUseCase:
                     item.media_id,
                 )
                 continue
-            result.append(CustomListItemOutput.from_entity(entity=item, summary=summary))
+            result.append(
+                CustomListItemOutput.from_entity(
+                    entity=item,
+                    summary=summary,
+                    progress=progress.get(item.media_id.value),
+                )
+            )
 
         return result
 

--- a/src/modules/collections/application/use_cases/get_watchlist.py
+++ b/src/modules/collections/application/use_cases/get_watchlist.py
@@ -6,7 +6,7 @@ from src.modules.collections.application.dtos import (
     GetWatchlistInput,
     WatchlistItemOutput,
 )
-from src.modules.collections.application.ports import MediaLookupPort
+from src.modules.collections.application.ports import MediaLookupPort, ProgressLookupPort
 from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
 from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
@@ -31,15 +31,18 @@ class GetWatchlistUseCase:
         self,
         uow_factory: CollectionsUnitOfWorkFactory,
         media_lookup: MediaLookupPort,
+        progress_lookup: ProgressLookupPort,
     ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh collections Unit of Work.
             media_lookup: Port for resolving media display metadata.
+            progress_lookup: Port for resolving the caller's watch progress.
         """
         self._uow_factory = uow_factory
         self._media_lookup = media_lookup
+        self._progress_lookup = progress_lookup
 
     async def execute(self, input_dto: GetWatchlistInput) -> list[WatchlistItemOutput]:
         """Execute the use case.
@@ -63,13 +66,26 @@ class GetWatchlistUseCase:
 
         summaries = await self._media_lookup.get_many(movie_ids, series_ids, input_dto.lang)
 
+        # Progress only exists for movies (series progress lives on
+        # episodes — deferred), so look up movie ids only.
+        movie_id_strs = [i.media_id.value for i in items if i.media_type == MediaType.MOVIE]
+        progress = await self._progress_lookup.get_progress(
+            movie_id_strs, profile_id=input_dto.profile_id
+        )
+
         result: list[WatchlistItemOutput] = []
         for item in items:
             summary = summaries.get((item.media_type, item.media_id.value))
             if summary is None:
                 _logger.warning("Could not find media for watchlist item: %s", item.media_id)
                 continue
-            result.append(WatchlistItemOutput.from_entity(entity=item, summary=summary))
+            result.append(
+                WatchlistItemOutput.from_entity(
+                    entity=item,
+                    summary=summary,
+                    progress=progress.get(item.media_id.value),
+                )
+            )
 
         return result
 

--- a/src/modules/collections/infrastructure/acl/__init__.py
+++ b/src/modules/collections/infrastructure/acl/__init__.py
@@ -3,5 +3,8 @@
 from src.modules.collections.infrastructure.acl.media_lookup_adapter import (
     MediaLookupAdapter,
 )
+from src.modules.collections.infrastructure.acl.progress_lookup_adapter import (
+    ProgressLookupAdapter,
+)
 
-__all__ = ["MediaLookupAdapter"]
+__all__ = ["MediaLookupAdapter", "ProgressLookupAdapter"]

--- a/src/modules/collections/infrastructure/acl/progress_lookup_adapter.py
+++ b/src/modules/collections/infrastructure/acl/progress_lookup_adapter.py
@@ -1,0 +1,42 @@
+"""Adapter implementing ``ProgressLookupPort`` via the Watch Progress UoW.
+
+This is the only file in the Collections BC that imports from the Watch
+Progress BC for progress reads. Above it, use cases only see
+``ProgressLookupPort``.
+"""
+
+from collections.abc import Sequence
+
+from src.modules.collections.application.ports.progress_lookup_port import ProgressLookupPort
+from src.modules.watch_progress.application.unit_of_work import (
+    WatchProgressUnitOfWorkFactory,
+)
+from src.modules.watch_progress.domain.value_objects import WatchableMediaId
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+
+class ProgressLookupAdapter(ProgressLookupPort):
+    """Resolve watched fractions via the Watch Progress Unit of Work."""
+
+    def __init__(self, watch_progress_uow_factory: WatchProgressUnitOfWorkFactory) -> None:
+        self._watch_progress_uow_factory = watch_progress_uow_factory
+
+    async def get_progress(
+        self,
+        media_ids: Sequence[str],
+        *,
+        profile_id: str,
+    ) -> dict[str, float]:
+        """Fetch watched fractions scoped to the caller's profile."""
+        if not media_ids:
+            return {}
+        profile = ProfileId(profile_id)
+        typed_ids = [WatchableMediaId(media_id) for media_id in media_ids]
+        async with self._watch_progress_uow_factory() as uow:
+            progress_map = await uow.progress.find_by_media_ids(typed_ids, profile)
+        return {
+            media_id: progress.percentage / 100.0 for media_id, progress in progress_map.items()
+        }
+
+
+__all__ = ["ProgressLookupAdapter"]

--- a/tests/modules/collections/integration/acl/test_collections_progress_lookup_adapter.py
+++ b/tests/modules/collections/integration/acl/test_collections_progress_lookup_adapter.py
@@ -1,0 +1,92 @@
+"""Integration tests for the Collections ProgressLookupAdapter."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.modules.collections.infrastructure.acl import ProgressLookupAdapter
+from src.modules.watch_progress.domain.entities import WatchProgress
+from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.modules.watch_progress.infrastructure.persistence.repositories import (
+    SQLAlchemyWatchProgressRepository,
+)
+from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyWatchProgressUnitOfWorkFactory,
+)
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
+_OTHER_PROFILE_ID = ProfileId("prf_otherprofile")
+
+
+def _movie_progress(
+    media_id: str,
+    position: int = 1800,
+    duration: int = 3600,
+    *,
+    profile_id: ProfileId = _PROFILE_ID,
+) -> WatchProgress:
+    return WatchProgress.create(
+        profile_id=profile_id,
+        media_id=media_id,
+        media_type=WatchableMediaType.MOVIE,
+        position_seconds=position,
+        duration_seconds=duration,
+    )
+
+
+def _make_adapter(session_factory: async_sessionmaker[AsyncSession]) -> ProgressLookupAdapter:
+    return ProgressLookupAdapter(SqlAlchemyWatchProgressUnitOfWorkFactory(session_factory))
+
+
+@pytest.mark.integration
+class TestCollectionsProgressLookupAdapter:
+    """The adapter exposes watched fractions for the Collections BC."""
+
+    async def test_get_progress_returns_fraction_for_caller_profile(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_movie_progress("mov_abc123def456", position=900, duration=3600))
+        await db_session.commit()
+
+        adapter = _make_adapter(session_factory)
+
+        result = await adapter.get_progress(
+            ["mov_abc123def456", "mov_missing00000"],
+            profile_id=_PROFILE_ID.value,
+        )
+
+        # 900 / 3600 = 0.25; unknown id is simply absent.
+        assert result == {"mov_abc123def456": pytest.approx(0.25)}
+
+    async def test_get_progress_with_empty_input(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        adapter = _make_adapter(session_factory)
+
+        assert await adapter.get_progress([], profile_id=_PROFILE_ID.value) == {}
+
+    async def test_get_progress_isolates_across_profiles(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        repo = SQLAlchemyWatchProgressRepository(db_session)
+        await repo.save(_movie_progress("mov_abc123def456", position=900))
+        await repo.save(
+            _movie_progress("mov_abc123def456", position=3600, profile_id=_OTHER_PROFILE_ID),
+        )
+        await db_session.commit()
+
+        adapter = _make_adapter(session_factory)
+
+        mine = await adapter.get_progress(["mov_abc123def456"], profile_id=_PROFILE_ID.value)
+        theirs = await adapter.get_progress(
+            ["mov_abc123def456"], profile_id=_OTHER_PROFILE_ID.value
+        )
+
+        assert mine["mov_abc123def456"] == pytest.approx(0.25)
+        assert theirs["mov_abc123def456"] == pytest.approx(1.0)

--- a/tests/modules/collections/unit/application/use_cases/conftest.py
+++ b/tests/modules/collections/unit/application/use_cases/conftest.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from src.modules.collections.application.ports import MediaLookupPort, MediaSummary
+from src.modules.collections.application.ports import (
+    MediaLookupPort,
+    MediaSummary,
+    ProgressLookupPort,
+)
 from src.shared_kernel.value_objects import MediaType
 
 MediaSummaryFactory = Callable[..., MediaSummary]
@@ -67,4 +71,11 @@ def make_media_lookup_mock(*summaries: MediaSummary) -> AsyncMock:
     """Build an ``AsyncMock`` of ``MediaLookupPort`` returning ``summaries``."""
     mock = AsyncMock(spec=MediaLookupPort)
     mock.get_many.return_value = {(s.media_type, s.media_id): s for s in summaries}
+    return mock
+
+
+def make_progress_lookup_mock(progress: dict[str, float] | None = None) -> AsyncMock:
+    """Build an ``AsyncMock`` of ``ProgressLookupPort`` returning ``progress``."""
+    mock = AsyncMock(spec=ProgressLookupPort)
+    mock.get_progress.return_value = progress or {}
     return mock

--- a/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_custom_list_items.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from tests.modules.collections.unit.application.use_cases.conftest import (
     make_media_lookup_mock,
+    make_progress_lookup_mock,
 )
 from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
@@ -58,6 +59,7 @@ class TestGetCustomListItemsUseCase:
         use_case = GetCustomListItemsUseCase(
             uow_factory=mocks.factory,
             media_lookup=media_lookup,
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         result = await use_case.execute(
@@ -80,12 +82,41 @@ class TestGetCustomListItemsUseCase:
         assert result[0].hdr is True
 
     @pytest.mark.asyncio
+    async def test_should_attach_progress_for_movie_items(
+        self, movie_summary: MediaSummaryFactory
+    ) -> None:
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
+        items = [
+            CustomListItem.create(
+                media_id="mov_abc123def456",
+                media_type=MediaType.MOVIE,
+                position=0,
+            ),
+        ]
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.find_by_id.return_value = custom_list
+        mocks.custom_lists.list_items.return_value = items
+
+        use_case = GetCustomListItemsUseCase(
+            uow_factory=mocks.factory,
+            media_lookup=make_media_lookup_mock(movie_summary("mov_abc123def456")),
+            progress_lookup=make_progress_lookup_mock({"mov_abc123def456": 0.5}),
+        )
+
+        result = await use_case.execute(
+            GetCustomListItemsInput(profile_id=_PROFILE_ID.value, list_id=str(custom_list.id))
+        )
+
+        assert result[0].progress == 0.5
+
+    @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:
         mocks = make_collections_uow_mock()
         mocks.custom_lists.find_by_id.return_value = None
         use_case = GetCustomListItemsUseCase(
             uow_factory=mocks.factory,
             media_lookup=AsyncMock(spec=MediaLookupPort),
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         with pytest.raises(ResourceNotFoundException) as exc_info:
@@ -107,6 +138,7 @@ class TestGetCustomListItemsUseCase:
         use_case = GetCustomListItemsUseCase(
             uow_factory=mocks.factory,
             media_lookup=AsyncMock(spec=MediaLookupPort),
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         result = await use_case.execute(
@@ -135,6 +167,7 @@ class TestGetCustomListItemsUseCase:
         use_case = GetCustomListItemsUseCase(
             uow_factory=mocks.factory,
             media_lookup=make_media_lookup_mock(),
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         result = await use_case.execute(
@@ -177,6 +210,7 @@ class TestGetCustomListItemsUseCase:
         use_case = GetCustomListItemsUseCase(
             uow_factory=mocks.factory,
             media_lookup=media_lookup,
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         result = await use_case.execute(
@@ -211,6 +245,7 @@ class TestGetCustomListItemsUseCase:
         use_case = GetCustomListItemsUseCase(
             uow_factory=mocks.factory,
             media_lookup=media_lookup,
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         await use_case.execute(

--- a/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
+++ b/tests/modules/collections/unit/application/use_cases/test_get_watchlist.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from tests.modules.collections.unit.application.use_cases.conftest import (
     make_media_lookup_mock,
+    make_progress_lookup_mock,
 )
 from tests.modules.collections.unit.conftest import make_collections_uow_mock
 
@@ -55,6 +56,7 @@ class TestGetWatchlistUseCase:
         use_case = GetWatchlistUseCase(
             uow_factory=mocks.factory,
             media_lookup=media_lookup,
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         result = await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value))
@@ -78,7 +80,11 @@ class TestGetWatchlistUseCase:
         mocks.watchlist.list_all.return_value = items
         media_lookup = make_media_lookup_mock(movie_summary("mov_abc123def456"))
 
-        use_case = GetWatchlistUseCase(uow_factory=mocks.factory, media_lookup=media_lookup)
+        use_case = GetWatchlistUseCase(
+            uow_factory=mocks.factory,
+            media_lookup=media_lookup,
+            progress_lookup=make_progress_lookup_mock(),
+        )
 
         out = (await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value)))[0]
 
@@ -89,12 +95,37 @@ class TestGetWatchlistUseCase:
         assert out.hdr is True
 
     @pytest.mark.asyncio
+    async def test_should_attach_progress_for_movies(
+        self, movie_summary: MediaSummaryFactory
+    ) -> None:
+        items = [
+            WatchlistItem.create(
+                profile_id=_PROFILE_ID,
+                media_id="mov_abc123def456",
+                media_type=MediaType.MOVIE,
+            ),
+        ]
+        mocks = make_collections_uow_mock()
+        mocks.watchlist.list_all.return_value = items
+
+        use_case = GetWatchlistUseCase(
+            uow_factory=mocks.factory,
+            media_lookup=make_media_lookup_mock(movie_summary("mov_abc123def456")),
+            progress_lookup=make_progress_lookup_mock({"mov_abc123def456": 0.42}),
+        )
+
+        out = (await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value)))[0]
+
+        assert out.progress == 0.42
+
+    @pytest.mark.asyncio
     async def test_should_return_empty_list_when_no_items(self) -> None:
         mocks = make_collections_uow_mock()
         mocks.watchlist.list_all.return_value = []
         use_case = GetWatchlistUseCase(
             uow_factory=mocks.factory,
             media_lookup=AsyncMock(spec=MediaLookupPort),
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         result = await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value))
@@ -116,6 +147,7 @@ class TestGetWatchlistUseCase:
         use_case = GetWatchlistUseCase(
             uow_factory=mocks.factory,
             media_lookup=make_media_lookup_mock(),  # no summaries
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         result = await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value))
@@ -151,6 +183,7 @@ class TestGetWatchlistUseCase:
         use_case = GetWatchlistUseCase(
             uow_factory=mocks.factory,
             media_lookup=media_lookup,
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         result = await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value))
@@ -166,6 +199,7 @@ class TestGetWatchlistUseCase:
         use_case = GetWatchlistUseCase(
             uow_factory=mocks.factory,
             media_lookup=AsyncMock(spec=MediaLookupPort),
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value, limit=25))
@@ -191,6 +225,7 @@ class TestGetWatchlistUseCase:
         use_case = GetWatchlistUseCase(
             uow_factory=mocks.factory,
             media_lookup=media_lookup,
+            progress_lookup=make_progress_lookup_mock(),
         )
 
         await use_case.execute(GetWatchlistInput(profile_id=_PROFILE_ID.value, lang="pt-BR"))


### PR DESCRIPTION
## Summary

- Adds a **`ProgressLookupPort`** to the Collections BC (+ an ACL adapter over the Watch Progress UoW, ADR-009) — the cross-BC read surface for the caller's watch progress, mirroring Media's `ProgressLookupPort` pattern.
- Surfaces a **`progress`** fraction in `[0, 1]` on `WatchlistItemOutput` and `CustomListItemOutput` (the GET `/watchlist` and `/custom-lists/{id}/items` responses), so the redesigned **My Lists** UI can draw per-item progress bars and an "assistidos" count.
- Progress is resolved for **movies only** — series progress lives on episodes (composite ids) and is deferred, so series items report `null`. The use cases look up movie ids only.
- Wires `watch_progress_uow_factory` into `CollectionsContainer` (parent composition in `config/containers/main.py`). No schema change / no migration.

## Part of

My Lists redesign — backend phase B2 (progress). The list poster-collage `poster_paths` optimization is intentionally deferred (the collage already works via a per-card client fetch). Frontend wiring of the progress bar + "assistidos" count follows.

## Test plan

- [x] `pytest tests/modules/collections` — 206 passed (incl. progress flow-through unit tests + 3 ProgressLookupAdapter integration tests: fraction, profile isolation, empty input)
- [x] `pytest tests/modules/watch_progress` + settings e2e green (full DI container boots with the new wiring)
- [x] `ruff check` + `ruff format` clean
- [x] `mypy` clean on the edited logic files (the `providers.Dependency()` annotation note is pre-existing across containers and CI-tolerated)