### PR TITLE
refactor(media): add SubtitleFormat enum as canonical format vocabulary

### DIFF
--- a/src/modules/media/infrastructure/streaming/media_probe_service.py
+++ b/src/modules/media/infrastructure/streaming/media_probe_service.py
@@ -18,7 +18,7 @@ from src.modules.media.application.ports.media_probe_port import MediaProbePort,
 from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
-from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleFormat, SubtitleTrack
 
 _logger = logging.getLogger(__name__)
 
@@ -51,18 +51,20 @@ _RESOLUTION_THRESHOLDS: list[tuple[int, str]] = [
     (500, "360p"),
 ]
 
-# ffprobe codec_name → SubtitleTrack format
-_SUBTITLE_CODEC_MAP: dict[str, str] = {
-    "subrip": "srt",
-    "srt": "srt",
-    "ass": "ass",
-    "ssa": "ass",
-    "webvtt": "vtt",
-    "mov_text": "srt",
-    "hdmv_pgs_subtitle": "pgs",
-    "pgssub": "pgs",
-    "dvd_subtitle": "vobsub",
-    "dvdsub": "vobsub",
+# ffprobe codec_name → canonical SubtitleFormat. An unmapped codec falls
+# through to its raw codec_name (see _parse_subtitle_tracks) so exotic
+# formats round-trip verbatim.
+_SUBTITLE_CODEC_MAP: dict[str, SubtitleFormat] = {
+    "subrip": SubtitleFormat.SRT,
+    "srt": SubtitleFormat.SRT,
+    "ass": SubtitleFormat.ASS,
+    "ssa": SubtitleFormat.ASS,
+    "webvtt": SubtitleFormat.VTT,
+    "mov_text": SubtitleFormat.SRT,
+    "hdmv_pgs_subtitle": SubtitleFormat.PGS,
+    "pgssub": SubtitleFormat.PGS,
+    "dvd_subtitle": SubtitleFormat.VOBSUB,
+    "dvdsub": SubtitleFormat.VOBSUB,
 }
 
 # External subtitle file extensions
@@ -419,7 +421,8 @@ class MediaProbeService(MediaProbePort):
             tags = stream.get("tags", {})
 
             codec_name = stream.get("codec_name", "unknown").lower()
-            fmt = _SUBTITLE_CODEC_MAP.get(codec_name, codec_name)
+            mapped = _SUBTITLE_CODEC_MAP.get(codec_name)
+            fmt = mapped.value if mapped is not None else codec_name
             lang = MediaProbeService._extract_language(stream)
             title = tags.get("title", tags.get("TITLE"))
 

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -17,7 +17,7 @@ from src.shared_kernel.value_objects.media_id import (
 )
 from src.shared_kernel.value_objects.media_type import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
-from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleFormat, SubtitleTrack
 from src.shared_kernel.value_objects.user_id import UserId
 
 __all__ = [
@@ -36,6 +36,7 @@ __all__ = [
     "ProfileId",
     "SeasonId",
     "SeriesId",
+    "SubtitleFormat",
     "SubtitleTrack",
     "UserId",
     "parse_media_id",

--- a/src/shared_kernel/value_objects/tracks.py
+++ b/src/shared_kernel/value_objects/tracks.py
@@ -1,5 +1,6 @@
 """Audio and subtitle track value objects."""
 
+from enum import StrEnum
 from typing import ClassVar
 
 from pydantic import Field, model_validator
@@ -15,6 +16,85 @@ CHANNEL_LAYOUTS: dict[int, str] = {
     6: "5.1",
     8: "7.1",
 }
+
+
+class SubtitleFormat(StrEnum):
+    """Canonical subtitle formats, with text-vs-image classification.
+
+    Single source of truth for the subtitle-format vocabulary: which
+    formats HomeFlix recognizes and which are text-based (stylable /
+    searchable) versus image-based (bitmap). ``SubtitleTrack.format``
+    deliberately stays a plain ``str`` rather than this enum so that an
+    exotic ffprobe codec (DVB, EIA-608, …) round-trips verbatim through
+    persistence instead of being forced into the enum and lost;
+    classification of an unrecognized value falls through as "neither
+    text nor image" (see :meth:`classify`).
+
+    Example:
+        >>> SubtitleFormat.classify("SRT").is_text
+        True
+        >>> SubtitleFormat.classify("dvb_subtitle") is None
+        True
+    """
+
+    SRT = "srt"
+    ASS = "ass"
+    SSA = "ssa"
+    VTT = "vtt"
+    SUB = "sub"
+    PGS = "pgs"
+    SUP = "sup"
+    VOBSUB = "vobsub"
+    IDX = "idx"
+
+    @classmethod
+    def text_formats(cls) -> frozenset["SubtitleFormat"]:
+        """Text-based formats: can be styled, searched, or burned as text."""
+        return _TEXT_SUBTITLE_FORMATS
+
+    @classmethod
+    def image_formats(cls) -> frozenset["SubtitleFormat"]:
+        """Image-based (bitmap) formats: must be rendered as pictures."""
+        return _IMAGE_SUBTITLE_FORMATS
+
+    @classmethod
+    def classify(cls, value: str) -> "SubtitleFormat | None":
+        """Return the canonical format for a raw value, or ``None`` if unknown.
+
+        Case-insensitive. ``None`` for any value outside the recognized
+        vocabulary (e.g. an unmapped ffprobe codec name), so callers treat
+        it as neither text nor image rather than raising.
+        """
+        try:
+            return cls(value.lower())
+        except ValueError:
+            return None
+
+    @property
+    def is_text(self) -> bool:
+        """Whether this format is text-based."""
+        return self in _TEXT_SUBTITLE_FORMATS
+
+    @property
+    def is_image(self) -> bool:
+        """Whether this format is image-based (bitmap)."""
+        return self in _IMAGE_SUBTITLE_FORMATS
+
+
+# Built once (not per call): the canonical text/image partitions of
+# SubtitleFormat. SubtitleTrack derives its string frozensets from these.
+_TEXT_SUBTITLE_FORMATS: frozenset[SubtitleFormat] = frozenset(
+    {
+        SubtitleFormat.SRT,
+        SubtitleFormat.ASS,
+        SubtitleFormat.SSA,
+        SubtitleFormat.VTT,
+        SubtitleFormat.SUB,
+    }
+)
+_IMAGE_SUBTITLE_FORMATS: frozenset[SubtitleFormat] = frozenset(
+    {SubtitleFormat.PGS, SubtitleFormat.SUP, SubtitleFormat.VOBSUB, SubtitleFormat.IDX}
+)
 
 
 class AudioTrack(CompoundValueObject):
@@ -87,7 +167,10 @@ class SubtitleTrack(CompoundValueObject):
     Attributes:
         index: Track index (0-based, unique across embedded + external).
         language: ISO 639-1 language code.
-        format: Subtitle format (srt, ass, vtt, pgs, sup).
+        format: Subtitle format as a raw string (srt, ass, vtt, pgs, sup,
+            …). Kept as ``str`` (not :class:`SubtitleFormat`) so an exotic
+            ffprobe codec round-trips verbatim; use
+            :meth:`SubtitleFormat.classify` to classify it.
         title: Descriptive title.
         is_default: Whether marked as default.
         is_forced: Whether this is a forced subtitle track (signs only).
@@ -111,8 +194,13 @@ class SubtitleTrack(CompoundValueObject):
         ... )
     """
 
-    TEXT_FORMATS: ClassVar[frozenset[str]] = frozenset({"srt", "ass", "ssa", "vtt", "sub"})
-    IMAGE_FORMATS: ClassVar[frozenset[str]] = frozenset({"pgs", "sup", "vobsub", "idx"})
+    # Derived from SubtitleFormat so the format vocabulary lives in one place.
+    TEXT_FORMATS: ClassVar[frozenset[str]] = frozenset(
+        f.value for f in SubtitleFormat.text_formats()
+    )
+    IMAGE_FORMATS: ClassVar[frozenset[str]] = frozenset(
+        f.value for f in SubtitleFormat.image_formats()
+    )
 
     index: int = Field(ge=0)
     language: LanguageCode
@@ -156,4 +244,4 @@ class SubtitleTrack(CompoundValueObject):
         return self.format.lower() in self.IMAGE_FORMATS
 
 
-__all__ = ["AudioTrack", "SubtitleTrack"]
+__all__ = ["AudioTrack", "SubtitleFormat", "SubtitleTrack"]

--- a/tests/shared_kernel/unit/value_objects/test_tracks.py
+++ b/tests/shared_kernel/unit/value_objects/test_tracks.py
@@ -5,7 +5,7 @@ import pytest
 from src.building_blocks.domain.errors import DomainValidationException
 from src.shared_kernel.value_objects.file_path import FilePath
 from src.shared_kernel.value_objects.language_code import LanguageCode
-from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleFormat, SubtitleTrack
 
 
 class TestAudioTrackCreation:
@@ -221,3 +221,49 @@ class TestSubtitleTrackProperties:
             )
             assert track.is_image_based is True, f"Expected {fmt} to be image-based"
             assert track.is_text_based is False
+
+    def test_unknown_format_round_trips_and_classifies_as_neither(self):
+        # An exotic ffprobe codec must survive verbatim (no enum coercion)
+        # and count as neither text nor image.
+        track = SubtitleTrack(
+            index=0,
+            language=LanguageCode("en"),
+            format="dvb_subtitle",
+        )
+        assert track.format == "dvb_subtitle"
+        assert track.is_text_based is False
+        assert track.is_image_based is False
+
+
+class TestSubtitleFormat:
+    """Tests for the SubtitleFormat canonical vocabulary."""
+
+    def test_classify_is_case_insensitive(self):
+        assert SubtitleFormat.classify("SRT") is SubtitleFormat.SRT
+        assert SubtitleFormat.classify("Ass") is SubtitleFormat.ASS
+
+    def test_classify_returns_none_for_unknown(self):
+        assert SubtitleFormat.classify("dvb_subtitle") is None
+        assert SubtitleFormat.classify("") is None
+
+    def test_text_and_image_sets_are_disjoint_and_complete(self):
+        text = SubtitleFormat.text_formats()
+        image = SubtitleFormat.image_formats()
+        assert text.isdisjoint(image)
+        assert text | image == set(SubtitleFormat)
+
+    @pytest.mark.parametrize("fmt", list(SubtitleFormat))
+    def test_is_text_and_is_image_are_exact_complements_per_member(self, fmt: SubtitleFormat):
+        assert fmt.is_text is (fmt in SubtitleFormat.text_formats())
+        assert fmt.is_image is (fmt in SubtitleFormat.image_formats())
+        # Every member is exactly one of the two — never both, never neither.
+        assert fmt.is_text != fmt.is_image
+
+    def test_subtitle_track_sets_derive_from_the_enum(self):
+        # The VO classification stays single-sourced from SubtitleFormat...
+        assert {f.value for f in SubtitleFormat.text_formats()} == SubtitleTrack.TEXT_FORMATS
+        assert {f.value for f in SubtitleFormat.image_formats()} == SubtitleTrack.IMAGE_FORMATS
+        # ...and matches the exact vocabulary, so enum + derivation can't
+        # drift together unnoticed.
+        assert {"srt", "ass", "ssa", "vtt", "sub"} == SubtitleTrack.TEXT_FORMATS
+        assert {"pgs", "sup", "vobsub", "idx"} == SubtitleTrack.IMAGE_FORMATS


### PR DESCRIPTION
## Summary
- F-4 from the architecture audit (Stringly-Typed `SubtitleTrack.format: str`, smell rated 🔵 0.4).
- The subtitle-format vocabulary was split across `SubtitleTrack`'s two frozensets and the probe's `_SUBTITLE_CODEC_MAP`. Introduce **`SubtitleFormat` (StrEnum)** in `shared_kernel` as the single canonical vocabulary + text/image classification; derive the VO's `TEXT_FORMATS`/`IMAGE_FORMATS` from it and route the probe map through it.
- **`SubtitleTrack.format` stays `str` on purpose**: an exotic ffprobe codec (DVB, EIA-608, …) round-trips verbatim through persistence instead of being coerced into the enum and lost — a strict enum field would break re-hydration (the documented reason 6.9 deferred this). `SubtitleFormat.classify()` returns `None` for unrecognized values (neither text nor image).
- Behavior-preserving; no migration. (`MediaType`/ADR-016 is the precedent for a canonical StrEnum in shared_kernel.)

## Test plan
- [x] `SubtitleFormat`: classify (case-insensitive / unknown→None / empty), per-member is_text/is_image complementarity, disjoint+complete invariant
- [x] Lossless round-trip of an unknown format (verbatim + classifies as neither)
- [x] Single-source derivation locked (VO frozensets == enum, == explicit literals)
- [x] Probe codec→format mapping + unmapped passthrough still green (output strings unchanged)
- [x] shared_kernel + media suites (1959 passed) + ruff check/format clean + mypy clean
- [x] mr-review (4 subagents: architecture/domain/regression/tests) — 0 blocking

## Summary by Sourcery

Introduce a canonical SubtitleFormat StrEnum as the shared subtitle format vocabulary and wire media probing and value objects to derive classifications from it while preserving raw string formats.

New Features:
- Add SubtitleFormat StrEnum in shared_kernel as the canonical subtitle format vocabulary with text/image classification helpers.

Enhancements:
- Derive SubtitleTrack.TEXT_FORMATS and IMAGE_FORMATS from SubtitleFormat to keep the format vocabulary single-sourced.
- Expose SubtitleFormat from shared_kernel value_objects to other modules and update media probe subtitle codec mapping to use the enum instead of raw strings.

Tests:
- Add unit tests for SubtitleFormat classification, text/image partition invariants, and verification that SubtitleTrack format sets derive from the enum.
- Extend subtitle track tests to cover unknown codec round-tripping and classification as neither text nor image.