### PR TITLE
refactor: expose AuthenticatedUser DTO to route boundaries [ADR-009]

### DIFF
--- a/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
@@ -17,8 +17,7 @@ from src.modules.catalog_requests.application.use_cases import (
     IncludeCatalogRequestUseCase,
     ListAdminCatalogRequestsUseCase,
 )
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 
 router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Catalog Requests"])
 
@@ -27,7 +26,7 @@ router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Catalog Requests"])
 @inject  # type: ignore[misc]
 async def list_admin_catalog_requests(
     lang: str = "en",
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListAdminCatalogRequestsUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.list_admin_catalog_requests],
     ),
@@ -36,7 +35,7 @@ async def list_admin_catalog_requests(
 
     Admin-only queue: each row carries the base request fields
     (including ``source`` + derived ``status``) plus ``subscriber_count``
-    (the "Inscritos" column). Admin-gated via ``current_admin_user``.
+    (the "Inscritos" column). Admin-gated via ``authenticated_admin``.
     ``lang`` selects the per-request localized title snapshot.
     """
     items = await use_case.execute(lang)
@@ -49,7 +48,7 @@ async def list_admin_catalog_requests(
 @inject  # type: ignore[misc]
 async def include_catalog_request(
     request_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: IncludeCatalogRequestUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.include_catalog_request],
     ),
@@ -70,7 +69,7 @@ async def include_catalog_request(
 @inject  # type: ignore[misc]
 async def dismiss_catalog_request(
     request_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: DismissCatalogRequestUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.dismiss_catalog_request],
     ),

--- a/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
@@ -24,8 +24,7 @@ from src.modules.catalog_requests.application.use_cases import (
 from src.modules.catalog_requests.application.use_cases.list_catalog_request_feed import (
     ListCatalogRequestFeedInput,
 )
-from src.modules.identity.infrastructure.auth import current_active_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_user
 from src.shared_kernel.value_objects import MediaType
 
 router = APIRouter(prefix="/api/v1/catalog-requests", tags=["Catalog Requests"])
@@ -76,7 +75,7 @@ class SubscribeNotifyRequest(BaseModel):
 @inject  # type: ignore[misc]
 async def create_catalog_request(
     body: CreateCatalogRequestRequest,
-    user: UserModel = Depends(current_active_user),
+    user: AuthenticatedUser = Depends(authenticated_user),
     use_case: RequestCatalogInclusionUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.request_catalog_inclusion],
     ),
@@ -109,7 +108,7 @@ async def create_catalog_request(
 async def subscribe_catalog_notification(
     tmdb_id: int,
     body: SubscribeNotifyRequest,
-    user: UserModel = Depends(current_active_user),
+    user: AuthenticatedUser = Depends(authenticated_user),
     use_case: SubscribeCatalogNotificationUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.subscribe_catalog_notification],
     ),
@@ -139,7 +138,7 @@ async def subscribe_catalog_notification(
 async def unsubscribe_catalog_notification(
     tmdb_id: int,
     media_type: MediaType = Query(...),
-    user: UserModel = Depends(current_active_user),
+    user: AuthenticatedUser = Depends(authenticated_user),
     use_case: UnsubscribeCatalogNotificationUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.unsubscribe_catalog_notification],
     ),
@@ -171,7 +170,7 @@ async def unsubscribe_catalog_notification(
 async def list_catalog_requests(
     collection_tmdb_id: int | None = Query(default=None, ge=1),
     lang: str = "en",
-    user: UserModel = Depends(current_active_user),
+    user: AuthenticatedUser = Depends(authenticated_user),
     use_case: ListCatalogRequestFeedUseCase = Depends(
         Provide[ApplicationContainer.catalog_requests.list_catalog_request_feed],
     ),

--- a/src/modules/identity/infrastructure/auth/__init__.py
+++ b/src/modules/identity/infrastructure/auth/__init__.py
@@ -7,16 +7,22 @@ used for our domain use cases. The two coexist: routes import
 ``IdentityContainer``.
 """
 
+from src.modules.identity.infrastructure.auth.authenticated_user import AuthenticatedUser
 from src.modules.identity.infrastructure.auth.backend import auth_backend
 from src.modules.identity.infrastructure.auth.dependencies import get_session_token
 from src.modules.identity.infrastructure.auth.fastapi_users import (
+    authenticated_admin,
+    authenticated_user,
     current_active_user,
     current_admin_user,
     fastapi_users,
 )
 
 __all__ = [
+    "AuthenticatedUser",
     "auth_backend",
+    "authenticated_admin",
+    "authenticated_user",
     "current_active_user",
     "current_admin_user",
     "fastapi_users",

--- a/src/modules/identity/infrastructure/auth/authenticated_user.py
+++ b/src/modules/identity/infrastructure/auth/authenticated_user.py
@@ -1,0 +1,27 @@
+"""Published authenticated-identity contract for cross-BC route guards.
+
+Other bounded contexts' routes gate on Identity's auth dependencies but
+should not depend on Identity's ``UserModel`` ORM (ADR-009). This is the
+minimal, ORM-free shape those routes receive instead — just the public
+id and the role bit a guard needs.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AuthenticatedUser:
+    """The authenticated caller, as exposed across bounded contexts.
+
+    Attributes:
+        external_id: Prefixed public user id (``usr_xxx``) — what routes
+            forward to use cases as the acting/requesting user.
+        is_admin: Whether the caller holds the admin role (the same check
+            ``authenticated_admin`` enforces before returning).
+    """
+
+    external_id: str
+    is_admin: bool
+
+
+__all__ = ["AuthenticatedUser"]

--- a/src/modules/identity/infrastructure/auth/fastapi_users.py
+++ b/src/modules/identity/infrastructure/auth/fastapi_users.py
@@ -18,6 +18,7 @@ from fastapi_users import FastAPIUsers
 
 from src.building_blocks.application.errors import ForbiddenOperationException
 from src.modules.identity.domain.value_objects.user_role import UserRole
+from src.modules.identity.infrastructure.auth.authenticated_user import AuthenticatedUser
 from src.modules.identity.infrastructure.auth.backend import auth_backend
 from src.modules.identity.infrastructure.auth.dependencies import get_user_manager
 from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
@@ -56,4 +57,41 @@ async def current_admin_user(
     return user
 
 
-__all__ = ["current_active_user", "current_admin_user", "fastapi_users"]
+def _to_authenticated(user: UserModel) -> AuthenticatedUser:
+    """Project the Identity ``UserModel`` to the published contract."""
+    return AuthenticatedUser(
+        external_id=user.external_id,
+        is_admin=user.role == UserRole.ADMIN.value,
+    )
+
+
+async def authenticated_user(
+    user: UserModel = Depends(current_active_user),
+) -> AuthenticatedUser:
+    """Active caller as the ORM-free :class:`AuthenticatedUser`.
+
+    The cross-BC counterpart of ``current_active_user`` — routes in other
+    bounded contexts depend on this so they never import Identity's
+    ``UserModel`` (ADR-009). Same cookie/active validation underneath.
+    """
+    return _to_authenticated(user)
+
+
+async def authenticated_admin(
+    user: UserModel = Depends(current_admin_user),
+) -> AuthenticatedUser:
+    """Admin caller as :class:`AuthenticatedUser`.
+
+    Composes on ``current_admin_user`` (which already enforces the admin
+    role + 403), returning the published contract instead of the ORM.
+    """
+    return _to_authenticated(user)
+
+
+__all__ = [
+    "authenticated_admin",
+    "authenticated_user",
+    "current_active_user",
+    "current_admin_user",
+    "fastapi_users",
+]

--- a/src/modules/library/presentation/routes/library_routes.py
+++ b/src/modules/library/presentation/routes/library_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.library.application.dtos.library_dtos import (
     CreateLibraryInput,
     DeleteLibraryInput,
@@ -33,7 +32,7 @@ router = APIRouter(prefix="/api/v1/libraries", tags=["Libraries"])
 @inject  # type: ignore[misc]
 async def create_library(
     body: CreateLibraryRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: CreateLibraryUseCase = Depends(
         Provide[ApplicationContainer.library.create_library],
     ),
@@ -83,7 +82,7 @@ async def get_library(
 async def update_library(
     library_id: str,
     body: UpdateLibraryRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: UpdateLibraryUseCase = Depends(
         Provide[ApplicationContainer.library.update_library],
     ),
@@ -112,7 +111,7 @@ async def update_library(
 @inject  # type: ignore[misc]
 async def delete_library(
     library_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: DeleteLibraryUseCase = Depends(
         Provide[ApplicationContainer.library.delete_library],
     ),

--- a/src/modules/media/presentation/routes/admin_conflicts_routes.py
+++ b/src/modules/media/presentation/routes/admin_conflicts_routes.py
@@ -19,8 +19,7 @@ from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PA
 from src.building_blocks.presentation import api_list, api_single
 from src.building_blocks.presentation.responses import Pagination
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.conflict_dtos import (
     BulkMarkDistinctInput,
     ListConflictsInput,
@@ -92,7 +91,7 @@ async def list_admin_conflicts(
     source: Literal["manual", "auto"] | None = Query(default=None),
     cursor: str | None = Query(default=None),
     limit: int = Query(default=DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListConflictsUseCase = Depends(
         Provide[ApplicationContainer.media.list_conflicts],
     ),
@@ -126,7 +125,7 @@ async def list_admin_conflicts(
 async def resolve_admin_conflict(
     body: ResolveConflictBody,
     conflict_id: str = Path(..., min_length=1, max_length=50),
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ResolveMediaConflictUseCase = Depends(
         Provide[ApplicationContainer.media.resolve_media_conflict],
     ),
@@ -158,7 +157,7 @@ async def resolve_admin_conflict(
 @inject
 async def bulk_mark_distinct_conflicts(
     body: BulkMarkDistinctBody,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: BulkMarkDistinctConflictsUseCase = Depends(
         Provide[ApplicationContainer.media.bulk_mark_distinct_conflicts],
     ),
@@ -180,7 +179,7 @@ async def bulk_mark_distinct_conflicts(
 @router.post("/sweep")
 @inject
 async def sweep_admin_conflicts(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: SweepMovieConflictsUseCase = Depends(
         Provide[ApplicationContainer.media.sweep_movie_conflicts],
     ),

--- a/src/modules/media/presentation/routes/admin_credits_routes.py
+++ b/src/modules/media/presentation/routes/admin_credits_routes.py
@@ -14,8 +14,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.credits_dtos import (
     ListCreditsStatusInput,
     ResetCreditsDetectionInput,
@@ -43,7 +42,7 @@ async def list_credits_status(
     state: str | None = None,
     limit: int = 50,
     offset: int = 0,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListCreditsStatusUseCase = Depends(
         Provide[ApplicationContainer.media.list_credits_status],
     ),
@@ -70,7 +69,7 @@ async def list_credits_status(
 async def set_credits_marker(
     media_id: str,
     body: SetCreditsRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: SetCreditsMarkerUseCase = Depends(
         Provide[ApplicationContainer.media.set_credits_marker],
     ),
@@ -90,7 +89,7 @@ async def set_credits_marker(
 @inject  # type: ignore[misc]
 async def clear_credits_marker(
     media_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ClearCreditsMarkerUseCase = Depends(
         Provide[ApplicationContainer.media.clear_credits_marker],
     ),
@@ -107,7 +106,7 @@ async def clear_credits_marker(
 @inject  # type: ignore[misc]
 async def reset_credits_detection(
     media_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ResetCreditsDetectionUseCase = Depends(
         Provide[ApplicationContainer.media.reset_credits_detection],
     ),

--- a/src/modules/media/presentation/routes/admin_intro_detection_routes.py
+++ b/src/modules/media/presentation/routes/admin_intro_detection_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.intro_detection_run_dtos import (
     GetIntroDetectionRunInput,
     ListIntroDetectionRunsInput,
@@ -31,7 +30,7 @@ async def list_intro_detection_runs(
     series_id: str | None = None,
     limit: int = 50,
     offset: int = 0,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListIntroDetectionRunsUseCase = Depends(
         Provide[ApplicationContainer.media.list_intro_detection_runs],
     ),
@@ -52,7 +51,7 @@ async def list_intro_detection_runs(
 @inject  # type: ignore[misc]
 async def get_intro_detection_run(
     run_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: GetIntroDetectionRunUseCase = Depends(
         Provide[ApplicationContainer.media.get_intro_detection_run],
     ),

--- a/src/modules/media/presentation/routes/admin_jobs_routes.py
+++ b/src/modules/media/presentation/routes/admin_jobs_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.job_dtos import ListJobRunsInput, TriggerJobInput
 from src.modules.media.application.use_cases.list_job_runs import ListJobRunsUseCase
 from src.modules.media.application.use_cases.list_jobs import ListJobsUseCase
@@ -24,7 +23,7 @@ router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Jobs"])
 @router.get("/jobs")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_admin_jobs(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListJobsUseCase = Depends(Provide[ApplicationContainer.list_jobs]),
 ) -> dict[str, Any]:
     """Overview of every background job: live schedule + last run + running-now.
@@ -43,7 +42,7 @@ async def list_admin_job_runs(
     job_id: str | None = None,
     limit: int = 50,
     offset: int = 0,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListJobRunsUseCase = Depends(
         Provide[ApplicationContainer.media.list_job_runs],
     ),
@@ -59,7 +58,7 @@ async def list_admin_job_runs(
 @inject  # type: ignore[misc]
 async def trigger_admin_job(
     job_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: TriggerJobUseCase = Depends(
         Provide[ApplicationContainer.trigger_job],
     ),

--- a/src/modules/media/presentation/routes/admin_overview_routes.py
+++ b/src/modules/media/presentation/routes/admin_overview_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.use_cases.get_library_usage import (
     GetLibraryUsageUseCase,
 )
@@ -24,7 +23,7 @@ router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Overview"])
 @router.get("/overview/stats")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def get_admin_overview_stats(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: GetOverviewStatsUseCase = Depends(
         Provide[ApplicationContainer.media.get_overview_stats],
     ),
@@ -43,7 +42,7 @@ async def get_admin_overview_stats(
 @router.get("/now-playing")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def get_admin_now_playing(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: GetNowPlayingUseCase = Depends(
         Provide[ApplicationContainer.media.get_now_playing],
     ),
@@ -62,7 +61,7 @@ async def get_admin_now_playing(
 @router.get("/library-usage")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def get_admin_library_usage(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: GetLibraryUsageUseCase = Depends(
         Provide[ApplicationContainer.media.get_library_usage],
     ),

--- a/src/modules/media/presentation/routes/admin_relink_routes.py
+++ b/src/modules/media/presentation/routes/admin_relink_routes.py
@@ -1,6 +1,6 @@
 """Admin REST API routes for the TMDB relink / enrichment-review workflow.
 
-All endpoints are gated by ``current_admin_user``. Movies:
+All endpoints are gated by ``authenticated_admin``. Movies:
 
 * ``GET  /admin/movies/needs-review`` — listing of movies whose
   enrichment couldn't find a TMDB match (or were flagged as wrong).
@@ -31,8 +31,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.admin_relink_dtos import (
     FlagMovieEnrichmentReviewInput,
     FlagSeriesEnrichmentReviewInput,
@@ -77,7 +76,7 @@ router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Movie Relink"])
 @router.get("/movies/needs-review")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_movies_needing_review(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListMoviesNeedingReviewUseCase = Depends(
         Provide[ApplicationContainer.media.list_movies_needing_review],
     ),
@@ -91,7 +90,7 @@ async def list_movies_needing_review(
 @inject  # type: ignore[misc]
 async def flag_movie_enrichment(
     movie_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: FlagMovieEnrichmentReviewUseCase = Depends(
         Provide[ApplicationContainer.media.flag_movie_enrichment_review],
     ),
@@ -105,7 +104,7 @@ async def flag_movie_enrichment(
 @inject  # type: ignore[misc]
 async def get_movie_tmdb_suggestions(
     movie_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: GetMovieTmdbSuggestionsUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_tmdb_suggestions],
     ),
@@ -120,7 +119,7 @@ async def get_movie_tmdb_suggestions(
 async def relink_movie(
     movie_id: str,
     body: RelinkMovieRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: RelinkMovieUseCase = Depends(
         Provide[ApplicationContainer.media.relink_movie],
     ),
@@ -141,7 +140,7 @@ async def relink_movie(
 async def promote_movie_to_series(
     movie_id: str,
     body: PromoteMovieToSeriesRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: PromoteMovieToSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.promote_movie_to_series],
     ),
@@ -156,7 +155,7 @@ async def promote_movie_to_series(
 @router.get("/series/needs-review")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_series_needing_review(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListSeriesNeedingReviewUseCase = Depends(
         Provide[ApplicationContainer.media.list_series_needing_review],
     ),
@@ -170,7 +169,7 @@ async def list_series_needing_review(
 @inject  # type: ignore[misc]
 async def flag_series_enrichment(
     series_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: FlagSeriesEnrichmentReviewUseCase = Depends(
         Provide[ApplicationContainer.media.flag_series_enrichment_review],
     ),
@@ -184,7 +183,7 @@ async def flag_series_enrichment(
 @inject  # type: ignore[misc]
 async def get_series_tmdb_suggestions(
     series_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: GetSeriesTmdbSuggestionsUseCase = Depends(
         Provide[ApplicationContainer.media.get_series_tmdb_suggestions],
     ),
@@ -199,7 +198,7 @@ async def get_series_tmdb_suggestions(
 async def relink_series(
     series_id: str,
     body: RelinkSeriesRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: RelinkSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.relink_series],
     ),

--- a/src/modules/media/presentation/routes/admin_scan_routes.py
+++ b/src/modules/media/presentation/routes/admin_scan_routes.py
@@ -9,8 +9,7 @@ from pydantic import BaseModel
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.scan_run_dtos import (
     GetScanRunInput,
     ListScanRunsInput,
@@ -50,7 +49,7 @@ async def list_admin_scans(
     library_id: str | None = None,
     limit: int = 50,
     offset: int = 0,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListScanRunsUseCase = Depends(
         Provide[ApplicationContainer.media.list_scan_runs],
     ),
@@ -78,7 +77,7 @@ async def list_admin_scans(
 @inject  # type: ignore[misc]
 async def get_admin_scan(
     run_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: GetScanRunUseCase = Depends(
         Provide[ApplicationContainer.media.get_scan_run],
     ),
@@ -92,7 +91,7 @@ async def get_admin_scan(
 @inject  # type: ignore[misc]
 async def trigger_admin_scan(
     body: TriggerScanRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: TriggerScanUseCase = Depends(
         Provide[ApplicationContainer.media.trigger_scan],
     ),
@@ -119,7 +118,7 @@ async def trigger_admin_scan(
 @inject  # type: ignore[misc]
 async def trigger_admin_bulk_enrich(
     body: TriggerBulkEnrichRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: TriggerBulkEnrichUseCase = Depends(
         Provide[ApplicationContainer.media.trigger_bulk_enrich],
     ),

--- a/src/modules/media/presentation/routes/admin_system_routes.py
+++ b/src/modules/media/presentation/routes/admin_system_routes.py
@@ -7,8 +7,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.use_cases.clear_hls_cache_global import (
     ClearHlsCacheGlobalUseCase,
 )
@@ -22,7 +21,7 @@ router = APIRouter(prefix="/api/v1/admin", tags=["Admin — System"])
 @router.get("/hls-cache")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def get_hls_cache_stats(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: GetHlsCacheStatsUseCase = Depends(
         Provide[ApplicationContainer.media.get_hls_cache_stats],
     ),
@@ -49,7 +48,7 @@ async def get_hls_cache_stats(
 @router.delete("/hls-cache", status_code=204)  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def clear_hls_cache_global(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ClearHlsCacheGlobalUseCase = Depends(
         Provide[ApplicationContainer.media.clear_hls_cache_global],
     ),

--- a/src/modules/media/presentation/routes/enrichment_routes.py
+++ b/src/modules/media/presentation/routes/enrichment_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.enrichment_dtos import (
     BulkEnrichInput,
     EnrichMediaInput,
@@ -33,7 +32,7 @@ router = APIRouter(prefix="/api/v1", tags=["Metadata Enrichment"])
 async def enrich_movie(
     movie_id: str,
     body: EnrichRequest | None = None,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: EnrichMovieMetadataUseCase = Depends(
         Provide[ApplicationContainer.media.enrich_movie_metadata],
     ),
@@ -49,7 +48,7 @@ async def enrich_movie(
 async def enrich_series(
     series_id: str,
     body: EnrichRequest | None = None,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: EnrichSeriesMetadataUseCase = Depends(
         Provide[ApplicationContainer.media.enrich_series_metadata],
     ),
@@ -64,7 +63,7 @@ async def enrich_series(
 @inject  # type: ignore[misc]
 async def bulk_enrich(
     body: EnrichRequest | None = None,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: BulkEnrichMetadataUseCase = Depends(
         Provide[ApplicationContainer.media.bulk_enrich_metadata],
     ),

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.building_blocks.presentation import Pagination, api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
     GetFileVariantsInput,
@@ -197,7 +196,7 @@ async def get_related_movies(
 @inject  # type: ignore[misc]
 async def delete_movie(
     movie_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: DeleteMovieUseCase = Depends(
         Provide[ApplicationContainer.media.delete_movie],
     ),
@@ -231,7 +230,7 @@ async def get_file_variants(
 async def add_file_variant(
     movie_id: str,
     body: AddFileVariantRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: AddFileVariantUseCase = Depends(
         Provide[ApplicationContainer.media.add_file_variant],
     ),
@@ -257,7 +256,7 @@ async def add_file_variant(
 async def remove_file_variant(
     movie_id: str,
     body: RemoveFileVariantRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: RemoveFileVariantUseCase = Depends(
         Provide[ApplicationContainer.media.remove_file_variant],
     ),
@@ -273,7 +272,7 @@ async def remove_file_variant(
 async def set_primary_file(
     movie_id: str,
     body: SetPrimaryFileRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: SetPrimaryFileUseCase = Depends(
         Provide[ApplicationContainer.media.set_primary_file],
     ),

--- a/src/modules/media/presentation/routes/scan_routes.py
+++ b/src/modules/media/presentation/routes/scan_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
 from src.modules.media.application.ports.library_lookup_port import LibraryLookupPort
 from src.modules.media.application.use_cases.scan_media_directories import (
@@ -24,7 +23,7 @@ router = APIRouter(prefix="/api/v1/scan", tags=["Scan"])
 @inject  # type: ignore[misc]
 async def scan_media(
     body: ScanMediaRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ScanMediaDirectoriesUseCase = Depends(
         Provide[ApplicationContainer.media.scan_media_directories],
     ),

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.building_blocks.presentation import Pagination, api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.intro_dtos import (
     ClearEpisodeIntroInput,
     ResetSeasonIntroDetectionInput,
@@ -153,7 +152,7 @@ async def get_series(
 @inject  # type: ignore[misc]
 async def delete_series(
     series_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: DeleteSeriesUseCase = Depends(
         Provide[ApplicationContainer.media.delete_series],
     ),
@@ -219,7 +218,7 @@ async def get_episode_file_variants(
 async def add_episode_file_variant(
     episode_id: str,
     body: AddFileVariantRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: AddFileVariantUseCase = Depends(
         Provide[ApplicationContainer.media.add_file_variant],
     ),
@@ -245,7 +244,7 @@ async def add_episode_file_variant(
 async def remove_episode_file_variant(
     episode_id: str,
     body: RemoveFileVariantRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: RemoveFileVariantUseCase = Depends(
         Provide[ApplicationContainer.media.remove_file_variant],
     ),
@@ -261,7 +260,7 @@ async def remove_episode_file_variant(
 async def set_episode_primary_file(
     episode_id: str,
     body: SetPrimaryFileRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: SetPrimaryFileUseCase = Depends(
         Provide[ApplicationContainer.media.set_primary_file],
     ),
@@ -278,7 +277,7 @@ async def set_episode_primary_file(
 async def set_episode_intro(
     episode_id: str,
     body: SetIntroRequest,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: SetEpisodeIntroUseCase = Depends(
         Provide[ApplicationContainer.media.set_episode_intro],
     ),
@@ -302,7 +301,7 @@ async def set_episode_intro(
 @inject  # type: ignore[misc]
 async def clear_episode_intro(
     episode_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ClearEpisodeIntroUseCase = Depends(
         Provide[ApplicationContainer.media.clear_episode_intro],
     ),
@@ -320,7 +319,7 @@ async def clear_episode_intro(
 @inject  # type: ignore[misc]
 async def reset_season_intro_detection(
     season_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ResetSeasonIntroDetectionUseCase = Depends(
         Provide[ApplicationContainer.media.reset_season_intro_detection],
     ),

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -22,8 +22,7 @@ from fastapi.responses import FileResponse, Response, StreamingResponse
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.config.containers import ApplicationContainer
 from src.infrastructure.scheduling import ThumbnailBackfillJob
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
 from src.modules.media.application.dtos.series_dtos import (
     EpisodeOutput,
@@ -385,7 +384,7 @@ async def episode_scrub_preview_sprite(
 @inject  # type: ignore[misc]
 async def clear_movie_hls_cache(
     movie_id: str,
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     profile_id: str = Depends(resolve_profile_id),
     movie_uc: GetMovieByIdUseCase = Depends(
         Provide[ApplicationContainer.media.get_movie_by_id],

--- a/src/modules/media/presentation/routes/tmdb_lookup_routes.py
+++ b/src/modules/media/presentation/routes/tmdb_lookup_routes.py
@@ -18,8 +18,7 @@ from fastapi import APIRouter, Depends, Query
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_active_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_user
 from src.modules.media.application.dtos.tmdb_lookup_dtos import SearchTmdbTitlesInput
 from src.modules.media.application.use_cases.search_tmdb_titles import (
     SearchTmdbTitlesUseCase,
@@ -38,7 +37,7 @@ router = APIRouter(prefix="/api/v1/catalog", tags=["Catalog Lookup"])
 async def lookup_catalog_title(
     q: str = Query(..., min_length=1, max_length=_MAX_QUERY_LEN),
     limit: int = Query(default=_DEFAULT_LIMIT, ge=_MIN_LIMIT, le=_MAX_LIMIT),
-    _user: UserModel = Depends(current_active_user),
+    _user: AuthenticatedUser = Depends(authenticated_user),
     use_case: SearchTmdbTitlesUseCase = Depends(
         Provide[ApplicationContainer.media.search_tmdb_titles],
     ),

--- a/src/modules/notifications/presentation/routes/notification_routes.py
+++ b/src/modules/notifications/presentation/routes/notification_routes.py
@@ -8,8 +8,7 @@ from fastapi import APIRouter, Depends, Query
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_active_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_user
 from src.modules.notifications.application.dtos import (
     ListUserNotificationsInput,
     MarkAllNotificationsReadInput,
@@ -27,7 +26,7 @@ router = APIRouter(prefix="/api/v1/notifications", tags=["Notifications"])
 @router.get("")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def list_user_notifications(
-    user: UserModel = Depends(current_active_user),
+    user: AuthenticatedUser = Depends(authenticated_user),
     unread_only: bool = Query(default=False),
     limit: int = Query(default=50, ge=1, le=200),
     use_case: ListUserNotificationsUseCase = Depends(
@@ -60,7 +59,7 @@ async def list_user_notifications(
 @inject  # type: ignore[misc]
 async def mark_notification_read(
     notification_id: str,
-    user: UserModel = Depends(current_active_user),
+    user: AuthenticatedUser = Depends(authenticated_user),
     use_case: MarkNotificationReadUseCase = Depends(
         Provide[ApplicationContainer.notifications.mark_notification_read],
     ),
@@ -85,7 +84,7 @@ async def mark_notification_read(
 @router.post("/read-all")  # type: ignore[misc]
 @inject  # type: ignore[misc]
 async def mark_all_notifications_read(
-    user: UserModel = Depends(current_active_user),
+    user: AuthenticatedUser = Depends(authenticated_user),
     use_case: MarkAllNotificationsReadUseCase = Depends(
         Provide[ApplicationContainer.notifications.mark_all_notifications_read],
     ),

--- a/src/modules/settings/presentation/routes/admin_settings_routes.py
+++ b/src/modules/settings/presentation/routes/admin_settings_routes.py
@@ -15,8 +15,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import current_admin_user
-from src.modules.identity.infrastructure.persistence.models.user_model import UserModel
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.settings.application.dtos import UpdateSettingInput
 from src.modules.settings.application.use_cases import (
     ListSettingsUseCase,
@@ -39,7 +38,7 @@ router = APIRouter(prefix="/api/v1/admin/settings", tags=["Admin — Settings"])
 @router.get("")
 @inject
 async def list_admin_settings(
-    _admin: UserModel = Depends(current_admin_user),
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: ListSettingsUseCase = Depends(
         Provide[ApplicationContainer.settings.list_settings],
     ),
@@ -58,7 +57,7 @@ async def list_admin_settings(
 @inject
 async def update_scheduler_settings(
     body: SchedulerConfig,
-    admin: UserModel = Depends(current_admin_user),
+    admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: UpdateSettingUseCase = Depends(
         Provide[ApplicationContainer.settings.update_setting],
     ),
@@ -78,7 +77,7 @@ async def update_scheduler_settings(
 @inject
 async def update_thumbnail_backfill_settings(
     body: ThumbnailBackfillConfig,
-    admin: UserModel = Depends(current_admin_user),
+    admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: UpdateSettingUseCase = Depends(
         Provide[ApplicationContainer.settings.update_setting],
     ),
@@ -98,7 +97,7 @@ async def update_thumbnail_backfill_settings(
 @inject
 async def update_intro_detection_settings(
     body: IntroDetectionConfig,
-    admin: UserModel = Depends(current_admin_user),
+    admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: UpdateSettingUseCase = Depends(
         Provide[ApplicationContainer.settings.update_setting],
     ),
@@ -118,7 +117,7 @@ async def update_intro_detection_settings(
 @inject
 async def update_credits_detection_settings(
     body: CreditsDetectionConfig,
-    admin: UserModel = Depends(current_admin_user),
+    admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: UpdateSettingUseCase = Depends(
         Provide[ApplicationContainer.settings.update_setting],
     ),
@@ -138,7 +137,7 @@ async def update_credits_detection_settings(
 @inject
 async def update_streaming_settings(
     body: StreamingConfig,
-    admin: UserModel = Depends(current_admin_user),
+    admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: UpdateSettingUseCase = Depends(
         Provide[ApplicationContainer.settings.update_setting],
     ),
@@ -158,7 +157,7 @@ async def update_streaming_settings(
 @inject
 async def update_avatar_settings(
     body: AvatarConfig,
-    admin: UserModel = Depends(current_admin_user),
+    admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: UpdateSettingUseCase = Depends(
         Provide[ApplicationContainer.settings.update_setting],
     ),
@@ -178,7 +177,7 @@ async def update_avatar_settings(
 @inject
 async def update_scan_dedup_settings(
     body: ScanDedupConfig,
-    admin: UserModel = Depends(current_admin_user),
+    admin: AuthenticatedUser = Depends(authenticated_admin),
     use_case: UpdateSettingUseCase = Depends(
         Provide[ApplicationContainer.settings.update_setting],
     ),


### PR DESCRIPTION
## Summary

Phase 3 / PR-3.4 of the architecture-audit remediation (Tema A, finding F5/M-7). 19 non-identity route files annotated their auth guard with Identity's `UserModel` ORM — a cross-BC leak of an infra/persistence type into presentation across 5 modules.

- New published contract `AuthenticatedUser` (`external_id` + `is_admin`) + dependencies `authenticated_user` / `authenticated_admin` that project the `UserModel`. The deps **compose on** the existing `current_active_user` / `current_admin_user`, so the cookie + admin-role (403) checks are byte-identical.
- Migrated all **19 non-identity** route files (media 14, library 1, catalog_requests 2, notifications 1, settings 1): `Depends(current_*_user)` → `Depends(authenticated_*)`, `UserModel` annotation → `AuthenticatedUser`, dropped the `user_model import UserModel`. The 16 `.external_id` call sites are unchanged.
- **Identity's own routes keep using `UserModel`** (they read `role`/`email`/`is_verified`/`is_active`) — that's internal use, not a cross-BC leak.

No behavioral change.

## Test plan

- [x] `pytest tests/modules/{media,identity,library,catalog_requests,notifications,settings}` → 2137 passed, 5 skipped
- [x] Acceptance: zero `UserModel` in non-identity presentation; identity's 5 files untouched
- [x] e2e `dependency_overrides` on `current_*_user` still flow through (new deps compose on them) — no fixture changes needed
- [x] `ruff check` + `ruff format --check` clean; no new mypy errors in changed files