### PR TITLE
refactor(media): wrap malformed TMDB JSON as GatewayBadResponseException

### DIFF
--- a/src/modules/media/application/ports/metadata_provider_port.py
+++ b/src/modules/media/application/ports/metadata_provider_port.py
@@ -474,11 +474,12 @@ class MetadataProvider(ABC):
 
         Raises:
             GatewayException: On provider failure (network error, auth,
-                rate limit, 5xx), wrapped in the subtype matching the
-                cause so the API surfaces 429/502/503/504 instead of a
-                generic 500. Callers must distinguish "no such movie"
-                (``None``) from "TMDB unavailable" (raises) — a
-                transient failure must not masquerade as not-found.
+                rate limit, 5xx, or a malformed/non-JSON 2xx body),
+                wrapped in the subtype matching the cause so the API
+                surfaces 429/502/503/504 instead of a generic 500.
+                Callers must distinguish "no such movie" (``None``) from
+                "TMDB unavailable" (raises) — a transient failure must
+                not masquerade as not-found.
         """
         ...
 
@@ -509,7 +510,15 @@ class MetadataProvider(ABC):
         Returns:
             All candidates matched by the id, in arbitrary order
             (caller stable-sorts). Empty list when the provider has
-            no match for the id or the call fails.
+            no match for the id.
+
+        Raises:
+            GatewayException: On provider failure — network error, auth,
+                rate limit, 5xx, or a malformed/non-JSON 2xx body —
+                wrapped in the subtype matching the cause so the API
+                surfaces 429/502/503/504 instead of a generic 500. This
+                is a load-bearing lookup, so a transient failure raises
+                rather than collapsing to an (ambiguous) empty list.
         """
         ...
 

--- a/src/modules/media/infrastructure/metadata/tmdb_client.py
+++ b/src/modules/media/infrastructure/metadata/tmdb_client.py
@@ -268,6 +268,33 @@ class TmdbClient(MetadataProvider):
         )
 
     @staticmethod
+    def _json(resp: httpx.Response) -> Any:
+        """Parse a TMDB response body as JSON, wrapping malformed payloads.
+
+        TMDB occasionally returns a non-JSON body — an HTML error page,
+        a truncated/empty payload — alongside a ``2xx`` status.
+        ``httpx.Response.json`` raises ``ValueError``
+        (``json.JSONDecodeError``) for those, which would otherwise leak
+        past this ACL and surface as a generic ``500``. Translating it to
+        :class:`GatewayBadResponseException` lets the global handler report
+        ``502`` ("the provider sent us garbage", not "our server crashed")
+        and lets best-effort callers that already catch ``GatewayException``
+        degrade gracefully — the same way they treat a wrapped transport
+        failure.
+
+        Raises:
+            GatewayBadResponseException: The response body is not valid JSON.
+        """
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise GatewayBadResponseException(
+                message="TMDB returned a malformed response",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=f"{type(exc).__name__}: {exc}",
+            ) from exc
+
+    @staticmethod
     def _logo_rank(logo: dict[str, object], target: str, target_base: str) -> int:
         """Score a TMDB logo entry for language preference (lower = better).
 
@@ -327,7 +354,7 @@ class TmdbClient(MetadataProvider):
             params=self._params(query=title, year=year),
         )
         self._raise_for_status(resp)
-        results = resp.json().get("results", [])
+        results = self._json(resp).get("results", [])
 
         best = self._pick_year_match(results, year, "release_date")
         if best is None:
@@ -351,7 +378,7 @@ class TmdbClient(MetadataProvider):
             params=self._params(query=title, first_air_date_year=year),
         )
         self._raise_for_status(resp)
-        results = resp.json().get("results", [])
+        results = self._json(resp).get("results", [])
 
         best = self._pick_year_match(results, year, "first_air_date")
         if best is None:
@@ -376,7 +403,7 @@ class TmdbClient(MetadataProvider):
             params=self._params(query=title, year=year),
         )
         self._raise_for_status(resp)
-        results = resp.json().get("results", [])
+        results = self._json(resp).get("results", [])
         return [_to_movie_candidate(r, self._image_url) for r in results[:limit]]
 
     async def find_series_candidates(
@@ -391,7 +418,7 @@ class TmdbClient(MetadataProvider):
             params=self._params(query=title, first_air_date_year=year),
         )
         self._raise_for_status(resp)
-        results = resp.json().get("results", [])
+        results = self._json(resp).get("results", [])
         return [_to_series_candidate(r, self._image_url) for r in results[:limit]]
 
     async def get_movie_summary_by_id(self, tmdb_id: int) -> SearchCandidate | None:
@@ -409,7 +436,7 @@ class TmdbClient(MetadataProvider):
         if resp.status_code == httpx.codes.NOT_FOUND:
             return None
         self._raise_for_status(resp)
-        return _to_movie_candidate(resp.json(), self._image_url)
+        return _to_movie_candidate(self._json(resp), self._image_url)
 
     async def get_series_summary_by_id(self, tmdb_id: int) -> SearchCandidate | None:
         """Cheap ``/tv/{id}`` fetch shaped as a picker candidate.
@@ -425,7 +452,7 @@ class TmdbClient(MetadataProvider):
         if resp.status_code == httpx.codes.NOT_FOUND:
             return None
         self._raise_for_status(resp)
-        return _to_series_candidate(resp.json(), self._image_url)
+        return _to_series_candidate(self._json(resp), self._image_url)
 
     async def find_by_imdb_id(self, imdb_id: str) -> list[SearchCandidate]:
         """Resolve an IMDb id via ``/find`` and return movie + TV hits.
@@ -442,7 +469,7 @@ class TmdbClient(MetadataProvider):
             params=self._params(external_source="imdb_id"),
         )
         self._raise_for_status(resp)
-        payload = resp.json()
+        payload = self._json(resp)
         movies = [_to_movie_candidate(r, self._image_url) for r in payload.get("movie_results", [])]
         series = [_to_series_candidate(r, self._image_url) for r in payload.get("tv_results", [])]
         return [*movies, *series]
@@ -519,12 +546,12 @@ class TmdbClient(MetadataProvider):
                     include_image_language=f"{locale},en,null",
                 ),
             )
+            if resp.status_code != 200:
+                return None
+            data = self._json(resp)
         except GatewayException:
             return None
-        if resp.status_code != 200:
-            return None
 
-        data = resp.json()
         return LocalizedFields(
             title=data.get("title"),
             synopsis=data.get("overview"),
@@ -563,11 +590,11 @@ class TmdbClient(MetadataProvider):
                 f"/collection/{tmdb_id}",
                 params=self._params(language=language),
             )
+            if resp.status_code != 200:
+                return None
+            data = self._json(resp)
         except GatewayException:
             return None
-        if resp.status_code != 200:
-            return None
-        data = resp.json()
         if not isinstance(data, dict):
             return None
 
@@ -723,12 +750,11 @@ class TmdbClient(MetadataProvider):
                 f"/movie/{tmdb_id}",
                 params=self._params(),
             )
+            if resp.status_code != 200:
+                return []
+            coll = self._json(resp).get("belongs_to_collection")
         except GatewayException:
             return []
-        if resp.status_code != 200:
-            return []
-
-        coll = resp.json().get("belongs_to_collection")
         if not isinstance(coll, dict):
             return []
         coll_id = coll.get("id")
@@ -740,12 +766,11 @@ class TmdbClient(MetadataProvider):
                 f"/collection/{coll_id}",
                 params=self._params(),
             )
+            if resp.status_code != 200:
+                return []
+            parts = self._json(resp).get("parts") or []
         except GatewayException:
             return []
-        if resp.status_code != 200:
-            return []
-
-        parts = resp.json().get("parts") or []
         ids: list[int] = []
         for part in parts:
             if not isinstance(part, dict):
@@ -774,11 +799,11 @@ class TmdbClient(MetadataProvider):
                 f"/{media_type}/{tmdb_id}/{endpoint}",
                 params=self._params(),
             )
+            if resp.status_code != 200:
+                return []
+            results = self._json(resp).get("results") or []
         except GatewayException:
             return []
-        if resp.status_code != 200:
-            return []
-        results = resp.json().get("results") or []
         ids: list[int] = []
         for item in results:
             raw = item.get("id") if isinstance(item, dict) else None
@@ -826,11 +851,11 @@ class TmdbClient(MetadataProvider):
                 f"/person/{tmdb_id}",
                 params=self._params(language=language),
             )
+            if resp.status_code != 200:
+                return None
+            data = self._json(resp)
         except GatewayException:
             return None
-        if resp.status_code != 200:
-            return None
-        data = resp.json()
         if not isinstance(data, dict):
             return None
         # ``id`` and ``name`` are required for the UI to render
@@ -895,12 +920,11 @@ class TmdbClient(MetadataProvider):
                 f"/{path}/{tmdb_id}/translations",
                 params=self._params(),
             )
+            if resp.status_code != 200:
+                return {}
+            translations = self._json(resp).get("translations", [])
         except GatewayException:
             return {}
-        if resp.status_code != 200:
-            return {}
-
-        translations = resp.json().get("translations", [])
         titles: dict[str, str] = {}
         for locale in self._supported_locales:
             title = _pick_translation_title(translations, locale, title_key)
@@ -926,12 +950,12 @@ class TmdbClient(MetadataProvider):
                     include_image_language=f"{locale},en,null",
                 ),
             )
+            if resp.status_code != 200:
+                return None
+            data = self._json(resp)
         except GatewayException:
             return None
-        if resp.status_code != 200:
-            return None
 
-        data = resp.json()
         return LocalizedFields(
             title=data.get("name"),
             synopsis=data.get("overview"),
@@ -963,7 +987,7 @@ class TmdbClient(MetadataProvider):
         if resp.status_code == 404:
             return None
         self._raise_for_status(resp)
-        data = resp.json()
+        data = self._json(resp)
 
         year = None
         if data.get("release_date"):
@@ -1020,11 +1044,11 @@ class TmdbClient(MetadataProvider):
                 f"/collection/{coll_id}",
                 params=self._params(),
             )
+            if resp.status_code != 200:
+                return None
+            parts = self._json(resp).get("parts") or []
         except GatewayException:
             return None
-        if resp.status_code != 200:
-            return None
-        parts = resp.json().get("parts") or []
         return CollectionMetadata(tmdb_id=coll_id, name=name, parts_count=len(parts))
 
     async def _fetch_series_details(self, tmdb_id: int) -> MediaMetadata | None:
@@ -1045,7 +1069,7 @@ class TmdbClient(MetadataProvider):
         if resp.status_code == 404:
             return None
         self._raise_for_status(resp)
-        data = resp.json()
+        data = self._json(resp)
 
         # Top-billed cast comes back nested under ``credits.cast`` thanks
         # to the ``credits`` append above. Reuse the same parser the
@@ -1159,17 +1183,17 @@ class TmdbClient(MetadataProvider):
                 f"/tv/{series_id}/season/{season_number}",
                 params=self._params(language=language),
             )
+            if resp.status_code == 404:
+                return None
+            if language is not None and resp.status_code != 200:
+                return None
+            if language is None:
+                self._raise_for_status(resp)
+            data: dict[str, Any] = self._json(resp)
         except GatewayException:
             if language is None:
                 raise
             return None
-        if resp.status_code == 404:
-            return None
-        if language is not None and resp.status_code != 200:
-            return None
-        if language is None:
-            self._raise_for_status(resp)
-        data: dict[str, Any] = resp.json()
         return data
 
     @staticmethod

--- a/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_tmdb_client.py
@@ -1,6 +1,7 @@
 """Tests for TmdbClient."""
 
 import itertools
+import json
 from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
@@ -38,6 +39,21 @@ def _build_response(
         response.raise_for_status.side_effect = httpx.HTTPStatusError(
             "error", request=MagicMock(), response=response
         )
+    return response
+
+
+def _malformed_response(status_code: int = 200) -> MagicMock:
+    """Build a 2xx-ish response whose body is not valid JSON.
+
+    Mirrors a TMDB hiccup that returns an HTML error page / truncated
+    payload with a success status — ``httpx.Response.json`` raises
+    ``json.JSONDecodeError`` (a ``ValueError`` subclass) for those.
+    """
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.side_effect = json.JSONDecodeError("Expecting value", "<!DOCTYPE", 0)
+    response.headers = {}
+    response.raise_for_status = MagicMock()
     return response
 
 
@@ -564,6 +580,68 @@ class TestGatewayErrorTranslation:
         # ...but the English base failing is fatal and propagates.
         with pytest.raises(GatewayUnavailableException):
             await client._fetch_season_payload(1, 1, None)
+
+    def test_json_helper_wraps_malformed_body(self) -> None:
+        # A 2xx with a non-JSON body must not leak ValueError past the
+        # ACL — it becomes a GatewayBadResponseException (502), not a 500.
+        with pytest.raises(GatewayBadResponseException):
+            TmdbClient._json(_malformed_response())
+
+    @pytest.mark.asyncio
+    async def test_load_bearing_path_raises_bad_response_on_malformed_json(self) -> None:
+        client = _make_client(get_responses=_malformed_response())
+
+        with pytest.raises(GatewayBadResponseException):
+            await client.get_movie_summary_by_id(1)
+
+    @pytest.mark.asyncio
+    async def test_best_effort_methods_degrade_on_malformed_json(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(return_value=_malformed_response())
+
+        # Malformed JSON is just another "provider misbehaved" signal —
+        # best-effort paths swallow it the same way they swallow a
+        # transport error, rather than 502-ing the whole request.
+        assert await client.get_collection(10) is None
+        assert await client.get_person(287) is None
+        assert await client.get_movie_recommendations(1) == []
+        assert await client._fetch_movie_localized_fields(1, "pt-BR") is None
+        assert await client._fetch_series_localized_fields(1, "pt-BR") is None
+        assert await client.get_translated_titles(1, MediaType.MOVIE) == {}
+
+    @pytest.mark.asyncio
+    async def test_season_overlay_skips_but_base_raises_on_malformed_json(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(return_value=_malformed_response())
+
+        # Overlay locale degrades; the English base 502s like any other
+        # bad provider response.
+        assert await client._fetch_season_payload(1, 1, "pt-BR") is None
+        with pytest.raises(GatewayBadResponseException):
+            await client._fetch_season_payload(1, 1, None)
+
+    @pytest.mark.asyncio
+    async def test_collection_metadata_degrades_on_malformed_json(self) -> None:
+        client = _make_client()
+        client._client.get = AsyncMock(return_value=_malformed_response())
+
+        # belongs_to_collection is valid, but the /collection polish fetch
+        # returns garbage — movie enrichment must not break over it.
+        assert await client._fetch_collection_metadata({"id": 10, "name": "Saw Collection"}) is None
+
+    @pytest.mark.asyncio
+    async def test_collection_movie_ids_degrades_on_malformed_second_fetch(self) -> None:
+        # First /movie fetch is valid (carries belongs_to_collection); the
+        # follow-up /collection fetch returns malformed JSON. The second
+        # _json site degrades to [] rather than 502-ing recommendations.
+        client = _make_client(
+            get_responses=[
+                _build_response(json_data={"belongs_to_collection": {"id": 99}}),
+                _malformed_response(),
+            ]
+        )
+
+        assert await client._fetch_collection_movie_ids(1) == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- A non-JSON body on a 2xx TMDB response (HTML error page, truncated/empty payload) made `resp.json()` raise `ValueError`, leaking past the ACL and surfacing as a generic **500**.
- Adds a `TmdbClient._json(resp)` helper that translates the `ValueError` into `GatewayBadResponseException` (registry-mapped to **502** via ADR-012). All 19 `resp.json()` call sites now route through it.
- Load-bearing paths (after `_raise_for_status`) propagate the 502; best-effort paths had their status-check + parse moved inside the existing `try/except GatewayException` so a malformed body degrades to `None`/`[]`/`{}` the same way a transport failure already did.
- Aligns the `MetadataProvider` port docstrings (`find_by_imdb_id` raises on failure; summary-by-id cause list) with the now-extended raise set.
- Deferred second half of Card A (#338), which had wrapped transport/status failures but left malformed-body parsing leaking 500.

## Test plan
- [x] `test_json_helper_wraps_malformed_body` — helper raises `GatewayBadResponseException`
- [x] `test_load_bearing_path_raises_bad_response_on_malformed_json` — load-bearing → 502
- [x] `test_best_effort_methods_degrade_on_malformed_json` — best-effort paths degrade
- [x] `test_season_overlay_skips_but_base_raises_on_malformed_json` — base raises / overlay degrades
- [x] `test_collection_metadata_degrades_on_malformed_json` + `test_collection_movie_ids_degrades_on_malformed_second_fetch`
- [x] `make test` (media suite, 1779 passed) + `ruff check`/`ruff format` clean; no new mypy errors

## Summary by Sourcery

Handle malformed TMDB JSON responses as gateway bad responses and ensure callers either propagate a 502 or degrade gracefully instead of leaking 500s.

Bug Fixes:
- Wrap ValueError from parsing non-JSON TMDB bodies into GatewayBadResponseException so malformed 2xx responses no longer surface as generic 500 errors.

Enhancements:
- Add a shared JSON parsing helper to TmdbClient and route all response parsing through it for consistent error handling.
- Adjust best-effort TMDB metadata lookups to treat malformed JSON like other provider failures, returning None/empty collections instead of failing requests.
- Update metadata provider port documentation to reflect the extended failure modes and clarify which lookups are load-bearing versus best-effort.

Tests:
- Add unit tests covering the JSON helper behavior, load-bearing versus best-effort handling of malformed TMDB responses, and collection/season edge cases.