### PR TITLE
docs(audits): architecture audit and remediation plan

### DIFF
--- a/docs/audits/00-executive-summary.md
+++ b/docs/audits/00-executive-summary.md
@@ -1,0 +1,179 @@
+# HomeFlix — Auditoria de Arquitetura (Sumário Executivo)
+
+**Data:** 2026-06-27 · **Modo:** READ-ONLY (nenhum código alterado, nenhum commit) · **Branch:** `develop`
+
+Auditoria multidimensional do backend, varrida **módulo a módulo** sobre os seis
+alvos solicitados — `media`, `library`, `watch_progress`, `collections`,
+`building_blocks`, `shared_kernel`. Cinco dimensões, uma skill (ou conjunto de
+princípios) por dimensão. Cada achado tem `arquivo:linha`, severidade, root cause,
+skill que detectou e confiança nos relatórios por dimensão.
+
+> **Escopo.** O projeto tem **9 módulos** (`catalog_requests`, `identity`,
+> `notifications`, `preferences`, `settings` além dos seis). Mantive o foco nos
+> seis pedidos; arestas *de entrada* desses outros módulos sobre os seis foram
+> contabilizadas (acoplamento, eventos, `UserModel`), mas seus internos não foram
+> varridos. Recomendo uma segunda passada cobrindo-os.
+
+## Relatórios por dimensão
+
+| # | Dimensão | Skill / método | Arquivo | Achados |
+|---|----------|----------------|---------|---------|
+| 01 | Clean Architecture / DDD | `homeflix-arch` + `clean-arch-python` | [`01-clean-architecture.md`](01-clean-architecture.md) | 13 |
+| 02 | ACL / adapters / gateways | princípios ADR-009 (sem skill dedicada) | [`02-acl-adapters.md`](02-acl-adapters.md) | 7 |
+| 03 | Code smells (modelagem) | `code-smell-review` | [`03-code-smells.md`](03-code-smells.md) | 22 |
+| 04 | Acoplamento (Strength×Distance×Volatility) | framework (sem skill dedicada) | [`04-coupling.md`](04-coupling.md) | 10 |
+| 05 | Doc drift | `doc-drift-audit` | [`05-doc-drift.md`](05-doc-drift.md) | 10 |
+
+**Total bruto: 62 achados** — 🔴 **3 crítico** · 🟠 **11 alto** · 🟡 **31 médio** · 🔵 **17 baixo**.
+
+> **Atenção à sobreposição:** as três dimensões estruturais (01, 04, 05) enxergam
+> em grande parte **os mesmos defeitos** por lentes diferentes. Os atalhos cross-BC
+> do `media` aparecem em 01 *e* 04 *e* 05. A contagem "62" é por-lente, não por
+> defeito distinto. Defeitos raiz distintos ≈ **40**. Os temas abaixo deduplicam.
+
+---
+
+## Veredito geral
+
+A base está **arquiteturalmente saudável no núcleo**: `building_blocks/domain` e
+`shared_kernel` não têm dependências para fora (verificado, zero ocorrências); o
+domínio está livre de FastAPI/SQLAlchemy; os agregados de ciclo de vida
+(`WatchProgress`, `Library`, `CustomList`, `Season`/intro, `MediaConflict`) são
+ricos, não anêmicos; e onde o **ADR-009 foi seguido** (watch_progress/collections →
+media via `media_lookup_port` + ACL) o isolamento é exemplar (12 adapters ACL, 24
+ports, defaults deny-all corretos).
+
+A dívida é **localizada e convergente**: concentra-se no módulo **`media`** (o maior,
+~34k LOC) e em **leituras cross-BC adicionadas tardiamente** que recorreram a
+atalhos em vez do mecanismo que o próprio projeto define. Não há ciclos de import
+entre módulos. Não há violação crítica de direção de dependência no núcleo.
+
+---
+
+## Temas transversais (priorizados — atacar nesta ordem)
+
+### 🔴 TEMA A — Ausência de mecanismo de integração cross-BC consistente
+**Corroborado por:** Clean Arch (F1/F2/F3 alto) · Coupling (F1 crítico, F2/F3 alto) · Doc-drift (#2 alto)
+**Epicentro:** `media`. **Root cause único:** o ADR-009 (Read Port + ACL + DTO)
+foi seguido nas primeiras leituras cross-BC; as posteriores pegaram atalhos. O
+pacote `src/shared_kernel/integration_events/` foi previsto mas está **vazio** — a
+abstração de contrato de integração nunca foi construída, então cada consumidor
+improvisou.
+
+Defeitos que compõem o tema:
+- `media/application/services/scan_run_service.py:21` — importa a **entidade de
+  domínio `Library`** de outro BC e a passa para `run_scan()` (acoplamento
+  intrusivo; **F1 crítico de coupling**).
+- `media/application/use_cases/get_overview_stats.py:3` e `trigger_scan.py:6` —
+  pegam emprestadas `IdentityUnitOfWorkFactory` / `LibraryUnitOfWorkFactory` em vez
+  de Read Port (a própria docstring de `get_overview_stats` admite o atalho).
+- `watch_progress`/`collections` `event_handlers/*.py` — assinam as **classes de
+  domain event internas** de `media`/`identity` (5 consumidores), sem contrato de
+  integration event.
+- `UserModel` (ORM do identity) **vaza para ~20 sites de rotas** em 5 módulos via o
+  crosscut de auth (deveria retornar DTO).
+
+**Direção de correção:** materializar `shared_kernel/integration_events` com
+contratos versionados; promover as três leituras de `media` a Read Ports + ACL;
+trocar `UserModel` por um `AuthenticatedUser` DTO no crosscut de auth. É a maior
+alavanca de redução de risco da base.
+
+### 🔴 TEMA B — Metadados localizados como `dict` não-tipado (corrupção silenciosa)
+**Corroborado por:** Code-smell (#1 **crítico**) · Doc-drift (gap: iniciativa sem ADR)
+`localized: dict[str, dict[str, Any]]` com chaves mágicas, espalhado por 4
+entidades (`movie`/`series`/`episode`/`season`) + use cases de enrich, persistido e
+relido via SQL `json_extract`. Uma chave digitada errado **nunca dá round-trip e
+falha em silêncio** — e isso **já aconteceu** (tagline perdida entre as variantes
+movie/series, conforme a própria docstring). A iniciativa de localização (config-
+driven, season/episode, catalog-requests, ordenação) é transversal e **não tem ADR**.
+
+**Direção:** extrair um VO `LocalizedMetadata`; escrever o ADR da localização.
+
+### 🟠 TEMA C — Política de negócio e perda de sinal nos gateways de provider do `media`
+**Corroborado por:** ACL (4 médios) · Code-smell (boolean blindness `force`)
+A ACL de metadados decide regras que pertencem ao domínio / descarta sinal do
+provider:
+- `tmdb_client.py:1096,1153` — **jurisdição de content-rating hardcoded** (`BR or
+  US`), colapsando as demais.
+- `tmdb_client.py:266-292` — `HTTPError`/não-200 colapsam no **mesmo `None` de um
+  404 real** (provider-down vira "não encontrado"); inconsistente com os paths de
+  search que fazem `raise_for_status()`.
+- `media_probe_service.py:403-405` — probe **fabrica** uma disposição de áudio
+  default (`tracks[0]`) que o container nunca declarou (concern do `TrackSelector`
+  da Library).
+- `scanner.py:160-161` — raiz desmontada/ausente **pulada em silêncio**,
+  indistinguível de raiz vazia (reconcile poderia ler "disco desmontado" como
+  "tudo deletado").
+- `force: bool` atravessa ~12 funções de enrich bifurcando fill-vs-overwrite de
+  forma invisível → `MergePolicy` enum.
+
+### 🟠 TEMA D — Drift em documentação fundacional (engana quem implementa)
+**Corroborado por:** Doc-drift (#1 crítico, #3 alto, + médios)
+- **CLAUDE.md ensina o envelope de response errado** (`{"data","meta",request_id no
+  body}`) vs. o real `responses.py:73,101` (`{"type","data","metadata"}`,
+  `request_id` em header). 🔴
+- `PresentationException` + 3 subclasses **totalmente documentadas** em
+  `exception-hierarchy-clean-architecture.md:128,867-943` mas **inexistentes** no
+  código (`grep` zero). 🟠
+- Listas de módulos/BC mostram **4, a realidade é 9** (CLAUDE.md e ADR-008 com a
+  árvore desatualizada — contradição interna com a própria seção "Fase Atual").
+- **i18n docs descrevem um sistema que não existe** (`i18n/locales/{en,pt-BR}/` +
+  Accept-Language); o real é query param `lang` + `get_title(lang)` config-driven.
+- Contagens estagnadas: endpoints 107→**132 reais**; testes 2530→**2941 reais**.
+
+### 🟠 TEMA E — Regra de merge provider⇄entidade anêmica e repetida (Shotgun Surgery)
+**Corroborado por:** Code-smell (#2 alto)
+A regra de merge metadado-provider está **copiada ~23×** em
+`enrich_movie/series_metadata.py`; `Movie`/`Series` não têm `merged_with`. Uma
+mudança na regra obriga edição em muitos pontos. → domain service `MetadataReconciler`.
+
+### 🟡 TEMA F — Primitive Obsession em fronteiras de idioma e em request models
+**Corroborado por:** Code-smell (#4 alto + médios)
+`lang: str = "en"` cru em ~20 accessors de entidade + 14 use cases enquanto
+`LanguageTag`/`LanguageCode` existem **sem uso** (tag inválida cai no fallback em
+silêncio). Library aceita `list[dict[str, Any]]` na borda. Candidatos a VO:
+`Confidence [0,1]`, modelos de request tipados.
+
+---
+
+## Lista mestra por severidade (top do funil)
+
+### 🔴 Crítico (3 defeitos raiz distintos)
+1. **Coupling F1** — `media/application/services/scan_run_service.py:21` importa o
+   agregado `Library` de outro BC. *(Tema A)*
+2. **Code-smell #1** — `localized: dict[str, dict[str, Any]]` em 4 entidades; já
+   causou perda de dado silenciosa. *(Tema B)*
+3. **Doc-drift #1** — `CLAUDE.md` documenta envelope de response incompatível com
+   `responses.py`. *(Tema D)*
+
+### 🟠 Alto (núcleo, deduplicado)
+- Atalhos de UoW cross-BC: `get_overview_stats.py:3`, `trigger_scan.py:6` *(Tema A)*
+- 5 consumidores assinam domain events crus; `integration_events` vazio *(Tema A)*
+- `UserModel` ORM em ~20 sites de rotas *(Tema A)*
+- `force: bool` (boolean blindness) em ~12 funções de enrich *(Tema C)*
+- Regra de merge copiada ~23× / entidades sem `merged_with` *(Tema E)*
+- `lang: str` cru com VOs existentes não usados *(Tema F)*
+- `PresentationException` documentada mas inexistente *(Tema D)*
+
+*(Médios e baixos — 48 itens — detalhados nos relatórios por dimensão.)*
+
+---
+
+## Ordem de ataque recomendada
+
+1. **Doc-drift de alta alavancagem, baixo custo** (Tema D): corrigir o envelope no
+   CLAUDE.md, o `PresentationException` fantasma, as listas de módulos e o i18n.
+   Barato, evita que novos PRs herdem o erro. *(horas)*
+2. **VO `LocalizedMetadata` + ADR de localização** (Tema B): estanca corrupção
+   silenciosa ativa. *(dias)*
+3. **Mecanismo de integração cross-BC** (Tema A): `integration_events` + promover as
+   3 leituras de `media` a Read Port/ACL + `AuthenticatedUser` DTO. Maior redução de
+   risco estrutural. *(dias–semanas; faseável)*
+4. **Limpeza dos gateways de provider** (Tema C) e **`MetadataReconciler`** (Tema E):
+   movem política para o domínio e param a perda de sinal. *(dias)*
+5. **Primitive Obsession de idioma** (Tema F): incremental, casa com o passo 2.
+
+> **Nota sobre acoplamento bom:** o `shared_kernel` (~14 arquivos) e
+> `building_blocks` (~23) ainda são pequenos e estáveis — **não** estão virando
+> dumping ground. Manter assim ao materializar os integration events (contratos
+> finos, não modelos de domínio compartilhados).

--- a/docs/audits/01-clean-architecture.md
+++ b/docs/audits/01-clean-architecture.md
@@ -1,0 +1,219 @@
+# Auditoria 01 — Clean Architecture / DDD
+
+**Escopo:** auditoria READ-ONLY da direção de dependências, isolamento de bounded
+contexts (ADR-008/009), pureza de domínio (ADR-001/017) e shape de use cases nos
+seis alvos: `src/modules/media`, `src/modules/library`, `src/modules/watch_progress`,
+`src/modules/collections`, `src/building_blocks`, `src/shared_kernel`. Metodologia:
+skills `homeflix-arch` + `clean-arch-python` e os ADRs do projeto. Todos os números de
+linha foram verificados lendo os arquivos. A estrutura geral é sólida — Screaming
+Architecture bem aplicada, ports/ACL presentes onde a leitura cross-BC é correta; os
+achados concentram-se em **leituras cross-BC feitas por atalho** (importar UoW/entidade
+de outro módulo em vez de Port+ACL+DTO) e em pequenos desvios de direção de dependência.
+
+## Resumo por severidade
+
+| Módulo | Crítico | Alto | Médio | Baixo |
+|---|---|---|---|---|
+| media | 0 | 3 | 4 | 0 |
+| library | 0 | 0 | 1 (ref. sistêmico) | 0 |
+| watch_progress | 0 | 0 | 1 | 1 |
+| collections | 0 | 0 | 1 | 1 |
+| building_blocks | 0 | 0 | 0 | 1 |
+| shared_kernel | 0 | 0 | 0 | 0 |
+| **Total** | **0** | **3** | **7** | **3** |
+
+> O achado "rotas importam `identity.infrastructure` (auth + UserModel ORM)" é
+> **sistêmico** (~15 arquivos em media + 1 em library). Está contado uma vez em media
+> (M-7) e referenciado em library.
+
+---
+
+## media
+
+### A-1 — Application service importa entidade de domínio de outro BC · ALTO
+- **arquivo:linha**: `src/modules/media/application/services/scan_run_service.py:21`
+- **evidência**: `from src.modules.library.domain.entities.library import Library`
+- **root cause**: o orquestrador de scan trafega o agregado `Library` de outro BC
+  diretamente, em vez de um DTO local obtido via Read Port + ACL. Acopla a aplicação de
+  `media` ao modelo de domínio interno de `library` — qualquer mudança no agregado
+  `Library` repercute em `media`.
+- **skill + confiança**: homeflix-arch (ADR-008/009) · 0.9
+
+### A-2 — Leitura cross-BC via UoW alheia (identity) em vez de Read Port · ALTO
+- **arquivo:linha**: `src/modules/media/application/use_cases/get_overview_stats.py:3`
+- **evidência**: `from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory`
+  — a própria docstring admite "Cross-BC reads (the users count) go through the identity
+  UoW factory injected at the composition root".
+- **root cause**: contagem de usuários (leitura cross-BC) é feita pegando emprestada a
+  Unit of Work de `identity`, contornando o padrão ADR-009 (Port local + adapter ACL +
+  DTO). O consumidor passa a depender da infraestrutura transacional do produtor.
+- **skill + confiança**: homeflix-arch (ADR-009) · 0.9
+
+### A-3 — Leitura cross-BC via UoW alheia (library) em vez de Read Port · ALTO
+- **arquivo:linha**: `src/modules/media/application/use_cases/trigger_scan.py:6`
+- **evidência**: `from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory`
+- **root cause**: mesmo anti-padrão de A-2 — para resolver uma `Library` o use case
+  importa e usa a UoW de `library`. O caminho correto seria `LibraryLookupPort` +
+  adapter em `media/infrastructure/acl/` retornando um DTO próprio.
+- **skill + confiança**: homeflix-arch (ADR-009) · 0.9
+
+### M-4 — Repositório de domínio depende de tipo da application layer · MÉDIO
+- **arquivo:linha**: `src/modules/media/domain/repositories/movie_repository.py:7`
+  (idem `series_repository.py:7`, `media_conflict_repository.py:5`)
+- **evidência**: `from src.building_blocks.application.pagination import PaginatedResult`
+- **root cause**: a interface de repositório vive no domínio mas seu tipo de retorno
+  (`PaginatedResult`) mora em `building_blocks/application`. Direção invertida:
+  domínio → application. O contrato de paginação é parte do contrato de repositório e
+  deveria estar em `building_blocks/domain` (ou um VO de paginação no domínio).
+- **skill + confiança**: clean-arch-python · 0.85
+
+### M-5 — Infra de media tipada contra a infra de settings (cross-BC) · MÉDIO
+- **arquivo:linha**: `src/modules/media/infrastructure/streaming/hls_service.py:68`
+  (idem `streaming/thumbnail_service.py:36`, `streaming/scrub_preview_locator.py:18`,
+  `video/credits_detector.py:47`, `video/frame_hasher.py:30`, `audio/audio_extractor.py:32`)
+- **evidência** (todas sob `if TYPE_CHECKING:`):
+  `from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings`
+- **root cause**: serviços de infraestrutura de `media` são tipados contra o holder
+  concreto `RuntimeSettings` de outro BC. É só type-coupling (TYPE_CHECKING), mas amarra
+  `media` à implementação concreta de `settings` em vez de um Protocol/port de config
+  local. Severidade contida por ser type-only.
+- **skill + confiança**: homeflix-arch (ADR-009) · 0.7
+
+### M-6 — Use case de conflitos com type-import cross-BC de settings · MÉDIO
+- **arquivo:linha**: `src/modules/media/application/use_cases/detect_movie_conflicts.py:32-33`
+- **evidência** (sob `if TYPE_CHECKING:`):
+  `from src.modules.settings.domain.value_objects import ScanDedupConfig`
+  e `from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings`
+- **root cause**: application de `media` referencia VO de domínio + infra concreta de
+  `settings`. Type-only, mas a configuração cross-BC deveria chegar como DTO/port local.
+- **skill + confiança**: homeflix-arch (ADR-009) · 0.65
+
+### M-7 — Rotas importam a INFRAESTRUTURA de identity (auth + UserModel ORM) · MÉDIO (sistêmico)
+- **arquivo:linha**: `src/modules/media/presentation/routes/movie_routes.py:11-12`
+  e ~14 outras rotas (`stream_routes.py:25-26`, `series_routes.py:11-12`,
+  `scan_routes.py:11-13`, `tmdb_lookup_routes.py:21-22`, todos os `admin_*_routes.py`).
+- **evidência**:
+  `from src.modules.identity.infrastructure.auth import current_admin_user` e
+  `from src.modules.identity.infrastructure.persistence.models.user_model import UserModel`
+- **root cause**: a presentation de `media` depende da **infraestrutura** de `identity`
+  — em particular do modelo ORM `UserModel`, usado como tipo do usuário injetado. Mistura
+  fronteira de auth com modelo de persistência de outro BC. O contrato de auth deveria
+  ser exposto como dependência de presentation (ex.: um `AuthenticatedUser`/DTO ou um
+  `Depends` reexportado), não o ORM. Pervasivo, daí "sistêmico".
+- **skill + confiança**: clean-arch-python + homeflix-arch · 0.8
+
+**Saudável em media**: domínio sem imports de FastAPI/SQLAlchemy; uso de
+`pydantic.Field/model_validator` no domínio é sancionado pelo ADR-001 (não é violação);
+catálogo rico de ports em `application/ports/`; ACL em `infrastructure/acl/`;
+`scan_run_service`/`job_run_service` são orquestração legítima (não contêm regra de
+domínio).
+
+---
+
+## library
+
+### Ref. M-7 — Rota importa infra de identity · MÉDIO (parte do sistêmico)
+- **arquivo:linha**: `src/modules/library/presentation/routes/library_routes.py:11-12`
+- **evidência**: mesmos imports `identity.infrastructure.auth` + `UserModel`.
+- **root cause**: idêntico a M-7.
+- **skill + confiança**: clean-arch-python · 0.8
+
+**Saudável em library**: domínio puro; invariantes em `Library`/VOs (ADR-017);
+`TrackSelector` corretamente em `domain/services/`; leitura cross-BC exposta via
+`application/ports/media_count_query_port.py` + ACL. Sem leaks de SQLAlchemy/FastAPI no
+domínio ou application.
+
+---
+
+## watch_progress
+
+### M-8 — Event handlers importam domain events de outros BCs (sem integration event) · MÉDIO
+- **arquivo:linha**: `src/modules/watch_progress/application/event_handlers/on_movie_merged.py:7`
+  (idem `on_movie_promoted_to_series.py:7` → `media.domain.events`;
+  `on_user_deleted.py:7` → `identity.domain.events`)
+- **evidência**: `from src.modules.media.domain.events import MovieMergedEvent`
+- **root cause**: o consumidor acopla-se às **classes de domain event internas** do
+  produtor. `src/shared_kernel/integration_events/` existe mas está **vazio** (só
+  docstring) — a abstração de integration event pretendida nunca foi construída, então
+  domain events fazem o papel de contrato de integração cross-BC, ferindo o isolamento
+  do ADR-008 ("módulos NÃO importam entre si").
+- **skill + confiança**: homeflix-arch (ADR-008/009) · 0.8
+
+### B-9 — Presentation depende de presentation de identity · BAIXO
+- **arquivo:linha**: `src/modules/watch_progress/presentation/dependencies.py:11`
+- **evidência**: `from src.modules.identity.presentation.dependencies import resolve_profile_id`
+- **root cause**: acoplamento presentation→presentation cross-BC. Menos grave (camada de
+  borda, sem ORM), mas ainda assim uma dependência direta entre módulos.
+- **skill + confiança**: homeflix-arch · 0.55
+
+**Saudável em watch_progress**: `media_lookup_port` + adapter ACL corretos; domínio puro
+com `ContinueWatchingSelector` em `domain/services/`.
+
+---
+
+## collections
+
+### M-9 — Event handlers importam domain events de outros BCs (sem integration event) · MÉDIO
+- **arquivo:linha**: `src/modules/collections/application/event_handlers/on_movie_merged.py:11`
+  (idem `on_movie_promoted_to_series.py:11` → `media.domain.events`;
+  `on_user_deleted.py:10` → `identity.domain.events`)
+- **evidência**: `from src.modules.media.domain.events import MovieMergedEvent`
+- **root cause**: idêntico a M-8 — consumo direto das classes de domain event do produtor
+  por falta da camada de integration events em `shared_kernel`.
+- **skill + confiança**: homeflix-arch (ADR-008/009) · 0.8
+
+### B-10 — Presentation depende de presentation de identity · BAIXO
+- **arquivo:linha**: `src/modules/collections/presentation/dependencies.py:10`
+- **evidência**: `from src.modules.identity.presentation.dependencies import resolve_profile_id`
+- **root cause**: igual a B-9.
+- **skill + confiança**: homeflix-arch · 0.55
+
+**Saudável em collections**: `media_lookup_port` + `progress_lookup_port` + dois adapters
+ACL corretos; domínio puro (`Watchlist`, `CustomList`, VOs com invariantes via Pydantic
+do ADR-001).
+
+---
+
+## building_blocks
+
+### B-11 — Tipos de contrato de domínio residem na application layer · BAIXO
+- **arquivo:linha**: `src/building_blocks/application/pagination.py` (consumido pelo
+  domínio em M-4) e `src/building_blocks/application/errors.py` (consumido por
+  `src/modules/identity/domain/errors.py:10`, fora do escopo dos seis alvos).
+- **evidência**: `PaginatedResult` e as bases de exceção (`ResourceNotFoundException`
+  etc.) ficam em `building_blocks/application` mas são necessários por contratos/erros de
+  camada de domínio de vários módulos.
+- **root cause**: a fronteira application/domain dentro de `building_blocks` deixa na
+  application tipos que fazem parte de contratos de domínio (paginação de repositório;
+  bases de exceção de domínio). Reclassificar `PaginatedResult` (e as bases de exceção
+  de domínio) para `building_blocks/domain` eliminaria as direções invertidas de M-4 e do
+  import em identity.
+- **skill + confiança**: clean-arch-python · 0.6
+
+**Saudável em building_blocks**: `building_blocks/domain` **não** importa de
+`application/infrastructure/presentation` (verificado, zero ocorrências). Bases
+`DomainModel`/`ValueObject`/`AggregateRoot` encapsulam Pydantic conforme ADR-001.
+
+---
+
+## shared_kernel
+
+**Sem achados.** Verificado: nenhum import de `src.modules.*` nem de
+`building_blocks.application/infrastructure/presentation` (zero ocorrências). Os VOs
+(`FilePath`, `LanguageCode`, `AudioTrack`, `ImageUrl`, etc.) usam apenas
+`pydantic.model_validator/Field` — sancionado pelo ADR-001. `integration_events/` está
+presente porém **vazio** (relevante para M-8/M-9: a abstração existe como pasta mas não
+como código).
+
+---
+
+## Observação cross-cutting
+
+Os achados de maior severidade (A-1, A-2, A-3) e os médios M-8/M-9 compartilham **uma
+única causa raiz**: a ausência de um mecanismo de integração cross-BC consistente. Onde
+ADR-009 foi seguido (watch_progress/collections → media via `media_lookup_port` + ACL) o
+isolamento é exemplar; onde a leitura cross-BC apareceu depois (media → library/identity
+para stats e scan; handlers consumindo domain events) recorreu-se a atalhos: importar a
+UoW/entidade alheia ou o domain event do produtor. Fechar o gap = (a) `LibraryLookupPort`
+/ `IdentityCountPort` em `media` com adapters ACL, e (b) materializar
+`shared_kernel/integration_events` com contratos de evento publicados.

--- a/docs/audits/02-acl-adapters.md
+++ b/docs/audits/02-acl-adapters.md
@@ -1,0 +1,211 @@
+# Audit 02 — ACL / Adapters / Gateways
+
+**Scope.** Read-only audit of the boundary code in the HomeFlix backend: every
+`infrastructure/acl/` adapter (cross-BC Read Port implementations per ADR-009),
+the external provider gateways under `src/modules/media/infrastructure/`
+(`metadata/` TMDB client, `file_system/`, `audio/`, `video/`, `streaming/`), and
+a sweep of `building_blocks` / `shared_kernel` for boundary surface.
+
+**Principles applied.** No dedicated `acl-audit` skill exists in this repo, so
+findings are tagged `acl-audit (principles)` and grounded in **ADR-009**
+(Cross-BC Read Ports + Anti-Corruption Layer). Hunt targets: business/domain
+policy living in the adapter, provider signal discarded/collapsed/first-wins,
+silently permissive defaults, missing translation (foreign type leak), and leaky
+error handling.
+
+**No source was modified.** This file is the only artifact written.
+
+## Severity counts by module
+
+| Module | crítico | alto | médio | baixo | Total |
+|---|---|---|---|---|---|
+| media (TMDB gateway) | 0 | 0 | 2 | 1 | 3 |
+| media (probe / scanner) | 0 | 0 | 2 | 1 | 3 |
+| collections (ACL) | 0 | 0 | 0 | 1 | 1 |
+| library / watch_progress / catalog_requests / notifications | 0 | 0 | 0 | 0 | 0 (healthy) |
+| building_blocks / shared_kernel | 0 | 0 | 0 | 0 | 0 (no surface) |
+| **Total** | **0** | **0** | **4** | **3** | **7** |
+
+---
+
+## Module: media — TMDB gateway (`infrastructure/metadata/tmdb_client.py`)
+
+### Finding 1 — Content-rating jurisdiction policy hardcoded in the gateway (+ all other countries discarded)
+- **arquivo:linha**: `src/modules/media/infrastructure/metadata/tmdb_client.py:1096` and `:1153`
+- **severidade**: médio
+- **root cause**: The gateway decides *which jurisdiction's* content rating is
+  authoritative — a product/domain policy ("Brazil's DEJUS rating preferred,
+  US as fallback") — instead of translating the provider's full per-country
+  rating set and letting the domain choose. It also collapses TMDB's rich
+  `results[]` (one cert per country) into a single string, silently dropping
+  every other country with no record of the loss. Adding a third supported
+  locale would require editing this gateway, not config/domain.
+- **skill + confiança**: acl-audit (principles), 0.7
+- **evidence**:
+  ```python
+  # _parse_content_rating (movies)
+  selected = ratings_by_country.get("BR") or ratings_by_country.get("US")
+  return ContentRating(selected) if selected else None
+  # _parse_series_content_rating (series) — same BR-then-US literal policy
+  selected = ratings_by_country.get("BR") or ratings_by_country.get("US")
+  ```
+
+### Finding 2 — `get_*_summary_by_id` collapses transient/auth failures into "not found"
+- **arquivo:linha**: `src/modules/media/infrastructure/metadata/tmdb_client.py:266-277` (movie) and `:279-292` (series)
+- **severidade**: médio
+- **root cause**: Both the `httpx.HTTPError` path and every non-200 status are
+  mapped to the same `None` the method already uses for a genuine 404. A picker
+  caller (admin relink) cannot distinguish "no such TMDB id" from "TMDB is down
+  / API key rejected / rate-limited." This is *leaky error handling via a
+  misleading domain outcome*, and it is inconsistent with the search paths in
+  the same client (`search_movie`/`search_series`/`find_by_imdb_id`) which call
+  `resp.raise_for_status()` and let failures surface.
+- **skill + confiança**: acl-audit (principles), 0.65
+- **evidence**:
+  ```python
+  except httpx.HTTPError:
+      return None
+  if resp.status_code == 404:
+      return None
+  if resp.status_code != 200:
+      return None   # 401/429/500 indistinguishable from a true 404
+  return _to_movie_candidate(resp.json(), self._image_url)
+  ```
+
+### Finding 3 — Cast list silently truncated to top 15 with no loss signal
+- **arquivo:linha**: `src/modules/media/infrastructure/metadata/tmdb_client.py:27` (`_MAX_CAST = 15`), applied at `:1045-1052`
+- **severidade**: baixo
+- **root cause**: Provider returns the full ordered cast; the gateway flattens
+  it to the first 15 with the cap hardcoded as a module constant rather than a
+  configurable/domain concern, and records nothing about the truncation. A
+  reasonable UI cap, but it is a provider-signal-discard decision living in the
+  ACL.
+- **skill + confiança**: acl-audit (principles), 0.5
+- **evidence**:
+  ```python
+  sorted_cast = sorted(cast_data, key=lambda c: _safe_int(c.get("order"), 999))
+  return [self._to_credit_person(c, role_key="character")
+          for c in sorted_cast[:_MAX_CAST] if c.get("name")]
+  ```
+
+> Note (not a finding): the broad `except httpx.HTTPError: return None` /
+> `status_code != 200: return None` pattern across `get_collection`,
+> `get_movie_recommendations`, `_fetch_collection_movie_ids`,
+> `_fetch_related_ids`, `get_person`, `get_translated_titles` is **documented and
+> intentional best-effort polish** (recommendations/collections/translations are
+> non-load-bearing) — accepted. The `_pick_translation_title`, `_logo_rank`, and
+> `_parse_trailer` ranking functions are legitimate multi-value→single-field ACL
+> translation, not domain policy.
+
+---
+
+## Module: media — probe & scanner
+
+### Finding 4 — Probe fabricates an audio-default disposition the container never declared (first-wins)
+- **arquivo:linha**: `src/modules/media/infrastructure/streaming/media_probe_service.py:403-405`
+- **severidade**: médio
+- **root cause**: When the source file declares *no* default audio stream, the
+  probe adapter invents one by forcing `tracks[0]` to default. "Which audio is
+  the default" is a selection concern the Library BC already owns
+  (`TrackSelector`, ADR-005); manufacturing a provider signal that did not
+  exist, and doing it first-wins, lets an arbitrary first track masquerade as an
+  authoritative default downstream. The loss of "the file had no default" is
+  not preserved.
+- **skill + confiança**: acl-audit (principles), 0.6
+- **evidence**:
+  ```python
+  # Ensure at least one track is default
+  if tracks and not any(t.is_default for t in tracks):
+      tracks[0] = tracks[0].with_updates(is_default=True)
+  ```
+
+### Finding 5 — Scanner silently treats a missing/unmounted directory as "empty"
+- **arquivo:linha**: `src/modules/media/infrastructure/file_system/scanner.py:160-161`
+- **severidade**: médio
+- **root cause**: An unmounted/missing library root is skipped with `continue`,
+  so the scan returns *no files* for that root with no distinguishable signal
+  from "root mounted and genuinely empty." Downstream reconciliation could
+  mistake an unmounted disk for "all media deleted." Partially mitigated by
+  `LibraryHealthAdapter.is_library_root_accessible` (which deliberately returns
+  `False` on partial mount to avoid trusting file-missing signals), but the
+  scanner gateway itself is silently permissive.
+- **skill + confiança**: acl-audit (principles), 0.55
+- **evidence**:
+  ```python
+  dir_path = Path(directory.value)
+  if not dir_path.is_dir():
+      continue   # unmounted root == empty scan, no signal raised
+  ```
+
+### Finding 6 — Probe permissive defaults for missing stream metadata
+- **arquivo:linha**: `src/modules/media/infrastructure/streaming/media_probe_service.py:373` (channels→2) and `:349-357` (unknown language→`"un"`)
+- **severidade**: baixo
+- **root cause**: A missing `channels` field defaults to stereo (2), and any
+  3-letter ISO code not in the map (or an out-of-shape tag) collapses to `"un"`.
+  Both are silent guesses that the provider data didn't supply; reasonable
+  fallbacks but they erase the "unknown" distinction.
+- **skill + confiança**: acl-audit (principles), 0.45
+- **evidence**:
+  ```python
+  channels = int(stream.get("channels", 2))
+  ...
+  mapped = _ISO639_2_TO_1.get(lang)
+  if mapped is None:
+      return "un"
+  ```
+
+---
+
+## Module: collections — ACL (`infrastructure/acl/media_lookup_adapter.py`)
+
+### Finding 7 — Series quality fields (runtime/resolution/HDR) dropped to null in batch lookup
+- **arquivo:linha**: `src/modules/collections/infrastructure/acl/media_lookup_adapter.py:56-66`
+- **severidade**: baixo
+- **root cause**: The batch series resolution leaves `runtime_seconds`,
+  `resolution`, and `hdr` null because the batch loader doesn't hydrate
+  episodes — a provider-signal-collapse the movie branch (same method) does fill
+  in. Documented and the client hides absent fields, so this is an accepted
+  asymmetry, flagged for visibility rather than as a defect.
+- **skill + confiança**: acl-audit (principles), 0.4
+- **evidence**:
+  ```python
+  # Runtime/resolution/HDR live on the series' episodes,
+  # which the batch lookup doesn't hydrate — left null
+  result[(MediaType.SERIES, media_id)] = MediaSummary(
+      media_id=media_id, media_type=MediaType.SERIES,
+      title=series.get_title(lang), poster_path=series.get_poster_path(lang),
+      year=series.start_year.value, genres=tuple(series.get_genres(lang)),
+  )
+  ```
+
+---
+
+## Healthy notes
+
+- **ADR-009 structure is followed faithfully.** Every cross-BC adapter is the
+  *single* file importing the provider BC, returns a consumer-owned DTO/VO (no
+  foreign aggregate leaks), and exposes a batch shape where needed
+  (`MediaLookupAdapter.get_many`, `CatalogRequestLookupAdapter.get_for_movie_tmdb_ids`,
+  `ProgressLookupAdapter.find_for_media_ids`). No raw provider repository or
+  entity escapes upward.
+- **Permissive defaults are deliberate and consistent where they matter.**
+  `ProfileLibraryAccessAdapter.find_for_profile` returns `[]` (deny-all) for a
+  missing profile, and the consumer use cases short-circuit on the empty list
+  (`get_movie_by_id.py:75-76`) while repositories translate an empty allow-list
+  to `IN ()` = match-nothing — so the "missing data → denied" semantics are
+  end-to-end correct, not accidentally permissive.
+- **`LibraryHealthAdapter`** correctly fails *closed*: missing library and
+  partial mount both return `False` with an explicit rationale, exactly the
+  safe direction for a file-missing signal.
+- **Detection gateways are clean ACLs, not policy holders.** `CreditsDetector`,
+  `ChromaprintCorrelator`, and the frame-hash detectors hold only the
+  algorithm (per ADR-020/021's pluggable-port design); thresholds arrive as
+  injected `*Tuning` from runtime settings (ADR-013) and the final
+  `min_confidence` gate is applied by the orchestrating job, not the detector.
+  They honestly return `None` ("no intro/credits found") rather than guessing.
+- **`NotificationPublisherAdapter`** keeps all per-kind copy/payload shaping on
+  the notifications side and accepts only a typed DTO; `body=None` is a
+  documented frontend-fallback choice, not a swallowed value.
+- **`building_blocks` / `shared_kernel`** expose no boundary-adapter surface
+  (`building_blocks/infrastructure/` holds only the generic event bus + UoW), so
+  there is nothing to anti-corrupt there.

--- a/docs/audits/03-code-smells.md
+++ b/docs/audits/03-code-smells.md
@@ -1,0 +1,259 @@
+# Auditoria 03 — Code Smells de Modelagem de Domínio
+
+**Tipo:** READ-ONLY (nenhum código modificado).
+**Metodologia:** skill `code-smell-review` (9 smells de modelagem/design de objetos).
+**Âncora de severidade (HomeFlix):** o pior dano é **corrupção de dado persistido ou perda silenciosa** — valor que grava errado, não faz round-trip na leitura, ou cai em fallback sem erro.
+**Escopo:** camadas de **domínio e aplicação** dos módulos `media`, `library`, `watch_progress`, `collections`, e a base `building_blocks` + `shared_kernel`. Cheiros estruturais (direção de import, fronteira de BC) foram deixados para a auditoria de arquitetura.
+
+> Convenção: cada achado traz `arquivo:linha`, severidade, smell, confiança (0–1), e linhas de **O quê / Dano / Correção**.
+
+---
+
+## Resumo executivo
+
+A base (`building_blocks` + `shared_kernel`) é a parte mais saudável e estabelece um padrão alto: VOs `frozen` validados na construção, `DomainModel.__init_subclass__` forçando invariantes no tipo, enums em todos os discriminadores. Os agregados de lifecycle (`MediaConflict`, `Season` intro-detection, `WatchProgress`, `CustomList`, `Library`) são **ricos e bem modelados** — não anêmicos.
+
+O eixo de dano concentra-se em **um conceito de domínio ausente**: **metadados localizados** são carregados como `dict[str, dict[str, Any]]` com chaves mágicas, atravessam domínio e aplicação, são persistidos e relidos via `json_extract` — e **já causaram drift silencioso** (tagline perdida entre as variantes movie/series). É o achado mais grave e mais recorrente. Ao redor dele orbitam a regra de reconciliação de metadados anêmica (espalhada ~23×) e o flag `force: bool` que a parametriza.
+
+### Contagem por módulo e severidade
+
+| Módulo | Crítico | Alto | Médio | Baixo | Total |
+|---|---:|---:|---:|---:|---:|
+| media (domínio) | — | 1¹ | 3 | 3 | 7 |
+| media (aplicação) | — | 2 | 4 | 1² | 7 |
+| **localized metadata (cross-cutting domínio+aplicação)** | 1 | — | — | — | 1 |
+| library | — | — | 1 | 1 | 2 |
+| watch_progress | — | — | — | 1 | 1 |
+| collections | — | — | 1 | — | 1 |
+| building_blocks | — | — | 1 | — | 1 |
+| shared_kernel | — | — | 1 | 1 | 2 |
+| **Total** | **1** | **3** | **11** | **7** | **22** |
+
+¹ O smell `lang: str` (ALTO) está contado em media-domínio; sua manifestação na aplicação (BAIXO²) é a mesma raiz.
+² Não dupla-contado no total agregado de "localized" — ver achado cross-cutting.
+
+---
+
+## Achado cross-cutting (CRÍTICO)
+
+### [CRÍTICO] Stringly-Typed + Anemic — metadados localizados como `dict[str, dict[str, Any]]`
+**arquivo:linha (domínio):** `src/modules/media/domain/entities/movie.py:95`; `series.py:78`; `episode.py:67`; `season.py:57`
+**arquivo:linha (aplicação):** `src/modules/media/application/use_cases/enrich_movie_metadata.py:344`; `enrich_series_metadata.py:260`; `_localized_metadata_helpers.py:45-61`
+**smell:** Stringly-Typed Code + Primitive Obsession + Anemic Domain · **confiança: 0.9**
+**Princípio:** estado ilegal representável + comportamento longe dos dados
+- **O quê:** O provider entrega um `LocalizedTextFields` tipado; o use case o **achata** de volta para um dict aninhado com chaves de linguagem-string e chaves literais internas (`"title"`, `"synopsis"`, `"tagline"`, `"poster_path"`…). As quatro entidades de conteúdo o carregam e o leem com ~24 acessores `str(loc.get("title") or self.title.value)`. `LanguageCode`/`LanguageTag` existem em `shared_kernel` e são ignorados.
+- **Dano (âncora HomeFlix):** o dict é **persistido e relido via SQL `json_extract(localized, lang)`** para ordenação/busca. Uma chave interna ou string de locale errada grava dado que **silenciosamente nunca faz round-trip na leitura** — corrupção de dado persistido sem erro. **Já ocorreu**: o docstring de `_localized_metadata_helpers` registra que as variantes movie/series divergiram (a de movie levava `tagline`, a de series o descartava). `Any` desliga o type checker exatamente sobre o dado persistido.
+- **Correção:** Extract Value Object `LocalizedMetadata` (registro por-locale tipado, chaveado por `LanguageTag`) com um método `merge(other, policy)`; serializar **só** na borda de persistência. Centraliza chaves mágicas + fallback num único lugar.
+- **Esforço:** Grande. **Candidato a ADR** ("Metadados localizados como Value Object").
+
+---
+
+## media — domínio
+
+### [ALTO] Primitive Obsession — `lang: str = "en"` em todos os acessores localizados
+**arquivo:linha:** `movie.py:131,136,141,146,154,168,180`; `series.py:106,111,116,124,138,150`; `episode.py:95,100`; `season.py:139,146`
+**smell:** Primitive Obsession (VO ignorado) · **confiança: 0.85**
+- **O quê:** O locale é `str` cru com default mágico `"en"` em ~20 assinaturas, embora `LanguageTag`/`LanguageCode` existam e estejam importáveis.
+- **Dano:** Sem normalização na borda (`"pt-BR"` vs `"pt_BR"` vs `"PT-br"` não casa a chave localizada); um tag inválido retorna o fallback silenciosamente; o conceito "linguagem" da linguagem ubíqua se perde.
+- **Correção:** Tipar o parâmetro como `LanguageTag` (ou coagir uma vez na borda). **Candidato a ADR** (locale como VO no catálogo).
+- **Esforço:** Médio.
+
+### [MÉDIO] Primitive Obsession — `confidence: float` sem limites
+**arquivo:linha:** `src/modules/media/domain/entities/intro_detection_run.py:43` (`EpisodeDetectionResult.confidence`), `:85` (`min_confidence`)
+**smell:** Primitive Obsession (invariante ignorada) · **confiança: 0.8**
+- **O quê:** Confiança (`[0.0,1.0]`) é `float` irrestrito aqui, enquanto `IntroMarker`/`CreditsMarker` impõem `Field(ge=0.0, le=1.0)` no mesmo conceito.
+- **Dano:** O agregado de auditoria pode persistir `confidence=1.7`/`-0.3` — a invariante protegida nos markers cai silenciosamente no registro que os explica; confiança corrupta em linhas voltadas ao operador.
+- **Correção:** Extract VO `Confidence` (valida `[0,1]`) e reusar em markers + `EpisodeDetectionResult`. **Candidato a ADR** (aparece em 4+ lugares).
+- **Esforço:** Médio.
+
+### [MÉDIO] Data Clump + Primitive Obsession — pares candidato id/type em `MediaConflict`
+**arquivo:linha:** `src/modules/media/domain/entities/media_conflict.py:111-114,122`
+**smell:** Data Clumps + Primitive Obsession · **confiança: 0.7**
+- **O quê:** `candidate_a_id: str` + `candidate_a_type: MediaType` (e o par `_b_`) andam sempre juntos por `detect()` (6+ params), `resolve()`, `loser_id()`, com ids como string crua.
+- **Dano:** O conceito "referência de mídia = (id, type)" é implícito; fácil casar id com o type errado; ids escapam do VO de id prefixado.
+- **Correção:** Introduce Parameter Object `ConflictCandidate(id, type)`.
+- **Esforço:** Pequeno.
+
+### [MÉDIO] Stringly-Typed — `ScanRun.summary: dict[str, Any]` com duas formas implícitas
+**arquivo:linha:** `src/modules/media/domain/entities/scan_run.py:85` (uso `:105,114`)
+**smell:** Stringly-Typed Code · **confiança: 0.6**
+- **O quê:** Dict contador de chaves mágicas (`movies_created`, `enriched`…) cuja forma depende silenciosamente do `kind` (scan vs enrich).
+- **Dano:** Contrato de chaves implícito e duplicado em escrita/leitura; contador renomeado ou chave do kind errado falha em silêncio numa linha de histórico persistida. (Trade-off "evitar tabela larga" é legítimo — mas as chaves mágicas são o custo.)
+- **Correção:** Dois VOs contadores tipados (`ScanCounters`/`EnrichCounters`) ou união marcada, serializados na coluna única.
+- **Esforço:** Médio.
+
+### [BAIXO] Modelagem inconsistente — `directors`/`writers: list[str]` ao lado de `cast: list[CastMember]`
+**arquivo:linha:** `src/modules/media/domain/entities/movie.py:82-83`
+**smell:** Primitive Obsession (assimétrico) · **confiança: 0.55**
+- **O quê:** Cast é VO rico (name/role/tmdb_id); directors/writers são strings cruas no mesmo agregado.
+- **Dano:** Sem paridade "navegar por diretor"; colisão de homônimos. Baixo — metadado aditivo, não corrupção.
+- **Correção:** VO `CrewMember` (ou generalizar `CastMember`) se navegação por crew for desejada; senão aceitar.
+- **Esforço:** Pequeno.
+
+### [BAIXO] Inconsistência — segundos `int` nos markers vs `float` em `EpisodeDetectionResult`
+**arquivo:linha:** `intro_detection_run.py:42-43` (`start_seconds: float`, `end_seconds: float`) vs `intro_marker.py:51-52` / `credits_marker.py:52` (`int`)
+**smell:** Primitive Obsession / inconsistência · **confiança: 0.5**
+- **O quê:** O mesmo "offset em segundos" é `float` no registro de detecção e `int` no marker persistido; `(start_seconds, end_seconds)` recorre como time-span implícito.
+- **Dano:** Mismatch de arredondamento/identidade ao comparar detecção vs marker gerado. Menor.
+- **Correção:** Um tipo numérico para segundos no módulo; opcionalmente VO `TimeSpan`.
+- **Esforço:** Pequeno.
+
+### [BAIXO] Primitive Obsession (borderline / delegado) — `library_id: str`
+**arquivo:linha:** `movie.py:58`, `series.py:52`, `scan_run.py:81`, candidatos em `media_conflict.py`
+**smell:** Primitive Obsession · **confiança: 0.3**
+- **O quê:** Referência à library dona como `str` cru, embora `shared_kernel/value_objects/library_id.py` (`LibraryId`) exista e seja importável.
+- **Dano:** Baixo; documentado como trade-off de fronteira ADR-008. **Território da skill de arquitetura** — apontado, não analisado aqui.
+- **Correção:** Avaliar `LibraryId` na fronteira se a auditoria de arquitetura concordar.
+- **Esforço:** Médio.
+
+---
+
+## media — aplicação
+
+### [ALTO] Anemic Domain + Shotgun Surgery — regra de reconciliação de metadados nos use cases
+**arquivo:linha:** `enrich_movie_metadata.py:236-345`; `enrich_series_metadata.py:165-480`; `_localized_metadata_helpers.py:15-101`
+**smell:** Anemic Domain Model + Shotgun Surgery · **confiança: 0.85**
+- **O quê:** A regra "provider ⇄ entidade" (`if meta_val and (force or not entity_val): updates[...] = convert(meta_val)`) vive em funções de use case soltas, repetida ~23× (11 series, 12 movie). `Movie`/`Series` não têm `apply_metadata`/`merged_with` — só existe `with_enrichment_review_flagged`.
+- **Dano:** **Já causou drift real** (tagline divergiu entre as cópias movie/series — registrado no docstring). Adicionar campo ou mudar o guard exige editar muitos pontos paralelos; omissões são silenciosas.
+- **Correção:** Move Method — serviço de domínio `MetadataReconciler` ou `entity.merged_with(metadata, policy)` dono da regra "preencher-se-vazio" uma vez.
+- **Esforço:** Grande.
+
+### [ALTO] Boolean Blindness — `force: bool` enfiado em ~12 assinaturas de enrich
+**arquivo:linha:** `enrich_movie_metadata.py:240,293,317`; `enrich_series_metadata.py:171,276,290,354,450`
+**smell:** Boolean Blindness / Flag Argument · **confiança: 0.8**
+- **O quê:** Um único `force` bifurca cada função apply em dois comportamentos (preencher-se-vazio vs sobrescrever) e é plumbado por ~12 funções.
+- **Dano:** Cada call site reraciocina o que `force=True` significa; o split de comportamento é invisível na chamada (`_apply_episode_metadata(ep, meta, force=force)`).
+- **Correção:** Replace Flag with enum (`MergePolicy.FILL_IF_EMPTY | OVERWRITE`) carregado pelo reconciler; casa com o achado anterior.
+- **Esforço:** Médio.
+
+### [MÉDIO] Stringly-Typed — sentinela `"Unknown"` de resolução no scan
+**arquivo:linha:** `scan_media_directories.py:180` (`... or "Unknown"`), `:203` (`current.resolution.name == "Unknown"`)
+**smell:** Stringly-Typed Code · **confiança: 0.75**
+- **O quê:** Literal mágico `"Unknown"` constrói o VO `Resolution` na escrita, e o gate de re-probe compara `.name == "Unknown"` na leitura.
+- **Dano:** A regra "resolução desconhecida?" está partida entre literal-na-escrita e compare-de-string-na-leitura; rename/typo quebra o gate silenciosamente (nunca re-probar, ou sempre).
+- **Correção:** Constante `Resolution.UNKNOWN` + método `resolution.is_unknown()` no VO.
+- **Esforço:** Pequeno.
+
+### [MÉDIO] Temporal Coupling — validação descartada antes do update direto de coluna
+**arquivo:linha:** `set_episode_intro.py:87`; `set_credits_marker.py:70`
+**smell:** Temporal Coupling · **confiança: 0.7**
+- **O quê:** Ambos chamam `entity.with_intro_marker(marker)` / `with_credits_marker(marker)` só pelo efeito de rodar a invariante "marker ≤ duração", **descartam a cópia imutável retornada**, e persistem via update de coluna separado (`update_episode_intro` / `update_creditable_credits`).
+- **Dano:** A chamada de validação e a de persistência são independentes; nada força a primeira preceder a segunda. Se um edit futuro remover a linha 87/70, a checagem some mas a escrita ainda passa → marker fora de faixa persiste em silêncio.
+- **Correção:** O método de repositório recebe a entidade/marker validado e impõe o bound, ou retornar-e-usar a cópia validada (caminho único).
+- **Esforço:** Pequeno.
+
+### [MÉDIO] Data Clump — par `(paths, by_path)` em cinco métodos do scan
+**arquivo:linha:** `scan_media_directories.py:261,287,299,312,354`
+**smell:** Data Clumps · **confiança: 0.7**
+- **O quê:** O par `paths: list[str]` + `by_path: dict[str, ScannedFile]` viaja junto por cinco métodos; é "um grupo de variantes escaneadas".
+- **Dano:** Long parameter lists; cada método refaz `by_path[path]`; adicionar dado de grupo toca os cinco.
+- **Correção:** Parameter Object `VariantGroup(scanned_files)` com `paths`/lookup como métodos.
+- **Esforço:** Pequeno.
+
+### [MÉDIO] Feature Envy / Anemic — upsert de episódio/season fora do agregado
+**arquivo:linha:** `scan_media_directories.py:554-575` (`_upsert_episode_in_season`, `_upsert_season_in_series`)
+**smell:** Feature Envy / Anemic Domain · **confiança: 0.65**
+- **O quê:** Funções de módulo fazem replace-or-append em `Season.episodes`/`Series.seasons`, mexendo em internos do agregado embora `Series` já tenha `with_season`/`get_season`.
+- **Dano:** A invariante de coleção (sem episode_number duplicado por season) vive fora do agregado dono; ignora o vocabulário de upsert do próprio agregado.
+- **Correção:** Move Method — `Season.with_episode_upserted(...)`, `Series.with_season_upserted(...)`.
+- **Esforço:** Médio.
+
+### [BAIXO] Primitive Obsession (read-path) — `lang: str` nos helpers de summary
+**arquivo:linha:** `_movie_summary_helpers.py:14`; `_series_summary_helpers.py`; `list_by_genre.py`; `search_catalog.py` (14 arquivos)
+**smell:** Primitive Obsession · **confiança: 0.5**
+- **O quê:** `lang: str = "en"` cru no caminho de leitura/exibição; mesma raiz do achado ALTO do domínio.
+- **Dano:** Baixo (display), mas é bypass uniforme de um VO existente; tag inválido cai no fallback em silêncio.
+- **Correção:** Aceitar `LanguageCode`/`LanguageTag` na borda do use case; parsear a string crua uma vez na presentation.
+- **Esforço:** Médio (junto com o ADR de locale).
+
+---
+
+## library
+
+### [MÉDIO] Stringly-Typed (dict-as-struct) — `metadata_providers`/`settings` como `list[dict[str,Any]]`
+**arquivo:linha:** `update_library.py:71-79`; DTOs `library_dtos.py:60-62,81-83`; espelhado em `create_library._build_settings`
+**smell:** Stringly-Typed Code / Primitive Obsession · **confiança: 0.7**
+- **O quê:** `metadata_providers: list[dict[str, Any]]` e `settings: dict[str, Any]` cruzam a fronteira da aplicação e são desempacotados por chave mágica, embora `MetadataProviderConfig` (VO real) já exista.
+- **Dano:** Typo de chave ou mudança de shape só falha em runtime (`KeyError`); tratamento inconsistente — `p["provider"]` é obrigatório mas `p.get("priority",1)`/`p.get("enabled",True)` defaultam em silêncio, persistindo config errada-mas-válida; lógica duplicada entre create e update (risco de Shotgun Surgery).
+- **Correção:** Tipar o campo do DTO de input como o VO estruturado (ou sub-model de request tipado), converter uma vez na borda.
+- **Esforço:** Médio. (Recorre com o padrão de settings ADR-013/014 — se reaparecer em outros módulos, vira ADR "request models tipados na borda".)
+
+### [BAIXO] Primitive Obsession — `scan_schedule: str` (cron) validado por regex frouxo
+**arquivo:linha:** `library.py:66-69`
+**smell:** Primitive Obsession · **confiança: 0.4**
+- **O quê:** Expressão cron como `str | None` validada por `^(\S+\s+){4}\S+$`.
+- **Dano:** Regex aceita cron semanticamente inválido (`99 99 99 99 99`); schedule ruim persiste e nunca dispara. Baixo (validado num só lugar).
+- **Correção:** VO `CronExpression` validando faixas reais dos campos.
+- **Esforço:** Pequeno.
+
+---
+
+## watch_progress
+
+### [BAIXO] Stringly-Typed / sentinela sobrecarregada — `subtitle_track: int | None`
+**arquivo:linha:** `watch_progress.py:64-65,112-113`
+**smell:** Magic Value / sentinel overload · **confiança: 0.45**
+- **O quê:** `subtitle_track` sobrecarrega dois sentidos — `None` = "não mudar", `-1` = "legenda off"; a convenção `-1` vive só num docstring.
+- **Dano:** `0`/`None`/`-1` não distinguem "off" de "no-op" sem ler a prosa; valor errado persiste preferência ruim.
+- **Correção:** Modelar preferência como VO/enum (`Off | Track(index)`), ou separar "clear" de "set".
+- **Esforço:** Pequeno.
+
+---
+
+## collections
+
+### [MÉDIO] Temporal Coupling — `item_count` denormalizado drifta dos itens reais
+**arquivo:linha:** `custom_list.py:117,196-219`; conduzido por `add_item_to_custom_list.py:42-53` e `remove_item_from_custom_list.py:24-31`
+**smell:** Temporal Coupling + invariante denormalizada · **confiança: 0.7**
+- **O quê:** `item_count` é contador armazenado no agregado, mas os itens vivem numa coleção de repositório separada. Toda mutação exige **duas** chamadas coordenadas — `add_item()` + `increment_item_count()`/`update()` (e remove + decrement) — sem nada forçando o pareamento.
+- **Dano:** Se algum caminho adicionar/remover sem a chamada de contador correspondente (ou reordenar as duas em falha), o count drifta → rejeição errada de `MAX_ITEMS_PER_LIST` ou total exibido errado. A invariante "lista cheia" é checada contra o contador, não as linhas reais.
+- **Correção:** Derivar o count dos itens (`COUNT` query / agregado dono dos itens), ou unir add-item-e-bump num único método do agregado.
+- **Esforço:** Médio.
+
+---
+
+## building_blocks
+
+### [MÉDIO] Temporal Coupling — `with_updates` muta a fonte ao copiar
+**arquivo:linha:** `entity.py:104-115` (`AggregateRoot.with_updates`)
+**smell:** Temporal Coupling / mutação surpresa em API "imutável" · **confiança: 0.7**
+- **O quê:** `with_updates` retorna uma nova instância mas **muta a fonte** — `self._events.clear()` esvazia os eventos pendentes do agregado antigo como efeito colateral da cópia (`new_instance._events = self._events[:]; self._events.clear()`).
+- **Dano:** Numa entidade imutável, quem chama razoavelmente mantém a referência antiga; qualquer `old.pull_events()` após `with_updates` retorna vazio em silêncio → eventos de domínio (que dirigem persistência/integração) são perdidos sem erro. A ordem obrigatória (usar a instância retornada, nunca a antiga) não é forçada por nada.
+- **Correção:** Tornar o hand-off de eventos explícito (coletor separado puxado no save) ou contrato hard return-only, para que a cópia imutável nunca mute a fonte.
+- **Esforço:** Médio.
+
+---
+
+## shared_kernel
+
+### [MÉDIO] Primitive Obsession + Stringly-Typed — formato composto de `episode_composite_id`
+**arquivo:linha:** `episode_composite_id.py:31-33,59-83`
+**smell:** Primitive Obsession + Stringly-Typed (duplicação de formato wire) · **confiança: 0.65**
+- **O quê:** `series_id: str` (cru, não `SeriesId`); o formato `epi_ser_{id}_{S}_{E}` é montado/parseado por cirurgia de string (`media_id[4:]`, `rsplit("_",2)`), duplicando o esquema de prefixo que `media_id.py` já possui. `parse` retorna `None` em qualquer má-formação, engolindo "não é chave de episódio" vs "chave corrompida".
+- **Dano:** O formato vive em dois lugares — mudar o esquema `epi_`/`ser_` exige caçar ambos. `None` silencioso deixa um id malformado-mas-presente cair num branch errado.
+- **Correção:** Centralizar o formato composto junto de `parse_media_id`; tipar `series_id` como `SeriesId`; distinguir "não-episódio" de "malformado".
+- **Esforço:** Médio.
+
+### [BAIXO] Stringly-Typed — `codec: str` / `format: str` em tracks
+**arquivo:linha:** `tracks.py:54,119`
+**smell:** Stringly-Typed Code · **confiança: 0.4**
+- **O quê:** `AudioTrack.codec` e `SubtitleTrack.format` são `str` aberta do ffprobe. `format` é efetivamente fechado (dirige `is_text_based`/`is_image_based`) mas continua string crua.
+- **Dano:** Baixo — `format` typo'd reporta ambos `is_text_based` e `is_image_based` como `False` em vez de erro. Vocabulário de codec é genuinamente aberto.
+- **Correção:** Opcional: promover `format` a enum `SubtitleFormat`; deixar `codec` como `str`. Tolerável.
+- **Esforço:** Pequeno.
+
+---
+
+## Padrões recorrentes (candidatos a ADR)
+
+1. **Locale como Value Object no catálogo** — `lang: str`/`"en"` aparece em ~20 acessores de entidade + 14 use cases, e o **dict `localized` não-tipado** é o achado CRÍTICO. Um ADR "Metadados localizados + locale como VO" + cards de migração incremental (Strangler Fig) cobre o eixo de maior dano.
+2. **`Confidence` VO `[0,1]`** — bounds impostos em markers mas não em `EpisodeDetectionResult`/`min_confidence`; um VO único elimina o drift de invariante (4+ lugares).
+3. **Request models tipados na borda** — `list[dict[str,Any]]` em library espelha o padrão de settings buckets (ADR-013/014); se recorrer, vira decisão de padrão, não card isolado.
+4. **`MergePolicy` enum** substituindo `force: bool` — acompanha a extração do `MetadataReconciler`.
+
+## O que está bom (calibra a confiança no resto)
+
+- **`building_blocks`/`shared_kernel`** — a parte mais saudável. VO base `frozen` + validado; `DomainModel.__init_subclass__` força `extra="forbid"`/`validate_assignment` no tipo; `ExternalId`/`MediaType`/`Severity` como enums; `FilePath`/`LanguageCode`/`LanguageTag` ricos e validados; `SqlAlchemyUnitOfWork` usa `raise` em vez de `assert` (respeita `python -O`).
+- **Agregados de lifecycle ricos** — `MediaConflict` (`detect()`/`resolve()`/`loser_id()` + 5 `model_validator`s tornando estados ilegais irrepresentáveis); `Season` intro-detection (transições `with_detection_*` + `_guard_transition`); `WatchProgress` (`_watched_ratio` como fonte única de verdade, transição COMPLETED interna); `CustomList`/`WatchlistItem` (`MAX_LISTS`/`MAX_ITEMS` via keyword-only não-bypassável, validador `media_id↔media_type`); `Library` (paths únicos/não-vazios + prioridades únicas no `model_validator`).
+- **`IntroMarker`/`CreditsMarker`** — invariante cruzada `source`+`confidence` corretamente imposta; `with_*` dos markers checam "marker ≤ duração" dentro da entidade (Tell, Don't Ask).
+- **DTOs/converters anêmicos por design** — `_movie_summary_helpers`/`_credits_media_helpers` corretamente finos; `resolve_media_conflict` delega a invariante ao agregado (`conflict.resolve(...)`); `streaming/thumbnail_vtt.py` com `SpriteLayout` VO + funções puras.

--- a/docs/audits/04-coupling.md
+++ b/docs/audits/04-coupling.md
@@ -1,0 +1,276 @@
+# 04 — Auditoria de Acoplamento Inter-Módulos (Bounded Contexts)
+
+**Tipo:** READ-ONLY. Nenhum código-fonte foi alterado.
+**Framework:** Coupling risk = **Integration Strength × Distance × Volatility** (Vlad Khononov).
+**Skill:** `coupling-analysis`
+**Data:** 2026-06-27
+
+## Escopo
+
+Análise de acoplamento entre os bounded contexts do backend HomeFlix, com foco
+nos seis módulos pedidos (`media`, `library`, `watch_progress`, `collections`,
+`building_blocks`, `shared_kernel`) mais as arestas **entrantes** vindas de
+`catalog_requests`, `identity`, `notifications`, `preferences` e `settings`,
+pois essas contam como acoplamento sobre os seis.
+
+Referências aplicadas: **ADR-008** (módulos não se importam; `modules →
+shared_kernel → building_blocks`), **ADR-009** (toda leitura cross-BC passa por
+**Read Port local + ACL adapter** no consumidor).
+
+### Eixos de pontuação
+
+- **Integration Strength** (pior → melhor): *intrusive* (entra no interno do
+  outro: entidade/aggregate, ORM model) > *functional/model* (compartilha
+  conhecimento de um modelo) > *contract* (port publicada, DTO estável).
+- **Distance:** mesmo módulo (baixo) < shared_kernel/building_blocks (esperado)
+  < outro bounded context (alto).
+- **Volatility:** acoplar a coisa que muda muito (entidade de domínio, ORM
+  model, runtime settings) é pior que acoplar a contrato estável.
+
+---
+
+## Matriz de Dependências de Módulos
+
+Mecanismo: **direct** (import interno cru — violação), **acl** (Read Port + ACL
+adapter, ADR-009 conforme), **acl-uow** (ACL adapter que importa a *UoW factory*
+do provedor — superfície ampla, tolerado), **event** (assina *domain event* do
+provedor via event bus), **auth** (crosscut de auth do `identity`), **port-impl**
+(implementa uma port definida no outro módulo), **dep** (helper de presentation
+publicado), **config** (importa `RuntimeSettings`/VO do `settings`), **sk** (via
+shared_kernel — esperado/permitido).
+
+| Importador ↓ \ Provedor → | media | library | watch_progress | collections | identity | settings | catalog_requests | notifications |
+|---|---|---|---|---|---|---|---|---|
+| **media** | — | **direct** + acl-uow | acl | — | acl-uow + **direct(use-case UoW)** + auth | **config** | port-impl | — |
+| **library** | acl-uow | — | — | — | auth | — | — | — |
+| **watch_progress** | event + acl-uow | — | — | — | event + dep | — | — | — |
+| **collections** | event + acl-uow | — | acl-uow | — | event + dep | — | — | — |
+| **catalog_requests** | event + acl | — | — | — | auth | — | — | — |
+| **identity** | — | — | — | — | — | **config** | — | — |
+| **notifications** | — | — | — | — | auth | — | port-impl | — |
+| **preferences** | — | — | — | — | dep | — | — | — |
+| **settings** | — | — | — | — | auth | — | — | — |
+
+Todos os módulos dependem de `shared_kernel` e `building_blocks` (esperado — não
+listado na matriz). Não há ciclos de **import** entre módulos; os pares
+bidirecionais (`media ↔ catalog_requests`, `media ↔ watch_progress`) são
+quebrados por port em direções separadas (ADR-009 §5), exceto o ciclo lógico
+`media ↔ library` que tem uma perna **direct** (ver F1/F2).
+
+### Observações estruturais
+
+- **`integration_events` está vazio.** `src/shared_kernel/integration_events/`
+  contém só um `__init__.py` com docstring. A abstração de *integration event*
+  prometida pelo ADR-008 ("comunicação futura via integration events") e pelo
+  ADR-009 (alternativa 3) **nunca foi construída**. Toda comunicação
+  event-driven cross-BC assina **domain events** crus do provedor (F3).
+- **12 ACL adapters / 24 ports** já existem — o padrão ADR-009 está amplamente
+  adotado e funcionando. As violações são exceções pontuais, não a regra.
+
+---
+
+## Achados (ordenados por severidade)
+
+### F1 — `media` importa o aggregate `Library` do BC `library` `[CRÍTICO]`
+
+- **arquivo:linha:** `src/modules/media/application/services/scan_run_service.py:21`
+  (`from src.modules.library.domain.entities.library import Library`); usado em
+  `run_scan(self, run_id: ScanRunId, library: Library)` (:86).
+- **root cause:** *Integration Strength = intrusive* (o pior caso): um serviço
+  de aplicação do Media recebe o **aggregate root** de outro BC como parâmetro,
+  não um DTO/port. *Distance = alto* (cruza fronteira de BC). *Volatility =
+  alta* — `Library` é uma entidade de domínio que evolui (settings, tracks,
+  paths). Qualquer mudança no aggregate `Library` arrasta o serviço de scan do
+  Media. É exatamente o acoplamento que o ADR-009 nasceu para eliminar.
+- **skill + confiança:** `coupling-analysis`, 0.95
+- **evidence:** assinatura `run_scan(..., library: Library)` força o Media a
+  conhecer o shape completo do aggregate do Library, sem port nem ACL.
+
+### F2 — Use cases / routes do `media` importam *UoW factories* de outros BCs (bypass de ACL) `[ALTO]`
+
+- **arquivos:linha:**
+  - `src/modules/media/application/use_cases/get_overview_stats.py:3`
+    (`IdentityUnitOfWorkFactory` direto em um use case)
+  - `src/modules/media/application/use_cases/trigger_scan.py:6`
+    (`LibraryUnitOfWorkFactory` em um use case)
+  - `src/modules/media/presentation/routes/scan_routes.py:13`
+    (`LibraryUnitOfWorkFactory` na camada de presentation)
+- **root cause:** ADR-009 §3 diz que o **use case só conhece a port local**; a
+  ACL vive na infra. Aqui a camada de aplicação (e até presentation) importa a
+  *Unit of Work* completa de outro BC, dando acesso a **todos** os repositórios
+  do provedor (superfície enorme) em vez de um contrato read-only mínimo.
+  *Strength = functional/model* (conhece a UoW do outro BC), *Distance = alto*,
+  *Volatility = média*. O próprio docstring de `get_overview_stats` admite o
+  atalho ("same pattern the trigger-scan use case uses").
+- **skill + confiança:** `coupling-analysis`, 0.9
+- **evidence:** três call-sites em camadas application/presentation importando
+  `*UnitOfWorkFactory` de `identity`/`library` sem port intermediária.
+
+### F3 — Consumidores assinam *domain events* crus do provedor (sem integration-event contract) `[ALTO]`
+
+- **arquivos:linha (representativos):**
+  - `src/modules/collections/application/event_handlers/on_movie_merged.py:11`
+    e `on_movie_promoted_to_series.py:11` → `media.domain.events`
+  - `src/modules/watch_progress/.../on_movie_merged.py:7`,
+    `on_movie_promoted_to_series.py:7` → `media.domain.events`
+  - `src/modules/catalog_requests/.../on_media_enriched.py:13` →
+    `media.domain.events.MediaEnrichedEvent`
+  - `src/modules/collections/.../on_user_deleted.py:10` e
+    `src/modules/watch_progress/.../on_user_deleted.py:7` →
+    `identity.domain.events.UserDeletedEvent`
+- **root cause:** *Strength = model coupling* sobre um artefato **interno de
+  domínio** do provedor. Os 5 consumidores acoplam à classe de *domain event*
+  do `media`/`identity` (que carrega VOs de domínio como `MovieId`/`SeriesId`).
+  Como `shared_kernel/integration_events` está vazio, não existe um contrato de
+  evento publicado e estável — o evento muda junto com o domínio (*Volatility
+  média-alta*), cruzando fronteira de BC (*Distance alto*). Renomear/alterar um
+  domain event do Media quebra 3+ BCs silenciosamente (shotgun surgery).
+- **skill + confiança:** `coupling-analysis`, 0.85
+- **evidence:** 5 arestas event-driven, todas importando de `*.domain.events`;
+  pacote `integration_events` desabitado.
+
+### F4 — `RuntimeSettings`/VOs do `settings` espalhados pela infra (e um use case) do `media` `[ALTO]`
+
+- **arquivos:linha:** 8 sites em `media` →
+  `src/modules/media/infrastructure/streaming/hls_service.py:68`,
+  `.../thumbnail_service.py:36`, `.../scrub_preview_locator.py:18`,
+  `infrastructure/audio/audio_extractor.py:32`,
+  `infrastructure/video/credits_detector.py:47`, `.../frame_hasher.py:30`, e
+  **`application/use_cases/detect_movie_conflicts.py:32-33`**
+  (`settings.domain.value_objects.ScanDedupConfig` +
+  `settings.infrastructure.runtime_settings.RuntimeSettings`).
+- **root cause:** `RuntimeSettings` é uma classe **concreta de infraestrutura**
+  de outro BC, importada em 8 pontos do Media — inclusive em um **use case**,
+  que ainda alcança um **VO de domínio** (`ScanDedupConfig`) do `settings`.
+  *Strength = intrusive/model* (depende do interno concreto, não de uma port de
+  config), *Distance = alto*, *Volatility = média* (settings é config-driven via
+  ADR-013/014 e muda por feature). Sem port (ex.: `StreamingConfigPort`), uma
+  refatoração de `RuntimeSettings` toca metade da infra do Media.
+- **skill + confiança:** `coupling-analysis`, 0.85
+- **evidence:** ADR-009 não foi aplicado ao `settings`; o BC é tratado como
+  biblioteca de config importável.
+
+### F5 — Vazamento do ORM `UserModel` do `identity` para as routes de 5 módulos `[MÉDIO]`
+
+- **arquivos:linha (representativos):**
+  `src/modules/media/presentation/routes/*` (14 pares auth+UserModel),
+  `catalog_requests/.../admin_catalog_request_routes.py:21` e
+  `catalog_request_routes.py:28`, `library/.../library_routes.py:12`,
+  `notifications/.../notification_routes.py:12`,
+  `settings/.../admin_settings_routes.py:19`.
+- **root cause:** As routes importam
+  `identity.infrastructure.persistence.models.user_model.UserModel` — um
+  **SQLAlchemy ORM model**, artefato de **infra interna** do `identity` — só
+  para anotar o parâmetro descartado `_admin: UserModel = Depends(...)`.
+  *Strength = intrusive* (toca o ORM do outro BC), porém *baixa funcionalidade*
+  (uso é só type hint, valor ignorado). *Distance = alto*, mas *Volatility =
+  média* e disseminação alta (≈20 sites) → risco de shotgun surgery se o ORM do
+  identity mudar. A dependência funcional `current_admin_user`/`current_active_user`
+  é um crosscut de auth legítimo (contrato publicado); o problema é o **tipo de
+  retorno** vazar o ORM em vez de um DTO/`AuthenticatedUser`.
+- **skill + confiança:** `coupling-analysis`, 0.8
+- **evidence:** 20+ imports do `UserModel` fora do `identity`, sempre como
+  anotação de dependência de auth.
+
+### F6 — `identity` importa `RuntimeSettings` do `settings` `[MÉDIO]`
+
+- **arquivo:linha:** `src/modules/identity/infrastructure/storage/local_avatar_storage.py:32`.
+- **root cause:** Mesma classe de problema do F4 em escala menor (1 site):
+  infra do `identity` depende do interno concreto de config do `settings` sem
+  port. *Strength = intrusive*, *Distance = alto*, *Volatility = média*. Isolado,
+  baixo impacto, mas reforça que `settings` virou dependência ambiente global.
+- **skill + confiança:** `coupling-analysis`, 0.75
+
+### F7 — ACL adapters importam a *UoW factory* completa do provedor `[MÉDIO]`
+
+- **arquivos:linha:**
+  `collections/.../media_lookup_adapter.py:13`,
+  `collections/.../progress_lookup_adapter.py:11`,
+  `library/.../media_count_query_adapter.py:13`,
+  `media/.../progress_lookup_adapter.py:14`,
+  `media/.../library_health_adapter.py:11`,
+  `media/.../profile_library_access_adapter.py:8`,
+  `media/.../profile_summary_adapter.py:21`.
+- **root cause:** Padrão ADR-009 corretamente aplicado (a importação está
+  **isolada no ACL adapter**, na infra do consumidor — é o lugar certo). A
+  ressalva: o adapter importa a `*UnitOfWorkFactory` do provedor, expondo
+  internamente **todos** os repositórios do outro BC, mais amplo que um repo
+  read-only focado (o próprio ADR-009 lista esse risco — "adapter virar
+  repositório mal disfarçado"). *Strength = functional/model*, *Distance =
+  alto*, *Volatility = baixa* (UoW factory é interface estável). Risco contido
+  porque o blast radius para no adapter; é o padrão sancionado, só monitorar.
+- **skill + confiança:** `coupling-analysis`, 0.7
+
+### F8 — `shared_kernel` acumulando VOs de identidade per-BC `[MÉDIO]`
+
+- **arquivos:** `src/shared_kernel/value_objects/` — 12 arquivos de VO, incluindo
+  `media_id.py` (`MovieId`/`SeriesId`/`SeasonId`/`EpisodeId` — linguagem do Media
+  BC), `media_type.py`, `library_id.py`, `profile_id.py`, `user_id.py`,
+  `episode_composite_id.py`.
+- **root cause:** ADR-008 definiu shared_kernel "mínimo" (3 VOs: FilePath,
+  LanguageCode, tracks). Hoje abriga identificadores que pertencem
+  conceitualmente a BCs específicos (`MovieId` é do Media; `LibraryId` do
+  Library; `UserId` do Identity). Foram promovidos porque domain events e ports
+  precisam referenciá-los entre BCs — é a **válvula de escape do acoplamento
+  F3**. Não é violação de direção (todos podem importar shared_kernel), mas é
+  *drift* do shared kernel virar dumping ground de tipos cross-BC. *Strength =
+  contract* (VOs estáveis), *Volatility = baixa* — por isso médio, não alto:
+  centralizar tipos estáveis é aceitável, mas merece vigilância de review (ADR-008
+  risco "shared_kernel crescer demais").
+- **skill + confiança:** `coupling-analysis`, 0.65
+
+### F9 — `resolve_profile_id` (presentation helper do `identity`) reusado por 4 módulos `[BAIXO]`
+
+- **arquivos:linha:** `media/presentation/dependencies.py:10`,
+  `collections/.../dependencies.py:10`, `watch_progress/.../dependencies.py:11`,
+  `preferences/.../dependencies.py:10`.
+- **root cause:** Importa um helper de **presentation** publicado do `identity`
+  (resolução de profile a partir do request). *Strength = contract* (função
+  utilitária estável de FastAPI dependency), *Volatility = baixa*. Aceitável como
+  crosscut de presentation; só não há contrato formal documentando-o como API
+  pública do identity.
+- **skill + confiança:** `coupling-analysis`, 0.6
+
+### F10 — Inversões de port: provedor implementa port definida no consumidor `[BAIXO]`
+
+- **arquivos:linha:**
+  `media/.../localized_title_provider_adapter.py:11` (implementa
+  `catalog_requests.application.ports.LocalizedTitleProviderPort`),
+  `notifications/.../notification_publisher_adapter.py:11` (implementa
+  `catalog_requests...notification_publisher_port`),
+  `catalog_requests/.../catalog_request_lookup_adapter.py:15` (implementa
+  `media.application.ports.catalog_request_lookup_port`).
+- **root cause:** Acoplamento via **contrato (port)** — o melhor caso de
+  Strength. O consumidor define a port; o provedor a implementa do outro lado
+  (ADR-009 conforme). A única nuance é que o adapter importa o **módulo** da port
+  do outro BC, mas como é uma ABC estável (contract), *Volatility = baixa* e o
+  risco é mínimo. Documentado nos próprios docstrings dos adapters. Sem ação.
+- **skill + confiança:** `coupling-analysis`, 0.6
+
+---
+
+## Resumo de Hotspots
+
+1. **`media` é o epicentro.** Concentra as arestas mais perigosas: F1 (import de
+   aggregate `Library`), F2 (UoW bypass para `identity`+`library`), F4
+   (`RuntimeSettings` em 8 sites). O par **`media ↔ library`** é o mais
+   degradado — tem leitura via ACL (`library_health_adapter`) **e** três
+   imports diretos que furam o padrão. Endereçar `media→library` primeiro.
+
+2. **`integration_events` morto + assinatura de domain events crus (F3).** A
+   abstração planejada não existe; 5 BCs acoplam a domain events internos. É a
+   dívida arquitetural de maior alcance lateral. Promover os ~4 eventos cross-BC
+   a *integration events* estáveis em `shared_kernel/integration_events`
+   resolveria F3 e aliviaria a pressão sobre o shared_kernel (F8).
+
+3. **`settings` virou dependência ambiente (F4+F6).** `RuntimeSettings` é
+   importado concretamente por `media` (8x) e `identity` (1x) sem nenhuma port.
+   Um `*ConfigPort` por consumidor alinharia ao ADR-009.
+
+4. **`identity` vaza ORM via auth (F5).** O crosscut de auth é legítimo, mas o
+   tipo de retorno deveria ser um DTO (`AuthenticatedUser`), não o `UserModel`
+   SQLAlchemy — ~20 sites dependem hoje do interno de persistência do identity.
+
+5. **O padrão ADR-009 está saudável onde foi aplicado** (F7/F10): 12 ACL
+   adapters, 24 ports, sem ciclos de import. As violações são exceções
+   localizadas, não a norma — o refactor é cirúrgico, não estrutural.

--- a/docs/audits/05-doc-drift.md
+++ b/docs/audits/05-doc-drift.md
@@ -1,0 +1,225 @@
+# 📑 Doc Drift Audit — HomeFlix backend (snapshot)
+
+| | |
+|---|---|
+| **Projeto** | HomeFlix (backend) |
+| **Modo** | Auditoria de snapshot (READ-ONLY) — repo inteiro, não diff |
+| **Escopo** | ADRs 001–022, `docs/standards/*`, `.claude/CLAUDE.md`, `docs/roadmap.md`, docstrings (spot-check) vs. `src/` |
+| **Branch** | develop @ 25b5211 |
+| **Skill** | doc-drift-audit |
+| **Drift encontrado** | 10 achados (8 confiança ≥ 0.8) |
+
+## Tabela de severidade
+
+| Severidade | Qtde |
+|---|---|
+| 🔴 Crítico | 1 |
+| 🟠 Alto | 2 |
+| 🟡 Médio | 5 |
+| 🔵 Baixo | 2 |
+| **Total** | **10** |
+
+---
+
+## 🔴 Crítico
+
+### [CONTRADIÇÃO] CLAUDE.md "API Response Standard (resumo)" descreve um envelope que o código não usa `.claude/CLAUDE.md` (seção *API Response Standard (resumo)*) (confiança: 0.92)
+**Doc afirma:** CLAUDE.md ensina o envelope de sucesso como
+`{"data": {...}, "meta": {"request_id": "..."}}` (single) e
+`{"data": [...], "meta": {"request_id": "...", "pagination": {...}}}` (collection).
+**Código agora:** `src/building_blocks/presentation/responses.py:73` →
+`{"type": resource_type, "data": data}`; `:101` →
+`{"type": "list", "data": data, "metadata": {"pagination": {...}}}`. O `request_id`
+vai para o **header** (`request_context.py:64`, `X-Request-Id`), nunca no corpo.
+**Por que diverge:** três erros num só bloco — (1) o campo obrigatório `type` está
+ausente no resumo; (2) a chave é `metadata`, não `meta`; (3) `request_id` não existe
+no payload. Um implementador que seguir o CLAUDE.md monta um envelope incompatível com
+todo o resto da API e com o parser do frontend.
+**Sugestão de atualização:** alinhar o resumo do CLAUDE.md ao
+`api-response-standard-rest-v3.md` e ao `responses.py` (incluir `type`, usar
+`metadata`, mover `request_id` para header).
+
+> Drift relacionado mas inverso: o próprio `responses.py:11-15` (docstring) admite que
+> a paginação está aninhada em `metadata` enquanto o standard v3 a coloca no top-level —
+> ver finding médio abaixo. O standard e o código divergem entre si **e** o CLAUDE.md
+> diverge de ambos.
+
+---
+
+## 🟠 Alto
+
+### [CONTRADIÇÃO] "Módulos NÃO importam entre si" / ADR-009 rule #3 violado na camada de aplicação `.claude/CLAUDE.md` (regra de dependência) ↔ `docs/adr/ADR-009-cross-bc-read-ports.md:44` (confiança: 0.82)
+**Doc afirma:** CLAUDE.md: *"Módulos NÃO importam entre si — usar Read Port + ACL
+(ADR-009)"*. ADR-008:99 princípio #1: *"Módulos não importam entre si"*. ADR-009 regra
+#3: *"Adapter é o único import cross-BC domain. Use case só conhece a port local."*
+**Código agora:** imports cross-BC **fora** de `infrastructure/acl/`, na camada de aplicação:
+- `src/modules/media/application/services/scan_run_service.py:21` →
+  `from src.modules.library.domain.entities.library import Library` (entidade de outro BC
+  importada num application service do media).
+- `src/modules/media/application/use_cases/get_overview_stats.py:3` →
+  `from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory`.
+- `src/modules/media/application/use_cases/trigger_scan.py:6` →
+  `from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory`.
+**Por que diverge:** a regra textual ("o adapter é o *único* import cross-BC", "use case
+só conhece a port local") é violada — use cases/services do `media` importam UoW factories
+de `identity`/`library` e a entidade `Library` diretamente, sem port. Não é o ACL
+sancionado pela ADR-009.
+**Sugestão de atualização:** ou (a) registrar exceção explícita na ADR-009 para
+orquestração multi-UoW (ex.: scan/overview), ou (b) tratar como dívida de arquitetura e
+manter o ADR como está; de qualquer forma a afirmação absoluta do CLAUDE.md ("NÃO importam
+entre si") precisa de ressalva.
+
+### [OBSOLETO] Hierarquia `PresentationException` documentada não existe no código `docs/standards/exception-hierarchy-clean-architecture.md:128,867-943` (confiança: 0.83)
+**Doc afirma:** o guia documenta uma camada inteira `PresentationException` com
+`InvalidRequestFormatException`, `UnsupportedMediaTypeException`, `NotAcceptableException`
+(árvore na linha 128-131, definições em 890-943) e o CLAUDE.md aponta este guia como
+fonte para "criar/usar exceções".
+**Código agora:** `grep -rn PresentationException src/` → **zero ocorrências**.
+`building_blocks` define apenas `CoreException`, `DomainException`, `ApplicationException`,
+`InfrastructureException` e suas subclasses (`domain/errors.py`, `application/errors.py`,
+`infrastructure/errors.py`). Não há `building_blocks/presentation/errors.py`.
+**Por que diverge:** um engenheiro instruído a levantar `UnsupportedMediaTypeException`
+não encontra a classe. O guia descreve um ramo da hierarquia que nunca foi implementado.
+**Sugestão de atualização:** marcar a seção `PresentationException` como "não
+implementado / aspiracional" ou removê-la até existir o módulo correspondente.
+
+---
+
+## 🟡 Médio
+
+### [CONTRADIÇÃO] Árvore de estrutura e lista de Bounded Contexts do CLAUDE.md listam 4 módulos; existem 9 `.claude/CLAUDE.md` (seções *Estrutura* e *Bounded Contexts*) (confiança: 0.95)
+**Doc afirma:** o tree de `src/modules/` e a lista numerada de BCs citam apenas `media`,
+`library`, `watch_progress`, `collections`.
+**Código agora:** `src/modules/` contém **9** módulos: `media`, `library`,
+`watch_progress`, `collections`, `catalog_requests`, `identity`, `notifications`,
+`preferences`, `settings`. (O texto da "Fase Atual" já diz "9 bounded contexts", mas o
+tree e a lista de BCs não foram atualizados.)
+**Por que diverge:** quem procura onde mora auth/notificações/settings é levado a crer que
+não existem como módulos. Inconsistência interna no próprio CLAUDE.md (tree=4 vs texto=9).
+**Sugestão de atualização:** incluir os 5 módulos faltantes no tree e na lista de BCs.
+
+### [CONTRADIÇÃO] Standard v3 coloca `pagination` no top-level; o código aninha em `metadata` `docs/standards/api-response-standard-rest-v3.md:51-68` ↔ `src/building_blocks/presentation/responses.py:101-110` (confiança: 0.9)
+**Doc afirma:** v3 exibe a coleção como `{"type":"list","data":[...],"pagination":{...}}`
+com `pagination` no **nível raiz** e `metadata` reservado só para `filters_applied`.
+**Código agora:** `api_list` produz `{"type":"list","data":[...],"metadata":{"pagination":
+{...}}}` — paginação **aninhada** em `metadata`. O docstring `responses.py:11-15` reconhece
+explicitamente o desvio ("the standard doc describes a top-level placement that can be
+adopted in a future major").
+**Por que diverge:** cliente que lê o standard acessa `resp.pagination`; o real é
+`resp.metadata.pagination`.
+**Sugestão de atualização:** anotar no standard v3 a divergência atual (paginação em
+`metadata`) ou versionar o standard para refletir a implementação vigente.
+
+### [OBSOLETO] CLAUDE.md aponta i18n para `i18n/locales/{en,pt-BR}/` — diretório inexistente `.claude/CLAUDE.md` (checklist #8) (confiança: 0.85)
+**Doc afirma:** checklist de feature, item 8: *"i18n: traduções em
+`i18n/locales/{en,pt-BR}/`"*.
+**Código agora:** não existe `i18n/`, `locales/` nem catálogo JSON de tradução
+(`find` por `pt-BR/`, `i18n`, `*locale*.json` → vazio). A i18n é feita por **campos
+localizados por entidade** (`get_title(lang)` em `movie.py`/`series.py`/`season.py`/
+`episode.py`) com `lang` vindo de query param (`movie_routes.py:58 lang: str = "en"`).
+**Por que diverge:** o checklist manda criar arquivos num diretório que não existe e que
+não corresponde ao mecanismo real (campos localizados em DB, não message catalogs).
+**Sugestão de atualização:** reescrever o item 8 para "adicionar campos localizados na
+entidade + enrichment por locale (TMDB)"; remover o caminho `i18n/locales/`.
+
+### [OBSOLETO] api-i18n-guide descreve message-catalogs JSON + Accept-Language que não são usados `docs/standards/api-i18n-guide.md:32-58,68-73,175-201` (confiança: 0.7)
+**Doc afirma:** o guia especifica resolução por header `Accept-Language` com q-values,
+header `Content-Language` na resposta, diretório `locales/` com namespaces JSON e
+`SUPPORTED_LOCALES = ["en","pt-BR","pt","es"]` carregados de arquivos.
+**Código agora:** i18n real = `lang` query param (`movie_routes.py:58`) +
+`entity.get_title(lang)`; locales suportados são **config-driven** via
+`settings.py:176 supported_locales` (default `["en","pt-BR"]`), não a lista do guia; não há
+parsing de Accept-Language nem catálogos JSON.
+**Por que diverge:** o guia descreve uma arquitetura de i18n (catálogos de mensagem) que o
+backend não implementa; a localização é por dado de domínio enriquecido do TMDB.
+**Sugestão de atualização:** reescrever o guia para o modelo real (campo `lang`,
+`supported_locales` config-driven, localização por entidade) ou marcá-lo como design
+não adotado.
+
+### [CONTRADIÇÃO] Contagens de endpoints/testes desatualizadas `.claude/CLAUDE.md:186` e `docs/roadmap.md:69,114` (confiança: 0.9)
+**Doc afirma:** CLAUDE.md:186 e roadmap:69 — *"107 endpoints REST ... 2 530+ testes"*;
+roadmap:114 (entrada mais recente) — *"112 REST API endpoints ... 2 660+ tests"*.
+**Código agora:** `grep '@router.(get|post|put|patch|delete)'` → **132** rotas;
+`281` arquivos `test_*.py` com **2 941** funções `test_*`.
+**Por que diverge:** ambos os números (107/2530 e 112/2660) estão defasados frente a
+132/2941. Métricas factuais erradas.
+**Sugestão de atualização:** atualizar para ~132 endpoints / ~2940 testes (ou remover os
+números fixos e referir um comando de contagem).
+
+---
+
+## 🔵 Baixo
+
+### [OBSOLETO] ADR-008 "Estrutura Adotada" reflete só media+library e prevê eventos em shared_kernel `docs/adr/ADR-008-screaming-architecture.md:28-95,99` (confiança: 0.55)
+**Doc afirma:** o tree da ADR mostra apenas `modules/media` e `modules/library`;
+`config/containers/` lista só `media.py` e `library.py`; princípio #1 diz "comunicação
+futura via integration events **no shared_kernel**".
+**Código agora:** 9 módulos; `config/containers/` tem 11 arquivos (um por BC +
+`infrastructure.py`/`main.py`); integration events vivem em
+`modules/<bc>/domain/events.py` (não em shared_kernel) e **já** são usados em produção
+(event handlers cross-BC), não "futuramente".
+**Por que diverge:** ADR é um registro datado (2026-04-02) — o tree é snapshot histórico
+e por isso a severidade é baixa; ainda assim o status "Aceito" + o princípio #1 sobre
+shared_kernel descrevem um mecanismo que não foi o adotado.
+**Sugestão de atualização:** nota de revisão na ADR-008 esclarecendo que eventos ficam no
+domínio de cada BC e que o nº de módulos cresceu (sem reescrever o snapshot original).
+
+### [LACUNA] Módulos `notifications` e `preferences` sem ADR e fora da lista de ADRs do CLAUDE.md `docs/adr/` / `.claude/CLAUDE.md` (confiança: 0.6)
+**Doc afirma:** a lista de ADRs ativos no CLAUDE.md vai até ADR-022; não há ADR para
+`notifications` nem `preferences`.
+**Código agora:** existem `src/modules/notifications/` e `src/modules/preferences/` como
+BCs completos (4 camadas, rotas, containers).
+**Por que diverge:** `identity`→ADR-010, `catalog_requests`→ADR-022, `settings`→ADR-013/014,
+mas `notifications`/`preferences` não têm registro de decisão. Lacuna menor (preferences é
+pequeno; notifications nasceu junto da ADR-022 mas o publishing/transport não está coberto).
+**Sugestão de atualização:** avaliar um ADR curto para notifications (transport/fanout) se
+a decisão for relevante; caso contrário, registrar como deliberadamente sem ADR.
+
+---
+
+## 🟡 Lacunas de documentação (resumo)
+
+- **Iniciativa de localização sem ADR** (confiança 0.7): comportamento cross-cutting
+  significativo — `supported_locales` config-driven (`settings.py:176`), enriquecimento
+  TMDB por locale para temporadas/episódios, campos `localized` por entidade, indexação
+  FTS5 de campos localizados — **não tem ADR**. `catalog_requests` tem ADR-022, mas a
+  localização-como-arquitetura (a decisão de migrar de hardcoded en+pt-BR para
+  config-driven + localização per-entity) ficou sem registro. Candidato a ADR.
+- **PresentationException** (ver Alto): documentada, não implementada — gap inverso
+  (doc sem código).
+- **i18n message-catalog** (ver Médio): guia descreve sistema não implementado.
+
+## 🗺️ Cobertura
+
+| Símbolo/decisão | Doc relacionado | Status |
+|---|---|---|
+| Envelope de resposta (`api_single`/`api_list`) | CLAUDE.md resumo / standard v3 | 🔴 drift (3 lugares) |
+| Regra "módulos não importam entre si" | CLAUDE.md / ADR-008 / ADR-009 | 🔴 drift (application layer) |
+| Hierarquia de exceções | exception-hierarchy doc | 🟠 PresentationException ausente |
+| i18n (`lang` param, `get_title`, `supported_locales`) | CLAUDE.md #8 / api-i18n-guide | 🟠 drift (catálogo inexistente) |
+| Lista de módulos/BCs | CLAUDE.md tree+BC list / ADR-008 tree | 🟡 4 listados, 9 reais |
+| Contagem endpoints/testes | CLAUDE.md:186 / roadmap | 🟡 107·112 vs 132; 2530·2660 vs 2941 |
+| Prefixed IDs `mov_`/`ser_` (ADR-002) | ADR-002 | ✅ consistente (ExternalId em building_blocks) |
+| Exception base classes (Core/Domain/Application/Infrastructure) | exception-hierarchy doc | ✅ batem com `errors.py` |
+| ACL ports cross-BC (`infrastructure/acl/*`) | ADR-009 | ✅ padrão seguido na maioria dos pares |
+| Catalog Requests subscriptions/fanout | ADR-022 | ✅ atualizado junto do código |
+| Localização (config-driven/per-entity) | — | 🟡 sem ADR |
+| notifications / preferences | — | 🟡 sem ADR |
+
+## ✅ Higiene boa
+
+- **ADR-022** (catalog requests subscriptions + fanout) foi escrito junto da feature e bate
+  com o código atual (`modules/catalog_requests`, event handlers, ACL).
+- **ADR-010/011** (identity/auth) e **ADR-013/014** (settings) cobrem corretamente seus
+  módulos.
+- `responses.py:11-15` documenta **honestamente** seu próprio desvio do standard v3
+  (paginação em `metadata`) — boa sinalização, ainda que o standard devesse ser
+  reconciliado.
+- A hierarquia de exceções de domínio/aplicação/infra do guia bate 1:1 com
+  `building_blocks/*/errors.py` (só a camada de apresentação está sobre-documentada).
+
+## 🤔 Baixa confiança (verificar manualmente)
+
+- ADR-008 snapshot histórico (0.55) — listado em Baixo; pode-se decidir não tocar ADRs
+  datados por política.
+- notifications/preferences sem ADR (0.6) — pode ser ausência deliberada.

--- a/docs/audits/06-remediation-plan.md
+++ b/docs/audits/06-remediation-plan.md
@@ -1,0 +1,440 @@
+# HomeFlix — Plano de Remediação Faseado (PRs)
+
+**Data:** 2026-06-27 · **Base:** achados de [`00-executive-summary.md`](00-executive-summary.md)
+e dos 5 relatórios por dimensão (01–05). **Modo do plano:** proposta — nenhum
+código foi alterado.
+
+Este plano ataca **todos os ~40 defeitos raiz distintos** identificados, na ordem
+recomendada pelo sumário executivo (barato→estrutural→cleanup). Cada PR é
+independentemente revisável e mergeável.
+
+## Como ler
+
+Cada card de PR traz: **título** (Conventional Commits), **escopo**, **achados
+cobertos** (id do relatório de origem), **arquivos-chave**, **migration?**, **ADR?**,
+**esforço**, **depende de**. Severidade herda do relatório de origem.
+
+> **Regra de workflow (CLAUDE.md):** cada PR sai de um branch novo a partir de
+> `origin/develop` (`git checkout -b <type>/<slug> origin/develop`). Sem menções a
+> IA em commits/PRs/código. PR com `## Summary` + `## Test plan`.
+
+## Sequência global
+
+```
+FASE 1  Docs (baixo risco, alta alavancagem)         ── PR-D1..D4   [paralelizável]
+FASE 2  LocalizedMetadata VO + ADR  (CRÍTICO)         ── PR-2.1..2.3 [base p/ Fase 4 e 5]
+FASE 3  Mecanismo de integração cross-BC             ── PR-3.1..3.5 [faseável; epicentro media]
+FASE 4  Gateways de provider + MetadataReconciler     ── PR-4.1..4.4 [4.4 depende de Fase 2]
+FASE 5  Primitive Obsession de idioma (resto)         ── PR-5.1      [depende de Fase 2]
+FASE 6  Cleanup de modelagem (médios/baixos)          ── PR-6.1..6.11 [independentes entre si]
+```
+
+**Dependências duras:** Fase 4 (PR-4.4 reconciler) e Fase 5 consomem o VO da Fase 2.
+O resto é majoritariamente independente e pode ser paralelizado por revisor.
+
+> ⚠️ **Recomendação de reordenação:** **PR-6.2** (`with_updates` muta a fonte →
+> **perda silenciosa de domain events**) é o único achado "cleanup" que é um bug
+> latente de corrupção, não estética. Sugiro **puxá-lo para logo após a Fase 1**,
+> antes da Fase 3 (que vai mexer pesado em event handlers).
+
+---
+
+## FASE 1 — Documentação (Tema D)
+
+Sem risco de runtime, evita que novos PRs herdem doc errada. Os quatro são
+independentes; podem virar um único PR `docs:` se preferir.
+
+### PR-D1 · `docs(standards): align response envelope and pagination placement`
+- **Escopo:** corrigir o "API Response Standard (resumo)" do CLAUDE.md para o
+  envelope real (`type` obrigatório, chave `metadata` não `meta`, `request_id` no
+  header `X-Request-Id`, não no corpo). Anotar no `api-response-standard-rest-v3.md`
+  a divergência atual de paginação (aninhada em `metadata`, não top-level).
+- **Achados:** doc-drift 🔴 #1 (envelope) + 🟡 (pagination v3 vs código).
+- **Arquivos:** `.claude/CLAUDE.md` (seção API Response Standard);
+  `docs/standards/api-response-standard-rest-v3.md:51-68`. Referência real:
+  `src/building_blocks/presentation/responses.py:73,101`.
+- **Migration?** Não. **ADR?** Não. **Esforço:** XS.
+
+### PR-D2 · `docs: realign i18n docs with localized-field model`
+- **Escopo:** reescrever o checklist #8 do CLAUDE.md (remover `i18n/locales/{en,pt-BR}/`
+  inexistente) e o `api-i18n-guide.md` para o modelo real: query param `lang` +
+  `entity.get_title(lang)` + `supported_locales` config-driven; remover descrição de
+  message-catalogs JSON + Accept-Language não usada.
+- **Achados:** doc-drift 🟠 (i18n catálogo) + 🟡 (api-i18n-guide obsoleto).
+- **Arquivos:** `.claude/CLAUDE.md` (checklist #8);
+  `docs/standards/api-i18n-guide.md:32-58,68-73,175-201`. Referência:
+  `src/config/settings.py:176`, `movie_routes.py:58`.
+- **Migration?** Não. **ADR?** Não (o ADR da localização é a Fase 2). **Esforço:** S.
+
+### PR-D3 · `docs(standards): mark PresentationException layer as not implemented`
+- **Escopo:** marcar a seção `PresentationException` (e subclasses) como
+  "aspiracional / não implementada" ou removê-la até existir o módulo.
+- **Achados:** doc-drift 🟠 (PresentationException ausente).
+- **Arquivos:** `docs/standards/exception-hierarchy-clean-architecture.md:128,867-943`.
+  Verificação: `grep -rn PresentationException src/` → zero.
+- **Migration?** Não. **ADR?** Não. **Esforço:** XS.
+
+### PR-D4 · `docs: refresh module inventory and project counters`
+- **Escopo:** atualizar o tree de `src/modules/` e a lista de Bounded Contexts do
+  CLAUDE.md (4→9: incluir `catalog_requests`, `identity`, `notifications`,
+  `preferences`, `settings`); atualizar contagens (107/112→~132 endpoints;
+  2530/2660→~2941 testes); nota de revisão na ADR-008 (snapshot histórico + eventos
+  ficam no domínio de cada BC); registrar `notifications`/`preferences` como
+  deliberadamente sem ADR (ou abrir ADR curto p/ notifications transport).
+- **Achados:** doc-drift 🟡 (módulos 4 vs 9), 🟡 (contagens), 🔵 (ADR-008 tree),
+  🔵 (notifications/preferences sem ADR).
+- **Arquivos:** `.claude/CLAUDE.md` (Estrutura, Bounded Contexts, Fase Atual);
+  `docs/roadmap.md:69,114`; `docs/adr/ADR-008-screaming-architecture.md` (nota).
+- **Migration?** Não. **ADR?** Opcional (notifications). **Esforço:** S.
+
+---
+
+## FASE 2 — `LocalizedMetadata` Value Object + ADR (Tema B · CRÍTICO)
+
+Estanca a corrupção silenciosa ativa (chave mágica que não faz round-trip; tagline
+já foi perdida). Base para Fases 4 e 5.
+
+### PR-2.1 · `docs(adr): ADR-023 localized metadata as value object`
+- **Escopo:** ADR registrando (a) a iniciativa de localização config-driven (que hoje
+  não tem ADR) e (b) a decisão "metadados localizados como VO `LocalizedMetadata`
+  chaveado por `LanguageTag`, serializado só na borda de persistência". Usar a skill
+  `adr-writer`.
+- **Achados:** code-smell CRÍTICO (contexto) + doc-drift 🟡 (localização sem ADR).
+- **Arquivos:** `docs/adr/ADR-023-localized-metadata-value-object.md` (novo).
+- **Migration?** Não. **ADR?** É o ADR. **Esforço:** S. **Depende de:** —
+
+### PR-2.2 · `feat(media): introduce LocalizedMetadata value object (read path)`
+- **Escopo:** criar o VO `LocalizedMetadata` (registro por-locale tipado, chaveado por
+  `LanguageTag`, com `get(field, lang)` e fallback centralizado) e `merge(other,
+  policy)`. Trocar os ~24 acessores `str(loc.get("title") or ...)` das 4 entidades
+  para ler via VO. **Manter a serialização JSON idêntica** na borda de persistência
+  (mesmo shape no disco) para não exigir migration. Tipar `lang` desses acessores como
+  `LanguageTag` (coagindo a string crua uma vez).
+- **Achados:** code-smell 🔴 (dict localizado) + 🟠 (lang:str nos acessores de entidade).
+- **Arquivos:** `src/modules/media/domain/value_objects/` (novo VO);
+  `domain/entities/{movie.py:95,131-180, series.py:78,106-150, episode.py:67,95-100,
+  season.py:57,139-146}`; mapper/persistence boundary.
+- **Migration?** **Não** (wire JSON preservado) — verificar round-trip do
+  `json_extract(localized, lang)` em teste de integração. **ADR?** PR-2.1. **Esforço:**
+  G. **Depende de:** PR-2.1.
+
+### PR-2.3 · `refactor(media): write localized metadata through the VO on enrich`
+- **Escopo:** caminho de escrita do enrich passa a montar/gravar via `LocalizedMetadata`
+  em vez de achatar para dict aninhado em `_localized_metadata_helpers`. Remove a chance
+  de divergência de chave entre as variantes movie/series.
+- **Achados:** code-smell 🔴 (mesmo defeito, lado escrita).
+- **Arquivos:** `enrich_movie_metadata.py:344`, `enrich_series_metadata.py:260`,
+  `_localized_metadata_helpers.py:15-101`.
+- **Migration?** Não. **Esforço:** M. **Depende de:** PR-2.2. **Nota:** prepara o terreno
+  para o `MetadataReconciler` da Fase 4.
+
+---
+
+## FASE 3 — Mecanismo de integração cross-BC (Tema A)
+
+Maior alavanca estrutural. Epicentro `media`. Faseável em 5 PRs ortogonais.
+
+### PR-3.1 · `feat(shared_kernel): materialize integration events package`
+- **Escopo:** criar os contratos de integration event versionados/estáveis em
+  `shared_kernel/integration_events/` (hoje vazio) para os ~4 eventos cross-BC
+  (`MovieMerged`, `MoviePromotedToSeries`, `MediaEnriched`, `UserDeleted`). Publicar a
+  partir do produtor; consumidores deixam de importar `*.domain.events`.
+- **Achados:** clean-arch M-8/M-9 · coupling F3 (🟠) · doc-drift 🟠 (regra "módulos não
+  importam entre si").
+- **Arquivos:** `src/shared_kernel/integration_events/` (popular);
+  `media/domain/events.py`, `identity/domain/events.py` (publicar integration event);
+  `watch_progress|collections|catalog_requests/.../event_handlers/*.py` (consumir o
+  contrato). Atualizar ADR-008/009 (nota sobre integration events reais).
+- **Migration?** Não. **ADR?** Nota em ADR-008/009. **Esforço:** G. **Depende de:** —
+  (mas coordenar com PR-6.2 se reordenado, pois mexe em handlers).
+
+### PR-3.2 · `refactor(media): replace cross-BC UoW shortcuts with read ports`
+- **Escopo:** criar `IdentityUserCountPort` e `LibraryLookupPort` (ports locais em
+  `media/application/ports/`) + adapters ACL em `media/infrastructure/acl/` retornando
+  DTOs próprios; usar nos use cases que hoje pegam a UoW alheia.
+- **Achados:** clean-arch A-2/A-3 (🟠) · coupling F2 (🟠).
+- **Arquivos:** `media/application/use_cases/get_overview_stats.py:3`,
+  `trigger_scan.py:6`, `presentation/routes/scan_routes.py:13`; novos ports + adapters.
+- **Migration?** Não. **Esforço:** M. **Depende de:** —
+
+### PR-3.3 · `refactor(media): pass library data as DTO into scan, not the aggregate`
+- **Escopo:** `scan_run_service.run_scan(...)` deixa de receber o aggregate `Library`
+  de outro BC; recebe um DTO local (via `LibraryLookupPort` da PR-3.2). Elimina o
+  acoplamento *intrusive* mais grave da base.
+- **Achados:** clean-arch A-1 · coupling **F1 (🔴 CRÍTICO)** · doc-drift 🟠.
+- **Arquivos:** `media/application/services/scan_run_service.py:21,86`.
+- **Migration?** Não. **Esforço:** M. **Depende de:** PR-3.2 (reusa a port/DTO).
+
+### PR-3.4 · `refactor(identity): expose AuthenticatedUser DTO to route boundaries`
+- **Escopo:** o crosscut de auth passa a tipar o usuário injetado como um DTO
+  `AuthenticatedUser` (publicado pelo `identity`), não o ORM `UserModel`. Atualizar os
+  ~20 sites de rotas em 5 módulos.
+- **Achados:** clean-arch M-7 (🟡 sistêmico) · coupling F5 (🟡).
+- **Arquivos:** `identity/.../auth.py` (retorno DTO);
+  `media/presentation/routes/*` (~14), `library/.../library_routes.py:12`,
+  `catalog_requests`, `notifications`, `settings` routes.
+- **Migration?** Não. **Esforço:** M (mecânico, amplo). **Depende de:** —
+
+### PR-3.5 · `refactor(media): introduce config ports for runtime settings`
+- **Escopo:** substituir os imports concretos de `settings.RuntimeSettings`/VOs por
+  Protocols/ports de config locais (ex.: `StreamingConfigPort`, `ScanDedupConfigPort`)
+  injetados no composition root. Inclui o site `identity` (F6).
+- **Achados:** clean-arch M-5/M-6 · coupling F4 (🟠) + F6 (🟡).
+- **Arquivos:** `media/infrastructure/streaming/{hls_service.py:68,
+  thumbnail_service.py:36,scrub_preview_locator.py:18}`, `audio/audio_extractor.py:32`,
+  `video/{credits_detector.py:47,frame_hasher.py:30}`,
+  `application/use_cases/detect_movie_conflicts.py:32-33`;
+  `identity/.../local_avatar_storage.py:32`.
+- **Migration?** Não. **Esforço:** M. **Depende de:** —
+
+---
+
+## FASE 4 — Gateways de provider + `MetadataReconciler` (Temas C + E)
+
+### PR-4.1 · `fix(media): distinguish provider failure from not-found in TMDB lookups`
+- **Escopo:** `get_*_summary_by_id` para de colapsar `HTTPError`/não-200 no mesmo `None`
+  de um 404 real; alinhar ao comportamento dos paths de search (`raise_for_status`).
+  Caller (relink admin) passa a distinguir "id inexistente" de "TMDB fora/auth/rate".
+- **Achados:** ACL Finding 2 (🟡).
+- **Arquivos:** `media/infrastructure/metadata/tmdb_client.py:266-292`.
+- **Migration?** Não. **Esforço:** S.
+
+### PR-4.2 · `refactor(media): move content-rating jurisdiction policy out of the gateway`
+- **Escopo:** o gateway TMDB passa a **traduzir o conjunto completo** de ratings por
+  país; a escolha de jurisdição (hoje `BR or US` hardcoded) vira política
+  domínio/config (alinha com `supported_locales` da Fase 2). Para de descartar
+  silenciosamente os demais países.
+- **Achados:** ACL Finding 1 (🟡).
+- **Arquivos:** `media/infrastructure/metadata/tmdb_client.py:1096,1153`.
+- **Migration?** Não (se o campo persistido continuar `ContentRating` único; a escolha
+  muda de lugar). **Esforço:** M.
+
+### PR-4.3 · `fix(media): preserve "no default audio / unmounted root" signals`
+- **Escopo:** (a) probe deixa de fabricar `tracks[0].is_default=True` quando o container
+  não declara default — preserva "sem default" e deixa a seleção para o `TrackSelector`
+  da Library; (b) scanner distingue raiz desmontada/ausente de raiz vazia (sinal
+  explícito, não `continue` silencioso); (c) opcional: tornar explícitos os defaults
+  `channels→2` / `lang→"un"`.
+- **Achados:** ACL Finding 4 + 5 (🟡), Finding 6 (🔵).
+- **Arquivos:** `media/infrastructure/streaming/media_probe_service.py:403-405,373,349-357`;
+  `media/infrastructure/file_system/scanner.py:160-161`.
+- **Migration?** Não. **Esforço:** M.
+
+### PR-4.4 · `refactor(media): extract MetadataReconciler domain service + MergePolicy`
+- **Escopo:** mover a regra "provider ⇄ entidade" (`if meta_val and (force or not
+  entity_val)`), hoje copiada ~23× nos use cases, para um domain service
+  `MetadataReconciler` (ou `entity.merged_with(metadata, policy)`); substituir o
+  `force: bool` plumbado por ~12 funções por `MergePolicy.FILL_IF_EMPTY | OVERWRITE`.
+  Usa o `LocalizedMetadata.merge()` da Fase 2.
+- **Achados:** code-smell 🟠 (anemic+shotgun, reconciler) + 🟠 (force boolean blindness).
+- **Arquivos:** `enrich_movie_metadata.py:236-345`, `enrich_series_metadata.py:165-480`,
+  `_localized_metadata_helpers.py:15-101`; novo domain service em
+  `media/domain/services/`.
+- **Migration?** Não. **Esforço:** G. **Depende de:** PR-2.2/2.3.
+
+### PR-4.5 (opcional) · `chore(media): make cast truncation configurable`
+- **Escopo:** `_MAX_CAST = 15` hardcoded vira config; registrar/logar a truncagem.
+- **Achados:** ACL Finding 3 (🔵). **Esforço:** XS. **Pode virar won't-fix** se 15 for OK.
+
+---
+
+## FASE 5 — Primitive Obsession de idioma (resto do Tema F)
+
+### PR-5.1 · `refactor(media): accept LanguageTag across read-path use cases`
+- **Escopo:** estender o `LanguageTag` (introduzido na Fase 2) ao caminho de leitura
+  restante — os ~14 use cases/helpers de summary que ainda recebem `lang: str = "en"`
+  cru; parsear a string crua uma vez na presentation.
+- **Achados:** code-smell 🔵 (lang:str read-path) — mesma raiz do 🟠 da Fase 2.
+- **Arquivos:** `_movie_summary_helpers.py:14`, `_series_summary_helpers.py`,
+  `list_by_genre.py`, `search_catalog.py` (~14 arquivos).
+- **Migration?** Não. **Esforço:** M. **Depende de:** PR-2.2.
+
+---
+
+## FASE 6 — Cleanup de modelagem (médios/baixos)
+
+PRs pequenos e independentes entre si. Ordem livre; ver recomendação de puxar PR-6.2.
+
+### PR-6.1 · `refactor(building_blocks): move repository/domain contracts to domain layer`
+- **Escopo:** reclassificar `PaginatedResult` (e bases de exceção de domínio) de
+  `building_blocks/application` → `building_blocks/domain`, eliminando a direção
+  invertida domínio→application nas interfaces de repositório.
+- **Achados:** clean-arch M-4 + B-11 (🔵).
+- **Arquivos:** `building_blocks/application/pagination.py`,
+  `domain/repositories/{movie_repository.py:7,series_repository.py:7,
+  media_conflict_repository.py:5}`. **Esforço:** S.
+
+### PR-6.2 · `fix(building_blocks): make aggregate event hand-off explicit` ⚠️ prioridade
+- **Escopo:** `AggregateRoot.with_updates` deixa de **mutar a fonte** (`self._events.clear()`)
+  — hand-off de eventos explícito (coletor puxado no save) ou contrato return-only. Hoje
+  qualquer `old.pull_events()` após `with_updates` retorna vazio → **domain events
+  perdidos em silêncio** (dirigem persistência/integração). Bug latente, não estética.
+- **Achados:** code-smell 🟡 (temporal coupling / mutação surpresa).
+- **Arquivos:** `building_blocks/domain/entity.py:104-115`. **Esforço:** M.
+  **Recomendação:** mergear logo após a Fase 1, antes da Fase 3.
+
+### PR-6.3 · `refactor(media): introduce Confidence value object [0,1]`
+- **Escopo:** VO `Confidence` (valida `[0,1]`) reusado em `IntroMarker`/`CreditsMarker`
+  e em `EpisodeDetectionResult`/`min_confidence` (hoje `float` irrestrito); de quebra,
+  unificar segundos `int` vs `float` entre markers e `EpisodeDetectionResult`.
+- **Achados:** code-smell 🟡 (Confidence) + 🔵 (int/float seconds).
+- **Arquivos:** `intro_detection_run.py:42-43,85`, `intro_marker.py:51-52`,
+  `credits_marker.py:52`. **Esforço:** M.
+
+### PR-6.4 · `refactor(media): ConflictCandidate parameter object`
+- **Escopo:** par `(candidate_*_id, candidate_*_type)` vira VO `ConflictCandidate(id,
+  type)` em `MediaConflict.detect/resolve/loser_id`.
+- **Achados:** code-smell 🟡 (data clump + primitive obsession).
+- **Arquivos:** `media/domain/entities/media_conflict.py:111-114,122`. **Esforço:** S.
+
+### PR-6.5 · `refactor(media): tidy scanner domain modeling`
+- **Escopo:** cluster de smells do scan: `ScanRun.summary` dict→VOs contadores tipados
+  (`ScanCounters`/`EnrichCounters`); `Resolution.UNKNOWN` + `is_unknown()` em vez do
+  literal `"Unknown"`; parameter object `VariantGroup` para o par `(paths, by_path)`;
+  mover upsert para `Season.with_episode_upserted`/`Series.with_season_upserted`.
+- **Achados:** code-smell 🟡 (ScanRun.summary, "Unknown" sentinel, (paths,by_path) clump,
+  feature-envy upsert).
+- **Arquivos:** `scan_run.py:85,105,114`, `scan_media_directories.py:180,203,261-354,
+  554-575`. **Migration?** Não (summary continua JSON). **Esforço:** M-G. *(pode dividir
+  em 2 PRs: counters/Unknown vs VariantGroup/upsert.)*
+
+### PR-6.6 · `fix(media): single validated path for intro/credits marker persistence`
+- **Escopo:** remover o temporal coupling em que a validação `with_*_marker` é chamada só
+  pelo efeito e a cópia validada é **descartada** antes do update direto de coluna; o
+  repositório passa a receber a entidade/marker validado (caminho único).
+- **Achados:** code-smell 🟡 (temporal coupling).
+- **Arquivos:** `set_episode_intro.py:87`, `set_credits_marker.py:70`. **Esforço:** S.
+
+### PR-6.7 · `refactor(collections): derive list item_count from items`
+- **Escopo:** eliminar o contador denormalizado `item_count` que drifta dos itens reais
+  (duas chamadas coordenadas hoje); derivar via `COUNT`/agregado dono, ou unir
+  add-item+bump num único método. A invariante `MAX_ITEMS` passa a checar a verdade.
+- **Achados:** code-smell 🟡 (temporal coupling / invariante denormalizada).
+- **Arquivos:** `custom_list.py:117,196-219`, `add_item_to_custom_list.py:42-53`,
+  `remove_item_from_custom_list.py:24-31`. **Migration?** Talvez (se a coluna
+  `item_count` for removida) — avaliar. **Esforço:** M.
+
+### PR-6.8 · `refactor(library): typed request models + CronExpression VO`
+- **Escopo:** `metadata_providers`/`settings` na borda da aplicação deixam de ser
+  `list[dict[str,Any]]`/`dict[str,Any]` e passam a usar o VO `MetadataProviderConfig`
+  (já existe) / sub-models de request tipados, convertidos uma vez na borda; VO
+  `CronExpression` validando faixas reais para `scan_schedule`.
+- **Achados:** code-smell 🟡 (library list[dict]) + 🔵 (scan_schedule cron).
+- **Arquivos:** `update_library.py:71-79`, `library_dtos.py:60-62,81-83`,
+  `create_library._build_settings`, `library.py:66-69`. **Esforço:** M.
+
+### PR-6.9 · `refactor(shared_kernel): centralize episode composite id format`
+- **Escopo:** centralizar o formato `epi_ser_{id}_{S}_{E}` junto de `parse_media_id`
+  (hoje duplicado por cirurgia de string); tipar `series_id` como `SeriesId`; distinguir
+  "não-episódio" de "malformado" (em vez de `None` para ambos). Opcional: enum
+  `SubtitleFormat` para `tracks.format`.
+- **Achados:** code-smell 🟡 (episode_composite_id) + 🔵 (codec/format str).
+- **Arquivos:** `shared_kernel/value_objects/episode_composite_id.py:31-83`,
+  `media_id.py`, `tracks.py:54,119`. **Esforço:** M.
+
+### PR-6.10 · `refactor(watch_progress): model subtitle preference explicitly`
+- **Escopo:** substituir o sentinela sobrecarregado `subtitle_track: int | None`
+  (`None`=no-op, `-1`=off, só no docstring) por um modelo explícito (`Off | Track(index)`)
+  ou separar "clear" de "set".
+- **Achados:** code-smell 🔵 (magic value / sentinel overload).
+- **Arquivos:** `watch_progress.py:64-65,112-113`. **Esforço:** S.
+
+### PR-6.11 · `refactor(presentation): formalize resolve_profile_id as identity contract`
+- **Escopo:** o helper de presentation `resolve_profile_id` é reusado por 4 módulos via
+  import direto cross-BC; promover a contrato de presentation publicado do `identity`
+  (ou documentar como API pública estável).
+- **Achados:** clean-arch B-9/B-10 (🔵) · coupling F9 (🔵).
+- **Arquivos:** `identity/presentation/dependencies.py`;
+  `media|collections|watch_progress|preferences/presentation/dependencies.py:10-11`.
+  **Esforço:** S.
+
+---
+
+## Itens sem PR (vigiar / decisão consciente)
+
+| Item | Origem | Decisão sugerida |
+|---|---|---|
+| `shared_kernel` acumulando VOs de id per-BC (`MovieId`…) | coupling F8 (🟡) | **Vigiar em review.** Aliviado naturalmente pela PR-3.1 (integration events tipados); não promover modelos de domínio ao shared kernel. |
+| Inversões de port (provedor implementa port do consumidor) | coupling F10 (🔵) | **Sem ação** — é o melhor caso de Strength (contrato). |
+| `directors`/`writers: list[str]` vs `cast: list[CastMember]` | code-smell 🔵 | **Won't-fix** salvo se navegação por crew for desejada → VO `CrewMember`. |
+| `collections` ACL: campos quality da série nulos no batch | ACL Finding 7 (🔵) | **Aceito/documentado** (cliente esconde campos ausentes); rever só se a UI precisar. |
+| `library_id: str` cru nas entidades | code-smell 🔵 | **Adiado** (território de arquitetura/ADR-008); reavaliar com a Fase 3. |
+
+---
+
+## Matriz de cobertura (achado → PR)
+
+| Relatório | Achado | Sev | PR |
+|---|---|---|---|
+| 01 clean-arch | A-1 (Library aggregate) | 🟠 | PR-3.3 |
+| 01 | A-2 / A-3 (UoW alheia) | 🟠 | PR-3.2 |
+| 01 | M-4 (PaginatedResult na app) | 🟡 | PR-6.1 |
+| 01 | M-5 / M-6 (settings type-coupling) | 🟡 | PR-3.5 |
+| 01 | M-7 (UserModel em rotas) | 🟡 | PR-3.4 |
+| 01 | M-8 / M-9 (domain events crus) | 🟡 | PR-3.1 |
+| 01 | B-9 / B-10 (presentation→presentation) | 🔵 | PR-6.11 |
+| 01 | B-11 (contratos na app layer) | 🔵 | PR-6.1 |
+| 02 ACL | Finding 1 (rating jurisdiction) | 🟡 | PR-4.2 |
+| 02 | Finding 2 (erro→not-found) | 🟡 | PR-4.1 |
+| 02 | Finding 3 (cast truncado) | 🔵 | PR-4.5 |
+| 02 | Finding 4 (audio default fabricado) | 🟡 | PR-4.3 |
+| 02 | Finding 5 (raiz desmontada silenciosa) | 🟡 | PR-4.3 |
+| 02 | Finding 6 (defaults de probe) | 🔵 | PR-4.3 |
+| 02 | Finding 7 (quality fields nulos) | 🔵 | won't-fix |
+| 03 code-smell | Localized dict | 🔴 | PR-2.2/2.3 |
+| 03 | lang:str (entidades) | 🟠 | PR-2.2 |
+| 03 | lang:str (read-path use cases) | 🔵 | PR-5.1 |
+| 03 | MetadataReconciler (anemic+shotgun) | 🟠 | PR-4.4 |
+| 03 | force:bool (boolean blindness) | 🟠 | PR-4.4 |
+| 03 | Confidence float | 🟡 | PR-6.3 |
+| 03 | int/float seconds | 🔵 | PR-6.3 |
+| 03 | ConflictCandidate (data clump) | 🟡 | PR-6.4 |
+| 03 | ScanRun.summary stringly | 🟡 | PR-6.5 |
+| 03 | "Unknown" resolution sentinel | 🟡 | PR-6.5 |
+| 03 | (paths, by_path) data clump | 🟡 | PR-6.5 |
+| 03 | upsert episode/season (feature envy) | 🟡 | PR-6.5 |
+| 03 | temporal coupling markers | 🟡 | PR-6.6 |
+| 03 | library list[dict] request models | 🟡 | PR-6.8 |
+| 03 | scan_schedule cron | 🔵 | PR-6.8 |
+| 03 | item_count denormalizado | 🟡 | PR-6.7 |
+| 03 | with_updates muta a fonte | 🟡 | PR-6.2 ⚠️ |
+| 03 | episode_composite_id format | 🟡 | PR-6.9 |
+| 03 | codec/format str | 🔵 | PR-6.9 |
+| 03 | subtitle_track sentinel | 🔵 | PR-6.10 |
+| 03 | directors/writers list[str] | 🔵 | won't-fix |
+| 03 | library_id:str | 🔵 | adiado |
+| 04 coupling | F1 | 🔴 | PR-3.3 |
+| 04 | F2 | 🟠 | PR-3.2 |
+| 04 | F3 | 🟠 | PR-3.1 |
+| 04 | F4 / F6 | 🟠/🟡 | PR-3.5 |
+| 04 | F5 | 🟡 | PR-3.4 |
+| 04 | F7 | 🟡 | vigiar (sancionado) |
+| 04 | F8 | 🟡 | vigiar (aliviado por PR-3.1) |
+| 04 | F9 | 🔵 | PR-6.11 |
+| 04 | F10 | 🔵 | sem ação |
+| 05 doc-drift | #1 envelope | 🔴 | PR-D1 |
+| 05 | regra módulos não importam | 🟠 | PR-D4 + corrigido por Fase 3 |
+| 05 | PresentationException | 🟠 | PR-D3 |
+| 05 | módulos 4 vs 9 | 🟡 | PR-D4 |
+| 05 | pagination v3 vs código | 🟡 | PR-D1 |
+| 05 | i18n catálogo / api-i18n-guide | 🟠/🟡 | PR-D2 |
+| 05 | contagens endpoints/testes | 🟡 | PR-D4 |
+| 05 | ADR-008 tree | 🔵 | PR-D4 |
+| 05 | localização sem ADR | 🟡 | PR-2.1 |
+| 05 | notifications/preferences sem ADR | 🔵 | PR-D4 |
+
+---
+
+## Resumo de esforço por fase
+
+| Fase | PRs | Esforço agregado | Migration? | ADR? |
+|---|---|---|---|---|
+| 1 Docs | 4 | XS–S (horas) | Não | Não |
+| 2 LocalizedMetadata | 3 | G (dias) | **Não** (wire preservado) | **ADR-023** |
+| 3 Cross-BC | 5 | M–G (dias–semanas) | Não | nota ADR-008/009 |
+| 4 Gateways + Reconciler | 4–5 | M–G (dias) | Não | Não |
+| 5 Lang read-path | 1 | M | Não | Não |
+| 6 Cleanup | 11 | XS–M cada (independentes) | Só PR-6.7 talvez | Não |
+
+**Total: ~28 PRs.** Caminho mínimo de maior impacto: **Fase 1 → PR-6.2 → Fase 2 →
+Fase 3** já fecha os 3 críticos e os 11 altos.


### PR DESCRIPTION
## Summary

- Adds a read-only, multi-dimensional architecture audit of the six core modules (media, library, watch_progress, collections, building_blocks, shared_kernel).
- Five dimension reports: clean architecture, ACL/adapters, code smells, coupling (strength × distance × volatility), and doc drift.
- `00-executive-summary.md`: cross-cutting themes prioritized by severity (3 critical, 11 high, 31 medium, 17 low).
- `06-remediation-plan.md`: phased PR plan (~28 PRs) following the recommended order, with a finding→PR coverage matrix.

No source code changed — documentation only.

## Test plan

- [ ] Docs render correctly (tables, links between reports resolve)
- [ ] No source files modified (`git diff --stat` touches only `docs/audits/`)

## Summary by Sourcery

Add a suite of architecture audit documents and a phased remediation plan outlining prioritized refactors and fixes across core backend modules, without changing any source code.

Documentation:
- Document a five-dimensional architecture audit covering clean architecture, ACL/adapters, domain code smells, inter-module coupling, and documentation drift for the HomeFlix backend.
- Provide a detailed executive summary that consolidates roughly 40 distinct root issues into cross-cutting themes with severity and recommended order of attack.
- Add a phased remediation plan describing around 28 proposed pull requests, grouped by theme and phase, including dependencies, effort estimates, and a finding-to-PR coverage matrix.