### PR TITLE
feat(media): order genre/actor listings by localized title

### DIFF
--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -128,6 +128,7 @@ class ListByGenreUseCase:
             decoded=decoded,
             limit=input_dto.limit,
             media_type=input_dto.media_type,
+            lang=input_dto.lang,
             allowed_library_ids=allowed,
         )
 
@@ -140,11 +141,17 @@ class ListByGenreUseCase:
             _MergedItem(kind=MediaType.SERIES, source_index=index, entity=item)
             for index, item in enumerate(series_page.items)
         ]
-        # Sort by (lowercase title, source index) — the source index
-        # tie-breaker matches the SQL `(LOWER(title), id) ASC` order
-        # within each stream and gives a stable cross-stream order
-        # when two rows share a title.
-        tagged.sort(key=lambda mi: (mi.entity.title.value.lower(), mi.source_index))
+        # Sort by (lowercase localized title, source index) — the source
+        # index tie-breaker matches the SQL
+        # `(LOWER(COALESCE(localized[lang].title, title)), id) ASC` order
+        # within each stream and gives a stable cross-stream order when
+        # two rows share a title.
+        tagged.sort(
+            key=lambda mi: (
+                (mi.entity.get_title(input_dto.lang) or "").lower(),
+                mi.source_index,
+            )
+        )
 
         page_items = tagged[: input_dto.limit]
 
@@ -190,6 +197,7 @@ class ListByGenreUseCase:
         decoded: DualCursorValue,
         limit: int,
         media_type: MediaType | None,
+        lang: str,
         allowed_library_ids: Sequence[LibraryId],
     ) -> tuple[PaginatedResult[Movie], PaginatedResult[Series]]:
         """Fetch the movie and series pages, honoring the media-type filter.
@@ -210,6 +218,7 @@ class ListByGenreUseCase:
                     genre=genre,
                     cursor=decoded.movies,
                     limit=limit,
+                    lang=lang,
                     allowed_library_ids=allowed_library_ids,
                 )
             return movies_page, _empty_page(Series)
@@ -219,6 +228,7 @@ class ListByGenreUseCase:
                     genre=genre,
                     cursor=decoded.series,
                     limit=limit,
+                    lang=lang,
                     allowed_library_ids=allowed_library_ids,
                 )
             return _empty_page(Movie), series_page
@@ -227,12 +237,14 @@ class ListByGenreUseCase:
                 genre=genre,
                 cursor=decoded.movies,
                 limit=limit,
+                lang=lang,
                 allowed_library_ids=allowed_library_ids,
             ),
             self._fetch_series_page(
                 genre=genre,
                 cursor=decoded.series,
                 limit=limit,
+                lang=lang,
                 allowed_library_ids=allowed_library_ids,
             ),
         )
@@ -243,6 +255,7 @@ class ListByGenreUseCase:
         genre: Genre,
         cursor: str | None,
         limit: int,
+        lang: str,
         allowed_library_ids: Sequence[LibraryId],
     ) -> PaginatedResult[Movie]:
         async with self._uow_factory() as uow:
@@ -250,6 +263,7 @@ class ListByGenreUseCase:
                 genre=genre,
                 cursor=cursor,
                 limit=limit,
+                lang=lang,
                 allowed_library_ids=allowed_library_ids,
             )
 
@@ -259,6 +273,7 @@ class ListByGenreUseCase:
         genre: Genre,
         cursor: str | None,
         limit: int,
+        lang: str,
         allowed_library_ids: Sequence[LibraryId],
     ) -> PaginatedResult[Series]:
         async with self._uow_factory() as uow:
@@ -266,6 +281,7 @@ class ListByGenreUseCase:
                 genre=genre,
                 cursor=cursor,
                 limit=limit,
+                lang=lang,
                 allowed_library_ids=allowed_library_ids,
             )
 

--- a/src/modules/media/application/use_cases/list_movies_by_actor.py
+++ b/src/modules/media/application/use_cases/list_movies_by_actor.py
@@ -98,6 +98,7 @@ class ListMoviesByActorUseCase:
                 actor_name=input_dto.actor_name,
                 cursor=input_dto.cursor,
                 limit=input_dto.limit,
+                lang=input_dto.lang,
                 allowed_library_ids=allowed,
             )
 

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -245,14 +245,16 @@ class MovieRepository(ABC):
         cursor: str | None,
         limit: int,
         *,
+        lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies belonging to a specific genre, paginated.
 
-        Sorted by ``(LOWER(title) ASC, id ASC)`` so the catalog
-        carousel renders alphabetically. The cursor is a
-        ``(title, id)`` composite (see ``encode_title_cursor`` in the
-        pagination building block) — the ``id`` tie-breaker keeps
+        Sorted by ``(LOWER(COALESCE(localized[lang].title, title)) ASC,
+        id ASC)`` so the catalog carousel renders alphabetically in the
+        viewer's language (falling back to the canonical title). The
+        cursor is a ``(title, id)`` composite (see ``encode_title_cursor``
+        in the pagination building block) — the ``id`` tie-breaker keeps
         pagination stable when two rows share a title.
 
         The genre filter matches the canonical English genre name
@@ -269,6 +271,8 @@ class MovieRepository(ABC):
                 fall back to the first page.
             limit: Page size. The repository fetches ``limit + 1``
                 rows and trims the sentinel to detect ``has_more``.
+            lang: Language whose localized title drives the sort order
+                (falls back to the canonical ``title`` when absent).
             allowed_library_ids: Optional per-profile ACL filter. When
                 non-``None``, results are restricted to rows whose
                 ``library_id`` is in the supplied set. ``None``
@@ -290,14 +294,16 @@ class MovieRepository(ABC):
         cursor: str | None,
         limit: int,
         *,
+        lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies whose cast includes a member named ``actor_name``.
 
-        Sorted by ``(LOWER(title) ASC, id ASC)`` so the actor-page
-        carousel renders alphabetically. The cursor is a
-        ``(title, id)`` composite (see ``encode_title_cursor``) — same
-        contract as ``list_paginated_by_genre``.
+        Sorted by ``(LOWER(COALESCE(localized[lang].title, title)) ASC,
+        id ASC)`` so the actor-page carousel renders alphabetically in
+        the viewer's language. The cursor is a ``(title, id)`` composite
+        (see ``encode_title_cursor``) — same contract as
+        ``list_paginated_by_genre``.
 
         Match is by exact name. The local catalog has no actor id
         (TMDB person ids aren't persisted yet, see CLAUDE.md
@@ -314,6 +320,8 @@ class MovieRepository(ABC):
                 fall back to the first page.
             limit: Page size. Implementations fetch ``limit + 1`` rows
                 to detect ``has_more`` cheaply.
+            lang: Language whose localized title drives the sort order
+                (falls back to the canonical ``title`` when absent).
             allowed_library_ids: Optional per-profile ACL filter. When
                 non-``None``, results are restricted to rows whose
                 ``library_id`` is in the supplied set. ``None``

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -216,11 +216,13 @@ class SeriesRepository(ABC):
         cursor: str | None,
         limit: int,
         *,
+        lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Series]:
         """List series belonging to a specific genre, paginated.
 
-        Sorted by ``(LOWER(title) ASC, id ASC)``. Same contract as
+        Sorted by ``(LOWER(COALESCE(localized[lang].title, title)) ASC,
+        id ASC)``. Same contract as
         ``MovieRepository.list_paginated_by_genre`` — see that method
         for the full description of the cursor format and the genre
         filter (whole-word LIKE on the comma-separated ``genres``

--- a/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
@@ -20,6 +20,7 @@ the column format changes.
 """
 
 import json
+import re
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, TypeVar
 
@@ -50,6 +51,41 @@ def split_genres(raw: str | None) -> list[str]:
     if not raw:
         return []
     return [g.strip() for g in raw.split(",") if g.strip()]
+
+
+def localized_title_sort_key(model: Any, lang: str) -> Any:
+    """SQL sort key ``LOWER(COALESCE(localized[lang].title, title))``.
+
+    Orders a title listing by the localized title when the requested
+    language has one, falling back to the canonical (English base)
+    ``title`` column. ``lang`` is sanitized to ``[A-Za-z-]`` before
+    going into the JSON path; it binds as a parameter, so a stray
+    character can only yield a ``NULL`` extraction (→ fallback), never
+    SQL injection. SQLite-specific (``json_extract``) — consistent with
+    the FTS5 coupling already in the search path.
+    """
+    safe_lang = re.sub(r"[^A-Za-z-]", "", lang)
+    localized_title = func.json_extract(model.localized, f'$."{safe_lang}".title')
+    return func.lower(func.coalesce(localized_title, model.title))
+
+
+def localized_title_for(localized_json: str | None, base_title: str, lang: str) -> str:
+    """Python mirror of ``COALESCE(localized[lang].title, title)``.
+
+    Used to build the title cursor from a fetched row so the encoded
+    value matches the SQL ``ORDER BY`` key. Returns the localized title
+    when present and non-empty, otherwise ``base_title``.
+    """
+    if localized_json:
+        try:
+            data = json.loads(localized_json)
+        except (TypeError, ValueError):
+            data = None
+        if isinstance(data, dict):
+            block = data.get(lang)
+            if isinstance(block, dict) and block.get("title"):
+                return str(block["title"])
+    return base_title
 
 
 def localized_genres_for(localized_json: str | None, lang: str) -> list[str]:
@@ -125,6 +161,7 @@ async def fetch_genre_paginated_page(
     genre: Genre,
     cursor: str | None,
     limit: int,
+    lang: str = "en",
     allowed_library_ids: Sequence[LibraryId] | None = None,
 ) -> PaginatedResult[TEntity]:
     """Run one page of the title-sorted by-genre listing for ``model``.
@@ -153,6 +190,8 @@ async def fetch_genre_paginated_page(
             fall back to the first page.
         limit: Page size. The query fetches ``limit + 1`` rows and
             trims the sentinel.
+        lang: Language whose localized title drives the sort order
+            (falls back to the canonical ``title`` when absent).
         allowed_library_ids: Optional per-profile ACL filter. When
             non-``None``, rows are restricted to those whose
             ``library_id`` is in the supplied set. ``None`` (default)
@@ -169,7 +208,7 @@ async def fetch_genre_paginated_page(
     # "Action Adventure". The matching pattern wraps the genre value
     # the same way.
     delimited_genres = func.concat(",", func.coalesce(model.genres, ""), ",")
-    title_lower = func.lower(model.title)
+    title_lower = localized_title_sort_key(model, lang)
 
     stmt = (
         select(model)
@@ -209,7 +248,10 @@ async def fetch_genre_paginated_page(
     # Per-item cursor list — the catalog by-genre use case may
     # consume only a prefix of this page after merging with the
     # other media stream, so each item carries its own resume token.
-    item_cursors = [encode_title_cursor(row.title, row.id) for row in rows]
+    item_cursors = [
+        encode_title_cursor(localized_title_for(row.localized, row.title, lang), row.id)
+        for row in rows
+    ]
 
     next_cursor: str | None = None
     if has_more and rows:
@@ -227,5 +269,7 @@ __all__ = [
     "fetch_genre_paginated_page",
     "fetch_genre_rows",
     "localized_genres_for",
+    "localized_title_for",
+    "localized_title_sort_key",
     "split_genres",
 ]

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -35,6 +35,8 @@ from src.modules.media.infrastructure.persistence.models import (
 from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
     fetch_genre_paginated_page,
     fetch_genre_rows,
+    localized_title_for,
+    localized_title_sort_key,
 )
 from src.modules.media.infrastructure.persistence.repositories._path_prefix_helpers import (
     build_path_prefix_filters,
@@ -363,15 +365,16 @@ class SQLAlchemyMovieRepository(MovieRepository):
         cursor: str | None,
         limit: int,
         *,
+        lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies for a single genre, paginated and sorted by title.
 
         Delegates the SQL boilerplate (delimited LIKE filter,
-        ``LOWER(title)`` cursor, fetch N+1 trick, per-item cursor
-        population) to the shared ``fetch_genre_paginated_page``
-        helper so this method and its series counterpart can't drift
-        apart.
+        localized ``LOWER(COALESCE(localized[lang].title, title))``
+        cursor, fetch N+1 trick, per-item cursor population) to the
+        shared ``fetch_genre_paginated_page`` helper so this method and
+        its series counterpart can't drift apart.
         """
         return await fetch_genre_paginated_page(
             session=self._session,
@@ -381,6 +384,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
             genre=genre,
             cursor=cursor,
             limit=limit,
+            lang=lang,
             allowed_library_ids=allowed_library_ids,
         )
 
@@ -390,6 +394,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
         cursor: str | None,
         limit: int,
         *,
+        lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies whose ``cast`` JSON contains an entry for ``actor_name``.
@@ -425,7 +430,7 @@ class SQLAlchemyMovieRepository(MovieRepository):
         # of ``name_json``.
         needle_escaped = needle.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
-        title_lower = func.lower(MovieModel.title)
+        title_lower = localized_title_sort_key(MovieModel, lang)
 
         stmt = (
             select(MovieModel)
@@ -461,7 +466,10 @@ class SQLAlchemyMovieRepository(MovieRepository):
 
         next_cursor: str | None = None
         if has_more and rows:
-            next_cursor = encode_title_cursor(rows[-1].title, rows[-1].id)
+            next_cursor = encode_title_cursor(
+                localized_title_for(rows[-1].localized, rows[-1].title, lang),
+                rows[-1].id,
+            )
 
         return PaginatedResult(
             items=[MovieMapper.to_entity(m) for m in rows],

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -417,6 +417,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         cursor: str | None,
         limit: int,
         *,
+        lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Series]:
         """List series for a single genre, paginated and sorted by title.
@@ -436,6 +437,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             genre=genre,
             cursor=cursor,
             limit=limit,
+            lang=lang,
             allowed_library_ids=allowed_library_ids,
         )
 

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -1482,3 +1482,64 @@ class TestFindNeedsEnrichmentReview:
         result = await repo.find_needs_enrichment_review()
 
         assert result == []
+
+
+@pytest.mark.integration
+class TestLocalizedGenreOrdering:
+    """``list_paginated_by_genre`` orders by the localized title for ``lang``."""
+
+    async def test_orders_by_localized_title(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # English order: "Apple" < "Zebra".
+        # pt-BR order is the opposite: "Abelha" (Zebra) < "Zztop" (Apple).
+        zebra = _create_movie(
+            title="Zebra",
+            file_path="/movies/zebra.mkv",
+            genres=[Genre("Action")],
+            localized={"pt-BR": {"title": "Abelha"}},
+        )
+        apple = _create_movie(
+            title="Apple",
+            file_path="/movies/apple.mkv",
+            genres=[Genre("Action")],
+            localized={"pt-BR": {"title": "Zztop"}},
+        )
+        await repo.save(zebra)
+        await repo.save(apple)
+
+        en_page = await repo.list_paginated_by_genre(
+            Genre("Action"), cursor=None, limit=10, lang="en"
+        )
+        pt_page = await repo.list_paginated_by_genre(
+            Genre("Action"), cursor=None, limit=10, lang="pt-BR"
+        )
+
+        assert [m.title.value for m in en_page.items] == ["Apple", "Zebra"]
+        # pt-BR reverses the order via the localized titles.
+        assert [m.title.value for m in pt_page.items] == ["Zebra", "Apple"]
+
+    async def test_falls_back_to_base_title_when_locale_missing(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # Only one movie has a pt-BR title; the other falls back to base.
+        beta = _create_movie(
+            title="Beta",
+            file_path="/movies/beta.mkv",
+            genres=[Genre("Drama")],
+        )
+        alpha = _create_movie(
+            title="Zeta",
+            file_path="/movies/zeta.mkv",
+            genres=[Genre("Drama")],
+            localized={"pt-BR": {"title": "Alfa"}},
+        )
+        await repo.save(beta)
+        await repo.save(alpha)
+
+        pt_page = await repo.list_paginated_by_genre(
+            Genre("Drama"), cursor=None, limit=10, lang="pt-BR"
+        )
+
+        # "Alfa" (localized) < "Beta" (base fallback).
+        assert [m.title.value for m in pt_page.items] == ["Zeta", "Beta"]

--- a/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
@@ -83,6 +83,7 @@ class TestListMoviesByActorUseCase:
             actor_name="Sigourney Weaver",
             cursor=None,
             limit=20,
+            lang="en",
             allowed_library_ids=[_LIBRARY_ID],
         )
 
@@ -108,6 +109,7 @@ class TestListMoviesByActorUseCase:
             actor_name="Sigourney Weaver",
             cursor="abc123",
             limit=15,
+            lang="en",
             allowed_library_ids=[_LIBRARY_ID],
         )
 


### PR DESCRIPTION
## Summary

- Alphabetical catalog orderings sorted on the canonical English `title` column, so a pt-BR catalog rendered in English alphabetical order. The **by-genre** carousels and the **actor page** now order by `LOWER(COALESCE(localized[lang].title, title))` — the viewer's localized title with English fallback.
- New `localized_title_sort_key` SQL helper drives both the genre helper (`fetch_genre_paginated_page`, used by movie + series) and the movie cast-member query. Uses SQLite `json_extract`; `lang` is sanitized to `[A-Za-z-]` and bound as a parameter (a stray char can only yield a NULL extraction → fallback, never injection). Consistent with the existing SQLite/FTS5 coupling in the search path.
- The opaque `(title, id)` pagination cursor is preserved: a Python `localized_title_for` mirror builds the cursor value from the fetched row so it matches the SQL `ORDER BY` key exactly (same ASCII-lower contract the English path already used). No cursor-format change.
- `lang` is threaded from the use cases (`list_by_genre`, `list_movies_by_actor`) through the repository ports into the queries; the by-genre in-memory cross-stream merge now sorts by `get_title(lang)` too, so it stays in lockstep with the SQL order.
- No schema change (reads the existing `localized` JSON column).

## Notes

- Main catalog (`list_movies`/`list_series`) sorts by insertion order, search by relevance, recently-added by date — none are title-sorted, so they're unaffected (and correct as-is).
- The two `list_all()` admin helpers still sort by English title (internal, no `lang` in scope) — intentionally out of scope.

## Test plan

- [x] `pytest tests/modules/media` — 1662 passed
- [x] New integration tests: by-genre orders by pt-BR title (reverses an English-ascending pair); falls back to base title when a locale is missing
- [x] Updated actor-page unit tests for the new `lang` kwarg
- [x] `ruff check` + `ruff format --check` clean; no new `mypy` errors in changed files
- [ ] Manual smoke: open a genre carousel / actor page in pt-BR and confirm alphabetical order follows the pt-BR titles