### PR TITLE
refactor(media): consolidate shared metadata reconciler + ADR-025

### DIFF
--- a/docs/adr/ADR-025-provider-metadata-reconciliation-in-application.md
+++ b/docs/adr/ADR-025-provider-metadata-reconciliation-in-application.md
@@ -1,0 +1,117 @@
+# ADR-025: Reconciliação de Metadados de Provider é Concern de Application
+
+**Status:** Aceito
+**Data:** 2026-06-29
+**Deciders:** Lucas
+**Technical Story:** Backlog F-1 (`docs/audits/07-phase6-backlog.md`) — achado code-smell ALTO (conf 0.85): Anemic Domain Model + Shotgun Surgery na regra fill-if-empty dos use cases `enrich_movie/series_metadata`.
+
+---
+
+## Contexto
+
+A auditoria de code-smells apontou (ALTO, conf 0.85) que a regra de reconciliação "provider ⇄ entidade" (fill-if-empty / overwrite) vive nos use cases `enrich_movie_metadata` e `enrich_series_metadata`, e não no domínio — caracterizando **Anemic Domain Model** (a entidade é um saco passivo de campos; o "como mesclar dados do provider" mora fora dela) e **Shotgun Surgery / Divergent Change** (adicionar um campo de metadado exigia editar os dois use cases).
+
+A proposta literal da auditoria — um domain service `MetadataReconciler` ou `entity.merged_with(metadata, policy)` — esbarra num obstáculo arquitetural concreto e **já foi recusada duas vezes** em revisão (mr-review do #331 e nota explícita do Card D #345): a reconciliação **lê DTOs de port da camada de application** (`MediaMetadata`, `SeasonMetadata`, `EpisodeMetadata`, `CollectionMetadata`, `LocalizedTextFields` em `media/application/ports`). Um domain service ou método de entidade que recebesse esses DTOs faria `domain → application`, invertendo a regra de dependência do ADR-008.
+
+A "regra de reconciliação", olhada de perto, são quatro responsabilidades distintas:
+
+1. **Política de merge** (fill-if-empty vs overwrite) — **já está no domínio** (`MergePolicy.should_write` / `.overwrites`, extraída no #331).
+2. **Classificação por-campo** — quais campos são always-overwrite, quais fill-if-empty, e guards especiais (duração probada nunca é sobrescrita; `end_year` é limpo no overwrite para não tropeçar no invariante `end_year >= start_year`; título de filme segue o TMDB enquanto o de série é scanner-derived).
+3. **Tradução provider-DTO → VO de domínio** — `Title(...)`, `[Genre(g) ...]`, `ImageUrl(...)`, conversão de `CastMember`, mapeamento de `LocalizedFields`.
+4. **Orquestração de coleções-filhas** — caminhar seasons → episodes, multi-segmento, índice TMDB.
+
+Itens 3 e 4 são inerentemente de application/ACL. O item 1 já está no domínio. O ponto de fricção é só o item 2, e ele está expresso **em termos** do item 3 (lê a forma do DTO do provider).
+
+## Decisão
+
+Nós manteremos a reconciliação de metadados de provider na **camada de application**, e a tornaremos explícita como tal:
+
+- O **domínio** é dono da *política* (`MergePolicy`) e dos *invariantes* (as entidades `Movie`/`Series`/`Season`/`Episode` validam na construção e em `with_*`).
+- A **application** é dona da *preferência de fonte por-campo* entre valor armazenado e candidato do provider — porque essa preferência é definida sobre DTOs do provider (concern de ACL/tradução de fonte externa).
+- A duplicação entre os dois use cases é consolidada num **reconciler compartilhado** (`media/application/use_cases/_metadata_field_merge.py`): `reconcile_common_fields` cobre os campos idênticos (ids do provider, o `COMMON_FILL_IF_EMPTY` partilhado por filme e série, cast e overlay localizado) num lugar só; cada use case sobrepõe apenas suas regras genuinamente divergentes de always-overwrite.
+
+Não criaremos um `MetadataReconciler` no domínio nem um `entity.merged_with(metadata, ...)` que receba DTOs do provider, porque isso inverteria a regra de dependência do ADR-008.
+
+## Consequências
+
+### Positivas
+
+- Adicionar um campo de metadado compartilhado por filme e série passa a ser uma edição em **um** lugar (`COMMON_FILL_IF_EMPTY`), eliminando o Shotgun Surgery / Divergent Change que motivou o achado.
+- A regra de dependência (`modules → shared_kernel → building_blocks`, domínio não importa application) fica preservada e a decisão fica *discoverable* na base de ADRs — o item da auditoria não ressurge sem contexto.
+- O domínio continua dono do que é de fato invariante (validação) e da política (`MergePolicy`); a fronteira fica nítida.
+
+### Negativas
+
+- A metade "Anemic Domain" do achado fica conscientemente **não-endereçada no sentido purista**: os guards por-campo (duração, end_year, identidade do título) continuam expressos na application, não como comportamento da entidade.
+- O reconciler compartilhado é duck-typed (`entity: Any`) sobre Movie/Series — abre mão de checagem estática de tipo no acesso a `.cast`/`.localized` em troca de não duplicar a lógica por tipo.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| As regras de reconciliação crescerem (conflito por-campo, proveniência, estratégias por-campo) e a application virar o lugar errado | Baixa | Médio | Este ADR é o ponto de revisita (Strangler): se as regras enriquecerem, mover o item 2 para a entidade via VO de domínio (a application traduz DTO → VO; a entidade reconcilia) — sem inverter dependência |
+| Um campo divergente ser adicionado por engano no mapa comum | Baixa | Baixo | `COMMON_FILL_IF_EMPTY` é só o subconjunto partilhado; extras type-specific ficam no use case; testes de enrich cobrem ambos os caminhos |
+
+## Alternativas Consideradas
+
+### 1. `MetadataReconciler` domain service / `entity.merged_with(metadata, policy)`
+
+Mover a regra inteira para um domain service ou método de entidade que receba o DTO do provider.
+
+**Rejeitado porque:** o DTO (`MediaMetadata` et al.) vive em `application/ports`; recebê-lo no domínio inverte `domain → application` (ADR-008). Já recusado em duas revisões (#331, #345).
+
+### 2. VOs de "merge input" no domínio (`entity.merged_with(candidate_vo, policy)`)
+
+A application traduz o DTO do provider em VOs de enrichment do domínio (`MovieEnrichment`, `SeriesEnrichment`, …); a entidade reconcilia sobre esses VOs.
+
+**Rejeitado (por ora) porque:** introduz 4 VOs paralelos que espelham os campos opcionais das entidades — risco de só realocar o `MediaMetadata` para dentro do domínio sob outro nome, trocando "anêmico" por "domínio gordo", a custo alto em código core (enrich, data-mutating). Fica como o caminho de revisita se as regras crescerem.
+
+### 3. Won't-fix puro
+
+Fechar o item sem refactor, alegando que a política já está no domínio.
+
+**Rejeitado porque:** deixaria o Shotgun Surgery (duplicação filme/série) de pé; a consolidação tem valor real e baixo risco.
+
+## Referências
+
+- ADR-008 (Screaming Architecture — módulos isolados, regra de dependência)
+- ADR-009 (Cross-BC Read Ports) — para reads de domínio cross-BC, não é o caso aqui
+- ADR-001 (Pydantic para Domain Models), ADR-017 (Invariantes na camada de domínio) — o domínio segue dono dos invariantes
+- `src/modules/media/domain/value_objects/merge_policy.py` (`MergePolicy`, #331)
+- `src/modules/media/application/use_cases/_metadata_field_merge.py` (reconciler compartilhado)
+- `docs/audits/07-phase6-backlog.md` (item F-1) e `docs/audits/03-code-smells.md` (achado ALTO)
+
+---
+
+## Notas de Implementação
+
+```python
+# media/application/use_cases/_metadata_field_merge.py
+COMMON_FILL_IF_EMPTY = {  # partilhado por filme e série
+    "synopsis": ("synopsis", None),
+    "genres": ("genres", lambda v: [Genre(g) for g in v]),
+    ...
+}
+
+def reconcile_common_fields(entity, metadata, *, policy, fill_if_empty):
+    updates = {}
+    set_provider_ids(updates, metadata)              # tmdb_id / imdb_id / original_title
+    set_if_missing(updates, metadata, entity, fill_if_empty, policy=policy)
+    set_cast_if_missing(updates, metadata, entity, policy=policy)
+    loc = merge_media_localized(entity.localized, metadata, policy=policy)
+    if loc is not None:
+        updates["localized"] = loc
+    return updates
+
+# enrich_movie_metadata.py — só o que diverge fica aqui
+updates = reconcile_common_fields(movie, metadata, policy=policy,
+    fill_if_empty={**COMMON_FILL_IF_EMPTY, "tagline": ..., "collection": ..., ...})
+if metadata.title: updates["title"] = Title(metadata.title)   # movie: always-overwrite
+...
+```
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-06-29 | Lucas | Criação inicial |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-022](./ADR-022-catalog-requests-subscriptions-fanout.md) | Subscriptions Multi-Usuário + Fanout em Catalog Requests | ✅ Aceito | 2026-06-23 |
 | [ADR-023](./ADR-023-localized-metadata-value-object.md) | Metadados Localizados como Value Object | ✅ Aceito | 2026-06-27 |
 | [ADR-024](./ADR-024-published-presentation-contracts-cross-bc.md) | Contratos de Presentation Publicados para Imports Cross-BC | ✅ Aceito | 2026-06-29 |
+| [ADR-025](./ADR-025-provider-metadata-reconciliation-in-application.md) | Reconciliação de Metadados de Provider é Concern de Application | ✅ Aceito | 2026-06-29 |
 
 ## Como Criar um Novo ADR
 

--- a/src/modules/media/application/use_cases/_metadata_field_merge.py
+++ b/src/modules/media/application/use_cases/_metadata_field_merge.py
@@ -1,18 +1,54 @@
-"""Table-driven merge of provider metadata fields into an entity.
+"""Shared reconciliation of provider metadata into a media entity.
 
 Both ``enrich_movie_metadata`` and ``enrich_series_metadata`` fold a bag of
-provider fields onto the entity under a :class:`MergePolicy`. The
-"don't-overwrite" fields all share one shape — write when the provider has
-a value and the policy allows it — so the rule lives here once, driven by a
-per-call field map, instead of being hand-rolled field by field in each use
-case (which had drifted into two parallel implementations).
+provider fields onto the entity under a :class:`MergePolicy`. The pieces that
+are identical between the two — the provider identity fields, the
+"don't-overwrite" fill-if-empty fields shared by movie and series, the cast
+conversion, and the localized overlay — live here once so a new shared field
+is added in a single place instead of being hand-rolled in each use case
+(which had drifted into two parallel implementations). The genuinely
+divergent always-overwrite rules (movie title tracks TMDB while series title
+is scanner-derived; ``year`` vs ``start_year``/``end_year``; the probed-
+duration guard) stay explicit in each use case.
+
+Per ADR-025, this reconciliation is an application/ACL concern: it consumes
+provider port DTOs (:class:`MediaMetadata`) and translates them into domain
+value objects. The domain owns the *policy* (:class:`MergePolicy`) and the
+*invariants* (the entities validate on construction); this module owns the
+field-by-field source-preference between stored and provider values.
 """
 
 from collections.abc import Callable
 from typing import Any
 
 from src.modules.media.application.ports import MediaMetadata
-from src.modules.media.domain.value_objects.merge_policy import MergePolicy
+from src.modules.media.application.use_cases._localized_metadata_helpers import (
+    merge_media_localized,
+)
+from src.modules.media.domain.value_objects import (
+    CastMember,
+    ContentRating,
+    Genre,
+    ImageUrl,
+    ImdbId,
+    MergePolicy,
+    Title,
+    TmdbId,
+)
+
+# Fields shared by movie and series that are filled only when the entity left
+# them empty (unless ``OVERWRITE``), keyed ``provider_attr: (entity_attr,
+# converter)``. Each use case overlays its own type-specific entries on top
+# (e.g. movie adds tagline / collection / directors / writers).
+COMMON_FILL_IF_EMPTY: dict[str, tuple[str, Callable[[Any], Any] | None]] = {
+    "synopsis": ("synopsis", None),
+    "genres": ("genres", lambda v: [Genre(g) for g in v]),
+    "poster_url": ("poster_path", ImageUrl),
+    "backdrop_url": ("backdrop_path", ImageUrl),
+    "logo_url": ("logo_path", ImageUrl),
+    "content_rating": ("content_rating", ContentRating),
+    "trailer_url": ("trailer_url", None),
+}
 
 
 def set_if_missing(
@@ -52,4 +88,87 @@ def set_if_missing(
             updates[entity_attr] = converter(meta_val) if converter is not None else meta_val
 
 
-__all__ = ["set_if_missing"]
+def set_provider_ids(updates: dict[str, object], metadata: MediaMetadata) -> None:
+    """Always-overwrite the provider identity fields shared by movie and series.
+
+    ``tmdb_id`` / ``imdb_id`` / ``original_title`` track the picked provider
+    entry on every enrich (no fill-if-empty guard) and are written whenever
+    the provider supplies them. Movie- and series-specific always-overwrite
+    fields (title, year/start_year, end_year) stay in their use cases because
+    their rules diverge.
+    """
+    if metadata.tmdb_id:
+        updates["tmdb_id"] = TmdbId(metadata.tmdb_id)
+    if metadata.imdb_id:
+        updates["imdb_id"] = ImdbId(metadata.imdb_id)
+    if metadata.original_title:
+        updates["original_title"] = Title(metadata.original_title)
+
+
+def set_cast_if_missing(
+    updates: dict[str, object],
+    metadata: MediaMetadata,
+    entity: Any,
+    *,
+    policy: MergePolicy = MergePolicy.FILL_IF_EMPTY,
+) -> None:
+    """Fill-if-empty the cast, converting each ``CreditPerson`` to ``CastMember``.
+
+    Same fill-if-empty rule as the table-driven fields, kept as its own
+    helper because of the per-element DTO → value-object conversion. ``entity``
+    is duck-typed (Movie or Series, both expose ``cast``).
+    """
+    if metadata.cast and policy.should_write(entity.cast):
+        updates["cast"] = [
+            CastMember(
+                name=p.name,
+                profile_path=p.profile_url,
+                role=p.role,
+                tmdb_id=p.tmdb_id,
+            )
+            for p in metadata.cast
+        ]
+
+
+def reconcile_common_fields(
+    entity: Any,
+    metadata: MediaMetadata,
+    *,
+    policy: MergePolicy,
+    fill_if_empty: dict[str, tuple[str, Callable[[Any], Any] | None]],
+) -> dict[str, object]:
+    """Build the ``with_updates`` kwargs shared by movie and series enrich.
+
+    Folds the provider identity fields, the ``fill_if_empty`` table, the cast,
+    and the localized overlay into a fresh updates dict under ``policy``. Each
+    use case then layers its type-specific always-overwrite fields (title,
+    year/start_year/end_year, duration) onto the returned dict before applying
+    it with ``with_updates``.
+
+    Args:
+        entity: Aggregate being enriched (Movie or Series, duck-typed).
+        metadata: Provider payload.
+        policy: Merge policy gating every write.
+        fill_if_empty: The fill-if-empty field map for this entity type
+            (``COMMON_FILL_IF_EMPTY`` plus any type-specific entries).
+
+    Returns:
+        A mutable updates dict the caller extends and passes to ``with_updates``.
+    """
+    updates: dict[str, object] = {}
+    set_provider_ids(updates, metadata)
+    set_if_missing(updates, metadata, entity, fill_if_empty, policy=policy)
+    set_cast_if_missing(updates, metadata, entity, policy=policy)
+    new_localized = merge_media_localized(entity.localized, metadata, policy=policy)
+    if new_localized is not None:
+        updates["localized"] = new_localized
+    return updates
+
+
+__all__ = [
+    "COMMON_FILL_IF_EMPTY",
+    "reconcile_common_fields",
+    "set_cast_if_missing",
+    "set_if_missing",
+    "set_provider_ids",
+]

--- a/src/modules/media/application/use_cases/enrich_movie_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_movie_metadata.py
@@ -14,23 +14,17 @@ from src.modules.media.application.ports import (
     MetadataProvider,
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-from src.modules.media.application.use_cases._localized_metadata_helpers import (
-    merge_media_localized,
+from src.modules.media.application.use_cases._metadata_field_merge import (
+    COMMON_FILL_IF_EMPTY,
+    reconcile_common_fields,
 )
-from src.modules.media.application.use_cases._metadata_field_merge import set_if_missing
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
-    CastMember,
     Collection,
-    ContentRating,
     Duration,
-    Genre,
-    ImageUrl,
-    ImdbId,
     MergePolicy,
     MovieId,
     Title,
-    TmdbId,
     Year,
 )
 from src.shared_kernel.integration_events import MediaEnrichedEvent
@@ -255,20 +249,31 @@ def _apply_movie_metadata(
     every guard is bypassed and TMDB's payload wins — used by the bulk
     enrich's "force update" toggle to backfill new fields (like the
     cast member ``tmdb_id``) on rows that were already enriched.
-    """
-    updates: dict[str, object] = {}
 
-    # Always-overwrite fields — written whenever the provider has them
-    # (no fill-if-empty guard). The base title tracks the picked TMDB
-    # entry on every enrich (unlike series, where it is scanner-derived).
+    The provider ids, the fill-if-empty fields shared with series, the
+    cast, and the localized overlay are reconciled by
+    :func:`reconcile_common_fields`; only the movie-specific always-overwrite
+    rules (base title, year, the probed-duration guard) and the movie-only
+    fill-if-empty fields (tagline / collection / directors / writers) live here.
+    """
+    updates = reconcile_common_fields(
+        movie,
+        metadata,
+        policy=policy,
+        fill_if_empty={
+            **COMMON_FILL_IF_EMPTY,
+            "tagline": ("tagline", None),
+            "collection": ("collection", _to_collection),
+            "directors": ("directors", lambda v: [p.name for p in v]),
+            "writers": ("writers", lambda v: [p.name for p in v]),
+        },
+    )
+
+    # Movie-specific always-overwrite fields — written whenever the provider
+    # has them (no fill-if-empty guard). The base title tracks the picked
+    # TMDB entry on every enrich (unlike series, where it is scanner-derived).
     if metadata.title:
         updates["title"] = Title(metadata.title)
-    if metadata.tmdb_id:
-        updates["tmdb_id"] = TmdbId(metadata.tmdb_id)
-    if metadata.imdb_id:
-        updates["imdb_id"] = ImdbId(metadata.imdb_id)
-    if metadata.original_title:
-        updates["original_title"] = Title(metadata.original_title)
     if metadata.year:
         updates["year"] = Year(metadata.year)
     # Duration is the file's real (probed) length — the scanner stamps it.
@@ -276,44 +281,6 @@ def _apply_movie_metadata(
     # (duration still 0); never overwrite a real duration, even on OVERWRITE.
     if metadata.duration_seconds and movie.duration.value == 0:
         updates["duration"] = Duration(metadata.duration_seconds)
-
-    # Don't-overwrite fields (fill-if-empty unless ``OVERWRITE``), table-driven.
-    set_if_missing(
-        updates,
-        metadata,
-        movie,
-        {
-            "synopsis": ("synopsis", None),
-            "genres": ("genres", lambda v: [Genre(g) for g in v]),
-            "poster_url": ("poster_path", ImageUrl),
-            "backdrop_url": ("backdrop_path", ImageUrl),
-            "logo_url": ("logo_path", ImageUrl),
-            "tagline": ("tagline", None),
-            "collection": ("collection", _to_collection),
-            "directors": ("directors", lambda v: [p.name for p in v]),
-            "writers": ("writers", lambda v: [p.name for p in v]),
-            "content_rating": ("content_rating", ContentRating),
-            "trailer_url": ("trailer_url", None),
-        },
-        policy=policy,
-    )
-
-    # Cast: same fill-if-empty rule, kept explicit for the per-element
-    # CreditPerson → CastMember conversion (mirrors the series enrich).
-    if metadata.cast and policy.should_write(movie.cast):
-        updates["cast"] = [
-            CastMember(
-                name=p.name,
-                profile_path=p.profile_url,
-                role=p.role,
-                tmdb_id=p.tmdb_id,
-            )
-            for p in metadata.cast
-        ]
-
-    new_localized = merge_media_localized(movie.localized, metadata, policy=policy)
-    if new_localized is not None:
-        updates["localized"] = new_localized
 
     if updates:
         movie = movie.with_updates(**updates)

--- a/src/modules/media/application/use_cases/enrich_series_metadata.py
+++ b/src/modules/media/application/use_cases/enrich_series_metadata.py
@@ -17,25 +17,22 @@ from src.modules.media.application.ports import (
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.application.use_cases._localized_metadata_helpers import (
-    merge_media_localized,
     merge_text_localized,
 )
-from src.modules.media.application.use_cases._metadata_field_merge import set_if_missing
+from src.modules.media.application.use_cases._metadata_field_merge import (
+    COMMON_FILL_IF_EMPTY,
+    reconcile_common_fields,
+)
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
     AirDate,
-    CastMember,
-    ContentRating,
     Duration,
-    Genre,
     ImageUrl,
-    ImdbId,
     LocalizedFields,
     LocalizedMetadata,
     MergePolicy,
     SeriesId,
     Title,
-    TmdbId,
     Year,
 )
 from src.shared_kernel.integration_events import MediaEnrichedEvent
@@ -179,16 +176,18 @@ def _apply_series_metadata(
     ``MergePolicy.OVERWRITE`` (a relink, where the existing data belongs to
     a wrong match) every guard is bypassed and the provider payload wins —
     including a full replace of the ``localized`` overrides and the base title.
-    """
-    updates: dict[str, object] = {}
 
-    # Always-overwrite fields
-    if metadata.tmdb_id:
-        updates["tmdb_id"] = TmdbId(metadata.tmdb_id)
-    if metadata.imdb_id:
-        updates["imdb_id"] = ImdbId(metadata.imdb_id)
-    if metadata.original_title:
-        updates["original_title"] = Title(metadata.original_title)
+    The provider ids, the fill-if-empty fields shared with movies, the cast,
+    and the localized overlay are reconciled by
+    :func:`reconcile_common_fields`; only the series-specific always-overwrite
+    rules (scanner-derived title, ``start_year``/``end_year`` with its
+    invariant-clearing) live here.
+    """
+    updates = reconcile_common_fields(
+        series, metadata, policy=policy, fill_if_empty=COMMON_FILL_IF_EMPTY
+    )
+
+    # Series-specific always-overwrite fields.
     if metadata.year:
         updates["start_year"] = Year(metadata.year)
     if metadata.end_year:
@@ -204,41 +203,6 @@ def _apply_series_metadata(
     # canonical title tracks the newly-picked TMDB entry.
     if metadata.title and policy.overwrites:
         updates["title"] = Title(metadata.title)
-
-    # Don't-overwrite fields (only set if empty, unless ``OVERWRITE``)
-    set_if_missing(
-        updates,
-        metadata,
-        series,
-        {
-            "synopsis": ("synopsis", None),
-            "genres": ("genres", lambda v: [Genre(g) for g in v]),
-            "poster_url": ("poster_path", ImageUrl),
-            "backdrop_url": ("backdrop_path", ImageUrl),
-            "logo_url": ("logo_path", ImageUrl),
-            "content_rating": ("content_rating", ContentRating),
-            "trailer_url": ("trailer_url", None),
-        },
-        policy=policy,
-    )
-
-    # Cast: same fill-if-empty rule as the rest of the don't-overwrite
-    # block, but kept explicit (outside ``set_if_missing``) for the
-    # per-element ``CreditPerson`` → ``CastMember`` conversion.
-    if metadata.cast and policy.should_write(series.cast):
-        updates["cast"] = [
-            CastMember(
-                name=p.name,
-                profile_path=p.profile_url,
-                role=p.role,
-                tmdb_id=p.tmdb_id,
-            )
-            for p in metadata.cast
-        ]
-
-    new_localized = merge_media_localized(series.localized, metadata, policy=policy)
-    if new_localized is not None:
-        updates["localized"] = new_localized
 
     if updates:
         series = series.with_updates(**updates)

--- a/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
+++ b/tests/modules/media/unit/application/use_cases/test_enrich_movie_metadata.py
@@ -101,6 +101,61 @@ class TestEnrichMovieMetadata:
         assert result.enriched is True
 
     @pytest.mark.asyncio
+    async def test_writes_provider_duration_when_probe_left_it_zero(self) -> None:
+        # The scanner stamps the real probed duration; when it failed
+        # (duration still 0) TMDB's nominal runtime is the fallback.
+        movie = _make_movie()  # duration=0
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = _make_metadata()  # duration_seconds=8880
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        saved = mocks.movies.save.call_args.args[0]
+        assert saved.duration.value == 8880
+
+    @pytest.mark.asyncio
+    async def test_never_overwrites_a_real_probed_duration_even_on_force(self) -> None:
+        # A real probed duration is truth — TMDB's nominal runtime must
+        # never clobber it, even under the OVERWRITE (force) policy.
+        movie = Movie.create(
+            library_id=_LIBRARY_ID,
+            title="Inception",
+            year=2010,
+            duration=7200,
+            file_path="/movies/inception.mkv",
+            file_size=4_000_000_000,
+            resolution="1080p",
+        )
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = _make_metadata()  # duration_seconds=8880
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id), force=True))
+
+        saved = mocks.movies.save.call_args.args[0]
+        assert saved.duration.value == 7200
+
+    @pytest.mark.asyncio
+    async def test_base_title_and_year_track_the_provider_entry(self) -> None:
+        # Unlike series (scanner-derived title), a movie's base title/year
+        # always track the picked TMDB entry — no fill-if-empty guard.
+        movie = _make_movie()  # title="Inception", year=2010
+        provider = AsyncMock(spec=MetadataProvider)
+        provider.search_movie.return_value = MediaMetadata(
+            title="Inception Reborn",
+            year=2011,
+            tmdb_id=27205,
+        )
+
+        use_case, mocks = _set_up_enrichment(movie, provider)
+        await use_case.execute(EnrichMediaInput(media_id=str(movie.id)))
+
+        saved = mocks.movies.save.call_args.args[0]
+        assert saved.title.value == "Inception Reborn"
+        assert saved.year.value == 2011
+
+    @pytest.mark.asyncio
     async def test_should_use_fallback_when_primary_fails(self) -> None:
         movie = _make_movie()
         mocks = make_media_uow_mock()

--- a/tests/modules/media/unit/application/use_cases/test_metadata_field_merge.py
+++ b/tests/modules/media/unit/application/use_cases/test_metadata_field_merge.py
@@ -1,11 +1,23 @@
-"""Tests for the shared set_if_missing metadata merge helper."""
+"""Tests for the shared provider-metadata reconciliation helpers."""
 
 from types import SimpleNamespace
 
 import pytest
 
-from src.modules.media.application.use_cases._metadata_field_merge import set_if_missing
-from src.modules.media.domain.value_objects import MergePolicy
+from src.modules.media.application.use_cases._metadata_field_merge import (
+    COMMON_FILL_IF_EMPTY,
+    reconcile_common_fields,
+    set_cast_if_missing,
+    set_if_missing,
+    set_provider_ids,
+)
+from src.modules.media.domain.value_objects import (
+    ImdbId,
+    LocalizedMetadata,
+    MergePolicy,
+    Title,
+    TmdbId,
+)
 
 _FIELD_MAP = {"poster_url": ("poster_path", str.upper)}
 
@@ -56,3 +68,132 @@ class TestSetIfMissing:
         set_if_missing(updates, metadata, entity, {"synopsis": ("synopsis", None)})
 
         assert updates == {"synopsis": "plot"}
+
+
+@pytest.mark.unit
+class TestSetProviderIds:
+    def test_writes_all_three_identity_fields_as_value_objects(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(tmdb_id=27205, imdb_id="tt1375666", original_title="Inception")
+
+        set_provider_ids(updates, metadata)
+
+        assert updates == {
+            "tmdb_id": TmdbId(27205),
+            "imdb_id": ImdbId("tt1375666"),
+            "original_title": Title("Inception"),
+        }
+
+    def test_skips_fields_the_provider_omits(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(tmdb_id=27205, imdb_id=None, original_title=None)
+
+        set_provider_ids(updates, metadata)
+
+        assert updates == {"tmdb_id": TmdbId(27205)}
+
+
+@pytest.mark.unit
+class TestSetCastIfMissing:
+    @staticmethod
+    def _person() -> SimpleNamespace:
+        return SimpleNamespace(
+            name="Leonardo DiCaprio", profile_url=None, role="Cobb", tmdb_id=6193
+        )
+
+    def test_fills_and_converts_credit_person_to_cast_member(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(cast=[self._person()])
+        entity = SimpleNamespace(cast=[])
+
+        set_cast_if_missing(updates, metadata, entity)
+
+        cast = updates["cast"]
+        assert [m.name for m in cast] == ["Leonardo DiCaprio"]
+        assert cast[0].tmdb_id == 6193
+
+    def test_fill_if_empty_keeps_existing_cast(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(cast=[self._person()])
+        entity = SimpleNamespace(cast=["already here"])
+
+        set_cast_if_missing(updates, metadata, entity)
+
+        assert updates == {}
+
+    def test_overwrite_replaces_existing_cast(self) -> None:
+        updates: dict[str, object] = {}
+        metadata = SimpleNamespace(cast=[self._person()])
+        entity = SimpleNamespace(cast=["stale"])
+
+        set_cast_if_missing(updates, metadata, entity, policy=MergePolicy.OVERWRITE)
+
+        assert [m.name for m in updates["cast"]] == ["Leonardo DiCaprio"]
+
+
+@pytest.mark.unit
+class TestReconcileCommonFields:
+    @staticmethod
+    def _metadata(**overrides: object) -> SimpleNamespace:
+        base = {
+            "tmdb_id": 27205,
+            "imdb_id": "tt1375666",
+            "original_title": "Inception",
+            "synopsis": "plot",
+            "genres": [],
+            "poster_url": None,
+            "backdrop_url": None,
+            "logo_url": None,
+            "content_rating": None,
+            "trailer_url": None,
+            "cast": [SimpleNamespace(name="Leo", profile_url=None, role="Cobb", tmdb_id=6193)],
+            "localized": {},
+        }
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def test_folds_ids_fill_and_cast_into_one_updates_dict(self) -> None:
+        entity = SimpleNamespace(cast=[], localized=LocalizedMetadata({}))
+
+        updates = reconcile_common_fields(
+            entity,
+            self._metadata(),
+            policy=MergePolicy.FILL_IF_EMPTY,
+            fill_if_empty=COMMON_FILL_IF_EMPTY,
+        )
+
+        assert updates["tmdb_id"] == TmdbId(27205)
+        assert updates["synopsis"] == "plot"
+        assert [m.name for m in updates["cast"]] == ["Leo"]
+        # The provider supplied no localized overrides, so localized is untouched.
+        assert "localized" not in updates
+
+    def test_empty_provider_localized_leaves_localized_untouched(self) -> None:
+        entity = SimpleNamespace(cast=[], localized=LocalizedMetadata({}))
+
+        updates = reconcile_common_fields(
+            entity,
+            self._metadata(synopsis=None, cast=[]),
+            policy=MergePolicy.FILL_IF_EMPTY,
+            fill_if_empty=COMMON_FILL_IF_EMPTY,
+        )
+
+        # Only the always-overwrite provider ids remain.
+        assert set(updates) == {"tmdb_id", "imdb_id", "original_title"}
+
+    def test_overwrite_folds_over_a_populated_entity(self) -> None:
+        # Under OVERWRITE the fill-if-empty guard is bypassed: provider
+        # values win even when the entity already has them.
+        entity = SimpleNamespace(
+            synopsis="old plot", cast=["stale"], localized=LocalizedMetadata({})
+        )
+
+        updates = reconcile_common_fields(
+            entity,
+            self._metadata(),
+            policy=MergePolicy.OVERWRITE,
+            fill_if_empty=COMMON_FILL_IF_EMPTY,
+        )
+
+        assert updates["synopsis"] == "plot"
+        assert [m.name for m in updates["cast"]] == ["Leo"]


### PR DESCRIPTION
## Summary
- F-1 from the architecture audit (code-smell ALTO 0.85: Anemic Domain + Shotgun Surgery on the provider→entity fill-if-empty rule, duplicated across `enrich_movie` and `enrich_series`).
- The audit's literal fix (a `MetadataReconciler` domain service / `entity.merged_with(metadata, …)`) was **declined**: the reconciliation consumes application-port DTOs (`MediaMetadata`), so a domain service would invert dependency direction (domain→application, ADR-008) — already declined twice in prior review (#331, #345).
- Chosen approach: extract the identical spine — provider ids, the shared `COMMON_FILL_IF_EMPTY` fields, cast, localized overlay — into `reconcile_common_fields`, leaving only each type's genuinely-divergent always-overwrite rules in its use case. A shared field is now added in **one** place.
- **ADR-025** records why reconciliation stays in application (it consumes provider DTOs): the domain owns the *policy* (`MergePolicy`) and the *invariants*; application owns the per-field source preference. Strangler revisit path documented if the rules grow.
- Behavior-preserving (no migration); the divergent special cases (movie probed-duration guard, series `end_year`-clearing / title-on-overwrite) kept verbatim per use case.

## Test plan
- [x] 68 enrich integration tests green (behavior preserved)
- [x] New unit tests for `set_provider_ids`, `set_cast_if_missing`, `reconcile_common_fields` (incl. OVERWRITE fold)
- [x] New movie-side tests: probed-duration guard (write-when-0 + never-overwrite-real-on-force), title/year always-overwrite
- [x] Full media suite (1790 passed) + ruff check/format clean + mypy clean on changed source
- [x] mr-review (5 subagents: architecture/domain/regression/tests/doc-drift) — 0 blocking

## Summary by Sourcery

Consolidate shared provider-metadata reconciliation logic between movie and series enrich use cases and document the architectural decision to keep this reconciliation in the application layer.

Enhancements:
- Introduce a shared reconciliation helper that handles provider IDs, common fill-if-empty fields, cast conversion, and localized metadata overlay for both movies and series.
- Define a COMMON_FILL_IF_EMPTY field map to centralize shared non-overwriting metadata rules while allowing type-specific extensions in each use case.

Documentation:
- Add ADR-025 describing why provider metadata reconciliation remains an application concern and update the ADR index accordingly.

Tests:
- Expand unit tests to cover provider ID setting, cast reconciliation behavior under different merge policies, and the new shared reconcile_common_fields helper.
- Add movie enrichment tests validating probed-duration overwrite guards and that base title/year always track the provider entry.