### PR TITLE
fix(media): distinguish TMDB not-found from provider failure [audit C]

### DIFF
--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -469,14 +469,25 @@ class MetadataProvider(ABC):
             tmdb_id: TMDB numeric id.
 
         Returns:
-            ``SearchCandidate`` when the id resolves to a movie;
-            ``None`` on 404 / network failure / malformed payload.
+            ``SearchCandidate`` when the id resolves to a movie, or
+            ``None`` when the id is genuinely not a movie (HTTP 404).
+
+        Raises:
+            httpx.HTTPError: On provider failure (network error, auth,
+                rate limit, 5xx). Callers must distinguish "no such
+                movie" (``None``) from "TMDB unavailable" (raises) — a
+                transient failure must not masquerade as not-found.
         """
         ...
 
     @abstractmethod
     async def get_series_summary_by_id(self, tmdb_id: int) -> "SearchCandidate | None":
-        """Cheap card-level fetch for one TV series by id."""
+        """Cheap card-level fetch for one TV series by id.
+
+        Like :meth:`get_movie_summary_by_id`: ``None`` only on a genuine
+        404 (the id isn't a series); raises ``httpx.HTTPError`` on any
+        provider failure rather than collapsing it to not-found.
+        """
         ...
 
     @abstractmethod

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -262,33 +262,36 @@ class TmdbClient(MetadataProvider):
         return [_to_series_candidate(r, self._image_url) for r in results[:limit]]
 
     async def get_movie_summary_by_id(self, tmdb_id: int) -> SearchCandidate | None:
-        """Cheap ``/movie/{id}`` fetch shaped as a picker candidate."""
-        try:
-            resp = await self._client.get(
-                f"{self._base_url}/movie/{tmdb_id}",
-                params=self._params(),
-            )
-        except httpx.HTTPError:
+        """Cheap ``/movie/{id}`` fetch shaped as a picker candidate.
+
+        A genuine 404 (the id is not a movie) returns ``None``; any other
+        failure (network, auth, rate limit, 5xx) propagates via
+        ``raise_for_status`` — consistent with the search paths — so a
+        transient outage doesn't masquerade as "not found".
+        """
+        resp = await self._client.get(
+            f"{self._base_url}/movie/{tmdb_id}",
+            params=self._params(),
+        )
+        if resp.status_code == httpx.codes.NOT_FOUND:
             return None
-        if resp.status_code == 404:
-            return None
-        if resp.status_code != 200:
-            return None
+        resp.raise_for_status()
         return _to_movie_candidate(resp.json(), self._image_url)
 
     async def get_series_summary_by_id(self, tmdb_id: int) -> SearchCandidate | None:
-        """Cheap ``/tv/{id}`` fetch shaped as a picker candidate."""
-        try:
-            resp = await self._client.get(
-                f"{self._base_url}/tv/{tmdb_id}",
-                params=self._params(),
-            )
-        except httpx.HTTPError:
+        """Cheap ``/tv/{id}`` fetch shaped as a picker candidate.
+
+        404 (the id is not a series) returns ``None``; any other failure
+        propagates via ``raise_for_status`` instead of collapsing to
+        not-found.
+        """
+        resp = await self._client.get(
+            f"{self._base_url}/tv/{tmdb_id}",
+            params=self._params(),
+        )
+        if resp.status_code == httpx.codes.NOT_FOUND:
             return None
-        if resp.status_code == 404:
-            return None
-        if resp.status_code != 200:
-            return None
+        resp.raise_for_status()
         return _to_series_candidate(resp.json(), self._image_url)
 
     async def find_by_imdb_id(self, imdb_id: str) -> list[SearchCandidate]:

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -323,6 +323,76 @@ class TestParseTrailer:
 
 
 @pytest.mark.unit
+class TestSummaryByIdErrorHandling:
+    """``get_*_summary_by_id`` separates not-found from provider failure.
+
+    A genuine 404 (the id isn't that media kind) returns ``None``; any
+    other failure (HTTP status or transport/connection) raises so a
+    transient outage doesn't masquerade as "no such id".
+    """
+
+    @pytest.mark.asyncio
+    async def test_movie_summary_returns_none_on_404(self) -> None:
+        client = _make_client(get_responses=_build_response(status_code=404))
+
+        assert await client.get_movie_summary_by_id(123) is None
+
+    @pytest.mark.asyncio
+    async def test_series_summary_returns_none_on_404(self) -> None:
+        client = _make_client(get_responses=_build_response(status_code=404))
+
+        assert await client.get_series_summary_by_id(123) is None
+
+    @pytest.mark.asyncio
+    async def test_movie_summary_raises_on_server_error(self) -> None:
+        client = _make_client(get_responses=_build_response(status_code=500))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_movie_summary_by_id(123)
+
+    @pytest.mark.asyncio
+    async def test_series_summary_raises_on_server_error(self) -> None:
+        client = _make_client(get_responses=_build_response(status_code=500))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.get_series_summary_by_id(123)
+
+    @pytest.mark.asyncio
+    async def test_movie_summary_returns_candidate_on_200(self) -> None:
+        client = _make_client(get_responses=_build_response(json_data=_movie_details()))
+
+        result = await client.get_movie_summary_by_id(27205)
+
+        assert result is not None
+        assert result.tmdb_id == 27205
+
+    @pytest.mark.asyncio
+    async def test_series_summary_returns_candidate_on_200(self) -> None:
+        client = _make_client(get_responses=_build_response(json_data=_series_details()))
+
+        result = await client.get_series_summary_by_id(1396)
+
+        assert result is not None
+        assert result.tmdb_id == 1396
+
+    @pytest.mark.asyncio
+    async def test_movie_summary_propagates_connection_error(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
+
+        with pytest.raises(httpx.ConnectError):
+            await client.get_movie_summary_by_id(123)
+
+    @pytest.mark.asyncio
+    async def test_series_summary_propagates_connection_error(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
+
+        with pytest.raises(httpx.ConnectError):
+            await client.get_series_summary_by_id(123)
+
+
+@pytest.mark.unit
 class TestParseCast:
     """Tests for _parse_cast."""
 


### PR DESCRIPTION
## Summary

Phase 4 / PR-4.1 of the architecture-audit remediation (Tema C, ACL Finding 2). `TmdbClient.get_movie_summary_by_id` / `get_series_summary_by_id` mapped both `httpx.HTTPError` and every non-200 status to the same `None` a genuine 404 returns — so the admin relink picker could not distinguish "no such TMDB id" from "TMDB is down / API key rejected / rate-limited", and it was inconsistent with the search paths (which `raise_for_status()`).

- Only a real **404 → `None`** (the id isn't that media kind).
- Any other failure (network, auth, rate limit, 5xx) **propagates** via `raise_for_status()`.
- The 404→None path is preserved, so the "bare numeric id is a movie but not a series" lookup (`_fetch_by_tmdb_id` gather) still works.
- Port contract docstring updated (`None` = not-found; raises on provider failure) + regression tests.

## Test plan

- [x] New `TestSummaryByIdErrorHandling`: 404→None and 5xx→raises, for both movie and series
- [x] `pytest tests/modules/media` → 1678 passed, 5 skipped
- [x] `ruff check` clean; changed lines mypy-clean (pre-existing errors elsewhere in the file untouched)

## Summary by Sourcery

Clarify TMDB summary-by-id behavior to distinguish genuine not-found responses from provider failures and align it with other TMDB client paths.

Bug Fixes:
- Ensure movie and series summary-by-id calls return None only on HTTP 404 and propagate other HTTP and network errors instead of masking them as not-found.

Enhancements:
- Document the metadata provider port contract to specify that summary-by-id methods return None for genuine not-found and raise on provider failures.
- Add regression tests covering 404 and server-error handling for movie and series summary-by-id calls.