### PR TITLE
refactor(media): VO-native localized metadata in enrich write path [ADR-023]

### DIFF
--- a/src/modules/media/application/use_cases/_localized_metadata_helpers.py
+++ b/src/modules/media/application/use_cases/_localized_metadata_helpers.py
@@ -1,104 +1,77 @@
-"""Shared helper for merging per-language metadata overrides.
+"""Build per-language metadata overrides as LocalizedMetadata value objects.
 
-Both the movie and series enrich use cases need to fold the provider's
-``localized`` payload into the entity's existing ``localized`` dict. The
-two copies had already drifted — the movie variant carried ``tagline``
-while the series variant silently dropped it — so the merge now lives in
-one place and is applied uniformly to both media types.
+The movie/series and season/episode enrich use cases fold a provider's
+per-language overrides into the entity's stored ``localized``. Both the
+provider→VO translation and the merge-vs-replace decision live here so the
+use cases stay declarative and no call site has to reach for the wire-dict
+form (the VO owns serialization). ``force`` (a relink) replaces the stored
+overrides outright; otherwise the provider's locales are overlaid on the
+existing ones (:meth:`LocalizedMetadata.merge`).
 """
 
-from typing import Any
-
 from src.modules.media.application.ports import LocalizedTextFields, MediaMetadata
+from src.modules.media.domain.value_objects.localized_metadata import (
+    LocalizedFields,
+    LocalizedMetadata,
+)
 
 
-def merge_localized_metadata(
-    updates: dict[str, object],
-    existing: dict[str, dict[str, object]],
-    metadata: MediaMetadata,
-    *,
-    force: bool = False,
-) -> None:
-    """Merge per-language overrides from ``metadata`` into ``updates``.
+def _resolved(
+    existing: LocalizedMetadata, provider: LocalizedMetadata, *, force: bool
+) -> LocalizedMetadata | None:
+    """Merge or replace, returning ``None`` when the provider has nothing.
 
-    Builds one entry per language with only the fields the provider
-    actually returned (falsy values are dropped), then merges them over
-    the entity's current ``localized`` dict. ``tagline`` is carried for
-    every media type so a localized tagline from the provider is never
-    discarded; entities that have no use for it simply ignore the key.
-
-    Args:
-        updates: The mutable updates dict the use case applies to the
-            entity. ``"localized"`` is set here when there is anything
-            to merge.
-        existing: The entity's current ``localized`` mapping.
-        metadata: Provider metadata carrying the ``localized`` overrides.
-        force: When ``True`` (a relink / forced refresh) the entity's
-            current ``localized`` is **replaced** by the provider's,
-            dropping stale language entries left over from a wrong
-            match. When ``False`` the new entries are merged over the
-            existing ones (the default fill-and-update behavior).
+    ``None`` lets the caller leave the entity's ``localized`` untouched.
     """
-    if not metadata.localized:
-        return
-
-    localized: dict[str, dict[str, object]] = {}
-    for lang, fields in metadata.localized.items():
-        candidates = {
-            "title": fields.title,
-            "synopsis": fields.synopsis,
-            "tagline": fields.tagline,
-            "genres": fields.genres or None,
-            "logo_path": fields.logo_url,
-            "poster_path": fields.poster_url,
-            "backdrop_path": fields.backdrop_url,
-        }
-        loc_entry: dict[str, object] = {k: v for k, v in candidates.items() if v}
-        if loc_entry:
-            localized[lang] = loc_entry
-
-    if localized:
-        updates["localized"] = localized if force else {**existing, **localized}
+    if provider.is_empty():
+        return None
+    return provider if force else existing.merge(provider)
 
 
-def build_localized_text(
+def merge_media_localized(
+    existing: LocalizedMetadata, metadata: MediaMetadata, *, force: bool = False
+) -> LocalizedMetadata | None:
+    """Fold a movie/series provider's full per-language overrides into ``existing``.
+
+    Maps the provider's ``localized`` records (which name artwork fields
+    ``*_url``) onto :class:`LocalizedFields`, dropping locales that carry no
+    usable field. Returns the merged value object, or ``None`` when the
+    provider supplied no localized data.
+    """
+    by_locale: dict[str, LocalizedFields] = {}
+    for lang, f in metadata.localized.items():
+        fields = LocalizedFields(
+            title=f.title or None,
+            synopsis=f.synopsis or None,
+            tagline=f.tagline or None,
+            genres=tuple(f.genres) if f.genres else (),
+            logo_path=f.logo_url or None,
+            poster_path=f.poster_url or None,
+            backdrop_path=f.backdrop_url or None,
+        )
+        if not fields.is_empty():
+            by_locale[lang] = fields
+    return _resolved(existing, LocalizedMetadata(by_locale), force=force)
+
+
+def merge_text_localized(
+    existing: LocalizedMetadata,
     provider_localized: dict[str, LocalizedTextFields],
-    existing: dict[str, dict[str, Any]],
     *,
     force: bool = False,
-) -> dict[str, dict[str, Any]] | None:
-    """Merge per-language title/synopsis overrides for a season or episode.
+) -> LocalizedMetadata | None:
+    """Fold a season/episode provider's title/synopsis overrides into ``existing``.
 
-    The season/episode counterpart to :func:`merge_localized_metadata` —
-    seasons and episodes only localize ``title`` and ``synopsis`` (no
-    artwork/genres), so this builds the lighter ``{lang: {title,
-    synopsis}}`` shape. Falsy values are dropped per language.
-
-    Args:
-        provider_localized: The provider's per-language overrides.
-        existing: The entity's current ``localized`` mapping.
-        force: When ``True`` (a relink / forced refresh) the entity's
-            ``localized`` is **replaced**, dropping stale languages;
-            otherwise the new entries are merged over the existing ones.
-
-    Returns:
-        The merged ``localized`` dict to store, or ``None`` when there
-        is nothing to merge (so the caller leaves the field untouched).
+    The lean counterpart to :func:`merge_media_localized` — seasons and
+    episodes only localize ``title``/``synopsis``. Drops locales with
+    neither; returns ``None`` when nothing is supplied.
     """
-    if not provider_localized:
-        return None
-
-    built: dict[str, dict[str, Any]] = {}
-    for lang, fields in provider_localized.items():
-        entry: dict[str, Any] = {
-            k: v for k, v in {"title": fields.title, "synopsis": fields.synopsis}.items() if v
-        }
-        if entry:
-            built[lang] = entry
-
-    if not built:
-        return None
-    return built if force else {**existing, **built}
+    by_locale: dict[str, LocalizedFields] = {}
+    for lang, f in provider_localized.items():
+        fields = LocalizedFields(title=f.title or None, synopsis=f.synopsis or None)
+        if not fields.is_empty():
+            by_locale[lang] = fields
+    return _resolved(existing, LocalizedMetadata(by_locale), force=force)
 
 
-__all__ = ["build_localized_text", "merge_localized_metadata"]
+__all__ = ["merge_media_localized", "merge_text_localized"]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -11,7 +11,7 @@ from src.modules.media.application.dtos.enrichment_dtos import (
 from src.modules.media.application.ports import MediaMetadata, MetadataProvider
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._localized_metadata_helpers import (
-    merge_localized_metadata,
+    merge_media_localized,
 )
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.events import MediaEnrichedEvent
@@ -341,7 +341,9 @@ def _apply_credits(
         updates["content_rating"] = ContentRating(metadata.content_rating)
     if metadata.trailer_url and (force or not movie.trailer_url):
         updates["trailer_url"] = metadata.trailer_url
-    merge_localized_metadata(updates, movie.localized.to_serializable(), metadata, force=force)
+    new_localized = merge_media_localized(movie.localized, metadata, force=force)
+    if new_localized is not None:
+        updates["localized"] = new_localized
 
 
 __all__ = ["EnrichMovieMetadataUseCase"]

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -19,8 +19,8 @@ from src.modules.media.application.ports import (
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._localized_metadata_helpers import (
-    build_localized_text,
-    merge_localized_metadata,
+    merge_media_localized,
+    merge_text_localized,
 )
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.events import MediaEnrichedEvent
@@ -32,6 +32,8 @@ from src.modules.media.domain.value_objects import (
     Genre,
     ImageUrl,
     ImdbId,
+    LocalizedFields,
+    LocalizedMetadata,
     SeriesId,
     Title,
     TmdbId,
@@ -257,7 +259,9 @@ def _apply_series_metadata(
             for p in metadata.cast
         ]
 
-    merge_localized_metadata(updates, series.localized.to_serializable(), metadata, force=force)
+    new_localized = merge_media_localized(series.localized, metadata, force=force)
+    if new_localized is not None:
+        updates["localized"] = new_localized
 
     if updates:
         series = series.with_updates(**updates)
@@ -299,9 +303,7 @@ def _apply_season_metadata(season: Season, meta: SeasonMetadata, *, force: bool 
         parsed = _parse_date(meta.air_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
-    season_localized = build_localized_text(
-        meta.localized, season.localized.to_serializable(), force=force
-    )
+    season_localized = merge_text_localized(season.localized, meta.localized, force=force)
     if season_localized is not None:
         updates["localized"] = season_localized
 
@@ -407,9 +409,7 @@ def _apply_multi_episode_metadata(
         if parsed:
             updates["air_date"] = AirDate(parsed)
 
-    combined_localized = _combine_localized_segments(
-        present, episode.localized.to_serializable(), force=force
-    )
+    combined_localized = _combine_localized_segments(present, episode.localized, force=force)
     if combined_localized is not None:
         updates["localized"] = combined_localized
 
@@ -421,33 +421,35 @@ def _apply_multi_episode_metadata(
 
 def _combine_localized_segments(
     present: list[EpisodeMetadata],
-    existing: dict[str, dict[str, Any]],
+    existing: LocalizedMetadata,
     *,
     force: bool,
-) -> dict[str, dict[str, Any]] | None:
+) -> LocalizedMetadata | None:
     """Combine per-locale title/synopsis across a multi-segment file's episodes.
 
     Mirrors the English combine (titles joined with `` / ``, synopses
     with `` ◆ ``) per locale so a translated multi-segment file keeps
-    its localized text. Returns ``None`` when no locale has data.
+    its localized text. Returns ``None`` when no locale has data; otherwise
+    replaces (``force``) or merges the combined overrides over ``existing``.
     """
     locales = {loc for m in present for loc in m.localized}
-    combined: dict[str, dict[str, Any]] = {}
+    by_locale: dict[str, LocalizedFields] = {}
     for loc in locales:
         segments = [m.localized[loc] for m in present if loc in m.localized]
         titles = [s.title for s in segments if s.title]
         synopses = [s.synopsis for s in segments if s.synopsis]
-        entry: dict[str, Any] = {}
-        if titles:
-            entry["title"] = " / ".join(titles)
-        if synopses:
-            entry["synopsis"] = " ◆ ".join(synopses)
-        if entry:
-            combined[loc] = entry
+        fields = LocalizedFields(
+            title=" / ".join(titles) if titles else None,
+            synopsis=" ◆ ".join(synopses) if synopses else None,
+        )
+        if not fields.is_empty():
+            by_locale[loc] = fields
 
-    if not combined:
+    if not by_locale:
         return None
-    return combined if force else {**existing, **combined}
+
+    combined = LocalizedMetadata(by_locale)
+    return combined if force else existing.merge(combined)
 
 
 def _apply_episode_metadata(
@@ -474,9 +476,7 @@ def _apply_episode_metadata(
         updates["duration"] = Duration(meta.duration_seconds)
     if meta.still_url and (force or not episode.thumbnail_path):
         updates["thumbnail_path"] = ImageUrl(meta.still_url)
-    episode_localized = build_localized_text(
-        meta.localized, episode.localized.to_serializable(), force=force
-    )
+    episode_localized = merge_text_localized(episode.localized, meta.localized, force=force)
     if episode_localized is not None:
         updates["localized"] = episode_localized
 

--- a/src/modules/media/domain/value_objects/localized_metadata.py
+++ b/src/modules/media/domain/value_objects/localized_metadata.py
@@ -64,6 +64,18 @@ class LocalizedFields(CompoundValueObject):
     poster_path: str | None = None
     backdrop_path: str | None = None
 
+    def is_empty(self) -> bool:
+        """Return ``True`` when no field carries a value."""
+        return not (
+            self.title
+            or self.synopsis
+            or self.tagline
+            or self.genres
+            or self.logo_path
+            or self.poster_path
+            or self.backdrop_path
+        )
+
 
 def _canonical(lang: str) -> str:
     """Return the canonical BCP-47 tag for *lang*, or the raw value.
@@ -139,6 +151,17 @@ class LocalizedMetadata(RootModel[dict[str, LocalizedFields]], ValueObject):
     def is_empty(self) -> bool:
         """Return ``True`` when there are no localized overrides."""
         return not self.root
+
+    def merge(self, other: "LocalizedMetadata") -> "LocalizedMetadata":
+        """Return a copy with *other*'s locales overlaid on this one.
+
+        Locale-level (not field-level) override: a locale present in
+        *other* replaces this object's entry for that locale entirely,
+        while locales only in ``self`` are kept. Mirrors the previous
+        ``{**existing, **provider}`` merge — used by the enrich write
+        path to fold provider overrides over the stored ones.
+        """
+        return LocalizedMetadata({**self.root, **other.root})
 
     def to_serializable(self) -> dict[str, dict[str, Any]]:
         """Serialize to the stored JSON shape (only non-falsy fields).

--- a/tests/modules/media/unit/domain/value_objects/test_localized_metadata.py
+++ b/tests/modules/media/unit/domain/value_objects/test_localized_metadata.py
@@ -1,0 +1,90 @@
+"""Tests for the LocalizedMetadata value object (ADR-023)."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.media.domain.value_objects.localized_metadata import (
+    LocalizedField,
+    LocalizedFields,
+    LocalizedMetadata,
+)
+
+
+@pytest.mark.unit
+class TestLocalizedFields:
+    """Per-locale record emptiness."""
+
+    def test_is_empty_when_all_fields_unset(self) -> None:
+        assert LocalizedFields().is_empty() is True
+
+    def test_not_empty_with_any_field(self) -> None:
+        assert LocalizedFields(title="X").is_empty() is False
+        assert LocalizedFields(genres=("Ação",)).is_empty() is False
+
+
+@pytest.mark.unit
+class TestLocalizedMetadataMerge:
+    """merge() overlays another VO's locales at the locale level."""
+
+    def test_merge_overlays_provider_locale_over_existing(self) -> None:
+        existing = LocalizedMetadata.from_serializable(
+            {"pt-BR": {"title": "Antigo", "synopsis": "Velha sinopse"}}
+        )
+        provider = LocalizedMetadata.from_serializable({"pt-BR": {"title": "Novo"}})
+
+        merged = existing.merge(provider)
+
+        # Locale-level (not field-level) override: the whole pt-BR entry is
+        # replaced, so the stale synopsis is dropped — matching the legacy
+        # {**existing, **provider} behavior.
+        assert merged.text(LocalizedField.TITLE, "pt-BR") == "Novo"
+        assert merged.text(LocalizedField.SYNOPSIS, "pt-BR") is None
+
+    def test_merge_keeps_locales_absent_from_provider(self) -> None:
+        existing = LocalizedMetadata.from_serializable({"es": {"title": "Español"}})
+        provider = LocalizedMetadata.from_serializable({"pt-BR": {"title": "Português"}})
+
+        merged = existing.merge(provider)
+
+        assert merged.text(LocalizedField.TITLE, "es") == "Español"
+        assert merged.text(LocalizedField.TITLE, "pt-BR") == "Português"
+
+    def test_merge_with_empty_provider_is_noop(self) -> None:
+        existing = LocalizedMetadata.from_serializable({"pt-BR": {"title": "Mantido"}})
+
+        merged = existing.merge(LocalizedMetadata())
+
+        assert merged.to_serializable() == {"pt-BR": {"title": "Mantido"}}
+
+    def test_merge_does_not_mutate_operands(self) -> None:
+        existing = LocalizedMetadata.from_serializable({"pt-BR": {"title": "A"}})
+        provider = LocalizedMetadata.from_serializable({"pt-BR": {"title": "B"}})
+
+        existing.merge(provider)
+
+        assert existing.text(LocalizedField.TITLE, "pt-BR") == "A"
+        assert provider.text(LocalizedField.TITLE, "pt-BR") == "B"
+
+
+@pytest.mark.unit
+class TestLocalizedMetadataRoundTrip:
+    """Serialization anchors the no-migration guarantee."""
+
+    def test_to_serializable_omits_falsy_and_lists_genres(self) -> None:
+        meta = LocalizedMetadata.from_serializable(
+            {"pt-BR": {"title": "T", "synopsis": "", "genres": ["Ação"]}}
+        )
+
+        # Empty synopsis dropped; genres stays a list.
+        assert meta.to_serializable() == {"pt-BR": {"title": "T", "genres": ["Ação"]}}
+
+    def test_unknown_internal_key_is_rejected(self) -> None:
+        with pytest.raises(DomainValidationException):
+            LocalizedMetadata.from_serializable({"pt-BR": {"bogus": "x"}})
+
+    def test_lenient_lookup_canonicalizes_locale(self) -> None:
+        meta = LocalizedMetadata.from_serializable({"pt-BR": {"title": "Olá"}})
+
+        # Non-canonical casing resolves; an unparseable tag just misses.
+        assert meta.text(LocalizedField.TITLE, "PT-br") == "Olá"
+        assert meta.text(LocalizedField.TITLE, "zz") is None


### PR DESCRIPTION
## Summary

Phase 2 / PR-2.3 of the architecture-audit remediation — completes ADR-023 by making the enrich **write path** value-object-native.

- Adds `LocalizedMetadata.merge(other)` (locale-level override, mirrors the old `{**existing, **provider}`).
- Replaces the dict-based helpers `merge_localized_metadata` / `build_localized_text` with VO-native builders `merge_media_localized` (movie/series, full fields) and `merge_text_localized` (season/episode, title/synopsis), which translate provider overrides into a `LocalizedMetadata` and fold them over the entity's stored VO. The multi-segment `_combine_localized_segments` now returns a VO too.
- **Removes all five `entity.localized.to_serializable()` call sites** the read-path PR (#321) introduced — the exact fragility the episode hotfix (#322) patched. A new localized merge site can no longer silently skip the conversion, since merge happens through the VO.
- Addresses the Sourcery "5th call site" concern from #322 structurally (no transient helper).

No wire-format change, no migration. `force` stays a bool here; it becomes `MergePolicy` in Phase 4 (MetadataReconciler).

## Test plan

- [x] New `test_localized_metadata.py`: `merge()` semantics (locale-level override, keep-non-overlapping, empty no-op, no mutation) + round-trip / `extra="forbid"` / lenient lookup — 7 tests
- [x] `pytest tests/modules/media/` → 1670 passed, 5 skipped
- [x] Cross-BC `pytest tests/modules/{collections,catalog_requests,watch_progress}` → 388 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] No `to_serializable()` left in `application/use_cases`; old helper names gone

## Summary by Sourcery

Make enrich write-path handling of localized media metadata value-object-native and eliminate direct serialization usage.

Enhancements:
- Introduce LocalizedMetadata.merge for locale-level overlay semantics matching prior dict-based merges.
- Replace dict-based localized metadata helpers with VO-based merge_media_localized and merge_text_localized used across movie, series, season, and episode enrich flows.
- Update multi-episode localized combination logic to operate on LocalizedMetadata and return a VO instead of raw dicts.

Tests:
- Add unit tests for LocalizedMetadata merge semantics, serialization round-trip behavior, validation of unknown keys, and lenient locale lookup.