### PR TITLE
refactor(media): VariantGroup + upsert into Season/Series aggregates

### DIFF
--- a/src/modules/media/application/use_cases/_variant_group.py
+++ b/src/modules/media/application/use_cases/_variant_group.py
@@ -1,0 +1,64 @@
+"""Parameter object for a group of scanned movie file variants.
+
+Replaces the ``(paths: list[str], by_path: dict[str, ScannedFile])`` pair
+that used to travel together through the movie-processing methods: the
+list said *which* paths form one logical movie and the dict resolved each
+back to its :class:`ScannedFile`. Bundling them removes the repeated
+``by_path[path]`` lookups and the long parameter lists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from src.modules.media.application.ports.file_scanner_port import ScannedFile
+
+
+@dataclass(frozen=True)
+class VariantGroup:
+    """The scanned files that are variants of one logical movie.
+
+    The first file is treated as the primary variant; the rest are
+    additional quality/format variants of the same movie.
+
+    Attributes:
+        files: The scanned files in the group (non-empty; first is primary).
+    """
+
+    files: tuple[ScannedFile, ...]
+
+    def __post_init__(self) -> None:
+        """Reject an empty group — a group always has at least a primary."""
+        if not self.files:
+            raise ValueError("VariantGroup requires at least one scanned file")
+
+    @classmethod
+    def of(cls, files: Iterable[ScannedFile]) -> VariantGroup:
+        """Build a group from scanned files (order preserved)."""
+        return cls(tuple(files))
+
+    @property
+    def primary(self) -> ScannedFile:
+        """The primary variant (first file)."""
+        return self.files[0]
+
+    @property
+    def additional(self) -> tuple[ScannedFile, ...]:
+        """The non-primary variants."""
+        return self.files[1:]
+
+    @property
+    def paths(self) -> list[str]:
+        """The file-path strings of every variant in the group."""
+        return [f.file_path.value for f in self.files]
+
+    def __iter__(self) -> Iterator[ScannedFile]:
+        """Iterate the scanned files in group order."""
+        return iter(self.files)
+
+
+__all__ = ["VariantGroup"]

--- a/src/modules/media/application/use_cases/scan_media_directories.py
+++ b/src/modules/media/application/use_cases/scan_media_directories.py
@@ -20,6 +20,7 @@ from src.modules.media.application.unit_of_work import (
     MediaUnitOfWork,
     MediaUnitOfWorkFactory,
 )
+from src.modules.media.application.use_cases._variant_group import VariantGroup
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.events import MediaCreatedEvent
 from src.modules.media.domain.value_objects import (
@@ -246,66 +247,60 @@ class ScanMediaDirectoriesUseCase:
         groups = self._variant_detector.group_variants(file_paths)
         by_path = {f.file_path.value: f for f in files}
 
-        for _base_name, paths in groups.items():
+        for base_name, paths in groups.items():
+            group = VariantGroup.of(by_path[path] for path in paths)
             try:
-                c, u = await self._process_movie_group(paths, by_path, library_id=library_id)
+                c, u = await self._process_movie_group(group, library_id=library_id)
                 created += c
                 updated += u
             except Exception:
                 # Log the full exception (it may carry SQL / driver detail)
                 # but keep the user-facing message free of infrastructure.
-                _logger.exception("Failed to process movie file group: %s", paths)
-                errors.append(f"Failed to process movie: {_base_name}")
+                _logger.exception("Failed to process movie file group: %s", group.paths)
+                errors.append(f"Failed to process movie: {base_name}")
 
         return created, updated, errors
 
     async def _process_movie_group(
         self,
-        paths: list[str],
-        by_path: dict[str, ScannedFile],
+        group: VariantGroup,
         *,
         library_id: str,
     ) -> tuple[int, int]:
         """Process a single group of movie file variants in its own UoW."""
         async with self._uow_factory() as uow:
-            existing = await self._find_existing_movie(uow, paths, by_path)
+            existing = await self._find_existing_movie(uow, group)
             if existing:
-                created, updated, events = await self._update_movie(uow, existing, paths, by_path)
-            elif await self._path_owned_by_series(uow, paths, by_path):
+                created, updated, events = await self._update_movie(uow, existing, group)
+            elif await self._path_owned_by_series(uow, group):
                 # A path already registered to a series episode (e.g. a
                 # movie that was promoted to a series) must not be
                 # re-registered as a movie — that would duplicate the file
                 # and collide on the unique file_path. Skip it.
-                _logger.info("Skipping movie create; path belongs to a series episode: %s", paths)
+                _logger.info(
+                    "Skipping movie create; path belongs to a series episode: %s", group.paths
+                )
                 return 0, 0
             else:
                 created, updated, events = await self._create_movie(
-                    uow, paths, by_path, library_id=library_id
+                    uow, group, library_id=library_id
                 )
         await self._dispatch_events(events)
         return created, updated
 
     @staticmethod
-    async def _path_owned_by_series(
-        uow: MediaUnitOfWork,
-        paths: list[str],
-        by_path: dict[str, ScannedFile],
-    ) -> bool:
-        """Return True if any path is already an episode of some series."""
-        for path in paths:
-            if await uow.series.find_by_file_path(by_path[path].file_path):
+    async def _path_owned_by_series(uow: MediaUnitOfWork, group: VariantGroup) -> bool:
+        """Return True if any variant is already an episode of some series."""
+        for scanned in group:
+            if await uow.series.find_by_file_path(scanned.file_path):
                 return True
         return False
 
     @staticmethod
-    async def _find_existing_movie(
-        uow: MediaUnitOfWork,
-        paths: list[str],
-        by_path: dict[str, ScannedFile],
-    ) -> Movie | None:
-        """Find an existing movie matching any of the given file paths."""
-        for path in paths:
-            movie = await uow.movies.find_by_file_path(by_path[path].file_path)
+    async def _find_existing_movie(uow: MediaUnitOfWork, group: VariantGroup) -> Movie | None:
+        """Find an existing movie matching any of the group's file paths."""
+        for scanned in group:
+            movie = await uow.movies.find_by_file_path(scanned.file_path)
             if movie:
                 return movie
         return None
@@ -314,15 +309,14 @@ class ScanMediaDirectoriesUseCase:
         self,
         uow: MediaUnitOfWork,
         movie: Movie,
-        paths: list[str],
-        by_path: dict[str, ScannedFile],
+        group: VariantGroup,
     ) -> tuple[int, int, list[DomainEvent]]:
         """Add new file variants and refresh existing ones from a fresh scan."""
         files = list(movie.files)
         changed = False
 
-        for path in paths:
-            scanned = by_path[path]
+        for scanned in group:
+            path = scanned.file_path.value
             existing_idx = next(
                 (i for i, f in enumerate(files) if f.file_path.value == path),
                 None,
@@ -355,13 +349,12 @@ class ScanMediaDirectoriesUseCase:
     async def _create_movie(
         self,
         uow: MediaUnitOfWork,
-        paths: list[str],
-        by_path: dict[str, ScannedFile],
+        group: VariantGroup,
         *,
         library_id: str,
     ) -> tuple[int, int, list[DomainEvent]]:
         """Create a new movie from a group of file variants."""
-        first = by_path[paths[0]]
+        first = group.primary
         primary_file, duration = await self._build_new_media_file(first, is_primary=True)
         movie_id = MovieId.generate()
         movie = Movie(
@@ -374,8 +367,8 @@ class ScanMediaDirectoriesUseCase:
             scrub_preview_path=await self._locate_scrub_preview(first.file_path.value),
         )
         movie.add_event(MediaCreatedEvent(media_id=movie_id, media_type=CatalogMediaType.MOVIE))
-        for path in paths[1:]:
-            variant_file, _ = await self._build_new_media_file(by_path[path], is_primary=False)
+        for scanned in group.additional:
+            variant_file, _ = await self._build_new_media_file(scanned, is_primary=False)
             movie = movie.with_file(variant_file)
         events = movie.pull_events()
         await uow.movies.save(movie)
@@ -482,8 +475,8 @@ class ScanMediaDirectoriesUseCase:
             episode = await self._create_episode(series, season_num, episode_num, ep_files)
             created, updated = 1, 0
 
-        season = _upsert_episode_in_season(season, episode)
-        series = _upsert_season_in_series(series, season)
+        season = season.with_episode_upserted(episode)
+        series = series.with_season_upserted(season)
 
         return series, created, updated
 
@@ -550,30 +543,6 @@ class ScanMediaDirectoriesUseCase:
             episode = episode.with_updates(**updates)
             return episode, True
         return episode, False
-
-
-def _upsert_episode_in_season(season: Season, episode: Episode) -> Season:
-    """Replace or append an episode in a season's episode list."""
-    episodes = list(season.episodes)
-    for idx, existing in enumerate(episodes):
-        if existing.episode_number == episode.episode_number:
-            episodes[idx] = episode
-            break
-    else:
-        episodes.append(episode)
-    return season.with_updates(episodes=episodes)
-
-
-def _upsert_season_in_series(series: Series, season: Season) -> Series:
-    """Replace or append a season in a series' season list."""
-    seasons = list(series.seasons)
-    for idx, existing in enumerate(seasons):
-        if existing.season_number == season.season_number:
-            seasons[idx] = season
-            break
-    else:
-        seasons.append(season)
-    return series.with_updates(seasons=seasons)
 
 
 def _current_year() -> int:

--- a/src/modules/media/domain/entities/season.py
+++ b/src/modules/media/domain/entities/season.py
@@ -91,6 +91,24 @@ class Season(DomainEntity[SeasonId]):
         """
         return len(self.episodes)
 
+    def _ensure_owns(self, episode: Episode) -> None:
+        """Validate the episode belongs to this season.
+
+        Raises:
+            BusinessRuleViolationException: If episode series_id or
+                season_number doesn't match this season.
+        """
+        if episode.series_id != self.series_id:
+            raise BusinessRuleViolationException(
+                message="Episode series_id must match Season series_id",
+                rule_code=MediaRuleCodes.EPISODE_SERIES_MISMATCH,
+            )
+        if episode.season_number != self.season_number:
+            raise BusinessRuleViolationException(
+                message="Episode season_number must match Season",
+                rule_code=MediaRuleCodes.EPISODE_SEASON_MISMATCH,
+            )
+
     def with_episode(self, episode: Episode) -> Self:
         """Return a copy with the episode added.
 
@@ -103,19 +121,41 @@ class Season(DomainEntity[SeasonId]):
         Raises:
             BusinessRuleViolationException: If episode series_id or season_number doesn't match.
         """
-        if episode.series_id != self.series_id:
-            raise BusinessRuleViolationException(
-                message="Episode series_id must match Season series_id",
-                rule_code=MediaRuleCodes.EPISODE_SERIES_MISMATCH,
-            )
-        if episode.season_number != self.season_number:
-            raise BusinessRuleViolationException(
-                message="Episode season_number must match Season",
-                rule_code=MediaRuleCodes.EPISODE_SEASON_MISMATCH,
-            )
+        self._ensure_owns(episode)
         if episode in self.episodes:
             return self
         return self.with_updates(episodes=[*self.episodes, episode])
+
+    def with_episode_upserted(self, episode: Episode) -> Self:
+        """Return a copy with the episode added or replaced by its number.
+
+        Unlike :meth:`with_episode` (a no-op when the episode is already
+        present), this replaces any existing episode that shares the same
+        ``episode_number`` — the scanner uses it to refresh an episode in
+        place while keeping the "one episode per number" invariant owned
+        by the season. Always returns a new instance (it never short-circuits
+        to ``self``), since the replacement may carry refreshed content under
+        the same number.
+
+        Args:
+            episode: The episode to upsert.
+
+        Returns:
+            A new Season with the episode inserted or replaced.
+
+        Raises:
+            BusinessRuleViolationException: If episode series_id or
+                season_number doesn't match this season.
+        """
+        self._ensure_owns(episode)
+        episodes = list(self.episodes)
+        for idx, existing in enumerate(episodes):
+            if existing.episode_number == episode.episode_number:
+                episodes[idx] = episode
+                break
+        else:
+            episodes.append(episode)
+        return self.with_updates(episodes=episodes)
 
     def get_episode(self, episode_number: EpisodeNumber | int) -> Episode | None:
         """Find an episode by its number.

--- a/src/modules/media/domain/entities/series.py
+++ b/src/modules/media/domain/entities/series.py
@@ -214,6 +214,18 @@ class Series(AggregateRoot[SeriesId]):
             return self
         return self.with_updates(needs_enrichment_review=True)
 
+    def _ensure_owns(self, season: Season) -> None:
+        """Validate the season belongs to this series.
+
+        Raises:
+            BusinessRuleViolationException: If season series_id doesn't match.
+        """
+        if season.series_id != self.id:
+            raise BusinessRuleViolationException(
+                message="Season series_id must match Series id",
+                rule_code=MediaRuleCodes.SEASON_SERIES_MISMATCH,
+            )
+
     def with_season(self, season: Season) -> Self:
         """Return a copy with the season added.
 
@@ -226,14 +238,41 @@ class Series(AggregateRoot[SeriesId]):
         Raises:
             BusinessRuleViolationException: If season series_id doesn't match.
         """
-        if season.series_id != self.id:
-            raise BusinessRuleViolationException(
-                message="Season series_id must match Series id",
-                rule_code=MediaRuleCodes.SEASON_SERIES_MISMATCH,
-            )
+        self._ensure_owns(season)
         if season in self.seasons:
             return self
         return self.with_updates(seasons=[*self.seasons, season])
+
+    def with_season_upserted(self, season: Season) -> Self:
+        """Return a copy with the season added or replaced by its number.
+
+        Unlike :meth:`with_season` (a no-op when the season is already
+        present), this replaces any existing season that shares the same
+        ``season_number`` — the scanner uses it to fold a refreshed season
+        back into the series while keeping the "one season per number"
+        invariant owned by the series. Always returns a new instance (it
+        never short-circuits to ``self``), since the replacement may carry
+        a refreshed season under the same number.
+
+        Args:
+            season: The season to upsert.
+
+        Returns:
+            A new Series with the season inserted or replaced.
+
+        Raises:
+            BusinessRuleViolationException: If season series_id doesn't
+                match this series.
+        """
+        self._ensure_owns(season)
+        seasons = list(self.seasons)
+        for idx, existing in enumerate(seasons):
+            if existing.season_number == season.season_number:
+                seasons[idx] = season
+                break
+        else:
+            seasons.append(season)
+        return self.with_updates(seasons=seasons)
 
     def get_season(self, season_number: SeasonNumber | int) -> Season | None:
         """Find a season by its number.

--- a/tests/modules/media/unit/application/use_cases/test_variant_group.py
+++ b/tests/modules/media/unit/application/use_cases/test_variant_group.py
@@ -1,0 +1,48 @@
+"""Tests for the VariantGroup parameter object."""
+
+import pytest
+
+from src.modules.media.application.ports.file_scanner_port import MediaType, ScannedFile
+from src.modules.media.application.use_cases._variant_group import VariantGroup
+from src.shared_kernel.value_objects.file_path import FilePath
+
+
+def _scanned(path: str) -> ScannedFile:
+    return ScannedFile(
+        file_path=FilePath(path),
+        file_size=1,
+        media_type=MediaType.MOVIE,
+        title="Movie",
+    )
+
+
+@pytest.mark.unit
+class TestVariantGroup:
+    def test_primary_is_first_and_additional_is_the_rest(self) -> None:
+        a, b, c = _scanned("/m/a.mkv"), _scanned("/m/b.mkv"), _scanned("/m/c.mkv")
+        group = VariantGroup.of([a, b, c])
+
+        assert group.primary is a
+        assert group.additional == (b, c)
+
+    def test_paths_lists_every_variant_path(self) -> None:
+        group = VariantGroup.of([_scanned("/m/a.mkv"), _scanned("/m/b.mkv")])
+
+        assert group.paths == ["/m/a.mkv", "/m/b.mkv"]
+
+    def test_iterates_in_order(self) -> None:
+        files = [_scanned("/m/a.mkv"), _scanned("/m/b.mkv")]
+        group = VariantGroup.of(files)
+
+        assert list(group) == files
+
+    def test_single_file_group_has_no_additional(self) -> None:
+        only = _scanned("/m/a.mkv")
+        group = VariantGroup.of([only])
+
+        assert group.primary is only
+        assert group.additional == ()
+
+    def test_empty_group_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            VariantGroup.of([])

--- a/tests/modules/media/unit/domain/entities/test_season.py
+++ b/tests/modules/media/unit/domain/entities/test_season.py
@@ -225,6 +225,70 @@ class TestSeasonEpisodeManagement:
         with pytest.raises(BusinessRuleViolationException, match="season_number"):
             season.with_episode(episode)
 
+    def test_upsert_should_append_a_new_episode(self):
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
+
+        series_id = SeriesId.generate()
+        season = Season(series_id=series_id, season_number=1)
+
+        season = season.with_episode_upserted(
+            _make_episode(series_id, season_number=1, episode_number=1)
+        )
+
+        assert season.episode_count == 1
+
+    def test_upsert_should_replace_existing_episode_with_same_number(self):
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
+
+        series_id = SeriesId.generate()
+        original = _make_episode(series_id, season_number=1, episode_number=1)
+        season = Season(series_id=series_id, season_number=1).with_episode(original)
+
+        replacement = _make_episode(series_id, season_number=1, episode_number=1)
+        season = season.with_episode_upserted(replacement)
+
+        assert season.episode_count == 1
+        assert season.episodes[0].id == replacement.id
+        assert season.episodes[0].id != original.id
+
+    def test_upsert_should_preserve_order_when_replacing(self):
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
+
+        series_id = SeriesId.generate()
+        season = Season(series_id=series_id, season_number=1)
+        for n in (1, 2, 3):
+            season = season.with_episode(
+                _make_episode(series_id, season_number=1, episode_number=n)
+            )
+
+        replacement = _make_episode(series_id, season_number=1, episode_number=2)
+        season = season.with_episode_upserted(replacement)
+
+        assert [ep.episode_number.value for ep in season.episodes] == [1, 2, 3]
+        assert season.episodes[1].id == replacement.id
+
+    def test_upsert_should_reject_episode_with_wrong_series_id(self):
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
+
+        season = Season(series_id=SeriesId.generate(), season_number=1)
+
+        with pytest.raises(BusinessRuleViolationException, match="series_id"):
+            season.with_episode_upserted(_make_episode(SeriesId.generate(), season_number=1))
+
+    def test_upsert_should_reject_episode_with_wrong_season_number(self):
+        from src.modules.media.domain.entities import Season
+        from src.modules.media.domain.value_objects import SeriesId
+
+        series_id = SeriesId.generate()
+        season = Season(series_id=series_id, season_number=1)
+
+        with pytest.raises(BusinessRuleViolationException, match="season_number"):
+            season.with_episode_upserted(_make_episode(series_id, season_number=2))
+
     def test_should_get_episode_by_number(self):
         from src.modules.media.domain.entities import Season
         from src.modules.media.domain.value_objects import SeriesId

--- a/tests/modules/media/unit/domain/entities/test_series.py
+++ b/tests/modules/media/unit/domain/entities/test_series.py
@@ -119,6 +119,42 @@ class TestSeriesSeasonManagement:
         with pytest.raises(BusinessRuleViolationException, match="series_id"):
             series.with_season(season)
 
+    def test_upsert_should_append_a_new_season(self):
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId
+
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
+        season = Season(id=SeasonId.generate(), series_id=series.id, season_number=1)
+
+        series = series.with_season_upserted(season)
+
+        assert series.season_count == 1
+
+    def test_upsert_should_replace_existing_season_with_same_number(self):
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId
+
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
+        original = Season(id=SeasonId.generate(), series_id=series.id, season_number=1)
+        series = series.with_season(original)
+
+        replacement = Season(id=SeasonId.generate(), series_id=series.id, season_number=1)
+        series = series.with_season_upserted(replacement)
+
+        assert series.season_count == 1
+        assert series.seasons[0].id == replacement.id
+        assert series.seasons[0].id != original.id
+
+    def test_upsert_should_reject_season_with_wrong_series_id(self):
+        from src.modules.media.domain.entities import Season, Series
+        from src.modules.media.domain.value_objects import SeasonId, SeriesId
+
+        series = Series.create(library_id=_LIBRARY_ID, title="Breaking Bad", start_year=2008)
+        season = Season(id=SeasonId.generate(), series_id=SeriesId.generate(), season_number=1)
+
+        with pytest.raises(BusinessRuleViolationException, match="series_id"):
+            series.with_season_upserted(season)
+
     def test_should_get_season_by_number(self):
         from src.modules.media.domain.entities import Season, Series
         from src.modules.media.domain.value_objects import SeasonId


### PR DESCRIPTION
## Summary

Backlog item 6.5, **PR-B of 2** (scanner modeling) — the remaining two sub-smells.

**Data Clump → VariantGroup.** The `(paths: list[str], by_path: dict[str, ScannedFile])` pair travelled together through five movie-scan methods, each re-doing `by_path[path]` lookups. A `VariantGroup` parameter object now bundles the scanned files of one logical movie and exposes `primary` / `additional` / `paths` / iteration, so the five methods take a single argument and the lookups are gone.

**Feature Envy → aggregate methods.** The module-level `_upsert_episode_in_season` / `_upsert_season_in_series` helpers did replace-or-append on aggregate internals from outside. They moved onto the owning aggregates as `Season.with_episode_upserted` / `Series.with_season_upserted`, so the "one episode/season per number" collection invariant lives in the aggregate — with the same id-match guards as `with_episode` / `with_season` (extracted into a shared private `_ensure_owns`).

Pure structural refactor: behavior preserved (verified by review at the file level), no migration.

## Test plan

- [x] `pytest tests/modules/media/` — green (1755 passed), incl. new `test_variant_group.py` (primary/additional/paths/iter, single-file group, empty-group rejection), upsert tests on `Season`/`Series` (append, replace-by-number proving the replacement won, order preservation, id-match guard rejections), and the existing scanner tests still exercising the create/refresh paths through the new aggregate methods.
- [x] Behavior equivalence verified: `VariantGroup` reconstructs the same files in the same order; the new id-match guards are always satisfied by the scanner (episodes/seasons built with matching ids), so no new exception path triggers.
- [x] `ruff check` + `ruff format --check` clean; `mypy src --ignore-missing-imports` adds no new errors in the changed files.

## Note

This is PR-B of the 6.5 split, completing the item. PR-A (#342, merged) covered the typed scan-run counters and `Resolution.is_unknown()`.