### PR TITLE
refactor: read runtime config via local Protocol ports [ADR-009]

### DIFF
--- a/docs/adr/ADR-009-cross-bc-read-ports.md
+++ b/docs/adr/ADR-009-cross-bc-read-ports.md
@@ -157,8 +157,28 @@ class WatchProgressContainer(containers.DeclarativeContainer):
     )
 ```
 
+## Variante aceita: Protocol port (sem adapter) para config injetada do provider
+
+Quando o consumidor recebe **diretamente** uma instância do provider via
+composition root (não um repositório por-sessão), o par ABC + adapter não cabe:
+uma ABC forçaria o provider a herdar a port do consumidor — acoplamento
+provider→consumidor, ferindo a regra #4. Nesses casos é aceitável uma **port
+como `typing.Protocol`** (tipagem estrutural) que descreve só os getters que o
+consumidor chama; o provider a satisfaz estruturalmente, sem adapter e sem saber
+quem o consome.
+
+Trade-off explícito (alinhamento **parcial** à regra #1): os tipos de retorno
+podem ser os **value objects de domínio do provider** (contratos publicados
+estáveis, importados sob `TYPE_CHECKING`) em vez de DTOs próprios + adapter
+tradutor — aceitável para **leitura de config read-only** (VOs imutáveis,
+não-agregado), onde DTO+adapter por bucket seria boilerplate desproporcional. O
+ganho central — sair da fachada concreta de **infra** de outro BC — é mantido.
+Exemplo: `media/application/ports/runtime_config_ports.py` e
+`identity/application/ports/avatar_config_port.py` lendo `RuntimeSettings`.
+
 ## Histórico de Revisões
 
 | Data | Autor | Mudança |
 |------|-------|---------|
 | 2026-04-18 | Lucas Cristovam | Criação inicial (Fase 1 da refatoração Clean Architecture) |
+| 2026-06-27 | Lucas Cristovam | Variante "Protocol port (sem adapter)" para config injetada do provider |

--- a/src/modules/identity/application/ports/avatar_config_port.py
+++ b/src/modules/identity/application/ports/avatar_config_port.py
@@ -1,0 +1,27 @@
+"""Protocol port for reading the avatar runtime-config bucket.
+
+ADR-009-aligned (partial), the "Protocol port (no adapter)" variant:
+Identity's avatar storage no longer names the Settings BC's concrete
+``RuntimeSettings`` facade. This local Protocol describes only the getter
+it calls; ``RuntimeSettings`` satisfies it structurally. The return type
+is the Settings ``AvatarConfig`` VO (a stable published contract), not a
+re-declared consumer DTO.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from src.modules.settings.domain.value_objects import AvatarConfig
+
+
+class AvatarConfigPort(Protocol):
+    """Access to the current avatar config."""
+
+    async def avatar(self) -> AvatarConfig:
+        """Return the current ``AvatarConfig``."""
+        ...
+
+
+__all__ = ["AvatarConfigPort"]

--- a/src/modules/identity/infrastructure/storage/local_avatar_storage.py
+++ b/src/modules/identity/infrastructure/storage/local_avatar_storage.py
@@ -29,7 +29,7 @@ from src.modules.identity.application.ports.avatar_storage_port import (
 )
 
 if TYPE_CHECKING:
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+    from src.modules.identity.application.ports.avatar_config_port import AvatarConfigPort
 
 _logger = get_logger()
 
@@ -59,17 +59,17 @@ class LocalAvatarStorage(AvatarStoragePort):
     """Resize uploaded avatars and write WebP files to local disk.
 
     The on-disk directory is locked in on the **first** save/delete
-    using ``avatar.storage_subdir`` from :class:`RuntimeSettings`.
-    Subsequent changes to that field have no effect until the process
-    restarts — admin edits to ``storage_subdir`` would otherwise
-    orphan every avatar already on disk. ``max_size_mb`` and
-    ``size_pixels`` come straight from :class:`RuntimeSettings` per
-    upload so admin edits to those propagate immediately.
+    using ``avatar.storage_subdir`` from the injected
+    :class:`AvatarConfigPort`. Subsequent changes to that field have no
+    effect until the process restarts — admin edits to ``storage_subdir``
+    would otherwise orphan every avatar already on disk. ``max_size_mb``
+    and ``size_pixels`` are read per upload so admin edits to those
+    propagate immediately.
     """
 
     def __init__(
         self,
-        runtime_settings: RuntimeSettings,
+        runtime_settings: AvatarConfigPort,
         *,
         root_directory: str,
     ) -> None:

--- a/src/modules/media/application/ports/runtime_config_ports.py
+++ b/src/modules/media/application/ports/runtime_config_ports.py
@@ -1,0 +1,56 @@
+"""Protocol ports for reading runtime config buckets.
+
+ADR-009-aligned (partial): these local Protocols invert the type
+dependency so Media services no longer name the Settings BC's concrete
+``RuntimeSettings`` infrastructure facade. Each Protocol describes only
+the getter its consumer calls; ``RuntimeSettings`` satisfies them
+structurally, so the composition root keeps injecting it unchanged and
+the live snapshot/TTL behaviour is preserved.
+
+This is the lighter "Protocol port (no adapter)" variant noted in ADR-009:
+the return types are the Settings config value objects (stable published
+contracts), not re-declared consumer-owned DTOs + an ACL adapter. Imported
+under ``TYPE_CHECKING`` so the dependency stays annotation-only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from src.modules.settings.domain.value_objects import (
+        ScanDedupConfig,
+        StreamingConfig,
+        ThumbnailBackfillConfig,
+    )
+
+
+class StreamingConfigPort(Protocol):
+    """Synchronous access to the current streaming-config snapshot."""
+
+    def streaming_snapshot_sync(self) -> StreamingConfig:
+        """Return the latest ``StreamingConfig`` without awaiting a refresh."""
+        ...
+
+
+class ThumbnailConfigPort(Protocol):
+    """Access to the current thumbnail-backfill config."""
+
+    async def thumbnail_backfill(self) -> ThumbnailBackfillConfig:
+        """Return the current ``ThumbnailBackfillConfig``."""
+        ...
+
+
+class ScanDedupConfigPort(Protocol):
+    """Access to the current scan-dedup config."""
+
+    async def scan_dedup(self) -> ScanDedupConfig:
+        """Return the current ``ScanDedupConfig``."""
+        ...
+
+
+__all__ = [
+    "ScanDedupConfigPort",
+    "StreamingConfigPort",
+    "ThumbnailConfigPort",
+]

--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -25,10 +25,10 @@ if TYPE_CHECKING:
     from src.modules.media.application.ports.library_health_port import (
         LibraryHealthPort,
     )
+    from src.modules.media.application.ports.runtime_config_ports import ScanDedupConfigPort
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
     from src.modules.media.domain.entities.movie import Movie
     from src.modules.settings.domain.value_objects import ScanDedupConfig
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = logging.getLogger(__name__)
 
@@ -76,7 +76,7 @@ class DetectMovieConflictsUseCase:
         uow_factory: MediaUnitOfWorkFactory,
         library_health: LibraryHealthPort | None = None,
         event_bus: EventBus | None = None,
-        runtime_settings: RuntimeSettings | None = None,
+        runtime_settings: ScanDedupConfigPort | None = None,
     ) -> None:
         self._uow_factory = uow_factory
         self._library_health = library_health

--- a/src/modules/media/infrastructure/audio/audio_extractor.py
+++ b/src/modules/media/infrastructure/audio/audio_extractor.py
@@ -29,7 +29,7 @@ from src.modules.media.infrastructure.streaming._subprocess import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+    from src.modules.media.application.ports.runtime_config_ports import StreamingConfigPort
 
 _logger = logging.getLogger(__name__)
 
@@ -77,7 +77,7 @@ class AudioExtractor:
 
     def __init__(
         self,
-        runtime_settings: RuntimeSettings,
+        runtime_settings: StreamingConfigPort,
         *,
         timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
         sample_rate: int = _DEFAULT_SAMPLE_RATE,

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -65,7 +65,7 @@ from src.modules.media.infrastructure.streaming._subprocess import (
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
 
 if TYPE_CHECKING:
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+    from src.modules.media.application.ports.runtime_config_ports import StreamingConfigPort
     from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 _logger = logging.getLogger(__name__)
@@ -179,7 +179,7 @@ class HlsService(HlsPlaylistPort):
 
     def __init__(
         self,
-        runtime_settings: RuntimeSettings,
+        runtime_settings: StreamingConfigPort,
         cache_dir: str = "./hls_cache",
         probe_service: MediaProbeService | None = None,
         idle_timeout: float = _DEFAULT_IDLE_TIMEOUT,

--- a/src/modules/media/infrastructure/streaming/scrub_preview_locator.py
+++ b/src/modules/media/infrastructure/streaming/scrub_preview_locator.py
@@ -15,7 +15,7 @@ from src.modules.media.infrastructure.streaming.thumbnail_service import (
 )
 
 if TYPE_CHECKING:
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+    from src.modules.media.application.ports.runtime_config_ports import ThumbnailConfigPort
 
 
 class FilesystemScrubPreviewLocator(ScrubPreviewLocatorPort):
@@ -27,7 +27,7 @@ class FilesystemScrubPreviewLocator(ScrubPreviewLocatorPort):
     for both the VTT and its sprite.
     """
 
-    def __init__(self, runtime_settings: RuntimeSettings) -> None:
+    def __init__(self, runtime_settings: ThumbnailConfigPort) -> None:
         self._runtime_settings = runtime_settings
 
     async def locate(self, source_file_path: str) -> str | None:

--- a/src/modules/media/infrastructure/streaming/thumbnail_service.py
+++ b/src/modules/media/infrastructure/streaming/thumbnail_service.py
@@ -33,7 +33,9 @@ from src.modules.media.infrastructure.streaming._subprocess import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+    from src.modules.media.application.ports.runtime_config_ports import (
+        StreamingConfigPort,
+    )
 
 _logger = logging.getLogger(__name__)
 
@@ -104,7 +106,7 @@ class ThumbnailGenerationService:
             restart.
     """
 
-    def __init__(self, runtime_settings: RuntimeSettings) -> None:
+    def __init__(self, runtime_settings: StreamingConfigPort) -> None:
         self._runtime_settings = runtime_settings
 
     def generate(

--- a/src/modules/media/infrastructure/video/credits_detector.py
+++ b/src/modules/media/infrastructure/video/credits_detector.py
@@ -44,7 +44,7 @@ from src.modules.media.infrastructure.streaming._subprocess import (
 )
 
 if TYPE_CHECKING:
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+    from src.modules.media.application.ports.runtime_config_ports import StreamingConfigPort
 
 _logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ class CreditsDetector(CreditsDetectorPort):
 
     def __init__(
         self,
-        runtime_settings: RuntimeSettings,
+        runtime_settings: StreamingConfigPort,
         *,
         timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
     ) -> None:

--- a/src/modules/media/infrastructure/video/frame_hasher.py
+++ b/src/modules/media/infrastructure/video/frame_hasher.py
@@ -27,7 +27,7 @@ from PIL import Image
 from src.modules.media.infrastructure.streaming._subprocess import with_ffmpeg_threads
 
 if TYPE_CHECKING:
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+    from src.modules.media.application.ports.runtime_config_ports import StreamingConfigPort
 
 _logger = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ class FrameHasher:
 
     def __init__(
         self,
-        runtime_settings: RuntimeSettings,
+        runtime_settings: StreamingConfigPort,
         *,
         timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
         scale_px: int = _DEFAULT_SCALE_PX,


### PR DESCRIPTION
## Summary

Phase 3 / PR-3.5 (last item) of the architecture-audit remediation (Tema A, findings F4/F6/M-5/M-6). 8 Media services + Identity's avatar storage type-annotated against the Settings BC's concrete `RuntimeSettings` infrastructure facade.

- New **local Protocol config readers** describing only the getters each consumer calls:
  - media `application/ports/runtime_config_ports.py`: `StreamingConfigReader` (`streaming_snapshot_sync`), `ThumbnailConfigReader` (`thumbnail_backfill`), `ThumbnailServiceConfigReader` (both — the sprite generator needs ffmpeg threads + backfill), `ScanDedupConfigReader` (`scan_dedup`).
  - identity `application/ports/avatar_config_port.py`: `AvatarConfigReader` (`avatar`).
- Consumers now type against the Protocols; `RuntimeSettings` satisfies them **structurally**, so the composition root keeps injecting it unchanged and the live snapshot/TTL behaviour is preserved. **No consumer imports the concrete cross-BC facade anymore.**
- Per Option A (your call): the Protocols still reference the Settings config VOs (`StreamingConfig` etc.) as return types — stable published contracts, imported `TYPE_CHECKING`-only. Full consumer-owned-DTO decoupling left as a future card.

No behavioral change; no container/runtime change.

## Test plan

- [x] `pytest tests/modules/media tests/modules/identity` → 1892 passed, 5 skipped
- [x] `mypy src`: zero errors in all touched files (caught + fixed that `thumbnail_service` needs both buckets)
- [x] `ruff check` + `ruff format` clean
- [x] Zero `RuntimeSettings` imports left in media/identity consumers; `import src.main` resolves

## Summary by Sourcery

Introduce protocol-based runtime configuration reader ports for media and identity modules and refactor consumers to depend on these ports instead of the concrete RuntimeSettings facade.

Enhancements:
- Add media runtime configuration Protocol ports for streaming, thumbnail, scan-dedup, and combined thumbnail service readers.
- Add an identity avatar runtime configuration Protocol port decoupling avatar storage from the Settings RuntimeSettings implementation.
- Update media and identity infrastructure classes to accept the new configuration reader protocols while preserving existing runtime behavior and settings value object contracts.