### PR TITLE
feat(media): TrackSelector + stop probe fabricating audio default

### DIFF
--- a/src/modules/media/application/dtos/stream_dtos.py
+++ b/src/modules/media/application/dtos/stream_dtos.py
@@ -14,6 +14,7 @@ from src.modules.media.domain.services.track_naming import (
     audio_version_labels,
     subtitle_version_labels,
 )
+from src.modules.media.domain.services.track_selector import TrackSelector
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -96,6 +97,11 @@ def serialize_tracks(probe: ProbeResult) -> TrackListOutput:
     audio_versions = audio_version_labels(probe.audio_tracks)
     text_subs = [t for t in probe.all_subtitles if t.is_text_based]
     sub_versions = subtitle_version_labels(text_subs)
+    # The probe reports ``is_default`` truthfully (container-declared only),
+    # so pick the player's default audio here via the ADR-005 selector. With
+    # no library preference available at this boundary it falls back to the
+    # container default, else the first track — keeping exactly one default.
+    default_audio = TrackSelector().select_audio(probe.audio_tracks)
     return TrackListOutput(
         audio_tracks=[
             {
@@ -106,7 +112,7 @@ def serialize_tracks(probe: ProbeResult) -> TrackListOutput:
                 "channel_layout": t.channel_layout,
                 "title": t.title,
                 "version": _version_dict(audio_versions.get(t.index)),
-                "is_default": t.is_default,
+                "is_default": t is default_audio,
             }
             for t in probe.audio_tracks
         ],

--- a/src/modules/media/application/use_cases/_media_file_helpers.py
+++ b/src/modules/media/application/use_cases/_media_file_helpers.py
@@ -5,11 +5,12 @@ from src.modules.media.application.dtos.media_file_dtos import (
     MediaFileOutput,
     SubtitleTrackOutput,
 )
+from src.modules.media.domain.services.track_selector import TrackSelector
 from src.modules.media.domain.value_objects import MediaFile
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 
-def _to_audio_track_output(track: AudioTrack) -> AudioTrackOutput:
+def _to_audio_track_output(track: AudioTrack, *, is_default: bool) -> AudioTrackOutput:
     return AudioTrackOutput(
         index=track.index,
         language=track.language.value,
@@ -17,7 +18,7 @@ def _to_audio_track_output(track: AudioTrack) -> AudioTrackOutput:
         channels=track.channels,
         channel_layout=track.channel_layout,
         title=track.title,
-        is_default=track.is_default,
+        is_default=is_default,
     )
 
 
@@ -42,6 +43,11 @@ def to_media_file_output(file: MediaFile) -> MediaFileOutput:
     Returns:
         MediaFileOutput with serialized fields.
     """
+    # The probe persists ``is_default`` truthfully (container-declared only),
+    # so pick the default audio via the ADR-005 selector here too — keeping
+    # exactly one default in the output (container default, else first), the
+    # same contract the player-facing /tracks projection uses.
+    default_audio = TrackSelector().select_audio(file.audio_tracks)
     return MediaFileOutput(
         file_path=file.file_path.value,
         file_size=file.file_size,
@@ -51,6 +57,8 @@ def to_media_file_output(file: MediaFile) -> MediaFileOutput:
         hdr_format=file.hdr_format.value if file.hdr_format else None,
         is_primary=file.is_primary,
         added_at=file.added_at.isoformat(),
-        audio_tracks=[_to_audio_track_output(t) for t in file.audio_tracks],
+        audio_tracks=[
+            _to_audio_track_output(t, is_default=t is default_audio) for t in file.audio_tracks
+        ],
         subtitle_tracks=[_to_subtitle_track_output(t) for t in file.subtitle_tracks],
     )

--- a/src/modules/media/domain/services/track_selector.py
+++ b/src/modules/media/domain/services/track_selector.py
@@ -1,0 +1,60 @@
+"""Track selection domain service (ADR-005).
+
+Owns the rule for *which* audio track is the default, so the probe can
+report tracks truthfully (only the container's declared default) instead
+of fabricating one. The decision is made at read time from the tracks plus
+the caller's preference, not baked into the persisted data.
+
+Only :meth:`select_audio` exists today — that is the rule Card B needs. The
+subtitle-by-mode selection ADR-005 also sketches has no consumer yet (the
+probe never fabricates a subtitle default), so it is deferred until one
+appears.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.shared_kernel.value_objects.language_code import LanguageCode
+    from src.shared_kernel.value_objects.tracks import AudioTrack
+
+
+class TrackSelector:
+    """Selects appropriate tracks based on preferences (ADR-005)."""
+
+    def select_audio(
+        self,
+        tracks: list[AudioTrack],
+        preferred_language: LanguageCode | None = None,
+    ) -> AudioTrack | None:
+        """Pick the default audio track for a file.
+
+        Priority (ADR-005):
+
+        1. A track in the preferred language, choosing the one with the
+           most channels.
+        2. The track the container declares default.
+        3. The first track.
+
+        Args:
+            tracks: The file's audio tracks, in container order.
+            preferred_language: The library's preferred audio language, or
+                ``None`` when no preference is available (e.g. at a
+                library-agnostic boundary).
+
+        Returns:
+            The selected track, or ``None`` when there are no audio tracks.
+        """
+        if not tracks:
+            return None
+
+        if preferred_language is not None:
+            in_language = [t for t in tracks if t.language == preferred_language]
+            if in_language:
+                return max(in_language, key=lambda t: t.channels)
+
+        return next((t for t in tracks if t.is_default), tracks[0])
+
+
+__all__ = ["TrackSelector"]

--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -400,10 +400,10 @@ class MediaProbeService(MediaProbePort):
             )
             audio_index += 1
 
-        # Ensure at least one track is default
-        if tracks and not any(t.is_default for t in tracks):
-            tracks[0] = tracks[0].with_updates(is_default=True)
-
+        # Report tracks truthfully: ``is_default`` reflects only what the
+        # container declared. Choosing a default when none is declared is
+        # the TrackSelector's job (ADR-005), applied at read time — see
+        # ``serialize_tracks``.
         return tracks
 
     @staticmethod

--- a/tests/modules/media/unit/application/use_cases/test_get_file_tracks.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_file_tracks.py
@@ -62,6 +62,73 @@ class TestGetFileTracksUseCase:
         hls.probe_tracks.assert_called_once_with("/m.mkv")
 
     @pytest.mark.asyncio
+    async def test_marks_first_audio_default_when_container_declares_none(self) -> None:
+        # Probe now reports truthfully (no fabricated default); the selector
+        # must still hand the player exactly one default audio (the first).
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[
+                AudioTrack(index=0, language=LanguageCode("en"), codec="aac", channels=2),
+                AudioTrack(index=1, language=LanguageCode("pt"), codec="ac3", channels=6),
+            ],
+            subtitle_tracks=[],
+        )
+        use_case = GetFileTracksUseCase(hls=hls)
+
+        output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
+
+        defaults = [t for t in output.audio_tracks if t["is_default"]]
+        assert len(defaults) == 1
+        assert defaults[0]["index"] == 0
+
+    @pytest.mark.asyncio
+    async def test_preserves_container_declared_default_audio(self) -> None:
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[
+                AudioTrack(index=0, language=LanguageCode("en"), codec="aac", channels=2),
+                AudioTrack(
+                    index=1,
+                    language=LanguageCode("pt"),
+                    codec="ac3",
+                    channels=6,
+                    is_default=True,
+                ),
+            ],
+            subtitle_tracks=[],
+        )
+        use_case = GetFileTracksUseCase(hls=hls)
+
+        output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
+
+        defaults = [t for t in output.audio_tracks if t["is_default"]]
+        assert len(defaults) == 1
+        assert defaults[0]["index"] == 1
+
+    @pytest.mark.asyncio
+    async def test_preserves_container_declared_default_subtitle(self) -> None:
+        # The change is audio-only: a container-declared subtitle default
+        # passes through serialize_tracks untouched.
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[_audio()],
+            subtitle_tracks=[
+                SubtitleTrack(
+                    index=0,
+                    language=LanguageCode("en"),
+                    format="srt",
+                    is_default=True,
+                    is_external=False,
+                ),
+            ],
+        )
+        use_case = GetFileTracksUseCase(hls=hls)
+
+        output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
+
+        assert output.subtitle_tracks[0]["is_default"] is True
+
+    @pytest.mark.asyncio
     async def test_should_drop_image_based_subtitles(self) -> None:
         hls = MagicMock(spec=HlsPlaylistPort)
         hls.probe_tracks.return_value = ProbeResult(

--- a/tests/modules/media/unit/application/use_cases/test_media_file_helpers.py
+++ b/tests/modules/media/unit/application/use_cases/test_media_file_helpers.py
@@ -114,6 +114,25 @@ class TestToMediaFileOutputTracks:
         assert s1.is_forced is False
         assert s1.is_external is True
 
+    def test_marks_first_audio_default_when_container_declares_none(self) -> None:
+        # New scans persist truthful is_default (possibly all-False); the
+        # output still reports exactly one default audio via the selector.
+        media_file = MediaFile(
+            file_path=FilePath("/movies/movie.mkv"),
+            file_size=1_000,
+            resolution=Resolution("1080p"),
+            is_primary=True,
+            audio_tracks=[
+                AudioTrack(index=0, language=LanguageCode("en"), codec="aac", channels=2),
+                AudioTrack(index=1, language=LanguageCode("pt"), codec="ac3", channels=6),
+            ],
+        )
+        output = to_media_file_output(media_file)
+
+        defaults = [a for a in output.audio_tracks if a.is_default]
+        assert len(defaults) == 1
+        assert defaults[0].index == 0
+
     def test_should_return_empty_tracks_when_none_present(self) -> None:
         media_file = MediaFile(
             file_path=FilePath("/movies/movie.mkv"),

--- a/tests/modules/media/unit/domain/services/test_track_selector.py
+++ b/tests/modules/media/unit/domain/services/test_track_selector.py
@@ -1,0 +1,64 @@
+"""Tests for the TrackSelector domain service (ADR-005)."""
+
+import pytest
+
+from src.modules.media.domain.services.track_selector import TrackSelector
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import AudioTrack
+
+
+def _audio(
+    index: int,
+    *,
+    language: str = "en",
+    channels: int = 2,
+    is_default: bool = False,
+) -> AudioTrack:
+    return AudioTrack(
+        index=index,
+        language=LanguageCode(language),
+        codec="aac",
+        channels=channels,
+        is_default=is_default,
+    )
+
+
+@pytest.mark.unit
+class TestSelectAudio:
+    def test_returns_none_for_no_tracks(self) -> None:
+        assert TrackSelector().select_audio([]) is None
+
+    def test_no_preference_falls_back_to_container_default(self) -> None:
+        tracks = [_audio(0), _audio(1, is_default=True), _audio(2)]
+        assert TrackSelector().select_audio(tracks) is tracks[1]
+
+    def test_no_preference_no_default_falls_back_to_first(self) -> None:
+        # Reproduces the old probe behaviour without persisting a fabricated flag.
+        tracks = [_audio(0), _audio(1)]
+        assert TrackSelector().select_audio(tracks) is tracks[0]
+
+    def test_preferred_language_wins_over_container_default(self) -> None:
+        tracks = [
+            _audio(0, language="en", is_default=True),
+            _audio(1, language="pt", channels=6),
+        ]
+        selected = TrackSelector().select_audio(tracks, LanguageCode("pt"))
+        assert selected is tracks[1]
+
+    def test_preferred_language_picks_most_channels(self) -> None:
+        tracks = [
+            _audio(0, language="pt", channels=2),
+            _audio(1, language="pt", channels=8),
+            _audio(2, language="en", channels=6),
+        ]
+        selected = TrackSelector().select_audio(tracks, LanguageCode("pt"))
+        assert selected is tracks[1]
+
+    def test_preferred_language_absent_falls_back_to_default_then_first(self) -> None:
+        tracks = [_audio(0, language="en"), _audio(1, language="en", is_default=True)]
+        # No Japanese track → fall through to the container default.
+        assert TrackSelector().select_audio(tracks, LanguageCode("ja")) is tracks[1]
+
+    def test_preferred_language_absent_no_default_falls_back_to_first(self) -> None:
+        tracks = [_audio(0, language="en"), _audio(1, language="en")]
+        assert TrackSelector().select_audio(tracks, LanguageCode("ja")) is tracks[0]

--- a/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_media_probe_service.py
@@ -141,7 +141,7 @@ class TestParseAudioTracks:
         assert tracks[1].codec == "ac3"
         assert tracks[1].channels == 6
 
-    def test_should_ensure_default_track_when_none_marked(self) -> None:
+    def test_should_not_fabricate_default_when_none_marked(self) -> None:
         streams = [
             _ffprobe_stream(codec_name="aac", language="en", default=False),
             _ffprobe_stream(codec_name="ac3", language="pt", default=False),
@@ -149,9 +149,9 @@ class TestParseAudioTracks:
 
         tracks = MediaProbeService._parse_audio_tracks(streams)
 
-        # First track should be forced to default
-        assert tracks[0].is_default is True
-        assert tracks[1].is_default is False
+        # The probe reports truthfully — no fabricated default. Choosing a
+        # default when the container declares none is the TrackSelector's job.
+        assert all(t.is_default is False for t in tracks)
 
     def test_should_parse_bitrate(self) -> None:
         streams = [_ffprobe_stream(codec_name="aac", bit_rate="192000")]


### PR DESCRIPTION
## Summary

Phase-6 backlog "Card B". The media probe fabricated a default audio track — it forced `tracks[0].is_default = True` when the container declared none, persisting a flag the container never set. The decision of *which* audio is default belongs to a `TrackSelector` (ADR-005), made at read time, not baked into the data by the prober.

- **`TrackSelector` domain service** (`media/domain/services/track_selector.py`, per ADR-005): `select_audio(tracks, preferred_language=None)` → a preferred-language track (most channels), else the container-declared default, else the first track. `select_subtitle` is deferred (no consumer; the probe never fabricates a subtitle default).
- **Probe reports truthfully** — `_parse_audio_tracks` no longer forces a default; `is_default` reflects only the container.
- **Selector applied at every read boundary that emits an audio default**: the player-facing `/tracks` (`serialize_tracks`) and the detail/admin views (`to_media_file_output`). Each still reports exactly one default audio (container default, else first), so with no library preference the output is identical to the old fabricated behaviour — and the old-vs-newly-scanned persistence inconsistency is hidden behind the selector.

HLS playback is unaffected: the master playlist already ignores `is_default` and uses `tracks[0]` as the primary rendition. Audio-only — subtitle defaults (container-declared, never fabricated) pass through untouched.

Verified by manual player smoke test: `/tracks` returns exactly one default audio, the right track auto-plays, and track switching works.

## Test plan

- [x] `pytest` (full suite) — 3218 passed.
- [x] New `test_track_selector.py` (7 cases: empty, container-default, first fallback, preferred-language most-channels, preferred-absent fallbacks).
- [x] `test_get_file_tracks.py` + `test_media_file_helpers.py`: both read boundaries report exactly one default audio (first when none declared; container default preserved); subtitle default left untouched.
- [x] Probe test inverted (`test_should_not_fabricate_default_when_none_marked` asserts all-False; container-default-preserved test still passes).
- [x] `ruff check` + `ruff format --check` clean; `mypy src --ignore-missing-imports` adds no new errors.
- [x] Manual smoke test on a dual-audio title (player auto-selects + switches correctly).
- [ ] No DB migration. `is_default` persists truthfully going forward; existing rows are unaffected at read (both boundaries recompute via the selector).

## Follow-ups (deferred, non-blocking)

- Wire `LibrarySettings.preferred_audio_language` into the `/tracks` boundary (cross-BC via an ACL port) so the selector's preferred-language branch drives the default — today it always falls back to container/first (same as before this PR). The selector already supports it.
- `select_subtitle` (mode-based) + ADR-005 note that `preferred_language` is optional at the library-agnostic boundary.

## Summary by Sourcery

Introduce an audio TrackSelector domain service and shift default audio selection from the media probe into read-time boundaries while preserving a single default audio in player-facing outputs.

New Features:
- Add TrackSelector domain service to choose the default audio track based on preferred language, container-declared default, and track order.

Bug Fixes:
- Stop the media probe from fabricating a default audio flag when the container declares none, ensuring persisted is_default reflects only container metadata.

Enhancements:
- Apply TrackSelector in serialize_tracks and to_media_file_output so player and admin views consistently expose exactly one default audio track without altering stored probe data.
- Keep container-declared subtitle defaults unchanged while updating audio default selection logic.

Tests:
- Add unit tests for TrackSelector selection rules and for use cases ensuring first-or-container default audio behavior and preserved subtitle defaults.
- Update media probe tests to assert that no default audio is fabricated when the container marks none.