### PR TITLE
feat(media): resolve /tracks default audio from profile preference (ADR-026 ph2)

### DIFF
--- a/docs/adr/ADR-026-server-authoritative-track-selection.md
+++ b/docs/adr/ADR-026-server-authoritative-track-selection.md
@@ -109,8 +109,10 @@ Deixar back e front como estão.
 # media/application/ports/profile_playback_preference_port.py (cross-BC read, ADR-009)
 class ProfilePlaybackPreferencePort(ABC):
     @abstractmethod
-    async def for_profile(self, profile_id: str) -> PlaybackPreference | None: ...
-    # PlaybackPreference: audio_language, subtitle_language, subtitle_mode (consumer-owned DTO)
+    async def for_profile(self, profile_id: str) -> PlaybackPreference: ...
+    # PlaybackPreference: audio_language, subtitle_language, subtitle_mode (consumer-owned DTO).
+    # Defaults applied on absent row (mirrors GetPreferences), so the server resolves the
+    # same default the client would apply — never an empty result.
 
 # Resolução única, consumida por /tracks E pelo manifesto HLS:
 #   TrackSelector.select_audio(tracks, pref.audio_language)

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -48,6 +48,9 @@ from src.modules.media.infrastructure.scheduling.scheduler_controller import (
 from src.modules.media.infrastructure.scheduling.scheduler_inspector import (
     LibraryScanSchedulerInspector,
 )
+from src.modules.preferences.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyPreferencesUnitOfWorkFactory,
+)
 from src.modules.settings.domain.value_objects import IntroDetectionAlgorithm
 from src.modules.watch_progress.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyWatchProgressUnitOfWorkFactory,
@@ -130,6 +133,14 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         session_factory=infrastructure.session_factory,
     )
 
+    # Preferences UoW factory built at the composition root so Media can
+    # read a profile's playback preference (ADR-026 — default audio at
+    # /tracks) without forward-referencing the Preferences container.
+    _preferences_uow_factory_for_media = providers.Singleton(
+        SqlAlchemyPreferencesUnitOfWorkFactory,
+        session_factory=infrastructure.session_factory,
+    )
+
     # ADR-015 Phase 3: the auto-merge detector needs to ask "is
     # this file accessible?" and "is the library root mounted?"
     # before silently absorbing an orphan candidate. The adapter
@@ -209,6 +220,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         library_uow_factory=_library_uow_factory_for_media,
         library_health=_library_health_adapter,
         identity_uow_factory=_identity_uow_factory_for_profile_library_access,
+        preferences_uow_factory=_preferences_uow_factory_for_media,
         tmdb_api_key=config.provided.tmdb_api_key,
         supported_locales=config.provided.supported_locales,
         hls_cache_directory=config.provided.hls_cache_directory,

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -149,6 +149,9 @@ from src.modules.media.infrastructure.acl.identity_user_count_adapter import (
 from src.modules.media.infrastructure.acl.library_lookup_adapter import (
     LibraryLookupAdapter,
 )
+from src.modules.media.infrastructure.acl.profile_playback_preference_adapter import (
+    ProfilePlaybackPreferenceAdapter,
+)
 from src.modules.media.infrastructure.acl.profile_summary_adapter import (
     ProfileSummaryAdapter,
 )
@@ -230,6 +233,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # ``library_uow_factory`` above: a read-only cross-BC count
     # for admin dashboard aggregation, not domain coupling.
     identity_uow_factory = providers.Dependency()
+
+    # Wired at the composition root — ADR-026: the /tracks use case reads
+    # the viewing profile's preferred audio language from the Preferences BC
+    # to pick the default audio track at read time.
+    preferences_uow_factory = providers.Dependency()
 
     # Must be wired from parent container (Settings.hls_cache_directory).
     # Only the filesystem path remains in ``.env``; ``ffmpeg_threads``
@@ -449,6 +457,10 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         IdentityUserCountAdapter,
         identity_uow_factory=identity_uow_factory,
     )
+    playback_preference = providers.Singleton(
+        ProfilePlaybackPreferenceAdapter,
+        preferences_uow_factory=preferences_uow_factory,
+    )
 
     # Singleton because ``ThumbnailGenerationService`` is stateless apart
     # from the runtime config it reads per call; sharing one instance
@@ -538,6 +550,7 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     get_file_tracks = providers.Factory(
         GetFileTracksUseCase,
         hls=hls_service,
+        playback_preference=playback_preference,
     )
 
     clear_hls_cache = providers.Factory(

--- a/src/modules/media/application/dtos/stream_dtos.py
+++ b/src/modules/media/application/dtos/stream_dtos.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from src.modules.media.application.ports.media_probe_port import ProbeResult
+    from src.shared_kernel.value_objects.language_code import LanguageCode
 
 
 @dataclass(frozen=True)
@@ -85,7 +86,10 @@ def _version_dict(version: TrackVersion | None) -> dict[str, str] | None:
     return {"kind": version.kind, "value": version.value}
 
 
-def serialize_tracks(probe: ProbeResult) -> TrackListOutput:
+def serialize_tracks(
+    probe: ProbeResult,
+    preferred_audio_language: LanguageCode | None = None,
+) -> TrackListOutput:
     """Project a ``ProbeResult`` into the flat track DTO.
 
     Each track carries a structured ``version`` differentiating it from
@@ -93,15 +97,22 @@ def serialize_tracks(probe: ProbeResult) -> TrackListOutput:
     ordinal), or ``None`` when the language alone is unambiguous. The
     raw ``title`` is kept for reference; the player should prefer the
     language + ``version`` and localize them.
+
+    Args:
+        probe: The probed track list for the file.
+        preferred_audio_language: The viewer profile's preferred audio
+            language (ADR-026, resolved server-side from the Preferences
+            BC), or ``None`` when unavailable — then the default audio
+            falls back to the container-declared default, else the first.
     """
     audio_versions = audio_version_labels(probe.audio_tracks)
     text_subs = [t for t in probe.all_subtitles if t.is_text_based]
     sub_versions = subtitle_version_labels(text_subs)
     # The probe reports ``is_default`` truthfully (container-declared only),
-    # so pick the player's default audio here via the ADR-005 selector. With
-    # no library preference available at this boundary it falls back to the
-    # container default, else the first track — keeping exactly one default.
-    default_audio = TrackSelector().select_audio(probe.audio_tracks)
+    # so pick the player's default audio here via the ADR-005 selector: a
+    # track in the profile's preferred language wins (most channels), else
+    # the container default, else the first — keeping exactly one default.
+    default_audio = TrackSelector().select_audio(probe.audio_tracks, preferred_audio_language)
     return TrackListOutput(
         audio_tracks=[
             {

--- a/src/modules/media/application/ports/profile_playback_preference_port.py
+++ b/src/modules/media/application/ports/profile_playback_preference_port.py
@@ -1,0 +1,56 @@
+"""Port for reading a profile's playback preference from the Preferences BC.
+
+ADR-026 makes the server the authority for the default audio/subtitle
+track, resolved from the *per-user* preference (the Preferences BC), not
+per-library settings. This port exposes the slice the track selector needs
+so Media never imports the Preferences aggregate or its Unit of Work above
+the adapter (ADR-009). The adapter lives in ``media.infrastructure.acl``.
+
+Phase 2 consumes only ``audio_language`` (the ``/tracks`` audio default).
+``subtitle_language`` / ``subtitle_mode`` are added when ``select_subtitle``
+moves server-side (ADR-026 phase 4).
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from src.shared_kernel.value_objects.language_code import LanguageCode
+
+
+@dataclass(frozen=True)
+class PlaybackPreference:
+    """Consumer-owned projection of a profile's playback preference.
+
+    Attributes:
+        audio_language: The profile's preferred audio language as a strict
+            ISO 639-1 :class:`LanguageCode` (the base subtag of the stored
+            IETF tag, e.g. ``pt-BR`` → ``pt``), matched against a media
+            track's language. ``None`` when the stored tag has no usable
+            ISO 639-1 base — the selector then applies no preference.
+    """
+
+    audio_language: LanguageCode | None
+
+
+class ProfilePlaybackPreferencePort(ABC):
+    """Read a profile's playback preference without the Preferences aggregate."""
+
+    @abstractmethod
+    async def for_profile(self, profile_id: str) -> PlaybackPreference:
+        """Return the profile's playback preference.
+
+        Mirrors the Preferences BC's own default-on-absent behavior: a
+        profile that never saved preferences resolves to the factory
+        defaults (so server-side selection matches what the client would
+        apply), never an empty result.
+
+        Args:
+            profile_id: Prefixed external id (``prf_xxx``).
+
+        Returns:
+            A :class:`PlaybackPreference` (defaults applied when absent).
+        """
+        ...
+
+
+__all__ = ["PlaybackPreference", "ProfilePlaybackPreferencePort"]

--- a/src/modules/media/application/use_cases/get_file_tracks.py
+++ b/src/modules/media/application/use_cases/get_file_tracks.py
@@ -7,6 +7,9 @@ from src.modules.media.application.dtos.stream_dtos import (
     serialize_tracks,
 )
 from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.ports.profile_playback_preference_port import (
+    ProfilePlaybackPreferencePort,
+)
 
 
 @dataclass(frozen=True)
@@ -15,21 +18,41 @@ class GetFileTracksInput:
 
     Attributes:
         file_path: Absolute path to the source video file.
+        profile_id: External id (``prf_xxx``) of the viewing profile, used
+            to resolve its preferred audio language for the default-audio
+            choice (ADR-026). ``None`` skips the preference (container
+            default wins).
     """
 
     file_path: str
+    profile_id: str | None = None
 
 
 class GetFileTracksUseCase:
-    """Return the audio and text subtitle tracks a player can select."""
+    """Return the audio and text subtitle tracks a player can select.
 
-    def __init__(self, hls: HlsPlaylistPort) -> None:
+    Resolves the viewing profile's preferred audio language (ADR-026) via a
+    cross-BC read port to the Preferences BC, and applies it to the
+    default-audio choice. The probe still reports ``is_default`` truthfully;
+    the preference only steers which track this projection marks as default.
+    """
+
+    def __init__(
+        self,
+        hls: HlsPlaylistPort,
+        playback_preference: ProfilePlaybackPreferencePort,
+    ) -> None:
         self._hls = hls
+        self._playback_preference = playback_preference
 
     async def execute(self, input_dto: GetFileTracksInput) -> TrackListOutput:
         """Probe ``file_path`` (using the cache when available) and project."""
         probe = self._hls.probe_tracks(input_dto.file_path)
-        return serialize_tracks(probe)
+        preferred_audio_language = None
+        if input_dto.profile_id is not None:
+            preference = await self._playback_preference.for_profile(input_dto.profile_id)
+            preferred_audio_language = preference.audio_language
+        return serialize_tracks(probe, preferred_audio_language)
 
 
 __all__ = ["GetFileTracksInput", "GetFileTracksUseCase"]

--- a/src/modules/media/domain/services/track_selector.py
+++ b/src/modules/media/domain/services/track_selector.py
@@ -39,9 +39,9 @@ class TrackSelector:
 
         Args:
             tracks: The file's audio tracks, in container order.
-            preferred_language: The library's preferred audio language, or
-                ``None`` when no preference is available (e.g. at a
-                library-agnostic boundary).
+            preferred_language: The viewing profile's preferred audio
+                language (ADR-026), or ``None`` when no preference is
+                available (e.g. at a profile-agnostic boundary).
 
         Returns:
             The selected track, or ``None`` when there are no audio tracks.

--- a/src/modules/media/infrastructure/acl/profile_playback_preference_adapter.py
+++ b/src/modules/media/infrastructure/acl/profile_playback_preference_adapter.py
@@ -1,0 +1,52 @@
+"""Adapter implementing ``ProfilePlaybackPreferencePort`` via the Preferences UoW.
+
+Keeps the cross-BC read behind the abstract port: the ``/tracks`` use case
+sees only the port, while this adapter is the single place Media touches the
+Preferences BC to read playback preferences (ADR-026 / ADR-009).
+"""
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.media.application.ports.profile_playback_preference_port import (
+    PlaybackPreference,
+    ProfilePlaybackPreferencePort,
+)
+from src.modules.preferences.application.unit_of_work import PreferencesUnitOfWorkFactory
+from src.modules.preferences.domain.entities import PlaybackPreferences
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.language_tag import LanguageTag
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+
+def _to_language_code(tag: LanguageTag) -> LanguageCode | None:
+    """Bridge a preference's IETF tag to a track's strict ISO 639-1 code.
+
+    Compares on the primary subtag (``pt-BR`` → ``pt``), as documented on
+    :attr:`LanguageTag.primary_subtag`. Returns ``None`` when the primary
+    subtag is not a valid ISO 639-1 code (e.g. a 3-letter tag) so the
+    caller applies no audio preference rather than raising.
+    """
+    try:
+        return LanguageCode(tag.primary_subtag)
+    except DomainValidationException:
+        return None
+
+
+class ProfilePlaybackPreferenceAdapter(ProfilePlaybackPreferencePort):
+    """Resolve a profile's playback preference through the Preferences UoW."""
+
+    def __init__(self, preferences_uow_factory: PreferencesUnitOfWorkFactory) -> None:
+        self._preferences_uow_factory = preferences_uow_factory
+
+    async def for_profile(self, profile_id: str) -> PlaybackPreference:
+        """Load the profile's preferences (defaulting on first access)."""
+        pid = ProfileId(profile_id)
+        async with self._preferences_uow_factory() as uow:
+            prefs = await uow.preferences.find_by_profile_id(pid)
+        # Match GetPreferencesUseCase: absent row → factory defaults, so the
+        # server resolves the same default the client would apply.
+        if prefs is None:
+            prefs = PlaybackPreferences.default_for(pid)
+        return PlaybackPreference(audio_language=_to_language_code(prefs.audio_lang))
+
+
+__all__ = ["ProfilePlaybackPreferenceAdapter"]

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -251,7 +251,7 @@ async def movie_tracks(
     """Get available audio and subtitle tracks for a movie."""
     movie = await movie_uc.execute(GetMovieByIdInput(profile_id=profile_id, movie_id=movie_id))
     file_path = _require_file(movie.file_path)
-    tracks = await tracks_uc.execute(GetFileTracksInput(file_path=file_path))
+    tracks = await tracks_uc.execute(GetFileTracksInput(file_path=file_path, profile_id=profile_id))
     return asdict(tracks)
 
 
@@ -274,7 +274,7 @@ async def episode_tracks(
         series_uc, profile_id, series_id, season_number, episode_number
     )
     file_path = _require_file(file_path)
-    tracks = await tracks_uc.execute(GetFileTracksInput(file_path=file_path))
+    tracks = await tracks_uc.execute(GetFileTracksInput(file_path=file_path, profile_id=profile_id))
     return asdict(tracks)
 
 

--- a/tests/modules/media/integration/acl/test_profile_playback_preference_adapter.py
+++ b/tests/modules/media/integration/acl/test_profile_playback_preference_adapter.py
@@ -1,0 +1,78 @@
+"""Integration tests for the Media ProfilePlaybackPreferenceAdapter."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.modules.media.infrastructure.acl.profile_playback_preference_adapter import (
+    ProfilePlaybackPreferenceAdapter,
+)
+from src.modules.preferences.domain.entities import PlaybackPreferences
+from src.modules.preferences.infrastructure.persistence.repositories import (
+    SQLAlchemyPreferencesRepository,
+)
+from src.modules.preferences.infrastructure.persistence.sqlalchemy_unit_of_work import (
+    SqlAlchemyPreferencesUnitOfWorkFactory,
+)
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.profile_id import ProfileId
+
+_PROFILE_ID = ProfileId("prf_test12345678")
+
+
+def _make_adapter(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> ProfilePlaybackPreferenceAdapter:
+    return ProfilePlaybackPreferenceAdapter(SqlAlchemyPreferencesUnitOfWorkFactory(session_factory))
+
+
+@pytest.mark.integration
+class TestProfilePlaybackPreferenceAdapter:
+    """The adapter reads audio_lang and bridges the IETF tag to a LanguageCode."""
+
+    async def test_returns_base_language_code_of_configured_audio_lang(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        repo = SQLAlchemyPreferencesRepository(db_session)
+        await repo.save(
+            PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(audio_lang="pt-BR"),
+        )
+        await db_session.commit()
+
+        adapter = _make_adapter(session_factory)
+        result = await adapter.for_profile(str(_PROFILE_ID))
+
+        # IETF "pt-BR" bridges to the strict ISO 639-1 base "pt".
+        assert result.audio_language == LanguageCode("pt")
+
+    async def test_defaults_when_no_preferences_row(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # First access: no row → factory default (pt-BR) → base "pt", so the
+        # server resolves the same default the client would apply.
+        adapter = _make_adapter(session_factory)
+
+        result = await adapter.for_profile(str(_PROFILE_ID))
+
+        assert result.audio_language == LanguageCode("pt")
+
+    async def test_unbridgeable_tag_yields_no_audio_language(
+        self,
+        db_session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # A 3-letter primary subtag is a valid IETF tag but not a strict
+        # ISO 639-1 code, so it can't bridge to a LanguageCode → the adapter
+        # applies no audio preference (None) rather than raising.
+        repo = SQLAlchemyPreferencesRepository(db_session)
+        await repo.save(
+            PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(audio_lang="fil"),
+        )
+        await db_session.commit()
+
+        adapter = _make_adapter(session_factory)
+        result = await adapter.for_profile(str(_PROFILE_ID))
+
+        assert result.audio_language is None

--- a/tests/modules/media/unit/application/use_cases/test_get_file_tracks.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_file_tracks.py
@@ -1,17 +1,36 @@
 """Tests for GetFileTracksUseCase."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from src.modules.media.application.ports import ProbeResult
 from src.modules.media.application.ports.hls_playlist_port import HlsPlaylistPort
+from src.modules.media.application.ports.profile_playback_preference_port import (
+    PlaybackPreference,
+    ProfilePlaybackPreferencePort,
+)
 from src.modules.media.application.use_cases.get_file_tracks import (
     GetFileTracksInput,
     GetFileTracksUseCase,
 )
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+
+def _make_use_case(
+    hls: MagicMock, preferred_audio: LanguageCode | None = None
+) -> tuple[GetFileTracksUseCase, MagicMock]:
+    """Build the use case with a mocked playback-preference port.
+
+    The port returns a ``PlaybackPreference`` with the given audio language
+    (default: none → no preference applied).
+    """
+    pref_port = MagicMock(spec=ProfilePlaybackPreferencePort)
+    pref_port.for_profile = AsyncMock(
+        return_value=PlaybackPreference(audio_language=preferred_audio)
+    )
+    return GetFileTracksUseCase(hls=hls, playback_preference=pref_port), pref_port
 
 
 def _audio(index: int = 0, lang: str = "en") -> AudioTrack:
@@ -51,7 +70,7 @@ class TestGetFileTracksUseCase:
             audio_tracks=[_audio(0, "en"), _audio(1, "pt")],
             subtitle_tracks=[_text_subtitle(0, "en")],
         )
-        use_case = GetFileTracksUseCase(hls=hls)
+        use_case, _ = _make_use_case(hls)
 
         output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
 
@@ -73,7 +92,7 @@ class TestGetFileTracksUseCase:
             ],
             subtitle_tracks=[],
         )
-        use_case = GetFileTracksUseCase(hls=hls)
+        use_case, _ = _make_use_case(hls)
 
         output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
 
@@ -97,7 +116,7 @@ class TestGetFileTracksUseCase:
             ],
             subtitle_tracks=[],
         )
-        use_case = GetFileTracksUseCase(hls=hls)
+        use_case, _ = _make_use_case(hls)
 
         output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
 
@@ -122,7 +141,7 @@ class TestGetFileTracksUseCase:
                 ),
             ],
         )
-        use_case = GetFileTracksUseCase(hls=hls)
+        use_case, _ = _make_use_case(hls)
 
         output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
 
@@ -135,9 +154,88 @@ class TestGetFileTracksUseCase:
             audio_tracks=[_audio()],
             subtitle_tracks=[_text_subtitle(0, "en"), _image_subtitle(1, "ja")],
         )
-        use_case = GetFileTracksUseCase(hls=hls)
+        use_case, _ = _make_use_case(hls)
 
         output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
 
         assert len(output.subtitle_tracks) == 1
         assert output.subtitle_tracks[0]["language"] == "en"
+
+    @pytest.mark.asyncio
+    async def test_profile_preferred_language_drives_default_audio(self) -> None:
+        # Only the preference can explain the result: the pt track has FEWER
+        # channels than en and is not the container default, so neither the
+        # max-channels tiebreak nor the first/container fallback would pick it.
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[
+                AudioTrack(index=0, language=LanguageCode("en"), codec="ac3", channels=6),
+                AudioTrack(index=1, language=LanguageCode("pt"), codec="aac", channels=2),
+            ],
+            subtitle_tracks=[],
+        )
+        use_case, pref_port = _make_use_case(hls, preferred_audio=LanguageCode("pt"))
+
+        output = await use_case.execute(
+            GetFileTracksInput(file_path="/m.mkv", profile_id="prf_abc12345")
+        )
+
+        defaults = [t for t in output.audio_tracks if t["is_default"]]
+        assert len(defaults) == 1
+        assert defaults[0]["language"] == "pt"
+        pref_port.for_profile.assert_awaited_once_with("prf_abc12345")
+
+    @pytest.mark.asyncio
+    async def test_profile_with_no_usable_audio_pref_falls_back_to_container(self) -> None:
+        # profile_id present but the preference yields no audio language
+        # (e.g. an unbridgeable tag) → the container default stands, and the
+        # port was still consulted.
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[
+                AudioTrack(index=0, language=LanguageCode("en"), codec="aac", channels=2),
+                AudioTrack(
+                    index=1,
+                    language=LanguageCode("pt"),
+                    codec="ac3",
+                    channels=6,
+                    is_default=True,
+                ),
+            ],
+            subtitle_tracks=[],
+        )
+        use_case, pref_port = _make_use_case(hls, preferred_audio=None)
+
+        output = await use_case.execute(
+            GetFileTracksInput(file_path="/m.mkv", profile_id="prf_abc12345")
+        )
+
+        defaults = [t for t in output.audio_tracks if t["is_default"]]
+        assert defaults[0]["index"] == 1  # container default
+        pref_port.for_profile.assert_awaited_once_with("prf_abc12345")
+
+    @pytest.mark.asyncio
+    async def test_no_profile_id_skips_preference_lookup(self) -> None:
+        # Without a profile_id the cross-BC port is not consulted and the
+        # container-declared default stands.
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[
+                AudioTrack(index=0, language=LanguageCode("en"), codec="aac", channels=2),
+                AudioTrack(
+                    index=1,
+                    language=LanguageCode("pt"),
+                    codec="ac3",
+                    channels=6,
+                    is_default=True,
+                ),
+            ],
+            subtitle_tracks=[],
+        )
+        use_case, pref_port = _make_use_case(hls, preferred_audio=LanguageCode("en"))
+
+        output = await use_case.execute(GetFileTracksInput(file_path="/m.mkv"))
+
+        defaults = [t for t in output.audio_tracks if t["is_default"]]
+        assert defaults[0]["index"] == 1  # container default; preference not applied
+        pref_port.for_profile.assert_not_awaited()


### PR DESCRIPTION
## Summary
- **ADR-026 phase 2.** The server becomes the authority for the `/tracks` default audio. `GetFileTracksUseCase` resolves the viewing profile's preferred audio language from the **Preferences BC** via a new cross-BC read port (`ProfilePlaybackPreferencePort` + ACL adapter, ADR-009) and passes it to `TrackSelector`.
- The adapter mirrors `GetPreferences` default-on-absent (so the server resolves the same default the client would apply) and bridges the IETF `LanguageTag` (`pt-BR`) to the track's strict ISO 639-1 `LanguageCode` (`pt`) via `LanguageTag.primary_subtag`.
- Scope is audio-only (subtitle/`select_subtitle` is phase 4). The probe still reports `is_default` truthfully; only **which** audio `/tracks` marks default changes. No `profile_id` (or unbridgeable tag) → container default.

## Visibility / risk
- **Invisible to users until phase 5.** The frontend still resolves audio client-side (its own `playbackPrefs.audioLang` via `findTrackByLang`) and ignores `/tracks` `is_default` for audio — so this changes no user-visible behavior yet. Low risk; no smoke needed (full suite + e2e cover it). It builds the server foundation; the front flips in phase 5.

## Test plan
- [x] Use case: preference drives default (confound removed), no `profile_id` skips port, `profile_id`+no-usable-pref → container default
- [x] Adapter (integration): `pt-BR`→`pt` bridge, default-on-absent→`pt`, unbridgeable 3-letter tag→`None`
- [x] Full suite 3248 passed; ruff check/format clean; mypy clean on changed files
- [x] mr-review (5 subagents: architecture/ACL/coupling/regression/tests) — 0 blocking

## Summary by Sourcery

Make server-side track selection use the viewing profile’s preferred audio language for /tracks default audio, backed by a cross-BC playback preference port and adapter wired at the composition root.

New Features:
- Add a profile-aware GetFileTracksInput and use case that accept profile_id and apply the profile’s preferred audio language when choosing the default audio track.
- Introduce a ProfilePlaybackPreferencePort and Media ACL adapter to read playback preferences from the Preferences bounded context, bridging IETF language tags to strict ISO 639-1 language codes.

Enhancements:
- Update track serialization and TrackSelector to accept a preferred audio language so default audio is selected per-profile rather than purely by container metadata.
- Wire Preferences persistence into the Media container and application composition root to support cross-BC playback preference reads without tight coupling.

Documentation:
- Extend ADR-026 documentation to reflect server-authoritative default audio resolution via the playback preference port.

Tests:
- Add unit tests for GetFileTracksUseCase covering profile-driven default audio and fallback behaviors when preferences are absent or unusable.
- Add integration tests for the ProfilePlaybackPreferenceAdapter to verify language tag bridging, default-on-absent behavior, and handling of unbridgeable tags.