### PR TITLE
chore(media): fix ruff formatter drift

### DIFF
--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -469,9 +469,7 @@ def _apply_episode_metadata(
     """
     updates: dict[str, object] = {}
 
-    if meta.title and (
-        policy.overwrites or episode.title.value.startswith("Episode ")
-    ):
+    if meta.title and (policy.overwrites or episode.title.value.startswith("Episode ")):
         updates["title"] = Title(meta.title)
     if meta.synopsis and policy.should_write(episode.synopsis):
         updates["synopsis"] = meta.synopsis

--- a/tests/modules/media/unit/infrastructure/file_system/test_scanner.py
+++ b/tests/modules/media/unit/infrastructure/file_system/test_scanner.py
@@ -120,9 +120,7 @@ class TestScanDirectories:
         monkeypatch.setattr(Path, "rglob", flaky_rglob)
 
         with caplog.at_level(logging.WARNING):
-            results = scanner.scan_directories(
-                [FilePath(str(root_a)), FilePath(str(root_b))]
-            )
+            results = scanner.scan_directories([FilePath(str(root_a)), FilePath(str(root_b))])
 
         assert {r.title for r in results} == {"FromRootB"}
         assert "walk aborted" in caplog.text


### PR DESCRIPTION
## Summary
- Run `ruff format` on two files whose formatting drifted: `enrich_series_metadata.py` (from #331) and `test_scanner.py` (from #333). In both, a line that previously wrapped now fits within the line length, so `ruff format --check` wants to collapse it.
- These are formatter-only failures that slipped past `ruff check` and left the **develop CI Lint gate red on the last 3 merges** (#332/#333/#334). This restores a green gate so subsequent PRs don't inherit the failure.

No behavior change — purely cosmetic line reflow.

## Test plan
- [x] `ruff format --check src tests` → all 1120 files already formatted
- [x] `ruff check src tests` → clean

## Summary by Sourcery

Restore CI lint gate by reformatting two media-related files to satisfy the current Ruff formatting rules.

Enhancements:
- Apply Ruff formatting to enrich_series_metadata episode title logic to eliminate formatter drift.
- Apply Ruff formatting to media file system scanner tests to align with updated style expectations.

Tests:
- Update media file system scanner test code formatting to pass Ruff format checks.