### PR TITLE
fix(media): log missing/unmounted scan root [audit C]

### DIFF
--- a/src/modules/media/infrastructure/file_system/scanner.py
+++ b/src/modules/media/infrastructure/file_system/scanner.py
@@ -1,10 +1,13 @@
 """Filesystem scanner for discovering media files."""
 
+import logging
 import re
 from pathlib import Path, PurePath
 
 from src.modules.media.application.ports import FileSystemScanner, MediaType, ScannedFile
 from src.shared_kernel.value_objects.file_path import FilePath
+
+_logger = logging.getLogger(__name__)
 
 _SUPPORTED_EXTENSIONS = frozenset({".mp4", ".mkv", ".avi", ".mov", ".wmv"})
 
@@ -158,6 +161,17 @@ class LocalFileSystemScanner(FileSystemScanner):
         for directory in directories:
             dir_path = Path(directory.value)
             if not dir_path.is_dir():
+                # Missing/unmounted root: skip, but log it. A silent skip
+                # looks identical to "root mounted and genuinely empty",
+                # so downstream reconciliation could mistake an unmounted
+                # disk for "all media deleted". The auto-merge path guards
+                # this via LibraryHealthPort; the warning makes the skip
+                # observable for the scan path too.
+                _logger.warning(
+                    "Scan root is missing or unmounted; skipping (its files "
+                    "will appear absent — do not treat as deleted): %s",
+                    directory.value,
+                )
                 continue
 
             for path in dir_path.rglob("*"):

--- a/tests/modules/media/unit/infrastructure/file_system/test_scanner.py
+++ b/tests/modules/media/unit/infrastructure/file_system/test_scanner.py
@@ -1,5 +1,6 @@
 """Unit tests for LocalFileSystemScanner."""
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,22 @@ class TestScanDirectories:
 
         assert len(results) == 2
         assert all(r.media_type == MediaType.MOVIE for r in results)
+
+    def test_should_skip_and_warn_on_missing_root(
+        self,
+        scanner: LocalFileSystemScanner,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # A missing/unmounted root is skipped, but the skip is logged so it
+        # isn't silently indistinguishable from "mounted and empty".
+        missing = FilePath(str(tmp_path / "unmounted_or_deleted"))
+
+        with caplog.at_level(logging.WARNING):
+            results = scanner.scan_directories([missing])
+
+        assert results == []
+        assert "missing or unmounted" in caplog.text
 
     def test_should_filter_unsupported_extensions(
         self, scanner: LocalFileSystemScanner, media_dir: Path


### PR DESCRIPTION
## Summary

Phase 4 / PR-4.3 (Tema C, ACL Finding 5). `LocalFileSystemScanner.scan_directories` silently `continue`d past a missing/unmounted root, making it indistinguishable from a mounted-but-empty root. Downstream reconciliation could then read an unmounted disk as "all media deleted". Now the skip emits a warning so it's observable (the dangerous auto-merge path already guards via `LibraryHealthPort`; the scan path didn't even surface it). The skip behavior itself is unchanged.

### Scope note (Findings 4 & 6 deferred)
This PR is **scanner-only**. The audit's Finding 4 (probe fabricating an audio default, `media_probe_service.py:403-405`) is **deferred**: its premise — "the Library's `TrackSelector` owns default selection" — doesn't hold, because **`TrackSelector` doesn't exist in code** (only planned in ADR-005; `library/domain/services/` is empty). That fabrication is currently the only default-audio signal and flows to the frontend player, so removing it risks a playback regression and needs a real `TrackSelector` (ADR-005 feature) + a manual player smoke test. Finding 6 (`channels`→2 default) is won't-fix (baixo; would ripple the `AudioTrack` VO to `int|None`).

## Test plan

- [x] New `test_should_skip_and_warn_on_missing_root` (missing root → `[]` + warning logged)
- [x] `pytest tests/modules/media` → 1687 passed, 5 skipped
- [x] `ruff check` clean

## Summary by Sourcery

Log and surface missing or unmounted filesystem scan roots when scanning media directories to make skipped roots observable to downstream reconciliation.

New Features:
- Emit a warning when a configured scan root is missing or unmounted so it is distinguishable from a mounted-but-empty directory.

Tests:
- Add a unit test verifying that missing scan roots are skipped, return no results, and emit a warning log entry.