### PR TITLE
refactor(identity): publish resolve_profile_id as a cross-BC contract

### DIFF
--- a/docs/adr/ADR-024-published-presentation-contracts-cross-bc.md
+++ b/docs/adr/ADR-024-published-presentation-contracts-cross-bc.md
@@ -1,0 +1,102 @@
+# ADR-024: Contratos de Presentation Publicados para Imports Cross-BC
+
+**Status:** Aceito
+**Data:** 2026-06-29
+**Deciders:** Lucas
+**Technical Story:** Backlog 6.11 (`docs/audits/07-phase6-backlog.md`) — achado clean-arch B-9/B-10 + coupling F9: `resolve_profile_id` reusado por import direto cross-BC em 4 módulos.
+
+---
+
+## Contexto
+
+ADR-008 estabelece que **módulos não importam uns aos outros**; leituras cross-BC passam por Read Port + ACL (ADR-009). ADR-010 reafirma que esses princípios valem para o `identity` **"sem exceção"**.
+
+Há, porém, uma dependência cross-BC que não se encaixa nesse mecanismo: a resolução de **"quem é o caller"** na borda HTTP. `identity.presentation.dependencies.resolve_profile_id` é uma dependency do FastAPI que lê o cookie de sessão, consulta `access_tokens` e devolve o `profile_id` ativo (ADR-010/011). Toda rota autenticada de `media`, `collections`, `watch_progress` e `preferences` precisa dela.
+
+Essa dependência **não pode** ser expressa pelo padrão do ADR-009: port + ACL governa leitura de **domínio/aplicação**, e não existe port de domínio capaz de carregar um `Request` do FastAPI. Também **não pode** descer para `building_blocks`/`shared_kernel`: ela depende de infra e domain do `identity` (settings, repo de `access_tokens`, erros de domínio), o que inverteria a regra de dependência (`modules → shared_kernel → building_blocks`).
+
+Na prática os 4 BCs já importavam `resolve_profile_id` cross-BC — mas de `identity.presentation.dependencies`, um módulo cuja superfície **mistura** o contrato com símbolos internos do `identity` (`get_current_profile`, `ProfileContext`, o resolver de UoW). Consumir um módulo de superfície mista acopla mais do que o necessário e expõe os 4 BCs a churn interno do `identity`.
+
+## Decisão
+
+Nós permitiremos imports cross-BC de presentation **exclusivamente através de um módulo de contrato publicado** `<módulo>/presentation/public.py`. Esse módulo declara, via `__all__`, a única superfície que outros bounded contexts podem importar; todo o resto de `presentation/` é interno e não deve ser importado cross-BC.
+
+O `identity` publica `resolve_profile_id` em `identity/presentation/public.py`. Os 4 BCs consumidores importam dele (através do seu shim local `presentation/dependencies.py`), nunca de `identity.presentation.dependencies`.
+
+Isto é uma **exceção estreita e documentada** ao ADR-008, restrita a **primitivas de presentation/auth que não podem ser expressas como port de domínio** (ADR-009). Não abre exceção para reads de domínio cross-BC — esses continuam via port + ACL, sem mudança.
+
+## Consequências
+
+### Positivas
+
+- A superfície de acoplamento cross-BC fica explícita e mínima (um símbolo nomeado), em vez de reaproveitar um módulo de superfície mista.
+- O contrato funciona como *firewall de volatilidade*: o `identity` refatora `presentation/dependencies.py` livremente sem ripple nos 4 consumidores, desde que `public.py` permaneça estável.
+- A exceção a "ADR-008 sem exceção" (ADR-010) passa a ser *discoverable* na base de ADRs, não escondida num docstring.
+
+### Negativas
+
+- Existe um import cross-BC sancionado (presentation → presentation de outro módulo) — uma exceção que precisa ser conhecida ao ler ADR-008/010.
+- A cadeia de re-export tem hops (`dependencies.py → public.py → shim do BC → routes`); o shim por BC permanece um re-export puro até que algum override por BC se materialize.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Um BC importar `identity.presentation.dependencies` direto, furando o contrato | Média | Baixo | Convenção documentada + `__all__` em `public.py`; teste de contrato fixa a identidade do símbolo; regra de import-linter pode ser adicionada se recorrer |
+| O padrão `public.py` ser usado para vazar lógica de domínio entre BCs | Baixa | Médio | Escopo explícito: só primitivas de presentation/auth sem port de domínio possível; reads de domínio continuam ADR-009 |
+
+## Alternativas Consideradas
+
+### 1. Read Port + ACL (ADR-009)
+
+Cada BC define um port e um adapter para resolver o profile.
+
+**Rejeitado porque:** ADR-009 governa reads de domínio/aplicação; `resolve_profile_id` é uma dependency de request-context na borda HTTP — não há port de domínio capaz de carregar um `Request`.
+
+### 2. Mover para `building_blocks`/`shared_kernel`
+
+Tornar a dependency um utilitário de presentation compartilhado.
+
+**Rejeitado porque:** ela depende de infra e domain do `identity`; movê-la inverteria a regra de dependência (`building_blocks` não pode importar um módulo).
+
+### 3. Cada BC reimplementar a resolução
+
+Cada consumidor lê o cookie e consulta `access_tokens` por conta própria.
+
+**Rejeitado porque:** duplica conhecimento de auth do `identity` em 4 lugares (Shotgun Surgery a cada mudança de cookie/sessão).
+
+### 4. Apenas docstring (sem ADR)
+
+Documentar a exceção só no `public.py`.
+
+**Rejeitado porque:** ADR-010 afirma "ADR-008/009 sem exceção"; uma exceção real precisa ser visível a quem trata ADRs como fonte da verdade. Há precedente (revisão do ADR-009 em 2026-06-27 para a variante "Protocol port sem adapter").
+
+## Referências
+
+- ADR-008 (Screaming Architecture — módulos isolados) — qualificado por esta decisão
+- ADR-009 (Cross-BC Read Ports) — continua para reads de domínio
+- ADR-010 (Identity Bounded Context) — a afirmação "sem exceção" passa a ter esta exceção estreita
+- ADR-011 (Authentication Strategy) — origem de `resolve_profile_id`
+- `docs/audits/07-phase6-backlog.md` (item 6.11)
+
+---
+
+## Notas de Implementação
+
+```python
+# src/modules/identity/presentation/public.py — o contrato publicado
+from src.modules.identity.presentation.dependencies import resolve_profile_id
+
+__all__ = ["resolve_profile_id"]
+
+# src/modules/<bc>/presentation/dependencies.py — shim local do consumidor
+from src.modules.identity.presentation.public import resolve_profile_id
+
+__all__ = ["resolve_profile_id"]
+```
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-06-29 | Lucas | Criação inicial |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-021](./ADR-021-credits-detector-per-file-visual.md) | Detector de Créditos Per-Arquivo por Sinais Visuais (Borda + Movimento) | ✅ Aceito | 2026-06-19 |
 | [ADR-022](./ADR-022-catalog-requests-subscriptions-fanout.md) | Subscriptions Multi-Usuário + Fanout em Catalog Requests | ✅ Aceito | 2026-06-23 |
 | [ADR-023](./ADR-023-localized-metadata-value-object.md) | Metadados Localizados como Value Object | ✅ Aceito | 2026-06-27 |
+| [ADR-024](./ADR-024-published-presentation-contracts-cross-bc.md) | Contratos de Presentation Publicados para Imports Cross-BC | ✅ Aceito | 2026-06-29 |
 
 ## Como Criar um Novo ADR
 

--- a/src/modules/collections/presentation/dependencies.py
+++ b/src/modules/collections/presentation/dependencies.py
@@ -1,12 +1,13 @@
 """FastAPI dependency that resolves the caller's ``profile_id`` for collections.
 
-Re-exports the canonical strict-mode helper from the identity BC.
+Re-exports identity's published cross-BC presentation contract
+(``identity.presentation.public``).
 The per-BC wrapper file still exists so route imports stay local
 (``from .dependencies import resolve_profile_id``) — if a future
 feature needs a collections-specific override (e.g. shared lists)
 it can wrap here without touching every route file.
 """
 
-from src.modules.identity.presentation.dependencies import resolve_profile_id
+from src.modules.identity.presentation.public import resolve_profile_id
 
 __all__ = ["resolve_profile_id"]

--- a/src/modules/identity/presentation/public.py
+++ b/src/modules/identity/presentation/public.py
@@ -1,0 +1,35 @@
+"""Published cross-bounded-context presentation contract for ``identity``.
+
+See ADR-024 (Published Presentation Contracts for Cross-BC Imports) for the
+decision and rationale that this module implements.
+
+This module is the **sanctioned, stable surface** that other bounded
+contexts' presentation layers may import from ``identity``. Everything
+else under ``identity/presentation/`` (``get_current_profile``,
+``ProfileContext``, the auth wiring, the UoW-factory resolver) is internal
+and must not be imported across BC boundaries.
+
+Why a cross-BC import is allowed here at all (vs. ADR-008 "modules don't
+import each other" / ADR-009 "cross-BC reads go through a port + ACL"):
+
+- ADR-009's port+ACL pattern governs **domain/application reads** — a use
+  case depending on another BC's data. ``resolve_profile_id`` is neither:
+  it is a **FastAPI request-context dependency** that turns the session
+  cookie into the caller's ``profile_id`` at the HTTP edge. There is no
+  domain port to route an ``Request`` through.
+- Per ADR-010/011 ``identity`` owns authentication and profile resolution;
+  every authenticated route in every BC needs "who is the caller". That
+  makes identity's auth dependency an inherently shared presentation
+  primitive, like a shared auth library — not an accidental reach into
+  another module's internals.
+
+Consumers import this via their own thin ``presentation/dependencies.py``
+shim (so route imports stay local and a BC can wrap for an override),
+which in turn imports from here. Keeping the contract in a dedicated
+module lets ``identity`` refactor its internal ``dependencies.py`` freely
+without rippling into four other bounded contexts.
+"""
+
+from src.modules.identity.presentation.dependencies import resolve_profile_id
+
+__all__ = ["resolve_profile_id"]

--- a/src/modules/media/presentation/dependencies.py
+++ b/src/modules/media/presentation/dependencies.py
@@ -1,12 +1,13 @@
 """FastAPI dependency that resolves the caller's ``profile_id`` for the catalog.
 
-Re-exports the canonical strict-mode helper from the identity BC.
+Re-exports identity's published cross-BC presentation contract
+(``identity.presentation.public``).
 The per-BC wrapper file still exists so route imports stay local
 (``from .dependencies import resolve_profile_id``) — future
 catalog-specific overrides (e.g. parental controls, kids-mode
 filtering) plug in here without touching every route file.
 """
 
-from src.modules.identity.presentation.dependencies import resolve_profile_id
+from src.modules.identity.presentation.public import resolve_profile_id
 
 __all__ = ["resolve_profile_id"]

--- a/src/modules/preferences/presentation/dependencies.py
+++ b/src/modules/preferences/presentation/dependencies.py
@@ -1,12 +1,13 @@
 """FastAPI dependency that resolves the caller's ``profile_id`` for preferences.
 
-Re-exports the canonical strict-mode helper from the identity BC.
+Re-exports identity's published cross-BC presentation contract
+(``identity.presentation.public``).
 The per-BC wrapper file still exists so route imports stay local
 (``from .dependencies import resolve_profile_id``) — future
 preference-specific overrides plug in here without touching every
 route file.
 """
 
-from src.modules.identity.presentation.dependencies import resolve_profile_id
+from src.modules.identity.presentation.public import resolve_profile_id
 
 __all__ = ["resolve_profile_id"]

--- a/src/modules/watch_progress/presentation/dependencies.py
+++ b/src/modules/watch_progress/presentation/dependencies.py
@@ -1,6 +1,7 @@
 """FastAPI dependency that resolves the caller's ``profile_id``.
 
-Re-exports the canonical strict-mode helper from the identity BC.
+Re-exports identity's published cross-BC presentation contract
+(``identity.presentation.public``).
 The per-BC wrapper file still exists so route imports stay
 local (``from .dependencies import resolve_profile_id``) — if a
 future feature needs a watch-progress-specific override (rate
@@ -8,6 +9,6 @@ limit, kids-mode gating, etc.) it can wrap here without touching
 every route file.
 """
 
-from src.modules.identity.presentation.dependencies import resolve_profile_id
+from src.modules.identity.presentation.public import resolve_profile_id
 
 __all__ = ["resolve_profile_id"]

--- a/tests/modules/identity/unit/presentation/test_public_contract.py
+++ b/tests/modules/identity/unit/presentation/test_public_contract.py
@@ -1,0 +1,30 @@
+"""The published cross-BC presentation contract for identity."""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestIdentityPublicContract:
+    """``identity.presentation.public`` is the sanctioned cross-BC surface."""
+
+    def test_exposes_resolve_profile_id(self) -> None:
+        from src.modules.identity.presentation import public
+
+        assert public.__all__ == ["resolve_profile_id"]
+        assert callable(public.resolve_profile_id)
+
+    def test_resolve_profile_id_is_the_canonical_dependency(self) -> None:
+        from src.modules.identity.presentation import dependencies, public
+
+        # The contract re-exports the one real implementation — no fork.
+        assert public.resolve_profile_id is dependencies.resolve_profile_id
+
+    def test_consumer_shims_re_export_the_same_object(self) -> None:
+        from src.modules.collections.presentation import dependencies as collections_deps
+        from src.modules.identity.presentation import public
+        from src.modules.media.presentation import dependencies as media_deps
+        from src.modules.preferences.presentation import dependencies as preferences_deps
+        from src.modules.watch_progress.presentation import dependencies as progress_deps
+
+        for shim in (collections_deps, media_deps, preferences_deps, progress_deps):
+            assert shim.resolve_profile_id is public.resolve_profile_id


### PR DESCRIPTION
## Summary

Backlog item 6.11 — a presentation/auth boundary cleanup.

`resolve_profile_id` (a FastAPI request-context dependency that turns the session cookie into the caller's `profile_id`) lived in `identity/presentation/dependencies.py` and was imported by four other bounded contexts' presentation shims (collections, media, preferences, watch_progress). That module mixes the cross-BC symbol with identity-internal helpers (`get_current_profile`, `ProfileContext`, the UoW resolver), so the consumers depended on a wider, more volatile surface than they used.

- Add `identity/presentation/public.py` — the explicit, documented, stable surface other BCs may import (just `resolve_profile_id`). The rest of `presentation/` is internal.
- Repoint the four per-BC dependency shims to import from `identity.presentation.public`.
- Document the decision in **ADR-024** (Published Presentation Contracts for Cross-BC Imports): `resolve_profile_id` can't go through an ADR-009 domain port (it's a `Request`-bound auth primitive at the HTTP edge) and can't move to `building_blocks` (it depends on identity infra/domain), so a published presentation contract is the sanctioned, narrow exception to ADR-008. This also corrects ADR-010's "ADR-008/009 sem exceção" claim, which now has this documented exception.

Pure re-export — behavior is unchanged (the published symbol *is* the same object).

## Test plan

- [x] `pytest tests/modules/{collections,preferences,watch_progress,identity} tests/modules/media/e2e` — green (635 passed); the consumer modules' e2e exercise the dependency end-to-end through the shims with real session cookies (unchanged).
- [x] New `test_public_contract.py` pins the contract: `public.resolve_profile_id is dependencies.resolve_profile_id` (no fork) and all four shims re-export the same object.
- [x] `ruff check` + `ruff format --check` clean; `mypy src --ignore-missing-imports` adds no new errors. No import cycle (`dependencies.py` does not import `public`).
- [x] No DB migration; no runtime change.

## Related

- ADR-024 (new) · qualifies ADR-008, notes the exception in ADR-010; ADR-009 (domain reads) unchanged.

## Summary by Sourcery

Introduce a published presentation contract in the identity module for resolving profile IDs and repoint dependent bounded contexts to consume this stable surface.

Enhancements:
- Add src.modules.identity.presentation.public as the sanctioned cross-BC entry point exposing resolve_profile_id while keeping other presentation internals private.
- Update collections, media, preferences, and watch_progress presentation dependency shims to import resolve_profile_id from identity.presentation.public instead of identity.presentation.dependencies.
- Add unit tests to pin the identity public contract and ensure all consumer shims re-export the same resolve_profile_id object.

Documentation:
- Document the new published presentation contract pattern and the specific resolve_profile_id exception via ADR-024, updating the ADR index accordingly.

Tests:
- Add tests verifying identity.presentation.public exposes resolve_profile_id, that it re-exports the canonical dependency, and that all four consumer shims share the same implementation.