### PR TITLE
feat(catalog-requests): localize request titles per language

### DIFF
--- a/migrations/versions/2026_06_26_add_localized_titles_to_catalog_requests.py
+++ b/migrations/versions/2026_06_26_add_localized_titles_to_catalog_requests.py
@@ -1,0 +1,36 @@
+"""Add localized_titles column to catalog_requests.
+
+Stores a per-language title snapshot (``{lang: title}``) resolved once
+from TMDB when a request is first created, so the "Em breve" feed and
+admin queue can render titles in the viewer's language with English
+fallback. Backfilled on the next request creation/reconcile; existing
+rows stay ``NULL`` and fall back to the plain ``title`` snapshot.
+
+Plain ``add_column`` (additive) — no table recreate; ``catalog_requests``
+is not part of the FTS5 index, so there are no search triggers to rebuild.
+
+Revision ID: c4a9e7b1d6f3
+Revises: b6e4d2a8f1c7
+Create Date: 2026-06-26 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c4a9e7b1d6f3"
+down_revision: str | Sequence[str] | None = "b6e4d2a8f1c7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the ``localized_titles`` column to ``catalog_requests``."""
+    op.add_column("catalog_requests", sa.Column("localized_titles", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the ``localized_titles`` column from ``catalog_requests``."""
+    op.drop_column("catalog_requests", "localized_titles")

--- a/src/config/containers/catalog_requests.py
+++ b/src/config/containers/catalog_requests.py
@@ -36,6 +36,11 @@ class CatalogRequestsContainer(containers.DeclarativeContainer):  # type: ignore
     # on the manual "mark as included" action (ADR-022 / ADR-009).
     notification_publisher = providers.Dependency()
 
+    # Cross-BC title provider (Media BC / TMDB) — resolves the
+    # per-language title snapshot at request-creation time. Wired at
+    # the composition root so this BC takes no Media dependency.
+    localized_title_provider = providers.Dependency()
+
     # =========================================================================
     # Unit of Work
     # =========================================================================
@@ -61,11 +66,13 @@ class CatalogRequestsContainer(containers.DeclarativeContainer):  # type: ignore
     request_catalog_inclusion = providers.Factory(
         RequestCatalogInclusionUseCase,
         uow_factory=catalog_requests_unit_of_work_factory,
+        localized_title_provider=localized_title_provider,
     )
 
     subscribe_catalog_notification = providers.Factory(
         SubscribeCatalogNotificationUseCase,
         uow_factory=catalog_requests_unit_of_work_factory,
+        localized_title_provider=localized_title_provider,
     )
 
     unsubscribe_catalog_notification = providers.Factory(

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -39,7 +39,9 @@ from src.modules.media.infrastructure.acl import (
     LibraryHealthAdapter,
     ProfileLibraryAccessAdapter,
     ProgressLookupAdapter,
+    TmdbLocalizedTitleAdapter,
 )
+from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
 from src.modules.media.infrastructure.scheduling.scheduler_controller import (
     LibraryScanSchedulerController,
 )
@@ -170,6 +172,22 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         session_factory=infrastructure.session_factory,
     )
 
+    # Cross-BC title provider for Catalog Requests: built here (not in
+    # MediaContainer) because Catalog Requests is composed before Media
+    # — wiring it through the Media container would invert the build
+    # order. A dedicated TMDB client keeps this independent of the
+    # Media container's own ``tmdb_client``.
+    _catalog_request_tmdb_client = providers.Singleton(
+        TmdbClient,
+        api_key=config.provided.tmdb_api_key,
+        supported_locales=config.provided.supported_locales,
+    )
+
+    _localized_title_provider_adapter = providers.Singleton(
+        TmdbLocalizedTitleAdapter,
+        tmdb_client=_catalog_request_tmdb_client,
+    )
+
     # Catalog Requests is built before Media so its ACL adapter can be
     # plumbed into the Media container as the ``CatalogRequestLookupPort``
     # implementation. Catalog Requests itself takes no Media dependency,
@@ -178,6 +196,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         CatalogRequestsContainer,
         session_factory=infrastructure.session_factory,
         notification_publisher=notifications.notification_publisher,
+        localized_title_provider=_localized_title_provider_adapter,
     )
 
     media = providers.Container(

--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -125,13 +125,21 @@ class CatalogRequestOutput:
     fulfilled_at: str | None
 
     @classmethod
-    def from_entity(cls, entity: CatalogRequest) -> CatalogRequestOutput:
-        """Build the DTO from a domain ``CatalogRequest`` aggregate."""
+    def from_entity(cls, entity: CatalogRequest, lang: str | None = None) -> CatalogRequestOutput:
+        """Build the DTO from a domain ``CatalogRequest`` aggregate.
+
+        Args:
+            entity: The request aggregate to serialize.
+            lang: When given, the title is resolved in that language via
+                the per-language snapshot (``get_title``); when ``None``
+                the raw ``title`` snapshot is returned as-is (the create
+                response echoes back what the client sent).
+        """
         return cls(
             id=str(entity.id),
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
-            title=entity.title,
+            title=entity.get_title(lang) if lang is not None else entity.title,
             poster_url=entity.poster_url,
             requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,

--- a/src/modules/catalog_requests/application/ports/__init__.py
+++ b/src/modules/catalog_requests/application/ports/__init__.py
@@ -1,8 +1,15 @@
 """Cross-BC ports owned by the Catalog Requests application layer."""
 
+from src.modules.catalog_requests.application.ports.localized_title_provider_port import (
+    LocalizedTitleProviderPort,
+)
 from src.modules.catalog_requests.application.ports.notification_publisher_port import (
     CatalogArrivalNotification,
     NotificationPublisherPort,
 )
 
-__all__ = ["CatalogArrivalNotification", "NotificationPublisherPort"]
+__all__ = [
+    "CatalogArrivalNotification",
+    "LocalizedTitleProviderPort",
+    "NotificationPublisherPort",
+]

--- a/src/modules/catalog_requests/application/ports/localized_title_provider_port.py
+++ b/src/modules/catalog_requests/application/ports/localized_title_provider_port.py
@@ -1,0 +1,34 @@
+"""Port for resolving per-language TMDB titles (cross-BC, ADR-009).
+
+Catalog Requests needs the localized title of a TMDB entry that is not
+yet in the local catalog, so it can snapshot every supported language
+at request-creation time. The capability lives in the Media BC (it owns
+the TMDB client); this port is the seam the Media adapter implements.
+"""
+
+from abc import ABC, abstractmethod
+
+from src.shared_kernel.value_objects import MediaType
+
+
+class LocalizedTitleProviderPort(ABC):
+    """Resolves ``{lang: title}`` for a TMDB id across supported locales."""
+
+    @abstractmethod
+    async def get_titles(self, tmdb_id: int, media_type: MediaType) -> dict[str, str]:
+        """Return per-language titles for the TMDB entry.
+
+        Args:
+            tmdb_id: TMDB numeric id of the title.
+            media_type: Whether the id refers to a movie or a series.
+
+        Returns:
+            A ``{bcp47_tag: title}`` mapping covering the configured
+            supported locales that have a TMDB translation. Best-effort:
+            an empty dict on any provider/network failure so request
+            creation never fails on a flaky TMDB.
+        """
+        raise NotImplementedError
+
+
+__all__ = ["LocalizedTitleProviderPort"]

--- a/src/modules/catalog_requests/application/use_cases/_localized_title_helpers.py
+++ b/src/modules/catalog_requests/application/use_cases/_localized_title_helpers.py
@@ -1,0 +1,36 @@
+"""Shared best-effort fetch of a TMDB per-language title snapshot.
+
+Both request-creation entry points ("Solicitar inclusão" and "Avisar
+quando chegar") snapshot the localized title once at creation. The fetch
+is best-effort: a TMDB/network failure must never fail the user action,
+so it degrades to an empty mapping and the entity falls back to the
+plain ``title`` snapshot.
+"""
+
+import logging
+
+from src.modules.catalog_requests.application.ports import LocalizedTitleProviderPort
+from src.shared_kernel.value_objects import MediaType
+
+_logger = logging.getLogger(__name__)
+
+
+async def resolve_localized_titles(
+    provider: LocalizedTitleProviderPort,
+    tmdb_id: int,
+    media_type: MediaType,
+) -> dict[str, str]:
+    """Return ``{lang: title}`` from TMDB, or ``{}`` on any failure."""
+    try:
+        return await provider.get_titles(tmdb_id, media_type)
+    except Exception:  # title localization is best-effort — never fail the action
+        _logger.warning(
+            "Localized title fetch failed for tmdb/%s/%s; falling back to snapshot",
+            media_type.value,
+            tmdb_id,
+            exc_info=True,
+        )
+        return {}
+
+
+__all__ = ["resolve_localized_titles"]

--- a/src/modules/catalog_requests/application/use_cases/list_admin_catalog_requests.py
+++ b/src/modules/catalog_requests/application/use_cases/list_admin_catalog_requests.py
@@ -27,8 +27,12 @@ class ListAdminCatalogRequestsUseCase:
         """
         self._uow_factory = uow_factory
 
-    async def execute(self) -> list[AdminCatalogRequestItem]:
-        """Return every pending request annotated with its subscriber count."""
+    async def execute(self, lang: str = "en") -> list[AdminCatalogRequestItem]:
+        """Return every pending request annotated with its subscriber count.
+
+        Args:
+            lang: Language for the per-request localized title snapshot.
+        """
         async with self._uow_factory() as uow:
             pending = await uow.catalog_requests.list_pending(None)
             request_ids = [r.id for r in pending if r.id is not None]
@@ -36,7 +40,7 @@ class ListAdminCatalogRequestsUseCase:
 
         return [
             AdminCatalogRequestItem(
-                request=CatalogRequestOutput.from_entity(request),
+                request=CatalogRequestOutput.from_entity(request, lang),
                 subscriber_count=counts.get(request.id, 0),
             )
             for request in pending

--- a/src/modules/catalog_requests/application/use_cases/list_catalog_request_feed.py
+++ b/src/modules/catalog_requests/application/use_cases/list_catalog_request_feed.py
@@ -24,6 +24,7 @@ class ListCatalogRequestFeedInput:
 
     user_id: str
     collection_tmdb_id: int | None = None
+    lang: str = "en"
 
 
 class ListCatalogRequestFeedUseCase:
@@ -66,7 +67,7 @@ class ListCatalogRequestFeedUseCase:
 
         return [
             CatalogRequestFeedItem(
-                request=CatalogRequestOutput.from_entity(request),
+                request=CatalogRequestOutput.from_entity(request, input_dto.lang),
                 subscriber_count=counts.get(request.id, 0),
                 is_subscribed=request.id in subscribed,
             )

--- a/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
+++ b/src/modules/catalog_requests/application/use_cases/request_catalog_inclusion.py
@@ -4,8 +4,12 @@ from src.modules.catalog_requests.application.dtos import (
     CatalogRequestOutput,
     CreateCatalogRequestInput,
 )
+from src.modules.catalog_requests.application.ports import LocalizedTitleProviderPort
 from src.modules.catalog_requests.application.unit_of_work import (
     CatalogRequestsUnitOfWorkFactory,
+)
+from src.modules.catalog_requests.application.use_cases._localized_title_helpers import (
+    resolve_localized_titles,
 )
 from src.modules.catalog_requests.domain.entities import CatalogRequest
 
@@ -36,17 +40,31 @@ class RequestCatalogInclusionUseCase:
         348
     """
 
-    def __init__(self, uow_factory: CatalogRequestsUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: CatalogRequestsUnitOfWorkFactory,
+        localized_title_provider: LocalizedTitleProviderPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh catalog-requests
                 Unit of Work.
+            localized_title_provider: Cross-BC port that resolves the
+                per-language TMDB title snapshot at creation time.
         """
         self._uow_factory = uow_factory
+        self._titles = localized_title_provider
 
     async def execute(self, input_dto: CreateCatalogRequestInput) -> CatalogRequestOutput:
         """Execute the use case.
+
+        Resolves the per-language title snapshot from TMDB **outside**
+        the write transaction (a single ``/translations`` round-trip),
+        so the DB write never holds a lock open during network I/O. The
+        existence check runs twice — once to decide whether a fetch is
+        even needed, once inside the write transaction to stay
+        idempotent on ``(tmdb_id, media_type)``.
 
         Args:
             input_dto: Carries the TMDB target plus optional
@@ -61,6 +79,21 @@ class RequestCatalogInclusionUseCase:
                 input_dto.tmdb_id,
                 input_dto.media_type,
             )
+
+        # Only pay the TMDB round-trip when there's no localized snapshot
+        # yet (new request, or a legacy row that predates this column).
+        need_titles = existing is None or not existing.localized_titles
+        localized_titles = (
+            await resolve_localized_titles(self._titles, input_dto.tmdb_id, input_dto.media_type)
+            if need_titles
+            else {}
+        )
+
+        async with self._uow_factory() as uow:
+            existing = await uow.catalog_requests.find_by_tmdb_id(
+                input_dto.tmdb_id,
+                input_dto.media_type,
+            )
             if existing is not None:
                 # Repeat submit: let the aggregate fold in the new data
                 # (first-owner-wins backfill + one-way notify opt-in).
@@ -70,6 +103,7 @@ class RequestCatalogInclusionUseCase:
                     poster_url=input_dto.poster_url,
                     requester_user_id=input_dto.requester_user_id,
                     notify=input_dto.notify_on_arrival,
+                    localized_titles=localized_titles,
                 )
                 if reconciled is None:
                     return CatalogRequestOutput.from_entity(existing)
@@ -84,6 +118,7 @@ class RequestCatalogInclusionUseCase:
                 requester_user_id=input_dto.requester_user_id,
                 collection_tmdb_id=input_dto.collection_tmdb_id,
                 notify_on_arrival=input_dto.notify_on_arrival,
+                localized_titles=localized_titles,
             )
             persisted = await uow.catalog_requests.add(request)
             return CatalogRequestOutput.from_entity(persisted)

--- a/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
+++ b/src/modules/catalog_requests/application/use_cases/subscribe_catalog_notification.py
@@ -4,9 +4,13 @@ from src.modules.catalog_requests.application.dtos import (
     CatalogRequestOutput,
     SubscribeCatalogNotificationInput,
 )
+from src.modules.catalog_requests.application.ports import LocalizedTitleProviderPort
 from src.modules.catalog_requests.application.unit_of_work import (
     CatalogRequestsUnitOfWork,
     CatalogRequestsUnitOfWorkFactory,
+)
+from src.modules.catalog_requests.application.use_cases._localized_title_helpers import (
+    resolve_localized_titles,
 )
 from src.modules.catalog_requests.domain.entities import (
     CatalogRequest,
@@ -39,14 +43,21 @@ class SubscribeCatalogNotificationUseCase:
         True
     """
 
-    def __init__(self, uow_factory: CatalogRequestsUnitOfWorkFactory) -> None:
+    def __init__(
+        self,
+        uow_factory: CatalogRequestsUnitOfWorkFactory,
+        localized_title_provider: LocalizedTitleProviderPort,
+    ) -> None:
         """Initialize the use case.
 
         Args:
             uow_factory: Factory that opens a fresh catalog-requests
                 Unit of Work.
+            localized_title_provider: Cross-BC port that resolves the
+                per-language TMDB title snapshot at creation time.
         """
         self._uow_factory = uow_factory
+        self._titles = localized_title_provider
 
     async def execute(
         self,
@@ -54,9 +65,27 @@ class SubscribeCatalogNotificationUseCase:
     ) -> CatalogRequestOutput:
         """Execute the use case.
 
+        Like "Solicitar inclusão", the per-language title snapshot is
+        resolved from TMDB **outside** the write transaction when the
+        request is first created (or lacks one), so the DB write never
+        holds a lock open during network I/O.
+
         Returns:
             The persisted request with ``notify_on_arrival=True``.
         """
+        async with self._uow_factory() as uow:
+            existing = await uow.catalog_requests.find_by_tmdb_id(
+                input_dto.tmdb_id,
+                input_dto.media_type,
+            )
+
+        need_titles = existing is None or not existing.localized_titles
+        localized_titles = (
+            await resolve_localized_titles(self._titles, input_dto.tmdb_id, input_dto.media_type)
+            if need_titles
+            else {}
+        )
+
         async with self._uow_factory() as uow:
             existing = await uow.catalog_requests.find_by_tmdb_id(
                 input_dto.tmdb_id,
@@ -70,6 +99,7 @@ class SubscribeCatalogNotificationUseCase:
                     poster_url=input_dto.poster_url,
                     requester_user_id=input_dto.requester_user_id,
                     notify=True,
+                    localized_titles=localized_titles,
                 )
                 request = (
                     existing
@@ -86,6 +116,7 @@ class SubscribeCatalogNotificationUseCase:
                         requester_user_id=input_dto.requester_user_id,
                         collection_tmdb_id=input_dto.collection_tmdb_id,
                         notify_on_arrival=True,
+                        localized_titles=localized_titles,
                     ),
                 )
 

--- a/src/modules/catalog_requests/domain/entities/catalog_request.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_request.py
@@ -76,6 +76,11 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
     tmdb_id: int
     media_type: MediaType
     title: str | None = None
+    # Per-language title snapshot built once at request creation from
+    # TMDB (``{lang: title}``). ``get_title(lang)`` reads this so the
+    # "Em breve" feed renders in the viewer's language; falls back to
+    # the English snapshot / ``title`` when a locale is missing.
+    localized_titles: dict[str, str] = Field(default_factory=dict)
     poster_url: str | None = None
     requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
@@ -94,6 +99,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         requester_user_id: str | None = None,
         collection_tmdb_id: int | None = None,
         notify_on_arrival: bool = False,
+        localized_titles: dict[str, str] | None = None,
     ) -> CatalogRequest:
         """Factory method with automatic ID generation.
 
@@ -105,6 +111,10 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
                 (older clients, programmatic ingest), the field stays
                 ``None`` and the admin queue falls back to the bare
                 ``tmdb/<id>`` link.
+            localized_titles: Per-language title snapshot ``{lang:
+                title}`` resolved once from TMDB at creation. Empty
+                when TMDB was unreachable; ``get_title`` then falls
+                back to ``title``.
             poster_url: Snapshot of the TMDB poster URL at request
                 time, for the "Em breve" grid. ``None`` when unknown.
             requester_user_id: External id (``usr_xxx``) of the user
@@ -124,6 +134,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
             tmdb_id=tmdb_id,
             media_type=media_type,
             title=title,
+            localized_titles=localized_titles or {},
             poster_url=poster_url,
             requester_user_id=requester_user_id,
             collection_tmdb_id=collection_tmdb_id,
@@ -132,6 +143,15 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
             requested_at=datetime.now(UTC),
             fulfilled_at=None,
         )
+
+    def get_title(self, lang: str = "en") -> str | None:
+        """Title in the requested language, falling back to the snapshot.
+
+        Resolution order: the requested locale's TMDB snapshot, then
+        the English snapshot, then the raw ``title`` the client sent at
+        request time (or ``None`` for legacy/programmatic rows).
+        """
+        return self.localized_titles.get(lang) or self.localized_titles.get("en") or self.title
 
     @property
     def is_fulfilled(self) -> bool:
@@ -172,6 +192,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         poster_url: str | None = None,
         requester_user_id: str | None = None,
         notify: bool = False,
+        localized_titles: dict[str, str] | None = None,
     ) -> CatalogRequest | None:
         """Fold a repeat request's data into this existing one.
 
@@ -194,6 +215,9 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
                 request.
             notify: Whether this entry point wants the arrival
                 notification enabled.
+            localized_titles: Per-language title snapshot to backfill
+                when the existing row has none yet (first-owner-wins,
+                same as ``title``).
 
         Returns:
             A new instance with the merged changes, or ``None`` when the
@@ -203,6 +227,8 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         updates: dict[str, object] = {}
         if self.title is None and title:
             updates["title"] = title
+        if not self.localized_titles and localized_titles:
+            updates["localized_titles"] = localized_titles
         if self.poster_url is None and poster_url:
             updates["poster_url"] = poster_url
         if self.requester_user_id is None and requester_user_id:

--- a/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
@@ -1,5 +1,7 @@
 """Mapper between ``CatalogRequest`` entity and ``CatalogRequestModel``."""
 
+import json
+
 from src.modules.catalog_requests.domain.entities import CatalogRequest
 from src.modules.catalog_requests.domain.value_objects import (
     CatalogRequestId,
@@ -41,6 +43,9 @@ class CatalogRequestMapper:
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
             title=entity.title,
+            localized_titles=json.dumps(entity.localized_titles, ensure_ascii=False)
+            if entity.localized_titles
+            else None,
             poster_url=entity.poster_url,
             requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
@@ -58,6 +63,7 @@ class CatalogRequestMapper:
             tmdb_id=model.tmdb_id,
             media_type=MediaType(model.media_type),
             title=model.title,
+            localized_titles=json.loads(model.localized_titles) if model.localized_titles else {},
             poster_url=model.poster_url,
             requester_user_id=model.requester_user_id,
             collection_tmdb_id=model.collection_tmdb_id,
@@ -85,6 +91,11 @@ class CatalogRequestMapper:
         recipient on legacy rows.
         """
         model.title = entity.title
+        model.localized_titles = (
+            json.dumps(entity.localized_titles, ensure_ascii=False)
+            if entity.localized_titles
+            else None
+        )
         model.poster_url = entity.poster_url
         model.requester_user_id = entity.requester_user_id
         model.collection_tmdb_id = entity.collection_tmdb_id

--- a/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/models/catalog_request_model.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Integer, String
+from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src.infrastructure.persistence.base import Base
@@ -47,6 +47,9 @@ class CatalogRequestModel(Base):
     tmdb_id: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
     media_type: Mapped[str] = mapped_column(String(20), nullable=False)
     title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # Per-language title snapshot as a JSON object (``{lang: title}``),
+    # resolved from TMDB once at creation. Null on legacy rows.
+    localized_titles: Mapped[str | None] = mapped_column(Text, nullable=True)
     poster_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     requester_user_id: Mapped[str | None] = mapped_column(
         String(50),

--- a/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
@@ -26,6 +26,7 @@ router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Catalog Requests"])
 @router.get("/catalog-requests")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_admin_catalog_requests(
+    lang: str = "en",
     _admin: UserModel = Depends(current_admin_user),
     use_case: ListAdminCatalogRequestsUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.list_admin_catalog_requests],
@@ -36,8 +37,9 @@ async def list_admin_catalog_requests(
     Admin-only queue: each row carries the base request fields
     (including ``source`` + derived ``status``) plus ``subscriber_count``
     (the "Inscritos" column). Admin-gated via ``current_admin_user``.
+    ``lang`` selects the per-request localized title snapshot.
     """
-    items = await use_case.execute()
+    items = await use_case.execute(lang)
     return api_list(
         [{**asdict(item.request), "subscriber_count": item.subscriber_count} for item in items],
     )

--- a/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
@@ -170,6 +170,7 @@ async def unsubscribe_catalog_notification(
 @inject  # type: ignore[misc]
 async def list_catalog_requests(
     collection_tmdb_id: int | None = Query(default=None, ge=1),
+    lang: str = "en",
     user: UserModel = Depends(current_active_user),
     use_case: ListCatalogRequestFeedUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.list_catalog_request_feed],
@@ -179,12 +180,14 @@ async def list_catalog_requests(
 
     Each item carries the base request fields plus ``subscriber_count``
     and the caller's ``is_subscribed`` flag (ADR-022). Optionally
-    scoped to a single franchise via ``collection_tmdb_id``.
+    scoped to a single franchise via ``collection_tmdb_id``. ``lang``
+    selects the per-request localized title snapshot.
     """
     items = await use_case.execute(
         ListCatalogRequestFeedInput(
             user_id=user.external_id,
             collection_tmdb_id=collection_tmdb_id,
+            lang=lang,
         ),
     )
     return api_list(

--- a/src/modules/media/infrastructure/acl/__init__.py
+++ b/src/modules/media/infrastructure/acl/__init__.py
@@ -3,6 +3,9 @@
 from src.modules.media.infrastructure.acl.library_health_adapter import (
     LibraryHealthAdapter,
 )
+from src.modules.media.infrastructure.acl.localized_title_provider_adapter import (
+    TmdbLocalizedTitleAdapter,
+)
 from src.modules.media.infrastructure.acl.profile_library_access_adapter import (
     ProfileLibraryAccessAdapter,
 )
@@ -14,4 +17,5 @@ __all__ = [
     "LibraryHealthAdapter",
     "ProfileLibraryAccessAdapter",
     "ProgressLookupAdapter",
+    "TmdbLocalizedTitleAdapter",
 ]

--- a/src/modules/media/infrastructure/acl/localized_title_provider_adapter.py
+++ b/src/modules/media/infrastructure/acl/localized_title_provider_adapter.py
@@ -1,0 +1,33 @@
+"""ACL adapter exposing TMDB localized titles to the Catalog Requests BC.
+
+Catalog Requests owns ``LocalizedTitleProviderPort`` (it needs the title
+of a not-yet-in-catalog TMDB entry in every supported language). The
+capability lives here in Media, which owns the TMDB client — so this
+provider-side adapter implements that port (ADR-009), mirroring how
+``CatalogRequestLookupAdapter`` implements Media's port from the other
+side.
+"""
+
+from src.modules.catalog_requests.application.ports import LocalizedTitleProviderPort
+from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
+from src.shared_kernel.value_objects import MediaType
+
+
+class TmdbLocalizedTitleAdapter(LocalizedTitleProviderPort):
+    """Resolves per-language TMDB titles via the Media TMDB client."""
+
+    def __init__(self, tmdb_client: TmdbClient) -> None:
+        """Initialize the adapter.
+
+        Args:
+            tmdb_client: The Media TMDB client used to fetch the
+                ``/translations`` payload.
+        """
+        self._tmdb = tmdb_client
+
+    async def get_titles(self, tmdb_id: int, media_type: MediaType) -> dict[str, str]:
+        """Return ``{lang: title}`` for the configured supported locales."""
+        return await self._tmdb.get_translated_titles(tmdb_id, media_type)
+
+
+__all__ = ["TmdbLocalizedTitleAdapter"]

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -22,6 +22,7 @@ from src.modules.media.application.ports import (
     SeasonMetadata,
 )
 from src.modules.media.domain.value_objects import ContentRating
+from src.shared_kernel.value_objects import MediaType
 
 _MAX_CAST = 15
 
@@ -57,6 +58,35 @@ def _episode_payload_by_number(
     return None
 
 
+def _pick_translation_title(
+    translations: list[dict[str, Any]], locale: str, title_key: str
+) -> str | None:
+    """Pick a title from a TMDB ``/translations`` payload for a BCP-47 locale.
+
+    Prefers an exact language+region match (``pt`` + ``BR`` for
+    ``pt-BR``), then falls back to the first entry sharing the base
+    language. Returns ``None`` when the locale has no usable title.
+    """
+    parts = locale.split("-", 1)
+    lang = parts[0].lower()
+    region = parts[1].upper() if len(parts) > 1 else None
+
+    base: str | None = None
+    for tr in translations:
+        if not isinstance(tr, dict):
+            continue
+        if str(tr.get("iso_639_1", "")).lower() != lang:
+            continue
+        title = (tr.get("data") or {}).get(title_key)
+        if not isinstance(title, str) or not title:
+            continue
+        if region and str(tr.get("iso_3166_1", "")).upper() == region:
+            return title
+        if base is None:
+            base = title
+    return base
+
+
 class TmdbClient(MetadataProvider):
     """The Movie Database (TMDB) API client.
 
@@ -87,6 +117,7 @@ class TmdbClient(MetadataProvider):
         self._api_key = api_key
         self._base_url = base_url
         self._client = httpx.AsyncClient(timeout=30.0)
+        self._supported_locales = list(supported_locales)
         # English is the base metadata, so it never appears as an
         # overlay. Everything else becomes one extra details fetch.
         self._localized_locales = [
@@ -703,6 +734,35 @@ class TmdbClient(MetadataProvider):
                 localized[locale] = fields
 
         return replace(en_meta, localized=localized)
+
+    async def get_translated_titles(self, tmdb_id: int, media_type: MediaType) -> dict[str, str]:
+        """Resolve per-locale titles for the configured supported locales.
+
+        One ``/translations`` round-trip; maps each supported BCP-47 tag
+        to its TMDB-translated title (e.g. ``{"en": ..., "pt-BR": ...}``).
+        Locales with no translation are omitted. Best-effort: returns
+        ``{}`` on any HTTP/parse failure so callers fall back to their
+        own snapshot.
+        """
+        path = "movie" if media_type == MediaType.MOVIE else "tv"
+        title_key = "title" if media_type == MediaType.MOVIE else "name"
+        try:
+            resp = await self._client.get(
+                f"{self._base_url}/{path}/{tmdb_id}/translations",
+                params=self._params(),
+            )
+        except httpx.HTTPError:
+            return {}
+        if resp.status_code != 200:
+            return {}
+
+        translations = resp.json().get("translations", [])
+        titles: dict[str, str] = {}
+        for locale in self._supported_locales:
+            title = _pick_translation_title(translations, locale, title_key)
+            if title:
+                titles[locale] = title
+        return titles
 
     async def _fetch_series_localized_fields(
         self, tmdb_id: int, locale: str

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_request_catalog_inclusion.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_request_catalog_inclusion.py
@@ -12,6 +12,7 @@ from src.modules.catalog_requests.domain.entities import CatalogRequest
 from src.shared_kernel.value_objects import MediaType
 from tests.modules.catalog_requests.unit.conftest import (
     make_catalog_requests_uow_mock,
+    make_fake_title_provider,
 )
 
 
@@ -25,7 +26,10 @@ class TestRequestCatalogInclusionUseCase:
         mocks.catalog_requests.find_by_tmdb_id.return_value = None
         # ``add`` returns the persisted aggregate.
         mocks.catalog_requests.add.side_effect = lambda req: req
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -50,7 +54,10 @@ class TestRequestCatalogInclusionUseCase:
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -72,7 +79,10 @@ class TestRequestCatalogInclusionUseCase:
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -90,7 +100,10 @@ class TestRequestCatalogInclusionUseCase:
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = None
         mocks.catalog_requests.add.side_effect = lambda req: req
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -114,7 +127,10 @@ class TestRequestCatalogInclusionUseCase:
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -138,7 +154,10 @@ class TestRequestCatalogInclusionUseCase:
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -155,7 +174,10 @@ class TestRequestCatalogInclusionUseCase:
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = None
         mocks.catalog_requests.add.side_effect = lambda req: req
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -179,7 +201,10 @@ class TestRequestCatalogInclusionUseCase:
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -204,7 +229,10 @@ class TestRequestCatalogInclusionUseCase:
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
-        use_case = RequestCatalogInclusionUseCase(uow_factory=mocks.factory)
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             CreateCatalogRequestInput(
@@ -216,3 +244,71 @@ class TestRequestCatalogInclusionUseCase:
 
         assert result.requester_user_id == "usr_alice"
         mocks.catalog_requests.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_populates_localized_titles_on_new_request(self) -> None:
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = None
+        mocks.catalog_requests.add.side_effect = lambda req: req
+        provider = make_fake_title_provider(
+            {"en": "Alien", "pt-BR": "Alien, o Oitavo Passageiro"},
+        )
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=provider,
+        )
+
+        await use_case.execute(
+            CreateCatalogRequestInput(tmdb_id=348, media_type=MediaType.MOVIE),
+        )
+
+        created = mocks.catalog_requests.add.call_args.args[0]
+        assert created.localized_titles == {
+            "en": "Alien",
+            "pt-BR": "Alien, o Oitavo Passageiro",
+        }
+        provider.get_titles.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_backfills_localized_titles_on_legacy_repeat(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            title="Alien",
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        mocks.catalog_requests.update.side_effect = lambda req: req
+        provider = make_fake_title_provider({"pt-BR": "Alien, o Oitavo Passageiro"})
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=provider,
+        )
+
+        await use_case.execute(
+            CreateCatalogRequestInput(tmdb_id=348, media_type=MediaType.MOVIE),
+        )
+
+        updated = mocks.catalog_requests.update.call_args.args[0]
+        assert updated.localized_titles == {"pt-BR": "Alien, o Oitavo Passageiro"}
+
+    @pytest.mark.asyncio
+    async def test_skips_title_fetch_when_already_localized(self) -> None:
+        existing = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            localized_titles={"pt-BR": "Alien, o Oitavo Passageiro"},
+        )
+        mocks = make_catalog_requests_uow_mock()
+        mocks.catalog_requests.find_by_tmdb_id.return_value = existing
+        provider = make_fake_title_provider({"pt-BR": "should-not-be-used"})
+        use_case = RequestCatalogInclusionUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=provider,
+        )
+
+        await use_case.execute(
+            CreateCatalogRequestInput(tmdb_id=348, media_type=MediaType.MOVIE),
+        )
+
+        provider.get_titles.assert_not_awaited()

--- a/tests/modules/catalog_requests/unit/application/use_cases/test_subscribe_catalog_notification.py
+++ b/tests/modules/catalog_requests/unit/application/use_cases/test_subscribe_catalog_notification.py
@@ -15,6 +15,7 @@ from src.modules.catalog_requests.domain.entities import (
 from src.shared_kernel.value_objects import MediaType
 from tests.modules.catalog_requests.unit.conftest import (
     make_catalog_requests_uow_mock,
+    make_fake_title_provider,
 )
 
 
@@ -27,7 +28,10 @@ class TestSubscribeCatalogNotificationUseCase:
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = None
         mocks.catalog_requests.add.side_effect = lambda req: req
-        use_case = SubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+        use_case = SubscribeCatalogNotificationUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             SubscribeCatalogNotificationInput(
@@ -49,7 +53,10 @@ class TestSubscribeCatalogNotificationUseCase:
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
-        use_case = SubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+        use_case = SubscribeCatalogNotificationUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             SubscribeCatalogNotificationInput(
@@ -70,7 +77,10 @@ class TestSubscribeCatalogNotificationUseCase:
         )
         mocks = make_catalog_requests_uow_mock()
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
-        use_case = SubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+        use_case = SubscribeCatalogNotificationUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         result = await use_case.execute(
             SubscribeCatalogNotificationInput(
@@ -95,7 +105,10 @@ class TestSubscribeCatalogNotificationUseCase:
         mocks.catalog_requests.find_by_tmdb_id.return_value = existing
         mocks.catalog_requests.update.side_effect = lambda req: req
         mocks.catalog_subscriptions.find.return_value = None
-        use_case = SubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+        use_case = SubscribeCatalogNotificationUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         await use_case.execute(
             SubscribeCatalogNotificationInput(
@@ -124,7 +137,10 @@ class TestSubscribeCatalogNotificationUseCase:
             existing.id,
             "usr_alice",
         )
-        use_case = SubscribeCatalogNotificationUseCase(uow_factory=mocks.factory)
+        use_case = SubscribeCatalogNotificationUseCase(
+            uow_factory=mocks.factory,
+            localized_title_provider=make_fake_title_provider(),
+        )
 
         await use_case.execute(
             SubscribeCatalogNotificationInput(

--- a/tests/modules/catalog_requests/unit/conftest.py
+++ b/tests/modules/catalog_requests/unit/conftest.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
+from src.modules.catalog_requests.application.ports import LocalizedTitleProviderPort
 from src.modules.catalog_requests.application.unit_of_work import (
     CatalogRequestsUnitOfWork,
     CatalogRequestsUnitOfWorkFactory,
@@ -11,6 +12,13 @@ from src.modules.catalog_requests.domain.repositories import (
     CatalogRequestRepository,
     CatalogSubscriptionRepository,
 )
+
+
+def make_fake_title_provider(titles: dict[str, str] | None = None) -> AsyncMock:
+    """Build a stub :class:`LocalizedTitleProviderPort` returning ``titles``."""
+    provider = AsyncMock(spec=LocalizedTitleProviderPort)
+    provider.get_titles.return_value = titles or {}
+    return provider
 
 
 @dataclass

--- a/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
+++ b/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
@@ -170,3 +170,35 @@ class TestCatalogRequest:
 
         # A later poster never overwrites the first snapshot.
         assert backfilled.reconcile(poster_url="https://img/other.jpg") is None
+
+    def test_get_title_prefers_locale_then_english_then_snapshot(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            title="Alien (snapshot)",
+            localized_titles={"en": "Alien", "pt-BR": "Alien, o Oitavo Passageiro"},
+        )
+
+        assert request.get_title("pt-BR") == "Alien, o Oitavo Passageiro"
+        assert request.get_title("en") == "Alien"
+        # Unknown locale falls back to the English snapshot.
+        assert request.get_title("es") == "Alien"
+
+    def test_get_title_falls_back_to_raw_snapshot_without_localized(self) -> None:
+        request = CatalogRequest.create(
+            tmdb_id=348,
+            media_type=MediaType.MOVIE,
+            title="Alien",
+        )
+
+        assert request.get_title("pt-BR") == "Alien"
+        assert request.get_title() == "Alien"
+
+    def test_reconcile_backfills_localized_titles_first_owner_wins(self) -> None:
+        without = CatalogRequest.create(tmdb_id=348, media_type=MediaType.MOVIE)
+        backfilled = without.reconcile(localized_titles={"pt-BR": "Alien, o Oitavo Passageiro"})
+
+        assert backfilled is not None
+        assert backfilled.localized_titles == {"pt-BR": "Alien, o Oitavo Passageiro"}
+        # A later snapshot never overwrites the first one.
+        assert backfilled.reconcile(localized_titles={"pt-BR": "Outro"}) is None

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -1,7 +1,7 @@
 """Tests for TmdbClient."""
 
 import itertools
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -12,6 +12,7 @@ from src.modules.media.infrastructure.metadata.tmdb_client import (
     TmdbClient,
     _safe_int,
 )
+from src.shared_kernel.value_objects import MediaType
 
 
 def _build_response(status_code: int = 200, json_data: dict[str, Any] | None = None) -> MagicMock:
@@ -1133,6 +1134,62 @@ class TestLocalizedSupportedLocales:
         assert result is not None
         assert set(result.localized) == {"pt-BR", "es-ES"}
         assert result.localized["es-ES"].synopsis == "ES"
+
+
+@pytest.mark.unit
+class TestGetTranslatedTitles:
+    """``get_translated_titles`` maps TMDB ``/translations`` to supported locales."""
+
+    _PAYLOAD: ClassVar[dict[str, Any]] = {
+        "translations": [
+            {"iso_639_1": "en", "iso_3166_1": "US", "data": {"title": "Alien", "name": "Alien"}},
+            {
+                "iso_639_1": "pt",
+                "iso_3166_1": "BR",
+                "data": {"title": "Alien, o Oitavo Passageiro", "name": "Alien BR"},
+            },
+            {
+                "iso_639_1": "pt",
+                "iso_3166_1": "PT",
+                "data": {"title": "Alien, o 8º Passageiro", "name": "Alien PT"},
+            },
+        ]
+    }
+
+    @pytest.mark.asyncio
+    async def test_movie_maps_supported_locales(self) -> None:
+        client = _make_client(get_responses=_build_response(json_data=self._PAYLOAD))
+
+        titles = await client.get_translated_titles(348, MediaType.MOVIE)
+
+        assert titles == {"en": "Alien", "pt-BR": "Alien, o Oitavo Passageiro"}
+
+    @pytest.mark.asyncio
+    async def test_series_uses_name_key(self) -> None:
+        client = _make_client(get_responses=_build_response(json_data=self._PAYLOAD))
+
+        titles = await client.get_translated_titles(1396, MediaType.SERIES)
+
+        assert titles == {"en": "Alien", "pt-BR": "Alien BR"}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_http_error(self) -> None:
+        client = _make_client(get_responses=_build_response(status_code=500))
+
+        assert await client.get_translated_titles(348, MediaType.MOVIE) == {}
+
+    @pytest.mark.asyncio
+    async def test_omits_locales_without_translation(self) -> None:
+        client = TmdbClient(api_key="test-key", supported_locales=("en", "pt-BR", "es-ES"))
+        mock_http = MagicMock()
+        mock_http.get = AsyncMock(return_value=_build_response(json_data=self._PAYLOAD))
+        client._client = mock_http
+
+        titles = await client.get_translated_titles(348, MediaType.MOVIE)
+
+        # No Spanish entry in the payload → es-ES is omitted.
+        assert "es-ES" not in titles
+        assert set(titles) == {"en", "pt-BR"}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- The "Em breve" feed and admin queue showed a single frozen title snapshot (whatever the first requester's client sent), never localized to the viewer. Now each catalog request **snapshots the TMDB title in every supported locale at creation** and serves it by the viewer's `lang` with English fallback.
- Why a creation-time snapshot (not a live serve-time lookup): the feed lists **pending** requests, which by definition aren't in the local catalog — so there's no local `Movie`/`Series` to resolve `get_title(lang)` from. The only localized source is TMDB, and fetching once at creation amortizes the cost (1 call per new request, not per feed load).
- New cross-BC `LocalizedTitleProviderPort` (owned by Catalog Requests) implemented by a Media `TmdbLocalizedTitleAdapter` over a new `TmdbClient.get_translated_titles` (one `/translations` round-trip, mapped to `supported_locales`). Wired at the composition root since Catalog Requests is built before Media (ADR-009).
- Both request entry points populate/backfill the snapshot: `request_catalog_inclusion` and `subscribe_catalog_notification`. The create flow is restructured into **two phases** so the TMDB call happens *outside* the write transaction (the DB write never holds a lock during network I/O). The fetch is best-effort — a TMDB failure degrades to the plain `title` snapshot, never failing the user action.
- `get_title(lang)` resolution: requested locale → English snapshot → raw `title`. The create response keeps echoing the client's raw snapshot (lang-less); the feed/admin serve paths pass `lang`.

## Migration

- `c4a9e7b1d6f3` adds a nullable `localized_titles` (`Text`/JSON) column to `catalog_requests`. Plain additive `add_column` (no table recreate; not in FTS5). **Requires `make migrate`.**
- Existing rows backfill on the next request/subscribe for that title; until then they fall back to the plain `title` snapshot.

## Test plan

- [x] `pytest tests/modules/catalog_requests tests/modules/media` — 1733 passed
- [x] New domain tests: `get_title` locale→en→snapshot fallback; `reconcile` first-owner-wins backfill of `localized_titles`
- [x] New TMDB tests: `get_translated_titles` maps locales, uses `name` for series, omits untranslated locales, `{}` on HTTP error
- [x] New use-case tests: create populates `localized_titles`; legacy repeat backfills; already-localized skips the fetch
- [x] Migration up/down verified on a scratch SQLite DB
- [x] DI composition verified (both use cases receive the TMDB title adapter)
- [x] `ruff check` + `ruff format --check` clean; no new `mypy` errors in changed files
- [ ] Manual smoke: request a not-yet-in-catalog title and confirm the "Em breve" feed shows it in pt-BR