### PR TITLE
docs: fix drift in standards, roadmap, and ADR-008 (Phase 1)

### DIFF
--- a/docs/adr/ADR-008-screaming-architecture.md
+++ b/docs/adr/ADR-008-screaming-architecture.md
@@ -8,6 +8,19 @@
 
 ---
 
+> 📝 **Nota de revisão (2026-06-27).** O snapshot de "Estrutura Adotada" abaixo é
+> histórico (data do ADR) e mostra só `media`/`library`; o projeto cresceu para
+> **9 módulos** (`media`, `library`, `watch_progress`, `collections`,
+> `catalog_requests`, `identity`, `notifications`, `preferences`, `settings`).
+> Além disso, o Princípio #1 prevê "integration events no shared_kernel": na
+> prática os **domain events vivem em `modules/<bc>/domain/events.py`** e a
+> comunicação cross-BC por evento **já é usada em produção** (event handlers),
+> não "futuramente". O pacote `shared_kernel/integration_events/` existe mas está
+> vazio — materializá-lo é trabalho planejado (ver `docs/audits/06-remediation-plan.md`,
+> Fase 3). O snapshot original é mantido como registro datado.
+
+---
+
 ## Contexto
 
 A estrutura anterior (ADR-003) organizava o código por **camadas técnicas** na raiz (`domain/`, `application/`, `infrastructure/`, `presentation/`), com bounded contexts aninhados dentro de cada camada. Isso significava:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,7 +111,7 @@ patterns are explicitly excluded.
   `POST /api/v1/admin/conflicts/sweep` endpoint runs the same pass
   on demand. Settings toggle + "Run sweep now" button in
   homeflix-web. ADR-015 closed.
-- 112 REST API endpoints across 9 bounded contexts, 2 660+ tests.
+- ~132 REST API endpoints across 9 bounded contexts, ~2 940 tests (live count: `grep -rE '@router\.(get|post|put|patch|delete)' src/ | wc -l`).
 
 ---
 

--- a/docs/standards/api-i18n-guide.md
+++ b/docs/standards/api-i18n-guide.md
@@ -2,6 +2,17 @@
 
 Guia completo para implementar internacionalização em APIs REST, cobrindo mensagens de erro, validação, formatos de data/número e boas práticas.
 
+> ⚠️ **Status no HomeFlix: design de referência, NÃO o modelo adotado.** Este
+> guia descreve i18n por **catálogos de mensagem JSON** + negociação via header
+> `Accept-Language`/`Content-Language`. O HomeFlix **não** implementa isso: a
+> localização é por **dado de domínio enriquecido do TMDB** — campos localizados
+> por entidade (`entity.get_title(lang)` em `movie`/`series`/`season`/`episode`),
+> com `lang` vindo de **query param** e os locales suportados definidos em
+> `settings.supported_locales` (config-driven, default `["en", "pt-BR"]`). Não
+> existe diretório `locales/`, catálogo JSON, nem parsing de `Accept-Language`.
+> Use as seções abaixo apenas como referência conceitual para mensagens de
+> erro/validação caso esse caminho seja adotado no futuro.
+
 ---
 
 ## Visão Geral

--- a/docs/standards/api-response-standard-rest-v3.md
+++ b/docs/standards/api-response-standard-rest-v3.md
@@ -68,6 +68,14 @@ Padrão de design para APIs RESTful otimizado para **cache HTTP**, **performance
 }
 ```
 
+> ⚠️ **Divergência implementação ↔ standard (vigente).** A implementação atual
+> (`src/building_blocks/presentation/responses.py:api_list`) **aninha** a
+> paginação em `metadata.pagination`, e não no top-level mostrado acima:
+> `{"type": "list", "data": [...], "metadata": {"pagination": {...}}}`. A
+> colocação top-level deste documento permanece como alvo de um major futuro;
+> até lá, clientes devem ler `resp.metadata.pagination`. O próprio `responses.py`
+> documenta esse desvio.
+
 ### Coleção com Filtros Aplicados
 
 ```json

--- a/docs/standards/exception-hierarchy-clean-architecture.md
+++ b/docs/standards/exception-hierarchy-clean-architecture.md
@@ -125,7 +125,7 @@ CoreException
 │       ├── DatabaseConnectionException
 │       └── DataIntegrityException
 │
-└── PresentationException
+└── PresentationException          # 🚧 NÃO IMPLEMENTADO (aspiracional — ver seção abaixo)
     ├── InvalidRequestFormatException
     ├── UnsupportedMediaTypeException
     ├── NotAcceptableException
@@ -865,6 +865,15 @@ class DataIntegrityException(RepositoryException):
 ```
 
 ### Apresentação (PresentationException)
+
+> 🚧 **Status: NÃO IMPLEMENTADO (aspiracional).** A hierarquia
+> `PresentationException` descrita nesta seção (e na árvore acima:
+> `InvalidRequestFormatException`, `UnsupportedMediaTypeException`,
+> `NotAcceptableException` etc.) **não existe no código** — `grep -rn
+> PresentationException src/` retorna zero. `building_blocks` define apenas
+> `CoreException`, `DomainException`, `ApplicationException` e
+> `InfrastructureException`. Trate o conteúdo abaixo como design proposto; não
+> tente levantar essas classes hoje.
 
 > **Observação importante**: A camada de apresentação (API REST) geralmente não precisa de exceções próprias porque ela é o **ponto de entrada** - ela recebe erros das outras camadas e os transforma em respostas HTTP. Porém, existem cenários onde exceções específicas da API fazem sentido.
 


### PR DESCRIPTION
## Summary

Phase 1 of the architecture-audit remediation plan (Tema D — doc drift). Aligns tracked documentation with the real implementation:

- **Response standard:** note that pagination is nested in `metadata.pagination` (not top-level), matching `responses.py:api_list`.
- **Exception hierarchy:** flag the `PresentationException` branch as not implemented (aspirational) — `grep` over `src/` returns zero.
- **i18n guide:** banner clarifying it describes a non-adopted message-catalog model; real i18n is per-entity localized fields + `lang` query param + config-driven `supported_locales`.
- **Roadmap:** refresh the latest shipped tally to ~132 endpoints / ~2 940 tests (with a live-count command).
- **ADR-008:** revision note — project grew to 9 modules; domain events live per-BC (not in shared_kernel), `integration_events/` is empty (Phase 3 work).

> Note: the equivalent fixes to `.claude/CLAUDE.md` (envelope summary, module list, counts, i18n checklist) were applied locally but `.claude/` is gitignored, so they are not part of this PR.

## Test plan

- [ ] Docs render correctly (callouts, tables, code fences)
- [ ] No source code changed (`git diff` touches only `docs/`)

## Summary by Sourcery

Update architecture and standards documentation to reflect the current implementation and project structure without changing source code.

Documentation:
- Clarify that the i18n guide describes a non-adopted message-catalog design and document the actual per-entity localization approach.
- Add a revision note to ADR-008 describing the expanded module set, current domain/integration events placement, and future integration events plan.
- Flag the PresentationException branch in the exception hierarchy standard as aspirational and not implemented in the codebase.
- Document the current pagination shape in the API response standard, noting the nesting under metadata.pagination and planned future alignment.
- Refresh roadmap metrics with updated endpoint and test counts, including a live-count command reference.