### PR TITLE
fix(media): serialize episode localized before merge in enrich

### DIFF
--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -474,7 +474,9 @@ def _apply_episode_metadata(
         updates["duration"] = Duration(meta.duration_seconds)
     if meta.still_url and (force or not episode.thumbnail_path):
         updates["thumbnail_path"] = ImageUrl(meta.still_url)
-    episode_localized = build_localized_text(meta.localized, episode.localized, force=force)
+    episode_localized = build_localized_text(
+        meta.localized, episode.localized.to_serializable(), force=force
+    )
     if episode_localized is not None:
         updates["localized"] = episode_localized
 

--- a/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_series_metadata.py
@@ -10,6 +10,7 @@ from src.modules.media.application.ports import (
     CreditPerson,
     EpisodeMetadata,
     LocalizedFields,
+    LocalizedTextFields,
     MediaMetadata,
     MetadataProvider,
     SeasonMetadata,
@@ -131,6 +132,55 @@ class TestEnrichSeriesMetadata:
         saved = mocks.series.save.call_args[0][0]
         episode = saved.seasons[0].episodes[0]
         assert episode.title.value == "Pilot"
+
+    @pytest.mark.asyncio
+    async def test_non_force_enrich_merges_localized_for_single_episode(self) -> None:
+        """Regression: a single-segment episode whose provider metadata carries
+        localized text must enrich (not crash) on a non-force run.
+
+        The localized merge fed ``episode.localized`` (a LocalizedMetadata VO)
+        into a ``{**existing, ...}`` spread, which raises
+        ``TypeError: 'LocalizedMetadata' object is not a mapping`` — the merge
+        must go through the serializable form instead.
+        """
+        series = _make_series()
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = series
+        mocks.series.save.side_effect = lambda s: s
+
+        metadata = MediaMetadata(
+            title="Breaking Bad",
+            original_title="Breaking Bad",
+            year=2008,
+            tmdb_id=1396,
+            seasons=[
+                SeasonMetadata(
+                    season_number=1,
+                    episodes=[
+                        EpisodeMetadata(
+                            season_number=1,
+                            episode_number=1,
+                            title="Pilot",
+                            localized={
+                                "pt-BR": LocalizedTextFields(
+                                    title="Piloto", synopsis="Walter White começa."
+                                )
+                            },
+                        ),
+                    ],
+                ),
+            ],
+        )
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_series.return_value = metadata
+
+        use_case = EnrichSeriesMetadataUseCase(uow_factory=mocks.factory, primary_provider=provider)
+        # No force — exercises the merge branch that previously crashed.
+        await use_case.execute(EnrichMediaInput(media_id=str(series.id)))
+
+        episode = mocks.series.save.call_args[0][0].seasons[0].episodes[0]
+        assert episode.get_title("pt-BR") == "Piloto"
+        assert episode.get_synopsis("pt-BR") == "Walter White começa."
 
     @pytest.mark.asyncio
     async def test_should_skip_already_enriched(self) -> None:


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #321 (PR-2.2, LocalizedMetadata VO).

The single-segment episode enrich path (`_apply_episode_metadata`) still passed `episode.localized` — now a `LocalizedMetadata` value object — directly into `build_localized_text`, which merges with `{**existing, **built}`. Spreading a VO raises `TypeError: 'LocalizedMetadata' object is not a mapping`, so **any non-force series enrich whose episode metadata carries localized text crashed**. PR-2.2 fixed the other four localized merge sites but missed this one (the test suite didn't cover single-episode + non-force + provider-localized).

Fix: feed `episode.localized.to_serializable()` like the other sites. Adds a regression test for the previously-uncovered path (verified it fails with the exact TypeError before the fix, passes after).

## Test plan

- [x] New regression test fails without the fix (`TypeError: ... not a mapping`), passes with it
- [x] `pytest tests/modules/media/` → 1663 passed, 5 skipped
- [x] `ruff check` + `ruff format --check` clean

## Summary by Sourcery

Fix episode enrichment to correctly merge localized metadata for single-episode, non-force runs without crashing.

Bug Fixes:
- Prevent TypeError when merging episode localized metadata by serializing the existing localized value object before merging.
- Ensure single-episode, non-force series enrichment correctly preserves provider-supplied localized title and synopsis.

Tests:
- Add regression test covering non-force enrichment of a single episode with provider-localized text to verify successful merge and prevent crashes.