### PR TITLE
fix(media): self-heal HLS cache after partial eviction

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -90,6 +90,11 @@ _EVICTION_INTERVAL = 10.0
 
 _VIDEO_DIR = "video"
 
+# Prefix marking a bucket dir that has been renamed out of the live cache
+# path and is awaiting deletion. The eviction scan skips (and retries
+# cleaning) these so they are never mistaken for a real bucket.
+_EVICTING_PREFIX = ".evicting-"
+
 # Wall-clock cap for the one-time NVENC functional probe. Deliberately
 # generous: the probe is the process's first CUDA call, so it absorbs the
 # cold driver / context init, which was measured at ~20s on a cold but
@@ -273,6 +278,11 @@ class HlsService(HlsPlaylistPort):
         for entry in self._cache_dir.iterdir():
             if not entry.is_dir():
                 continue
+            if entry.name.startswith(_EVICTING_PREFIX):
+                # Leftover from a prior cleanup whose delete was blocked
+                # (locked file). Retry it now and never count it as a bucket.
+                shutil.rmtree(entry, ignore_errors=True)
+                continue
             path_hash = entry.name
             size = sum(f.stat().st_size for f in entry.rglob("*") if f.is_file())
             total_size += size
@@ -301,12 +311,53 @@ class HlsService(HlsPlaylistPort):
                 path_hash,
                 size / (1024 * 1024),
             )
-            shutil.rmtree(bucket_path, ignore_errors=True)
+            if not self._remove_bucket_dir(bucket_path):
+                # A locked file blocked the atomic rename — the bucket is
+                # still fully intact. Leave it and retry next sweep rather
+                # than risk a partial delete; the cache stays briefly over
+                # budget, which is harmless.
+                continue
             with self._lock:
                 self._last_access.pop(path_hash, None)
             total_size -= size
             evicted.append(path_hash)
         return evicted
+
+    def _remove_bucket_dir(self, bucket_path: Path) -> bool:
+        """Remove a bucket directory without ever exposing a partial state.
+
+        Renames the bucket out of the live cache path in a single atomic
+        ``rename`` and only then deletes the renamed copy best-effort. A
+        reader therefore sees the bucket either fully present or fully
+        gone — never half-deleted. This is what closes the whole class of
+        partial-eviction zombies: a momentarily locked file (an AV scan
+        or the Windows indexer holding a segment) can no longer strand a
+        bucket with, say, its ``master.m3u8`` deleted but its nested
+        playlists intact, a state ``ensure_playlist`` would treat as
+        complete and then 404 on forever.
+
+        Args:
+            bucket_path: The live bucket directory to remove.
+
+        Returns:
+            ``True`` if the bucket left the live path (rename succeeded,
+            or it was already gone); ``False`` if a lock blocked the
+            rename and the bucket is still fully intact — the caller
+            should treat that as "not evicted" and retry on a later sweep.
+        """
+        if not bucket_path.exists():
+            return True
+        trash = bucket_path.with_name(f"{_EVICTING_PREFIX}{bucket_path.name}")
+        # A leftover trash dir from a previous blocked cleanup would make
+        # the rename target already exist; clear it first (best-effort).
+        if trash.exists():
+            shutil.rmtree(trash, ignore_errors=True)
+        try:
+            bucket_path.rename(trash)
+        except OSError:
+            return False
+        shutil.rmtree(trash, ignore_errors=True)
+        return True
 
     # -- Public API ------------------------------------------------------------
 
@@ -372,6 +423,21 @@ class HlsService(HlsPlaylistPort):
         nested_video_dir = bucket / _VIDEO_DIR
         if flat.is_file() and not nested_video_dir.is_dir():
             return _has_endlist(flat)
+
+        # The bucket is only reusable if the root master.m3u8 that
+        # get_master_playlist actually serves is present and non-empty.
+        # Without this guard a bucket whose nested playlists are sealed
+        # but whose master was lost — e.g. a partial rmtree that skipped
+        # a momentarily-locked file during LRU eviction — looks
+        # "complete", short-circuits regeneration in ensure_playlist, and
+        # then 404s forever on the missing master. Treating it as
+        # incomplete makes the next request regenerate and self-heal.
+        master = bucket / "master.m3u8"
+        try:
+            if not master.is_file() or master.stat().st_size == 0:
+                return False
+        except OSError:
+            return False
 
         playlists = list(bucket.glob("*/playlist.m3u8"))
         if not playlists:

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -247,13 +247,41 @@ class TestHlsServiceIsComplete:
 
     def test_should_return_true_when_endlist_marker_present(self, tmp_path: Path) -> None:
         service = HlsService(runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path))
+        bucket = tmp_path / "abc123"
+        video_dir = bucket / "video"
+        video_dir.mkdir(parents=True)
+        (video_dir / "playlist.m3u8").write_text(
+            "#EXTM3U\n#EXTINF:10,\nsegment_0000.ts\n#EXT-X-ENDLIST\n"
+        )
+        (bucket / "master.m3u8").write_text("#EXTM3U\nvideo/playlist.m3u8\n")
+
+        assert service.is_complete("abc123") is True
+
+    def test_should_return_false_when_master_missing(self, tmp_path: Path) -> None:
+        # Sealed nested playlist but no root master.m3u8: the zombie a
+        # partial LRU rmtree leaves behind. Must be treated as incomplete
+        # so ensure_playlist regenerates instead of 404ing forever.
+        service = HlsService(runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path))
         video_dir = tmp_path / "abc123" / "video"
         video_dir.mkdir(parents=True)
         (video_dir / "playlist.m3u8").write_text(
             "#EXTM3U\n#EXTINF:10,\nsegment_0000.ts\n#EXT-X-ENDLIST\n"
         )
 
-        assert service.is_complete("abc123") is True
+        assert service.is_complete("abc123") is False
+
+    def test_should_return_false_when_master_empty(self, tmp_path: Path) -> None:
+        # A torn write can leave a zero-byte master; that is not servable.
+        service = HlsService(runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path))
+        bucket = tmp_path / "abc123"
+        video_dir = bucket / "video"
+        video_dir.mkdir(parents=True)
+        (video_dir / "playlist.m3u8").write_text(
+            "#EXTM3U\n#EXTINF:10,\nsegment_0000.ts\n#EXT-X-ENDLIST\n"
+        )
+        (bucket / "master.m3u8").write_text("")
+
+        assert service.is_complete("abc123") is False
 
     def test_should_return_false_when_endlist_marker_missing(self, tmp_path: Path) -> None:
         service = HlsService(runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path))
@@ -1454,6 +1482,63 @@ class TestEvictLru:
 
         assert evicted == []
 
+    def test_should_not_leave_partial_bucket_behind(self, tmp_path: Path) -> None:
+        # Eviction must be all-or-nothing: a bucket either fully survives
+        # or fully disappears — never a half-deleted zombie.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hls_cache_max_size_mb=1),
+            cache_dir=str(tmp_path),
+        )
+        bucket = tmp_path / "old_hash"
+        (bucket / "video").mkdir(parents=True)
+        (bucket / "master.m3u8").write_text("#EXTM3U\nvideo/playlist.m3u8\n")
+        (bucket / "video" / "segment.ts").write_bytes(b"\x00" * 2_000_000)
+        service._last_access["old_hash"] = 100.0
+
+        evicted = service.evict_lru()
+
+        assert "old_hash" in evicted
+        assert not bucket.exists()
+        # No trash dir left lingering in the live cache path.
+        assert list(tmp_path.glob(".evicting-*")) == []
+
+    def test_should_keep_bucket_intact_when_rename_blocked(self, tmp_path: Path) -> None:
+        # If the atomic rename is blocked (a locked file), the bucket must
+        # stay 100% intact rather than be partially deleted.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hls_cache_max_size_mb=1),
+            cache_dir=str(tmp_path),
+        )
+        bucket = tmp_path / "locked_hash"
+        bucket.mkdir()
+        (bucket / "master.m3u8").write_text("#EXTM3U\nvideo/playlist.m3u8\n")
+        (bucket / "segment.ts").write_bytes(b"\x00" * 2_000_000)
+        service._last_access["locked_hash"] = 100.0
+
+        with patch.object(Path, "rename", side_effect=OSError("locked")):
+            evicted = service.evict_lru()
+
+        assert evicted == []
+        assert bucket.exists()
+        assert (bucket / "master.m3u8").is_file()
+        assert (bucket / "segment.ts").is_file()
+
+    def test_should_clean_leftover_trash_dir(self, tmp_path: Path) -> None:
+        # A leftover .evicting-* dir from a prior blocked cleanup is wiped
+        # on the next sweep and never counted as a real bucket.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(hls_cache_max_size_mb=100),
+            cache_dir=str(tmp_path),
+        )
+        trash = tmp_path / ".evicting-stale_hash"
+        trash.mkdir()
+        (trash / "segment.ts").write_bytes(b"\x00" * 1000)
+
+        evicted = service.evict_lru()
+
+        assert evicted == []
+        assert not trash.exists()
+
 
 @pytest.mark.unit
 class TestHasEndlist:
@@ -1610,6 +1695,7 @@ class TestHlsServiceIsCompleteAllPlaylists:
             (bucket / sub / "playlist.m3u8").write_text(
                 "#EXTM3U\n#EXTINF:10,\nseg.ts\n#EXT-X-ENDLIST\n"
             )
+        (bucket / "master.m3u8").write_text("#EXTM3U\nvideo/playlist.m3u8\n")
 
         assert service.is_complete("abc") is True
 


### PR DESCRIPTION
## Summary

- A resumed playback returned `404 HlsMasterPlaylist not found` and stayed broken until the HLS cache was cleared by hand. Root cause: a bucket could survive in a half-deleted state that `ensure_playlist` still treated as complete, so it skipped regeneration and 404'd forever.
- `is_complete()` checked only the nested `*/playlist.m3u8` for `#EXT-X-ENDLIST`, never the root `master.m3u8` that `get_master_playlist()` actually serves. A bucket with a sealed video playlist but a missing master looked "complete". Now it requires a non-empty `master.m3u8`, so such a bucket regenerates on the next request and self-heals.
- `evict_lru()` deleted buckets in place with `rmtree(ignore_errors=True)`, which on a momentarily locked file (AV scan / Windows indexer) leaves a partially-deleted zombie. Eviction is now **atomic**: rename the bucket out of the live path in one step, then delete the renamed copy. A reader sees the bucket fully present or fully gone — never half-deleted. A blocked rename leaves the bucket 100% intact to retry on the next sweep, and leftover `.evicting-*` dirs are cleaned and never counted as buckets.

## Test plan

- [x] `pytest tests/modules/media/unit/infrastructure/streaming/test_hls_service.py` — 136 passing (7 new: master-present/missing/empty in `is_complete`, plus atomic-eviction all-or-nothing, rename-blocked-keeps-intact, and trash-dir cleanup)
- [x] `pytest tests/modules/media/ -k "hls or evict or playlist or cache"` — 152 passing
- [x] `ruff check` + `ruff format --check` clean on both files
- [x] Manual smoke: resumed a previously-stuck episode — bucket regenerated and served 200 instead of 404
- [ ] Manual smoke: let the cache exceed `hls_cache_max_size_mb` and confirm LRU evicts cleanly (no `.evicting-*` left behind) and a resume regenerates