### PR TITLE
feat(collections): add description to custom lists

### DIFF
--- a/migrations/versions/2026_06_26_add_custom_list_description.py
+++ b/migrations/versions/2026_06_26_add_custom_list_description.py
@@ -1,0 +1,36 @@
+"""Add description column to custom_lists.
+
+Lets users attach an optional free-text description to a custom list
+(shown in the list-detail header). Nullable so existing lists are
+unaffected.
+
+Revision ID: d8e2f4a6c1b9
+Revises: 7c2f9a1b3e4d
+Create Date: 2026-06-26 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d8e2f4a6c1b9"
+down_revision: str | Sequence[str] | None = "7c2f9a1b3e4d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``description`` to ``custom_lists``.
+
+    Plain ``add_column`` (not batch) so SQLite uses a native
+    ``ALTER TABLE ADD COLUMN`` instead of a table-recreate — the latter
+    trips the ``custom_list_items`` FK when the table holds data.
+    """
+    op.add_column("custom_lists", sa.Column("description", sa.String(length=500), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop ``description`` from ``custom_lists`` (native, no recreate)."""
+    op.drop_column("custom_lists", "description")

--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -17,6 +17,7 @@ class CreateCustomListInput:
 
     profile_id: str
     name: str
+    description: str | None = None
 
 
 @dataclass(frozen=True)
@@ -28,6 +29,7 @@ class CustomListOutput:
     item_count: int
     created_at: str
     updated_at: str
+    description: str | None = None
 
     @classmethod
     def from_entity(cls, entity: CustomList) -> CustomListOutput:
@@ -38,6 +40,7 @@ class CustomListOutput:
             item_count=entity.item_count,
             created_at=entity.created_at.isoformat(),
             updated_at=entity.updated_at.isoformat(),
+            description=entity.description,
         )
 
 
@@ -48,6 +51,7 @@ class RenameCustomListInput:
     profile_id: str
     list_id: str
     name: str
+    description: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/modules/collections/application/use_cases/create_custom_list.py
+++ b/src/modules/collections/application/use_cases/create_custom_list.py
@@ -30,6 +30,7 @@ class CreateCustomListUseCase:
                 profile_id=profile_id,
                 name=input_dto.name,
                 existing_count=current_count,
+                description=(input_dto.description or "").strip() or None,
             )
 
             existing = await uow.custom_lists.find_by_name(input_dto.name.strip(), profile_id)

--- a/src/modules/collections/application/use_cases/rename_custom_list.py
+++ b/src/modules/collections/application/use_cases/rename_custom_list.py
@@ -33,7 +33,10 @@ class RenameCustomListUseCase:
                     rule_code="CUSTOM_LIST_NAME_DUPLICATE",
                 )
 
-            updated = custom_list.rename(new_name)
+            updated = custom_list.with_details(
+                name=new_name,
+                description=(input_dto.description or "").strip() or None,
+            )
             saved = await uow.custom_lists.update(updated)
         return CustomListOutput.from_entity(saved)
 

--- a/src/modules/collections/domain/entities/custom_list.py
+++ b/src/modules/collections/domain/entities/custom_list.py
@@ -113,6 +113,7 @@ class CustomList(AggregateRoot[ListId]):
 
     profile_id: ProfileId
     name: ListName
+    description: str | None = Field(default=None, max_length=500)
     item_count: int = 0
 
     @field_validator("name", mode="before")
@@ -128,6 +129,7 @@ class CustomList(AggregateRoot[ListId]):
         name: str | ListName,
         *,
         existing_count: int,
+        description: str | None = None,
     ) -> CustomList:
         """Factory method with automatic ID generation.
 
@@ -142,6 +144,7 @@ class CustomList(AggregateRoot[ListId]):
                 their lists separate.
             name: Display name for the list.
             existing_count: Number of lists the profile already has.
+            description: Optional free-text description.
 
         Returns:
             A new CustomList instance.
@@ -160,6 +163,7 @@ class CustomList(AggregateRoot[ListId]):
             id=ListId.generate(),
             profile_id=profile_id,
             name=name,
+            description=description,
             item_count=0,
         )
 
@@ -173,6 +177,21 @@ class CustomList(AggregateRoot[ListId]):
             A new CustomList instance with updated name.
         """
         return self.with_updates(name=new_name)
+
+    def with_details(self, *, name: str | ListName, description: str | None) -> CustomList:
+        """Create a copy with the edited name and description.
+
+        Both are authoritative — the edit form sends the full state, so
+        passing ``description=None`` clears it.
+
+        Args:
+            name: The new display name.
+            description: The new description, or ``None`` to clear it.
+
+        Returns:
+            A new CustomList instance with both fields updated.
+        """
+        return self.with_updates(name=name, description=description)
 
     def increment_item_count(self) -> CustomList:
         """Increment item count after adding an item.

--- a/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
+++ b/src/modules/collections/infrastructure/persistence/mappers/custom_list_mapper.py
@@ -28,6 +28,7 @@ class CustomListMapper:
             external_id=str(entity.id),
             profile_id=str(entity.profile_id),
             name=entity.name.value,
+            description=entity.description,
             item_count=entity.item_count,
         )
 
@@ -38,6 +39,7 @@ class CustomListMapper:
             id=ListId(model.external_id),
             profile_id=ProfileId(model.profile_id),
             name=model.name,
+            description=model.description,
             item_count=model.item_count,
             created_at=model.created_at,
             updated_at=model.updated_at,
@@ -47,6 +49,7 @@ class CustomListMapper:
     def update_model(model: CustomListModel, entity: CustomList) -> CustomListModel:
         """Update mutable fields. ``profile_id`` is intentionally not touched."""
         model.name = entity.name.value
+        model.description = entity.description
         model.item_count = entity.item_count
         return model
 

--- a/src/modules/collections/infrastructure/persistence/models/custom_list_model.py
+++ b/src/modules/collections/infrastructure/persistence/models/custom_list_model.py
@@ -20,6 +20,7 @@ class CustomListModel(Base):
 
     profile_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(500), nullable=True)
     item_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     items: Mapped[list["CustomListItemModel"]] = relationship(

--- a/src/modules/collections/presentation/routes/custom_list_routes.py
+++ b/src/modules/collections/presentation/routes/custom_list_routes.py
@@ -51,7 +51,9 @@ async def create_custom_list(
     ),
 ) -> dict[str, Any]:
     """Create a new custom list."""
-    result = await use_case.execute(CreateCustomListInput(profile_id=profile_id, name=body.name))
+    result = await use_case.execute(
+        CreateCustomListInput(profile_id=profile_id, name=body.name, description=body.description)
+    )
     return api_single("custom_list", asdict(result))
 
 
@@ -80,7 +82,12 @@ async def rename_custom_list(
 ) -> dict[str, Any]:
     """Rename a custom list owned by the caller."""
     result = await use_case.execute(
-        RenameCustomListInput(profile_id=profile_id, list_id=list_id, name=body.name)
+        RenameCustomListInput(
+            profile_id=profile_id,
+            list_id=list_id,
+            name=body.name,
+            description=body.description,
+        )
     )
     return api_single("custom_list", asdict(result))
 

--- a/src/modules/collections/presentation/schemas/custom_list_schemas.py
+++ b/src/modules/collections/presentation/schemas/custom_list_schemas.py
@@ -9,12 +9,14 @@ class CreateCustomListRequest(BaseModel):
     """Request body for creating a custom list."""
 
     name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=500)
 
 
 class RenameCustomListRequest(BaseModel):
-    """Request body for renaming a custom list."""
+    """Request body for editing a custom list (name + description)."""
 
     name: str = Field(..., min_length=1, max_length=200)
+    description: str | None = Field(default=None, max_length=500)
 
 
 class AddItemToCustomListRequest(BaseModel):

--- a/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_create_custom_list.py
@@ -42,6 +42,40 @@ class TestCreateCustomListUseCase:
         mock_repo.add.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_should_create_with_trimmed_description(self) -> None:
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
+        mock_repo.count.return_value = 0
+        mock_repo.find_by_name.return_value = None
+        mock_repo.add.side_effect = lambda entity: entity  # echo what was built
+        use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            CreateCustomListInput(
+                profile_id=_PROFILE_ID.value,
+                name="Horror Marathon",
+                description="  The season's scares  ",
+            )
+        )
+
+        assert result.description == "The season's scares"
+
+    @pytest.mark.asyncio
+    async def test_should_store_blank_description_as_none(self) -> None:
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
+        mock_repo.count.return_value = 0
+        mock_repo.find_by_name.return_value = None
+        mock_repo.add.side_effect = lambda entity: entity
+        use_case = CreateCustomListUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            CreateCustomListInput(profile_id=_PROFILE_ID.value, name="Plain", description="   ")
+        )
+
+        assert result.description is None
+
+    @pytest.mark.asyncio
     async def test_should_raise_when_list_limit_reached(self) -> None:
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists

--- a/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
+++ b/tests/modules/collections/unit/application/use_cases/test_rename_custom_list.py
@@ -45,6 +45,28 @@ class TestRenameCustomListUseCase:
         mock_repo.update.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_should_update_name_and_description(self) -> None:
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Old Name", existing_count=0)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
+        mock_repo.find_by_id.return_value = custom_list
+        mock_repo.find_by_name.return_value = None
+        mock_repo.update.side_effect = lambda entity: entity  # echo what was built
+        use_case = RenameCustomListUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            RenameCustomListInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+                name="New Name",
+                description="  A weekend of scares  ",
+            )
+        )
+
+        assert result.name == "New Name"
+        assert result.description == "A weekend of scares"
+
+    @pytest.mark.asyncio
     async def test_should_raise_when_list_not_found(self) -> None:
         mocks = make_collections_uow_mock()
         mock_repo = mocks.custom_lists


### PR DESCRIPTION
## Summary

- Adds an optional free-text **`description`** (max 500) to the `CustomList` aggregate, persisted via a new nullable `custom_lists.description` column.
- **Create** accepts a description; the **PATCH** endpoint now edits **name + description together** — the edit form is authoritative, so a blank/whitespace description stores `null` (`with_details` on the entity).
- `CustomListOutput` exposes `description` (for the My Lists detail header). Request schemas (`Create`/`Rename`) gain an optional `description` capped at 500.
- Migration uses **native** `add_column`/`drop_column` (not batch) so SQLite doesn't recreate `custom_lists` and trip the `custom_list_items` FK on populated data — verified up/down on a copy of the dev DB.

## Part of

My Lists redesign — the list `description` field (display already wired in F1). Frontend create/edit dialogs to follow.

## Migration steps

- `make migrate` (adds the nullable `description` column).

## Test plan

- [x] `pytest tests/modules/collections` — 209 passed (create trims/blanks→null, rename updates name+description, mapper round-trip)
- [x] settings e2e green (app boots with the schema change)
- [x] `ruff check` + `ruff format` clean
- [x] migration upgrade/downgrade verified on a populated DB copy