### PR TITLE
feat(media): resolve /tracks default subtitle by mode server-side (ADR-026)

### DIFF
--- a/docs/adr/ADR-005-library-as-configuration-entity.md
+++ b/docs/adr/ADR-005-library-as-configuration-entity.md
@@ -10,8 +10,11 @@
 > passam a viver no Preferences BC (por-usuário); a autoridade de seleção de
 > faixa default passa a ser o **servidor** (manifesto HLS + `/tracks`
 > concordando), não o cliente. O `TrackSelector` segue sendo a regra de
-> domínio, agora alimentado pela preferência por-usuário. Os demais aspectos
-> deste ADR (Library como config de scan/provedores, VOs de faixa) permanecem.
+> domínio, agora alimentado pela preferência por-usuário. O `SubtitleMode`
+> esboçado abaixo no domínio da library vive hoje em `shared_kernel`
+> (membros reais `OFF`/`FOREIGN_ONLY`/`ALWAYS`/`FORCED_ONLY`), compartilhado
+> por Preferences e Media. Os demais aspectos deste ADR (Library como config
+> de scan/provedores, VOs de faixa) permanecem.
 
 ---
 

--- a/src/modules/media/application/dtos/stream_dtos.py
+++ b/src/modules/media/application/dtos/stream_dtos.py
@@ -21,7 +21,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from src.modules.media.application.ports.media_probe_port import ProbeResult
-    from src.shared_kernel.value_objects.language_code import LanguageCode
+    from src.modules.media.application.ports.profile_playback_preference_port import (
+        PlaybackPreference,
+    )
 
 
 @dataclass(frozen=True)
@@ -88,7 +90,7 @@ def _version_dict(version: TrackVersion | None) -> dict[str, str] | None:
 
 def serialize_tracks(
     probe: ProbeResult,
-    preferred_audio_language: LanguageCode | None = None,
+    preference: PlaybackPreference | None = None,
 ) -> TrackListOutput:
     """Project a ``ProbeResult`` into the flat track DTO.
 
@@ -100,19 +102,35 @@ def serialize_tracks(
 
     Args:
         probe: The probed track list for the file.
-        preferred_audio_language: The viewer profile's preferred audio
-            language (ADR-026, resolved server-side from the Preferences
-            BC), or ``None`` when unavailable — then the default audio
-            falls back to the container-declared default, else the first.
+        preference: The viewer profile's playback preference (ADR-026,
+            resolved server-side from the Preferences BC), or ``None`` when
+            unavailable. When present, the audio and subtitle defaults are
+            server-resolved via :class:`TrackSelector`; when ``None`` the
+            audio default falls back to the container default (else first)
+            and each subtitle keeps its container-declared ``is_default``.
     """
     audio_versions = audio_version_labels(probe.audio_tracks)
     text_subs = [t for t in probe.all_subtitles if t.is_text_based]
     sub_versions = subtitle_version_labels(text_subs)
-    # The probe reports ``is_default`` truthfully (container-declared only),
-    # so pick the player's default audio here via the ADR-005 selector: a
-    # track in the profile's preferred language wins (most channels), else
-    # the container default, else the first — keeping exactly one default.
-    default_audio = TrackSelector().select_audio(probe.audio_tracks, preferred_audio_language)
+    # The probe reports ``is_default`` truthfully (container-declared only);
+    # the ADR-005/026 selector resolves the player's defaults from the
+    # profile preference (exactly one default audio, and at most one subtitle).
+    selector = TrackSelector()
+    default_audio = selector.select_audio(
+        probe.audio_tracks, preference.audio_language if preference else None
+    )
+    # ``preference is not None`` (not the ``resolve_subtitle`` flag) so mypy
+    # narrows the Optional before we read ``preference.subtitle_*`` below.
+    resolve_subtitle = preference is not None
+    default_subtitle = None
+    if preference is not None:
+        chosen_audio_language = default_audio.language if default_audio else None
+        default_subtitle = selector.select_subtitle(
+            text_subs,
+            chosen_audio_language,
+            preference.subtitle_language,
+            preference.subtitle_mode,
+        )
     return TrackListOutput(
         audio_tracks=[
             {
@@ -134,7 +152,7 @@ def serialize_tracks(
                 "format": t.format,
                 "title": t.title,
                 "version": _version_dict(sub_versions.get(t.index)),
-                "is_default": t.is_default,
+                "is_default": (t is default_subtitle) if resolve_subtitle else t.is_default,
                 "is_forced": t.is_forced,
                 "is_external": t.is_external,
                 "is_image_based": t.is_image_based,

--- a/src/modules/media/application/ports/profile_playback_preference_port.py
+++ b/src/modules/media/application/ports/profile_playback_preference_port.py
@@ -6,30 +6,36 @@ per-library settings. This port exposes the slice the track selector needs
 so Media never imports the Preferences aggregate or its Unit of Work above
 the adapter (ADR-009). The adapter lives in ``media.infrastructure.acl``.
 
-Phase 2 consumes only ``audio_language`` (the ``/tracks`` audio default).
-``subtitle_language`` / ``subtitle_mode`` are added when ``select_subtitle``
-moves server-side (ADR-026 phase 4).
+Carries the audio default (phase 2) plus the subtitle language + mode the
+domain ``select_subtitle`` rule needs (phase 4).
 """
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
 
 
 @dataclass(frozen=True)
 class PlaybackPreference:
     """Consumer-owned projection of a profile's playback preference.
 
+    Language fields are the strict ISO 639-1 base subtag of the stored IETF
+    tag (e.g. ``pt-BR`` → ``pt``), matched against a media track's language;
+    ``None`` when the stored tag has no usable ISO 639-1 base (the selector
+    then applies no preference for that axis).
+
     Attributes:
-        audio_language: The profile's preferred audio language as a strict
-            ISO 639-1 :class:`LanguageCode` (the base subtag of the stored
-            IETF tag, e.g. ``pt-BR`` → ``pt``), matched against a media
-            track's language. ``None`` when the stored tag has no usable
-            ISO 639-1 base — the selector then applies no preference.
+        audio_language: Preferred audio language, or ``None``.
+        subtitle_language: Preferred subtitle language, or ``None``.
+        subtitle_mode: When to auto-enable a subtitle (always present —
+            the Preferences BC defaults it).
     """
 
     audio_language: LanguageCode | None
+    subtitle_language: LanguageCode | None
+    subtitle_mode: SubtitleMode
 
 
 class ProfilePlaybackPreferencePort(ABC):

--- a/src/modules/media/application/use_cases/get_file_tracks.py
+++ b/src/modules/media/application/use_cases/get_file_tracks.py
@@ -31,10 +31,11 @@ class GetFileTracksInput:
 class GetFileTracksUseCase:
     """Return the audio and text subtitle tracks a player can select.
 
-    Resolves the viewing profile's preferred audio language (ADR-026) via a
-    cross-BC read port to the Preferences BC, and applies it to the
-    default-audio choice. The probe still reports ``is_default`` truthfully;
-    the preference only steers which track this projection marks as default.
+    Resolves the viewing profile's playback preference (ADR-026) via a
+    cross-BC read port to the Preferences BC, and applies it to the default
+    audio and subtitle choice. The probe still reports ``is_default``
+    truthfully; the preference only steers which tracks this projection marks
+    as default.
     """
 
     def __init__(
@@ -48,11 +49,10 @@ class GetFileTracksUseCase:
     async def execute(self, input_dto: GetFileTracksInput) -> TrackListOutput:
         """Probe ``file_path`` (using the cache when available) and project."""
         probe = self._hls.probe_tracks(input_dto.file_path)
-        preferred_audio_language = None
+        preference = None
         if input_dto.profile_id is not None:
             preference = await self._playback_preference.for_profile(input_dto.profile_id)
-            preferred_audio_language = preference.audio_language
-        return serialize_tracks(probe, preferred_audio_language)
+        return serialize_tracks(probe, preference)
 
 
 __all__ = ["GetFileTracksInput", "GetFileTracksUseCase"]

--- a/src/modules/media/domain/services/track_selector.py
+++ b/src/modules/media/domain/services/track_selector.py
@@ -1,27 +1,25 @@
-"""Track selection domain service (ADR-005).
+"""Track selection domain service (ADR-005 / ADR-026).
 
-Owns the rule for *which* audio track is the default, so the probe can
-report tracks truthfully (only the container's declared default) instead
-of fabricating one. The decision is made at read time from the tracks plus
-the caller's preference, not baked into the persisted data.
-
-Only :meth:`select_audio` exists today — that is the rule Card B needs. The
-subtitle-by-mode selection ADR-005 also sketches has no consumer yet (the
-probe never fabricates a subtitle default), so it is deferred until one
-appears.
+Owns the rule for *which* audio and subtitle track is the default, so the
+probe can report tracks truthfully (only the container's declared default)
+instead of fabricating one. The decision is made at read time from the
+tracks plus the viewing profile's preference, not baked into the persisted
+data — the server is the authority (ADR-026).
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
+
 if TYPE_CHECKING:
     from src.shared_kernel.value_objects.language_code import LanguageCode
-    from src.shared_kernel.value_objects.tracks import AudioTrack
+    from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 
 class TrackSelector:
-    """Selects appropriate tracks based on preferences (ADR-005)."""
+    """Selects appropriate tracks based on preferences (ADR-005 / ADR-026)."""
 
     def select_audio(
         self,
@@ -55,6 +53,59 @@ class TrackSelector:
                 return max(in_language, key=lambda t: t.channels)
 
         return next((t for t in tracks if t.is_default), tracks[0])
+
+    def select_subtitle(
+        self,
+        subtitles: list[SubtitleTrack],
+        audio_language: LanguageCode | None,
+        preferred_language: LanguageCode | None,
+        mode: SubtitleMode,
+    ) -> SubtitleTrack | None:
+        """Pick the default subtitle track for a file (ADR-005 / ADR-026).
+
+        Behavior per ``mode``:
+
+        - ``OFF``: never auto-enable a subtitle.
+        - ``FORCED_ONLY``: the first forced subtitle (on-screen signs /
+          foreign lines), regardless of language; ``None`` if none is forced.
+          Intentionally independent of ``preferred_language`` — forced signs
+          should show whatever the language preference is (ADR-026).
+        - ``ALWAYS``: a subtitle in ``preferred_language``.
+        - ``FOREIGN_ONLY``: a subtitle in ``preferred_language``, but only
+          when the chosen audio is *not* already in that language (i.e. the
+          viewer is watching foreign-language audio). An unknown audio
+          language (``None``) is treated as foreign, so the subtitle shows.
+
+        ``subtitles`` should be the selectable (text) tracks — image-based
+        subtitles can't be served as WebVTT, so they are never defaulted.
+
+        Args:
+            subtitles: The file's selectable subtitle tracks, in order.
+            audio_language: Language of the audio track that was selected
+                (needed by ``FOREIGN_ONLY``), or ``None``.
+            preferred_language: The profile's preferred subtitle language,
+                or ``None`` when unavailable.
+            mode: The profile's subtitle mode.
+
+        Returns:
+            The subtitle to mark default, or ``None`` when none applies.
+        """
+        if not subtitles or mode is SubtitleMode.OFF:
+            return None
+
+        if mode is SubtitleMode.FORCED_ONLY:
+            return next((s for s in subtitles if s.is_forced), None)
+
+        if preferred_language is None:
+            return None
+
+        in_language = next((s for s in subtitles if s.language == preferred_language), None)
+        # ALWAYS shows the preferred-language subtitle; FOREIGN_ONLY shows it
+        # only when the chosen audio is not already in that language.
+        show = mode is SubtitleMode.ALWAYS or (
+            mode is SubtitleMode.FOREIGN_ONLY and audio_language != preferred_language
+        )
+        return in_language if show else None
 
 
 __all__ = ["TrackSelector"]

--- a/src/modules/media/infrastructure/acl/profile_playback_preference_adapter.py
+++ b/src/modules/media/infrastructure/acl/profile_playback_preference_adapter.py
@@ -46,7 +46,11 @@ class ProfilePlaybackPreferenceAdapter(ProfilePlaybackPreferencePort):
         # server resolves the same default the client would apply.
         if prefs is None:
             prefs = PlaybackPreferences.default_for(pid)
-        return PlaybackPreference(audio_language=_to_language_code(prefs.audio_lang))
+        return PlaybackPreference(
+            audio_language=_to_language_code(prefs.audio_lang),
+            subtitle_language=_to_language_code(prefs.subtitle_lang),
+            subtitle_mode=prefs.subtitle_mode,
+        )
 
 
 __all__ = ["ProfilePlaybackPreferenceAdapter"]

--- a/src/modules/preferences/domain/value_objects/__init__.py
+++ b/src/modules/preferences/domain/value_objects/__init__.py
@@ -3,6 +3,6 @@
 from src.modules.preferences.domain.value_objects.preferences_id import PreferencesId
 from src.modules.preferences.domain.value_objects.quality import Quality
 from src.modules.preferences.domain.value_objects.speed import Speed
-from src.modules.preferences.domain.value_objects.subtitle_mode import SubtitleMode
+from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
 
 __all__ = ["PreferencesId", "Quality", "Speed", "SubtitleMode"]

--- a/src/shared_kernel/value_objects/__init__.py
+++ b/src/shared_kernel/value_objects/__init__.py
@@ -17,6 +17,7 @@ from src.shared_kernel.value_objects.media_id import (
 )
 from src.shared_kernel.value_objects.media_type import MediaType
 from src.shared_kernel.value_objects.profile_id import ProfileId
+from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleFormat, SubtitleTrack
 from src.shared_kernel.value_objects.user_id import UserId
 
@@ -37,6 +38,7 @@ __all__ = [
     "SeasonId",
     "SeriesId",
     "SubtitleFormat",
+    "SubtitleMode",
     "SubtitleTrack",
     "UserId",
     "parse_media_id",

--- a/src/shared_kernel/value_objects/subtitle_mode.py
+++ b/src/shared_kernel/value_objects/subtitle_mode.py
@@ -1,4 +1,4 @@
-"""Subtitle mode enumeration for playback preferences."""
+"""Subtitle display mode — shared playback-selection vocabulary."""
 
 from enum import StrEnum
 
@@ -6,9 +6,11 @@ from enum import StrEnum
 class SubtitleMode(StrEnum):
     """Default subtitle behavior during playback.
 
-    String values are the canonical ones persisted on the
-    ``preferences`` table — the values the frontend sends and
-    receives verbatim.
+    Shared cross-module vocabulary (ADR-026): the Preferences BC persists
+    the per-user choice, and the Media BC's ``TrackSelector.select_subtitle``
+    consumes it to resolve the default subtitle. String values are the
+    canonical ones persisted on the ``preferences`` table — the values the
+    frontend sends and receives verbatim.
 
     Attributes:
         OFF: Never show subtitles.

--- a/tests/modules/media/integration/acl/test_profile_playback_preference_adapter.py
+++ b/tests/modules/media/integration/acl/test_profile_playback_preference_adapter.py
@@ -15,6 +15,7 @@ from src.modules.preferences.infrastructure.persistence.sqlalchemy_unit_of_work 
 )
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.profile_id import ProfileId
+from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
 
 _PROFILE_ID = ProfileId("prf_test12345678")
 
@@ -36,15 +37,21 @@ class TestProfilePlaybackPreferenceAdapter:
     ) -> None:
         repo = SQLAlchemyPreferencesRepository(db_session)
         await repo.save(
-            PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(audio_lang="pt-BR"),
+            PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(
+                audio_lang="pt-BR",
+                subtitle_lang="en-US",
+                subtitle_mode="always",
+            ),
         )
         await db_session.commit()
 
         adapter = _make_adapter(session_factory)
         result = await adapter.for_profile(str(_PROFILE_ID))
 
-        # IETF "pt-BR" bridges to the strict ISO 639-1 base "pt".
+        # IETF tags bridge to strict ISO 639-1 bases; the mode passes through.
         assert result.audio_language == LanguageCode("pt")
+        assert result.subtitle_language == LanguageCode("en")
+        assert result.subtitle_mode is SubtitleMode.ALWAYS
 
     async def test_defaults_when_no_preferences_row(
         self,
@@ -57,6 +64,8 @@ class TestProfilePlaybackPreferenceAdapter:
         result = await adapter.for_profile(str(_PROFILE_ID))
 
         assert result.audio_language == LanguageCode("pt")
+        assert result.subtitle_language == LanguageCode("pt")
+        assert result.subtitle_mode is SubtitleMode.FOREIGN_ONLY
 
     async def test_unbridgeable_tag_yields_no_audio_language(
         self,
@@ -68,7 +77,10 @@ class TestProfilePlaybackPreferenceAdapter:
         # applies no audio preference (None) rather than raising.
         repo = SQLAlchemyPreferencesRepository(db_session)
         await repo.save(
-            PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(audio_lang="fil"),
+            PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(
+                audio_lang="fil",
+                subtitle_lang="fil",
+            ),
         )
         await db_session.commit()
 
@@ -76,3 +88,4 @@ class TestProfilePlaybackPreferenceAdapter:
         result = await adapter.for_profile(str(_PROFILE_ID))
 
         assert result.audio_language is None
+        assert result.subtitle_language is None

--- a/tests/modules/media/unit/application/use_cases/test_get_file_tracks.py
+++ b/tests/modules/media/unit/application/use_cases/test_get_file_tracks.py
@@ -15,20 +15,28 @@ from src.modules.media.application.use_cases.get_file_tracks import (
     GetFileTracksUseCase,
 )
 from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 
 def _make_use_case(
-    hls: MagicMock, preferred_audio: LanguageCode | None = None
+    hls: MagicMock,
+    preferred_audio: LanguageCode | None = None,
+    preferred_subtitle: LanguageCode | None = None,
+    subtitle_mode: SubtitleMode = SubtitleMode.OFF,
 ) -> tuple[GetFileTracksUseCase, MagicMock]:
     """Build the use case with a mocked playback-preference port.
 
-    The port returns a ``PlaybackPreference`` with the given audio language
-    (default: none → no preference applied).
+    The port returns a ``PlaybackPreference`` (subtitle mode defaults to OFF
+    so audio-focused tests keep subtitle defaults untouched).
     """
     pref_port = MagicMock(spec=ProfilePlaybackPreferencePort)
     pref_port.for_profile = AsyncMock(
-        return_value=PlaybackPreference(audio_language=preferred_audio)
+        return_value=PlaybackPreference(
+            audio_language=preferred_audio,
+            subtitle_language=preferred_subtitle,
+            subtitle_mode=subtitle_mode,
+        )
     )
     return GetFileTracksUseCase(hls=hls, playback_preference=pref_port), pref_port
 
@@ -239,3 +247,66 @@ class TestGetFileTracksUseCase:
         defaults = [t for t in output.audio_tracks if t["is_default"]]
         assert defaults[0]["index"] == 1  # container default; preference not applied
         pref_port.for_profile.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_subtitle_mode_always_overrides_container_default_subtitle(self) -> None:
+        # Mode ALWAYS + preferred pt: the pt sub becomes default, and the
+        # container-declared en default is normalized away (exactly one).
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[_audio(0, "en")],
+            subtitle_tracks=[
+                SubtitleTrack(
+                    index=0,
+                    language=LanguageCode("en"),
+                    format="srt",
+                    is_default=True,
+                    is_external=False,
+                ),
+                SubtitleTrack(
+                    index=1,
+                    language=LanguageCode("pt"),
+                    format="srt",
+                    is_external=False,
+                ),
+            ],
+        )
+        use_case, _ = _make_use_case(
+            hls,
+            preferred_subtitle=LanguageCode("pt"),
+            subtitle_mode=SubtitleMode.ALWAYS,
+        )
+
+        output = await use_case.execute(
+            GetFileTracksInput(file_path="/m.mkv", profile_id="prf_abc12345")
+        )
+
+        defaults = [t for t in output.subtitle_tracks if t["is_default"]]
+        assert len(defaults) == 1
+        assert defaults[0]["language"] == "pt"
+
+    @pytest.mark.asyncio
+    async def test_subtitle_mode_off_strips_container_default_subtitle(self) -> None:
+        # With a profile whose mode is OFF, a container-declared subtitle
+        # default is dropped — distinct from the no-profile case, which keeps
+        # the container default.
+        hls = MagicMock(spec=HlsPlaylistPort)
+        hls.probe_tracks.return_value = ProbeResult(
+            audio_tracks=[_audio(0, "en")],
+            subtitle_tracks=[
+                SubtitleTrack(
+                    index=0,
+                    language=LanguageCode("en"),
+                    format="srt",
+                    is_default=True,
+                    is_external=False,
+                ),
+            ],
+        )
+        use_case, _ = _make_use_case(hls, subtitle_mode=SubtitleMode.OFF)
+
+        output = await use_case.execute(
+            GetFileTracksInput(file_path="/m.mkv", profile_id="prf_abc12345")
+        )
+
+        assert [t for t in output.subtitle_tracks if t["is_default"]] == []

--- a/tests/modules/media/unit/domain/services/test_track_selector.py
+++ b/tests/modules/media/unit/domain/services/test_track_selector.py
@@ -1,10 +1,11 @@
-"""Tests for the TrackSelector domain service (ADR-005)."""
+"""Tests for the TrackSelector domain service (ADR-005 / ADR-026)."""
 
 import pytest
 
 from src.modules.media.domain.services.track_selector import TrackSelector
 from src.shared_kernel.value_objects.language_code import LanguageCode
-from src.shared_kernel.value_objects.tracks import AudioTrack
+from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
+from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 
 def _audio(
@@ -20,6 +21,20 @@ def _audio(
         codec="aac",
         channels=channels,
         is_default=is_default,
+    )
+
+
+def _sub(
+    index: int,
+    *,
+    language: str = "en",
+    is_forced: bool = False,
+) -> SubtitleTrack:
+    return SubtitleTrack(
+        index=index,
+        language=LanguageCode(language),
+        format="srt",
+        is_forced=is_forced,
     )
 
 
@@ -62,3 +77,69 @@ class TestSelectAudio:
     def test_preferred_language_absent_no_default_falls_back_to_first(self) -> None:
         tracks = [_audio(0, language="en"), _audio(1, language="en")]
         assert TrackSelector().select_audio(tracks, LanguageCode("ja")) is tracks[0]
+
+
+@pytest.mark.unit
+class TestSelectSubtitle:
+    _PT = LanguageCode("pt")
+    _EN = LanguageCode("en")
+
+    def test_returns_none_for_no_subtitles(self) -> None:
+        assert TrackSelector().select_subtitle([], self._EN, self._PT, SubtitleMode.ALWAYS) is None
+
+    def test_off_never_selects(self) -> None:
+        subs = [_sub(0, language="pt")]
+        assert TrackSelector().select_subtitle(subs, self._EN, self._PT, SubtitleMode.OFF) is None
+
+    def test_forced_only_returns_first_forced_regardless_of_language(self) -> None:
+        subs = [_sub(0, language="pt"), _sub(1, language="de", is_forced=True)]
+        selected = TrackSelector().select_subtitle(
+            subs, self._EN, self._PT, SubtitleMode.FORCED_ONLY
+        )
+        assert selected is subs[1]
+
+    def test_forced_only_none_when_no_forced_track(self) -> None:
+        subs = [_sub(0, language="pt"), _sub(1, language="de")]
+        assert (
+            TrackSelector().select_subtitle(subs, self._EN, self._PT, SubtitleMode.FORCED_ONLY)
+            is None
+        )
+
+    def test_always_returns_preferred_language(self) -> None:
+        subs = [_sub(0, language="de"), _sub(1, language="pt")]
+        selected = TrackSelector().select_subtitle(subs, self._EN, self._PT, SubtitleMode.ALWAYS)
+        assert selected is subs[1]
+
+    def test_always_none_when_preferred_language_absent(self) -> None:
+        subs = [_sub(0, language="de")]
+        assert (
+            TrackSelector().select_subtitle(subs, self._EN, self._PT, SubtitleMode.ALWAYS) is None
+        )
+
+    def test_always_none_when_no_preferred_language(self) -> None:
+        subs = [_sub(0, language="pt")]
+        assert TrackSelector().select_subtitle(subs, self._EN, None, SubtitleMode.ALWAYS) is None
+
+    def test_foreign_only_shows_sub_when_audio_is_foreign(self) -> None:
+        # Audio en, viewer prefers pt subs → foreign audio → show pt sub.
+        subs = [_sub(0, language="pt")]
+        selected = TrackSelector().select_subtitle(
+            subs, self._EN, self._PT, SubtitleMode.FOREIGN_ONLY
+        )
+        assert selected is subs[0]
+
+    def test_foreign_only_hides_sub_when_audio_matches_preferred(self) -> None:
+        # Audio pt, viewer prefers pt subs → not foreign → no sub.
+        subs = [_sub(0, language="pt")]
+        assert (
+            TrackSelector().select_subtitle(subs, self._PT, self._PT, SubtitleMode.FOREIGN_ONLY)
+            is None
+        )
+
+    def test_foreign_only_none_when_preferred_language_absent(self) -> None:
+        # Foreign audio, but no subtitle in the preferred language → None.
+        subs = [_sub(0, language="de")]
+        assert (
+            TrackSelector().select_subtitle(subs, self._EN, self._PT, SubtitleMode.FOREIGN_ONLY)
+            is None
+        )

--- a/tests/shared_kernel/unit/value_objects/test_subtitle_mode.py
+++ b/tests/shared_kernel/unit/value_objects/test_subtitle_mode.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.modules.preferences.domain.value_objects import SubtitleMode
+from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- ADR-026 phase 4: move subtitle-default selection into the domain.
- Add `TrackSelector.select_subtitle` (off / forcedOnly / always / foreignOnly, incl. auto-forced), fed the profile's subtitle language + mode resolved via the cross-BC Preferences port.
- `serialize_tracks` now resolves audio first (foreignOnly needs the chosen audio language) then subtitle, marking exactly one (or zero) subtitle default — normalizing files that declare multiple container-default subs.
- Promote `SubtitleMode` to `shared_kernel`: shared vocabulary between Preferences (stores it) and Media (consumes it), consistent with LanguageCode/MediaType/SubtitleFormat. Preferences re-exports it, so no churn there.
- Invisible to users until the front trusts the server (phase 5); the front still runs its own `pickPreferredSubtitleId` today.

## Test plan

- [x] `pytest tests/modules/media tests/modules/preferences tests/shared_kernel` (2024 passed, 5 skipped)
- [x] New unit coverage: all 4 subtitle modes + edges (FOREIGN_ONLY no-match, mode-OFF strips container default, ALWAYS overrides container default)
- [x] Adapter integration: subtitle_language/subtitle_mode bridged; unbridgeable tag → None
- [x] `ruff check` + `ruff format --check` clean; no new mypy errors on touched files
- [x] Container boots; `/tracks` response keys unchanged (only `is_default` value re-resolved)

## Summary by Sourcery

Resolve default subtitle selection for /tracks on the server using profile playback preferences and shared SubtitleMode, while keeping audio default logic unchanged.

New Features:
- Add TrackSelector.select_subtitle to choose a default subtitle based on audio language, preferred subtitle language, and subtitle mode.
- Support subtitle playback preferences (language and mode) in GetFileTracks, wiring them through the profile playback preference port and adapter to /tracks output.

Enhancements:
- Promote SubtitleMode to shared_kernel as a cross-BC value object reused by Preferences and Media.
- Normalize subtitle defaults in serialize_tracks so at most one text subtitle is marked default, overriding or clearing container defaults according to the subtitle mode.

Documentation:
- Update ADR-005 to document SubtitleMode living in the shared kernel and its role in server-side default track selection.

Tests:
- Add unit tests for subtitle selection behavior across all subtitle modes and edge cases.
- Extend media use case and ACL integration tests to cover subtitle preference bridging and container default normalization.
- Relocate and update subtitle mode unit tests under shared_kernel to reflect its new location.