### PR TITLE
refactor(media): LocalizedMetadata value object (read path) [ADR-023]

### DIFF
--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -341,7 +341,7 @@ def _apply_credits(
         updates["content_rating"] = ContentRating(metadata.content_rating)
     if metadata.trailer_url and (force or not movie.trailer_url):
         updates["trailer_url"] = metadata.trailer_url
-    merge_localized_metadata(updates, movie.localized, metadata, force=force)
+    merge_localized_metadata(updates, movie.localized.to_serializable(), metadata, force=force)
 
 
 __all__ = ["EnrichMovieMetadataUseCase"]

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -257,7 +257,7 @@ def _apply_series_metadata(
             for p in metadata.cast
         ]
 
-    merge_localized_metadata(updates, series.localized, metadata, force=force)
+    merge_localized_metadata(updates, series.localized.to_serializable(), metadata, force=force)
 
     if updates:
         series = series.with_updates(**updates)
@@ -299,7 +299,9 @@ def _apply_season_metadata(season: Season, meta: SeasonMetadata, *, force: bool 
         parsed = _parse_date(meta.air_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
-    season_localized = build_localized_text(meta.localized, season.localized, force=force)
+    season_localized = build_localized_text(
+        meta.localized, season.localized.to_serializable(), force=force
+    )
     if season_localized is not None:
         updates["localized"] = season_localized
 
@@ -405,7 +407,9 @@ def _apply_multi_episode_metadata(
         if parsed:
             updates["air_date"] = AirDate(parsed)
 
-    combined_localized = _combine_localized_segments(present, episode.localized, force=force)
+    combined_localized = _combine_localized_segments(
+        present, episode.localized.to_serializable(), force=force
+    )
     if combined_localized is not None:
         updates["localized"] = combined_localized
 

--- a/src/modules/media/domain/entities/episode.py
+++ b/src/modules/media/domain/entities/episode.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Self
+from typing import Self
 
 from pydantic import Field, field_validator
 
@@ -19,6 +19,8 @@ from src.modules.media.domain.value_objects import (
     EpisodeNumber,
     ImageUrl,
     IntroMarker,
+    LocalizedField,
+    LocalizedMetadata,
     MediaFile,
     SeasonNumber,
     SeriesId,
@@ -64,7 +66,7 @@ class Episode(FileVariantMixin, DomainEntity[EpisodeId]):
     # Per-language title/synopsis overrides, keyed by BCP-47 tag.
     # ``get_title(lang)`` / ``get_synopsis(lang)`` fall back to the
     # base (English) fields when a locale has no override.
-    localized: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    localized: LocalizedMetadata = Field(default_factory=LocalizedMetadata)
 
     # File variants
     files: list[MediaFile] = Field(default_factory=list)
@@ -94,13 +96,11 @@ class Episode(FileVariantMixin, DomainEntity[EpisodeId]):
 
     def get_title(self, lang: str = "en") -> str:
         """Get title in the requested language, falling back to the base."""
-        loc_title = self.localized.get(lang, {}).get("title")
-        return str(loc_title) if loc_title else self.title.value
+        return self.localized.text(LocalizedField.TITLE, lang) or self.title.value
 
     def get_synopsis(self, lang: str = "en") -> str | None:
         """Get synopsis in the requested language, falling back to the base."""
-        loc_synopsis = self.localized.get(lang, {}).get("synopsis")
-        return str(loc_synopsis) if loc_synopsis else self.synopsis
+        return self.localized.text(LocalizedField.SYNOPSIS, lang) or self.synopsis
 
     def with_intro_marker(self, marker: IntroMarker) -> Self:
         """Return a copy with the intro marker set.

--- a/src/modules/media/domain/entities/movie.py
+++ b/src/modules/media/domain/entities/movie.py
@@ -22,6 +22,8 @@ from src.modules.media.domain.value_objects import (
     Genre,
     ImageUrl,
     ImdbId,
+    LocalizedField,
+    LocalizedMetadata,
     MediaFile,
     MovieId,
     Resolution,
@@ -92,7 +94,7 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
     collection: Collection | None = None
 
     # Localized metadata: {"pt-BR": {"title": "...", "synopsis": "...", "genres": [...]}}
-    localized: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    localized: LocalizedMetadata = Field(default_factory=LocalizedMetadata)
 
     # External IDs for metadata enrichment
     tmdb_id: TmdbId | None = None
@@ -130,26 +132,20 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
 
     def get_title(self, lang: str = "en") -> str:
         """Get title in the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        return str(loc.get("title") or self.title.value)
+        return self.localized.text(LocalizedField.TITLE, lang) or self.title.value
 
     def get_synopsis(self, lang: str = "en") -> str | None:
         """Get synopsis in the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        return str(loc["synopsis"]) if loc.get("synopsis") else self.synopsis
+        return self.localized.text(LocalizedField.SYNOPSIS, lang) or self.synopsis
 
     def get_tagline(self, lang: str = "en") -> str | None:
         """Get tagline in the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        return str(loc["tagline"]) if loc.get("tagline") else self.tagline
+        return self.localized.text(LocalizedField.TAGLINE, lang) or self.tagline
 
     def get_genres(self, lang: str = "en") -> list[str]:
         """Get genres in the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        loc_genres = loc.get("genres")
-        if loc_genres and isinstance(loc_genres, list):
-            return [str(g) for g in loc_genres]
-        return [g.value for g in self.genres]
+        loc_genres = self.localized.genres(lang)
+        return list(loc_genres) if loc_genres else [g.value for g in self.genres]
 
     def get_logo_path(self, lang: str = "en") -> str | None:
         """Get title-logo URL for the requested language.
@@ -159,11 +155,9 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
         mirroring how ``get_title`` / ``get_synopsis`` behave so the
         UI sees a consistent "best available" graphic per language.
         """
-        loc = self.localized.get(lang, {})
-        loc_logo = loc.get("logo_path")
-        if loc_logo:
-            return str(loc_logo)
-        return self.logo_path.value if self.logo_path else None
+        return self.localized.text(LocalizedField.LOGO_PATH, lang) or (
+            self.logo_path.value if self.logo_path else None
+        )
 
     def get_poster_path(self, lang: str = "en") -> str | None:
         """Get poster URL for the requested language, falling back to default.
@@ -171,19 +165,15 @@ class Movie(FileVariantMixin, AggregateRoot[MovieId]):
         Mirrors ``get_logo_path``: returns the locale's localized poster
         when present, else the global (English base) ``poster_path``.
         """
-        loc = self.localized.get(lang, {})
-        loc_poster = loc.get("poster_path")
-        if loc_poster:
-            return str(loc_poster)
-        return self.poster_path.value if self.poster_path else None
+        return self.localized.text(LocalizedField.POSTER_PATH, lang) or (
+            self.poster_path.value if self.poster_path else None
+        )
 
     def get_backdrop_path(self, lang: str = "en") -> str | None:
         """Get backdrop URL for the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        loc_backdrop = loc.get("backdrop_path")
-        if loc_backdrop:
-            return str(loc_backdrop)
-        return self.backdrop_path.value if self.backdrop_path else None
+        return self.localized.text(LocalizedField.BACKDROP_PATH, lang) or (
+            self.backdrop_path.value if self.backdrop_path else None
+        )
 
     # ── genre helpers ─────────────────────────────────────────────────
 

--- a/src/modules/media/domain/entities/season.py
+++ b/src/modules/media/domain/entities/season.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime  # noqa: TCH003 — needed at runtime by Pydantic
-from typing import TYPE_CHECKING, Any, ClassVar, Self
+from typing import TYPE_CHECKING, ClassVar, Self
 
 from pydantic import Field, field_validator
 
@@ -15,6 +15,8 @@ from src.modules.media.domain.value_objects import (
     EpisodeNumber,
     ImageUrl,
     IntroDetectionState,
+    LocalizedField,
+    LocalizedMetadata,
     SeasonId,
     SeasonNumber,
     SeriesId,
@@ -54,7 +56,7 @@ class Season(DomainEntity[SeasonId]):
     # Per-language title/synopsis overrides, keyed by BCP-47 tag.
     # ``get_title(lang)`` / ``get_synopsis(lang)`` fall back to the
     # base (English) fields when a locale has no override.
-    localized: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    localized: LocalizedMetadata = Field(default_factory=LocalizedMetadata)
 
     # Metadata
     air_date: AirDate | None = None
@@ -138,17 +140,14 @@ class Season(DomainEntity[SeasonId]):
 
     def get_title(self, lang: str = "en") -> str | None:
         """Get title in the requested language, falling back to the base."""
-        loc_title = self.localized.get(lang, {}).get("title")
-        if loc_title:
-            return str(loc_title)
+        localized_title = self.localized.text(LocalizedField.TITLE, lang)
+        if localized_title:
+            return localized_title
         return self.title.value if self.title else None
 
     def get_synopsis(self, lang: str = "en") -> str | None:
         """Get synopsis in the requested language, falling back to the base."""
-        loc_synopsis = self.localized.get(lang, {}).get("synopsis")
-        if loc_synopsis:
-            return str(loc_synopsis)
-        return self.synopsis
+        return self.localized.text(LocalizedField.SYNOPSIS, lang) or self.synopsis
 
     # ── intro detection state transitions ─────────────────────────────
 

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -16,6 +16,8 @@ from src.modules.media.domain.value_objects import (
     Genre,
     ImageUrl,
     ImdbId,
+    LocalizedField,
+    LocalizedMetadata,
     SeasonNumber,
     SeriesId,
     Title,
@@ -75,7 +77,7 @@ class Series(AggregateRoot[SeriesId]):
     cast: list[CastMember] = Field(default_factory=list)
 
     # Localized metadata
-    localized: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    localized: LocalizedMetadata = Field(default_factory=LocalizedMetadata)
 
     # External IDs
     tmdb_id: TmdbId | None = None
@@ -105,21 +107,16 @@ class Series(AggregateRoot[SeriesId]):
 
     def get_title(self, lang: str = "en") -> str:
         """Get title in the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        return str(loc.get("title") or self.title.value)
+        return self.localized.text(LocalizedField.TITLE, lang) or self.title.value
 
     def get_synopsis(self, lang: str = "en") -> str | None:
         """Get synopsis in the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        return str(loc["synopsis"]) if loc.get("synopsis") else self.synopsis
+        return self.localized.text(LocalizedField.SYNOPSIS, lang) or self.synopsis
 
     def get_genres(self, lang: str = "en") -> list[str]:
         """Get genres in the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        loc_genres = loc.get("genres")
-        if loc_genres and isinstance(loc_genres, list):
-            return [str(g) for g in loc_genres]
-        return [g.value for g in self.genres]
+        loc_genres = self.localized.genres(lang)
+        return list(loc_genres) if loc_genres else [g.value for g in self.genres]
 
     def get_logo_path(self, lang: str = "en") -> str | None:
         """Get title-logo URL for the requested language.
@@ -129,11 +126,9 @@ class Series(AggregateRoot[SeriesId]):
         mirroring how ``get_title`` / ``get_synopsis`` behave so the
         UI sees a consistent "best available" graphic per language.
         """
-        loc = self.localized.get(lang, {})
-        loc_logo = loc.get("logo_path")
-        if loc_logo:
-            return str(loc_logo)
-        return self.logo_path.value if self.logo_path else None
+        return self.localized.text(LocalizedField.LOGO_PATH, lang) or (
+            self.logo_path.value if self.logo_path else None
+        )
 
     def get_poster_path(self, lang: str = "en") -> str | None:
         """Get poster URL for the requested language, falling back to default.
@@ -141,19 +136,15 @@ class Series(AggregateRoot[SeriesId]):
         Mirrors ``get_logo_path``: returns the locale's localized poster
         when present, else the global (English base) ``poster_path``.
         """
-        loc = self.localized.get(lang, {})
-        loc_poster = loc.get("poster_path")
-        if loc_poster:
-            return str(loc_poster)
-        return self.poster_path.value if self.poster_path else None
+        return self.localized.text(LocalizedField.POSTER_PATH, lang) or (
+            self.poster_path.value if self.poster_path else None
+        )
 
     def get_backdrop_path(self, lang: str = "en") -> str | None:
         """Get backdrop URL for the requested language, falling back to default."""
-        loc = self.localized.get(lang, {})
-        loc_backdrop = loc.get("backdrop_path")
-        if loc_backdrop:
-            return str(loc_backdrop)
-        return self.backdrop_path.value if self.backdrop_path else None
+        return self.localized.text(LocalizedField.BACKDROP_PATH, lang) or (
+            self.backdrop_path.value if self.backdrop_path else None
+        )
 
     @model_validator(mode="after")
     def validate_year_range(self) -> Series:

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -13,6 +13,11 @@ from src.modules.media.domain.value_objects.hdr_format import HdrFormat
 from src.modules.media.domain.value_objects.imdb_id import ImdbId
 from src.modules.media.domain.value_objects.intro_detection_state import IntroDetectionState
 from src.modules.media.domain.value_objects.intro_marker import IntroMarker, IntroMarkerSource
+from src.modules.media.domain.value_objects.localized_metadata import (
+    LocalizedField,
+    LocalizedFields,
+    LocalizedMetadata,
+)
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
 from src.modules.media.domain.value_objects.media_file import MediaFile
 from src.modules.media.domain.value_objects.resolution import Resolution
@@ -54,6 +59,9 @@ __all__ = [
     "IntroDetectionState",
     "IntroMarker",
     "IntroMarkerSource",
+    "LocalizedField",
+    "LocalizedFields",
+    "LocalizedMetadata",
     "MediaConflictId",
     "MediaFile",
     "MediaId",

--- a/src/modules/media/domain/value_objects/localized_metadata.py
+++ b/src/modules/media/domain/value_objects/localized_metadata.py
@@ -1,0 +1,171 @@
+"""Localized metadata value object (ADR-023).
+
+Replaces the untyped ``dict[str, dict[str, Any]]`` that the media content
+entities used to carry per-language overrides. The value object owns the
+single source of truth for the JSON field names (:class:`LocalizedField`)
+and the localized→base fallback, and serializes to exactly the same JSON
+wire shape the column already stores (so there is no migration).
+"""
+
+from enum import StrEnum
+from typing import Any, ClassVar
+
+from pydantic import ConfigDict, Field, RootModel, model_validator
+
+from src.building_blocks.domain.value_objects import CompoundValueObject, ValueObject
+from src.shared_kernel.value_objects.language_tag import LanguageTag
+
+
+class LocalizedField(StrEnum):
+    """Field names inside the ``localized`` JSON blob.
+
+    Single source of truth shared by the value object and the SQL
+    ``json_extract`` path builders (``_genre_helpers``), so the wire
+    format and the queries that read it cannot drift apart.
+    """
+
+    TITLE = "title"
+    SYNOPSIS = "synopsis"
+    TAGLINE = "tagline"
+    GENRES = "genres"
+    LOGO_PATH = "logo_path"
+    POSTER_PATH = "poster_path"
+    BACKDROP_PATH = "backdrop_path"
+
+
+class LocalizedFields(CompoundValueObject):
+    """Per-locale override record.
+
+    All fields are optional — the full set serves ``Movie``/``Series``
+    while ``Season``/``Episode`` only ever populate ``title``/``synopsis``.
+    Field names mirror :class:`LocalizedField`. ``extra="forbid"`` (inherited
+    from :class:`CompoundValueObject`) makes deserialization reject unknown
+    keys, per ADR-023.
+
+    Attributes:
+        title: Localized title.
+        synopsis: Localized synopsis.
+        tagline: Localized tagline.
+        genres: Localized genre names.
+        logo_path: Localized title-logo URL.
+        poster_path: Localized poster URL.
+        backdrop_path: Localized backdrop URL.
+
+    Example:
+        >>> LocalizedFields(title="O Espião").title
+        'O Espião'
+    """
+
+    title: str | None = None
+    synopsis: str | None = None
+    tagline: str | None = None
+    genres: tuple[str, ...] = ()
+    logo_path: str | None = None
+    poster_path: str | None = None
+    backdrop_path: str | None = None
+
+
+def _canonical(lang: str) -> str:
+    """Return the canonical BCP-47 tag for *lang*, or the raw value.
+
+    Lookups stay lenient: an unparseable tag simply misses (→ fallback),
+    matching the previous raw-``dict`` behavior.
+    """
+    try:
+        return LanguageTag(lang).value
+    except Exception:
+        return lang
+
+
+class LocalizedMetadata(RootModel[dict[str, LocalizedFields]], ValueObject):
+    """Per-language metadata overrides for a media content entity.
+
+    Maps a canonical language tag (``"en"``, ``"pt-BR"``) to its
+    :class:`LocalizedFields`. Read accessors return the localized value or
+    ``None`` (the entity owns the fallback to its base fields).
+    :meth:`to_serializable` reproduces the exact JSON shape stored today.
+
+    Example:
+        >>> meta = LocalizedMetadata.from_serializable({"pt-BR": {"title": "Aviões"}})
+        >>> meta.text(LocalizedField.TITLE, "pt-BR")
+        'Aviões'
+        >>> meta.text(LocalizedField.TITLE, "fr") is None
+        True
+    """
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(frozen=True, extra=None)
+
+    root: dict[str, LocalizedFields] = Field(default_factory=dict)
+
+    # noinspection PyNestedDecorators
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize(cls, value: Any) -> Any:
+        """Canonicalize locale keys and accept dict / VO / None inputs."""
+        if value is None:
+            return {}
+        if isinstance(value, LocalizedMetadata):
+            return value.root
+        if isinstance(value, dict):
+            return {
+                _canonical(str(key)): fields
+                for key, fields in value.items()
+                if fields not in (None, {})
+            }
+        return value
+
+    def _lookup(self, lang: str) -> LocalizedFields | None:
+        """Return the override record for *lang*, if any."""
+        return self.root.get(_canonical(lang))
+
+    def text(self, field: LocalizedField, lang: str) -> str | None:
+        """Return the localized scalar for *field*/*lang*, or ``None``.
+
+        Not for :attr:`LocalizedField.GENRES` — use :meth:`genres`.
+        """
+        fields = self._lookup(lang)
+        if fields is None:
+            return None
+        value = getattr(fields, field.value)
+        return str(value) if value else None
+
+    def genres(self, lang: str) -> tuple[str, ...] | None:
+        """Return localized genres for *lang*, or ``None`` when absent."""
+        fields = self._lookup(lang)
+        if fields is None:
+            return None
+        return fields.genres or None
+
+    def is_empty(self) -> bool:
+        """Return ``True`` when there are no localized overrides."""
+        return not self.root
+
+    def to_serializable(self) -> dict[str, dict[str, Any]]:
+        """Serialize to the stored JSON shape (only non-falsy fields).
+
+        Reproduces the legacy wire format exactly: per locale, only the
+        fields the provider actually supplied, ``genres`` as a list, and
+        locales with no surviving field omitted.
+        """
+        out: dict[str, dict[str, Any]] = {}
+        for lang, fields in self.root.items():
+            entry: dict[str, Any] = {}
+            for field in LocalizedField:
+                if field is LocalizedField.GENRES:
+                    if fields.genres:
+                        entry[field.value] = list(fields.genres)
+                else:
+                    value = getattr(fields, field.value)
+                    if value:
+                        entry[field.value] = value
+            if entry:
+                out[lang] = entry
+        return out
+
+    @classmethod
+    def from_serializable(cls, raw: dict[str, dict[str, Any]] | None) -> "LocalizedMetadata":
+        """Build from the stored JSON dict (``None`` → empty)."""
+        return cls(raw or {})
+
+
+__all__ = ["LocalizedField", "LocalizedFields", "LocalizedMetadata"]

--- a/src/modules/media/infrastructure/persistence/mappers/_localized.py
+++ b/src/modules/media/infrastructure/persistence/mappers/_localized.py
@@ -1,0 +1,28 @@
+"""Serialization helpers for the ``localized`` metadata column.
+
+Bridges the :class:`LocalizedMetadata` value object (ADR-023) and the
+JSON ``Text`` column. Kept in one place so every mapper stores/reads the
+blob the same way (and the JSON encoding lives only here).
+"""
+
+import json
+
+from src.modules.media.domain.value_objects.localized_metadata import LocalizedMetadata
+
+
+def dump_localized(localized: LocalizedMetadata) -> str | None:
+    """Serialize the value object to the stored JSON string, or ``None``.
+
+    Returns ``None`` when there are no overrides so the column stays
+    ``NULL`` instead of an empty ``{}`` blob (matching prior behavior).
+    """
+    data = localized.to_serializable()
+    return json.dumps(data, ensure_ascii=False) if data else None
+
+
+def load_localized(raw: str | None) -> LocalizedMetadata:
+    """Build the value object from the stored JSON string (``None`` → empty)."""
+    return LocalizedMetadata.from_serializable(json.loads(raw) if raw else None)
+
+
+__all__ = ["dump_localized", "load_localized"]

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -21,6 +21,10 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.modules.media.infrastructure.persistence.mappers._localized import (
+    dump_localized,
+    load_localized,
+)
 from src.modules.media.infrastructure.persistence.mappers.cast_serialization import (
     deserialize_cast,
     serialize_cast,
@@ -88,9 +92,7 @@ class MovieMapper:
             collection_tmdb_id=entity.collection.tmdb_id if entity.collection else None,
             collection_name=entity.collection.name if entity.collection else None,
             collection_parts_count=entity.collection.parts_count if entity.collection else None,
-            localized=json.dumps(entity.localized, ensure_ascii=False)
-            if entity.localized
-            else None,
+            localized=dump_localized(entity.localized),
             file_path=primary.file_path.value if primary else None,
             file_size=primary.file_size if primary else None,
             resolution=primary.resolution.value if primary else None,
@@ -180,7 +182,7 @@ class MovieMapper:
             content_rating=ContentRating(model.content_rating) if model.content_rating else None,
             trailer_url=model.trailer_url,
             collection=collection,
-            localized=json.loads(model.localized) if model.localized else {},
+            localized=load_localized(model.localized),
             files=files,
             tmdb_id=TmdbId(model.tmdb_id) if model.tmdb_id else None,
             imdb_id=ImdbId(model.imdb_id) if model.imdb_id else None,
@@ -237,9 +239,7 @@ class MovieMapper:
         model.collection_tmdb_id = entity.collection.tmdb_id if entity.collection else None
         model.collection_name = entity.collection.name if entity.collection else None
         model.collection_parts_count = entity.collection.parts_count if entity.collection else None
-        model.localized = (
-            json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None
-        )
+        model.localized = dump_localized(entity.localized)
         model.file_path = primary.file_path.value if primary else None
         model.file_size = primary.file_size if primary else None
         model.resolution = primary.resolution.value if primary else None

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -1,7 +1,5 @@
 """Mapper between Series/Season/Episode entities and ORM models."""
 
-import json
-
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
     AirDate,
@@ -27,6 +25,10 @@ from src.modules.media.domain.value_objects import (
     Title,
     TmdbId,
     Year,
+)
+from src.modules.media.infrastructure.persistence.mappers._localized import (
+    dump_localized,
+    load_localized,
 )
 from src.modules.media.infrastructure.persistence.mappers.cast_serialization import (
     deserialize_cast,
@@ -75,9 +77,7 @@ class EpisodeMapper:
             episode_number=entity.episode_number.value,
             title=entity.title.value,
             synopsis=entity.synopsis,
-            localized=json.dumps(entity.localized, ensure_ascii=False)
-            if entity.localized
-            else None,
+            localized=dump_localized(entity.localized),
             duration=entity.duration.value,
             file_path=primary.file_path.value if primary else None,
             file_size=primary.file_size if primary else None,
@@ -132,7 +132,7 @@ class EpisodeMapper:
             episode_number=EpisodeNumber(model.episode_number),
             title=Title(model.title),
             synopsis=model.synopsis,
-            localized=json.loads(model.localized) if model.localized else {},
+            localized=load_localized(model.localized),
             duration=Duration(model.duration),
             files=files,
             thumbnail_path=ImageUrl(model.thumbnail_path) if model.thumbnail_path else None,
@@ -169,9 +169,7 @@ class EpisodeMapper:
         model.episode_number = entity.episode_number.value
         model.title = entity.title.value
         model.synopsis = entity.synopsis
-        model.localized = (
-            json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None
-        )
+        model.localized = dump_localized(entity.localized)
         model.duration = entity.duration.value
         model.file_path = primary.file_path.value if primary else None
         model.file_size = primary.file_size if primary else None
@@ -221,9 +219,7 @@ class SeasonMapper:
             season_number=entity.season_number.value,
             title=entity.title.value if entity.title else None,
             synopsis=entity.synopsis,
-            localized=json.dumps(entity.localized, ensure_ascii=False)
-            if entity.localized
-            else None,
+            localized=dump_localized(entity.localized),
             poster_path=entity.poster_path.value if entity.poster_path else None,
             air_date=entity.air_date.value if entity.air_date else None,
             intro_detection_state=entity.intro_detection_state.value,
@@ -255,7 +251,7 @@ class SeasonMapper:
             season_number=SeasonNumber(model.season_number),
             title=Title(model.title) if model.title else None,
             synopsis=model.synopsis,
-            localized=json.loads(model.localized) if model.localized else {},
+            localized=load_localized(model.localized),
             poster_path=ImageUrl(model.poster_path) if model.poster_path else None,
             air_date=AirDate(model.air_date) if model.air_date else None,
             episodes=episode_list,
@@ -281,9 +277,7 @@ class SeasonMapper:
         model.season_number = entity.season_number.value
         model.title = entity.title.value if entity.title else None
         model.synopsis = entity.synopsis
-        model.localized = (
-            json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None
-        )
+        model.localized = dump_localized(entity.localized)
         model.poster_path = entity.poster_path.value if entity.poster_path else None
         model.air_date = entity.air_date.value if entity.air_date else None
         model.intro_detection_state = entity.intro_detection_state.value
@@ -330,9 +324,7 @@ class SeriesMapper:
             content_rating=entity.content_rating.value if entity.content_rating else None,
             trailer_url=entity.trailer_url,
             cast=serialize_cast(entity.cast),
-            localized=json.dumps(entity.localized, ensure_ascii=False)
-            if entity.localized
-            else None,
+            localized=dump_localized(entity.localized),
             tmdb_id=entity.tmdb_id.value if entity.tmdb_id else None,
             imdb_id=entity.imdb_id.value if entity.imdb_id else None,
             needs_enrichment_review=entity.needs_enrichment_review,
@@ -372,7 +364,7 @@ class SeriesMapper:
             content_rating=ContentRating(model.content_rating) if model.content_rating else None,
             trailer_url=model.trailer_url,
             cast=deserialize_cast(model.cast),
-            localized=json.loads(model.localized) if model.localized else {},
+            localized=load_localized(model.localized),
             tmdb_id=TmdbId(model.tmdb_id) if model.tmdb_id else None,
             imdb_id=ImdbId(model.imdb_id) if model.imdb_id else None,
             needs_enrichment_review=bool(model.needs_enrichment_review),
@@ -407,9 +399,7 @@ class SeriesMapper:
         model.content_rating = entity.content_rating.value if entity.content_rating else None
         model.trailer_url = entity.trailer_url
         model.cast = serialize_cast(entity.cast)
-        model.localized = (
-            json.dumps(entity.localized, ensure_ascii=False) if entity.localized else None
-        )
+        model.localized = dump_localized(entity.localized)
         model.tmdb_id = entity.tmdb_id.value if entity.tmdb_id else None
         model.imdb_id = entity.imdb_id.value if entity.imdb_id else None
         model.needs_enrichment_review = entity.needs_enrichment_review

--- a/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
@@ -35,7 +35,7 @@ from src.building_blocks.application.pagination import (
     encode_title_cursor,
 )
 from src.modules.media.domain.repositories.movie_repository import GenreRow
-from src.modules.media.domain.value_objects import Genre
+from src.modules.media.domain.value_objects import Genre, LocalizedField
 from src.shared_kernel.value_objects.library_id import LibraryId
 
 TModel = TypeVar("TModel")
@@ -65,7 +65,9 @@ def localized_title_sort_key(model: Any, lang: str) -> Any:
     the FTS5 coupling already in the search path.
     """
     safe_lang = re.sub(r"[^A-Za-z-]", "", lang)
-    localized_title = func.json_extract(model.localized, f'$."{safe_lang}".title')
+    localized_title = func.json_extract(
+        model.localized, f'$."{safe_lang}".{LocalizedField.TITLE.value}'
+    )
     return func.lower(func.coalesce(localized_title, model.title))
 
 
@@ -83,8 +85,8 @@ def localized_title_for(localized_json: str | None, base_title: str, lang: str) 
             data = None
         if isinstance(data, dict):
             block = data.get(lang)
-            if isinstance(block, dict) and block.get("title"):
-                return str(block["title"])
+            if isinstance(block, dict) and block.get(LocalizedField.TITLE.value):
+                return str(block[LocalizedField.TITLE.value])
     return base_title
 
 
@@ -108,7 +110,7 @@ def localized_genres_for(localized_json: str | None, lang: str) -> list[str]:
     lang_block = data.get(lang) if isinstance(data, dict) else None
     if not isinstance(lang_block, dict):
         return []
-    raw = lang_block.get("genres")
+    raw = lang_block.get(LocalizedField.GENRES.value)
     if not isinstance(raw, list):
         return []
     return [str(g) for g in raw]

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -264,7 +264,7 @@ class TestEnrichMovieMetadata:
         assert result.enriched is True
         provider.get_movie_localized.assert_awaited_once_with(27205)
         saved = mocks.movies.save.call_args[0][0]
-        assert "pt-BR" in saved.localized
+        assert "pt-BR" in saved.localized.to_serializable()
 
     @pytest.mark.asyncio
     async def test_should_retry_with_cleaned_title_preserving_year(self) -> None:
@@ -513,9 +513,9 @@ class TestApplyMetadataFields:
         await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
 
         saved = mocks.movies.save.call_args[0][0]
-        assert saved.localized["pt-BR"]["title"] == "A Origem"
-        assert saved.localized["pt-BR"]["synopsis"] == "Sonho dentro do sonho."
-        assert saved.localized["pt-BR"]["genres"] == ["Ficção Científica"]
+        assert saved.localized.to_serializable()["pt-BR"]["title"] == "A Origem"
+        assert saved.localized.to_serializable()["pt-BR"]["synopsis"] == "Sonho dentro do sonho."
+        assert saved.localized.to_serializable()["pt-BR"]["genres"] == ["Ficção Científica"]
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -242,7 +242,7 @@ class TestEnrichSeriesMetadata:
         # localized is replaced, not merged: new pt-BR wins and the
         # stale "es" entry from the wrong match is dropped.
         assert saved.get_title("pt-BR") == "From (Correto)"
-        assert "es" not in saved.localized
+        assert "es" not in saved.localized.to_serializable()
 
     @pytest.mark.asyncio
     async def test_force_clears_stale_end_year_when_new_match_has_none(self) -> None:
@@ -308,7 +308,7 @@ class TestEnrichSeriesMetadata:
         assert saved.backdrop_path.value == "https://img.example/existing-backdrop.jpg"
         # Merge: new lang added, existing lang kept.
         assert saved.get_title("pt-BR") == "From pt"
-        assert saved.localized["es"]["title"] == "Título Existente"
+        assert saved.localized.to_serializable()["es"]["title"] == "Título Existente"
 
     @pytest.mark.asyncio
     async def test_should_enrich_double_episode(self) -> None:
@@ -610,7 +610,7 @@ class TestEnrichSeriesByTmdbId:
         assert result.enriched is True
         provider.get_series_localized.assert_awaited_once_with(1396)
         saved = mocks.series.save.call_args[0][0]
-        assert "pt-BR" in saved.localized
+        assert "pt-BR" in saved.localized.to_serializable()
 
 
 @pytest.mark.unit
@@ -745,8 +745,8 @@ class TestApplySeriesFields:
         await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
         saved = mocks.series.save.call_args[0][0]
-        assert "pt-BR" in saved.localized
-        assert saved.localized["pt-BR"]["synopsis"] == "Drama de crime."
+        assert "pt-BR" in saved.localized.to_serializable()
+        assert saved.localized.to_serializable()["pt-BR"]["synopsis"] == "Drama de crime."
 
     async def test_should_carry_localized_tagline(self) -> None:
         # Regression: the series localized merge used to drop tagline
@@ -774,4 +774,7 @@ class TestApplySeriesFields:
         await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
 
         saved = mocks.series.save.call_args[0][0]
-        assert saved.localized["pt-BR"]["tagline"] == "Toda escolha tem consequências."
+        assert (
+            saved.localized.to_serializable()["pt-BR"]["tagline"]
+            == "Toda escolha tem consequências."
+        )


### PR DESCRIPTION
## Summary

Phase 2 / PR-2.2 of the architecture-audit remediation — addresses the only **critical** modeling finding (silent persisted-data corruption: a mistyped locale/key in the untyped `localized` dict never round-trips; tagline drift was already observed). Implements ADR-023.

- New `LocalizedMetadata` value object (`RootModel[dict[str, LocalizedFields]]`) with a single `LocalizedField` StrEnum as the source of truth for the JSON key names, shared with the `json_extract` path builders in `_genre_helpers` so the wire format and the SQL that reads it can't drift.
- `Movie`/`Series`/`Season`/`Episode` carry `localized: LocalizedMetadata` instead of `dict[str, dict[str, Any]]`; read accessors delegate to the VO and keep their exact fallback behavior. Locale keys are canonicalized via `LanguageTag`; unknown internal keys are rejected (`extra="forbid"`, the ADR decision).
- **No migration:** `to_serializable()` reproduces the stored JSON byte-shape (only non-falsy fields, `genres` as list, empty locales omitted). Mappers (de)serialize through shared `dump_localized`/`load_localized` helpers.
- Enrich write path keeps working unchanged at the helper level (call sites feed `.to_serializable()`); the VO-native write path is PR-2.3.

### Deviations
- Accessor signatures stay `lang: str = "en"` (not `LanguageTag`) to avoid breaking ~14 external callers — typing them is PR-5.1's scope. `LanguageTag` is used *inside* the VO for canonical lookup, so the read path goes through it without the ripple.

## Test plan

- [x] `pytest tests/modules/media/` → 1662 passed, 5 skipped
- [x] Cross-BC consumers `pytest tests/modules/{collections,catalog_requests,watch_progress}` → 388 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] Round-trip / `json_extract` ordering tests pass (no migration; wire shape preserved)
- [ ] 2 enrich unit tests adapted to access `saved.localized.to_serializable()` (representation only — behavioral assertions unchanged)