### PR TITLE
refactor(media): bundle conflict candidate id+type into a ConflictCandidate VO

### DIFF
--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -16,7 +16,7 @@ from src.modules.media.domain.entities.media_conflict import (
     ResolutionSource,
 )
 from src.modules.media.domain.events import MediaConflictDetectedEvent
-from src.modules.media.domain.value_objects import MovieId
+from src.modules.media.domain.value_objects import ConflictCandidate, MovieId
 from src.shared_kernel.integration_events import MovieMergedEvent
 from src.shared_kernel.value_objects.media_type import MediaType
 
@@ -225,11 +225,9 @@ class DetectMovieConflictsUseCase:
     ) -> tuple[MediaConflict, MediaConflictDetectedEvent]:
         """Persist a pending conflict for the pair and build its event."""
         conflict = MediaConflict.detect(
-            candidate_a_id=self_id,
-            candidate_a_type=MediaType.MOVIE,
+            candidate_a=ConflictCandidate(id=self_id, type=MediaType.MOVIE),
             candidate_a_runtime_minutes=self_runtime,
-            candidate_b_id=str(other.id),
-            candidate_b_type=MediaType.MOVIE,
+            candidate_b=ConflictCandidate(id=str(other.id), type=MediaType.MOVIE),
             candidate_b_runtime_minutes=_runtime_minutes(other),
             match_reason=match_reason,
             abs_threshold_minutes=abs_threshold,
@@ -238,8 +236,8 @@ class DetectMovieConflictsUseCase:
         persisted = await uow.media_conflicts.save(conflict)  # type: ignore[attr-defined]
         event = MediaConflictDetectedEvent(
             conflict_id=str(persisted.id),
-            candidate_a_id=MovieId(persisted.candidate_a_id),
-            candidate_b_id=MovieId(persisted.candidate_b_id),
+            candidate_a_id=MovieId(persisted.candidate_a.id),
+            candidate_b_id=MovieId(persisted.candidate_b.id),
             match_reason=persisted.match_reason.value,
             suggested_action=persisted.suggested_action.value,
         )
@@ -297,11 +295,9 @@ class DetectMovieConflictsUseCase:
         # module — the caller passes the live UoW from the same
         # ``async with`` block above.
         conflict = MediaConflict.detect(
-            candidate_a_id=str(self_movie.id),
-            candidate_a_type=MediaType.MOVIE,
+            candidate_a=ConflictCandidate(id=str(self_movie.id), type=MediaType.MOVIE),
             candidate_a_runtime_minutes=self_runtime,
-            candidate_b_id=str(orphan.id),
-            candidate_b_type=MediaType.MOVIE,
+            candidate_b=ConflictCandidate(id=str(orphan.id), type=MediaType.MOVIE),
             candidate_b_runtime_minutes=_runtime_minutes(orphan),
             match_reason=MatchReason.TMDB_ID,
         )

--- a/src/modules/media/application/use_cases/list_conflicts.py
+++ b/src/modules/media/application/use_cases/list_conflicts.py
@@ -22,7 +22,7 @@ from src.shared_kernel.value_objects.media_type import MediaType
 if TYPE_CHECKING:
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
     from src.modules.media.domain.entities.movie import Movie
-    from src.modules.media.domain.value_objects import MediaFile
+    from src.modules.media.domain.value_objects import ConflictCandidate, MediaFile
 
 _VALID_STATES = ("pending", "resolved")
 _VALID_SOURCES = ("manual", "auto")
@@ -115,14 +115,11 @@ def _collect_movie_ids(conflicts: list[MediaConflict]) -> list[MovieId]:
     seen: set[str] = set()
     out: list[MovieId] = []
     for c in conflicts:
-        for candidate_id, candidate_type in (
-            (c.candidate_a_id, c.candidate_a_type),
-            (c.candidate_b_id, c.candidate_b_type),
-        ):
-            if candidate_type is not MediaType.MOVIE or candidate_id in seen:
+        for candidate in (c.candidate_a, c.candidate_b):
+            if candidate.type is not MediaType.MOVIE or candidate.id in seen:
                 continue
-            seen.add(candidate_id)
-            out.append(MovieId(candidate_id))
+            seen.add(candidate.id)
+            out.append(MovieId(candidate.id))
     return out
 
 
@@ -133,16 +130,8 @@ def _build_summary(
     """Project a ``MediaConflict`` + looked-up candidate movies into the DTO."""
     return ConflictSummary(
         conflict_id=str(conflict.id),
-        candidate_a=_build_candidate(
-            conflict.candidate_a_id,
-            conflict.candidate_a_type,
-            movies_by_id,
-        ),
-        candidate_b=_build_candidate(
-            conflict.candidate_b_id,
-            conflict.candidate_b_type,
-            movies_by_id,
-        ),
+        candidate_a=_build_candidate(conflict.candidate_a, movies_by_id),
+        candidate_b=_build_candidate(conflict.candidate_b, movies_by_id),
         match_reason=conflict.match_reason.value,
         runtime_delta_minutes=conflict.runtime_delta_minutes,
         suggested_action=conflict.suggested_action.value,
@@ -157,24 +146,23 @@ def _build_summary(
 
 
 def _build_candidate(
-    media_id: str,
-    media_type: MediaType,
+    candidate: ConflictCandidate,
     movies_by_id: dict[str, Movie],
 ) -> ConflictCandidateSummary:
     """Hydrate one side of the pair with the looked-up movie (when present)."""
-    if media_type is MediaType.MOVIE:
-        movie = movies_by_id.get(media_id)
+    if candidate.type is MediaType.MOVIE:
+        movie = movies_by_id.get(candidate.id)
         if movie is not None:
             return ConflictCandidateSummary(
-                media_id=media_id,
-                media_type=media_type,
+                media_id=candidate.id,
+                media_type=candidate.type,
                 title=movie.title.value,
                 year=movie.year.value,
                 files=[_build_file(f) for f in movie.files],
             )
     return ConflictCandidateSummary(
-        media_id=media_id,
-        media_type=media_type,
+        media_id=candidate.id,
+        media_type=candidate.type,
         title=None,
         year=None,
         files=[],

--- a/src/modules/media/application/use_cases/resolve_media_conflict.py
+++ b/src/modules/media/application/use_cases/resolve_media_conflict.py
@@ -170,8 +170,8 @@ class ResolveMediaConflictUseCase:
 def _ensure_movie_pair(conflict: MediaConflict) -> None:
     """Reject cross-type conflicts the use case is not equipped to handle."""
     if (
-        conflict.candidate_a_type is not MediaType.MOVIE
-        or conflict.candidate_b_type is not MediaType.MOVIE
+        conflict.candidate_a.type is not MediaType.MOVIE
+        or conflict.candidate_b.type is not MediaType.MOVIE
     ):
         raise DomainValidationException(
             message="ResolveMediaConflictUseCase only handles movie-vs-movie conflicts",

--- a/src/modules/media/domain/entities/media_conflict.py
+++ b/src/modules/media/domain/entities/media_conflict.py
@@ -14,10 +14,10 @@ from src.building_blocks.domain.errors import (
     DomainValidationException,
 )
 from src.modules.media.domain.rule_codes import MediaRuleCodes
-from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
-from src.shared_kernel.value_objects.media_type import (
-    MediaType,  # noqa: TCH001 — runtime for Pydantic
+from src.modules.media.domain.value_objects.conflict_candidate import (
+    ConflictCandidate,  # noqa: TCH001 — runtime for Pydantic
 )
+from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
 
 
 class MatchReason(str, Enum):
@@ -75,10 +75,10 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
 
     Attributes:
         id: External id (``cnf_xxx``).
-        candidate_a_id: External id of one side (e.g. ``mov_xxx``).
-        candidate_a_type: ``"movie"`` (Phase 1) or ``"series"`` (later).
-        candidate_b_id: External id of the other side.
-        candidate_b_type: Same contract as ``candidate_a_type``.
+        candidate_a: One side of the pair — its external id (e.g.
+            ``mov_xxx``) and media-type discriminator (``"movie"`` in
+            Phase 1, ``"series"`` in a later phase).
+        candidate_b: The other side, same contract as ``candidate_a``.
         match_reason: Which identity rule fired.
         runtime_delta_minutes: Absolute difference between the two
             sides' runtimes, in minutes. ``None`` when one or both
@@ -108,10 +108,8 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
 
     id: MediaConflictId | None = Field(default=None)
 
-    candidate_a_id: str
-    candidate_a_type: MediaType
-    candidate_b_id: str
-    candidate_b_type: MediaType
+    candidate_a: ConflictCandidate
+    candidate_b: ConflictCandidate
 
     match_reason: MatchReason
     runtime_delta_minutes: float | None = None
@@ -125,8 +123,8 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
     @model_validator(mode="after")
     def _validate_candidates_distinct(self) -> Self:
         """Reject self-collisions (programmer error in the detector)."""
-        if self.candidate_a_id == self.candidate_b_id:
-            raise ValueError("candidate_a_id and candidate_b_id must differ")
+        if self.candidate_a.id == self.candidate_b.id:
+            raise ValueError("candidate_a and candidate_b must have different ids")
         return self
 
     @model_validator(mode="after")
@@ -153,7 +151,7 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
                 raise ValueError(
                     "winner_id is required for MERGE_KEEP_BOTH / MERGE_REPLACE resolutions",
                 )
-            if self.winner_id not in {self.candidate_a_id, self.candidate_b_id}:
+            if self.winner_id not in {self.candidate_a.id, self.candidate_b.id}:
                 raise ValueError("winner_id must be one of the conflict's candidates")
         elif self.winner_id is not None:
             raise ValueError("winner_id must be None for pending or MARK_DISTINCT rows")
@@ -181,11 +179,9 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
     def detect(
         cls,
         *,
-        candidate_a_id: str,
-        candidate_a_type: MediaType,
+        candidate_a: ConflictCandidate,
         candidate_a_runtime_minutes: float | None,
-        candidate_b_id: str,
-        candidate_b_type: MediaType,
+        candidate_b: ConflictCandidate,
         candidate_b_runtime_minutes: float | None,
         match_reason: MatchReason,
         abs_threshold_minutes: float | None = None,
@@ -198,12 +194,10 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         runtime-delta heuristic.
 
         Args:
-            candidate_a_id: External id of one side (e.g. ``mov_xxx``).
-            candidate_a_type: ``"movie"`` (Phase 1) or ``"series"``.
+            candidate_a: One side of the pair (external id + media type).
             candidate_a_runtime_minutes: Runtime of side A, in minutes,
                 or ``None`` when unknown.
-            candidate_b_id: External id of the other side.
-            candidate_b_type: Same contract as ``candidate_a_type``.
+            candidate_b: The other side, same contract as ``candidate_a``.
             candidate_b_runtime_minutes: Runtime of side B, in minutes,
                 or ``None`` when unknown.
             match_reason: Which identity rule fired the collision.
@@ -232,10 +226,8 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
             relative_threshold=relative_threshold,
         )
         return cls(
-            candidate_a_id=candidate_a_id,
-            candidate_a_type=candidate_a_type,
-            candidate_b_id=candidate_b_id,
-            candidate_b_type=candidate_b_type,
+            candidate_a=candidate_a,
+            candidate_b=candidate_b,
             match_reason=match_reason,
             runtime_delta_minutes=delta,
             suggested_action=action,
@@ -352,7 +344,7 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
                     message_code=MediaRuleCodes.MEDIA_CONFLICT_WINNER_REQUIRED,
                     object_type="MediaConflict",
                 )
-            if winner_id not in {self.candidate_a_id, self.candidate_b_id}:
+            if winner_id not in {self.candidate_a.id, self.candidate_b.id}:
                 raise DomainValidationException(
                     message="winner_id must be one of the conflict's candidates",
                     message_code=MediaRuleCodes.MEDIA_CONFLICT_WINNER_NOT_IN_PAIR,
@@ -384,7 +376,7 @@ class MediaConflict(AggregateRoot[MediaConflictId]):
         """For MERGE resolutions, the id of the soft-deleted side."""
         if self.winner_id is None:
             return None
-        return self.candidate_b_id if self.winner_id == self.candidate_a_id else self.candidate_a_id
+        return self.candidate_b.id if self.winner_id == self.candidate_a.id else self.candidate_a.id
 
 
 def _compute_runtime_delta(a: float | None, b: float | None) -> float | None:

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -3,6 +3,7 @@
 from src.modules.media.domain.value_objects.air_date import AirDate
 from src.modules.media.domain.value_objects.cast_member import CastMember
 from src.modules.media.domain.value_objects.collection import Collection
+from src.modules.media.domain.value_objects.conflict_candidate import ConflictCandidate
 from src.modules.media.domain.value_objects.content_rating import ContentRating
 from src.modules.media.domain.value_objects.credits_detection_state import CreditsDetectionState
 from src.modules.media.domain.value_objects.credits_marker import CreditsMarker, CreditsMarkerSource
@@ -45,6 +46,7 @@ __all__ = [
     "AudioTrack",
     "CastMember",
     "Collection",
+    "ConflictCandidate",
     "ContentRating",
     "CreditsDetectionState",
     "CreditsMarker",

--- a/src/modules/media/domain/value_objects/conflict_candidate.py
+++ b/src/modules/media/domain/value_objects/conflict_candidate.py
@@ -1,0 +1,30 @@
+"""ConflictCandidate value object — one side of a media-conflict pair."""
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+from src.shared_kernel.value_objects.media_type import MediaType
+
+
+class ConflictCandidate(CompoundValueObject):
+    """One side of a detected duplicate-identity collision.
+
+    Bundles the external id with its media-type discriminator so the
+    pair always travels together. Replaces the loose
+    ``(candidate_x_id: str, candidate_x_type: MediaType)`` data clump
+    that previously rode through :class:`MediaConflict`'s fields and
+    ``detect()``'s parameter list.
+
+    Attributes:
+        id: External id of the candidate (e.g. ``mov_xxx``).
+        type: ``MediaType.MOVIE`` (Phase 1) or ``MediaType.SERIES``
+            (later phase).
+
+    Example:
+        >>> ConflictCandidate(id="mov_2xK9mPqR7nL4", type=MediaType.MOVIE)
+        ConflictCandidate(id='mov_2xK9mPqR7nL4', type=<MediaType.MOVIE: 'movie'>)
+    """
+
+    id: str
+    type: MediaType
+
+
+__all__ = ["ConflictCandidate"]

--- a/src/modules/media/infrastructure/persistence/mappers/media_conflict_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/media_conflict_mapper.py
@@ -7,6 +7,7 @@ from src.modules.media.domain.entities.media_conflict import (
     ResolutionSource,
     SuggestedAction,
 )
+from src.modules.media.domain.value_objects.conflict_candidate import ConflictCandidate
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
 from src.modules.media.infrastructure.persistence.models.media_conflict import (
     MediaConflictModel,
@@ -22,10 +23,14 @@ class MediaConflictMapper:
         """Hydrate the aggregate from a row, preserving timestamps."""
         return MediaConflict(
             id=MediaConflictId(model.external_id),
-            candidate_a_id=model.candidate_a_id,
-            candidate_a_type=MediaType(model.candidate_a_type),
-            candidate_b_id=model.candidate_b_id,
-            candidate_b_type=MediaType(model.candidate_b_type),
+            candidate_a=ConflictCandidate(
+                id=model.candidate_a_id,
+                type=MediaType(model.candidate_a_type),
+            ),
+            candidate_b=ConflictCandidate(
+                id=model.candidate_b_id,
+                type=MediaType(model.candidate_b_type),
+            ),
             match_reason=MatchReason(model.match_reason),
             runtime_delta_minutes=model.runtime_delta_minutes,
             suggested_action=SuggestedAction(model.suggested_action),
@@ -48,10 +53,10 @@ class MediaConflictMapper:
             raise ValueError("MediaConflict must have an id before mapping to model")
         return MediaConflictModel(
             external_id=str(entity.id),
-            candidate_a_id=entity.candidate_a_id,
-            candidate_a_type=entity.candidate_a_type.value,
-            candidate_b_id=entity.candidate_b_id,
-            candidate_b_type=entity.candidate_b_type.value,
+            candidate_a_id=entity.candidate_a.id,
+            candidate_a_type=entity.candidate_a.type.value,
+            candidate_b_id=entity.candidate_b.id,
+            candidate_b_type=entity.candidate_b.type.value,
             match_reason=entity.match_reason.value,
             runtime_delta_minutes=entity.runtime_delta_minutes,
             suggested_action=entity.suggested_action.value,
@@ -66,10 +71,10 @@ class MediaConflictMapper:
     @staticmethod
     def update_model(model: MediaConflictModel, entity: MediaConflict) -> None:
         """Copy mutable fields from the entity onto an existing row."""
-        model.candidate_a_id = entity.candidate_a_id
-        model.candidate_a_type = entity.candidate_a_type.value
-        model.candidate_b_id = entity.candidate_b_id
-        model.candidate_b_type = entity.candidate_b_type.value
+        model.candidate_a_id = entity.candidate_a.id
+        model.candidate_a_type = entity.candidate_a.type.value
+        model.candidate_b_id = entity.candidate_b.id
+        model.candidate_b_type = entity.candidate_b.type.value
         model.match_reason = entity.match_reason.value
         model.runtime_delta_minutes = entity.runtime_delta_minutes
         model.suggested_action = entity.suggested_action.value

--- a/tests/modules/media/e2e/test_admin_conflicts_routes.py
+++ b/tests/modules/media/e2e/test_admin_conflicts_routes.py
@@ -12,6 +12,7 @@ from src.modules.media.domain.entities.media_conflict import (
     MediaConflict,
 )
 from src.modules.media.domain.value_objects import (
+    ConflictCandidate,
     Duration,
     FilePath,
     MediaFile,
@@ -59,11 +60,9 @@ async def _seed_conflict(
     async with session_factory() as session:
         repo = SqlAlchemyMediaConflictRepository(session)
         conflict = MediaConflict.detect(
-            candidate_a_id=a_id,
-            candidate_a_type="movie",
+            candidate_a=ConflictCandidate(id=a_id, type="movie"),
             candidate_a_runtime_minutes=120.0,
-            candidate_b_id=b_id,
-            candidate_b_type="movie",
+            candidate_b=ConflictCandidate(id=b_id, type="movie"),
             candidate_b_runtime_minutes=130.0,
             match_reason=MatchReason.TMDB_ID,
         )

--- a/tests/modules/media/integration/persistence/repositories/test_media_conflict_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_media_conflict_repository.py
@@ -9,6 +9,7 @@ from src.modules.media.domain.entities.media_conflict import (
     ResolutionAction,
     ResolutionSource,
 )
+from src.modules.media.domain.value_objects import ConflictCandidate
 from src.modules.media.infrastructure.persistence.repositories.media_conflict_repository import (
     SqlAlchemyMediaConflictRepository,
 )
@@ -20,11 +21,9 @@ def _new_conflict(
     b_id: str = "mov_bbbbbbbbbbbb",
 ) -> MediaConflict:
     return MediaConflict.detect(
-        candidate_a_id=a_id,
-        candidate_a_type="movie",
+        candidate_a=ConflictCandidate(id=a_id, type="movie"),
         candidate_a_runtime_minutes=120.0,
-        candidate_b_id=b_id,
-        candidate_b_type="movie",
+        candidate_b=ConflictCandidate(id=b_id, type="movie"),
         candidate_b_runtime_minutes=125.0,
         match_reason=MatchReason.TMDB_ID,
     )
@@ -88,12 +87,12 @@ class TestFindBlockingPair:
         repo = SqlAlchemyMediaConflictRepository(db_session)
         saved = await repo.save(_new_conflict())
         await repo.save(
-            saved.resolve(ResolutionAction.MERGE_REPLACE, winner_id=saved.candidate_a_id)
+            saved.resolve(ResolutionAction.MERGE_REPLACE, winner_id=saved.candidate_a.id)
         )
 
         result = await repo.find_blocking_pair(
-            saved.candidate_a_id,
-            saved.candidate_b_id,
+            saved.candidate_a.id,
+            saved.candidate_b.id,
         )
 
         assert result is None
@@ -109,8 +108,8 @@ class TestFindBlockingPair:
         resolved = await repo.save(saved.resolve(ResolutionAction.MARK_DISTINCT))
 
         result = await repo.find_blocking_pair(
-            saved.candidate_a_id,
-            saved.candidate_b_id,
+            saved.candidate_a.id,
+            saved.candidate_b.id,
         )
 
         assert result is not None
@@ -138,7 +137,7 @@ class TestListPending:
         await repo.save(
             resolved.resolve(
                 ResolutionAction.MERGE_KEEP_BOTH,
-                winner_id=resolved.candidate_a_id,
+                winner_id=resolved.candidate_a.id,
             ),
         )
 
@@ -206,7 +205,7 @@ class TestListResolved:
         auto_resolved = await repo.save(
             auto.resolve(
                 ResolutionAction.MERGE_REPLACE,
-                winner_id=auto.candidate_a_id,
+                winner_id=auto.candidate_a.id,
                 source=ResolutionSource.AUTO,
             ),
         )
@@ -227,7 +226,7 @@ class TestListResolved:
         await repo.save(
             auto.resolve(
                 ResolutionAction.MERGE_REPLACE,
-                winner_id=auto.candidate_a_id,
+                winner_id=auto.candidate_a.id,
                 source=ResolutionSource.AUTO,
             ),
         )

--- a/tests/modules/media/unit/application/use_cases/test_bulk_mark_distinct_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_bulk_mark_distinct_conflicts.py
@@ -11,17 +11,16 @@ from src.modules.media.domain.entities.media_conflict import (
     MediaConflict,
     ResolutionAction,
 )
+from src.modules.media.domain.value_objects import ConflictCandidate
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
 from tests.modules.media.unit.conftest import make_media_uow_mock
 
 
 def _pending(conflict_id: str) -> MediaConflict:
     detected = MediaConflict.detect(
-        candidate_a_id="mov_aaaaaaaaaaaa",
-        candidate_a_type="movie",
+        candidate_a=ConflictCandidate(id="mov_aaaaaaaaaaaa", type="movie"),
         candidate_a_runtime_minutes=120.0,
-        candidate_b_id="mov_bbbbbbbbbbbb",
-        candidate_b_type="movie",
+        candidate_b=ConflictCandidate(id="mov_bbbbbbbbbbbb", type="movie"),
         candidate_b_runtime_minutes=120.0,
         match_reason=MatchReason.TMDB_ID,
     )

--- a/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_detect_movie_conflicts.py
@@ -19,6 +19,7 @@ from src.modules.media.domain.entities.media_conflict import (
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.events import MediaConflictDetectedEvent
 from src.modules.media.domain.value_objects import (
+    ConflictCandidate,
     Duration,
     FilePath,
     MediaFile,
@@ -165,11 +166,9 @@ class TestDetectMovieConflictsUseCase:
         mocks.movies.find_all_by_tmdb_id.return_value = [self_movie, other]
 
         existing = MediaConflict.detect(
-            candidate_a_id="mov_mnopqrstuvwx",
-            candidate_a_type="movie",
+            candidate_a=ConflictCandidate(id="mov_mnopqrstuvwx", type="movie"),
             candidate_a_runtime_minutes=120.0,
-            candidate_b_id="mov_abcdefghijkl",
-            candidate_b_type="movie",
+            candidate_b=ConflictCandidate(id="mov_abcdefghijkl", type="movie"),
             candidate_b_runtime_minutes=120.0,
             match_reason=MatchReason.TMDB_ID,
         )

--- a/tests/modules/media/unit/application/use_cases/test_list_conflicts.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_conflicts.py
@@ -14,6 +14,7 @@ from src.modules.media.domain.entities.media_conflict import (
 )
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.value_objects import (
+    ConflictCandidate,
     Duration,
     MediaFile,
     MovieId,
@@ -36,11 +37,9 @@ def _conflict(
     b_type: str = "movie",
 ) -> MediaConflict:
     detected = MediaConflict.detect(
-        candidate_a_id=a_id,
-        candidate_a_type=a_type,
+        candidate_a=ConflictCandidate(id=a_id, type=a_type),
         candidate_a_runtime_minutes=120.0,
-        candidate_b_id=b_id,
-        candidate_b_type=b_type,
+        candidate_b=ConflictCandidate(id=b_id, type=b_type),
         candidate_b_runtime_minutes=120.0,
         match_reason=MatchReason.TMDB_ID,
     )

--- a/tests/modules/media/unit/application/use_cases/test_resolve_media_conflict.py
+++ b/tests/modules/media/unit/application/use_cases/test_resolve_media_conflict.py
@@ -17,6 +17,7 @@ from src.modules.media.domain.entities.media_conflict import (
     MatchReason,
     MediaConflict,
 )
+from src.modules.media.domain.value_objects import ConflictCandidate
 from src.modules.media.domain.value_objects.media_conflict_id import MediaConflictId
 from src.shared_kernel.integration_events import MovieMergedEvent
 from tests.modules.media.unit.conftest import make_media_uow_mock
@@ -32,11 +33,9 @@ def _pending(
     b_id: str = _LOSER,
 ) -> MediaConflict:
     base = MediaConflict.detect(
-        candidate_a_id=a_id,
-        candidate_a_type="movie",
+        candidate_a=ConflictCandidate(id=a_id, type="movie"),
         candidate_a_runtime_minutes=120.0,
-        candidate_b_id=b_id,
-        candidate_b_type="movie",
+        candidate_b=ConflictCandidate(id=b_id, type="movie"),
         candidate_b_runtime_minutes=125.0,
         match_reason=MatchReason.TMDB_ID,
     )

--- a/tests/modules/media/unit/domain/entities/test_media_conflict.py
+++ b/tests/modules/media/unit/domain/entities/test_media_conflict.py
@@ -16,6 +16,7 @@ from src.modules.media.domain.entities.media_conflict import (
     SuggestedAction,
 )
 from src.modules.media.domain.rule_codes import MediaRuleCodes
+from src.modules.media.domain.value_objects import ConflictCandidate
 
 _A = "mov_aaaaaaaaaaaa"
 _B = "mov_bbbbbbbbbbbb"
@@ -28,11 +29,9 @@ def _detect(
     match_reason: MatchReason = MatchReason.TMDB_ID,
 ) -> MediaConflict:
     return MediaConflict.detect(
-        candidate_a_id=_A,
-        candidate_a_type="movie",
+        candidate_a=ConflictCandidate(id=_A, type="movie"),
         candidate_a_runtime_minutes=runtime_a,
-        candidate_b_id=_B,
-        candidate_b_type="movie",
+        candidate_b=ConflictCandidate(id=_B, type="movie"),
         candidate_b_runtime_minutes=runtime_b,
         match_reason=match_reason,
     )
@@ -81,22 +80,18 @@ class TestTunableThresholds:
     def test_stricter_thresholds_flag_a_default_likely_same_pair(self) -> None:
         # 5 min / 4.2% delta — LIKELY_SAME under the defaults.
         baseline = MediaConflict.detect(
-            candidate_a_id=_A,
-            candidate_a_type="movie",
+            candidate_a=ConflictCandidate(id=_A, type="movie"),
             candidate_a_runtime_minutes=120.0,
-            candidate_b_id=_B,
-            candidate_b_type="movie",
+            candidate_b=ConflictCandidate(id=_B, type="movie"),
             candidate_b_runtime_minutes=125.0,
             match_reason=MatchReason.TMDB_ID,
         )
         assert baseline.suggested_action is SuggestedAction.LIKELY_SAME_RELEASE
 
         stricter = MediaConflict.detect(
-            candidate_a_id=_A,
-            candidate_a_type="movie",
+            candidate_a=ConflictCandidate(id=_A, type="movie"),
             candidate_a_runtime_minutes=120.0,
-            candidate_b_id=_B,
-            candidate_b_type="movie",
+            candidate_b=ConflictCandidate(id=_B, type="movie"),
             candidate_b_runtime_minutes=125.0,
             match_reason=MatchReason.TMDB_ID,
             abs_threshold_minutes=2.0,
@@ -106,11 +101,9 @@ class TestTunableThresholds:
 
     def test_looser_thresholds_absorb_a_default_different_edit_pair(self) -> None:
         looser = MediaConflict.detect(
-            candidate_a_id=_A,
-            candidate_a_type="movie",
+            candidate_a=ConflictCandidate(id=_A, type="movie"),
             candidate_a_runtime_minutes=138.0,
-            candidate_b_id=_B,
-            candidate_b_type="movie",
+            candidate_b=ConflictCandidate(id=_B, type="movie"),
             candidate_b_runtime_minutes=192.0,
             match_reason=MatchReason.TMDB_ID,
             abs_threshold_minutes=60.0,
@@ -120,11 +113,9 @@ class TestTunableThresholds:
 
     def test_none_thresholds_fall_back_to_class_defaults(self) -> None:
         explicit = MediaConflict.detect(
-            candidate_a_id=_A,
-            candidate_a_type="movie",
+            candidate_a=ConflictCandidate(id=_A, type="movie"),
             candidate_a_runtime_minutes=138.0,
-            candidate_b_id=_B,
-            candidate_b_type="movie",
+            candidate_b=ConflictCandidate(id=_B, type="movie"),
             candidate_b_runtime_minutes=192.0,
             match_reason=MatchReason.TMDB_ID,
             abs_threshold_minutes=None,
@@ -139,11 +130,9 @@ class TestInvariants:
     def test_self_collision_is_rejected(self) -> None:
         with pytest.raises(DomainValidationException):
             MediaConflict.detect(
-                candidate_a_id=_A,
-                candidate_a_type="movie",
+                candidate_a=ConflictCandidate(id=_A, type="movie"),
                 candidate_a_runtime_minutes=120.0,
-                candidate_b_id=_A,
-                candidate_b_type="movie",
+                candidate_b=ConflictCandidate(id=_A, type="movie"),
                 candidate_b_runtime_minutes=120.0,
                 match_reason=MatchReason.TMDB_ID,
             )
@@ -151,10 +140,8 @@ class TestInvariants:
     def test_negative_runtime_delta_is_rejected(self) -> None:
         with pytest.raises(DomainValidationException):
             MediaConflict(
-                candidate_a_id=_A,
-                candidate_a_type="movie",
-                candidate_b_id=_B,
-                candidate_b_type="movie",
+                candidate_a=ConflictCandidate(id=_A, type="movie"),
+                candidate_b=ConflictCandidate(id=_B, type="movie"),
                 match_reason=MatchReason.TMDB_ID,
                 runtime_delta_minutes=-1.0,
                 suggested_action=SuggestedAction.LIKELY_SAME_RELEASE,
@@ -164,10 +151,8 @@ class TestInvariants:
         # ``resolved_at`` without ``resolution`` is inconsistent.
         with pytest.raises(DomainValidationException):
             MediaConflict(
-                candidate_a_id=_A,
-                candidate_a_type="movie",
-                candidate_b_id=_B,
-                candidate_b_type="movie",
+                candidate_a=ConflictCandidate(id=_A, type="movie"),
+                candidate_b=ConflictCandidate(id=_B, type="movie"),
                 match_reason=MatchReason.TMDB_ID,
                 runtime_delta_minutes=0.0,
                 suggested_action=SuggestedAction.LIKELY_SAME_RELEASE,
@@ -260,10 +245,8 @@ class TestResolutionSourceInvariants:
         # Directly constructing a pending row with a source set is invalid.
         with pytest.raises(DomainValidationException):
             MediaConflict(
-                candidate_a_id=_A,
-                candidate_a_type="movie",
-                candidate_b_id=_B,
-                candidate_b_type="movie",
+                candidate_a=ConflictCandidate(id=_A, type="movie"),
+                candidate_b=ConflictCandidate(id=_B, type="movie"),
                 match_reason=MatchReason.TMDB_ID,
                 runtime_delta_minutes=0.0,
                 suggested_action=SuggestedAction.LIKELY_SAME_RELEASE,

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_media_conflict_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_media_conflict_mapper.py
@@ -40,10 +40,12 @@ def _model(
 class TestMediaConflictMapperToEntity:
     """``to_entity`` hydrates the aggregate from a row."""
 
-    def test_candidate_types_become_media_type_enum(self) -> None:
+    def test_candidates_compose_id_and_type(self) -> None:
         entity = MediaConflictMapper.to_entity(_model())
 
+        assert entity.candidate_a.id == "mov_aaaaaaaaaaaa"
         assert entity.candidate_a.type is MediaType.MOVIE
+        assert entity.candidate_b.id == "mov_bbbbbbbbbbbb"
         assert entity.candidate_b.type is MediaType.MOVIE
 
     def test_unknown_candidate_type_fails_loudly(self) -> None:
@@ -55,19 +57,21 @@ class TestMediaConflictMapperToEntity:
 
 
 class TestMediaConflictMapperRoundTrip:
-    """Entity → model → entity preserves the typed discriminator."""
+    """Entity → model → entity preserves each candidate's id and type."""
 
-    def test_round_trip_preserves_candidate_types(self) -> None:
+    def test_round_trip_preserves_candidates(self) -> None:
         entity = MediaConflictMapper.to_entity(_model())
         model = MediaConflictMapper.to_model(entity)
 
-        # to_model writes the raw enum value back to the String column...
+        # to_model decomposes the VO back onto the flat columns...
+        assert model.candidate_a_id == "mov_aaaaaaaaaaaa"
         assert model.candidate_a_type == "movie"
+        assert model.candidate_b_id == "mov_bbbbbbbbbbbb"
         assert model.candidate_b_type == "movie"
 
-        # ...and reading it back yields the typed enum again.
+        # ...and reading it back recomposes the same VO.
         model.created_at = _NOW
         model.updated_at = _NOW
         rehydrated = MediaConflictMapper.to_entity(model)
-        assert rehydrated.candidate_a.type is MediaType.MOVIE
-        assert rehydrated.candidate_b.type is MediaType.MOVIE
+        assert rehydrated.candidate_a == entity.candidate_a
+        assert rehydrated.candidate_b == entity.candidate_b

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_media_conflict_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_media_conflict_mapper.py
@@ -43,8 +43,8 @@ class TestMediaConflictMapperToEntity:
     def test_candidate_types_become_media_type_enum(self) -> None:
         entity = MediaConflictMapper.to_entity(_model())
 
-        assert entity.candidate_a_type is MediaType.MOVIE
-        assert entity.candidate_b_type is MediaType.MOVIE
+        assert entity.candidate_a.type is MediaType.MOVIE
+        assert entity.candidate_b.type is MediaType.MOVIE
 
     def test_unknown_candidate_type_fails_loudly(self) -> None:
         # ADR-016: a corrupted persisted discriminator must surface as an
@@ -69,5 +69,5 @@ class TestMediaConflictMapperRoundTrip:
         model.created_at = _NOW
         model.updated_at = _NOW
         rehydrated = MediaConflictMapper.to_entity(model)
-        assert rehydrated.candidate_a_type is MediaType.MOVIE
-        assert rehydrated.candidate_b_type is MediaType.MOVIE
+        assert rehydrated.candidate_a.type is MediaType.MOVIE
+        assert rehydrated.candidate_b.type is MediaType.MOVIE


### PR DESCRIPTION
## Summary
- Introduce a `ConflictCandidate(id, type)` value object (`CompoundValueObject`) and replace `MediaConflict`'s four loose fields (`candidate_a_id`, `candidate_a_type`, `candidate_b_id`, `candidate_b_type`) with two `candidate_a` / `candidate_b` VO fields.
- Collapse the data clump everywhere it traveled together: `MediaConflict.detect(candidate_a=ConflictCandidate(...), candidate_b=...)`, the distinct/winner/loser invariants, the conflict list/summary builders, and the resolve-flow type guard.
- The mapper composes/decomposes the VO over the **unchanged** ORM columns (`candidate_a_id`, `candidate_a_type`, …), so there is **no schema change and no migration**.

Implements backlog item **6.4** (`docs/audits/07-phase6-backlog.md`); code-smell finding (data clump + primitive obsession on the raw candidate ids).

## Test plan
- [x] `ruff check src tests` + `ruff format --check` clean
- [x] `pytest tests/modules/media/` — 1708 passed, 5 skipped
- [x] Conflict + cross-BC handler suite (detect / resolve / list / bulk-mark-distinct / mapper / repository / e2e routes / on_movie_merged) — 101 passed
- [x] `mypy` on the 6 changed `src/` files — no issues
- [x] No DB migration (ORM columns unchanged; VO is composed in the mapper)