### PR TITLE
refactor: materialize integration events for cross-BC contracts [ADR-009]

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -281,17 +281,11 @@ async def _subscribe_event_handlers(container: ApplicationContainer) -> None:
     from src.modules.collections.application.event_handlers import (
         OnUserDeletedHandler as CollectionsOnUserDeletedHandler,
     )
-    from src.modules.identity.domain.events import UserDeletedEvent
     from src.modules.media.application.event_handlers import OnMediaCreatedHandler
     from src.modules.media.application.event_handlers import (
         OnMediaEnrichedHandler as MediaOnEnrichedConflictsHandler,
     )
-    from src.modules.media.domain.events import (
-        MediaCreatedEvent,
-        MediaEnrichedEvent,
-        MovieMergedEvent,
-        MoviePromotedToSeriesEvent,
-    )
+    from src.modules.media.domain.events import MediaCreatedEvent
     from src.modules.watch_progress.application.event_handlers import (
         OnMovieMergedHandler as ProgressOnMovieMergedHandler,
     )
@@ -300,6 +294,12 @@ async def _subscribe_event_handlers(container: ApplicationContainer) -> None:
     )
     from src.modules.watch_progress.application.event_handlers import (
         OnUserDeletedHandler as ProgressOnUserDeletedHandler,
+    )
+    from src.shared_kernel.integration_events import (
+        MediaEnrichedEvent,
+        MovieMergedEvent,
+        MoviePromotedToSeriesEvent,
+        UserDeletedEvent,
     )
 
     event_bus = container.infrastructure.event_bus()

--- a/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
+++ b/src/modules/catalog_requests/application/event_handlers/on_media_enriched.py
@@ -10,7 +10,7 @@ from src.modules.catalog_requests.application.ports import (
     CatalogArrivalNotification,
     NotificationPublisherPort,
 )
-from src.modules.media.domain.events import MediaEnrichedEvent
+from src.shared_kernel.integration_events import MediaEnrichedEvent
 from src.shared_kernel.value_objects.media_type import MediaType
 
 if TYPE_CHECKING:

--- a/src/modules/collections/application/event_handlers/on_movie_merged.py
+++ b/src/modules/collections/application/event_handlers/on_movie_merged.py
@@ -8,7 +8,7 @@ from src.modules.collections.application.unit_of_work import (
     CollectionsUnitOfWorkFactory,
 )
 from src.modules.collections.domain.value_objects import CollectionMediaId
-from src.modules.media.domain.events import MovieMergedEvent
+from src.shared_kernel.integration_events import MovieMergedEvent
 from src.shared_kernel.value_objects import MediaType
 
 _logger = logging.getLogger(__name__)

--- a/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/collections/application/event_handlers/on_movie_promoted_to_series.py
@@ -8,7 +8,7 @@ from src.modules.collections.application.unit_of_work import (
     CollectionsUnitOfWorkFactory,
 )
 from src.modules.collections.domain.value_objects import CollectionMediaId
-from src.modules.media.domain.events import MoviePromotedToSeriesEvent
+from src.shared_kernel.integration_events import MoviePromotedToSeriesEvent
 from src.shared_kernel.value_objects import MediaType
 
 _logger = logging.getLogger(__name__)

--- a/src/modules/collections/application/event_handlers/on_user_deleted.py
+++ b/src/modules/collections/application/event_handlers/on_user_deleted.py
@@ -7,7 +7,7 @@ from src.building_blocks.domain.events import DomainEvent
 from src.modules.collections.application.unit_of_work import (
     CollectionsUnitOfWorkFactory,
 )
-from src.modules.identity.domain.events import UserDeletedEvent
+from src.shared_kernel.integration_events import UserDeletedEvent
 
 _logger = logging.getLogger(__name__)
 

--- a/src/modules/identity/application/use_cases/delete_admin_user.py
+++ b/src/modules/identity/application/use_cases/delete_admin_user.py
@@ -9,9 +9,9 @@ from src.modules.identity.domain.errors import (
     CannotDeleteSelfError,
     UserNotFoundException,
 )
-from src.modules.identity.domain.events import UserDeletedEvent
 from src.modules.identity.domain.services import AdminQuorum
 from src.modules.identity.domain.value_objects.user_role import UserRole
+from src.shared_kernel.integration_events import UserDeletedEvent
 from src.shared_kernel.value_objects.user_id import UserId
 
 _logger = logging.getLogger(__name__)

--- a/src/modules/identity/domain/events.py
+++ b/src/modules/identity/domain/events.py
@@ -1,42 +1,8 @@
-"""Domain events for the Identity bounded context."""
+"""Domain events for the Identity bounded context.
 
-from dataclasses import dataclass, field
+``UserDeletedEvent`` moved to :mod:`src.shared_kernel.integration_events`
+(ADR-009) — it is a cross-BC contract consumed by ``watch_progress`` and
+``collections``, so it no longer lives in this module's internals.
+"""
 
-from src.building_blocks.domain.events import DomainEvent
-
-
-@dataclass(frozen=True)
-class UserDeletedEvent(DomainEvent):
-    """Emitted when an admin soft-deletes a user account.
-
-    Carries the full list of profile ids owned by the deleted user
-    so downstream bounded contexts can cascade their per-profile
-    state without re-querying identity (which would race against the
-    soft-delete tombstone). Profile ids are passed by-value because
-    cross-BC FKs are forbidden by ADR-008.
-
-    Cross-BC handlers:
-        - ``watch_progress`` soft-deletes every ``watch_progresses``
-          row whose ``profile_id`` matches one of the deleted user's
-          profiles. The half-watched position belongs to that
-          person; restoring it later would be a privacy footgun.
-        - ``collections`` soft-deletes the user's watchlists and
-          custom lists (lists belong to profiles, not users) so the
-          ex-user's library state isn't visible to anyone else.
-
-    Both handlers run fire-and-forget on the event bus — failures
-    are logged but the user-delete still commits. Operators can
-    re-run the cleanup later if a downstream BC was offline.
-
-    Attributes:
-        user_id: External ID of the deleted user (usr_xxx).
-        profile_ids: External IDs of every profile the user owned
-            at deletion time (pro_xxx). May be empty if the user
-            never created a profile.
-    """
-
-    user_id: str = ""
-    profile_ids: tuple[str, ...] = field(default_factory=tuple)
-
-
-__all__ = ["UserDeletedEvent"]
+__all__: list[str] = []

--- a/src/modules/media/application/event_handlers/on_media_enriched.py
+++ b/src/modules/media/application/event_handlers/on_media_enriched.py
@@ -9,7 +9,7 @@ from src.modules.media.application.dtos.conflict_dtos import DetectMovieConflict
 from src.modules.media.application.use_cases.detect_movie_conflicts import (
     DetectMovieConflictsUseCase,
 )
-from src.modules.media.domain.events import MediaEnrichedEvent
+from src.shared_kernel.integration_events import MediaEnrichedEvent
 from src.shared_kernel.value_objects.media_type import MediaType
 
 _logger = logging.getLogger(__name__)

--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -15,11 +15,9 @@ from src.modules.media.domain.entities.media_conflict import (
     ResolutionAction,
     ResolutionSource,
 )
-from src.modules.media.domain.events import (
-    MediaConflictDetectedEvent,
-    MovieMergedEvent,
-)
+from src.modules.media.domain.events import MediaConflictDetectedEvent
 from src.modules.media.domain.value_objects import MovieId
+from src.shared_kernel.integration_events import MovieMergedEvent
 from src.shared_kernel.value_objects.media_type import MediaType
 
 if TYPE_CHECKING:

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -14,7 +14,6 @@ from src.modules.media.application.use_cases._localized_metadata_helpers import 
     merge_media_localized,
 )
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.events import MediaEnrichedEvent
 from src.modules.media.domain.value_objects import (
     CastMember,
     Collection,
@@ -28,6 +27,7 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.shared_kernel.integration_events import MediaEnrichedEvent
 from src.shared_kernel.value_objects.media_type import MediaType
 
 _logger = logging.getLogger(__name__)

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -23,7 +23,6 @@ from src.modules.media.application.use_cases._localized_metadata_helpers import 
     merge_text_localized,
 )
 from src.modules.media.domain.entities import Episode, Season, Series
-from src.modules.media.domain.events import MediaEnrichedEvent
 from src.modules.media.domain.value_objects import (
     AirDate,
     CastMember,
@@ -39,6 +38,7 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.shared_kernel.integration_events import MediaEnrichedEvent
 from src.shared_kernel.value_objects.media_type import MediaType
 
 

--- a/src/modules/media/application/use_cases/promote_movie_to_series.py
+++ b/src/modules/media/application/use_cases/promote_movie_to_series.py
@@ -18,7 +18,6 @@ from src.modules.media.application.use_cases.enrich_series_metadata import (
     EnrichSeriesMetadataUseCase,
 )
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
-from src.modules.media.domain.events import MoviePromotedToSeriesEvent
 from src.modules.media.domain.value_objects import (
     Duration,
     EpisodeId,
@@ -31,6 +30,7 @@ from src.modules.media.domain.value_objects import (
     TmdbId,
     Year,
 )
+from src.shared_kernel.integration_events import MoviePromotedToSeriesEvent
 
 _logger = logging.getLogger(__name__)
 

--- a/src/modules/media/application/use_cases/resolve_media_conflict.py
+++ b/src/modules/media/application/use_cases/resolve_media_conflict.py
@@ -18,10 +18,10 @@ from src.modules.media.domain.entities.media_conflict import (
     MediaConflict,
     ResolutionAction,
 )
-from src.modules.media.domain.events import MovieMergedEvent
 from src.modules.media.domain.rule_codes import MediaRuleCodes
 from src.modules.media.domain.value_objects import MovieId
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+from src.shared_kernel.integration_events import MovieMergedEvent
 from src.shared_kernel.value_objects.media_type import MediaType
 
 if TYPE_CHECKING:

--- a/src/modules/media/domain/events.py
+++ b/src/modules/media/domain/events.py
@@ -80,33 +80,6 @@ class IntroClearedEvent(DomainEvent):
 
 
 @dataclass(frozen=True, kw_only=True)
-class MediaEnrichedEvent(DomainEvent):
-    """Emitted when an enrichment pass finishes with a known TMDB id.
-
-    Distinct from ``MediaCreatedEvent`` because the TMDB id is only
-    populated *after* enrichment runs — ``MediaCreatedEvent`` fires
-    on scan with just the internal id, so a handler that needs the
-    tmdb id (e.g. ``catalog_requests`` marking a pending request as
-    fulfilled once the title finally lands) can't piggy-back on it.
-
-    Fires both on the first successful enrichment and on a forced
-    refresh that re-runs against TMDB. Downstream handlers should
-    treat it as idempotent: re-firing on an already-fulfilled
-    catalog request must short-circuit, not duplicate state.
-
-    Attributes:
-        media_id: External ID of the enriched media (mov_xxx or
-            ser_xxx).
-        media_type: :class:`MediaType` of the enriched media.
-        tmdb_id: TMDB numeric id the enrichment locked onto.
-    """
-
-    media_id: MovieId | SeriesId
-    media_type: MediaType
-    tmdb_id: int = 0
-
-
-@dataclass(frozen=True, kw_only=True)
 class MediaConflictDetectedEvent(DomainEvent):
     """Emitted when the dedup detector queues a new conflict.
 
@@ -132,81 +105,10 @@ class MediaConflictDetectedEvent(DomainEvent):
     suggested_action: str = ""
 
 
-@dataclass(frozen=True, kw_only=True)
-class MovieMergedEvent(DomainEvent):
-    """Emitted when two movies are merged via the conflict queue.
-
-    Triggered by either the admin resolve endpoint (ADR-015 Phase 2,
-    ``is_auto=False``) or the post-enrich detector silently absorbing
-    an orphaned candidate (ADR-015 Phase 3, ``is_auto=True``). Carries
-    the cross-BC fan-out signal: ``watch_progress`` deletes the loser's
-    progress rows and ``collections`` repoints watchlist / custom-list
-    items from loser → winner. The loser movie itself is already
-    soft-deleted by the trigger before the event publishes, so handlers
-    don't need to touch the catalog row.
-
-    Attributes:
-        conflict_id: External id of the resolved conflict (``cnf_xxx``).
-        winner_id: External id of the surviving movie (``mov_xxx``).
-        loser_id: External id of the soft-deleted movie (``mov_xxx``).
-        keep_loser_variants: ``True`` when the resolution was
-            ``MERGE_KEEP_BOTH`` — the loser's file variants were
-            transferred to the winner; cross-BC handlers can treat
-            this identically to ``MERGE_REPLACE`` (rows still need to
-            be repointed). Surfaced for analytics / audit.
-        is_auto: ``True`` when the merge was decided by the auto-merge
-            path (orphan + healthy library), ``False`` when an admin
-            picked the resolution. Cross-BC handlers apply the same
-            fan-out either way; the flag is surfaced for logs and
-            audit reports.
-    """
-
-    conflict_id: str = ""
-    winner_id: MovieId
-    loser_id: MovieId
-    keep_loser_variants: bool = False
-    is_auto: bool = False
-
-
-@dataclass(frozen=True, kw_only=True)
-class MoviePromotedToSeriesEvent(DomainEvent):
-    """Emitted when an admin promotes a movie into a series.
-
-    Driven by the cross-type relink flow (e.g. ``Salem's Lot (1979)``,
-    which TMDB catalogs as a TV miniseries rather than a film).
-
-    The original movie row is soft-deleted; a new series + season
-    + episodes structure takes its place. All file variants of the
-    movie are reattached to the first episode (``first_episode_id``)
-    so external bounded contexts know where playback state should
-    migrate (or — per the agreed design — where to delete it).
-
-    Cross-BC handlers:
-        - ``watch_progress`` deletes WatchProgress rows for the old
-          movie id (safer than mapping a position across a possibly
-          re-cut episode boundary).
-        - ``collections`` rewrites watchlist + custom-list entries
-          to point at the new series id.
-
-    Attributes:
-        movie_id: External ID of the source movie (mov_xxx).
-        series_id: External ID of the new series (ser_xxx).
-        first_episode_id: External ID of the first episode (epi_xxx)
-            that now owns the movie's file variants.
-    """
-
-    movie_id: MovieId
-    series_id: SeriesId
-    first_episode_id: EpisodeId
-
-
 __all__ = [
     "IntroClearedEvent",
     "IntroDetectedEvent",
     "IntroManuallySetEvent",
     "MediaConflictDetectedEvent",
     "MediaCreatedEvent",
-    "MediaEnrichedEvent",
-    "MovieMergedEvent",
-    "MoviePromotedToSeriesEvent",
 ]

--- a/src/modules/watch_progress/application/event_handlers/on_movie_merged.py
+++ b/src/modules/watch_progress/application/event_handlers/on_movie_merged.py
@@ -4,10 +4,10 @@ import logging
 
 from src.building_blocks.application.event_bus import EventHandler
 from src.building_blocks.domain.events import DomainEvent
-from src.modules.media.domain.events import MovieMergedEvent
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.shared_kernel.integration_events import MovieMergedEvent
 
 _logger = logging.getLogger(__name__)
 

--- a/src/modules/watch_progress/application/event_handlers/on_movie_promoted_to_series.py
+++ b/src/modules/watch_progress/application/event_handlers/on_movie_promoted_to_series.py
@@ -4,10 +4,10 @@ import logging
 
 from src.building_blocks.application.event_bus import EventHandler
 from src.building_blocks.domain.events import DomainEvent
-from src.modules.media.domain.events import MoviePromotedToSeriesEvent
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.shared_kernel.integration_events import MoviePromotedToSeriesEvent
 
 _logger = logging.getLogger(__name__)
 

--- a/src/modules/watch_progress/application/event_handlers/on_user_deleted.py
+++ b/src/modules/watch_progress/application/event_handlers/on_user_deleted.py
@@ -4,10 +4,10 @@ import logging
 
 from src.building_blocks.application.event_bus import EventHandler
 from src.building_blocks.domain.events import DomainEvent
-from src.modules.identity.domain.events import UserDeletedEvent
 from src.modules.watch_progress.application.unit_of_work import (
     WatchProgressUnitOfWorkFactory,
 )
+from src.shared_kernel.integration_events import UserDeletedEvent
 
 _logger = logging.getLogger(__name__)
 

--- a/src/shared_kernel/integration_events/__init__.py
+++ b/src/shared_kernel/integration_events/__init__.py
@@ -1,1 +1,22 @@
-"""Integration events for inter-module communication."""
+"""Integration events for inter-module communication.
+
+Stable cross-BC published contracts (ADR-009). Producers publish these and
+consumers subscribe to them, so neither imports the other's ``domain.events``
+module. See :mod:`src.shared_kernel.integration_events.events`.
+"""
+
+from src.shared_kernel.integration_events.base import IntegrationEvent
+from src.shared_kernel.integration_events.events import (
+    MediaEnrichedEvent,
+    MovieMergedEvent,
+    MoviePromotedToSeriesEvent,
+    UserDeletedEvent,
+)
+
+__all__ = [
+    "IntegrationEvent",
+    "MediaEnrichedEvent",
+    "MovieMergedEvent",
+    "MoviePromotedToSeriesEvent",
+    "UserDeletedEvent",
+]

--- a/src/shared_kernel/integration_events/base.py
+++ b/src/shared_kernel/integration_events/base.py
@@ -1,0 +1,18 @@
+"""Base class for integration events (ADR-009)."""
+
+from dataclasses import dataclass
+
+from src.building_blocks.domain.events import DomainEvent
+
+
+@dataclass(frozen=True)
+class IntegrationEvent(DomainEvent):
+    """Base for stable cross-BC published contracts.
+
+    Distinct from a bounded context's internal domain events: an
+    integration event is the *published* shape other BCs subscribe to,
+    so it lives in ``shared_kernel`` and neither producer nor consumer
+    imports the other's internals (ADR-009). Subclasses ``DomainEvent``
+    so the in-process event bus — which dispatches by exact concrete
+    type — handles it unchanged.
+    """

--- a/src/shared_kernel/integration_events/events.py
+++ b/src/shared_kernel/integration_events/events.py
@@ -1,0 +1,153 @@
+"""Cross-BC integration event contracts (ADR-009).
+
+These are the stable, published shapes that bounded contexts subscribe to
+across the in-process event bus. They live in ``shared_kernel`` so a
+consumer never imports a producer's ``domain.events`` module.
+"""
+
+from dataclasses import dataclass, field
+
+from src.shared_kernel.integration_events.base import IntegrationEvent
+from src.shared_kernel.value_objects.media_id import EpisodeId, MovieId, SeriesId
+from src.shared_kernel.value_objects.media_type import MediaType
+
+
+@dataclass(frozen=True, kw_only=True)
+class MediaEnrichedEvent(IntegrationEvent):
+    """Emitted when an enrichment pass finishes with a known TMDB id.
+
+    Distinct from ``MediaCreatedEvent`` because the TMDB id is only
+    populated *after* enrichment runs — ``MediaCreatedEvent`` fires
+    on scan with just the internal id, so a handler that needs the
+    tmdb id (e.g. ``catalog_requests`` marking a pending request as
+    fulfilled once the title finally lands) can't piggy-back on it.
+
+    Fires both on the first successful enrichment and on a forced
+    refresh that re-runs against TMDB. Downstream handlers should
+    treat it as idempotent: re-firing on an already-fulfilled
+    catalog request must short-circuit, not duplicate state.
+
+    Also consumed in-module by ``media`` itself (the content-identity
+    conflict detector), which is fine — ``media`` may import this
+    shared-kernel contract like any other consumer.
+
+    Attributes:
+        media_id: External ID of the enriched media (mov_xxx or
+            ser_xxx).
+        media_type: :class:`MediaType` of the enriched media.
+        tmdb_id: TMDB numeric id the enrichment locked onto.
+    """
+
+    media_id: MovieId | SeriesId
+    media_type: MediaType
+    tmdb_id: int = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class MovieMergedEvent(IntegrationEvent):
+    """Emitted when two movies are merged via the conflict queue.
+
+    Triggered by either the admin resolve endpoint (ADR-015 Phase 2,
+    ``is_auto=False``) or the post-enrich detector silently absorbing
+    an orphaned candidate (ADR-015 Phase 3, ``is_auto=True``). Carries
+    the cross-BC fan-out signal: ``watch_progress`` deletes the loser's
+    progress rows and ``collections`` repoints watchlist / custom-list
+    items from loser → winner. The loser movie itself is already
+    soft-deleted by the trigger before the event publishes, so handlers
+    don't need to touch the catalog row.
+
+    Attributes:
+        conflict_id: External id of the resolved conflict (``cnf_xxx``).
+        winner_id: External id of the surviving movie (``mov_xxx``).
+        loser_id: External id of the soft-deleted movie (``mov_xxx``).
+        keep_loser_variants: ``True`` when the resolution was
+            ``MERGE_KEEP_BOTH`` — the loser's file variants were
+            transferred to the winner; cross-BC handlers can treat
+            this identically to ``MERGE_REPLACE`` (rows still need to
+            be repointed). Surfaced for analytics / audit.
+        is_auto: ``True`` when the merge was decided by the auto-merge
+            path (orphan + healthy library), ``False`` when an admin
+            picked the resolution. Cross-BC handlers apply the same
+            fan-out either way; the flag is surfaced for logs and
+            audit reports.
+    """
+
+    conflict_id: str = ""
+    winner_id: MovieId
+    loser_id: MovieId
+    keep_loser_variants: bool = False
+    is_auto: bool = False
+
+
+@dataclass(frozen=True, kw_only=True)
+class MoviePromotedToSeriesEvent(IntegrationEvent):
+    """Emitted when an admin promotes a movie into a series.
+
+    Driven by the cross-type relink flow (e.g. ``Salem's Lot (1979)``,
+    which TMDB catalogs as a TV miniseries rather than a film).
+
+    The original movie row is soft-deleted; a new series + season
+    + episodes structure takes its place. All file variants of the
+    movie are reattached to the first episode (``first_episode_id``)
+    so external bounded contexts know where playback state should
+    migrate (or — per the agreed design — where to delete it).
+
+    Cross-BC handlers:
+        - ``watch_progress`` deletes WatchProgress rows for the old
+          movie id (safer than mapping a position across a possibly
+          re-cut episode boundary).
+        - ``collections`` rewrites watchlist + custom-list entries
+          to point at the new series id.
+
+    Attributes:
+        movie_id: External ID of the source movie (mov_xxx).
+        series_id: External ID of the new series (ser_xxx).
+        first_episode_id: External ID of the first episode (epi_xxx)
+            that now owns the movie's file variants.
+    """
+
+    movie_id: MovieId
+    series_id: SeriesId
+    first_episode_id: EpisodeId
+
+
+@dataclass(frozen=True)
+class UserDeletedEvent(IntegrationEvent):
+    """Emitted when an admin soft-deletes a user account.
+
+    Carries the full list of profile ids owned by the deleted user
+    so downstream bounded contexts can cascade their per-profile
+    state without re-querying identity (which would race against the
+    soft-delete tombstone). Profile ids are passed by-value because
+    cross-BC FKs are forbidden by ADR-008.
+
+    Cross-BC handlers:
+        - ``watch_progress`` soft-deletes every ``watch_progresses``
+          row whose ``profile_id`` matches one of the deleted user's
+          profiles. The half-watched position belongs to that
+          person; restoring it later would be a privacy footgun.
+        - ``collections`` soft-deletes the user's watchlists and
+          custom lists (lists belong to profiles, not users) so the
+          ex-user's library state isn't visible to anyone else.
+
+    Both handlers run fire-and-forget on the event bus — failures
+    are logged but the user-delete still commits. Operators can
+    re-run the cleanup later if a downstream BC was offline.
+
+    Attributes:
+        user_id: External ID of the deleted user (usr_xxx).
+        profile_ids: External IDs of every profile the user owned
+            at deletion time (pro_xxx). May be empty if the user
+            never created a profile.
+    """
+
+    user_id: str = ""
+    profile_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+__all__ = [
+    "MediaEnrichedEvent",
+    "MovieMergedEvent",
+    "MoviePromotedToSeriesEvent",
+    "UserDeletedEvent",
+]

--- a/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
+++ b/tests/modules/catalog_requests/unit/application/event_handlers/test_on_media_enriched.py
@@ -16,7 +16,8 @@ from src.modules.catalog_requests.domain.entities import (
     CatalogRequest,
     CatalogSubscription,
 )
-from src.modules.media.domain.events import MediaCreatedEvent, MediaEnrichedEvent
+from src.modules.media.domain.events import MediaCreatedEvent
+from src.shared_kernel.integration_events import MediaEnrichedEvent
 from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 from src.shared_kernel.value_objects.media_type import MediaType
 from tests.modules.catalog_requests.unit.conftest import (

--- a/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/collections/unit/application/event_handlers/test_on_movie_merged.py
@@ -8,10 +8,8 @@ from src.modules.collections.application.event_handlers.on_movie_merged import (
     OnMovieMergedHandler,
 )
 from src.modules.collections.domain.value_objects import CollectionMediaId
-from src.modules.media.domain.events import (
-    MediaCreatedEvent,
-    MovieMergedEvent,
-)
+from src.modules.media.domain.events import MediaCreatedEvent
+from src.shared_kernel.integration_events import MovieMergedEvent
 from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.media_id import MovieId
 

--- a/tests/modules/identity/unit/application/use_cases/test_delete_admin_user.py
+++ b/tests/modules/identity/unit/application/use_cases/test_delete_admin_user.py
@@ -22,9 +22,9 @@ from src.modules.identity.domain.errors import (
     CannotDemoteLastAdminError,
     UserNotFoundException,
 )
-from src.modules.identity.domain.events import UserDeletedEvent
 from src.modules.identity.domain.value_objects.email import Email
 from src.modules.identity.domain.value_objects.user_role import UserRole
+from src.shared_kernel.integration_events import UserDeletedEvent
 from src.shared_kernel.value_objects.user_id import UserId
 
 from .conftest import FakeIdentityUnitOfWork, FakeIdentityUnitOfWorkFactory

--- a/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
@@ -17,10 +17,7 @@ from src.modules.media.domain.entities.media_conflict import (
     SuggestedAction,
 )
 from src.modules.media.domain.entities.movie import Movie
-from src.modules.media.domain.events import (
-    MediaConflictDetectedEvent,
-    MovieMergedEvent,
-)
+from src.modules.media.domain.events import MediaConflictDetectedEvent
 from src.modules.media.domain.value_objects import (
     Duration,
     FilePath,
@@ -33,6 +30,7 @@ from src.modules.media.domain.value_objects import (
 )
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
 from src.modules.settings.domain.value_objects import ScanDedupConfig
+from src.shared_kernel.integration_events import MovieMergedEvent
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
 

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -17,9 +17,9 @@ from src.modules.media.application.use_cases.enrich_movie_metadata import (
     _clean_title,
 )
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.events import MediaEnrichedEvent
 from src.modules.media.domain.value_objects import ContentRating, TmdbId
 from src.modules.media.domain.value_objects.cast_member import CastMember
+from src.shared_kernel.integration_events import MediaEnrichedEvent
 from tests.modules.media.unit.conftest import MediaUoWMocks, make_media_uow_mock
 
 _LIBRARY_ID = "lib_test12345678"

--- a/tests/modules/media/unit/application/use_cases/test_promote_movie_to_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_promote_movie_to_series.py
@@ -26,8 +26,8 @@ from src.modules.media.application.use_cases.promote_movie_to_series import (
     PromoteMovieToSeriesUseCase,
 )
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.events import MoviePromotedToSeriesEvent
 from src.modules.media.domain.value_objects import MovieId
+from src.shared_kernel.integration_events import MoviePromotedToSeriesEvent
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
 _LIBRARY_ID = "lib_test12345678"

--- a/tests/modules/media/unit/application/use_cases/test_resolve_media_conflict.py
+++ b/tests/modules/media/unit/application/use_cases/test_resolve_media_conflict.py
@@ -17,8 +17,8 @@ from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     MediaConflict,
 )
-from src.modules.media.domain.events import MovieMergedEvent
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
+from src.shared_kernel.integration_events import MovieMergedEvent
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
 _CONFLICT_ID = "cnf_xxxxxxxxxxxx"

--- a/tests/modules/watch_progress/unit/application/event_handlers/test_on_movie_merged.py
+++ b/tests/modules/watch_progress/unit/application/event_handlers/test_on_movie_merged.py
@@ -4,13 +4,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.modules.media.domain.events import (
-    MediaCreatedEvent,
-    MovieMergedEvent,
-)
+from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.watch_progress.application.event_handlers.on_movie_merged import (
     OnMovieMergedHandler,
 )
+from src.shared_kernel.integration_events import MovieMergedEvent
 from src.shared_kernel.value_objects.media_id import MovieId
 
 


### PR DESCRIPTION
## Summary

Phase 3 / PR-3.1 of the architecture-audit remediation (Tema A) — closes the highest-reach ADR-009 violation: five bounded contexts subscribed to producers' internal `domain.events`, and the `shared_kernel/integration_events/` package promised by ADR-008/009 was an empty stub.

- Adds `IntegrationEvent(DomainEvent)` base + the four cross-BC contracts in `src/shared_kernel/integration_events/`: `MediaEnrichedEvent`, `MovieMergedEvent`, `MoviePromotedToSeriesEvent`, `UserDeletedEvent` (fields/defaults/docstrings carried over verbatim).
- Removes them from `media/domain/events.py` and `identity/domain/events.py` (the latter is now a stub). Producers publish and consumers subscribe **from shared_kernel**, so no BC imports another's `domain.events`.
- The in-process bus is unchanged: `IntegrationEvent` subclasses `DomainEvent` and dispatch is by exact concrete type.
- `MediaEnrichedEvent` is also consumed in-module by media (conflict detection); that handler now imports the shared-kernel contract like any other consumer (media→shared_kernel is allowed).

No behavioral change.

## Test plan

- [x] Acceptance grep: zero imports of the four events from `media`/`identity` `domain.events` across `src` + `tests`
- [x] `media`/`identity` `domain/events.py` contain no definitions of the four
- [x] `pytest tests/modules/{media,identity,collections,catalog_requests,watch_progress}` → 2278 passed, 5 skipped
- [x] `python -c "import src.main"` resolves (bus wiring intact)
- [x] `ruff check` + `ruff format --check` clean

## Summary by Sourcery

Introduce a shared integration events layer in the shared kernel and update all producers/consumers to use it as the cross-bounded-context event contract source instead of importing other modules’ internal domain events.

Enhancements:
- Add a shared IntegrationEvent base class and centralize cross-bounded-context event contracts (media enrichment, movie merged, movie promoted to series, user deleted) under src.shared_kernel.integration_events.
- Remove cross-BC integration event definitions from media and identity domain event modules to keep them internal-only per bounded context.
- Update application wiring, use cases, event handlers, and tests across modules to import and publish/consume the new shared-kernel integration events while preserving existing runtime behavior.