### PR TITLE
refactor(building_blocks): move pagination contract to domain layer

### DIFF
--- a/src/building_blocks/application/pagination.py
+++ b/src/building_blocks/application/pagination.py
@@ -29,6 +29,12 @@ point instead of a 400 in the middle of an infinite scroll.
 This building block is intentionally tiny and framework-agnostic so
 both the application layer (DTOs, use cases) and the infrastructure
 layer (SQLAlchemy queries) can share the same shapes.
+
+The repository pagination *contract* (``Pagination`` and
+``PaginatedResult``) lives in ``building_blocks/domain/pagination.py``
+so domain repository interfaces can declare it without depending on the
+application layer; this module holds the cursor codec and the ``limit``
+clamping constants that drive those repositories.
 """
 
 from __future__ import annotations
@@ -36,9 +42,6 @@ from __future__ import annotations
 import base64
 import binascii
 from dataclasses import dataclass
-from typing import Generic, TypeVar
-
-T = TypeVar("T")
 
 # Default and clamp values for the `limit` query param. Routes typically
 # expose `limit` as an int and clamp to ``[1, MAX_PAGE_SIZE]`` before
@@ -84,48 +87,6 @@ class DualCursorValue:
 
     movies: str | None
     series: str | None
-
-
-@dataclass(frozen=True)
-class Pagination:
-    """Pagination metadata returned alongside a page of items.
-
-    Attributes:
-        next_cursor: Opaque token to pass back as `cursor` on the next
-            request. ``None`` when there are no more pages.
-        has_more: Convenience flag — equivalent to ``next_cursor is not
-            None`` but explicit so clients don't have to infer it.
-    """
-
-    next_cursor: str | None
-    has_more: bool
-
-
-@dataclass(frozen=True)
-class PaginatedResult(Generic[T]):
-    """A page of results with its pagination metadata.
-
-    Attributes:
-        items: The page's items.
-        pagination: ``Pagination`` for ``next_cursor`` / ``has_more``.
-        total_count: Total rows matching the query, or ``None`` when
-            the caller did not request it. Computing the total requires
-            an extra ``COUNT(*)`` query, so it's opt-in.
-        item_cursors: Parallel to ``items`` — cursor that resumes
-            strictly after that item. Populated only by repository
-            methods whose consumers need to advance through a partial
-            prefix of the page (e.g. the catalog "by genre" listing,
-            which fetches movies and series in parallel and may use
-            only some items from each before the merged page is full).
-            For straight-through consumers that always exhaust the
-            whole page, ``pagination.next_cursor`` is enough and this
-            field stays ``None``.
-    """
-
-    items: list[T]
-    pagination: Pagination
-    total_count: int | None = None
-    item_cursors: list[str] | None = None
 
 
 def encode_cursor(internal_id: int) -> str:
@@ -266,8 +227,6 @@ __all__ = [
     "MAX_PAGE_SIZE",
     "CursorValue",
     "DualCursorValue",
-    "Pagination",
-    "PaginatedResult",
     "TitleCursorValue",
     "decode_cursor",
     "decode_dual_cursor",

--- a/src/building_blocks/domain/pagination.py
+++ b/src/building_blocks/domain/pagination.py
@@ -1,0 +1,69 @@
+"""Repository pagination contract shapes.
+
+These are the return types of paginated repository methods, so they
+belong in the domain layer alongside the repository interfaces that
+declare them — a domain port must not depend on an application-layer
+type for its own signature.
+
+``Pagination`` and ``PaginatedResult`` are pure data shapes with no
+knowledge of how a cursor is encoded; the opaque-token codec and the
+``limit`` clamping constants live in
+``building_blocks/application/pagination.py`` because they are
+mechanisms consumed by the application, infrastructure, and
+presentation layers — not part of the domain contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class Pagination:
+    """Pagination metadata returned alongside a page of items.
+
+    Attributes:
+        next_cursor: Opaque token to pass back as `cursor` on the next
+            request. ``None`` when there are no more pages.
+        has_more: Convenience flag — equivalent to ``next_cursor is not
+            None`` but explicit so clients don't have to infer it.
+    """
+
+    next_cursor: str | None
+    has_more: bool
+
+
+@dataclass(frozen=True)
+class PaginatedResult(Generic[T]):
+    """A page of results with its pagination metadata.
+
+    Attributes:
+        items: The page's items.
+        pagination: ``Pagination`` for ``next_cursor`` / ``has_more``.
+        total_count: Total rows matching the query, or ``None`` when
+            the caller did not request it. Computing the total requires
+            an extra ``COUNT(*)`` query, so it's opt-in.
+        item_cursors: Parallel to ``items`` — cursor that resumes
+            strictly after that item. Populated only by repository
+            methods whose consumers need to advance through a partial
+            prefix of the page (e.g. the catalog "by genre" listing,
+            which fetches movies and series in parallel and may use
+            only some items from each before the merged page is full).
+            For straight-through consumers that always exhaust the
+            whole page, ``pagination.next_cursor`` is enough and this
+            field stays ``None``.
+    """
+
+    items: list[T]
+    pagination: Pagination
+    total_count: int | None = None
+    item_cursors: list[str] | None = None
+
+
+__all__ = [
+    "PaginatedResult",
+    "Pagination",
+]

--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -7,11 +7,10 @@ from typing import TypeVar
 
 from src.building_blocks.application.pagination import (
     DualCursorValue,
-    PaginatedResult,
-    Pagination,
     decode_dual_cursor,
     encode_dual_cursor,
 )
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.application.dtos.catalog_dtos import (
     CatalogItemOutput,
     ListByGenreInput,

--- a/src/modules/media/domain/repositories/media_conflict_repository.py
+++ b/src/modules/media/domain/repositories/media_conflict_repository.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from src.building_blocks.application.pagination import PaginatedResult
+from src.building_blocks.domain.pagination import PaginatedResult
 from src.modules.media.domain.entities.media_conflict import (
     MediaConflict,
     ResolutionSource,

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from src.building_blocks.application.pagination import PaginatedResult
+from src.building_blocks.domain.pagination import PaginatedResult
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.value_objects import (
     CreditsDetectionState,

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from datetime import datetime
 
-from src.building_blocks.application.pagination import PaginatedResult
+from src.building_blocks.domain.pagination import PaginatedResult
 from src.modules.media.domain.entities.episode import Episode
 from src.modules.media.domain.entities.season import Season
 from src.modules.media.domain.entities.series import Series

--- a/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
@@ -29,11 +29,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.strategy_options import _AbstractLoad
 
 from src.building_blocks.application.pagination import (
-    PaginatedResult,
-    Pagination,
     decode_title_cursor,
     encode_title_cursor,
 )
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.repositories.movie_repository import GenreRow
 from src.modules.media.domain.value_objects import Genre, LocalizedField
 from src.shared_kernel.value_objects.library_id import LibraryId

--- a/src/modules/media/infrastructure/persistence/repositories/media_conflict_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/media_conflict_repository.py
@@ -4,11 +4,10 @@ from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.building_blocks.application.pagination import (
-    PaginatedResult,
-    Pagination,
     decode_cursor,
     encode_cursor,
 )
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.entities.media_conflict import (
     MediaConflict,
     ResolutionAction,

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -8,13 +8,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.building_blocks.application.pagination import (
-    PaginatedResult,
-    Pagination,
     decode_cursor,
     decode_title_cursor,
     encode_cursor,
     encode_title_cursor,
 )
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
 from src.modules.media.domain.repositories.movie_repository import CreditsStatusRow, GenreRow

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -9,11 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.building_blocks.application.pagination import (
-    PaginatedResult,
-    Pagination,
     decode_cursor,
     encode_cursor,
 )
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
 from src.modules.media.domain.repositories.movie_repository import CreditsStatusRow, GenreRow

--- a/tests/building_blocks/unit/application/test_pagination.py
+++ b/tests/building_blocks/unit/application/test_pagination.py
@@ -9,8 +9,6 @@ from src.building_blocks.application.pagination import (
     MAX_PAGE_SIZE,
     CursorValue,
     DualCursorValue,
-    PaginatedResult,
-    Pagination,
     TitleCursorValue,
     decode_cursor,
     decode_dual_cursor,
@@ -19,6 +17,7 @@ from src.building_blocks.application.pagination import (
     encode_dual_cursor,
     encode_title_cursor,
 )
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
@@ -3,11 +3,8 @@
 
 import pytest
 
-from src.building_blocks.application.pagination import (
-    PaginatedResult,
-    Pagination,
-    decode_dual_cursor,
-)
+from src.building_blocks.application.pagination import decode_dual_cursor
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.application.dtos.catalog_dtos import (
     CatalogItemOutput,
     ListByGenreInput,

--- a/tests/modules/media/unit/application/use_cases/test_list_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_conflicts.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from src.building_blocks.application.pagination import PaginatedResult, Pagination
 from src.building_blocks.domain.errors import DomainValidationException
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.application.dtos.conflict_dtos import ListConflictsInput
 from src.modules.media.application.use_cases.list_conflicts import ListConflictsUseCase
 from src.modules.media.domain.entities.media_conflict import (

--- a/tests/modules/media/unit/application/use_cases/test_list_movies.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.building_blocks.application.pagination import PaginatedResult, Pagination
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.application.dtos import ListMoviesInput, ListMoviesOutput, MovieSummaryOutput
 from src.modules.media.application.use_cases import ListMoviesUseCase
 from src.modules.media.domain.entities import Movie

--- a/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_movies_by_actor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.building_blocks.application.pagination import PaginatedResult, Pagination
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.application.use_cases.list_movies_by_actor import (
     ListMoviesByActorInput,
     ListMoviesByActorOutput,

--- a/tests/modules/media/unit/application/use_cases/test_list_series.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_series.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from src.building_blocks.application.pagination import PaginatedResult, Pagination
+from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.application.dtos import (
     ListSeriesInput,
     ListSeriesOutput,


### PR DESCRIPTION
## Summary
- Move the repository pagination **contract** (`Pagination`, `PaginatedResult`) from `building_blocks/application/pagination.py` into a new `building_blocks/domain/pagination.py`, so domain repository interfaces declare their own return type without depending on the application layer (fixes the inverted `domain → application` dependency).
- Keep the cursor codec (`encode/decode_*`, `CursorValue`, `TitleCursorValue`, `DualCursorValue`) and the `DEFAULT_PAGE_SIZE` / `MAX_PAGE_SIZE` clamping constants in the application module — they are mechanisms consumed by application/infrastructure/presentation, not part of the domain contract.
- Repoint all consumers (3 domain repos, 3 infra repos + `_genre_helpers`, `list_by_genre` use case, and the affected tests). Files that need both the contract and a cursor codec now import each from its proper home.

Implements backlog item **6.1** (`docs/audits/07-phase6-backlog.md`); addresses clean-arch findings **M-4** (conf 0.85) and **B-11** (conf 0.6).

### Note on the "domain exception bases" half of the card
B-11 also suggested moving "domain exception bases" to `building_blocks/domain`. On inspection the domain exception bases already live in `building_blocks/domain/errors.py`; what `identity/domain/errors.py` imports from `application/errors.py` (`ResourceNotFoundException`, `ForbiddenOperationException`, …) are genuinely **application** exceptions. Moving those into the domain layer would miscategorize them, so this PR scopes to the unambiguous pagination move.

## Test plan
- [x] `ruff check src/ tests/` clean; `ruff format` applied (unrelated pre-existing drift reverted)
- [x] `pytest tests/building_blocks/ tests/modules/media/` — 2036 passed, 5 skipped
- [x] Verified no remaining `Pagination`/`PaginatedResult` imports from `application.pagination`

## Summary by Sourcery

Move pagination result types into the domain layer and update media repositories, use cases, and tests to reference the new contract location.

Enhancements:
- Relocate Pagination and PaginatedResult data shapes from the application pagination module into a new domain pagination module to align repository contracts with the domain layer.
- Adjust media domain and infrastructure repositories and application use cases to import pagination contracts from the domain module while keeping cursor encoding and limit clamping in the application layer.

Tests:
- Update pagination and media listing tests to use the domain pagination contract and ensure behavior remains unchanged.