### PR TITLE
refactor(media): cross-BC read ports + library DTO into scan [ADR-009, fixes F1]

### DIFF
--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -143,6 +143,12 @@ from src.modules.media.application.use_cases.trigger_bulk_enrich import (
     TriggerBulkEnrichUseCase,
 )
 from src.modules.media.application.use_cases.trigger_scan import TriggerScanUseCase
+from src.modules.media.infrastructure.acl.identity_user_count_adapter import (
+    IdentityUserCountAdapter,
+)
+from src.modules.media.infrastructure.acl.library_lookup_adapter import (
+    LibraryLookupAdapter,
+)
 from src.modules.media.infrastructure.acl.profile_summary_adapter import (
     ProfileSummaryAdapter,
 )
@@ -432,6 +438,18 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         identity_uow_factory=identity_uow_factory,
     )
 
+    # Cross-BC read ports (ADR-009 ACL): the scan flow resolves a
+    # library's paths and the overview reads the users count without
+    # importing the Library / Identity Unit of Work above the adapter.
+    library_lookup = providers.Singleton(
+        LibraryLookupAdapter,
+        library_uow_factory=library_uow_factory,
+    )
+    identity_user_count = providers.Singleton(
+        IdentityUserCountAdapter,
+        identity_uow_factory=identity_uow_factory,
+    )
+
     # Singleton because ``ThumbnailGenerationService`` is stateless apart
     # from the runtime config it reads per call; sharing one instance
     # across the eager fire-and-forget path (``stream_routes``) and the
@@ -640,7 +658,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     trigger_scan = providers.Factory(
         TriggerScanUseCase,
         scan_run_service=scan_run_service,
-        library_uow_factory=library_uow_factory,
+        library_lookup=library_lookup,
     )
 
     trigger_bulk_enrich = providers.Factory(
@@ -711,7 +729,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     get_overview_stats = providers.Factory(
         GetOverviewStatsUseCase,
         media_uow_factory=media_unit_of_work_factory,
-        identity_uow_factory=identity_uow_factory,
+        user_count=identity_user_count,
         list_movies_needing_review=list_movies_needing_review,
         hls_playlist=hls_service,
     )

--- a/src/infrastructure/scheduling/scheduler_service.py
+++ b/src/infrastructure/scheduling/scheduler_service.py
@@ -19,6 +19,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from src.config.logging import get_logger
+from src.modules.media.application.ports.library_lookup_port import LibraryRef
 from src.modules.media.domain.entities.scan_run import ScanRunTrigger
 from src.shared_kernel.value_objects.library_id import LibraryId
 
@@ -286,7 +287,10 @@ class LibraryScanScheduler:
             )
             return
 
-        await self._scan_run_service.run_scan(run.id, library)
+        await self._scan_run_service.run_scan(
+            run.id,
+            LibraryRef(id=str(library.id), paths=tuple(library.paths)),
+        )
         await self._mark_library_scanned(library_id)
 
     async def _load_library(self, library_id: str) -> Library | None:

--- a/src/modules/media/application/ports/identity_user_count_port.py
+++ b/src/modules/media/application/ports/identity_user_count_port.py
@@ -1,0 +1,21 @@
+"""Port for the cross-BC users count used by the admin overview.
+
+The Overview dashboard shows a "users" card. That single count is the
+only thing Media needs from Identity, so it reads through this port
+instead of borrowing Identity's Unit of Work (ADR-009). The adapter
+lives in ``media.infrastructure.acl``.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class IdentityUserCountPort(ABC):
+    """Read the non-deleted user count from the Identity BC."""
+
+    @abstractmethod
+    async def count_users(self) -> int:
+        """Return the number of active (non-deleted) users."""
+        ...
+
+
+__all__ = ["IdentityUserCountPort"]

--- a/src/modules/media/application/ports/library_lookup_port.py
+++ b/src/modules/media/application/ports/library_lookup_port.py
@@ -1,0 +1,48 @@
+"""Port for resolving a library's scan inputs from the Library BC.
+
+The scan flow (route + ``TriggerScanUseCase``) only needs to confirm a
+library exists and read the paths to scan — not the whole ``Library``
+aggregate. This port exposes that minimal read as a consumer-owned DTO,
+so Media never imports the Library aggregate or its Unit of Work (ADR-009).
+The adapter lives in ``media.infrastructure.acl``.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from src.shared_kernel.value_objects.file_path import FilePath
+
+
+@dataclass(frozen=True)
+class LibraryRef:
+    """Minimal projection of a library for the scan flow.
+
+    Attributes:
+        id: Prefixed external id (``lib_xxx``) of the library.
+        paths: Filesystem roots to scan. ``FilePath`` is a shared-kernel
+            value object, so carrying it across the boundary does not
+            couple Media to the Library aggregate.
+    """
+
+    id: str
+    paths: tuple[FilePath, ...]
+
+
+class LibraryLookupPort(ABC):
+    """Read a library's scan inputs without touching the Library aggregate."""
+
+    @abstractmethod
+    async def find(self, library_id: str) -> LibraryRef | None:
+        """Return the library's scan projection, or ``None`` if absent.
+
+        Args:
+            library_id: Prefixed external id (``lib_xxx``).
+
+        Returns:
+            A :class:`LibraryRef`, or ``None`` when no such library
+            exists (the caller turns that into a 404 / domain error).
+        """
+        ...
+
+
+__all__ = ["LibraryLookupPort", "LibraryRef"]

--- a/src/modules/media/application/services/scan_run_service.py
+++ b/src/modules/media/application/services/scan_run_service.py
@@ -18,9 +18,9 @@ process restart any rows still marked ``running`` get swept to
 
 import logging
 
-from src.modules.library.domain.entities.library import Library
 from src.modules.media.application.dtos.enrichment_dtos import BulkEnrichInput
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
+from src.modules.media.application.ports.library_lookup_port import LibraryRef
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases.bulk_enrich_metadata import (
     BulkEnrichMetadataUseCase,
@@ -83,18 +83,20 @@ class ScanRunService:
                 ),
             )
 
-    async def run_scan(self, run_id: ScanRunId, library: Library) -> None:
+    async def run_scan(self, run_id: ScanRunId, library: LibraryRef) -> None:
         """Execute the scan and write the terminal row.
 
         Args:
             run_id: External id of the already-opened ``running`` row.
-            library: Pre-loaded library so the runner doesn't re-hit
-                the library UoW from inside the background task.
+            library: Pre-resolved scan inputs (id + paths) projected by
+                the caller, so the runner doesn't re-hit the Library UoW
+                from inside the background task — and the service stays
+                decoupled from the Library aggregate (ADR-009).
         """
         try:
             output = await self._scan.execute(
                 ScanMediaInput(
-                    library_id=str(library.id),
+                    library_id=library.id,
                     directories=list(library.paths),
                 ),
             )

--- a/src/modules/media/application/use_cases/get_overview_stats.py
+++ b/src/modules/media/application/use_cases/get_overview_stats.py
@@ -1,12 +1,14 @@
 """GetOverviewStatsUseCase — single aggregator for the admin dashboard."""
 
-from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.modules.media.application.dtos.overview_stats_dtos import (
     HlsCacheSnapshot,
     LastScanSnapshot,
     OverviewStatsOutput,
 )
 from src.modules.media.application.ports import HlsPlaylistPort
+from src.modules.media.application.ports.identity_user_count_port import (
+    IdentityUserCountPort,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases.list_movies_needing_review import (
     ListMoviesNeedingReviewUseCase,
@@ -23,21 +25,20 @@ class GetOverviewStatsUseCase:
     five keeps the cards in lockstep — no flicker as individual
     queries resolve — and saves a few request round-trips.
 
-    All reads are non-deleted-only. Cross-BC reads (the users
-    count) go through the identity UoW factory injected at the
-    composition root, same pattern the trigger-scan use case
-    uses to look up a library.
+    All reads are non-deleted-only. The cross-BC users count goes
+    through ``IdentityUserCountPort`` (an ACL adapter), so this use
+    case never imports Identity's Unit of Work (ADR-009).
     """
 
     def __init__(
         self,
         media_uow_factory: MediaUnitOfWorkFactory,
-        identity_uow_factory: IdentityUnitOfWorkFactory,
+        user_count: IdentityUserCountPort,
         list_movies_needing_review: ListMoviesNeedingReviewUseCase,
         hls_playlist: HlsPlaylistPort,
     ) -> None:
         self._media_uow_factory = media_uow_factory
-        self._identity_uow_factory = identity_uow_factory
+        self._user_count = user_count
         self._list_review = list_movies_needing_review
         self._hls = hls_playlist
 
@@ -51,8 +52,7 @@ class GetOverviewStatsUseCase:
                 limit=1,
             )
 
-        async with self._identity_uow_factory() as identity_uow:
-            users_count = await identity_uow.users.count()
+        users_count = await self._user_count.count_users()
 
         review = await self._list_review.execute()
         review_count = len(review.movies)

--- a/src/modules/media/application/use_cases/trigger_scan.py
+++ b/src/modules/media/application/use_cases/trigger_scan.py
@@ -3,17 +3,16 @@
 import asyncio
 import logging
 
-from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.media.application.dtos.scan_run_dtos import (
     ScanRunOutput,
     TriggerScanInput,
 )
+from src.modules.media.application.ports.library_lookup_port import LibraryLookupPort
 from src.modules.media.application.services.scan_run_service import ScanRunService
 from src.modules.media.application.use_cases._to_scan_run_output import (
     scan_run_to_output,
 )
 from src.modules.media.domain.entities.scan_run import ScanRunTrigger
-from src.shared_kernel.value_objects.library_id import LibraryId
 
 _logger = logging.getLogger(__name__)
 
@@ -39,21 +38,20 @@ class TriggerScanUseCase:
     def __init__(
         self,
         scan_run_service: ScanRunService,
-        library_uow_factory: LibraryUnitOfWorkFactory,
+        library_lookup: LibraryLookupPort,
     ) -> None:
         self._service = scan_run_service
-        self._library_uow_factory = library_uow_factory
+        self._library_lookup = library_lookup
 
     async def execute(self, input_dto: TriggerScanInput) -> ScanRunOutput:
         """Validate the library, open the row, schedule the work."""
-        async with self._library_uow_factory() as luow:
-            library = await luow.libraries.find_by_id(LibraryId(input_dto.library_id))
+        library = await self._library_lookup.find(input_dto.library_id)
         if library is None:
             raise LibraryNotFoundForScanError(input_dto.library_id)
 
         trigger = ScanRunTrigger(input_dto.trigger)
         run = await self._service.open_scan(
-            library_id=str(library.id),
+            library_id=library.id,
             trigger=trigger,
         )
 
@@ -73,7 +71,7 @@ class TriggerScanUseCase:
         return scan_run_to_output(run)
 
 
-def _log_task_failure(task: asyncio.Task) -> None:
+def _log_task_failure(task: asyncio.Task[None]) -> None:
     """Surface unexpected task crashes in the logs.
 
     Normal failure paths inside ``ScanRunService.run_scan`` write

--- a/src/modules/media/infrastructure/acl/identity_user_count_adapter.py
+++ b/src/modules/media/infrastructure/acl/identity_user_count_adapter.py
@@ -1,0 +1,26 @@
+"""Adapter implementing ``IdentityUserCountPort`` via the Identity UoW.
+
+Isolates the cross-BC users-count read for the admin overview so the
+aggregator use case depends only on the local port, not Identity's Unit
+of Work (ADR-009).
+"""
+
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.media.application.ports.identity_user_count_port import (
+    IdentityUserCountPort,
+)
+
+
+class IdentityUserCountAdapter(IdentityUserCountPort):
+    """Read the active users count through the Identity Unit of Work."""
+
+    def __init__(self, identity_uow_factory: IdentityUnitOfWorkFactory) -> None:
+        self._identity_uow_factory = identity_uow_factory
+
+    async def count_users(self) -> int:
+        """Return ``users.count()`` from a short-lived Identity UoW."""
+        async with self._identity_uow_factory() as uow:
+            return await uow.users.count()
+
+
+__all__ = ["IdentityUserCountAdapter"]

--- a/src/modules/media/infrastructure/acl/library_lookup_adapter.py
+++ b/src/modules/media/infrastructure/acl/library_lookup_adapter.py
@@ -1,0 +1,32 @@
+"""Adapter implementing ``LibraryLookupPort`` via the Library UoW.
+
+This is the only Media file (besides the other ACL adapters) that
+touches the Library BC for the scan flow. Above it, the scan route and
+``TriggerScanUseCase`` see only the abstract port + ``LibraryRef`` DTO,
+so the cross-BC boundary stays explicit (ADR-009).
+"""
+
+from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
+from src.modules.media.application.ports.library_lookup_port import (
+    LibraryLookupPort,
+    LibraryRef,
+)
+from src.shared_kernel.value_objects.library_id import LibraryId
+
+
+class LibraryLookupAdapter(LibraryLookupPort):
+    """Resolve a :class:`LibraryRef` through the Library Unit of Work."""
+
+    def __init__(self, library_uow_factory: LibraryUnitOfWorkFactory) -> None:
+        self._library_uow_factory = library_uow_factory
+
+    async def find(self, library_id: str) -> LibraryRef | None:
+        """Load the library and project it to the scan-only ``LibraryRef``."""
+        async with self._library_uow_factory() as uow:
+            library = await uow.libraries.find_by_id(LibraryId(library_id))
+        if library is None:
+            return None
+        return LibraryRef(id=str(library.id), paths=tuple(library.paths))
+
+
+__all__ = ["LibraryLookupAdapter"]

--- a/src/modules/media/presentation/routes/scan_routes.py
+++ b/src/modules/media/presentation/routes/scan_routes.py
@@ -10,13 +10,12 @@ from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
 from src.modules.identity.infrastructure.auth import current_admin_user
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
-from src.modules.library.application.unit_of_work import LibraryUnitOfWorkFactory
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
+from src.modules.media.application.ports.library_lookup_port import LibraryLookupPort
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
 )
 from src.modules.media.presentation.schemas import ScanMediaRequest
-from src.shared_kernel.value_objects.library_id import LibraryId
 
 router = APIRouter(prefix="/api/v1/scan", tags=["Scan"])
 
@@ -29,18 +28,18 @@ async def scan_media(
     use_case: ScanMediaDirectoriesUseCase = Depends(
         Provide[ApplicationContainer.media.scan_media_directories],
     ),
-    library_uow_factory: LibraryUnitOfWorkFactory = Depends(
-        Provide[ApplicationContainer.library.library_unit_of_work_factory],
+    library_lookup: LibraryLookupPort = Depends(
+        Provide[ApplicationContainer.media.library_lookup],
     ),
 ) -> dict[str, Any]:
     """Trigger a scan of the named library's configured paths.
 
-    The route loads the library to get its paths so the operator
-    only has to know the ``lib_xxx`` id — paths and the per-Movie /
-    per-Series ``library_id`` propagate from a single source of truth.
+    The route resolves the library's paths through the cross-BC
+    ``LibraryLookupPort`` so the operator only has to know the
+    ``lib_xxx`` id — paths and the per-Movie / per-Series
+    ``library_id`` propagate from a single source of truth.
     """
-    async with library_uow_factory() as uow:
-        library = await uow.libraries.find_by_id(LibraryId(body.library_id))
+    library = await library_lookup.find(body.library_id)
     if library is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -48,7 +47,7 @@ async def scan_media(
         )
 
     input_dto = ScanMediaInput(
-        library_id=str(library.id),
+        library_id=library.id,
         directories=list(library.paths),
     )
     output = await use_case.execute(input_dto)

--- a/tests/infrastructure/scheduling/test_scheduler_service.py
+++ b/tests/infrastructure/scheduling/test_scheduler_service.py
@@ -22,6 +22,7 @@ from src.infrastructure.scheduling.scheduler_service import (
 )
 from src.modules.library.domain.entities.library import Library
 from src.modules.library.domain.value_objects.library_type import LibraryType
+from src.modules.media.application.ports.library_lookup_port import LibraryRef
 from src.modules.media.domain.entities.scan_run import (
     ScanRun,
     ScanRunKind,
@@ -283,4 +284,6 @@ class TestRunScan:
         scan_run_service.run_scan.assert_awaited_once()
         run_args = scan_run_service.run_scan.await_args.args
         assert run_args[0] == run.id
-        assert run_args[1] is lib
+        # The loaded Library is projected to the consumer-owned LibraryRef
+        # (ADR-009) before reaching the scan service — no aggregate leaks.
+        assert run_args[1] == LibraryRef(id=str(lib.id), paths=tuple(lib.paths))

--- a/tests/modules/media/integration/acl/test_library_lookup_adapter.py
+++ b/tests/modules/media/integration/acl/test_library_lookup_adapter.py
@@ -1,0 +1,56 @@
+"""Integration tests for the Media LibraryLookupAdapter."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
+    SqlAlchemyLibraryRepository,
+)
+from src.modules.library.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyLibraryUnitOfWorkFactory,
+)
+from src.modules.media.application.ports.library_lookup_port import LibraryRef
+from src.modules.media.infrastructure.acl.library_lookup_adapter import LibraryLookupAdapter
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.library_id import LibraryId
+
+
+def _make_adapter(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> LibraryLookupAdapter:
+    return LibraryLookupAdapter(SqlAlchemyLibraryUnitOfWorkFactory(session_factory))
+
+
+@pytest.mark.integration
+class TestLibraryLookupAdapter:
+    """The adapter projects a Library to the consumer-owned LibraryRef."""
+
+    async def test_find_returns_libraryref_with_id_and_paths(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        repo = SqlAlchemyLibraryRepository(db_session)
+        saved = await repo.save(
+            Library.create(name="Movies", library_type="movies", paths=["/movies", "/more"]),
+        )
+        await db_session.commit()
+
+        adapter = _make_adapter(session_factory)
+        ref = await adapter.find(str(saved.id))
+
+        assert ref is not None
+        assert ref == LibraryRef(
+            id=str(saved.id),
+            paths=(FilePath("/movies"), FilePath("/more")),
+        )
+
+    async def test_find_returns_none_for_missing_library(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        adapter = _make_adapter(session_factory)
+
+        # Valid id shape, just not persisted → None (not an error).
+        assert await adapter.find(str(LibraryId.generate())) is None

--- a/tests/modules/media/unit/application/use_cases/test_get_overview_stats.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_overview_stats.py
@@ -36,13 +36,10 @@ def _media_uow_factory(
     return MagicMock(return_value=uow)
 
 
-def _identity_uow_factory(users_count: int) -> MagicMock:
-    uow = AsyncMock()
-    uow.__aenter__.return_value = uow
-    uow.__aexit__.return_value = None
-    uow.users = AsyncMock()
-    uow.users.count.return_value = users_count
-    return MagicMock(return_value=uow)
+def _user_count_port(users_count: int) -> MagicMock:
+    port = MagicMock()
+    port.count_users = AsyncMock(return_value=users_count)
+    return port
 
 
 pytestmark = pytest.mark.unit
@@ -74,7 +71,7 @@ class TestGetOverviewStatsUseCase:
                 series_count=7,
                 last_scan=last_scan,
             ),
-            identity_uow_factory=_identity_uow_factory(users_count=4),
+            user_count=_user_count_port(users_count=4),
             list_movies_needing_review=review_uc,
             hls_playlist=hls,
         ).execute()
@@ -105,7 +102,7 @@ class TestGetOverviewStatsUseCase:
                 series_count=0,
                 last_scan=None,
             ),
-            identity_uow_factory=_identity_uow_factory(users_count=1),
+            user_count=_user_count_port(users_count=1),
             list_movies_needing_review=review_uc,
             hls_playlist=hls,
         ).execute()

--- a/tests/modules/media/unit/application/use_cases/test_trigger_scan.py
+++ b/tests/modules/media/unit/application/use_cases/test_trigger_scan.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.modules.media.application.dtos.scan_run_dtos import TriggerScanInput
+from src.modules.media.application.ports.library_lookup_port import LibraryRef
 from src.modules.media.application.use_cases.trigger_scan import (
     LibraryNotFoundForScanError,
     TriggerScanUseCase,
@@ -19,12 +20,10 @@ from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
 from src.shared_kernel.value_objects.library_id import LibraryId
 
 
-def _build_library_uow_factory(library_repo: AsyncMock) -> MagicMock:
-    uow = AsyncMock()
-    uow.__aenter__.return_value = uow
-    uow.__aexit__.return_value = None
-    uow.libraries = library_repo
-    return MagicMock(return_value=uow)
+def _library_lookup(ref: LibraryRef | None) -> MagicMock:
+    port = MagicMock()
+    port.find = AsyncMock(return_value=ref)
+    return port
 
 
 pytestmark = pytest.mark.unit
@@ -32,9 +31,7 @@ pytestmark = pytest.mark.unit
 
 class TestTriggerScanUseCase:
     async def test_should_open_running_row_and_spawn_background_task(self) -> None:
-        library = MagicMock(id="lib_test12345678", paths=["/movies"])
-        library_repo = AsyncMock()
-        library_repo.find_by_id.return_value = library
+        ref = LibraryRef(id="lib_test12345678", paths=())
 
         service = AsyncMock()
         opened = ScanRun(
@@ -49,7 +46,7 @@ class TestTriggerScanUseCase:
 
         use_case = TriggerScanUseCase(
             scan_run_service=service,
-            library_uow_factory=_build_library_uow_factory(library_repo),
+            library_lookup=_library_lookup(ref),
         )
 
         result = await use_case.execute(
@@ -58,19 +55,20 @@ class TestTriggerScanUseCase:
 
         assert result.id == str(opened.id)
         assert result.status == "running"
-        service.open_scan.assert_awaited_once()
+        service.open_scan.assert_awaited_once_with(
+            library_id="lib_test12345678",
+            trigger=ScanRunTrigger.MANUAL,
+        )
         # Background task is fire-and-forget; let the loop run it.
         await asyncio.sleep(0)
-        service.run_scan.assert_awaited_once()
+        # The resolved LibraryRef (not a Library aggregate) flows to run_scan.
+        service.run_scan.assert_awaited_once_with(opened.id, ref)
 
     async def test_should_raise_when_library_not_found(self) -> None:
-        library_repo = AsyncMock()
-        library_repo.find_by_id.return_value = None
-
         service = AsyncMock()
         use_case = TriggerScanUseCase(
             scan_run_service=service,
-            library_uow_factory=_build_library_uow_factory(library_repo),
+            library_lookup=_library_lookup(None),
         )
 
         with pytest.raises(LibraryNotFoundForScanError):


### PR DESCRIPTION
## Summary

Phase 3 of the architecture-audit remediation (Tema A). Consolidates PR-3.2 (cross-BC read ports) **and** PR-3.3 (audit finding **F1**, critical) — they turned out coupled at `ScanRunService.run_scan`.

- New local read ports + ACL adapters (ADR-009): **`IdentityUserCountPort`** (overview users count) and **`LibraryLookupPort`** → a consumer-owned **`LibraryRef`** DTO (id + `FilePath` paths). `get_overview_stats`, `trigger_scan`, and the scan route depend on the ports; the foreign UoW import is confined to the adapters.
- **F1 (critical) resolved:** `ScanRunService.run_scan` no longer takes the `Library` aggregate — it accepts `LibraryRef`, dropping `from src.modules.library.domain.entities.library import Library`. Both callers (`trigger_scan`, `scheduler_service`) project their library to `LibraryRef`.

### Review fixes (mr-review)
- mypy-confirmed type error (`LibraryRef` passed where `Library` expected) fixed via the F1 change above.
- Added `integration/acl/test_library_lookup_adapter.py` (projection + None translation).
- Tightened `trigger_scan`/`scheduler` assertions (assert the resolved id/ref reaches `run_scan`/`open_scan`).
- Typed the fire-and-forget `asyncio.Task[None]`.
- Ignored (with reason): route e2e gap (pre-existing), ports `__init__` re-export (convention is mixed — `library_health_port` etc. also aren't), `LibraryRef.id` as `LibraryId` (whole scan flow is `str`-typed — future ADR-018 card), `is_running` no-any-return (pre-existing in scheduler).

## Test plan

- [x] `pytest tests/modules/media tests/infrastructure tests/modules/library tests/modules/identity` → 2041 passed, 5 skipped
- [x] `mypy src`: no new errors from this change (`run_scan` arg-type + `Task` errors fixed; only a pre-existing `is_running` no-any-return remains, unchanged from develop)
- [x] `ruff check` + `ruff format --check` clean
- [x] No `IdentityUnitOfWorkFactory`/`LibraryUnitOfWorkFactory` in media use_cases/presentation; `scan_run_service` no longer imports the Library aggregate