### PR TITLE
refactor(media): single validated path for marker persistence [audit 6.6]

### DIFF
--- a/src/modules/media/application/use_cases/set_credits_marker.py
+++ b/src/modules/media/application/use_cases/set_credits_marker.py
@@ -64,12 +64,14 @@ class SetCreditsMarkerUseCase:
             if entity is None:
                 raise ResourceNotFoundException.for_resource("CreditableMedia", input_dto.media_id)
 
-            # Enforce the duration-bound invariant on the entity; the
-            # returned copy is discarded — persistence uses the direct
-            # column update so the parent aggregate stays untouched.
-            entity.with_credits_marker(marker)
+            # Persist from the validated copy (entity.credits) so the write
+            # depends on with_credits_marker having run — validation and write
+            # are one path, not two. Direct column update (aggregate untouched).
+            entity = entity.with_credits_marker(marker)
 
-            await update_creditable_credits(uow, media_id, marker, CreditsDetectionState.COMPLETED)
+            await update_creditable_credits(
+                uow, media_id, entity.credits, CreditsDetectionState.COMPLETED
+            )
 
         return credits_marker_to_output(marker)
 

--- a/src/modules/media/application/use_cases/set_episode_intro.py
+++ b/src/modules/media/application/use_cases/set_episode_intro.py
@@ -80,13 +80,12 @@ class SetEpisodeIntroUseCase:
             if episode is None:
                 raise ResourceNotFoundException.for_resource("Episode", input_dto.episode_id)
 
-            # Trigger the duration-bound check on the entity. The
-            # returned instance is discarded — persistence goes through
-            # the direct-update path so the parent Series aggregate
-            # stays untouched.
-            episode.with_intro_marker(marker)
+            # Persist from the validated copy (episode.intro) so the write
+            # depends on with_intro_marker having run — validation and write
+            # are one path, not two. Direct column update (Series untouched).
+            episode = episode.with_intro_marker(marker)
 
-            await uow.series.update_episode_intro(episode_id, marker)
+            await uow.series.update_episode_intro(episode_id, episode.intro)
             series_id = episode.series_id
 
         if self._event_bus is not None:


### PR DESCRIPTION
## Summary

Phase 6 / PR-6.6 (code-smell: temporal coupling). `SetEpisodeIntroUseCase` / `SetCreditsMarkerUseCase` called `with_intro_marker` / `with_credits_marker` **only** to trigger the duration-bound invariant, **discarded** the returned validated copy, then persisted the **raw** marker through a separate column update. Validation and persistence were two independent calls — if a future edit dropped the validation line, an out-of-range marker would persist silently.

Fix: reassign to the validated copy and persist the marker **from it** (`episode.intro` / `entity.credits`), making validation and the write one data-dependent path (the write consumes the validation's output; removing the check now breaks the persisted value, which the happy-path tests catch). Repo signature unchanged (other callers pass `None` for clear/reset).

## Test plan

- [x] Existing invariant tests still pass (`test_raises_when_intro_exceeds_duration`, `test_rejects_onset_beyond_duration`)
- [x] `pytest tests/modules/media` → 1691 passed, 5 skipped
- [x] `ruff check` clean; behavior unchanged (the persisted marker equals the input marker as before)