### PR TITLE
refactor(media): type scan-run counters + Resolution.is_unknown

### DIFF
--- a/src/modules/media/application/services/scan_run_service.py
+++ b/src/modules/media/application/services/scan_run_service.py
@@ -33,6 +33,10 @@ from src.modules.media.domain.entities.scan_run import (
     ScanRunKind,
     ScanRunTrigger,
 )
+from src.modules.media.domain.value_objects.scan_counters import (
+    EnrichCounters,
+    ScanCounters,
+)
 from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
 
 _logger = logging.getLogger(__name__)
@@ -100,13 +104,13 @@ class ScanRunService:
                     directories=list(library.paths),
                 ),
             )
-            summary = {
-                "movies_created": output.movies_created,
-                "movies_updated": output.movies_updated,
-                "episodes_created": output.episodes_created,
-                "episodes_updated": output.episodes_updated,
-            }
-            await self._finalize_succeeded(run_id, summary, output.errors)
+            counters = ScanCounters(
+                movies_created=output.movies_created,
+                movies_updated=output.movies_updated,
+                episodes_created=output.episodes_created,
+                episodes_updated=output.episodes_updated,
+            )
+            await self._finalize_succeeded(run_id, counters, output.errors)
         except Exception as exc:
             _logger.exception("Scan run %s crashed for library %s", run_id, library.id)
             await self._finalize_failed(run_id, str(exc))
@@ -115,12 +119,12 @@ class ScanRunService:
         """Execute the bulk enrich and write the terminal row."""
         try:
             output = await self._bulk_enrich.execute(BulkEnrichInput(force=force))
-            summary = {
-                "movies_enriched": output.movies_enriched,
-                "series_enriched": output.series_enriched,
-                "skipped": output.skipped,
-            }
-            await self._finalize_succeeded(run_id, summary, output.errors)
+            counters = EnrichCounters(
+                movies_enriched=output.movies_enriched,
+                series_enriched=output.series_enriched,
+                skipped=output.skipped,
+            )
+            await self._finalize_succeeded(run_id, counters, output.errors)
         except Exception as exc:
             _logger.exception("Bulk enrich run %s crashed", run_id)
             await self._finalize_failed(run_id, str(exc))
@@ -128,7 +132,7 @@ class ScanRunService:
     async def _finalize_succeeded(
         self,
         run_id: ScanRunId,
-        summary: dict[str, int],
+        counters: ScanCounters | EnrichCounters,
         errors: list[str],
     ) -> None:
         async with self._media_uow_factory() as uow:
@@ -136,7 +140,7 @@ class ScanRunService:
             if run is None:  # pragma: no cover — defensive, deleted mid-run
                 _logger.warning("scan_run %s disappeared before finalize", run_id)
                 return
-            await uow.scan_runs.save(run.succeed(summary, errors))
+            await uow.scan_runs.save(run.succeed(counters, errors))
 
     async def _finalize_failed(self, run_id: ScanRunId, error_message: str) -> None:
         async with self._media_uow_factory() as uow:

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -177,11 +177,12 @@ class ScanMediaDirectoriesUseCase:
         ``None`` when the duration could not be read.
         """
         probed = await self._probe(scanned.file_path.value)
-        resolution = scanned.resolution or (probed.resolution if probed else None) or "Unknown"
+        resolution_name = scanned.resolution or (probed.resolution if probed else None)
+        resolution = Resolution(resolution_name) if resolution_name else Resolution.unknown()
         media_file = MediaFile(
             file_path=scanned.file_path,
             file_size=scanned.file_size,
-            resolution=Resolution(resolution),
+            resolution=resolution,
             audio_tracks=list(probed.audio_tracks) if probed else [],
             subtitle_tracks=list(probed.all_subtitles) if probed else [],
             is_primary=is_primary,
@@ -200,7 +201,7 @@ class ScanMediaDirectoriesUseCase:
         resolution or non-empty track lists. Returns ``None`` when no
         change is needed.
         """
-        needs_resolution = current.resolution.name == "Unknown"
+        needs_resolution = current.resolution.is_unknown()
         needs_audio = not current.audio_tracks
         needs_subtitles = not current.subtitle_tracks
         if not needs_resolution and not needs_audio and not needs_subtitles:

--- a/src/modules/media/domain/entities/scan_run.py
+++ b/src/modules/media/domain/entities/scan_run.py
@@ -9,6 +9,10 @@ from typing import Any, Self
 from pydantic import Field
 
 from src.building_blocks.domain import AggregateRoot
+from src.modules.media.domain.value_objects.scan_counters import (
+    EnrichCounters,
+    ScanCounters,
+)
 from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
 
 
@@ -65,10 +69,11 @@ class ScanRun(AggregateRoot[ScanRunId]):
         finished_at: ``None`` while ``running``; set on terminal
             transitions.
         status: Current lifecycle state.
-        summary: Per-kind counter dict. For scans:
-            ``movies_created`` / ``movies_updated`` /
-            ``episodes_created`` / ``episodes_updated``.
-            For enrich: ``enriched`` / ``skipped`` / ``failed``.
+        summary: Per-kind counter dict, serialized from the typed
+            ``ScanCounters`` (scan) or ``EnrichCounters`` (enrich) value
+            object — see those VOs for the canonical key set. Kept as a
+            plain dict on the aggregate so the history row stays
+            kind-agnostic (one JSON column, no wide table).
         errors: First N error messages emitted during the run.
             Truncated to ``_MAX_ERRORS_RETAINED`` so a degenerate
             scan can't bloat the row.
@@ -102,26 +107,64 @@ class ScanRun(AggregateRoot[ScanRunId]):
             status=ScanRunStatus.RUNNING,
         )
 
-    def succeed(self, summary: dict[str, Any], errors: list[str]) -> Self:
-        """Return a copy stamped with ``succeeded`` + the final counters."""
+    def _require_counters_match_kind(
+        self,
+        counters: ScanCounters | EnrichCounters,
+    ) -> None:
+        """Enforce that the counters VO matches this run's ``kind``.
+
+        Keeps the kind↔summary-shape invariant in the domain instead of
+        relying on the caller to pair them correctly.
+        """
+        expected = ScanCounters if self.kind is ScanRunKind.SCAN else EnrichCounters
+        if not isinstance(counters, expected):
+            raise ValueError(
+                f"{type(counters).__name__} cannot summarize a "
+                f"{self.kind.value} run; expected {expected.__name__}",
+            )
+
+    def succeed(
+        self,
+        counters: ScanCounters | EnrichCounters,
+        errors: list[str],
+    ) -> Self:
+        """Return a copy stamped with ``succeeded`` + the final counters.
+
+        The typed ``counters`` carry the canonical per-kind key set; they
+        are serialized into the kind-agnostic ``summary`` column.
+
+        Raises:
+            ValueError: If ``counters`` does not match this run's ``kind``.
+        """
+        self._require_counters_match_kind(counters)
         return self.with_updates(
             status=ScanRunStatus.SUCCEEDED,
             finished_at=datetime.now(UTC),
-            summary=summary,
+            summary=counters.to_summary(),
             errors=list(errors[:_MAX_ERRORS_RETAINED]),
         )
 
-    def fail(self, error_message: str, summary: dict[str, Any] | None = None) -> Self:
+    def fail(
+        self,
+        error_message: str,
+        counters: ScanCounters | EnrichCounters | None = None,
+    ) -> Self:
         """Return a copy stamped with ``failed`` + the error message.
 
         Used when the runner itself raised (vs. completing with a
-        bag of per-file errors). ``summary`` may carry partial
-        counters if some work succeeded before the crash.
+        bag of per-file errors). ``counters`` may carry partial
+        counts if some work succeeded before the crash; when omitted,
+        any counters already recorded are kept.
+
+        Raises:
+            ValueError: If ``counters`` is given and does not match ``kind``.
         """
+        if counters is not None:
+            self._require_counters_match_kind(counters)
         return self.with_updates(
             status=ScanRunStatus.FAILED,
             finished_at=datetime.now(UTC),
-            summary=summary or self.summary,
+            summary=counters.to_summary() if counters is not None else self.summary,
             errors=[error_message],
         )
 

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -23,6 +23,10 @@ from src.modules.media.domain.value_objects.media_conflict_id import MediaConfli
 from src.modules.media.domain.value_objects.media_file import MediaFile
 from src.modules.media.domain.value_objects.merge_policy import MergePolicy
 from src.modules.media.domain.value_objects.resolution import Resolution
+from src.modules.media.domain.value_objects.scan_counters import (
+    EnrichCounters,
+    ScanCounters,
+)
 from src.modules.media.domain.value_objects.scan_run_id import ScanRunId
 from src.modules.media.domain.value_objects.season_number import SeasonNumber
 from src.modules.media.domain.value_objects.title import Title
@@ -52,6 +56,7 @@ __all__ = [
     "CreditsMarker",
     "CreditsMarkerSource",
     "Duration",
+    "EnrichCounters",
     "EpisodeId",
     "EpisodeNumber",
     "FilePath",
@@ -71,6 +76,7 @@ __all__ = [
     "MergePolicy",
     "MovieId",
     "Resolution",
+    "ScanCounters",
     "ScanRunId",
     "SeasonId",
     "SeasonNumber",

--- a/src/modules/media/domain/value_objects/resolution.py
+++ b/src/modules/media/domain/value_objects/resolution.py
@@ -21,6 +21,9 @@ class _ResolutionSpec(NamedTuple):
     height: int
 
 
+# Single source for the "resolution undetermined" sentinel name.
+_UNKNOWN_NAME = "Unknown"
+
 _RESOLUTION_MAP: dict[str, _ResolutionSpec] = {
     "360p": _ResolutionSpec(640, 360),
     "480p": _ResolutionSpec(854, 480),
@@ -28,7 +31,7 @@ _RESOLUTION_MAP: dict[str, _ResolutionSpec] = {
     "1080p": _ResolutionSpec(1920, 1080),
     "2K": _ResolutionSpec(2560, 1440),
     "4K": _ResolutionSpec(3840, 2160),
-    "Unknown": _ResolutionSpec(0, 0),
+    _UNKNOWN_NAME: _ResolutionSpec(0, 0),
 }
 
 # Resolution categories
@@ -65,6 +68,7 @@ class Resolution(CompoundValueObject):
     """
 
     VALID_NAMES: ClassVar[frozenset[str]] = frozenset(_RESOLUTION_MAP.keys())
+    UNKNOWN_NAME: ClassVar[str] = _UNKNOWN_NAME
 
     width: int = Field(ge=0)
     height: int = Field(ge=0)
@@ -139,7 +143,15 @@ class Resolution(CompoundValueObject):
         Returns:
             A Resolution instance with value "Unknown".
         """
-        return cls("Unknown")
+        return cls(cls.UNKNOWN_NAME)
+
+    def is_unknown(self) -> bool:
+        """Whether the resolution is the undetermined sentinel.
+
+        Returns:
+            True when this is the "Unknown" placeholder (0x0).
+        """
+        return self.name == self.UNKNOWN_NAME
 
     # -- backward-compat property ------------------------------------------
 

--- a/src/modules/media/domain/value_objects/scan_counters.py
+++ b/src/modules/media/domain/value_objects/scan_counters.py
@@ -1,0 +1,52 @@
+"""Typed counters for a scan / bulk-enrich run.
+
+These replace the magic-key ``dict[str, Any]`` that the runner used to
+build by hand. The field names ARE the persisted summary keys, so the
+JSON shape stored on ``scan_runs.summary`` is unchanged — ``to_summary``
+is the single source of that contract.
+"""
+
+from pydantic import Field
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+
+
+class ScanCounters(CompoundValueObject):
+    """Per-kind counters produced by a catalog scan.
+
+    Attributes:
+        movies_created: Movies inserted during the scan.
+        movies_updated: Existing movies whose files were refreshed.
+        episodes_created: Episodes inserted during the scan.
+        episodes_updated: Existing episodes whose files were refreshed.
+    """
+
+    movies_created: int = Field(default=0, ge=0)
+    movies_updated: int = Field(default=0, ge=0)
+    episodes_created: int = Field(default=0, ge=0)
+    episodes_updated: int = Field(default=0, ge=0)
+
+    def to_summary(self) -> dict[str, int]:
+        """Serialize to the persisted summary shape (key = field name)."""
+        return self.model_dump()
+
+
+class EnrichCounters(CompoundValueObject):
+    """Per-kind counters produced by a bulk metadata enrich.
+
+    Attributes:
+        movies_enriched: Movies whose metadata was filled/refreshed.
+        series_enriched: Series whose metadata was filled/refreshed.
+        skipped: Items left untouched (already complete, or no match).
+    """
+
+    movies_enriched: int = Field(default=0, ge=0)
+    series_enriched: int = Field(default=0, ge=0)
+    skipped: int = Field(default=0, ge=0)
+
+    def to_summary(self) -> dict[str, int]:
+        """Serialize to the persisted summary shape (key = field name)."""
+        return self.model_dump()
+
+
+__all__ = ["EnrichCounters", "ScanCounters"]

--- a/src/modules/media/infrastructure/persistence/models/scan_run.py
+++ b/src/modules/media/infrastructure/persistence/models/scan_run.py
@@ -17,10 +17,11 @@ class ScanRunModel(Base):
     columns: ``kind`` (``scan`` | ``enrich``) tells *what* ran;
     ``trigger`` (``manual`` | ``scheduled``) tells *who* started it.
 
-    The per-kind counters live inside ``summary`` (JSON) — scans
-    track movies/episodes created+updated, enrich tracks
-    enriched/skipped/failed. Keeping them in JSON avoids a wide
-    column with mostly-null counters for whichever kind didn't run.
+    The per-kind counters live inside ``summary`` (JSON), serialized
+    from the typed ``ScanCounters`` / ``EnrichCounters`` value objects
+    (movies/episodes created+updated for scans; movies/series enriched +
+    skipped for enrich). Keeping them in JSON avoids a wide column with
+    mostly-null counters for whichever kind didn't run.
 
     Attributes:
         kind: ``scan`` or ``enrich``.

--- a/tests/modules/media/integration/persistence/repositories/test_scan_run_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_scan_run_repository.py
@@ -9,6 +9,7 @@ from src.modules.media.domain.entities.scan_run import (
     ScanRunStatus,
     ScanRunTrigger,
 )
+from src.modules.media.domain.value_objects.scan_counters import ScanCounters
 from src.modules.media.infrastructure.persistence.repositories.scan_run_repository import (
     SqlAlchemyScanRunRepository,
 )
@@ -40,13 +41,18 @@ class TestSaveAndFind:
         repo = SqlAlchemyScanRunRepository(db_session)
         opened = await repo.save(_new_scan())
 
-        finalized = opened.succeed({"movies_created": 5}, ["err1"])
+        finalized = opened.succeed(ScanCounters(movies_created=5), ["err1"])
         await repo.save(finalized)
         again = await repo.find_by_id(opened.id)  # type: ignore[arg-type]
 
         assert again is not None
         assert again.status == ScanRunStatus.SUCCEEDED
-        assert again.summary == {"movies_created": 5}
+        assert again.summary == {
+            "movies_created": 5,
+            "movies_updated": 0,
+            "episodes_created": 0,
+            "episodes_updated": 0,
+        }
         assert again.errors == ["err1"]
         assert again.finished_at is not None
 
@@ -103,7 +109,7 @@ class TestListByStatus:
     async def test_should_return_only_matching_status(self, db_session: AsyncSession) -> None:
         repo = SqlAlchemyScanRunRepository(db_session)
         opened = await repo.save(_new_scan())
-        await repo.save(opened.succeed({}, []))
+        await repo.save(opened.succeed(ScanCounters(), []))
         await repo.save(_new_scan())  # second row stays running
 
         running = await repo.list_by_status(ScanRunStatus.RUNNING)

--- a/tests/modules/media/unit/domain/entities/test_scan_run.py
+++ b/tests/modules/media/unit/domain/entities/test_scan_run.py
@@ -1,0 +1,71 @@
+"""Tests for the ScanRun aggregate's terminal transitions."""
+
+import pytest
+
+from src.modules.media.domain.entities.scan_run import (
+    ScanRun,
+    ScanRunKind,
+    ScanRunStatus,
+    ScanRunTrigger,
+)
+from src.modules.media.domain.value_objects.scan_counters import (
+    EnrichCounters,
+    ScanCounters,
+)
+
+
+def _running(kind: ScanRunKind) -> ScanRun:
+    return ScanRun.start(
+        kind=kind,
+        trigger=ScanRunTrigger.MANUAL,
+        library_id="lib_test12345678" if kind is ScanRunKind.SCAN else None,
+    )
+
+
+@pytest.mark.unit
+class TestScanRunSucceed:
+    def test_scan_counters_serialize_into_summary(self) -> None:
+        run = _running(ScanRunKind.SCAN).succeed(
+            ScanCounters(movies_created=2, episodes_updated=3), []
+        )
+        assert run.status is ScanRunStatus.SUCCEEDED
+        assert run.finished_at is not None
+        assert run.summary == {
+            "movies_created": 2,
+            "movies_updated": 0,
+            "episodes_created": 0,
+            "episodes_updated": 3,
+        }
+
+    def test_enrich_counters_serialize_into_summary(self) -> None:
+        run = _running(ScanRunKind.ENRICH).succeed(
+            EnrichCounters(movies_enriched=4, series_enriched=2, skipped=1), []
+        )
+        assert run.summary == {
+            "movies_enriched": 4,
+            "series_enriched": 2,
+            "skipped": 1,
+        }
+
+    def test_rejects_counters_that_do_not_match_kind(self) -> None:
+        with pytest.raises(ValueError, match="cannot summarize"):
+            _running(ScanRunKind.SCAN).succeed(EnrichCounters(), [])
+        with pytest.raises(ValueError, match="cannot summarize"):
+            _running(ScanRunKind.ENRICH).succeed(ScanCounters(), [])
+
+
+@pytest.mark.unit
+class TestScanRunFail:
+    def test_fail_without_counters_keeps_existing_summary(self) -> None:
+        run = _running(ScanRunKind.SCAN).fail("boom")
+        assert run.status is ScanRunStatus.FAILED
+        assert run.summary == {}
+        assert run.errors == ["boom"]
+
+    def test_fail_with_partial_counters_records_them(self) -> None:
+        run = _running(ScanRunKind.SCAN).fail("boom", ScanCounters(movies_created=1))
+        assert run.summary["movies_created"] == 1
+
+    def test_fail_rejects_mismatched_counters(self) -> None:
+        with pytest.raises(ValueError, match="cannot summarize"):
+            _running(ScanRunKind.SCAN).fail("boom", EnrichCounters())

--- a/tests/modules/media/unit/domain/value_objects/test_resolution.py
+++ b/tests/modules/media/unit/domain/value_objects/test_resolution.py
@@ -107,6 +107,12 @@ class TestResolutionFactoryMethods:
 
         assert resolution.value == "Unknown"
 
+    def test_is_unknown_distinguishes_the_sentinel(self):
+        from src.modules.media.domain.value_objects import Resolution
+
+        assert Resolution.unknown().is_unknown() is True
+        assert Resolution("1080p").is_unknown() is False
+
     def test_from_name_should_create_resolution(self):
         from src.modules.media.domain.value_objects import Resolution
 

--- a/tests/modules/media/unit/domain/value_objects/test_scan_counters.py
+++ b/tests/modules/media/unit/domain/value_objects/test_scan_counters.py
@@ -1,0 +1,56 @@
+"""Tests for the ScanCounters / EnrichCounters value objects."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.media.domain.value_objects.scan_counters import (
+    EnrichCounters,
+    ScanCounters,
+)
+
+
+@pytest.mark.unit
+class TestScanCounters:
+    def test_to_summary_has_the_canonical_scan_keys(self) -> None:
+        counters = ScanCounters(
+            movies_created=2,
+            movies_updated=1,
+            episodes_created=4,
+            episodes_updated=3,
+        )
+        assert counters.to_summary() == {
+            "movies_created": 2,
+            "movies_updated": 1,
+            "episodes_created": 4,
+            "episodes_updated": 3,
+        }
+
+    def test_defaults_are_zero(self) -> None:
+        assert ScanCounters().to_summary() == {
+            "movies_created": 0,
+            "movies_updated": 0,
+            "episodes_created": 0,
+            "episodes_updated": 0,
+        }
+
+    def test_negative_count_is_rejected(self) -> None:
+        with pytest.raises(DomainValidationException):
+            ScanCounters(movies_created=-1)
+
+
+@pytest.mark.unit
+class TestEnrichCounters:
+    def test_to_summary_has_the_canonical_enrich_keys(self) -> None:
+        counters = EnrichCounters(movies_enriched=4, series_enriched=2, skipped=1)
+        assert counters.to_summary() == {
+            "movies_enriched": 4,
+            "series_enriched": 2,
+            "skipped": 1,
+        }
+
+    def test_defaults_are_zero(self) -> None:
+        assert EnrichCounters().to_summary() == {
+            "movies_enriched": 0,
+            "series_enriched": 0,
+            "skipped": 0,
+        }


### PR DESCRIPTION
## Summary

Backlog item 6.5, **PR-A of 2** (scanner modeling). Two sub-smells:

**Typed scan-run counters.** `ScanRun.summary` was a magic-key `dict[str, Any]` assembled by hand in the runner, its key set depending silently on `kind` (and the docstrings listed the wrong enrich keys). New `ScanCounters` / `EnrichCounters` value objects own the key contract via `to_summary()`; `ScanRun.succeed`/`fail` now take the typed counters. The aggregate keeps `summary` as a kind-agnostic dict on purpose (one JSON column, no wide table), so the **persisted JSON shape is unchanged — no migration**; the typing lives at the write boundary. A domain guard (`_require_counters_match_kind`) enforces the kind↔counters invariant rather than trusting the caller.

**Resolution "Unknown" sentinel.** Replaced the scattered `"Unknown"` string literal with a single `Resolution.UNKNOWN_NAME` constant and a `Resolution.is_unknown()` predicate; the scanner's re-probe gate uses `is_unknown()` instead of comparing `.name` to a literal.

## Test plan

- [x] `pytest tests/modules/media/` — green (1742 passed), incl. new `test_scan_counters.py` (pins the exact `to_summary` keys for both VOs + defaults + negative rejection), new `test_scan_run.py` (succeed scan/enrich → summary, the kind↔counters guard, fail with/without counters), `is_unknown()` coverage, and the repo round-trip test hardened to the full-key shape.
- [x] Persisted JSON shape verified identical (keys == field names) at three levels — VO unit, entity-via-service, DB round-trip.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy src --ignore-missing-imports` adds no new errors in the changed files (CI mypy step is `continue-on-error`).
- [x] No DB migration: `scan_runs.summary` stays a JSON column; shape unchanged.

## Note

This is PR-A of the 6.5 split. PR-B will cover the remaining two sub-smells: a `VariantGroup` parameter object for the `(paths, by_path)` data clump, and moving episode/season upsert into the aggregate (`Season.with_episode_upserted` / `Series.with_season_upserted`).