### PR TITLE
feat(collections): reorder custom-list items

### DIFF
--- a/src/config/containers/collections.py
+++ b/src/config/containers/collections.py
@@ -12,6 +12,7 @@ from src.modules.collections.application.use_cases import (
     ListCustomListsUseCase,
     RemoveItemFromCustomListUseCase,
     RenameCustomListUseCase,
+    ReorderCustomListItemsUseCase,
     ToggleWatchlistUseCase,
 )
 from src.modules.collections.infrastructure.acl import MediaLookupAdapter, ProgressLookupAdapter
@@ -113,6 +114,11 @@ class CollectionsContainer(containers.DeclarativeContainer):  # type: ignore[mis
 
     remove_item_from_custom_list = providers.Factory(
         RemoveItemFromCustomListUseCase,
+        uow_factory=collections_unit_of_work_factory,
+    )
+
+    reorder_custom_list_items = providers.Factory(
+        ReorderCustomListItemsUseCase,
         uow_factory=collections_unit_of_work_factory,
     )
 

--- a/src/modules/collections/application/dtos/__init__.py
+++ b/src/modules/collections/application/dtos/__init__.py
@@ -9,6 +9,7 @@ from src.modules.collections.application.dtos.custom_list_dtos import (
     GetCustomListItemsInput,
     RemoveItemFromCustomListInput,
     RenameCustomListInput,
+    ReorderCustomListItemsInput,
 )
 from src.modules.collections.application.dtos.watchlist_dtos import (
     CheckWatchlistInput,
@@ -29,6 +30,7 @@ __all__ = [
     "GetWatchlistInput",
     "RemoveItemFromCustomListInput",
     "RenameCustomListInput",
+    "ReorderCustomListItemsInput",
     "ToggleWatchlistInput",
     "ToggleWatchlistOutput",
     "WatchlistItemOutput",

--- a/src/modules/collections/application/dtos/custom_list_dtos.py
+++ b/src/modules/collections/application/dtos/custom_list_dtos.py
@@ -82,6 +82,15 @@ class RemoveItemFromCustomListInput:
 
 
 @dataclass(frozen=True)
+class ReorderCustomListItemsInput:
+    """Input for ReorderCustomListItemsUseCase."""
+
+    profile_id: str
+    list_id: str
+    media_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class GetCustomListItemsInput:
     """Input for GetCustomListItemsUseCase."""
 

--- a/src/modules/collections/application/use_cases/__init__.py
+++ b/src/modules/collections/application/use_cases/__init__.py
@@ -27,6 +27,9 @@ from src.modules.collections.application.use_cases.remove_item_from_custom_list 
 from src.modules.collections.application.use_cases.rename_custom_list import (
     RenameCustomListUseCase,
 )
+from src.modules.collections.application.use_cases.reorder_custom_list_items import (
+    ReorderCustomListItemsUseCase,
+)
 from src.modules.collections.application.use_cases.toggle_watchlist import (
     ToggleWatchlistUseCase,
 )
@@ -41,5 +44,6 @@ __all__ = [
     "ListCustomListsUseCase",
     "RemoveItemFromCustomListUseCase",
     "RenameCustomListUseCase",
+    "ReorderCustomListItemsUseCase",
     "ToggleWatchlistUseCase",
 ]

--- a/src/modules/collections/application/use_cases/reorder_custom_list_items.py
+++ b/src/modules/collections/application/use_cases/reorder_custom_list_items.py
@@ -1,0 +1,33 @@
+"""ReorderCustomListItemsUseCase - Persist a manual item order."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.collections.application.dtos import ReorderCustomListItemsInput
+from src.modules.collections.application.unit_of_work import CollectionsUnitOfWorkFactory
+from src.modules.collections.domain.value_objects import CollectionMediaId
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+
+class ReorderCustomListItemsUseCase:
+    """Persist a manual ordering of a custom list's items.
+
+    The caller sends the full set of item media ids in the desired
+    order; each item's ``position`` becomes its index. Ids not in the
+    list are ignored by the repository.
+    """
+
+    def __init__(self, uow_factory: CollectionsUnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
+
+    async def execute(self, input_dto: ReorderCustomListItemsInput) -> None:
+        """Reorder items in a list owned by the caller's profile."""
+        profile_id = ProfileId(input_dto.profile_id)
+        async with self._uow_factory() as uow:
+            custom_list = await uow.custom_lists.find_by_id(input_dto.list_id, profile_id)
+            if not custom_list:
+                raise ResourceNotFoundException.for_resource("CustomList", input_dto.list_id)
+
+            ordered = [CollectionMediaId(media_id) for media_id in input_dto.media_ids]
+            await uow.custom_lists.reorder_items(input_dto.list_id, ordered, profile_id)
+
+
+__all__ = ["ReorderCustomListItemsUseCase"]

--- a/src/modules/collections/domain/repositories/custom_list_repository.py
+++ b/src/modules/collections/domain/repositories/custom_list_repository.py
@@ -1,6 +1,7 @@
 """CustomList repository interface."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
 from src.modules.collections.domain.value_objects import CollectionMediaId
@@ -86,6 +87,20 @@ class CustomListRepository(ABC):
         profile_id: ProfileId,
     ) -> bool:
         """Remove an item from a list owned by ``profile_id``."""
+
+    @abstractmethod
+    async def reorder_items(
+        self,
+        list_id: str,
+        ordered_media_ids: Sequence[CollectionMediaId],
+        profile_id: ProfileId,
+    ) -> None:
+        """Set each item's position to its index in ``ordered_media_ids``.
+
+        Scoped to a list owned by ``profile_id``. Ids not present in the
+        list are ignored; items missing from the sequence keep their
+        current position. No-op when the list doesn't resolve.
+        """
 
     @abstractmethod
     async def list_items(

--- a/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
+++ b/src/modules/collections/infrastructure/persistence/repositories/custom_list_repository.py
@@ -1,6 +1,8 @@
 """SQLAlchemy implementation of CustomListRepository."""
 
-from sqlalchemy import func, select
+from collections.abc import Sequence
+
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.collections.domain.entities import CustomList, CustomListItem
@@ -258,6 +260,28 @@ class SQLAlchemyCustomListRepository(CustomListRepository):
         )
         result = await self._session.execute(stmt)
         return [CustomListItemMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def reorder_items(
+        self,
+        list_id: str,
+        ordered_media_ids: Sequence[CollectionMediaId],
+        profile_id: ProfileId,
+    ) -> None:
+        """Rewrite each item's position to its index in the given order."""
+        internal_id = await self._get_list_internal_id(list_id, profile_id)
+        if internal_id is None:
+            return
+
+        for position, media_id in enumerate(ordered_media_ids):
+            await self._session.execute(
+                update(CustomListItemModel)
+                .where(
+                    CustomListItemModel.custom_list_id == internal_id,
+                    CustomListItemModel.media_id == media_id.value,
+                    CustomListItemModel.deleted_at.is_(None),
+                )
+                .values(position=position)
+            )
 
     async def get_next_position(
         self,

--- a/src/modules/collections/presentation/routes/custom_list_routes.py
+++ b/src/modules/collections/presentation/routes/custom_list_routes.py
@@ -15,6 +15,7 @@ from src.modules.collections.application.dtos import (
     GetCustomListItemsInput,
     RemoveItemFromCustomListInput,
     RenameCustomListInput,
+    ReorderCustomListItemsInput,
 )
 from src.modules.collections.application.use_cases import (
     AddItemToCustomListUseCase,
@@ -24,6 +25,7 @@ from src.modules.collections.application.use_cases import (
     ListCustomListsUseCase,
     RemoveItemFromCustomListUseCase,
     RenameCustomListUseCase,
+    ReorderCustomListItemsUseCase,
 )
 from src.modules.collections.application.use_cases.list_custom_lists import (
     ListCustomListsInput,
@@ -33,6 +35,7 @@ from src.modules.collections.presentation.schemas import (
     AddItemToCustomListRequest,
     CreateCustomListRequest,
     RenameCustomListRequest,
+    ReorderCustomListItemsRequest,
 )
 
 router = APIRouter(prefix="/api/v1/custom-lists", tags=["Custom Lists"])
@@ -147,6 +150,26 @@ async def add_item_to_custom_list(
     return api_single(
         "custom_list",
         {"list_id": list_id, "media_id": body.media_id, "added": True},
+    )
+
+
+@router.patch("/{list_id}/items/order", status_code=204)  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def reorder_custom_list_items(
+    list_id: str,
+    body: ReorderCustomListItemsRequest,
+    profile_id: str = Depends(resolve_profile_id),
+    use_case: ReorderCustomListItemsUseCase = Depends(
+        Provide[ApplicationContainer.collections.reorder_custom_list_items],
+    ),
+) -> None:
+    """Persist a manual item order for a custom list owned by the caller."""
+    await use_case.execute(
+        ReorderCustomListItemsInput(
+            profile_id=profile_id,
+            list_id=list_id,
+            media_ids=tuple(body.media_ids),
+        )
     )
 
 

--- a/src/modules/collections/presentation/schemas/__init__.py
+++ b/src/modules/collections/presentation/schemas/__init__.py
@@ -4,10 +4,12 @@ from src.modules.collections.presentation.schemas.custom_list_schemas import (
     AddItemToCustomListRequest,
     CreateCustomListRequest,
     RenameCustomListRequest,
+    ReorderCustomListItemsRequest,
 )
 
 __all__ = [
     "AddItemToCustomListRequest",
     "CreateCustomListRequest",
     "RenameCustomListRequest",
+    "ReorderCustomListItemsRequest",
 ]

--- a/src/modules/collections/presentation/schemas/custom_list_schemas.py
+++ b/src/modules/collections/presentation/schemas/custom_list_schemas.py
@@ -26,8 +26,19 @@ class AddItemToCustomListRequest(BaseModel):
     media_type: MediaType
 
 
+class ReorderCustomListItemsRequest(BaseModel):
+    """Request body for reordering a custom list's items.
+
+    ``media_ids`` is the full set of the list's item ids in the desired
+    order; each item's position becomes its index.
+    """
+
+    media_ids: list[str] = Field(..., min_length=1)
+
+
 __all__ = [
     "AddItemToCustomListRequest",
     "CreateCustomListRequest",
     "RenameCustomListRequest",
+    "ReorderCustomListItemsRequest",
 ]

--- a/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
+++ b/tests/modules/collections/integration/persistence/repositories/test_custom_list_repository.py
@@ -393,6 +393,40 @@ class TestSQLAlchemyCustomListRepositoryItems:
             "mov_third0000000",
         ]
 
+    async def test_reorder_items_should_rewrite_positions(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        custom_list = _create_list()
+        await repo.add(custom_list)
+        for i, media_id in enumerate(["mov_first0000000", "mov_second000000", "mov_third0000000"]):
+            await repo.add_item(
+                str(custom_list.id), _create_item(media_id=media_id, position=i), _PROFILE_ID
+            )
+
+        # New manual order: third, first, second.
+        await repo.reorder_items(
+            str(custom_list.id),
+            [
+                CollectionMediaId("mov_third0000000"),
+                CollectionMediaId("mov_first0000000"),
+                CollectionMediaId("mov_second000000"),
+            ],
+            _PROFILE_ID,
+        )
+
+        items = await repo.list_items(str(custom_list.id), _PROFILE_ID)
+        assert [item.media_id.value for item in items] == [
+            "mov_third0000000",
+            "mov_first0000000",
+            "mov_second000000",
+        ]
+
+    async def test_reorder_items_should_noop_for_unknown_list(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyCustomListRepository(db_session)
+        # Should not raise even when the list doesn't resolve.
+        await repo.reorder_items(MISSING_LIST_ID, [SAMPLE_MOVIE_ID], _PROFILE_ID)
+
     async def test_list_items_should_return_empty_when_list_not_found(
         self, db_session: AsyncSession
     ) -> None:

--- a/tests/modules/collections/unit/application/use_cases/test_reorder_custom_list_items.py
+++ b/tests/modules/collections/unit/application/use_cases/test_reorder_custom_list_items.py
@@ -1,0 +1,58 @@
+"""Tests for ReorderCustomListItemsUseCase."""
+
+import pytest
+from tests.modules.collections.unit.conftest import make_collections_uow_mock
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.collections.application.dtos import ReorderCustomListItemsInput
+from src.modules.collections.application.use_cases import ReorderCustomListItemsUseCase
+from src.modules.collections.domain.entities import CustomList
+from src.modules.collections.domain.value_objects import CollectionMediaId
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
+
+
+@pytest.mark.unit
+class TestReorderCustomListItemsUseCase:
+    """Tests for persisting a manual item order."""
+
+    @pytest.mark.asyncio
+    async def test_should_reorder_with_typed_ids(self) -> None:
+        custom_list = CustomList.create(profile_id=_PROFILE_ID, name="Test", existing_count=0)
+        mocks = make_collections_uow_mock()
+        mock_repo = mocks.custom_lists
+        mock_repo.find_by_id.return_value = custom_list
+        use_case = ReorderCustomListItemsUseCase(uow_factory=mocks.factory)
+
+        await use_case.execute(
+            ReorderCustomListItemsInput(
+                profile_id=_PROFILE_ID.value,
+                list_id=str(custom_list.id),
+                media_ids=("mov_abc123def456", "ser_xyz789abc123"),
+            )
+        )
+
+        mock_repo.reorder_items.assert_called_once_with(
+            str(custom_list.id),
+            [CollectionMediaId("mov_abc123def456"), CollectionMediaId("ser_xyz789abc123")],
+            _PROFILE_ID,
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_raise_when_list_not_found(self) -> None:
+        mocks = make_collections_uow_mock()
+        mocks.custom_lists.find_by_id.return_value = None
+        use_case = ReorderCustomListItemsUseCase(uow_factory=mocks.factory)
+
+        with pytest.raises(ResourceNotFoundException) as exc_info:
+            await use_case.execute(
+                ReorderCustomListItemsInput(
+                    profile_id=_PROFILE_ID.value,
+                    list_id="lst_nonexistent00",
+                    media_ids=("mov_abc123def456",),
+                )
+            )
+
+        assert exc_info.value.resource_type == "CustomList"
+        mocks.custom_lists.reorder_items.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds a **reorder endpoint** so a custom list's manual ("Ordem manual") order can be persisted: `PATCH /custom-lists/{list_id}/items/order` with `{ media_ids: [...] }` — the full set of the list's item ids in the desired order.
- `ReorderCustomListItemsUseCase` validates the list belongs to the caller's profile, then `repository.reorder_items` rewrites each item's `position` to its index. Ids not in the list are ignored; the op is a no-op for an unknown list.
- No schema change (the `position` column already existed).

## Part of

My Lists redesign — backend phase B3 (reorder of custom-list items). The watchlist/queue reorder stays deferred (it has no ordering infra). Frontend drag UI to follow.

## Test plan

- [x] `pytest tests/modules/collections` — 213 passed (repo: rewrite positions + no-op for unknown list; use case: typed-ids reorder + not-found raises)
- [x] `ruff check` + `ruff format` clean
- [x] `mypy` clean on the edited files (pre-existing noise lives in other modules)