### PR TITLE
refactor(progress): model subtitle preference as a value object

### DIFF
--- a/src/modules/watch_progress/application/dtos/progress_dtos.py
+++ b/src/modules/watch_progress/application/dtos/progress_dtos.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from src.modules.watch_progress.domain.value_objects import SubtitlePreference
+
 if TYPE_CHECKING:
     from src.modules.watch_progress.domain.entities import WatchProgress
 
@@ -22,7 +24,8 @@ class SaveProgressInput:
         position_seconds: Current playback position in seconds.
         duration_seconds: Total duration of the media in seconds.
         audio_track: Selected audio track index.
-        subtitle_track: Selected subtitle track index (-1 = off).
+        subtitle_track: Subtitle preference in wire form — see
+            ``SubtitlePreference.from_wire`` (``-1`` = off, ``>= 0`` = track).
     """
 
     profile_id: str
@@ -67,7 +70,7 @@ class ProgressOutput:
             percentage=progress.percentage,
             status=progress.status,
             audio_track=progress.audio_track,
-            subtitle_track=progress.subtitle_track,
+            subtitle_track=SubtitlePreference.to_wire(progress.subtitle_track),
             last_watched_at=progress.last_watched_at.isoformat(),
         )
 

--- a/src/modules/watch_progress/application/use_cases/save_progress.py
+++ b/src/modules/watch_progress/application/use_cases/save_progress.py
@@ -6,6 +6,7 @@ from src.modules.watch_progress.application.unit_of_work import (
 )
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import (
+    SubtitlePreference,
     WatchableMediaId,
     WatchableMediaType,
 )
@@ -22,6 +23,7 @@ class SaveProgressUseCase:
         """Persist progress for the caller's profile."""
         profile_id = ProfileId(input_dto.profile_id)
         media_id = WatchableMediaId(input_dto.media_id)
+        subtitle_track = SubtitlePreference.from_wire(input_dto.subtitle_track)
         async with self._uow_factory() as uow:
             existing = await uow.progress.find_by_media_id(media_id, profile_id)
 
@@ -30,7 +32,7 @@ class SaveProgressUseCase:
                     position_seconds=input_dto.position_seconds,
                     duration_seconds=input_dto.duration_seconds,
                     audio_track=input_dto.audio_track,
-                    subtitle_track=input_dto.subtitle_track,
+                    subtitle_track=subtitle_track,
                 )
             else:
                 progress = WatchProgress.create(
@@ -40,7 +42,7 @@ class SaveProgressUseCase:
                     position_seconds=input_dto.position_seconds,
                     duration_seconds=input_dto.duration_seconds,
                     audio_track=input_dto.audio_track,
-                    subtitle_track=input_dto.subtitle_track,
+                    subtitle_track=subtitle_track,
                 )
 
             saved = await uow.progress.save(progress)

--- a/src/modules/watch_progress/domain/entities/watch_progress.py
+++ b/src/modules/watch_progress/domain/entities/watch_progress.py
@@ -10,6 +10,7 @@ from pydantic import Field, model_validator
 from src.building_blocks.domain import AggregateRoot
 from src.modules.watch_progress.domain.value_objects import (
     ProgressId,
+    SubtitlePreference,
     WatchableMediaId,
     WatchableMediaType,
     WatchStatus,
@@ -62,7 +63,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
 
     # Track preferences
     audio_track: int | None = None
-    subtitle_track: int | None = None
+    subtitle_track: SubtitlePreference | None = None
 
     # Timestamps
     last_watched_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -99,7 +100,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
         position_seconds: int,
         duration_seconds: int | None = None,
         audio_track: int | None = None,
-        subtitle_track: int | None = None,
+        subtitle_track: SubtitlePreference | None = None,
     ) -> Self:
         """Return a copy with updated position and track preferences.
 
@@ -108,8 +109,10 @@ class WatchProgress(AggregateRoot[ProgressId]):
         Args:
             position_seconds: Current playback position in seconds.
             duration_seconds: Updated total duration (corrects stale values).
-            audio_track: Selected audio track index.
-            subtitle_track: Selected subtitle track index (-1 = off).
+            audio_track: Selected audio track index, or ``None`` to leave
+                the current preference unchanged.
+            subtitle_track: New subtitle preference, or ``None`` to leave
+                the current preference unchanged.
 
         Returns:
             New WatchProgress with updated fields.
@@ -145,7 +148,7 @@ class WatchProgress(AggregateRoot[ProgressId]):
         position_seconds: int,
         duration_seconds: int,
         audio_track: int | None = None,
-        subtitle_track: int | None = None,
+        subtitle_track: SubtitlePreference | None = None,
     ) -> WatchProgress:
         """Factory method with automatic ID generation.
 
@@ -159,7 +162,8 @@ class WatchProgress(AggregateRoot[ProgressId]):
             position_seconds: Current playback position in seconds.
             duration_seconds: Total duration of the media in seconds.
             audio_track: Selected audio track index.
-            subtitle_track: Selected subtitle track index.
+            subtitle_track: Subtitle preference (off or a track), or
+                ``None`` when no preference was recorded.
 
         Returns:
             A new WatchProgress instance.

--- a/src/modules/watch_progress/domain/value_objects/__init__.py
+++ b/src/modules/watch_progress/domain/value_objects/__init__.py
@@ -4,6 +4,9 @@ from src.modules.watch_progress.domain.value_objects.episode_candidate import (
     EpisodeCandidate,
 )
 from src.modules.watch_progress.domain.value_objects.progress_id import ProgressId
+from src.modules.watch_progress.domain.value_objects.subtitle_preference import (
+    SubtitlePreference,
+)
 from src.modules.watch_progress.domain.value_objects.watch_status import WatchStatus
 from src.modules.watch_progress.domain.value_objects.watchable_media_id import (
     WatchableMediaId,
@@ -15,6 +18,7 @@ from src.modules.watch_progress.domain.value_objects.watchable_media_type import
 __all__ = [
     "EpisodeCandidate",
     "ProgressId",
+    "SubtitlePreference",
     "WatchStatus",
     "WatchableMediaId",
     "WatchableMediaType",

--- a/src/modules/watch_progress/domain/value_objects/subtitle_preference.py
+++ b/src/modules/watch_progress/domain/value_objects/subtitle_preference.py
@@ -1,0 +1,88 @@
+"""Subtitle preference value object."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pydantic import Field
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+
+
+class SubtitlePreference(CompoundValueObject):
+    """A recorded subtitle choice: off, or a specific track index.
+
+    Replaces the overloaded ``int | None`` where ``-1`` meant "off" and
+    ``None`` meant "no preference". Here the *absence* of a preference is
+    modelled by the field being ``None``; a ``SubtitlePreference`` instance
+    always represents a concrete choice (off, or a track). The
+    wire/persistence format stays an int (``-1`` = off, ``>= 0`` = track
+    index) — that mapping is isolated to :meth:`from_wire` / :meth:`to_wire`,
+    the single home for the sentinel. Decoding is lenient (any negative
+    reads as "off"); encoding canonicalises "off" to ``-1``.
+
+    Attributes:
+        track_index: The chosen 0-based track index, or ``None`` for "off".
+
+    Example:
+        >>> SubtitlePreference.track(2).is_off
+        False
+        >>> SubtitlePreference.off().is_off
+        True
+        >>> SubtitlePreference.to_wire(SubtitlePreference.off())
+        -1
+        >>> SubtitlePreference.from_wire(2).track_index
+        2
+    """
+
+    _OFF_WIRE_VALUE: ClassVar[int] = -1
+
+    track_index: int | None = Field(ge=0)
+
+    @classmethod
+    def off(cls) -> SubtitlePreference:
+        """Subtitles explicitly turned off."""
+        return cls(track_index=None)
+
+    @classmethod
+    def track(cls, index: int) -> SubtitlePreference:
+        """A specific 0-based subtitle track."""
+        return cls(track_index=index)
+
+    @property
+    def is_off(self) -> bool:
+        """Whether subtitles are turned off."""
+        return self.track_index is None
+
+    @classmethod
+    def from_wire(cls, value: int | None) -> SubtitlePreference | None:
+        """Decode the persisted/wire int into a preference.
+
+        Args:
+            value: ``None`` (no preference recorded), a negative value
+                (off), or a ``>= 0`` track index.
+
+        Returns:
+            ``None`` when no preference is recorded, otherwise the
+            corresponding :class:`SubtitlePreference`.
+        """
+        if value is None:
+            return None
+        return cls.off() if value < 0 else cls.track(value)
+
+    @classmethod
+    def to_wire(cls, preference: SubtitlePreference | None) -> int | None:
+        """Encode a preference back into the persisted/wire int.
+
+        Args:
+            preference: A preference, or ``None`` for "no preference".
+
+        Returns:
+            ``None`` when no preference, ``-1`` for off, else the track index.
+        """
+        if preference is None:
+            return None
+        return cls._OFF_WIRE_VALUE if preference.is_off else preference.track_index
+
+
+__all__ = ["SubtitlePreference"]

--- a/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
+++ b/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
@@ -3,6 +3,7 @@
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import (
     ProgressId,
+    SubtitlePreference,
     WatchableMediaId,
     WatchableMediaType,
     WatchStatus,
@@ -41,7 +42,7 @@ class WatchProgressMapper:
             duration_seconds=entity.duration_seconds,
             status=entity.status,
             audio_track=entity.audio_track,
-            subtitle_track=entity.subtitle_track,
+            subtitle_track=SubtitlePreference.to_wire(entity.subtitle_track),
             last_watched_at=entity.last_watched_at,
             completed_at=entity.completed_at,
         )
@@ -58,7 +59,7 @@ class WatchProgressMapper:
             duration_seconds=model.duration_seconds,
             status=WatchStatus(model.status),
             audio_track=model.audio_track,
-            subtitle_track=model.subtitle_track,
+            subtitle_track=SubtitlePreference.from_wire(model.subtitle_track),
             last_watched_at=model.last_watched_at,
             completed_at=model.completed_at,
             created_at=model.created_at,
@@ -77,7 +78,7 @@ class WatchProgressMapper:
         model.duration_seconds = entity.duration_seconds
         model.status = entity.status
         model.audio_track = entity.audio_track
-        model.subtitle_track = entity.subtitle_track
+        model.subtitle_track = SubtitlePreference.to_wire(entity.subtitle_track)
         model.last_watched_at = entity.last_watched_at
         model.completed_at = entity.completed_at
         return model

--- a/src/modules/watch_progress/infrastructure/persistence/models/watch_progress_model.py
+++ b/src/modules/watch_progress/infrastructure/persistence/models/watch_progress_model.py
@@ -28,7 +28,8 @@ class WatchProgressModel(Base):
         duration_seconds: Total duration of the media.
         status: Watch status ("in_progress" or "completed").
         audio_track: Selected audio track index.
-        subtitle_track: Selected subtitle track index (-1 = off).
+        subtitle_track: Subtitle preference encoded as an int — see
+            ``SubtitlePreference.to_wire`` (``-1`` = off, ``>= 0`` = track).
         last_watched_at: Timestamp of last position update.
         completed_at: Timestamp when marked as completed.
     """

--- a/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_save_progress.py
@@ -113,3 +113,25 @@ class TestSaveProgressUseCase:
 
         assert result.audio_track == 2
         assert result.subtitle_track == 1
+
+    @pytest.mark.asyncio
+    async def test_subtitles_off_round_trips_through_the_use_case(self):
+        # The -1 = off sentinel must survive the full wire→VO→entity→wire path.
+        mocks = make_watch_progress_uow_mock()
+        mock_repo = mocks.progress
+        mock_repo.find_by_media_id.return_value = None
+        mock_repo.save.side_effect = lambda p: p
+        use_case = SaveProgressUseCase(uow_factory=mocks.factory)
+
+        result = await use_case.execute(
+            SaveProgressInput(
+                profile_id=_PROFILE_ID.value,
+                media_id="mov_abc123def456",
+                media_type="movie",
+                position_seconds=100,
+                duration_seconds=7200,
+                subtitle_track=-1,
+            )
+        )
+
+        assert result.subtitle_track == -1

--- a/tests/modules/watch_progress/unit/domain/entities/test_watch_progress.py
+++ b/tests/modules/watch_progress/unit/domain/entities/test_watch_progress.py
@@ -1,7 +1,10 @@
 """Tests for WatchProgress entity."""
 
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.modules.watch_progress.domain.value_objects import (
+    SubtitlePreference,
+    WatchableMediaType,
+)
 from src.shared_kernel.value_objects.profile_id import ProfileId
 
 _PROFILE_ID = ProfileId("prf_test12345678")
@@ -14,7 +17,7 @@ def _create_progress(
     position_seconds: int = 100,
     duration_seconds: int = 7200,
     audio_track: int | None = None,
-    subtitle_track: int | None = None,
+    subtitle_track: SubtitlePreference | None = None,
 ) -> WatchProgress:
     return WatchProgress.create(
         profile_id=_PROFILE_ID,
@@ -77,8 +80,14 @@ class TestWatchProgress:
 
     def test_update_position_saves_subtitle_track(self):
         progress = _create_progress()
-        updated = progress.update_position(200, subtitle_track=1)
-        assert updated.subtitle_track == 1
+        updated = progress.update_position(200, subtitle_track=SubtitlePreference.track(1))
+        assert updated.subtitle_track == SubtitlePreference.track(1)
+
+    def test_update_position_saves_subtitles_off(self):
+        progress = _create_progress()
+        updated = progress.update_position(200, subtitle_track=SubtitlePreference.off())
+        assert updated.subtitle_track is not None
+        assert updated.subtitle_track.is_off
 
     def test_is_completed_property(self):
         progress = _create_progress()

--- a/tests/modules/watch_progress/unit/domain/value_objects/test_subtitle_preference.py
+++ b/tests/modules/watch_progress/unit/domain/value_objects/test_subtitle_preference.py
@@ -1,0 +1,54 @@
+"""Tests for the SubtitlePreference value object."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.watch_progress.domain.value_objects import SubtitlePreference
+
+
+@pytest.mark.unit
+class TestSubtitlePreferenceConstruction:
+    """Factory methods and the off/track distinction."""
+
+    def test_track_holds_index_and_is_not_off(self) -> None:
+        pref = SubtitlePreference.track(3)
+        assert pref.track_index == 3
+        assert pref.is_off is False
+
+    def test_off_has_no_index_and_is_off(self) -> None:
+        pref = SubtitlePreference.off()
+        assert pref.track_index is None
+        assert pref.is_off is True
+
+    def test_off_and_track_are_not_equal(self) -> None:
+        assert SubtitlePreference.off() != SubtitlePreference.track(0)
+
+    def test_negative_track_index_is_rejected(self) -> None:
+        with pytest.raises(DomainValidationException):
+            SubtitlePreference.track(-1)
+
+
+@pytest.mark.unit
+class TestSubtitlePreferenceWireCodec:
+    """from_wire / to_wire isolate the -1 sentinel and None semantics."""
+
+    def test_none_is_no_preference(self) -> None:
+        assert SubtitlePreference.from_wire(None) is None
+        assert SubtitlePreference.to_wire(None) is None
+
+    def test_negative_decodes_to_off_and_encodes_back(self) -> None:
+        assert SubtitlePreference.from_wire(-1) == SubtitlePreference.off()
+        assert SubtitlePreference.to_wire(SubtitlePreference.off()) == -1
+
+    def test_index_round_trips(self) -> None:
+        assert SubtitlePreference.from_wire(0) == SubtitlePreference.track(0)
+        assert SubtitlePreference.to_wire(SubtitlePreference.track(5)) == 5
+
+    @pytest.mark.parametrize("wire", [None, -1, 0, 1, 7])
+    def test_wire_round_trip(self, wire: int | None) -> None:
+        assert SubtitlePreference.to_wire(SubtitlePreference.from_wire(wire)) == wire
+
+    def test_non_canonical_negative_decodes_to_off_and_canonicalizes(self) -> None:
+        # Decoding is lenient (any negative is "off"); encoding canonicalises to -1.
+        assert SubtitlePreference.from_wire(-5) == SubtitlePreference.off()
+        assert SubtitlePreference.to_wire(SubtitlePreference.from_wire(-5)) == -1

--- a/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
+++ b/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
@@ -5,7 +5,11 @@ from datetime import UTC, datetime
 import pytest
 
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import ProgressId, WatchableMediaType
+from src.modules.watch_progress.domain.value_objects import (
+    ProgressId,
+    SubtitlePreference,
+    WatchableMediaType,
+)
 from src.modules.watch_progress.infrastructure.persistence.mappers import (
     WatchProgressMapper,
 )
@@ -74,13 +78,28 @@ class TestWatchProgressMapperToModel:
             position_seconds=100,
             duration_seconds=7200,
             audio_track=1,
-            subtitle_track=2,
+            subtitle_track=SubtitlePreference.track(2),
         )
 
         model = WatchProgressMapper.to_model(progress)
 
         assert model.audio_track == 1
-        assert model.subtitle_track == 2
+        assert model.subtitle_track == 2  # wire encoding stays an int
+
+    def test_should_encode_subtitles_off_as_negative_one(self) -> None:
+        progress = WatchProgress(
+            id=ProgressId.generate(),
+            profile_id=_PROFILE_ID,
+            media_id="mov_abc123def456",
+            media_type=WatchableMediaType.MOVIE,
+            position_seconds=100,
+            duration_seconds=7200,
+            subtitle_track=SubtitlePreference.off(),
+        )
+
+        model = WatchProgressMapper.to_model(progress)
+
+        assert model.subtitle_track == -1
 
     def test_should_preserve_completed_status(self) -> None:
         now = datetime.now(UTC)
@@ -133,7 +152,29 @@ class TestWatchProgressMapperToEntity:
         assert entity.position_seconds == 900
         assert entity.status == "in_progress"
         assert entity.audio_track == 0
-        assert entity.subtitle_track == 1
+        assert entity.subtitle_track == SubtitlePreference.track(1)
+
+    def test_should_decode_negative_one_as_subtitles_off(self) -> None:
+        now = datetime.now(UTC)
+        model = WatchProgressModel(
+            external_id=str(ProgressId.generate()),
+            profile_id=str(_PROFILE_ID),
+            media_id="mov_abc123def456",
+            media_type="movie",
+            position_seconds=100,
+            duration_seconds=7200,
+            status="in_progress",
+            subtitle_track=-1,
+            last_watched_at=now,
+            completed_at=None,
+        )
+        model.created_at = now
+        model.updated_at = now
+
+        entity = WatchProgressMapper.to_entity(model)
+
+        assert entity.subtitle_track is not None
+        assert entity.subtitle_track.is_off
 
     def test_round_trip_should_preserve_fields(self) -> None:
         progress_id = ProgressId.generate()
@@ -182,7 +223,7 @@ class TestWatchProgressMapperUpdateModel:
             duration_seconds=7200,
             status="completed",
             audio_track=1,
-            subtitle_track=2,
+            subtitle_track=SubtitlePreference.track(2),
             last_watched_at=later,
             completed_at=later,
         )


### PR DESCRIPTION
## Summary

Backlog item 6.10 — `WatchProgress.subtitle_track` was an overloaded `int | None`: `None` meant "no preference", `-1` meant "subtitles off", and `>= 0` was a track index — a convention that lived only in docstrings and was untested at every layer.

It is now a `SubtitlePreference` value object (`Off | Track(index)`). The three states are unambiguous: the field being `None` means "no preference recorded", `SubtitlePreference.off()` means off, `SubtitlePreference.track(n)` means a specific track. The `-1` sentinel is isolated to `SubtitlePreference.from_wire` / `to_wire`, the single home for the wire encoding, and is finally covered by tests.

The persisted ORM column and the HTTP request/response contract stay `int | None` (`-1` = off), so there is **no migration and no frontend change**; conversion happens once at each boundary — the use case (HTTP in), the Output DTO `from_entity` (HTTP out), and the persistence mapper (DB in/out). `audio_track` is intentionally left as `int | None` (audio has no "off" concept).

No ADR: this is a localized VO covered by the existing ADR-001 (Pydantic domain models) and ADR-018 (VOs at boundaries) conventions.

## Test plan

- [x] `pytest tests/modules/watch_progress/` — green (119 passed), incl. new `test_subtitle_preference.py` (off/track/is_off, negative index rejected, `from_wire`/`to_wire` round-trip + non-canonical-negative collapse), the mapper now pinning `off→-1` / `-1→off` in both directions, an explicit-off `update_position` test, and a `save_progress` test that the `-1`=off sentinel round-trips through the full wire→VO→entity→wire path.
- [x] `ruff check` + `ruff format --check` clean on the touched files.
- [x] `mypy src --ignore-missing-imports` introduces no new errors in the changed files.
- [x] No DB migration: `subtitle_track` column stays `Integer` nullable; wire contract unchanged.