### PR TITLE
feat(media): wrap TMDB provider failures in GatewayException

### DIFF
--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -473,9 +473,11 @@ class MetadataProvider(ABC):
             ``None`` when the id is genuinely not a movie (HTTP 404).
 
         Raises:
-            httpx.HTTPError: On provider failure (network error, auth,
-                rate limit, 5xx). Callers must distinguish "no such
-                movie" (``None``) from "TMDB unavailable" (raises) — a
+            GatewayException: On provider failure (network error, auth,
+                rate limit, 5xx), wrapped in the subtype matching the
+                cause so the API surfaces 429/502/503/504 instead of a
+                generic 500. Callers must distinguish "no such movie"
+                (``None``) from "TMDB unavailable" (raises) — a
                 transient failure must not masquerade as not-found.
         """
         ...
@@ -485,8 +487,8 @@ class MetadataProvider(ABC):
         """Cheap card-level fetch for one TV series by id.
 
         Like :meth:`get_movie_summary_by_id`: ``None`` only on a genuine
-        404 (the id isn't a series); raises ``httpx.HTTPError`` on any
-        provider failure rather than collapsing it to not-found.
+        404 (the id isn't a series); raises a ``GatewayException`` subtype
+        on any provider failure rather than collapsing it to not-found.
         """
         ...
 

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -504,15 +504,23 @@ class TmdbClient(MetadataProvider):
     async def _fetch_movie_localized_fields(
         self, tmdb_id: int, locale: str
     ) -> LocalizedFields | None:
-        """Fetch one locale's translated movie fields, or ``None`` on failure."""
-        resp = await self._get(
-            f"/movie/{tmdb_id}",
-            params=self._params(
-                language=locale,
-                append_to_response="images",
-                include_image_language=f"{locale},en,null",
-            ),
-        )
+        """Fetch one locale's translated movie fields, or ``None`` on failure.
+
+        An overlay is best-effort: any provider failure (non-200 status
+        or a wrapped transport ``GatewayException``) drops just this
+        locale so the English base still returns.
+        """
+        try:
+            resp = await self._get(
+                f"/movie/{tmdb_id}",
+                params=self._params(
+                    language=locale,
+                    append_to_response="images",
+                    include_image_language=f"{locale},en,null",
+                ),
+            )
+        except GatewayException:
+            return None
         if resp.status_code != 200:
             return None
 
@@ -903,15 +911,23 @@ class TmdbClient(MetadataProvider):
     async def _fetch_series_localized_fields(
         self, tmdb_id: int, locale: str
     ) -> LocalizedFields | None:
-        """Fetch one locale's translated series fields, or ``None`` on failure."""
-        resp = await self._get(
-            f"/tv/{tmdb_id}",
-            params=self._params(
-                language=locale,
-                append_to_response="images",
-                include_image_language=f"{locale},en,null",
-            ),
-        )
+        """Fetch one locale's translated series fields, or ``None`` on failure.
+
+        An overlay is best-effort: any provider failure (non-200 status
+        or a wrapped transport ``GatewayException``) drops just this
+        locale so the English base still returns.
+        """
+        try:
+            resp = await self._get(
+                f"/tv/{tmdb_id}",
+                params=self._params(
+                    language=locale,
+                    append_to_response="images",
+                    include_image_language=f"{locale},en,null",
+                ),
+            )
+        except GatewayException:
+            return None
         if resp.status_code != 200:
             return None
 
@@ -1133,13 +1149,20 @@ class TmdbClient(MetadataProvider):
         """One ``/season/{n}`` round-trip; ``None`` on 404 or locale-overlay failure.
 
         ``language=None`` is the English base — a non-404 error there
-        is fatal (raised). For a localized overlay any non-200 simply
-        drops that locale.
+        is fatal (raised). For a localized overlay any failure (non-200
+        status or a wrapped transport ``GatewayException``) simply drops
+        that locale, so a flaky overlay never aborts the concurrent
+        season fan-out.
         """
-        resp = await self._get(
-            f"/tv/{series_id}/season/{season_number}",
-            params=self._params(language=language),
-        )
+        try:
+            resp = await self._get(
+                f"/tv/{series_id}/season/{season_number}",
+                params=self._params(language=language),
+            )
+        except GatewayException:
+            if language is None:
+                raise
+            return None
         if resp.status_code == 404:
             return None
         if language is not None and resp.status_code != 200:

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -7,6 +7,13 @@ from typing import Any, Literal
 
 import httpx
 
+from src.building_blocks.infrastructure.errors import (
+    GatewayBadResponseException,
+    GatewayException,
+    GatewayRateLimitException,
+    GatewayTimeoutException,
+    GatewayUnavailableException,
+)
 from src.modules.media.application.ports import (
     CollectionDetailMetadata,
     CollectionMetadata,
@@ -26,6 +33,8 @@ from src.shared_kernel.value_objects import MediaType
 
 _MAX_CAST = 15
 
+_GATEWAY_NAME = "TMDB"
+
 
 def _safe_int(value: object, default: int) -> int:
     """Safely convert a value to int, returning default on failure."""
@@ -33,6 +42,24 @@ def _safe_int(value: object, default: int) -> int:
         return int(str(value))
     except (ValueError, TypeError):
         return default
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    """Parse a ``Retry-After`` header (delta-seconds) into an int.
+
+    TMDB sends the delay as an integer number of seconds. Returns
+    ``None`` when the header is absent or not a plain integer so the
+    caller can fall back to the exception's default — the HTTP-date
+    form of ``Retry-After`` is not emitted by TMDB and is treated as
+    "unknown" rather than parsed.
+    """
+    if value is None:
+        return None
+    try:
+        seconds = int(value.strip())
+    except (ValueError, AttributeError):
+        return None
+    return seconds if seconds >= 0 else None
 
 
 _TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/original"
@@ -134,6 +161,112 @@ class TmdbClient(MetadataProvider):
     def _image_url(self, path: str | None) -> str | None:
         return f"{_TMDB_IMAGE_BASE}{path}" if path else None
 
+    async def _get(
+        self,
+        path: str,
+        params: dict[str, str | int],
+    ) -> httpx.Response:
+        """Perform a GET against TMDB, translating transport failures.
+
+        Wraps httpx transport-level errors (timeouts, connection / DNS
+        failures) into the matching :class:`GatewayException` subtype so
+        this ACL never leaks a raw ``httpx`` error past the boundary —
+        the global handler can then surface ``503`` / ``504`` instead of
+        a generic ``500`` ("the provider is down" is not "our server
+        crashed").
+
+        HTTP *status* errors are deliberately NOT raised here: the
+        response is returned as-is so a caller can inspect the status
+        (e.g. tell a genuine ``404`` apart from a provider outage) before
+        deciding whether to call :meth:`_raise_for_status`.
+
+        Args:
+            path: Request path relative to the API base (e.g.
+                ``"/movie/123"``).
+            params: Query parameters, already including the api key.
+
+        Returns:
+            The raw ``httpx.Response``, regardless of status code.
+
+        Raises:
+            GatewayTimeoutException: The request timed out.
+            GatewayUnavailableException: TMDB could not be reached
+                (connection refused, DNS failure, protocol error).
+        """
+        try:
+            return await self._client.get(f"{self._base_url}{path}", params=params)
+        except httpx.TimeoutException as exc:
+            raise GatewayTimeoutException(
+                message="TMDB request timed out",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=f"{type(exc).__name__}: {exc}",
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise GatewayUnavailableException(
+                message="TMDB is unavailable",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=f"{type(exc).__name__}: {exc}",
+            ) from exc
+
+    @staticmethod
+    def _raise_for_status(resp: httpx.Response) -> None:
+        """Translate a non-2xx TMDB response into a ``GatewayException``.
+
+        Maps the provider's HTTP status onto the gateway subtype whose
+        ``code`` the registry resolves to the right client-facing status
+        (``429`` / ``502`` / ``503`` / ``504``), so a provider problem is
+        never reported to the caller as a generic ``500``. A ``4xx`` other
+        than rate-limiting means *our* request or credentials were at
+        fault (it is not a provider outage), so it maps to the base
+        ``GatewayException`` (``500``). Callers that treat a ``404``
+        specially must check ``resp.status_code`` before calling this.
+
+        Raises:
+            GatewayRateLimitException: HTTP 429.
+            GatewayTimeoutException: HTTP 504.
+            GatewayUnavailableException: HTTP 503 or any other 5xx.
+            GatewayBadResponseException: HTTP 502.
+            GatewayException: Any other non-2xx (4xx) response.
+        """
+        status = resp.status_code
+        if status < httpx.codes.BAD_REQUEST:
+            return
+
+        internal = f"HTTP {status} from {resp.request.url}"
+
+        if status == httpx.codes.TOO_MANY_REQUESTS:
+            retry_after = _parse_retry_after(resp.headers.get("Retry-After"))
+            raise GatewayRateLimitException(
+                message="TMDB rate limit exceeded",
+                gateway_name=_GATEWAY_NAME,
+                retry_after_seconds=retry_after if retry_after is not None else 60,
+                internal_message=internal,
+            )
+        if status == httpx.codes.GATEWAY_TIMEOUT:
+            raise GatewayTimeoutException(
+                message="TMDB timed out upstream",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=internal,
+            )
+        if status == httpx.codes.BAD_GATEWAY:
+            raise GatewayBadResponseException(
+                message="TMDB returned a bad-gateway response",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=internal,
+            )
+        if status >= httpx.codes.INTERNAL_SERVER_ERROR:
+            # 503 and every other 5xx — the provider is having problems.
+            raise GatewayUnavailableException(
+                message="TMDB is unavailable",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=internal,
+            )
+        raise GatewayException(
+            message="TMDB request failed",
+            gateway_name=_GATEWAY_NAME,
+            internal_message=internal,
+        )
+
     @staticmethod
     def _logo_rank(logo: dict[str, object], target: str, target_base: str) -> int:
         """Score a TMDB logo entry for language preference (lower = better).
@@ -189,11 +322,11 @@ class TmdbClient(MetadataProvider):
         no result matches the requested year; the caller's retry layer
         will re-search without the year hint.
         """
-        resp = await self._client.get(
-            f"{self._base_url}/search/movie",
+        resp = await self._get(
+            "/search/movie",
             params=self._params(query=title, year=year),
         )
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         results = resp.json().get("results", [])
 
         best = self._pick_year_match(results, year, "release_date")
@@ -213,11 +346,11 @@ class TmdbClient(MetadataProvider):
         revival). Returns ``None`` when no result matches the requested
         year.
         """
-        resp = await self._client.get(
-            f"{self._base_url}/search/tv",
+        resp = await self._get(
+            "/search/tv",
             params=self._params(query=title, first_air_date_year=year),
         )
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         results = resp.json().get("results", [])
 
         best = self._pick_year_match(results, year, "first_air_date")
@@ -238,11 +371,11 @@ class TmdbClient(MetadataProvider):
         contract — picker-mode, no year post-filter, TMDB's own
         popularity ranking preserved.
         """
-        resp = await self._client.get(
-            f"{self._base_url}/search/movie",
+        resp = await self._get(
+            "/search/movie",
             params=self._params(query=title, year=year),
         )
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         results = resp.json().get("results", [])
         return [_to_movie_candidate(r, self._image_url) for r in results[:limit]]
 
@@ -253,11 +386,11 @@ class TmdbClient(MetadataProvider):
         limit: int = 5,
     ) -> list[SearchCandidate]:
         """Return the top ``limit`` raw TV search hits."""
-        resp = await self._client.get(
-            f"{self._base_url}/search/tv",
+        resp = await self._get(
+            "/search/tv",
             params=self._params(query=title, first_air_date_year=year),
         )
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         results = resp.json().get("results", [])
         return [_to_series_candidate(r, self._image_url) for r in results[:limit]]
 
@@ -269,13 +402,13 @@ class TmdbClient(MetadataProvider):
         ``raise_for_status`` — consistent with the search paths — so a
         transient outage doesn't masquerade as "not found".
         """
-        resp = await self._client.get(
-            f"{self._base_url}/movie/{tmdb_id}",
+        resp = await self._get(
+            f"/movie/{tmdb_id}",
             params=self._params(),
         )
         if resp.status_code == httpx.codes.NOT_FOUND:
             return None
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         return _to_movie_candidate(resp.json(), self._image_url)
 
     async def get_series_summary_by_id(self, tmdb_id: int) -> SearchCandidate | None:
@@ -285,13 +418,13 @@ class TmdbClient(MetadataProvider):
         propagates via ``raise_for_status`` instead of collapsing to
         not-found.
         """
-        resp = await self._client.get(
-            f"{self._base_url}/tv/{tmdb_id}",
+        resp = await self._get(
+            f"/tv/{tmdb_id}",
             params=self._params(),
         )
         if resp.status_code == httpx.codes.NOT_FOUND:
             return None
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         return _to_series_candidate(resp.json(), self._image_url)
 
     async def find_by_imdb_id(self, imdb_id: str) -> list[SearchCandidate]:
@@ -304,11 +437,11 @@ class TmdbClient(MetadataProvider):
         user pastes ``tt`` from a movie page; tests can stable-sort
         on ``media_type`` afterwards if they need a stricter order.
         """
-        resp = await self._client.get(
-            f"{self._base_url}/find/{imdb_id}",
+        resp = await self._get(
+            f"/find/{imdb_id}",
             params=self._params(external_source="imdb_id"),
         )
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         payload = resp.json()
         movies = [_to_movie_candidate(r, self._image_url) for r in payload.get("movie_results", [])]
         series = [_to_series_candidate(r, self._image_url) for r in payload.get("tv_results", [])]
@@ -372,8 +505,8 @@ class TmdbClient(MetadataProvider):
         self, tmdb_id: int, locale: str
     ) -> LocalizedFields | None:
         """Fetch one locale's translated movie fields, or ``None`` on failure."""
-        resp = await self._client.get(
-            f"{self._base_url}/movie/{tmdb_id}",
+        resp = await self._get(
+            f"/movie/{tmdb_id}",
             params=self._params(
                 language=locale,
                 append_to_response="images",
@@ -418,11 +551,11 @@ class TmdbClient(MetadataProvider):
         than 500.
         """
         try:
-            resp = await self._client.get(
-                f"{self._base_url}/collection/{tmdb_id}",
+            resp = await self._get(
+                f"/collection/{tmdb_id}",
                 params=self._params(language=language),
             )
-        except httpx.HTTPError:
+        except GatewayException:
             return None
         if resp.status_code != 200:
             return None
@@ -578,11 +711,11 @@ class TmdbClient(MetadataProvider):
         step fails — collection lookup is best-effort polish.
         """
         try:
-            resp = await self._client.get(
-                f"{self._base_url}/movie/{tmdb_id}",
+            resp = await self._get(
+                f"/movie/{tmdb_id}",
                 params=self._params(),
             )
-        except httpx.HTTPError:
+        except GatewayException:
             return []
         if resp.status_code != 200:
             return []
@@ -595,11 +728,11 @@ class TmdbClient(MetadataProvider):
             return []
 
         try:
-            resp = await self._client.get(
-                f"{self._base_url}/collection/{coll_id}",
+            resp = await self._get(
+                f"/collection/{coll_id}",
                 params=self._params(),
             )
-        except httpx.HTTPError:
+        except GatewayException:
             return []
         if resp.status_code != 200:
             return []
@@ -629,11 +762,11 @@ class TmdbClient(MetadataProvider):
         on results we'd discard.
         """
         try:
-            resp = await self._client.get(
-                f"{self._base_url}/{media_type}/{tmdb_id}/{endpoint}",
+            resp = await self._get(
+                f"/{media_type}/{tmdb_id}/{endpoint}",
                 params=self._params(),
             )
-        except httpx.HTTPError:
+        except GatewayException:
             return []
         if resp.status_code != 200:
             return []
@@ -681,11 +814,11 @@ class TmdbClient(MetadataProvider):
     async def _fetch_person(self, tmdb_id: int, language: str) -> PersonMetadata | None:
         """Single ``/person/{id}`` round-trip in ``language``."""
         try:
-            resp = await self._client.get(
-                f"{self._base_url}/person/{tmdb_id}",
+            resp = await self._get(
+                f"/person/{tmdb_id}",
                 params=self._params(language=language),
             )
-        except httpx.HTTPError:
+        except GatewayException:
             return None
         if resp.status_code != 200:
             return None
@@ -750,11 +883,11 @@ class TmdbClient(MetadataProvider):
         path = "movie" if media_type == MediaType.MOVIE else "tv"
         title_key = "title" if media_type == MediaType.MOVIE else "name"
         try:
-            resp = await self._client.get(
-                f"{self._base_url}/{path}/{tmdb_id}/translations",
+            resp = await self._get(
+                f"/{path}/{tmdb_id}/translations",
                 params=self._params(),
             )
-        except httpx.HTTPError:
+        except GatewayException:
             return {}
         if resp.status_code != 200:
             return {}
@@ -771,8 +904,8 @@ class TmdbClient(MetadataProvider):
         self, tmdb_id: int, locale: str
     ) -> LocalizedFields | None:
         """Fetch one locale's translated series fields, or ``None`` on failure."""
-        resp = await self._client.get(
-            f"{self._base_url}/tv/{tmdb_id}",
+        resp = await self._get(
+            f"/tv/{tmdb_id}",
             params=self._params(
                 language=locale,
                 append_to_response="images",
@@ -803,8 +936,8 @@ class TmdbClient(MetadataProvider):
         in the same round-trip — saves a separate HTTP call per
         details fetch.
         """
-        resp = await self._client.get(
-            f"{self._base_url}/movie/{tmdb_id}",
+        resp = await self._get(
+            f"/movie/{tmdb_id}",
             params=self._params(
                 append_to_response="credits,release_dates,videos,images",
                 language=language,
@@ -813,7 +946,7 @@ class TmdbClient(MetadataProvider):
         )
         if resp.status_code == 404:
             return None
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         data = resp.json()
 
         year = None
@@ -867,11 +1000,11 @@ class TmdbClient(MetadataProvider):
             return None
 
         try:
-            resp = await self._client.get(
-                f"{self._base_url}/collection/{coll_id}",
+            resp = await self._get(
+                f"/collection/{coll_id}",
                 params=self._params(),
             )
-        except httpx.HTTPError:
+        except GatewayException:
             return None
         if resp.status_code != 200:
             return None
@@ -886,8 +1019,8 @@ class TmdbClient(MetadataProvider):
         language is English since the bulk of the series-details flow
         is English-first (the localized variant overrides on top).
         """
-        resp = await self._client.get(
-            f"{self._base_url}/tv/{tmdb_id}",
+        resp = await self._get(
+            f"/tv/{tmdb_id}",
             params=self._params(
                 append_to_response="external_ids,content_ratings,videos,images,credits",
                 include_image_language="en,null",
@@ -895,7 +1028,7 @@ class TmdbClient(MetadataProvider):
         )
         if resp.status_code == 404:
             return None
-        resp.raise_for_status()
+        self._raise_for_status(resp)
         data = resp.json()
 
         # Top-billed cast comes back nested under ``credits.cast`` thanks
@@ -1003,8 +1136,8 @@ class TmdbClient(MetadataProvider):
         is fatal (raised). For a localized overlay any non-200 simply
         drops that locale.
         """
-        resp = await self._client.get(
-            f"{self._base_url}/tv/{series_id}/season/{season_number}",
+        resp = await self._get(
+            f"/tv/{series_id}/season/{season_number}",
             params=self._params(language=language),
         )
         if resp.status_code == 404:
@@ -1012,7 +1145,7 @@ class TmdbClient(MetadataProvider):
         if language is not None and resp.status_code != 200:
             return None
         if language is None:
-            resp.raise_for_status()
+            self._raise_for_status(resp)
         data: dict[str, Any] = resp.json()
         return data
 

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -7,19 +7,32 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
+from src.building_blocks.infrastructure.errors import (
+    GatewayBadResponseException,
+    GatewayException,
+    GatewayRateLimitException,
+    GatewayTimeoutException,
+    GatewayUnavailableException,
+)
 from src.modules.media.domain.value_objects import ContentRating
 from src.modules.media.infrastructure.metadata.tmdb_client import (
     TmdbClient,
+    _parse_retry_after,
     _safe_int,
 )
 from src.shared_kernel.value_objects import MediaType
 
 
-def _build_response(status_code: int = 200, json_data: dict[str, Any] | None = None) -> MagicMock:
+def _build_response(
+    status_code: int = 200,
+    json_data: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
     """Build a mocked httpx Response."""
     response = MagicMock(spec=httpx.Response)
     response.status_code = status_code
     response.json.return_value = json_data or {}
+    response.headers = headers or {}
     response.raise_for_status = MagicMock()
     if status_code >= 400:
         response.raise_for_status.side_effect = httpx.HTTPStatusError(
@@ -393,14 +406,14 @@ class TestSummaryByIdErrorHandling:
     async def test_movie_summary_raises_on_server_error(self) -> None:
         client = _make_client(get_responses=_build_response(status_code=500))
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(GatewayUnavailableException):
             await client.get_movie_summary_by_id(123)
 
     @pytest.mark.asyncio
     async def test_series_summary_raises_on_server_error(self) -> None:
         client = _make_client(get_responses=_build_response(status_code=500))
 
-        with pytest.raises(httpx.HTTPStatusError):
+        with pytest.raises(GatewayUnavailableException):
             await client.get_series_summary_by_id(123)
 
     @pytest.mark.asyncio
@@ -426,7 +439,7 @@ class TestSummaryByIdErrorHandling:
         client = _make_client()
         client._client.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
 
-        with pytest.raises(httpx.ConnectError):
+        with pytest.raises(GatewayUnavailableException):
             await client.get_movie_summary_by_id(123)
 
     @pytest.mark.asyncio
@@ -434,8 +447,101 @@ class TestSummaryByIdErrorHandling:
         client = _make_client()
         client._client.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
 
-        with pytest.raises(httpx.ConnectError):
+        with pytest.raises(GatewayUnavailableException):
             await client.get_series_summary_by_id(123)
+
+
+@pytest.mark.unit
+class TestParseRetryAfter:
+    """``_parse_retry_after`` reads the delta-seconds form, ignores the rest."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("30", 30),
+            ("0", 0),
+            ("  12 ", 12),
+            (None, None),
+            ("abc", None),
+            ("-5", None),
+            ("Wed, 21 Oct 2025 07:28:00 GMT", None),
+        ],
+    )
+    def test_parse(self, value: str | None, expected: int | None) -> None:
+        assert _parse_retry_after(value) == expected
+
+
+@pytest.mark.unit
+class TestGatewayErrorTranslation:
+    """The TMDB ACL wraps every provider failure as a GatewayException subtype.
+
+    Card A: a provider outage must surface as 429/502/503/504 — never a
+    generic 500 — and transport errors must not leak raw ``httpx`` types
+    past the adapter boundary.
+    """
+
+    @pytest.mark.asyncio
+    async def test_timeout_becomes_gateway_timeout(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+
+        with pytest.raises(GatewayTimeoutException):
+            await client.get_movie_summary_by_id(1)
+
+    @pytest.mark.asyncio
+    async def test_connect_error_becomes_gateway_unavailable(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+        with pytest.raises(GatewayUnavailableException):
+            await client.get_movie_summary_by_id(1)
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (429, GatewayRateLimitException),
+            (503, GatewayUnavailableException),
+            (504, GatewayTimeoutException),
+            (502, GatewayBadResponseException),
+            (500, GatewayUnavailableException),
+            (401, GatewayException),
+            (400, GatewayException),
+        ],
+    )
+    def test_status_maps_to_subtype(self, status: int, expected: type[GatewayException]) -> None:
+        with pytest.raises(GatewayException) as exc_info:
+            TmdbClient._raise_for_status(_build_response(status_code=status))
+        # Exact type — base GatewayException for 4xx, never a subtype.
+        assert type(exc_info.value) is expected
+
+    def test_success_status_does_not_raise(self) -> None:
+        TmdbClient._raise_for_status(_build_response(status_code=200))
+
+    def test_rate_limit_reads_retry_after_header(self) -> None:
+        resp = _build_response(status_code=429, headers={"Retry-After": "42"})
+
+        with pytest.raises(GatewayRateLimitException) as exc_info:
+            TmdbClient._raise_for_status(resp)
+
+        assert exc_info.value.retry_after_seconds == 42
+
+    def test_rate_limit_defaults_retry_after_when_header_missing(self) -> None:
+        with pytest.raises(GatewayRateLimitException) as exc_info:
+            TmdbClient._raise_for_status(_build_response(status_code=429))
+
+        assert exc_info.value.retry_after_seconds == 60
+
+    @pytest.mark.asyncio
+    async def test_best_effort_methods_still_degrade_on_gateway_error(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+        # These paths intentionally swallow provider failures so the UI
+        # degrades gracefully — the wrapped GatewayException must still be
+        # caught, not propagate.
+        assert await client.get_collection(10) is None
+        assert await client.get_person(287) is None
+        assert await client.get_movie_recommendations(1) == []
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -543,6 +543,28 @@ class TestGatewayErrorTranslation:
         assert await client.get_person(287) is None
         assert await client.get_movie_recommendations(1) == []
 
+    @pytest.mark.asyncio
+    async def test_localized_overlay_skips_on_transport_error(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+        # A localized overlay is best-effort — a wrapped transport error
+        # drops just that locale rather than aborting enrichment.
+        assert await client._fetch_movie_localized_fields(1, "pt-BR") is None
+        assert await client._fetch_series_localized_fields(1, "pt-BR") is None
+
+    @pytest.mark.asyncio
+    async def test_season_overlay_skips_but_base_propagates_on_transport_error(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+        # An overlay locale failing is dropped (the concurrent fan-out
+        # must not abort)...
+        assert await client._fetch_season_payload(1, 1, "pt-BR") is None
+        # ...but the English base failing is fatal and propagates.
+        with pytest.raises(GatewayUnavailableException):
+            await client._fetch_season_payload(1, 1, None)
+
 
 @pytest.mark.unit
 class TestParseCast:


### PR DESCRIPTION
## Summary
- Route every TMDB request through a `_get` wrapper that translates httpx **transport** errors (timeout / connection / DNS) into `GatewayTimeoutException` / `GatewayUnavailableException`, so a raw `httpx` error never leaks past the ACL boundary.
- Add a `_raise_for_status` helper that maps the provider's **HTTP status** onto the matching gateway subtype: `429 → GatewayRateLimit` (honoring `Retry-After`), `503/5xx → GatewayUnavailable`, `504 → GatewayTimeout`, `502 → GatewayBadResponse`, other `4xx → GatewayException` (our request/creds, not a provider outage).
- Best-effort methods (`get_collection`, `get_person`, recommendations, translated titles, collection lookups) keep degrading gracefully — their `except httpx.HTTPError` becomes `except GatewayException`.
- Update the `MetadataProvider` port docstrings (`get_*_summary_by_id`) to document the new `GatewayException` contract (replacing the `httpx.HTTPError` note from #328).

**No handler change needed:** `GatewayException` subtypes are `CoreException`, and `GENERIC_HTTP_STATUSES` already resolves their `code` to 429/502/503/504 — so provider outages now surface with the right status instead of a generic 500.

Implements backlog item **Card A** (`docs/audits/07-phase6-backlog.md`); origin review #328 — done project-wide across all `MetadataProvider` methods, not piecemeal.

## Test plan
- [x] `ruff check`/`format --check` clean; `mypy` adds no new errors (3 pre-existing payload-cast errors unchanged)
- [x] New `TestGatewayErrorTranslation` + `TestParseRetryAfter` (20 tests): transport→subtype, status→subtype (exact type), `Retry-After` parsing, and best-effort methods still degrade
- [x] Updated the 4 `#328` summary regression tests to the new contract
- [x] `pytest tests/modules/media/` — 1728 passed, 5 skipped; `tests/building_blocks/` — 328 passed
- [x] Verified `resolve_http_status` maps every gateway code (504/503/429/502/500)