### PR TITLE
fix(media): config-driven content-rating jurisdiction [audit C]

### DIFF
--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -1078,9 +1078,49 @@ class TmdbClient(MetadataProvider):
 
         return directors, writers
 
-    @staticmethod
-    def _parse_content_rating(release_dates: dict[str, object]) -> ContentRating | None:
-        """Extract content rating from TMDB release_dates, preferring BR then US."""
+    def _preferred_rating_countries(self) -> list[str]:
+        """Jurisdiction order for picking a content rating — config-driven.
+
+        Built from the *region* subtag of each ``supported_locales`` entry,
+        in order, with ``US`` appended as the English-base fallback. The
+        region is the trailing 2-letter alpha subtag (``pt-BR`` → ``BR``,
+        ``zh-Hant-TW`` → ``TW``) — parsed by content, not position, so a
+        script subtag (``Hant``) isn't mistaken for a region. For the
+        default ``("en", "pt-BR")`` this is ``["BR", "US"]`` — same
+        precedence as the old hardcoded pair.
+
+        Note: this reuses ``supported_locales`` (a UI/metadata language
+        axis) as a proxy for certification jurisdiction. They correlate but
+        can diverge; if a household ever needs a UI language whose region
+        should not drive ratings, add a dedicated
+        ``content_rating_jurisdictions`` setting rather than overloading
+        this one.
+        """
+        countries: list[str] = []
+        for locale in self._supported_locales:
+            subtags = locale.split("-")[1:]
+            region = next((s.upper() for s in subtags if len(s) == 2 and s.isalpha()), None)
+            if region and region not in countries:
+                countries.append(region)
+        if "US" not in countries:
+            countries.append("US")
+        return countries
+
+    def _select_content_rating(self, ratings_by_country: dict[str, str]) -> ContentRating | None:
+        """Pick the rating for the first preferred jurisdiction that has one."""
+        for country in self._preferred_rating_countries():
+            cert = ratings_by_country.get(country)
+            if cert:
+                return ContentRating(cert)
+        return None
+
+    def _parse_content_rating(self, release_dates: dict[str, object]) -> ContentRating | None:
+        """Extract a movie content rating from TMDB ``release_dates``.
+
+        Builds the full per-country certification map, then selects by the
+        config-driven jurisdiction order (see
+        :meth:`_preferred_rating_countries`).
+        """
         results = release_dates.get("results", [])
         if not isinstance(results, list):
             return None
@@ -1096,8 +1136,7 @@ class TmdbClient(MetadataProvider):
                 if cert and iso not in ratings_by_country:
                     ratings_by_country[iso] = cert
 
-        selected = ratings_by_country.get("BR") or ratings_by_country.get("US")
-        return ContentRating(selected) if selected else None
+        return self._select_content_rating(ratings_by_country)
 
     @staticmethod
     def _parse_trailer(videos: dict[str, object]) -> str | None:
@@ -1137,9 +1176,14 @@ class TmdbClient(MetadataProvider):
 
         return f"https://www.youtube.com/watch?v={best['key']}"
 
-    @staticmethod
-    def _parse_series_content_rating(content_ratings: dict[str, object]) -> ContentRating | None:
-        """Extract content rating from TMDB series content_ratings, preferring BR then US."""
+    def _parse_series_content_rating(
+        self, content_ratings: dict[str, object]
+    ) -> ContentRating | None:
+        """Extract a series content rating from TMDB ``content_ratings``.
+
+        Same config-driven jurisdiction selection as the movie path
+        (:meth:`_preferred_rating_countries`).
+        """
         results = content_ratings.get("results", [])
         if not isinstance(results, list):
             return None
@@ -1153,8 +1197,7 @@ class TmdbClient(MetadataProvider):
             if rating and iso not in ratings_by_country:
                 ratings_by_country[iso] = rating
 
-        selected = ratings_by_country.get("BR") or ratings_by_country.get("US")
-        return ContentRating(selected) if selected else None
+        return self._select_content_rating(ratings_by_country)
 
     def _to_credit_person(self, data: dict[str, object], role_key: str) -> CreditPerson:
         """Convert a TMDB cast/crew dict to a CreditPerson."""

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -192,7 +192,7 @@ class TestTmdbClientParams:
 
 @pytest.mark.unit
 class TestParseContentRating:
-    """Tests for _parse_content_rating static method."""
+    """Tests for _parse_content_rating (config-driven jurisdiction)."""
 
     def test_should_prefer_br_over_us(self) -> None:
         data: dict[str, Any] = {
@@ -207,7 +207,7 @@ class TestParseContentRating:
                 },
             ],
         }
-        assert TmdbClient._parse_content_rating(data) == ContentRating("14")
+        assert _make_client()._parse_content_rating(data) == ContentRating("14")
 
     def test_should_fallback_to_us(self) -> None:
         data: dict[str, Any] = {
@@ -218,16 +218,16 @@ class TestParseContentRating:
                 },
             ],
         }
-        assert TmdbClient._parse_content_rating(data) == ContentRating("PG-13")
+        assert _make_client()._parse_content_rating(data) == ContentRating("PG-13")
 
     def test_should_return_none_when_empty(self) -> None:
-        assert TmdbClient._parse_content_rating({"results": []}) is None
+        assert _make_client()._parse_content_rating({"results": []}) is None
 
     def test_should_return_none_when_missing_key(self) -> None:
-        assert TmdbClient._parse_content_rating({}) is None
+        assert _make_client()._parse_content_rating({}) is None
 
     def test_should_handle_invalid_results_type(self) -> None:
-        assert TmdbClient._parse_content_rating({"results": "bad"}) is None
+        assert _make_client()._parse_content_rating({"results": "bad"}) is None
 
     def test_should_skip_empty_certifications(self) -> None:
         data: dict[str, Any] = {
@@ -242,12 +242,58 @@ class TestParseContentRating:
                 },
             ],
         }
-        assert TmdbClient._parse_content_rating(data) == ContentRating("R")
+        assert _make_client()._parse_content_rating(data) == ContentRating("R")
+
+    def test_jurisdiction_order_is_config_driven(self) -> None:
+        # A newly supported locale's certification body is respected
+        # without editing the gateway: es-ES → ES wins over the US
+        # fallback (vs the old hardcoded BR-then-US).
+        client = TmdbClient(api_key="test-key", supported_locales=("en", "es-ES"))
+        data: dict[str, Any] = {
+            "results": [
+                {"iso_3166_1": "US", "release_dates": [{"certification": "PG-13"}]},
+                {"iso_3166_1": "ES", "release_dates": [{"certification": "12"}]},
+            ],
+        }
+        assert client._parse_content_rating(data) == ContentRating("12")
+
+    def test_returns_none_when_no_preferred_country_matches(self) -> None:
+        # Default prefs [BR, US]; payload only has FR → nothing selected.
+        data: dict[str, Any] = {
+            "results": [
+                {"iso_3166_1": "FR", "release_dates": [{"certification": "12"}]},
+            ],
+        }
+        assert _make_client()._parse_content_rating(data) is None
+
+    def test_region_parsed_by_content_not_position(self) -> None:
+        # A script subtag (zh-Hant-TW) must not be mistaken for the region:
+        # TW is the region, so a TW certification is selected over US.
+        client = TmdbClient(api_key="test-key", supported_locales=("en", "zh-Hant-TW"))
+        data: dict[str, Any] = {
+            "results": [
+                {"iso_3166_1": "US", "release_dates": [{"certification": "PG-13"}]},
+                {"iso_3166_1": "TW", "release_dates": [{"certification": "0+"}]},
+            ],
+        }
+        assert client._parse_content_rating(data) == ContentRating("0+")
 
 
 @pytest.mark.unit
 class TestParseSeriesContentRating:
     """Tests for _parse_series_content_rating."""
+
+    def test_jurisdiction_order_is_config_driven(self) -> None:
+        # Series selection is config-driven too (parity with movie): a
+        # configured locale's region wins over the US fallback.
+        client = TmdbClient(api_key="test-key", supported_locales=("en", "es-ES"))
+        data: dict[str, Any] = {
+            "results": [
+                {"iso_3166_1": "US", "rating": "TV-14"},
+                {"iso_3166_1": "ES", "rating": "12"},
+            ],
+        }
+        assert client._parse_series_content_rating(data) == ContentRating("12")
 
     def test_should_prefer_br(self) -> None:
         data: dict[str, Any] = {
@@ -256,17 +302,17 @@ class TestParseSeriesContentRating:
                 {"iso_3166_1": "BR", "rating": "18"},
             ],
         }
-        assert TmdbClient._parse_series_content_rating(data) == ContentRating("18")
+        assert _make_client()._parse_series_content_rating(data) == ContentRating("18")
 
     def test_should_fallback_to_us(self) -> None:
         data: dict[str, Any] = {"results": [{"iso_3166_1": "US", "rating": "TV-14"}]}
-        assert TmdbClient._parse_series_content_rating(data) == ContentRating("TV-14")
+        assert _make_client()._parse_series_content_rating(data) == ContentRating("TV-14")
 
     def test_should_return_none_when_empty(self) -> None:
-        assert TmdbClient._parse_series_content_rating({}) is None
+        assert _make_client()._parse_series_content_rating({}) is None
 
     def test_should_handle_invalid_results_type(self) -> None:
-        assert TmdbClient._parse_series_content_rating({"results": "bad"}) is None
+        assert _make_client()._parse_series_content_rating({"results": "bad"}) is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Phase 4 / PR-4.2 (Tema C, ACL Finding 1). `_parse_content_rating` / `_parse_series_content_rating` hardcoded `ratings_by_country.get("BR") or .get("US")` — a product/jurisdiction policy baked into the gateway that collapsed every other country's certification and required a code edit to support a new jurisdiction.

- Jurisdiction order is now **config-driven**: derived from the region subtags of `supported_locales` (`pt-BR` → `BR`), in order, with `US` appended as the English-base fallback (`_preferred_rating_countries`).
- Default `("en", "pt-BR")` → `["BR", "US"]` — **same precedence as before** (no behavior change for current config).
- A newly supported locale's certification body is respected without editing the gateway (e.g. `es-ES` → `ES` wins over the US fallback).
- The two parse methods became instance methods sharing `_select_content_rating`.

> Note: this picks one rating (the entity stores a single `ContentRating`); the full per-country map is still built. Mapping all TMDB provider failures to `GatewayException` (raised by #328's review) remains a separate project-wide follow-up.

## Test plan

- [x] `TestParseContentRating`/`TestParseSeriesContentRating` updated to instance calls; default still BR-then-US; added a config-driven test (`es-ES` → ES over US)
- [x] `pytest tests/modules/media` → 1683 passed, 5 skipped
- [x] `ruff check`/`format` clean; no new mypy errors in changed methods

## Summary by Sourcery

Make TMDB content rating selection jurisdiction-aware based on configured supported locales instead of hardcoded country fallbacks.

New Features:
- Support configuration-driven jurisdiction precedence for selecting TMDB content ratings derived from supported locales.

Bug Fixes:
- Ensure content ratings for newly supported locales take precedence over the US fallback instead of being ignored without code changes.

Enhancements:
- Refactor movie and series content rating parsing to share a common selection helper and rely on instance configuration rather than static methods.

Tests:
- Update and extend TMDB client content rating tests to cover config-driven jurisdiction ordering and instance-based parsing.