### PR TITLE
refactor(media): replace enrich force flag with MergePolicy [audit E/F]

### DIFF
--- a/src/modules/media/application/use_cases/_localized_metadata_helpers.py
+++ b/src/modules/media/application/use_cases/_localized_metadata_helpers.py
@@ -4,9 +4,9 @@ The movie/series and season/episode enrich use cases fold a provider's
 per-language overrides into the entity's stored ``localized``. Both the
 provider→VO translation and the merge-vs-replace decision live here so the
 use cases stay declarative and no call site has to reach for the wire-dict
-form (the VO owns serialization). ``force`` (a relink) replaces the stored
-overrides outright; otherwise the provider's locales are overlaid on the
-existing ones (:meth:`LocalizedMetadata.merge`).
+form (the VO owns serialization). ``MergePolicy.OVERWRITE`` (a relink)
+replaces the stored overrides outright; ``FILL_IF_EMPTY`` overlays the
+provider's locales on the existing ones (:meth:`LocalizedMetadata.merge`).
 """
 
 from src.modules.media.application.ports import LocalizedTextFields, MediaMetadata
@@ -14,10 +14,11 @@ from src.modules.media.domain.value_objects.localized_metadata import (
     LocalizedFields,
     LocalizedMetadata,
 )
+from src.modules.media.domain.value_objects.merge_policy import MergePolicy
 
 
 def _resolved(
-    existing: LocalizedMetadata, provider: LocalizedMetadata, *, force: bool
+    existing: LocalizedMetadata, provider: LocalizedMetadata, *, policy: MergePolicy
 ) -> LocalizedMetadata | None:
     """Merge or replace, returning ``None`` when the provider has nothing.
 
@@ -25,11 +26,14 @@ def _resolved(
     """
     if provider.is_empty():
         return None
-    return provider if force else existing.merge(provider)
+    return provider if policy.overwrites else existing.merge(provider)
 
 
 def merge_media_localized(
-    existing: LocalizedMetadata, metadata: MediaMetadata, *, force: bool = False
+    existing: LocalizedMetadata,
+    metadata: MediaMetadata,
+    *,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> LocalizedMetadata | None:
     """Fold a movie/series provider's full per-language overrides into ``existing``.
 
@@ -51,14 +55,14 @@ def merge_media_localized(
         )
         if not fields.is_empty():
             by_locale[lang] = fields
-    return _resolved(existing, LocalizedMetadata(by_locale), force=force)
+    return _resolved(existing, LocalizedMetadata(by_locale), policy=policy)
 
 
 def merge_text_localized(
     existing: LocalizedMetadata,
     provider_localized: dict[str, LocalizedTextFields],
     *,
-    force: bool = False,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> LocalizedMetadata | None:
     """Fold a season/episode provider's title/synopsis overrides into ``existing``.
 
@@ -71,7 +75,7 @@ def merge_text_localized(
         fields = LocalizedFields(title=f.title or None, synopsis=f.synopsis or None)
         if not fields.is_empty():
             by_locale[lang] = fields
-    return _resolved(existing, LocalizedMetadata(by_locale), force=force)
+    return _resolved(existing, LocalizedMetadata(by_locale), policy=policy)
 
 
 __all__ = ["merge_media_localized", "merge_text_localized"]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -22,6 +22,7 @@ from src.modules.media.domain.value_objects import (
     Genre,
     ImageUrl,
     ImdbId,
+    MergePolicy,
     MovieId,
     Title,
     TmdbId,
@@ -97,7 +98,9 @@ class EnrichMovieMetadataUseCase:
                 if localized_meta is not None:
                     metadata = localized_meta
 
-            movie = _apply_movie_metadata(movie, metadata, force=input_dto.force)
+            movie = _apply_movie_metadata(
+                movie, metadata, policy=MergePolicy.from_force(input_dto.force)
+            )
             if movie.needs_enrichment_review:
                 movie = movie.with_updates(needs_enrichment_review=False)
             await uow.movies.save(movie)
@@ -237,14 +240,14 @@ def _apply_movie_metadata(
     movie: Movie,
     metadata: MediaMetadata,
     *,
-    force: bool = False,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> Movie:
     """Apply metadata fields to a movie entity.
 
     Each field has a "fill if empty" guard by default so re-enrichment
     doesn't clobber user customizations (a synopsis the user edited,
-    a poster they picked manually, etc.). When ``force=True`` every
-    guard is bypassed and TMDB's payload wins — used by the bulk
+    a poster they picked manually, etc.). Under ``MergePolicy.OVERWRITE``
+    every guard is bypassed and TMDB's payload wins — used by the bulk
     enrich's "force update" toggle to backfill new fields (like the
     cast member ``tmdb_id``) on rows that were already enriched.
     """
@@ -252,9 +255,9 @@ def _apply_movie_metadata(
 
     if metadata.title:
         updates["title"] = Title(metadata.title)
-    if metadata.synopsis and (force or not movie.synopsis):
+    if metadata.synopsis and policy.should_write(movie.synopsis):
         updates["synopsis"] = metadata.synopsis
-    _apply_franchise_metadata(updates, movie, metadata, force=force)
+    _apply_franchise_metadata(updates, movie, metadata, policy=policy)
     if metadata.tmdb_id:
         updates["tmdb_id"] = TmdbId(metadata.tmdb_id)
     if metadata.imdb_id:
@@ -263,21 +266,21 @@ def _apply_movie_metadata(
         updates["original_title"] = Title(metadata.original_title)
     # Duration is the file's real (probed) length — the scanner stamps it.
     # TMDB's nominal runtime is only a fallback when the probe failed
-    # (duration still 0); never overwrite a real duration, even on force.
+    # (duration still 0); never overwrite a real duration, even on OVERWRITE.
     if metadata.duration_seconds and movie.duration.value == 0:
         updates["duration"] = Duration(metadata.duration_seconds)
     if metadata.year:
         updates["year"] = Year(metadata.year)
-    if metadata.genres and (force or not movie.genres):
+    if metadata.genres and policy.should_write(movie.genres):
         updates["genres"] = [Genre(g) for g in metadata.genres]
-    if metadata.poster_url and (force or not movie.poster_path):
+    if metadata.poster_url and policy.should_write(movie.poster_path):
         updates["poster_path"] = ImageUrl(metadata.poster_url)
-    if metadata.backdrop_url and (force or not movie.backdrop_path):
+    if metadata.backdrop_url and policy.should_write(movie.backdrop_path):
         updates["backdrop_path"] = ImageUrl(metadata.backdrop_url)
-    if metadata.logo_url and (force or not movie.logo_path):
+    if metadata.logo_url and policy.should_write(movie.logo_path):
         updates["logo_path"] = ImageUrl(metadata.logo_url)
 
-    _apply_credits(updates, movie, metadata, force=force)
+    _apply_credits(updates, movie, metadata, policy=policy)
 
     if updates:
         movie = movie.with_updates(**updates)
@@ -290,7 +293,7 @@ def _apply_franchise_metadata(
     movie: Movie,
     metadata: MediaMetadata,
     *,
-    force: bool = False,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> None:
     """Apply tagline + collection (franchise) metadata.
 
@@ -299,9 +302,9 @@ def _apply_franchise_metadata(
     user-edited tagline or a manually-cleared collection. Extracted
     out so the parent function stays under ``PLR0912``'s branch cap.
     """
-    if metadata.tagline and (force or not movie.tagline):
+    if metadata.tagline and policy.should_write(movie.tagline):
         updates["tagline"] = metadata.tagline
-    if metadata.collection and (force or not movie.collection):
+    if metadata.collection and policy.should_write(movie.collection):
         updates["collection"] = Collection(
             tmdb_id=metadata.collection.tmdb_id,
             name=metadata.collection.name,
@@ -314,16 +317,16 @@ def _apply_credits(
     movie: Movie,
     metadata: MediaMetadata,
     *,
-    force: bool = False,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> None:
     """Apply cast/director/writer credits.
 
-    Each field defaults to a "fill if empty" guard; ``force=True``
+    Each field defaults to a "fill if empty" guard; ``MergePolicy.OVERWRITE``
     bypasses the guard so a refresh repopulates credits from TMDB.
     The motivating use case is backfilling ``tmdb_id`` on cast
     members that were already saved before the id was captured.
     """
-    if metadata.cast and (force or not movie.cast):
+    if metadata.cast and policy.should_write(movie.cast):
         updates["cast"] = [
             CastMember(
                 name=p.name,
@@ -333,15 +336,15 @@ def _apply_credits(
             )
             for p in metadata.cast
         ]
-    if metadata.directors and (force or not movie.directors):
+    if metadata.directors and policy.should_write(movie.directors):
         updates["directors"] = [p.name for p in metadata.directors]
-    if metadata.writers and (force or not movie.writers):
+    if metadata.writers and policy.should_write(movie.writers):
         updates["writers"] = [p.name for p in metadata.writers]
-    if metadata.content_rating and (force or not movie.content_rating):
+    if metadata.content_rating and policy.should_write(movie.content_rating):
         updates["content_rating"] = ContentRating(metadata.content_rating)
-    if metadata.trailer_url and (force or not movie.trailer_url):
+    if metadata.trailer_url and policy.should_write(movie.trailer_url):
         updates["trailer_url"] = metadata.trailer_url
-    new_localized = merge_media_localized(movie.localized, metadata, force=force)
+    new_localized = merge_media_localized(movie.localized, metadata, policy=policy)
     if new_localized is not None:
         updates["localized"] = new_localized
 

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -33,6 +33,7 @@ from src.modules.media.domain.value_objects import (
     ImdbId,
     LocalizedFields,
     LocalizedMetadata,
+    MergePolicy,
     SeriesId,
     Title,
     TmdbId,
@@ -104,7 +105,9 @@ class EnrichSeriesMetadataUseCase:
                 if localized_meta is not None:
                     metadata = localized_meta
 
-            series = _apply_series_metadata(series, metadata, force=input_dto.force)
+            series = _apply_series_metadata(
+                series, metadata, policy=MergePolicy.from_force(input_dto.force)
+            )
             if series.needs_enrichment_review:
                 series = series.with_updates(needs_enrichment_review=False)
             await uow.series.save(series)
@@ -170,20 +173,21 @@ def _set_if_missing(
     entity: Series,
     field_map: dict[str, tuple[str, Callable[[Any], Any] | None]],
     *,
-    force: bool = False,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> None:
-    """Set fields in updates, respecting the fill-if-empty guard.
+    """Set fields in updates, respecting the merge policy.
 
-    A field is written when metadata has a value and either ``force``
-    is set or the entity field is empty. The fill-if-empty guard
-    protects user edits on a routine re-enrichment; ``force`` (a relink
-    / forced refresh) bypasses it so metadata from the newly-picked
-    match overwrites stale values left by a wrong match.
+    A field is written when metadata has a value and ``policy.should_write``
+    allows it (always under ``OVERWRITE``; only when the entity field is
+    empty under ``FILL_IF_EMPTY``). The fill-if-empty guard protects user
+    edits on a routine re-enrichment; ``OVERWRITE`` (a relink / forced
+    refresh) bypasses it so metadata from the newly-picked match overwrites
+    stale values left by a wrong match.
     """
     for meta_attr, (entity_attr, converter) in field_map.items():
         meta_val = getattr(metadata, meta_attr, None)
         entity_val = getattr(entity, entity_attr, None)
-        if meta_val and (force or not entity_val):
+        if meta_val and policy.should_write(entity_val):
             updates[entity_attr] = converter(meta_val) if converter is not None else meta_val
 
 
@@ -191,15 +195,15 @@ def _apply_series_metadata(
     series: Series,
     metadata: MediaMetadata,
     *,
-    force: bool = False,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> Series:
     """Apply metadata fields to a series entity.
 
     Each "don't-overwrite" field has a fill-if-empty guard by default so
-    a routine re-enrichment doesn't clobber user edits. When ``force``
-    is set (a relink, where the existing data belongs to a wrong match)
-    every guard is bypassed and the provider payload wins — including a
-    full replace of the ``localized`` overrides and the base title.
+    a routine re-enrichment doesn't clobber user edits. Under
+    ``MergePolicy.OVERWRITE`` (a relink, where the existing data belongs to
+    a wrong match) every guard is bypassed and the provider payload wins —
+    including a full replace of the ``localized`` overrides and the base title.
     """
     updates: dict[str, object] = {}
 
@@ -214,7 +218,7 @@ def _apply_series_metadata(
         updates["start_year"] = Year(metadata.year)
     if metadata.end_year:
         updates["end_year"] = Year(metadata.end_year)
-    elif force:
+    elif policy.overwrites:
         # On a relink the new match may be ongoing (no end_year) while a
         # stale end_year lingers from the wrong match. Left in place it
         # can fall before the new start_year and trip the
@@ -223,10 +227,10 @@ def _apply_series_metadata(
     # The base title normally stays scanner-derived, but on a forced
     # refresh it may belong to a wrong match — overwrite it so the
     # canonical title tracks the newly-picked TMDB entry.
-    if metadata.title and force:
+    if metadata.title and policy.overwrites:
         updates["title"] = Title(metadata.title)
 
-    # Don't-overwrite fields (only set if empty, unless ``force``)
+    # Don't-overwrite fields (only set if empty, unless ``OVERWRITE``)
     _set_if_missing(
         updates,
         metadata,
@@ -240,7 +244,7 @@ def _apply_series_metadata(
             "content_rating": ("content_rating", ContentRating),
             "trailer_url": ("trailer_url", None),
         },
-        force=force,
+        policy=policy,
     )
 
     # Cast: same fill-if-empty rule as the rest of the don't-overwrite
@@ -248,7 +252,7 @@ def _apply_series_metadata(
     # provider DTO uses a different field name (``cast`` ↔ ``cast``)
     # AND a per-element converter from ``CreditPerson`` to the
     # domain ``CastMember`` VO.
-    if metadata.cast and (force or not series.cast):
+    if metadata.cast and policy.should_write(series.cast):
         updates["cast"] = [
             CastMember(
                 name=p.name,
@@ -259,7 +263,7 @@ def _apply_series_metadata(
             for p in metadata.cast
         ]
 
-    new_localized = merge_media_localized(series.localized, metadata, force=force)
+    new_localized = merge_media_localized(series.localized, metadata, policy=policy)
     if new_localized is not None:
         updates["localized"] = new_localized
 
@@ -268,7 +272,7 @@ def _apply_series_metadata(
 
     # Enrich seasons and episodes
     if metadata.seasons:
-        series = _enrich_seasons(series, metadata.seasons, force=force)
+        series = _enrich_seasons(series, metadata.seasons, policy=policy)
 
     return series
 
@@ -277,7 +281,7 @@ def _enrich_seasons(
     series: Series,
     season_metas: list[SeasonMetadata],
     *,
-    force: bool = False,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> Series:
     """Enrich existing seasons with metadata."""
     meta_by_num = {s.season_number: s for s in season_metas}  # int keys from API
@@ -285,25 +289,27 @@ def _enrich_seasons(
     new_seasons = []
     for season in series.seasons:
         meta = meta_by_num.get(season.season_number.value)
-        enriched = _apply_season_metadata(season, meta, force=force) if meta else season
+        enriched = _apply_season_metadata(season, meta, policy=policy) if meta else season
         new_seasons.append(enriched)
 
     return series.with_updates(seasons=new_seasons)
 
 
-def _apply_season_metadata(season: Season, meta: SeasonMetadata, *, force: bool = False) -> Season:
+def _apply_season_metadata(
+    season: Season, meta: SeasonMetadata, *, policy: MergePolicy = MergePolicy.FILL_IF_EMPTY
+) -> Season:
     """Apply metadata to a season and its episodes."""
     updates: dict[str, object] = {}
 
-    if meta.title and (force or not season.title):
+    if meta.title and policy.should_write(season.title):
         updates["title"] = Title(meta.title)
-    if meta.synopsis and (force or not season.synopsis):
+    if meta.synopsis and policy.should_write(season.synopsis):
         updates["synopsis"] = meta.synopsis
-    if meta.air_date and (force or not season.air_date):
+    if meta.air_date and policy.should_write(season.air_date):
         parsed = _parse_date(meta.air_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
-    season_localized = merge_text_localized(season.localized, meta.localized, force=force)
+    season_localized = merge_text_localized(season.localized, meta.localized, policy=policy)
     if season_localized is not None:
         updates["localized"] = season_localized
 
@@ -320,11 +326,11 @@ def _apply_season_metadata(season: Season, meta: SeasonMetadata, *, force: bool 
             segment_count = _detect_multi_episode(ep.title.value)
             if segment_count > 1:
                 enriched_ep = _apply_multi_episode_metadata(
-                    ep, ep_by_num, segment_count, tmdb_start=tmdb_idx, force=force
+                    ep, ep_by_num, segment_count, tmdb_start=tmdb_idx, policy=policy
                 )
             else:
                 ep_meta = ep_by_num.get(tmdb_idx)
-                enriched_ep = _apply_episode_metadata(ep, ep_meta, force=force) if ep_meta else ep
+                enriched_ep = _apply_episode_metadata(ep, ep_meta, policy=policy) if ep_meta else ep
             new_episodes.append(enriched_ep)
             tmdb_idx += segment_count
         season = season.with_updates(episodes=new_episodes)
@@ -355,7 +361,7 @@ def _apply_multi_episode_metadata(
     segment_count: int,
     tmdb_start: int | None = None,
     *,
-    force: bool = False,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
 ) -> Episode:
     """Apply combined metadata from multiple TMDB episodes to a multi-segment file.
 
@@ -367,8 +373,8 @@ def _apply_multi_episode_metadata(
         ep_by_num: TMDB episodes keyed by episode number.
         segment_count: Number of TMDB episodes in this file.
         tmdb_start: Starting TMDB episode number (if None, uses episode.episode_number).
-        force: When ``True`` (a relink) the fill-if-empty guards are
-            bypassed so a wrong match's episode data is replaced.
+        policy: ``OVERWRITE`` (a relink) bypasses the fill-if-empty guards
+            so a wrong match's episode data is replaced.
     """
     start = tmdb_start if tmdb_start is not None else episode.episode_number.value
     metas = [ep_by_num.get(start + i) for i in range(segment_count)]
@@ -382,34 +388,34 @@ def _apply_multi_episode_metadata(
     # Concatenate titles from all segments (only if local title is from
     # scanner, or on a forced refresh where the stored title may be wrong)
     titles = [m.title for m in present if m.title]
-    if titles and (force or " / " not in episode.title.value):
+    if titles and (policy.overwrites or " / " not in episode.title.value):
         updates["title"] = Title(" / ".join(titles))
 
     # Synopsis: combine with separator
     synopses = [m.synopsis for m in present if m.synopsis]
-    if synopses and (force or not episode.synopsis):
+    if synopses and policy.should_write(episode.synopsis):
         updates["synopsis"] = " ◆ ".join(synopses)
 
     # Sum durations from all segments. Only a fallback — the scanner
     # stamps the file's real probed duration; never overwrite it (even on
-    # force) with TMDB's nominal runtime.
+    # OVERWRITE) with TMDB's nominal runtime.
     total_duration = sum(m.duration_seconds or 0 for m in present)
     if total_duration and episode.duration.value == 0:
         updates["duration"] = Duration(total_duration)
 
     # Thumbnail: first available
     first_still = next((m.still_url for m in present if m.still_url), None)
-    if first_still and (force or not episode.thumbnail_path):
+    if first_still and policy.should_write(episode.thumbnail_path):
         updates["thumbnail_path"] = ImageUrl(first_still)
 
     # Air date: first available
     first_date = next((m.air_date for m in present if m.air_date), None)
-    if first_date and (force or not episode.air_date):
+    if first_date and policy.should_write(episode.air_date):
         parsed = _parse_date(first_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
 
-    combined_localized = _combine_localized_segments(present, episode.localized, force=force)
+    combined_localized = _combine_localized_segments(present, episode.localized, policy=policy)
     if combined_localized is not None:
         updates["localized"] = combined_localized
 
@@ -423,14 +429,14 @@ def _combine_localized_segments(
     present: list[EpisodeMetadata],
     existing: LocalizedMetadata,
     *,
-    force: bool,
+    policy: MergePolicy,
 ) -> LocalizedMetadata | None:
     """Combine per-locale title/synopsis across a multi-segment file's episodes.
 
     Mirrors the English combine (titles joined with `` / ``, synopses
     with `` ◆ ``) per locale so a translated multi-segment file keeps
     its localized text. Returns ``None`` when no locale has data; otherwise
-    replaces (``force``) or merges the combined overrides over ``existing``.
+    replaces (``OVERWRITE``) or merges the combined overrides over ``existing``.
     """
     locales = {loc for m in present for loc in m.localized}
     by_locale: dict[str, LocalizedFields] = {}
@@ -449,34 +455,36 @@ def _combine_localized_segments(
         return None
 
     combined = LocalizedMetadata(by_locale)
-    return combined if force else existing.merge(combined)
+    return combined if policy.overwrites else existing.merge(combined)
 
 
 def _apply_episode_metadata(
-    episode: Episode, meta: EpisodeMetadata, *, force: bool = False
+    episode: Episode, meta: EpisodeMetadata, *, policy: MergePolicy = MergePolicy.FILL_IF_EMPTY
 ) -> Episode:
     """Apply metadata from a single TMDB episode.
 
     Each field is fill-if-empty by default (and the title only replaces
-    a generic scanner ``Episode N`` placeholder). ``force`` (a relink)
-    bypasses both guards so a wrong match's episode data is replaced.
+    a generic scanner ``Episode N`` placeholder). ``MergePolicy.OVERWRITE``
+    (a relink) bypasses both guards so a wrong match's episode data is replaced.
     """
     updates: dict[str, object] = {}
 
-    if meta.title and (force or episode.title.value.startswith("Episode ")):
+    if meta.title and (
+        policy.overwrites or episode.title.value.startswith("Episode ")
+    ):
         updates["title"] = Title(meta.title)
-    if meta.synopsis and (force or not episode.synopsis):
+    if meta.synopsis and policy.should_write(episode.synopsis):
         updates["synopsis"] = meta.synopsis
-    if meta.air_date and (force or not episode.air_date):
+    if meta.air_date and policy.should_write(episode.air_date):
         parsed = _parse_date(meta.air_date)
         if parsed:
             updates["air_date"] = AirDate(parsed)
     # Fallback only — real duration comes from the file probe at scan time.
     if meta.duration_seconds and episode.duration.value == 0:
         updates["duration"] = Duration(meta.duration_seconds)
-    if meta.still_url and (force or not episode.thumbnail_path):
+    if meta.still_url and policy.should_write(episode.thumbnail_path):
         updates["thumbnail_path"] = ImageUrl(meta.still_url)
-    episode_localized = merge_text_localized(episode.localized, meta.localized, force=force)
+    episode_localized = merge_text_localized(episode.localized, meta.localized, policy=policy)
     if episode_localized is not None:
         updates["localized"] = episode_localized
 

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -20,6 +20,7 @@ from src.modules.media.domain.value_objects.localized_metadata import (
 )
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
 from src.modules.media.domain.value_objects.media_file import MediaFile
+from src.modules.media.domain.value_objects.merge_policy import MergePolicy
 from src.modules.media.domain.value_objects.resolution import Resolution
 from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
 from src.modules.media.domain.value_objects.season_number import SeasonNumber
@@ -65,6 +66,7 @@ __all__ = [
     "MediaConflictId",
     "MediaFile",
     "MediaId",
+    "MergePolicy",
     "MovieId",
     "Resolution",
     "ScanRunId",

--- a/src/modules/media/domain/value_objects/merge_policy.py
+++ b/src/modules/media/domain/value_objects/merge_policy.py
@@ -1,0 +1,49 @@
+"""Policy for reconciling provider metadata with stored entity values."""
+
+from enum import StrEnum
+
+
+class MergePolicy(StrEnum):
+    """How an enrichment pass reconciles provider data with stored values.
+
+    ``FILL_IF_EMPTY``: routine re-enrich — only write a field the entity
+    left empty, protecting prior user/enrich edits.
+    ``OVERWRITE``: relink / forced refresh — replace stored values with the
+    newly-matched provider data.
+
+    Example:
+        >>> MergePolicy.FILL_IF_EMPTY.should_write("kept")
+        False
+        >>> MergePolicy.OVERWRITE.should_write("replaced")
+        True
+    """
+
+    FILL_IF_EMPTY = "fill_if_empty"
+    OVERWRITE = "overwrite"
+
+    @classmethod
+    def from_force(cls, force: bool) -> "MergePolicy":
+        """Bridge the public ``force`` flag (``EnrichMediaInput``) to a policy."""
+        return cls.OVERWRITE if force else cls.FILL_IF_EMPTY
+
+    def should_write(self, current: object) -> bool:
+        """Return ``True`` when a provider value should be written over *current*.
+
+        Always under ``OVERWRITE``; only when *current* is empty/falsy under
+        ``FILL_IF_EMPTY``. Replaces the old ``(force or not current)`` guard.
+        """
+        return self is MergePolicy.OVERWRITE or not current
+
+    @property
+    def overwrites(self) -> bool:
+        """Whether stored values are replaced regardless of emptiness.
+
+        For the custom guards that aren't plain fill-if-empty (clearing a
+        stale field, replacing a placeholder/combined title, replace-vs-merge
+        of localized overrides), so they read in intent terms and keep all
+        policy semantics on the value object.
+        """
+        return self is MergePolicy.OVERWRITE
+
+
+__all__ = ["MergePolicy"]

--- a/tests/modules/media/unit/domain/value_objects/test_merge_policy.py
+++ b/tests/modules/media/unit/domain/value_objects/test_merge_policy.py
@@ -1,0 +1,32 @@
+"""Tests for the MergePolicy value object."""
+
+import pytest
+
+from src.modules.media.domain.value_objects.merge_policy import MergePolicy
+
+
+@pytest.mark.unit
+class TestMergePolicy:
+    """The policy centralizes the fill-if-empty vs overwrite rule."""
+
+    def test_fill_if_empty_writes_only_when_current_is_empty(self) -> None:
+        policy = MergePolicy.FILL_IF_EMPTY
+        assert policy.should_write(None) is True
+        assert policy.should_write("") is True
+        assert policy.should_write([]) is True
+        assert policy.should_write("existing") is False
+        assert policy.should_write(["x"]) is False
+
+    def test_overwrite_always_writes(self) -> None:
+        policy = MergePolicy.OVERWRITE
+        assert policy.should_write(None) is True
+        assert policy.should_write("existing") is True
+        assert policy.should_write(["x"]) is True
+
+    def test_from_force_maps_the_public_flag(self) -> None:
+        assert MergePolicy.from_force(force=True) is MergePolicy.OVERWRITE
+        assert MergePolicy.from_force(force=False) is MergePolicy.FILL_IF_EMPTY
+
+    def test_overwrites_is_true_only_for_overwrite(self) -> None:
+        assert MergePolicy.OVERWRITE.overwrites is True
+        assert MergePolicy.FILL_IF_EMPTY.overwrites is False


### PR DESCRIPTION
## Summary

Phase 4 / PR-4.4 (Tema E + the Tema-F boolean-blindness item). The provider⇄entity merge rule `if meta.X and (force or not entity.Y): updates[...] = convert(...)` was copy-pasted ~23× across the movie/series/season/episode enrich paths, and a `force: bool` was threaded through ~12 functions (boolean blindness — every call site had to re-reason what `force=True` meant).

- New **`MergePolicy`** value object (domain): `FILL_IF_EMPTY` | `OVERWRITE`, with `should_write(current)` (the extracted "fill-if-empty vs overwrite" rule, in one place) and `from_force(bool)` bridging the still-public `EnrichMediaInput.force` at the two entry points.
- `force: bool` → `policy: MergePolicy` threaded through all enrich helpers + the localized merge helpers; the ~23× guard → `policy.should_write(X)`.
- The 5 non-standard guards mapped by meaning (stale `end_year` clear, multi-episode title combine, localized combine replace, episode-title placeholder → `policy is OVERWRITE or <heuristic>`); the 3 duration guards (`… == 0`, never overwritten even on force) left untouched.

A standalone *domain* `MetadataReconciler` service isn't cleanly layerable (the merge bridges the application provider-DTO to the entity, so it stays in application); `MergePolicy` is the extracted rule it would have owned.

No behavior change.

## Test plan

- [x] New `test_merge_policy.py` (`should_write` both members, `from_force`)
- [x] Existing force/relink, duration-never-overwritten, episode-title-placeholder, and localized replace-vs-merge tests validate OVERWRITE vs FILL_IF_EMPTY end-to-end unchanged (their `force=` is on the public `EnrichMediaInput`/`run_bulk_enrich`, untouched)
- [x] `pytest tests/modules/{media,collections,catalog_requests,watch_progress}` → 2078 passed, 5 skipped
- [x] `ruff check`/`format` + `mypy` clean on touched files; `force` gone from enrich internals (only the public-flag reads remain)