### PR TITLE
refactor(media): share set_if_missing field-map across enrich

### DIFF
--- a/src/modules/media/application/use_cases/_metadata_field_merge.py
+++ b/src/modules/media/application/use_cases/_metadata_field_merge.py
@@ -1,0 +1,55 @@
+"""Table-driven merge of provider metadata fields into an entity.
+
+Both ``enrich_movie_metadata`` and ``enrich_series_metadata`` fold a bag of
+provider fields onto the entity under a :class:`MergePolicy`. The
+"don't-overwrite" fields all share one shape — write when the provider has
+a value and the policy allows it — so the rule lives here once, driven by a
+per-call field map, instead of being hand-rolled field by field in each use
+case (which had drifted into two parallel implementations).
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from src.modules.media.application.ports import MediaMetadata
+from src.modules.media.domain.value_objects.merge_policy import MergePolicy
+
+
+def set_if_missing(
+    updates: dict[str, object],
+    metadata: MediaMetadata,
+    entity: object,
+    field_map: dict[str, tuple[str, Callable[[Any], Any] | None]],
+    *,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
+) -> None:
+    """Set fields in ``updates``, respecting the merge policy.
+
+    ``field_map`` maps a provider metadata attribute to ``(entity_attr,
+    converter)``. A field is written when the provider has a truthy value
+    and ``policy.should_write`` allows it (always under ``OVERWRITE``; only
+    when the entity field is empty under ``FILL_IF_EMPTY``). The
+    fill-if-empty guard protects user edits on a routine re-enrichment;
+    ``OVERWRITE`` (a relink / forced refresh) bypasses it so the
+    newly-picked match's metadata wins over stale values.
+
+    Args:
+        updates: Mutable dict of pending ``with_updates`` kwargs.
+        metadata: Provider payload to read from.
+        entity: Aggregate to read current values from (duck-typed via
+            ``getattr`` — Movie or Series).
+        field_map: ``{provider_attr: (entity_attr, converter | None)}``.
+        policy: Merge policy gating each write.
+    """
+    for meta_attr, (entity_attr, converter) in field_map.items():
+        # No default on the provider read: ``metadata`` is always a
+        # ``MediaMetadata`` with a fixed attribute set, so a mistyped map key
+        # should fail loudly instead of silently skipping the field. The
+        # default stays on the duck-typed ``entity`` (Movie or Series).
+        meta_val = getattr(metadata, meta_attr)
+        entity_val = getattr(entity, entity_attr, None)
+        if meta_val and policy.should_write(entity_val):
+            updates[entity_attr] = converter(meta_val) if converter is not None else meta_val
+
+
+__all__ = ["set_if_missing"]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -8,11 +8,16 @@ from src.modules.media.application.dtos.enrichment_dtos import (
     EnrichMediaInput,
     EnrichMediaOutput,
 )
-from src.modules.media.application.ports import MediaMetadata, MetadataProvider
+from src.modules.media.application.ports import (
+    CollectionMetadata,
+    MediaMetadata,
+    MetadataProvider,
+)
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._localized_metadata_helpers import (
     merge_media_localized,
 )
+from src.modules.media.application.use_cases._metadata_field_merge import set_if_missing
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
     CastMember,
@@ -253,79 +258,48 @@ def _apply_movie_metadata(
     """
     updates: dict[str, object] = {}
 
+    # Always-overwrite fields — written whenever the provider has them
+    # (no fill-if-empty guard). The base title tracks the picked TMDB
+    # entry on every enrich (unlike series, where it is scanner-derived).
     if metadata.title:
         updates["title"] = Title(metadata.title)
-    if metadata.synopsis and policy.should_write(movie.synopsis):
-        updates["synopsis"] = metadata.synopsis
-    _apply_franchise_metadata(updates, movie, metadata, policy=policy)
     if metadata.tmdb_id:
         updates["tmdb_id"] = TmdbId(metadata.tmdb_id)
     if metadata.imdb_id:
         updates["imdb_id"] = ImdbId(metadata.imdb_id)
     if metadata.original_title:
         updates["original_title"] = Title(metadata.original_title)
+    if metadata.year:
+        updates["year"] = Year(metadata.year)
     # Duration is the file's real (probed) length — the scanner stamps it.
     # TMDB's nominal runtime is only a fallback when the probe failed
     # (duration still 0); never overwrite a real duration, even on OVERWRITE.
     if metadata.duration_seconds and movie.duration.value == 0:
         updates["duration"] = Duration(metadata.duration_seconds)
-    if metadata.year:
-        updates["year"] = Year(metadata.year)
-    if metadata.genres and policy.should_write(movie.genres):
-        updates["genres"] = [Genre(g) for g in metadata.genres]
-    if metadata.poster_url and policy.should_write(movie.poster_path):
-        updates["poster_path"] = ImageUrl(metadata.poster_url)
-    if metadata.backdrop_url and policy.should_write(movie.backdrop_path):
-        updates["backdrop_path"] = ImageUrl(metadata.backdrop_url)
-    if metadata.logo_url and policy.should_write(movie.logo_path):
-        updates["logo_path"] = ImageUrl(metadata.logo_url)
 
-    _apply_credits(updates, movie, metadata, policy=policy)
+    # Don't-overwrite fields (fill-if-empty unless ``OVERWRITE``), table-driven.
+    set_if_missing(
+        updates,
+        metadata,
+        movie,
+        {
+            "synopsis": ("synopsis", None),
+            "genres": ("genres", lambda v: [Genre(g) for g in v]),
+            "poster_url": ("poster_path", ImageUrl),
+            "backdrop_url": ("backdrop_path", ImageUrl),
+            "logo_url": ("logo_path", ImageUrl),
+            "tagline": ("tagline", None),
+            "collection": ("collection", _to_collection),
+            "directors": ("directors", lambda v: [p.name for p in v]),
+            "writers": ("writers", lambda v: [p.name for p in v]),
+            "content_rating": ("content_rating", ContentRating),
+            "trailer_url": ("trailer_url", None),
+        },
+        policy=policy,
+    )
 
-    if updates:
-        movie = movie.with_updates(**updates)
-
-    return movie
-
-
-def _apply_franchise_metadata(
-    updates: dict[str, object],
-    movie: Movie,
-    metadata: MediaMetadata,
-    *,
-    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
-) -> None:
-    """Apply tagline + collection (franchise) metadata.
-
-    Both fields follow the same "fill if empty" guard as the rest of
-    ``_apply_movie_metadata`` so re-enrichment doesn't clobber a
-    user-edited tagline or a manually-cleared collection. Extracted
-    out so the parent function stays under ``PLR0912``'s branch cap.
-    """
-    if metadata.tagline and policy.should_write(movie.tagline):
-        updates["tagline"] = metadata.tagline
-    if metadata.collection and policy.should_write(movie.collection):
-        updates["collection"] = Collection(
-            tmdb_id=metadata.collection.tmdb_id,
-            name=metadata.collection.name,
-            parts_count=metadata.collection.parts_count,
-        )
-
-
-def _apply_credits(
-    updates: dict[str, object],
-    movie: Movie,
-    metadata: MediaMetadata,
-    *,
-    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
-) -> None:
-    """Apply cast/director/writer credits.
-
-    Each field defaults to a "fill if empty" guard; ``MergePolicy.OVERWRITE``
-    bypasses the guard so a refresh repopulates credits from TMDB.
-    The motivating use case is backfilling ``tmdb_id`` on cast
-    members that were already saved before the id was captured.
-    """
+    # Cast: same fill-if-empty rule, kept explicit for the per-element
+    # CreditPerson → CastMember conversion (mirrors the series enrich).
     if metadata.cast and policy.should_write(movie.cast):
         updates["cast"] = [
             CastMember(
@@ -336,17 +310,24 @@ def _apply_credits(
             )
             for p in metadata.cast
         ]
-    if metadata.directors and policy.should_write(movie.directors):
-        updates["directors"] = [p.name for p in metadata.directors]
-    if metadata.writers and policy.should_write(movie.writers):
-        updates["writers"] = [p.name for p in metadata.writers]
-    if metadata.content_rating and policy.should_write(movie.content_rating):
-        updates["content_rating"] = ContentRating(metadata.content_rating)
-    if metadata.trailer_url and policy.should_write(movie.trailer_url):
-        updates["trailer_url"] = metadata.trailer_url
+
     new_localized = merge_media_localized(movie.localized, metadata, policy=policy)
     if new_localized is not None:
         updates["localized"] = new_localized
+
+    if updates:
+        movie = movie.with_updates(**updates)
+
+    return movie
+
+
+def _to_collection(collection: CollectionMetadata) -> Collection:
+    """Convert the provider's collection DTO into the domain VO."""
+    return Collection(
+        tmdb_id=collection.tmdb_id,
+        name=collection.name,
+        parts_count=collection.parts_count,
+    )
 
 
 __all__ = ["EnrichMovieMetadataUseCase"]

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -1,9 +1,7 @@
 """Use case for enriching a series with external metadata."""
 
 import logging
-from collections.abc import Callable
 from datetime import date
-from typing import Any
 
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.building_blocks.application.event_bus import EventBus
@@ -22,6 +20,7 @@ from src.modules.media.application.use_cases._localized_metadata_helpers import 
     merge_media_localized,
     merge_text_localized,
 )
+from src.modules.media.application.use_cases._metadata_field_merge import set_if_missing
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
     AirDate,
@@ -167,30 +166,6 @@ class EnrichSeriesMetadataUseCase:
         return None, None
 
 
-def _set_if_missing(
-    updates: dict[str, object],
-    metadata: MediaMetadata,
-    entity: Series,
-    field_map: dict[str, tuple[str, Callable[[Any], Any] | None]],
-    *,
-    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
-) -> None:
-    """Set fields in updates, respecting the merge policy.
-
-    A field is written when metadata has a value and ``policy.should_write``
-    allows it (always under ``OVERWRITE``; only when the entity field is
-    empty under ``FILL_IF_EMPTY``). The fill-if-empty guard protects user
-    edits on a routine re-enrichment; ``OVERWRITE`` (a relink / forced
-    refresh) bypasses it so metadata from the newly-picked match overwrites
-    stale values left by a wrong match.
-    """
-    for meta_attr, (entity_attr, converter) in field_map.items():
-        meta_val = getattr(metadata, meta_attr, None)
-        entity_val = getattr(entity, entity_attr, None)
-        if meta_val and policy.should_write(entity_val):
-            updates[entity_attr] = converter(meta_val) if converter is not None else meta_val
-
-
 def _apply_series_metadata(
     series: Series,
     metadata: MediaMetadata,
@@ -231,7 +206,7 @@ def _apply_series_metadata(
         updates["title"] = Title(metadata.title)
 
     # Don't-overwrite fields (only set if empty, unless ``OVERWRITE``)
-    _set_if_missing(
+    set_if_missing(
         updates,
         metadata,
         series,
@@ -248,10 +223,8 @@ def _apply_series_metadata(
     )
 
     # Cast: same fill-if-empty rule as the rest of the don't-overwrite
-    # block, but built outside ``_set_if_missing`` because the
-    # provider DTO uses a different field name (``cast`` ↔ ``cast``)
-    # AND a per-element converter from ``CreditPerson`` to the
-    # domain ``CastMember`` VO.
+    # block, but kept explicit (outside ``set_if_missing``) for the
+    # per-element ``CreditPerson`` → ``CastMember`` conversion.
     if metadata.cast and policy.should_write(series.cast):
         updates["cast"] = [
             CastMember(

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -7,6 +7,7 @@ import pytest
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.modules.media.application.dtos.enrichment_dtos import EnrichMediaInput
 from src.modules.media.application.ports import (
+    CollectionMetadata,
     CreditPerson,
     LocalizedFields,
     MediaMetadata,
@@ -320,8 +321,8 @@ class TestEnrichMovieMetadataForce:
 
     Motivating use case: backfill ``tmdb_id`` on cast members of
     movies enriched before the id was captured. Without the force
-    bypass on ``_apply_credits`` the cast field stays untouched and
-    the actor page never gets bio links.
+    bypass the cast field stays untouched and the actor page never
+    gets bio links.
     """
 
     @pytest.mark.asyncio
@@ -516,6 +517,44 @@ class TestApplyMetadataFields:
         assert saved.localized.to_serializable()["pt-BR"]["title"] == "A Origem"
         assert saved.localized.to_serializable()["pt-BR"]["synopsis"] == "Sonho dentro do sonho."
         assert saved.localized.to_serializable()["pt-BR"]["genres"] == ["Ficção Científica"]
+
+    @pytest.mark.asyncio
+    async def test_should_apply_tagline_and_collection_when_missing(self) -> None:
+        movie = _make_movie()
+        metadata = MediaMetadata(
+            title="Inception",
+            tmdb_id=27205,
+            tagline="Your mind is the scene of the crime.",
+            collection=CollectionMetadata(tmdb_id=8091, name="Alien Collection", parts_count=6),
+        )
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = metadata
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        saved = mocks.movies.save.call_args[0][0]
+        assert saved.tagline == "Your mind is the scene of the crime."
+        # Exercises the _to_collection converter (CollectionMetadata → Collection VO).
+        assert saved.collection.tmdb_id == 8091
+        assert saved.collection.name == "Alien Collection"
+        assert saved.collection.parts_count == 6
+
+    @pytest.mark.asyncio
+    async def test_should_not_overwrite_existing_field_when_not_forced(self) -> None:
+        # A table-driven field must keep a user value on a routine re-enrich
+        # (fill-if-empty skip path) — guards the entity_attr in each map tuple.
+        movie = _make_movie().with_updates(tagline="user-edited tagline")
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = MediaMetadata(
+            title="Inception", tmdb_id=27205, tagline="TMDB tagline"
+        )
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        saved = mocks.movies.save.call_args[0][0]
+        assert saved.tagline == "user-edited tagline"
 
 
 @pytest.mark.unit

--- a/tests/modules/media/unit/application/use_cases/test_metadata_field_merge.py
+++ b/tests/modules/media/unit/application/use_cases/test_metadata_field_merge.py
@@ -1,0 +1,58 @@
+"""Tests for the shared set_if_missing metadata merge helper."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.modules.media.application.use_cases._metadata_field_merge import set_if_missing
+from src.modules.media.domain.value_objects import MergePolicy
+
+_FIELD_MAP = {"poster_url": ("poster_path", str.upper)}
+
+
+@pytest.mark.unit
+class TestSetIfMissing:
+    def test_fills_an_empty_field_and_applies_the_converter(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(poster_url="abc")
+        entity = SimpleNamespace(poster_path=None)
+
+        set_if_missing(updates, metadata, entity, _FIELD_MAP)
+
+        assert updates == {"poster_path": "ABC"}
+
+    def test_fill_if_empty_skips_when_entity_already_has_a_value(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(poster_url="abc")
+        entity = SimpleNamespace(poster_path="kept")
+
+        set_if_missing(updates, metadata, entity, _FIELD_MAP)
+
+        assert updates == {}
+
+    def test_overwrite_writes_even_when_entity_has_a_value(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(poster_url="abc")
+        entity = SimpleNamespace(poster_path="stale")
+
+        set_if_missing(updates, metadata, entity, _FIELD_MAP, policy=MergePolicy.OVERWRITE)
+
+        assert updates == {"poster_path": "ABC"}
+
+    def test_skips_when_provider_value_is_falsy(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(poster_url=None)
+        entity = SimpleNamespace(poster_path=None)
+
+        set_if_missing(updates, metadata, entity, _FIELD_MAP)
+
+        assert updates == {}
+
+    def test_none_converter_passes_the_value_through(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(synopsis="plot")
+        entity = SimpleNamespace(synopsis=None)
+
+        set_if_missing(updates, metadata, entity, {"synopsis": ("synopsis", None)})
+
+        assert updates == {"synopsis": "plot"}


### PR DESCRIPTION
## Summary

Phase-6 backlog "Card D" — Divergent Change cleanup in the metadata enrich flows.

The movie enrich applied ~14 fill-if-empty fields by hand (`if metadata.X and policy.should_write(movie.Y): updates[...] = conv(...)`), while the series enrich already table-drove the same shape through a private `_set_if_missing`. One merge rule, two implementations.

- Extract `set_if_missing` into a shared `_metadata_field_merge.py` (generalized from the series helper; `entity` duck-typed for Movie/Series).
- Table-drive the movie's don't-overwrite fields through it: synopsis, genres, poster/backdrop/logo, tagline, collection, directors, writers, content_rating, trailer. The two branch-cap helper functions (`_apply_franchise_metadata`/`_apply_credits`) are folded away.
- Keep the genuinely special fields explicit: `title` (movie always-overwrites — a real behavior difference from series), the always-overwrite ids, the never-overwrite-real-duration guard, the per-element `cast` conversion, and the `localized` merge.

Pure refactor — behavior verified field-by-field equivalent (the tagline-drift class of bug cannot recur). This is the lighter "adopt the existing pattern" step; the deeper `MetadataReconciler` / `Movie.merged_with` domain-service refactor stays a separate, larger backlog card.

## Test plan

- [x] `pytest tests/modules/media/` — green (1762 passed). New `test_metadata_field_merge.py` covers the shared helper (fill / skip / OVERWRITE / falsy / None-converter); new movie-enrich tests cover `collection`+`tagline` fill-when-empty (exercising the `_to_collection` converter) and the fill-if-empty *skip-when-present* path; existing movie/series enrich tests (unchanged) exercise the rest of the mapped fields.
- [x] Field-by-field equivalence audited (provider attr, entity attr, converter, guard) — no semantic drift; `set_if_missing` reads the same `entity_attr` each old guard checked.
- [x] `ruff check` + `ruff format --check` clean; `mypy src --ignore-missing-imports` adds no new errors. A mistyped field-map key now fails loudly (no silent skip).
- [x] No DB migration; no runtime change.

## Summary by Sourcery

Refactor metadata enrichment to share a table-driven helper for non-overwriting fields across movies and series.

Enhancements:
- Introduce a shared set_if_missing helper to centralize merge policy handling for provider metadata fields used by both movie and series enrichment flows.
- Update movie metadata enrichment to use the shared field-map helper for non-overwrite fields while keeping special-case fields explicit.
- Improve robustness of metadata field mapping by making incorrect provider attribute keys fail loudly instead of being silently ignored.

Tests:
- Add unit tests for the shared set_if_missing helper covering merge policy behavior, converter handling, and falsy provider values.
- Extend movie metadata enrichment tests to cover tagline and collection mapping and to verify that existing user-edited fields are not overwritten without force.