### PR TITLE
refactor(shared_kernel): tighten episode composite id VO

### DIFF
--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -86,10 +86,9 @@ class GetSeriesByIdUseCase:
         if series is None:
             raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
 
-        series_id_str = str(series.id)
         composite_ids = [
             EpisodeCompositeId.build(
-                series_id_str, s.season_number.value, ep.episode_number.value
+                series_id, s.season_number.value, ep.episode_number.value
             ).media_id
             for s in series.seasons
             for ep in s.episodes
@@ -99,11 +98,12 @@ class GetSeriesByIdUseCase:
             profile_id=input_dto.profile_id,
         )
 
-        return self._to_output(series, input_dto.lang, progress_map)
+        return self._to_output(series, series_id, input_dto.lang, progress_map)
 
     def _to_output(
         self,
         series: Series,
+        series_id: SeriesId,
         lang: str,
         progress_map: dict[str, ProgressSummary],
     ) -> SeriesOutput:
@@ -111,15 +111,15 @@ class GetSeriesByIdUseCase:
 
         Args:
             series: The Series entity to convert.
+            series_id: Typed external series ID for composite key lookup.
             lang: Language code for localized fields.
             progress_map: Map of composite media_id to progress summary.
 
         Returns:
             SeriesOutput with all fields and nested seasons/episodes.
         """
-        series_id = str(series.id)
         return SeriesOutput(
-            id=series_id,
+            id=str(series_id),
             title=series.get_title(lang),
             original_title=series.original_title.value if series.original_title else None,
             start_year=series.start_year.value,
@@ -156,7 +156,7 @@ class GetSeriesByIdUseCase:
     @staticmethod
     def _to_season_output(
         season: Season,
-        series_id: str,
+        series_id: SeriesId,
         progress_map: dict[str, ProgressSummary],
         lang: str = "en",
     ) -> SeasonOutput:
@@ -164,7 +164,7 @@ class GetSeriesByIdUseCase:
 
         Args:
             season: The Season entity to convert.
-            series_id: External series ID for composite key lookup.
+            series_id: Typed external series ID for composite key lookup.
             progress_map: Map of composite media_id to progress summary.
             lang: Language code for localized title/synopsis.
 
@@ -194,7 +194,7 @@ class GetSeriesByIdUseCase:
     @staticmethod
     def _to_episode_output(
         episode: Episode,
-        series_id: str,
+        series_id: SeriesId,
         season_number: int,
         progress_map: dict[str, ProgressSummary],
         lang: str = "en",
@@ -203,7 +203,7 @@ class GetSeriesByIdUseCase:
 
         Args:
             episode: The Episode entity to convert.
-            series_id: External series ID for composite key lookup.
+            series_id: Typed external series ID for composite key lookup.
             season_number: Season number for composite key lookup.
             progress_map: Map of composite media_id to progress summary.
             lang: Language code for localized title/synopsis.

--- a/src/modules/watch_progress/application/use_cases/get_continue_watching.py
+++ b/src/modules/watch_progress/application/use_cases/get_continue_watching.py
@@ -20,7 +20,6 @@ from src.modules.watch_progress.domain.value_objects.watchable_media_id import (
     WatchableMediaId,
 )
 from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
-from src.shared_kernel.value_objects.media_id import SeriesId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 if TYPE_CHECKING:
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
         WatchProgressUnitOfWorkFactory,
     )
     from src.modules.watch_progress.domain.entities import WatchProgress
+    from src.shared_kernel.value_objects.media_id import SeriesId
 
 _logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ class GetContinueWatchingUseCase:
         """Execute the use case for the caller's profile."""
         profile_id = ProfileId(input_dto.profile_id)
         items: list[ContinueWatchingItem] = []
-        seen_series: set[str] = set()
+        seen_series: set[SeriesId] = set()
 
         async with self._uow_factory() as uow:
             progress_list = await uow.progress.list_recently_watched(
@@ -99,7 +99,7 @@ class GetContinueWatchingUseCase:
                     seen_series.add(parsed.series_id)
                     item = await self._resolve_series_episode(
                         uow,
-                        SeriesId(parsed.series_id),
+                        parsed.series_id,
                         input_dto.lang,
                         profile_id,
                     )
@@ -149,7 +149,7 @@ class GetContinueWatchingUseCase:
         media_ids = [
             WatchableMediaId(
                 EpisodeCompositeId.build(
-                    series_id.value,
+                    series_id,
                     ep.season_number,
                     ep.episode_number,
                 ).media_id

--- a/src/modules/watch_progress/domain/value_objects/watchable_media_id.py
+++ b/src/modules/watch_progress/domain/value_objects/watchable_media_id.py
@@ -9,7 +9,7 @@ from pydantic import model_validator
 from src.building_blocks.domain.errors import DomainValidationException
 from src.building_blocks.domain.value_objects import StringValueObject
 from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
-from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
+from src.shared_kernel.value_objects.media_id import MovieId
 
 
 class WatchableMediaId(StringValueObject):
@@ -53,15 +53,13 @@ class WatchableMediaId(StringValueObject):
                 ) from exc
             return value
 
-        parsed = EpisodeCompositeId.parse(value)
+        try:
+            parsed = EpisodeCompositeId.parse(value)
+        except DomainValidationException as exc:
+            raise ValueError(
+                f"Malformed composite episode id: '{value}' [{cls._RULE_CODE}]"
+            ) from exc
         if parsed is not None:
-            try:
-                SeriesId(parsed.series_id)
-            except DomainValidationException as exc:
-                raise ValueError(
-                    f"Invalid series id inside composite episode id: '{value}' "
-                    f"[{cls._RULE_CODE}]"
-                ) from exc
             return value
 
         raise ValueError(

--- a/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
+++ b/src/modules/watch_progress/infrastructure/persistence/repositories/watch_progress_repository.py
@@ -15,6 +15,7 @@ from src.modules.watch_progress.infrastructure.persistence.mappers import (
 from src.modules.watch_progress.infrastructure.persistence.models import (
     WatchProgressModel,
 )
+from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
 from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
@@ -184,7 +185,7 @@ class SQLAlchemyWatchProgressRepository(WatchProgressRepository):
         profile_id: ProfileId,
     ) -> int:
         """Soft-delete every episode-progress row for this series in the profile."""
-        prefix = f"epi_{series_id.value}_"
+        prefix = EpisodeCompositeId.media_id_prefix_for(series_id)
         stmt = select(WatchProgressModel).where(
             WatchProgressModel.profile_id == str(profile_id),
             WatchProgressModel.media_id.startswith(prefix),

--- a/src/shared_kernel/value_objects/episode_composite_id.py
+++ b/src/shared_kernel/value_objects/episode_composite_id.py
@@ -2,47 +2,82 @@
 
 The frontend identifies episodes using composite keys in the format
 ``epi_{series_id}_{season_number}_{episode_number}`` (e.g.
-``epi_ser_Hy9VjMfILYZe_3_2``). This module provides build/parse
-utilities so the format is defined in a single place.
+``epi_ser_Hy9VjMfILYZe_3_2``). This module is the single place where
+that wire format is defined, built and parsed, so the scheme never has
+to be reconstructed by hand elsewhere.
 """
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 from src.building_blocks.domain.errors import DomainValidationException
 from src.building_blocks.domain.value_objects import CompoundValueObject
+from src.shared_kernel.value_objects.media_id import SeriesId
+
+# Marker that precedes the series id in every composite key. Derived from
+# ``SeriesId.EXPECTED_PREFIX`` so the ``ser`` scheme lives in one place
+# (``media_id.py``) instead of being duplicated as a literal here.
+_PREFIX = "epi_"
+_COMPOSITE_MARKER = f"{_PREFIX}{SeriesId.EXPECTED_PREFIX}_"
+
+
+class EpisodeCompositeIdRuleCodes(StrEnum):
+    """Rule codes for composite episode id parsing violations."""
+
+    MALFORMED_COMPOSITE_EPISODE_ID = "MALFORMED_COMPOSITE_EPISODE_ID"
 
 
 class EpisodeCompositeId(CompoundValueObject):
     """Composite episode identifier used by the frontend.
 
     Attributes:
-        series_id: External series ID (``ser_xxx`` format).
+        series_id: Typed external series ID (``ser_xxx`` format).
         season_number: Season number.
         episode_number: Episode number within the season.
 
     Example:
-        >>> eid = EpisodeCompositeId.build("ser_Hy9VjMfILYZe", 3, 2)
+        >>> from src.shared_kernel.value_objects.media_id import SeriesId
+        >>> eid = EpisodeCompositeId.build(SeriesId("ser_Hy9VjMfILYZe"), 3, 2)
         >>> eid.media_id
         'epi_ser_Hy9VjMfILYZe_3_2'
-        >>> EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_3_2")
-        EpisodeCompositeId(series_id='ser_Hy9VjMfILYZe', season_number=3, episode_number=2)
+        >>> EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_3_2").episode_number
+        2
     """
 
-    series_id: str
+    series_id: SeriesId
     season_number: int
     episode_number: int
 
     @property
     def media_id(self) -> str:
         """Build the composite media_id string."""
-        return f"epi_{self.series_id}_{self.season_number}_{self.episode_number}"
+        prefix = self.media_id_prefix_for(self.series_id)
+        return f"{prefix}{self.season_number}_{self.episode_number}"
 
     @classmethod
-    def build(cls, series_id: str, season_number: int, episode_number: int) -> EpisodeCompositeId:
+    def media_id_prefix_for(cls, series_id: SeriesId) -> str:
+        """Return the media_id prefix shared by every episode of a series.
+
+        Useful for prefix queries (e.g. soft-deleting every episode-progress
+        row of a series) without rebuilding the wire format by hand.
+
+        Args:
+            series_id: The series whose episode ids share the prefix.
+
+        Returns:
+            The ``epi_{series_id}_`` prefix string.
+        """
+        return f"{_PREFIX}{series_id}_"
+
+    @classmethod
+    def build(
+        cls, series_id: SeriesId, season_number: int, episode_number: int
+    ) -> EpisodeCompositeId:
         """Create from individual components.
 
         Args:
-            series_id: External series ID.
+            series_id: Typed external series ID.
             season_number: Season number.
             episode_number: Episode number.
 
@@ -59,28 +94,56 @@ class EpisodeCompositeId(CompoundValueObject):
     def parse(cls, media_id: str) -> EpisodeCompositeId | None:
         """Parse a composite media_id string.
 
+        Distinguishes "this is not a composite episode key" from "this is a
+        malformed one": only strings carrying the ``epi_ser_`` marker are
+        treated as episode keys, so a plain ``epi_{base62}`` catalog id, a
+        ``mov_xxx`` id or garbage yields ``None``, while a marker-bearing
+        string with a broken structure or invalid series id raises.
+
         Args:
-            media_id: The composite media_id (e.g. ``epi_ser_XXX_S_E``).
+            media_id: The candidate composite media_id (e.g. ``epi_ser_XXX_S_E``).
 
         Returns:
-            EpisodeCompositeId if valid, None otherwise.
+            EpisodeCompositeId when the string is a well-formed composite
+            episode key, or None when it is not an episode key at all.
+
+        Raises:
+            DomainValidationException: When the string carries the composite
+                marker but its structure, numbers or series id are invalid.
         """
-        if not media_id.startswith("epi_ser_"):
+        if not media_id.startswith(_COMPOSITE_MARKER):
             return None
+
         # epi_ser_Hy9VjMfILYZe_3_2 → strip "epi_" → "ser_Hy9VjMfILYZe_3_2"
-        rest = media_id[4:]
+        rest = media_id[len(_PREFIX) :]
         parts = rest.rsplit("_", 2)
         if len(parts) != 3:
-            return None
+            raise cls._malformed(media_id)
+
         series_id_str, season_str, episode_str = parts
         try:
-            return cls(
-                series_id=series_id_str,
-                season_number=int(season_str),
-                episode_number=int(episode_str),
-            )
-        except (ValueError, DomainValidationException):
-            return None
+            season_number = int(season_str)
+            episode_number = int(episode_str)
+        except ValueError as exc:
+            raise cls._malformed(media_id) from exc
+
+        # Re-wrap an invalid series part so every malformed-but-marked id
+        # surfaces under the same rule code instead of SeriesId's generic one.
+        try:
+            series_id = SeriesId(series_id_str)
+        except DomainValidationException as exc:
+            raise cls._malformed(media_id) from exc
+
+        return cls.build(series_id, season_number, episode_number)
+
+    @staticmethod
+    def _malformed(media_id: str) -> DomainValidationException:
+        """Build the uniform "malformed composite episode id" error."""
+        return DomainValidationException(
+            message=f"Malformed composite episode id: {media_id}",
+            message_code=EpisodeCompositeIdRuleCodes.MALFORMED_COMPOSITE_EPISODE_ID,
+            object_type="EpisodeCompositeId",
+        )
 
 
-__all__ = ["EpisodeCompositeId"]
+__all__ = ["EpisodeCompositeId", "EpisodeCompositeIdRuleCodes"]

--- a/tests/modules/watch_progress/unit/domain/value_objects/test_watchable_media_id.py
+++ b/tests/modules/watch_progress/unit/domain/value_objects/test_watchable_media_id.py
@@ -4,7 +4,7 @@ import pytest
 
 from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.watch_progress.domain.value_objects import WatchableMediaId
-from src.shared_kernel.value_objects.media_id import MovieId
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 
 
 class TestWatchableMediaIdMovie:
@@ -39,7 +39,7 @@ class TestWatchableMediaIdEpisode:
     def test_as_episode_parses_components(self):
         parsed = WatchableMediaId("epi_ser_3yL8nQsT9mK5_3_2").as_episode()
 
-        assert parsed.series_id == "ser_3yL8nQsT9mK5"
+        assert parsed.series_id == SeriesId("ser_3yL8nQsT9mK5")
         assert parsed.season_number == 3
         assert parsed.episode_number == 2
 

--- a/tests/shared_kernel/unit/test_episode_composite_id.py
+++ b/tests/shared_kernel/unit/test_episode_composite_id.py
@@ -2,25 +2,40 @@
 
 import pytest
 
-from src.shared_kernel.value_objects.episode_composite_id import EpisodeCompositeId
+from src.building_blocks.domain.errors import DomainValidationException
+from src.shared_kernel.value_objects.episode_composite_id import (
+    EpisodeCompositeId,
+    EpisodeCompositeIdRuleCodes,
+)
+from src.shared_kernel.value_objects.media_id import SeriesId
 
 
 class TestEpisodeCompositeIdBuild:
     """Tests for building composite IDs."""
 
     def test_build_creates_correct_media_id(self):
-        eid = EpisodeCompositeId.build("ser_Hy9VjMfILYZe", 3, 2)
+        eid = EpisodeCompositeId.build(SeriesId("ser_Hy9VjMfILYZe"), 3, 2)
         assert eid.media_id == "epi_ser_Hy9VjMfILYZe_3_2"
 
     def test_build_stores_components(self):
-        eid = EpisodeCompositeId.build("ser_abc123def456", 1, 5)
-        assert eid.series_id == "ser_abc123def456"
+        eid = EpisodeCompositeId.build(SeriesId("ser_abc123def456"), 1, 5)
+        assert eid.series_id == SeriesId("ser_abc123def456")
         assert eid.season_number == 1
         assert eid.episode_number == 5
 
     def test_build_with_large_numbers(self):
-        eid = EpisodeCompositeId.build("ser_XXXXXXXXXXXX", 25, 100)
+        eid = EpisodeCompositeId.build(SeriesId("ser_XXXXXXXXXXXX"), 25, 100)
         assert eid.media_id == "epi_ser_XXXXXXXXXXXX_25_100"
+
+
+class TestEpisodeCompositeIdPrefix:
+    """Tests for the shared series prefix."""
+
+    def test_prefix_matches_built_media_id(self):
+        series_id = SeriesId("ser_Hy9VjMfILYZe")
+        prefix = EpisodeCompositeId.media_id_prefix_for(series_id)
+        assert prefix == "epi_ser_Hy9VjMfILYZe_"
+        assert EpisodeCompositeId.build(series_id, 3, 2).media_id.startswith(prefix)
 
 
 class TestEpisodeCompositeIdParse:
@@ -29,7 +44,7 @@ class TestEpisodeCompositeIdParse:
     def test_parse_valid_composite_id(self):
         eid = EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_3_2")
         assert eid is not None
-        assert eid.series_id == "ser_Hy9VjMfILYZe"
+        assert eid.series_id == SeriesId("ser_Hy9VjMfILYZe")
         assert eid.season_number == 3
         assert eid.episode_number == 2
 
@@ -42,17 +57,44 @@ class TestEpisodeCompositeIdParse:
     def test_parse_returns_none_for_empty_string(self):
         assert EpisodeCompositeId.parse("") is None
 
-    def test_parse_returns_none_for_non_numeric_season(self):
-        assert EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_abc_2") is None
-
-    def test_parse_returns_none_for_non_numeric_episode(self):
-        assert EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_3_abc") is None
-
-    def test_parse_returns_none_for_missing_segments(self):
-        assert EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe") is None
-
-    def test_parse_returns_none_for_wrong_prefix(self):
+    def test_parse_returns_none_for_wrong_inner_prefix(self):
+        # No 'epi_ser_' marker → not a composite episode key at all.
         assert EpisodeCompositeId.parse("epi_mov_something_1_2") is None
+
+    def test_parse_raises_for_non_numeric_season(self):
+        with pytest.raises(DomainValidationException):
+            EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_abc_2")
+
+    def test_parse_raises_for_non_numeric_episode(self):
+        with pytest.raises(DomainValidationException):
+            EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe_3_abc")
+
+    def test_parse_raises_for_missing_segments(self):
+        with pytest.raises(DomainValidationException):
+            EpisodeCompositeId.parse("epi_ser_Hy9VjMfILYZe")
+
+    def test_parse_raises_for_invalid_series_id(self):
+        # Marker present but the series part is not a valid SeriesId.
+        with pytest.raises(DomainValidationException):
+            EpisodeCompositeId.parse("epi_ser_short_3_2")
+
+    @pytest.mark.parametrize(
+        "malformed",
+        [
+            "epi_ser_Hy9VjMfILYZe_abc_2",  # non-numeric season
+            "epi_ser_Hy9VjMfILYZe",  # missing segments
+            "epi_ser_short_3_2",  # invalid series id
+        ],
+    )
+    def test_parse_malformed_uses_uniform_rule_code(self, malformed: str) -> None:
+        # Every marker-bearing-but-broken shape surfaces under the same code,
+        # regardless of which sub-path (structure, numbers, series id) failed.
+        with pytest.raises(DomainValidationException) as exc_info:
+            EpisodeCompositeId.parse(malformed)
+        assert (
+            exc_info.value.message_code
+            == EpisodeCompositeIdRuleCodes.MALFORMED_COMPOSITE_EPISODE_ID
+        )
 
 
 class TestEpisodeCompositeIdRoundTrip:
@@ -67,9 +109,9 @@ class TestEpisodeCompositeIdRoundTrip:
         ],
     )
     def test_round_trip(self, series_id: str, season: int, episode: int) -> None:
-        built = EpisodeCompositeId.build(series_id, season, episode)
+        built = EpisodeCompositeId.build(SeriesId(series_id), season, episode)
         parsed = EpisodeCompositeId.parse(built.media_id)
         assert parsed is not None
-        assert parsed.series_id == series_id
+        assert parsed.series_id == SeriesId(series_id)
         assert parsed.season_number == season
         assert parsed.episode_number == episode


### PR DESCRIPTION
## Summary

- Type `EpisodeCompositeId.series_id` as `SeriesId` instead of a raw `str`, and derive the composite wire marker (`epi_ser_`) from `SeriesId.EXPECTED_PREFIX` so the `ser` scheme lives in one place (`media_id.py`).
- Split `parse()` into a clean two-mode contract: returns `None` when the string is not a composite episode key at all, and raises `DomainValidationException` (uniform `MALFORMED_COMPOSITE_EPISODE_ID` code) when the `epi_ser_` marker is present but the structure, numbers or series id are invalid — no more collapsing "not an episode" and "corrupt" into the same silent `None`.
- Add `media_id_prefix_for(series_id)` and route the watch_progress repository's episode-prefix query through it, removing the last hand-built `epi_{series}_` string from the persistence layer.
- Propagate the typed `SeriesId` through call sites (`get_series_by_id` projection helpers, `get_continue_watching`), dropping a redundant `SeriesId(parsed.series_id)` re-wrap and the now-unneeded series-id re-validation in `WatchableMediaId`.

Closes backlog item 6.9 (Primitive Obsession + Stringly-Typed on the composite episode key). The optional `SubtitleFormat` enum from the same card is deferred: subtitle `format` is fed open-vocabulary from ffprobe (unmapped codecs fall through as-is) and rehydrated from persisted JSON, so a strict enum would risk breaking scans/rehydration of exotic formats — out of step with this item's low-risk scope.

## Test plan

- [x] `pytest tests/shared_kernel/unit/test_episode_composite_id.py` — rewritten for the typed `SeriesId`, the None-vs-raise split (all four non-episode shapes + all malformed shapes), `media_id_prefix_for` tied back to a built id, and a parametrized assertion pinning the uniform rule code.
- [x] `pytest tests/modules/watch_progress/ tests/modules/media/ tests/shared_kernel/` — full suites green (1984 passed).
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy src` introduces no new errors (the 2 pre-existing `_to_entities_dropping_invalid` Sequence-vs-list errors exist on `develop`).