### PR TITLE
fix(media): scanner resilient to per-entry errors [audit Card C]

### DIFF
--- a/src/modules/media/infrastructure/file_system/scanner.py
+++ b/src/modules/media/infrastructure/file_system/scanner.py
@@ -136,6 +136,65 @@ def _find_series_name(file_path: str) -> str:
     return "Unknown Series"
 
 
+def _scanned_file(path: Path) -> ScannedFile | None:
+    """Build a ``ScannedFile`` from *path*, or ``None`` if it isn't media.
+
+    A dangling media-named symlink is logged and skipped (returns ``None``).
+
+    Args:
+        path: A filesystem entry yielded while walking a scan root.
+
+    Returns:
+        The parsed ``ScannedFile``, or ``None`` for directories, non-media
+        files, and broken media symlinks.
+
+    Raises:
+        OSError: If the entry is unreadable (vanished mid-scan, flaky mount,
+            permission error). The caller skips it without aborting the scan.
+    """
+    if not path.is_file():
+        # A dangling symlink to unmounted storage resolves to not-a-file and
+        # would be lost silently; surface it when it looks like media by name.
+        if path.is_symlink() and path.suffix.lower() in _SUPPORTED_EXTENSIONS:
+            _logger.warning(
+                "Skipping broken media symlink (target missing or unmounted): %s",
+                path,
+            )
+        return None
+
+    if path.suffix.lower() not in _SUPPORTED_EXTENSIONS:
+        return None
+
+    full_path = str(path)
+    file_size = path.stat().st_size
+    resolution = _extract_resolution(path.name)
+    episode_info = _detect_episode(full_path)
+
+    if episode_info:
+        series_name, season_num, episode_num = episode_info
+        return ScannedFile(
+            file_path=FilePath(full_path),
+            file_size=file_size,
+            media_type=MediaType.EPISODE,
+            title=series_name,
+            resolution=resolution,
+            series_name=series_name,
+            season_number=season_num,
+            episode_number=episode_num,
+            episode_title=_extract_episode_title(path.name),
+        )
+
+    year = _extract_year(path.name)
+    return ScannedFile(
+        file_path=FilePath(full_path),
+        file_size=file_size,
+        media_type=MediaType.MOVIE,
+        title=_extract_title(path.name, year),
+        year=year,
+        resolution=resolution,
+    )
+
+
 class LocalFileSystemScanner(FileSystemScanner):
     """Scan local directories for media files.
 
@@ -157,6 +216,7 @@ class LocalFileSystemScanner(FileSystemScanner):
             List of discovered media files with parsed metadata.
         """
         results: list[ScannedFile] = []
+        io_error_skips = 0
 
         for directory in directories:
             dir_path = Path(directory.value)
@@ -174,47 +234,47 @@ class LocalFileSystemScanner(FileSystemScanner):
                 )
                 continue
 
-            for path in dir_path.rglob("*"):
-                if not path.is_file():
+            walker = dir_path.rglob("*")
+            while True:
+                try:
+                    path = next(walker)
+                except StopIteration:
+                    break
+                except OSError as exc:
+                    # A directory became unreadable mid-walk. rglob's generator
+                    # can't resume after raising, so the rest of THIS root is
+                    # abandoned — but other roots still scan, instead of the
+                    # whole multi-root scan aborting.
+                    io_error_skips += 1
+                    _logger.warning("Scan walk aborted under %s: %s", dir_path, exc)
+                    break
+
+                try:
+                    scanned = _scanned_file(path)
+                except OSError as exc:
+                    # An unreadable entry (permission/IO error, or a file that
+                    # vanished between the is_file check and stat) must not abort
+                    # the whole multi-root scan — skip just this one. (A plain
+                    # ENOENT is absorbed by is_file() and skipped silently as a
+                    # non-file, which is fine.)
+                    io_error_skips += 1
+                    _logger.warning("Skipping unreadable scan entry %s: %s", path, exc)
                     continue
 
-                if path.suffix.lower() not in _SUPPORTED_EXTENSIONS:
-                    continue
+                if scanned is not None:
+                    results.append(scanned)
 
-                full_path = str(path)
-                file_size = path.stat().st_size
-                resolution = _extract_resolution(path.name)
-                episode_info = _detect_episode(full_path)
-
-                if episode_info:
-                    series_name, season_num, episode_num = episode_info
-                    ep_title = _extract_episode_title(path.name)
-                    results.append(
-                        ScannedFile(
-                            file_path=FilePath(full_path),
-                            file_size=file_size,
-                            media_type=MediaType.EPISODE,
-                            title=series_name,
-                            resolution=resolution,
-                            series_name=series_name,
-                            season_number=season_num,
-                            episode_number=episode_num,
-                            episode_title=ep_title,
-                        ),
-                    )
-                else:
-                    year = _extract_year(path.name)
-                    title = _extract_title(path.name, year)
-                    results.append(
-                        ScannedFile(
-                            file_path=FilePath(full_path),
-                            file_size=file_size,
-                            media_type=MediaType.MOVIE,
-                            title=title,
-                            year=year,
-                            resolution=resolution,
-                        ),
-                    )
+        if io_error_skips:
+            # One greppable line summarising a lossy scan, so a partially-flaky
+            # mount (root readable but N entries failing) is distinguishable
+            # from a genuinely empty/deleted catalog, not just N scattered
+            # warnings. Downstream must not treat the absent files as deleted.
+            _logger.error(
+                "Scan finished with %d entr%s skipped due to IO errors; results "
+                "may be incomplete — do not treat missing files as deleted.",
+                io_error_skips,
+                "y" if io_error_skips == 1 else "ies",
+            )
 
         return results
 

--- a/tests/modules/media/unit/infrastructure/file_system/test_scanner.py
+++ b/tests/modules/media/unit/infrastructure/file_system/test_scanner.py
@@ -61,6 +61,91 @@ class TestScanDirectories:
         assert results == []
         assert "missing or unmounted" in caplog.text
 
+    def test_should_skip_entry_that_errors_mid_scan_without_aborting(
+        self,
+        scanner: LocalFileSystemScanner,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A file that becomes unreadable mid-scan (TOCTOU / flaky mount) must
+        # not abort the whole scan — the other files are still discovered.
+        _create_file(tmp_path, "Good.2020.mkv")
+        _create_file(tmp_path, "Bad.2021.mkv")
+        real_stat = Path.stat
+
+        def flaky_stat(self: Path, *args: object, **kwargs: object) -> object:
+            if self.name == "Bad.2021.mkv":
+                # Errno-less so is_file() re-raises it (a plain ENOENT would be
+                # absorbed by pathlib and skipped silently as a non-file).
+                raise OSError("vanished mid-scan")
+            return real_stat(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "stat", flaky_stat)
+
+        with caplog.at_level(logging.WARNING):
+            results = scanner.scan_directories([FilePath(str(tmp_path))])
+
+        assert {r.title for r in results} == {"Good"}
+        assert "unreadable scan entry" in caplog.text
+        # A lossy scan is summarised once so it's greppable, not just N warnings.
+        assert "may be incomplete" in caplog.text
+
+    def test_should_continue_other_roots_when_a_walk_errors(
+        self,
+        scanner: LocalFileSystemScanner,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A directory going unreadable mid-walk must abort only that root, not
+        # the whole multi-root scan.
+        root_a = tmp_path / "a"
+        root_a.mkdir()
+        root_b = tmp_path / "b"
+        root_b.mkdir()
+        _create_file(root_b, "FromRootB.2021.mkv")
+        real_rglob = Path.rglob
+
+        def flaky_rglob(self: Path, pattern: str, *args: object, **kwargs: object) -> object:
+            if self.name == "a":
+
+                def _raises_on_walk() -> object:
+                    raise OSError("directory vanished mid-walk")
+                    yield  # pragma: no cover - only makes this a generator
+
+                return _raises_on_walk()
+            return real_rglob(self, pattern, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "rglob", flaky_rglob)
+
+        with caplog.at_level(logging.WARNING):
+            results = scanner.scan_directories(
+                [FilePath(str(root_a)), FilePath(str(root_b))]
+            )
+
+        assert {r.title for r in results} == {"FromRootB"}
+        assert "walk aborted" in caplog.text
+        assert "may be incomplete" in caplog.text
+
+    def test_should_skip_and_warn_on_broken_media_symlink(
+        self,
+        scanner: LocalFileSystemScanner,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # A dangling symlink to unmounted storage looks like media by name but
+        # resolves to not-a-file; it's excluded but the skip is logged.
+        _create_file(tmp_path, "Real.2020.mkv")
+        broken = tmp_path / "Broken.2021.mkv"
+        broken.symlink_to(tmp_path / "nonexistent_target.mkv")
+
+        with caplog.at_level(logging.WARNING):
+            results = scanner.scan_directories([FilePath(str(tmp_path))])
+
+        assert {r.title for r in results} == {"Real"}
+        assert "broken media symlink" in caplog.text
+
     def test_should_filter_unsupported_extensions(
         self, scanner: LocalFileSystemScanner, media_dir: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Phase 6 / Card C (follow-up surfaced by the #330 review). Two per-file resilience gaps in `LocalFileSystemScanner.scan_directories`:

- **`path.stat().st_size` had no guard** — a file that vanishes mid-scan (TOCTOU / flaky network mount) raised `OSError` and **aborted the entire multi-root scan** (every root, not just the affected file).
- **A dangling media symlink** (target unmounted) resolved to not-a-file and was skipped **silently**.

Fix: wrap the per-file IO (`is_file`/`suffix`/`stat`) in `try/except OSError` so a single bad entry is skipped and logged instead of failing the whole scan, and surface broken media symlinks with a warning.

> Deferred (non-blocking): exposing `skipped_roots` structurally on `ScanMediaOutput` (the reconcile/delete path is already guarded by `LibraryHealthPort`; left as a separate card).

## Test plan

- [x] `test_should_skip_entry_that_errors_mid_scan_without_aborting` (stat raises for one file → others still scanned + warning)
- [x] `test_should_skip_and_warn_on_broken_media_symlink` (dangling symlink excluded + warning)
- [x] `pytest tests/modules/media` → 1693 passed, 5 skipped
- [x] `ruff check` clean