### PR TITLE
feat(media): OCR image-based subtitles to selectable text (ADR-027)

### DIFF
--- a/docs/adr/ADR-027-ocr-image-based-subtitles.md
+++ b/docs/adr/ADR-027-ocr-image-based-subtitles.md
@@ -1,0 +1,200 @@
+# ADR-027: OCR de Legendas Baseadas em Imagem (PGS/VOBSUB) para Faixas de Texto Selecionáveis
+
+**Status:** Aceito  
+**Data:** 2026-07-04  
+**Deciders:** Lucas Cristovam  
+**Technical Story:** Legendas baseadas em imagem (PGS/SUP/VOBSUB) não aparecem como opção no player — só faixas de texto. Ex. real: filme com 1 SRT + 27 PGS mostra só a SRT; Nausicaä (Ghibli) tem **só** PGS e fica sem legenda alguma. Branch `feat/subtitle-ocr`.
+
+---
+
+## Contexto
+
+O HomeFlix serve legendas ao player como **WebVTT (texto)**. Tanto o endpoint `/tracks`
+(`serialize_tracks`) quanto o pipeline HLS (`_build_master_playlist`,
+`_start_generation`) filtram por `is_text_based`, descartando faixas
+`is_image_based` de propósito — um bitmap não vira WebVTT sem OCR. Não é regressão: é
+limitação de longa data (ver backlog `project_image_subtitle_support_backlog`).
+
+O impacto real é desigual entre acervos. Muitos remuxes de Blu-ray carregam legendas
+**exclusivamente** em PGS (o formato nativo de BD). Nesses títulos o usuário fica sem
+nenhuma legenda selecionável — inclusive em conteúdo onde a legenda é essencial
+(animação japonesa, filme estrangeiro). É o mesmo problema que Plex e Jellyfin
+resolvem com OCR em background.
+
+Um protótipo (2026-07-04) validou a viabilidade contra mídia real (Nausicaä, faixa PGS
+inglesa, 8.8 GB): um parser PGS próprio (decodifica RLE + paleta YCbCr→RGB, pareia
+display-sets show/clear em cues com timing) + **tesseract 5.3.4** produziu **1079 cues,
+0% vazias**, com um único erro sistemático — tesseract lê o "I" isolado como "|",
+corrigível por uma regra de uma linha (`|`→`I`), que zera o resíduo. Custo: ~96 s
+single-thread por faixa (~11 cues/s), decode pixel-perfeito. Sinal claro de **GO**.
+
+Restrições que moldam a decisão:
+
+1. **Faixas de legenda não são persistidas no banco.** São descobertas por probe
+   (ffprobe) na hora. Não há coluna SQL barata para "mídia com PGS sem OCR" — diferente
+   do backfill de thumbnails, que consulta `scrub_preview_path IS NULL`.
+2. **OCR é lento** (dezenas de segundos a minutos por faixa) — muito além dos 120 s que
+   a thread de extração HLS síncrona espera. Precisa ser trabalho de background.
+3. **O runtime de produção é Windows** (o backend chama `ffmpeg.exe`, paths `G:\`). Uma
+   dependência de OCR precisa existir no host Windows, não só no ambiente de dev (WSL).
+4. **ADR-026** já tornou o servidor autoritativo sobre qual faixa é default e o front
+   confia no `/tracks`. Qualquer faixa nova precisa apenas aparecer no `/tracks` como
+   texto para ser selecionável — sem mudança no front.
+
+## Decisão
+
+**Vamos habilitar legendas de imagem via OCR para WebVTT, materializando cada resultado
+como um sidecar de texto em disco que o probe expõe como uma faixa externa de texto —
+gerado por um job de background best-effort, sem migration.**
+
+1. **Representação = faixa externa de texto (VTT).** Para cada faixa `is_image_based`
+   cujo sidecar OCR já existe em disco, o probe passa a expor uma faixa **irmã**
+   `SubtitleTrack(is_external=True, format="vtt", file_path=<ocr.vtt>)` com um `index`
+   novo e único (após o máximo atual). A faixa PGS original permanece (segue filtrada).
+   Sem mutação da faixa de imagem, sem colisão de `sub_N`. Essa representação satisfaz
+   o validador do VO e **todos** os filtros `is_text_based` existentes — flui pelo ramo
+   externo do HLS (`ffmpeg -i ocr.vtt -c:s webvtt`) e pela seleção de default do
+   ADR-026 **sem alterar** o código de extração/serving.
+
+2. **Sidecar determinístico em disco, sem migration.** A saída OCR vive em
+   `<pasta-do-arquivo>/<subdir>/<stem>/ocr_s<streamIdx>_<lang>.vtt` (espelha
+   `scrub_preview_output_dir` do thumbnail). "Feito" = o arquivo existe. Um marcador
+   por-arquivo (`.ocr_done`) permite o job pular arquivos já processados **sem coluna
+   no banco** — contornando a restrição de que faixas não são persistidas.
+
+3. **Exposição = função pura aplicada em toda leitura de probe.**
+   `attach_ocr_subtitles(probe, source)` roda tanto em `HlsService.probe_tracks` (alimenta
+   `/tracks`) quanto em `_start_generation` (alimenta o HLS), recomputando `file_path` a
+   partir do caminho determinístico a cada vez. Isso contorna o gap conhecido em que
+   `_save/_deserialize_probe` não persiste `file_path` de faixas externas.
+
+4. **Geração = job de background agendado** (modelo Plex/Jellyfin — legenda pronta antes
+   de reproduzir), espelhando `ThumbnailBackfillJob`: varre a mídia em lotes, pula via
+   marcador `.ocr_done`, faz probe das faixas de imagem, OCR das faltantes, grava sidecar
+   + marcador. Registrado no scheduler com `job_id="homeflix:subtitle-ocr"` — a gravação
+   de `JobRun` e o dashboard `/admin/jobs` vêm de graça. `enabled`/lote/intervalo/langs
+   ficam em `SubtitleOcrConfig` persistido (ADR-013/014). Trigger eager on-play e endpoint
+   manual ficam adiados (best-effort primeiro).
+
+5. **Tesseract como dependência de OCR do host.** O serviço de OCR faz shell-out para
+   `tesseract` (como já faz para `ffmpeg`). O binário e os idiomas habilitados ficam em
+   config. **Produção exige tesseract no host Windows** (`choco install tesseract` + os
+   `tessdata` dos idiomas). Documentado como pré-requisito de deploy.
+
+6. **Mapa de idioma + best-effort.** ISO 639-1 (`en`/`pt`/`fr`) → tesseract 639-2/T
+   (`eng`/`por`/`fra`). Idioma desconhecido/sem `tessdata` → faixa pulada (logado).
+   Qualidade de OCR varia por fonte; assim como o detector de créditos (ADR-021), é
+   **best-effort** — sem ground-truth garantido, apoiado por refazível (deletar o sidecar
+   re-elege a faixa).
+
+## Consequências
+
+### Positivas
+
+- Legendas PGS/VOBSUB tornam-se **selecionáveis como texto**, incluindo títulos onde é
+  a única legenda existente (Blu-ray remux, animação).
+- Integra-se **sem alterar** o serving HLS, o `/tracks` ou a seleção de default do
+  ADR-026 — a faixa OCR é apenas mais uma faixa de texto.
+- **Zero migration** e zero mudança no front (backend-only). Idempotente e refazível
+  (o sidecar é derivado; apagar re-processa).
+- Observável de graça (`JobRun` + `/admin/jobs`) por reusar a maquinaria do scheduler.
+
+### Negativas
+
+- Nova dependência externa de runtime (**tesseract**) no host Windows — mais uma peça
+  de deploy além do ffmpeg.
+- OCR é caro (dezenas de segundos por faixa); o primeiro sweep de um acervo grande com
+  muito PGS consome CPU por bastante tempo (mitigado por lote + best-effort).
+- Qualidade não é garantida (fontes difíceis, estilos, idiomas sem `tessdata` bom).
+- Poluição leve do diretório de mídia com sidecars `.homeflix/subtitles/...` (mesmo
+  padrão já aceito para thumbnails).
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Faixa OCR quebra o player (índice/rendition inconsistente) | Baixa | Alto | Índice novo único; smoke test manual obrigatório antes de push (regra player-risk) |
+| tesseract ausente no host de produção | Média | Médio | Config `enabled=false` por default até o operador instalar; job degrada e loga |
+| OCR ruim vira legenda pior que nada | Média | Baixo | Best-effort + refazível (apagar sidecar); pós-fix `|`→`I`; faixa original PGS permanece |
+| Sweep satura CPU num acervo grande | Média | Médio | Lote (`batch_size`) + intervalo configuráveis; sequencial |
+
+## Alternativas Consideradas
+
+### 1. Burn-in (hardsub)
+
+Re-encodar o vídeo com a legenda de imagem sobreposta.
+
+**Rejeitado porque:** caro (re-encode por seleção), perde o "desligar legenda" e a
+troca de idioma, e é irreversível por faixa. OCR entrega texto real, selecionável e
+estilizável.
+
+### 2. Persistir faixas de legenda no banco + coluna de estado OCR
+
+Gravar as faixas no scan e ter uma coluna `ocr_state` para o job consultar (como
+`intro_detection_state`).
+
+**Rejeitado porque:** exige migration e mudança ampla no scanner (que hoje não persiste
+faixas), para eliminar um re-probe que o marcador `.ocr_done` em disco já resolve a
+custo baixo. Reavaliar se surgir necessidade de query/relatório sobre faixas.
+
+### 3. OCR eager on-play apenas (sem sweep)
+
+OCR disparado só quando alguém abre um título com PGS.
+
+**Rejeitado como MVP porque:** o primeiro play espera ~15–90 s sem legenda (UX ruim). O
+sweep agendado deixa a legenda pronta antes. O trigger eager fica como fase opcional
+posterior, complementar ao sweep.
+
+### 4. Won't-fix
+
+**Rejeitado porque:** o protótipo mostrou qualidade e custo aceitáveis, e o impacto em
+acervos só-PGS é alto (legenda essencial ausente).
+
+## Referências
+
+- Backlog: memória `project_image_subtitle_support_backlog` (descoberta + protótipo validado)
+- ADR-013/014 — Runtime Settings persistidos por bucket (`SubtitleOcrConfig`)
+- ADR-021 — Detector de Créditos (precedente best-effort per-arquivo + job + config)
+- ADR-026 — Seleção de Faixa Default Autoritativa no Servidor (a faixa OCR entra na seleção)
+- `ThumbnailBackfillJob` — blueprint do job de background (path determinístico, lote, JobRun)
+
+---
+
+## Notas de Implementação
+
+Representação da faixa OCR (satisfaz o validador e todos os filtros de texto):
+
+```python
+SubtitleTrack(
+    index=next_index,          # único, após o máx atual (evita colisão de sub_N)
+    language=pgs_track.language,
+    format="vtt",
+    is_external=True,
+    file_path=FilePath(str(ocr_vtt_path)),
+)
+```
+
+Caminho determinístico do sidecar (espelha `scrub_preview_output_dir`):
+
+```python
+def ocr_subtitle_output_dir(source: Path, subdir: str) -> Path:
+    # <source-dir>/<subdir>/<source-stem>/
+    return source.parent / subdir / source.stem
+```
+
+Rollout faseado (1 PR por fase; commits locais):
+
+1. **ADR-027** (este documento).
+2. **Pipeline OCR** — `SubtitleOcrPort` + `TesseractPgsOcrService` + `SubtitleOcrConfig`
+   (sem wiring, sem impacto no player).
+3. **Exposição** — `attach_ocr_subtitles` em `probe_tracks` + `_start_generation`
+   (⚠️ risco player → smoke test antes de push).
+4. **Job de background** — `SubtitleOcrBackfillJob` + DI + registro no scheduler.
+5. **Opcional/adiado** — trigger eager on-play, endpoint admin "OCR agora", rótulo
+   "(OCR)" no front.
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-07-04 | Lucas Cristovam | Criação inicial (decisão + rollout faseado) |

--- a/docs/adr/ADR-027-ocr-image-based-subtitles.md
+++ b/docs/adr/ADR-027-ocr-image-based-subtitles.md
@@ -152,6 +152,7 @@ acervos só-PGS é alto (legenda essencial ausente).
 
 ## Referências
 
+- **Guia operacional:** [`docs/standards/subtitle-ocr-guide.md`](../standards/subtitle-ocr-guide.md) (instalação do tesseract + modelos, configuração, trigger manual, observabilidade)
 - Backlog: memória `project_image_subtitle_support_backlog` (descoberta + protótipo validado)
 - ADR-013/014 — Runtime Settings persistidos por bucket (`SubtitleOcrConfig`)
 - ADR-021 — Detector de Créditos (precedente best-effort per-arquivo + job + config)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-024](./ADR-024-published-presentation-contracts-cross-bc.md) | Contratos de Presentation Publicados para Imports Cross-BC | ✅ Aceito | 2026-06-29 |
 | [ADR-025](./ADR-025-provider-metadata-reconciliation-in-application.md) | Reconciliação de Metadados de Provider é Concern de Application | ✅ Aceito | 2026-06-29 |
 | [ADR-026](./ADR-026-server-authoritative-track-selection.md) | Seleção de Faixa Default Autoritativa no Servidor a partir de Preferência por Usuário | ✅ Aceito | 2026-06-30 |
+| [ADR-027](./ADR-027-ocr-image-based-subtitles.md) | OCR de Legendas Baseadas em Imagem (PGS/VOBSUB) para Faixas de Texto Selecionáveis | ✅ Aceito | 2026-07-04 |
 
 ## Como Criar um Novo ADR
 

--- a/docs/standards/subtitle-ocr-guide.md
+++ b/docs/standards/subtitle-ocr-guide.md
@@ -1,0 +1,226 @@
+# Guia — OCR de Legendas Baseadas em Imagem (PGS/SUP)
+
+Este guia cobre a instalação, configuração e operação do **OCR de
+legendas** (ADR-027): a conversão de legendas baseadas em imagem
+(PGS/SUP, comuns em remuxes de Blu-ray) em texto WebVTT selecionável no
+player.
+
+> **Fonte da verdade da decisão:** [`docs/adr/ADR-027-ocr-image-based-subtitles.md`](../adr/ADR-027-ocr-image-based-subtitles.md).
+
+---
+
+## 1. Visão Geral
+
+Legendas de imagem não são selecionáveis no player porque o HLS serve
+legenda como texto (WebVTT). Este recurso faz **OCR** dessas faixas para
+sidecars de texto em disco, que o probe passa a expor como faixas de
+texto normais.
+
+Fluxo: **job de background** (ou **trigger manual**) → OCR → sidecar
+`.vtt` no disco → o probe expõe como faixa externa de texto → aparece no
+`/tracks` e vira uma rendition `sub_N` no HLS → selecionável no player.
+
+É **best-effort**: a qualidade varia por fonte, e depende de o idioma ter
+modelo de OCR instalado no host.
+
+---
+
+## 2. Pré-requisitos
+
+O backend roda **Windows-native** (chama `ffmpeg`/`ffprobe`/`tesseract`
+via `PATH`). O host precisa de:
+
+| Dependência | Uso |
+|-------------|-----|
+| **ffmpeg + ffprobe** | Demux da faixa PGS + probe de faixas |
+| **tesseract** | Motor de OCR |
+| **modelos de idioma (`*.traineddata`)** | Um por idioma que se queira extrair |
+
+> Sem tesseract, o job **pula todo tick** e o trigger manual grava um run
+> `FAILED` ("No tesseract language models installed") — nada é marcado
+> como processado silenciosamente.
+
+---
+
+## 3. Instalação (host Windows)
+
+### 3.1. tesseract
+
+```powershell
+choco install tesseract
+```
+
+Confirme que está no `PATH`:
+
+```powershell
+tesseract --version
+```
+
+Se não estiver no `PATH`, informe o caminho completo em
+`tesseract_binary` (ver §4).
+
+### 3.2. Modelos de idioma
+
+O pacote choco instala normalmente **só o inglês** (`eng`). Cada idioma
+adicional exige o `*.traineddata` correspondente na pasta `tessdata` do
+tesseract (ex.: `C:\Program Files\Tesseract-OCR\tessdata\`).
+
+Baixe o modelo do idioma desejado do repositório oficial e copie para
+`tessdata`. Exemplo para **português**:
+
+- <https://github.com/tesseract-ocr/tessdata_fast/blob/main/por.traineddata>
+  → salvar como `...\tessdata\por.traineddata`
+
+Confirme os modelos instalados:
+
+```powershell
+tesseract --list-langs
+```
+
+> **`SEM MODELO` na tela de execuções = o `*.traineddata` daquele idioma
+> não está no host.** Instale o modelo e reprocesse (ver §7).
+
+Mapeamento ISO 639-1 → modelo tesseract usado internamente:
+`en→eng`, `pt→por`, `fr→fra`, `es→spa`, `de→deu`, `it→ita`, `nl→nld`,
+`pl→pol`, `ru→rus`, `sv→swe`, `no→nor`, `da→dan`, `fi→fin`, `tr→tur`,
+`cs→ces`, `ja→jpn`, `ko→kor`, `zh→chi_sim`, `ar→ara`, `hi→hin`.
+Idioma fora dessa lista → `SEM MODELO`.
+
+### 3.3. Migration do banco
+
+O recurso persiste um log de execuções na tabela `subtitle_ocr_runs`.
+Rode a migration **antes** de subir o servidor:
+
+```bash
+make migrate      # revision 5d0b7e1c9a3f
+```
+
+> Se subir o dev server antes do migrate, `Base.metadata.create_all` cria
+> a tabela e o migrate depois falha com "table already exists". Nesse caso:
+> `poetry run alembic stamp 5d0b7e1c9a3f` (a tabela já está correta).
+
+---
+
+## 4. Configuração (bucket `subtitle_ocr`)
+
+Os knobs ficam no bucket de runtime settings `subtitle_ocr` (ADR-013/014),
+editável em **Admin → OCR de legendas** (card de settings) ou via API.
+
+| Campo | Default | Descrição |
+|-------|---------|-----------|
+| `enabled` | `false` | Liga o **job periódico**. O trigger manual funciona mesmo com isto desligado. |
+| `batch_size` | `2` | Arquivos processados por tick do job. OCR é caro — mantenha baixo. |
+| `interval_minutes` | `60` | Cadência do job. |
+| `subdir` | `.homeflix/subtitles` | Subpasta (relativa à pasta do arquivo) dos sidecars + marcador. |
+| `languages` | `[]` (todos) | Códigos ISO 639-1 a processar (ex.: `["pt","en"]`). **Vazio = todos os mapeáveis.** |
+| `tesseract_binary` | `tesseract` | Nome ou caminho completo do executável. |
+| `per_cue_timeout_seconds` | `30` | Timeout de uma chamada tesseract (uma legenda). |
+
+> ⚠️ **Defina `languages`.** Alguns remuxes carregam 20+ faixas PGS (ex.:
+> Rush Hour tem 27). Com `languages` vazio, o job **e** o trigger manual
+> fazem OCR de todas — horas de trabalho. Restrinja ao(s) seu(s) idioma(s).
+
+### 4.1. Via API
+
+```http
+PATCH /api/v1/admin/settings/subtitle-ocr
+Content-Type: application/json
+
+{
+  "enabled": true,
+  "batch_size": 2,
+  "interval_minutes": 60,
+  "subdir": ".homeflix/subtitles",
+  "languages": ["pt", "en"],
+  "tesseract_binary": "tesseract",
+  "per_cue_timeout_seconds": 30
+}
+```
+
+> Update é **full-replace**: envie o objeto inteiro. Alterar `languages`
+> vale no próximo tick/trigger sem restart (o snapshot invalida ao salvar).
+> Ligar/desligar o **job** exige restart (registro no boot).
+
+---
+
+## 5. Como Funciona
+
+### 5.1. Job de background (`homeflix:subtitle-ocr`)
+
+Registrado no scheduler quando `enabled=true` (no boot). Varre
+filmes/episódios, pula arquivos com marcador `.ocr_done` em disco, faz
+probe das faixas de imagem, OCR das faltantes (respeitando `languages`),
+grava sidecar + marcador, e registra um `SubtitleOcrRun`. Aparece no
+dashboard **Admin → Jobs** e permite "Run now".
+
+### 5.2. Trigger manual ("OCR neste título agora")
+
+Botão **admin** no detalhe do **filme** (ícone de legendas) dispara OCR
+sob demanda para aquele título:
+
+```http
+POST /api/v1/admin/subtitle-ocr/movies/{movie_id}/run      # 202 Accepted
+POST /api/v1/admin/subtitle-ocr/episodes/{episode_id}/run  # 202 Accepted
+```
+
+- É **fire-and-forget** (202): o OCR roda em background; o resultado
+  aparece na página de execuções quando termina (minutos).
+- Ignora o marcador `.ocr_done` (sempre reprocessa) mas **respeita
+  `languages`**.
+- Não exige o job periódico ligado.
+- `tesseract` ausente → grava um run `FAILED`.
+
+> O botão por-episódio (SeriesDetail) ainda não existe na UI; o endpoint
+> `/episodes/{id}/run` já funciona.
+
+### 5.3. Exposição no player
+
+Uma vez que o sidecar existe em disco, o probe o expõe como faixa externa
+de texto (sem alterar o serving HLS/`/tracks`). **Só faz efeito com o
+bucket `subtitle_ocr` `enabled=true`.** Se o título já foi transmitido, o
+`master.m3u8` está cacheado sem a rendition — limpe o cache HLS do título
+(**Admin → HLS Cache**, ou `DELETE /api/v1/stream/movie/{id}/hls/cache`)
+para regenerar.
+
+### 5.4. Observabilidade (**Admin → OCR de legendas**)
+
+`GET /api/v1/admin/subtitle-ocr/runs` — histórico por arquivo: título,
+desfecho, nº de faixas de imagem e, por faixa, idioma + desfecho +
+nº de legendas (cues) extraídas. Desfechos por-faixa: `extracted`,
+`no_text`, `unsupported_format`, `no_language_model` (SEM MODELO),
+`skipped_language`, `failed`.
+
+---
+
+## 6. Formatos Suportados
+
+- ✅ **PGS / SUP** (`hdmv_pgs_subtitle`) — decodificados e OCR'd.
+- ❌ **VOBSUB / IDX** — layout de bitmap diferente; retornam
+  `unsupported_format` (não implementado).
+- Legendas de **texto** (SRT/ASS/VTT) não passam por OCR — já são
+  selecionáveis diretamente.
+
+---
+
+## 7. Reprocessar um Título
+
+O marcador `.ocr_done` faz o job pular arquivos já processados. Para
+reprocessar (ex.: depois de instalar um novo modelo de idioma):
+
+- **Trigger manual:** já ignora o marcador — basta disparar de novo.
+- **Job periódico:** apague o marcador
+  `<pasta-do-arquivo>/.homeflix/subtitles/<stem>/.ocr_done`.
+- Para descartar o texto OCR'd, apague também os `ocr_s*.vtt` da mesma
+  pasta.
+
+---
+
+## 8. Diagnóstico Rápido
+
+| Sintoma | Causa provável | Ação |
+|---------|----------------|------|
+| Faixa diz `SEM MODELO` | `*.traineddata` do idioma ausente | Instalar o modelo em `tessdata` (§3.2) + reprocessar |
+| Nenhum run aparece / demora demais | `languages` vazio + título com muitas faixas PGS | Definir `languages` (§4) + reiniciar (mata a task) |
+| Run `FAILED` "No tesseract..." | tesseract fora do `PATH`/ausente | Instalar tesseract ou ajustar `tesseract_binary` |
+| Legenda OCR não aparece no player | cache HLS antigo do título | Limpar cache HLS do título (§5.3) |
+| Migrate falha "table already exists" | dev server rodou antes do migrate | `alembic stamp 5d0b7e1c9a3f` (§3.3) |

--- a/docs/standards/subtitle-ocr-guide.md
+++ b/docs/standards/subtitle-ocr-guide.md
@@ -172,8 +172,10 @@ POST /api/v1/admin/subtitle-ocr/episodes/{episode_id}/run  # 202 Accepted
 - Não exige o job periódico ligado.
 - `tesseract` ausente → grava um run `FAILED`.
 
-> O botão por-episódio (SeriesDetail) ainda não existe na UI; o endpoint
-> `/episodes/{id}/run` já funciona.
+> **Episódios não têm botão na UI, por design:** são melhor cobertos pelo
+> job periódico (com `languages` setado) — que converge o acervo — e pelo
+> endpoint `/episodes/{id}/run` para disparos avulsos via API. O botão fica
+> só no detalhe do filme.
 
 ### 5.3. Exposição no player
 

--- a/docs/standards/subtitle-ocr-guide.md
+++ b/docs/standards/subtitle-ocr-guide.md
@@ -164,7 +164,9 @@ POST /api/v1/admin/subtitle-ocr/episodes/{episode_id}/run  # 202 Accepted
 ```
 
 - É **fire-and-forget** (202): o OCR roda em background; o resultado
-  aparece na página de execuções quando termina (minutos).
+  aparece na página de execuções quando termina (minutos). Cliques
+  repetidos no mesmo título enquanto ele processa são ignorados
+  (single-flight; a resposta traz `"triggered": false`).
 - Ignora o marcador `.ocr_done` (sempre reprocessa) mas **respeita
   `languages`**.
 - Não exige o job periódico ligado.

--- a/migrations/versions/2026_07_04_add_subtitle_ocr_runs.py
+++ b/migrations/versions/2026_07_04_add_subtitle_ocr_runs.py
@@ -1,0 +1,85 @@
+"""Add subtitle_ocr_runs audit table.
+
+Append-only log written by the subtitle-OCR job / manual trigger: one
+row per media file with image-based subtitles processed, with per-track
+results (JSON) — so operators can see which titles were processed and
+what was extracted (ADR-027).
+
+Revision ID: 5d0b7e1c9a3f
+Revises: c4a9e7b1d6f3
+Create Date: 2026-07-04 12:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "5d0b7e1c9a3f"
+down_revision: str | Sequence[str] | None = "c4a9e7b1d6f3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``subtitle_ocr_runs`` table."""
+    op.create_table(
+        "subtitle_ocr_runs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("external_id", sa.String(length=50), nullable=False),
+        sa.Column("media_kind", sa.String(length=20), nullable=False),
+        sa.Column("media_id", sa.String(length=50), nullable=False),
+        sa.Column(
+            "media_title",
+            sa.String(length=500),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        sa.Column("file_path", sa.String(length=1000), nullable=False),
+        sa.Column("outcome", sa.String(length=30), nullable=False),
+        sa.Column("image_track_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("extracted_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("track_results", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+        sa.Column("error", sa.String(length=2000), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_subtitle_ocr_runs_external_id",
+        "subtitle_ocr_runs",
+        ["external_id"],
+        unique=True,
+    )
+    op.create_index("ix_subtitle_ocr_runs_media_kind", "subtitle_ocr_runs", ["media_kind"])
+    op.create_index("ix_subtitle_ocr_runs_media_id", "subtitle_ocr_runs", ["media_id"])
+    op.create_index("ix_subtitle_ocr_runs_outcome", "subtitle_ocr_runs", ["outcome"])
+    op.create_index("ix_subtitle_ocr_runs_deleted_at", "subtitle_ocr_runs", ["deleted_at"])
+
+
+def downgrade() -> None:
+    """Drop the ``subtitle_ocr_runs`` table."""
+    op.drop_index("ix_subtitle_ocr_runs_deleted_at", table_name="subtitle_ocr_runs")
+    op.drop_index("ix_subtitle_ocr_runs_outcome", table_name="subtitle_ocr_runs")
+    op.drop_index("ix_subtitle_ocr_runs_media_id", table_name="subtitle_ocr_runs")
+    op.drop_index("ix_subtitle_ocr_runs_media_kind", table_name="subtitle_ocr_runs")
+    op.drop_index("ix_subtitle_ocr_runs_external_id", table_name="subtitle_ocr_runs")
+    op.drop_table("subtitle_ocr_runs")

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -25,6 +25,7 @@ from src.infrastructure.scheduling import (
     IntroDetectionJob,
     LibraryScanScheduler,
     ScanDedupSweepJob,
+    SubtitleOcrBackfillJob,
     ThumbnailBackfillJob,
 )
 from src.modules.identity.infrastructure.persistence.sqlalchemy_unit_of_work import (
@@ -331,6 +332,14 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         ScanDedupSweepJob,
         sweep_use_case=media.sweep_movie_conflicts,
         runtime_settings=settings.runtime_settings,
+    )
+
+    subtitle_ocr_job = providers.Singleton(
+        SubtitleOcrBackfillJob,
+        media_uow_factory=media.media_unit_of_work_factory,
+        runtime_settings=settings.runtime_settings,
+        ocr_service=media.subtitle_ocr_service,
+        probe_service=media.media_probe_service,
     )
 
 

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -74,6 +74,9 @@ from src.modules.media.application.use_cases.get_series_by_id import GetSeriesBy
 from src.modules.media.application.use_cases.get_series_tmdb_suggestions import (
     GetSeriesTmdbSuggestionsUseCase,
 )
+from src.modules.media.application.use_cases.get_subtitle_ocr_run import (
+    GetSubtitleOcrRunUseCase,
+)
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.application.use_cases.list_conflicts import ListConflictsUseCase
 from src.modules.media.application.use_cases.list_credits_status import (
@@ -102,6 +105,9 @@ from src.modules.media.application.use_cases.list_scan_runs import ListScanRunsU
 from src.modules.media.application.use_cases.list_series import ListSeriesUseCase
 from src.modules.media.application.use_cases.list_series_needing_review import (
     ListSeriesNeedingReviewUseCase,
+)
+from src.modules.media.application.use_cases.list_subtitle_ocr_runs import (
+    ListSubtitleOcrRunsUseCase,
 )
 from src.modules.media.application.use_cases.promote_movie_to_series import (
     PromoteMovieToSeriesUseCase,
@@ -702,6 +708,16 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
 
     get_intro_detection_run = providers.Factory(
         GetIntroDetectionRunUseCase,
+        media_uow_factory=media_unit_of_work_factory,
+    )
+
+    list_subtitle_ocr_runs = providers.Factory(
+        ListSubtitleOcrRunsUseCase,
+        media_uow_factory=media_unit_of_work_factory,
+    )
+
+    get_subtitle_ocr_run = providers.Factory(
+        GetSubtitleOcrRunUseCase,
         media_uow_factory=media_unit_of_work_factory,
     )
 

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -8,6 +8,9 @@ from dependency_injector import containers, providers
 from src.modules.media.application.event_handlers import OnMediaCreatedHandler
 from src.modules.media.application.services.job_run_service import JobRunService
 from src.modules.media.application.services.scan_run_service import ScanRunService
+from src.modules.media.application.services.subtitle_ocr_processor import (
+    SubtitleOcrProcessor,
+)
 from src.modules.media.application.use_cases.add_file_variant import AddFileVariantUseCase
 from src.modules.media.application.use_cases.bulk_enrich_metadata import (
     BulkEnrichMetadataUseCase,
@@ -123,6 +126,9 @@ from src.modules.media.application.use_cases.reset_season_intro_detection import
 )
 from src.modules.media.application.use_cases.resolve_media_conflict import (
     ResolveMediaConflictUseCase,
+)
+from src.modules.media.application.use_cases.run_subtitle_ocr_for_media import (
+    RunSubtitleOcrForMediaUseCase,
 )
 from src.modules.media.application.use_cases.scan_media_directories import (
     ScanMediaDirectoriesUseCase,
@@ -719,6 +725,20 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     get_subtitle_ocr_run = providers.Factory(
         GetSubtitleOcrRunUseCase,
         media_uow_factory=media_unit_of_work_factory,
+    )
+
+    subtitle_ocr_processor = providers.Singleton(
+        SubtitleOcrProcessor,
+        probe_service=media_probe_service,
+        ocr_service=subtitle_ocr_service,
+    )
+
+    run_subtitle_ocr_for_media = providers.Factory(
+        RunSubtitleOcrForMediaUseCase,
+        media_uow_factory=media_unit_of_work_factory,
+        processor=subtitle_ocr_processor,
+        ocr_service=subtitle_ocr_service,
+        config=runtime_settings,
     )
 
     sweep_interrupted_scan_runs = providers.Factory(

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -166,7 +166,11 @@ from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
 from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyMediaUnitOfWorkFactory,
 )
-from src.modules.media.infrastructure.streaming import HlsService, MediaProbeService
+from src.modules.media.infrastructure.streaming import (
+    HlsService,
+    MediaProbeService,
+    TesseractPgsOcrService,
+)
 from src.modules.media.infrastructure.streaming.file_streamer import LocalFileStreamer
 from src.modules.media.infrastructure.streaming.now_playing_registry import (
     NowPlayingRegistry,
@@ -425,6 +429,8 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     variant_detector = providers.Factory(VariantDetector)
 
     media_probe_service = providers.Singleton(MediaProbeService)
+
+    subtitle_ocr_service = providers.Singleton(TesseractPgsOcrService)
 
     hls_service = providers.Singleton(
         HlsService,

--- a/src/infrastructure/scheduling/__init__.py
+++ b/src/infrastructure/scheduling/__init__.py
@@ -9,6 +9,7 @@ from src.infrastructure.scheduling.credits_detection_job import CreditsDetection
 from src.infrastructure.scheduling.intro_detection_job import IntroDetectionJob
 from src.infrastructure.scheduling.scan_dedup_sweep_job import ScanDedupSweepJob
 from src.infrastructure.scheduling.scheduler_service import LibraryScanScheduler
+from src.infrastructure.scheduling.subtitle_ocr_job import SubtitleOcrBackfillJob
 from src.infrastructure.scheduling.thumbnail_backfill_job import ThumbnailBackfillJob
 
 __all__ = [
@@ -16,5 +17,6 @@ __all__ = [
     "IntroDetectionJob",
     "LibraryScanScheduler",
     "ScanDedupSweepJob",
+    "SubtitleOcrBackfillJob",
     "ThumbnailBackfillJob",
 ]

--- a/src/infrastructure/scheduling/subtitle_ocr_job.py
+++ b/src/infrastructure/scheduling/subtitle_ocr_job.py
@@ -1,0 +1,213 @@
+"""Periodic backfill of OCR text sidecars for image-based subtitles.
+
+For each movie/episode that has not been processed yet, probes the file
+for image-based subtitle tracks (PGS/SUP) and OCRs each into a text
+WebVTT sidecar (ADR-027). Once a file's OCR sidecars exist, the probe
+surfaces them as selectable text subtitles (see
+``subtitle_ocr_surfacing``); the catalog therefore converges to "every
+PGS subtitle has a text sibling" without any user interaction.
+
+Work discovery is a per-file ``.ocr_done`` marker on disk, not a DB
+column: subtitle tracks are not persisted, so there is no cheap SQL
+predicate. The marker means "attempted" — it is written whenever a file
+is processed under a functioning tesseract, so a genuinely unusable
+track (e.g. VOBSUB) does not block the queue. To reprocess a file (after
+installing a new language model, say), delete its marker.
+
+If tesseract has no language models installed, the whole tick is skipped
+and no markers are written, so nothing is silently marked done while OCR
+is non-functional.
+
+Each tick processes at most ``batch_size`` files (movies first, then
+episodes) to keep CPU bounded — OCR is expensive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.config.logging import get_logger
+from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrOptions
+from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
+    ocr_subtitle_output_dir,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from src.modules.media.application.ports.media_probe_port import MediaProbePort
+    from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrPort
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.domain.entities import Episode, Movie
+    from src.modules.settings.domain.value_objects import SubtitleOcrConfig
+    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+
+_logger = get_logger()
+
+#: Sentinel written into a file's OCR output dir once it has been
+#: processed, so subsequent ticks skip it without re-probing.
+OCR_DONE_MARKER = ".ocr_done"
+
+
+class SubtitleOcrBackfillJob:
+    """OCR image-based subtitles to text sidecars for media missing them.
+
+    Movies are processed before episodes within the shared per-tick
+    budget, so a series of ticks grinds through the movie backlog first.
+    All knobs (``batch_size``, ``subdir``, ``languages``,
+    ``tesseract_binary``, ``per_cue_timeout_seconds``) are read from
+    :class:`RuntimeSettings` per ``run()`` so admin edits propagate to
+    the next tick without restart (ADR-013).
+
+    Args:
+        media_uow_factory: Builds fresh media UoWs per query. The job
+            opens a short-lived UoW to list media, then does OCR (slow,
+            off-session) without holding a DB session.
+        runtime_settings: Snapshot facade for :class:`SubtitleOcrConfig`
+            (and streaming ``ffmpeg_threads``).
+        ocr_service: The OCR engine (:class:`SubtitleOcrPort`).
+        probe_service: Discovers each file's subtitle tracks.
+    """
+
+    def __init__(
+        self,
+        media_uow_factory: MediaUnitOfWorkFactory,
+        runtime_settings: RuntimeSettings,
+        ocr_service: SubtitleOcrPort,
+        probe_service: MediaProbePort,
+    ) -> None:
+        self._media_uow_factory = media_uow_factory
+        self._runtime_settings = runtime_settings
+        self._ocr_service = ocr_service
+        self._probe = probe_service
+
+    async def run(self) -> None:
+        """Process one batch of media missing OCR sidecars."""
+        config = await self._runtime_settings.subtitle_ocr()
+        if not config.enabled:
+            return
+
+        available = self._ocr_service.available_languages(config.tesseract_binary)
+        if not available:
+            _logger.warning("[subtitle-ocr] no tesseract languages installed; skipping tick")
+            return
+
+        streaming = await self._runtime_settings.streaming()
+        options = SubtitleOcrOptions(
+            tesseract_binary=config.tesseract_binary,
+            per_cue_timeout_seconds=config.per_cue_timeout_seconds,
+            ffmpeg_threads=streaming.ffmpeg_threads,
+        )
+
+        budget = config.batch_size
+        movies = await self._unprocessed_movie_files(config.subdir, budget)
+        for source in movies:
+            await self._process_file(source, config, options)
+
+        episodes_done = 0
+        budget -= len(movies)
+        if budget > 0:
+            episodes = await self._unprocessed_episode_files(config.subdir, budget)
+            for source in episodes:
+                await self._process_file(source, config, options)
+            episodes_done = len(episodes)
+
+        if movies or episodes_done:
+            _logger.info(
+                "[subtitle-ocr] tick complete",
+                movies=len(movies),
+                episodes=episodes_done,
+                batch_size=config.batch_size,
+            )
+
+    async def _unprocessed_movie_files(self, subdir: str, limit: int) -> list[Path]:
+        async with self._media_uow_factory() as uow:
+            movies = await uow.movies.list_all()
+        return self._collect_unprocessed((self._primary_path(m) for m in movies), subdir, limit)
+
+    async def _unprocessed_episode_files(self, subdir: str, limit: int) -> list[Path]:
+        async with self._media_uow_factory() as uow:
+            series = await uow.series.list_all()
+        episodes = (
+            self._primary_path(episode)
+            for s in series
+            for season in s.seasons
+            for episode in season.episodes
+        )
+        return self._collect_unprocessed(episodes, subdir, limit)
+
+    @staticmethod
+    def _collect_unprocessed(sources: Iterable[Path | None], subdir: str, limit: int) -> list[Path]:
+        """Take the first ``limit`` on-disk files that lack a done marker."""
+        out: list[Path] = []
+        for source in sources:
+            if source is None or not source.is_file():
+                continue
+            if (ocr_subtitle_output_dir(source, subdir) / OCR_DONE_MARKER).exists():
+                continue
+            out.append(source)
+            if len(out) >= limit:
+                break
+        return out
+
+    @staticmethod
+    def _primary_path(entity: Movie | Episode) -> Path | None:
+        primary = entity.primary_file
+        if primary is None:
+            return None
+        return Path(primary.file_path.value)
+
+    async def _process_file(
+        self,
+        source: Path,
+        config: SubtitleOcrConfig,
+        options: SubtitleOcrOptions,
+    ) -> None:
+        """OCR a single file's image subtitles, then mark it processed.
+
+        Runs off the event loop (probe + OCR are synchronous, CPU/IO
+        bound). Best-effort: any failure is logged and the file is still
+        marked processed (the marker means "attempted"), so one bad file
+        never wedges the queue — the operator deletes the marker to retry.
+        """
+        try:
+            await asyncio.to_thread(self._ocr_file, source, config, options)
+        except Exception:
+            _logger.exception(
+                "[subtitle-ocr] failed to process file", extra={"source": str(source)}
+            )
+        self._write_marker(source, config.subdir)
+
+    def _ocr_file(
+        self,
+        source: Path,
+        config: SubtitleOcrConfig,
+        options: SubtitleOcrOptions,
+    ) -> None:
+        """Probe ``source`` and OCR each image subtitle track (sync)."""
+        probe = self._probe.probe(str(source))
+        image_tracks = [t for t in probe.all_subtitles if t.is_image_based]
+        wanted = _language_filter(config.languages)
+        output_dir = ocr_subtitle_output_dir(source, config.subdir)
+        for track in image_tracks:
+            if wanted is not None and track.language.value.lower() not in wanted:
+                continue
+            self._ocr_service.ocr_track(str(source), track, output_dir, options)
+
+    @staticmethod
+    def _write_marker(source: Path, subdir: str) -> None:
+        output_dir = ocr_subtitle_output_dir(source, subdir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / OCR_DONE_MARKER).write_text("", encoding="utf-8")
+
+
+def _language_filter(languages: tuple[str, ...]) -> frozenset[str] | None:
+    """Return the lowercased ISO allow-set, or None for 'all languages'."""
+    if not languages:
+        return None
+    return frozenset(lang.lower() for lang in languages)
+
+
+__all__ = ["OCR_DONE_MARKER", "SubtitleOcrBackfillJob"]

--- a/src/infrastructure/scheduling/subtitle_ocr_job.py
+++ b/src/infrastructure/scheduling/subtitle_ocr_job.py
@@ -36,15 +36,16 @@ from typing import TYPE_CHECKING
 
 from src.config.logging import get_logger
 from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrOptions
+from src.modules.media.application.services.subtitle_ocr_paths import (
+    OCR_DONE_MARKER,
+    ocr_subtitle_output_dir,
+)
 from src.modules.media.application.services.subtitle_ocr_processor import (
     FileOcrReport,
     SubtitleOcrProcessor,
 )
 from src.modules.media.domain.entities.subtitle_ocr_run import SubtitleOcrRun
 from src.modules.media.domain.value_objects.subtitle_ocr_outcome import SubtitleOcrOutcome
-from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
-    ocr_subtitle_output_dir,
-)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -57,10 +58,6 @@ if TYPE_CHECKING:
     from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = get_logger()
-
-#: Sentinel written into a file's OCR output dir once it has been
-#: processed, so subsequent ticks skip it without re-probing.
-OCR_DONE_MARKER = ".ocr_done"
 
 
 @dataclass(frozen=True)

--- a/src/infrastructure/scheduling/subtitle_ocr_job.py
+++ b/src/infrastructure/scheduling/subtitle_ocr_job.py
@@ -14,6 +14,10 @@ is processed under a functioning tesseract, so a genuinely unusable
 track (e.g. VOBSUB) does not block the queue. To reprocess a file (after
 installing a new language model, say), delete its marker.
 
+Each processed file that carries image subtitles (or that fails) also
+appends a row to ``subtitle_ocr_runs`` so operators can see which titles
+were processed and what was extracted per track.
+
 If tesseract has no language models installed, the whole tick is skipped
 and no markers are written, so nothing is silently marked done while OCR
 is non-functional.
@@ -25,11 +29,19 @@ episodes) to keep CPU bounded — OCR is expensive.
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from src.config.logging import get_logger
 from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrOptions
+from src.modules.media.application.services.subtitle_ocr_processor import (
+    FileOcrReport,
+    SubtitleOcrProcessor,
+)
+from src.modules.media.domain.entities.subtitle_ocr_run import SubtitleOcrRun
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import SubtitleOcrOutcome
 from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
     ocr_subtitle_output_dir,
 )
@@ -40,7 +52,7 @@ if TYPE_CHECKING:
     from src.modules.media.application.ports.media_probe_port import MediaProbePort
     from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrPort
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-    from src.modules.media.domain.entities import Episode, Movie
+    from src.modules.media.domain.entities import Episode, Movie, Series
     from src.modules.settings.domain.value_objects import SubtitleOcrConfig
     from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
@@ -49,6 +61,16 @@ _logger = get_logger()
 #: Sentinel written into a file's OCR output dir once it has been
 #: processed, so subsequent ticks skip it without re-probing.
 OCR_DONE_MARKER = ".ocr_done"
+
+
+@dataclass(frozen=True)
+class MediaFileRef:
+    """A media file to OCR, plus the identity to record on its run row."""
+
+    kind: str  # "movie" | "episode"
+    media_id: str
+    title: str
+    path: Path
 
 
 class SubtitleOcrBackfillJob:
@@ -63,8 +85,8 @@ class SubtitleOcrBackfillJob:
 
     Args:
         media_uow_factory: Builds fresh media UoWs per query. The job
-            opens a short-lived UoW to list media, then does OCR (slow,
-            off-session) without holding a DB session.
+            opens a short-lived UoW to list media / record a run, then
+            does OCR (slow, off-session) without holding a DB session.
         runtime_settings: Snapshot facade for :class:`SubtitleOcrConfig`
             (and streaming ``ffmpeg_threads``).
         ocr_service: The OCR engine (:class:`SubtitleOcrPort`).
@@ -81,7 +103,7 @@ class SubtitleOcrBackfillJob:
         self._media_uow_factory = media_uow_factory
         self._runtime_settings = runtime_settings
         self._ocr_service = ocr_service
-        self._probe = probe_service
+        self._processor = SubtitleOcrProcessor(probe_service, ocr_service)
 
     async def run(self) -> None:
         """Process one batch of media missing OCR sidecars."""
@@ -103,15 +125,15 @@ class SubtitleOcrBackfillJob:
 
         budget = config.batch_size
         movies = await self._unprocessed_movie_files(config.subdir, budget)
-        for source in movies:
-            await self._process_file(source, config, options)
+        for ref in movies:
+            await self._process_file(ref, config, options)
 
         episodes_done = 0
         budget -= len(movies)
         if budget > 0:
             episodes = await self._unprocessed_episode_files(config.subdir, budget)
-            for source in episodes:
-                await self._process_file(source, config, options)
+            for ref in episodes:
+                await self._process_file(ref, config, options)
             episodes_done = len(episodes)
 
         if movies or episodes_done:
@@ -122,35 +144,57 @@ class SubtitleOcrBackfillJob:
                 batch_size=config.batch_size,
             )
 
-    async def _unprocessed_movie_files(self, subdir: str, limit: int) -> list[Path]:
+    async def _unprocessed_movie_files(self, subdir: str, limit: int) -> list[MediaFileRef]:
         async with self._media_uow_factory() as uow:
             movies = await uow.movies.list_all()
-        return self._collect_unprocessed((self._primary_path(m) for m in movies), subdir, limit)
+        return self._collect_unprocessed((self._movie_ref(m) for m in movies), subdir, limit)
 
-    async def _unprocessed_episode_files(self, subdir: str, limit: int) -> list[Path]:
+    async def _unprocessed_episode_files(self, subdir: str, limit: int) -> list[MediaFileRef]:
         async with self._media_uow_factory() as uow:
             series = await uow.series.list_all()
-        episodes = (
-            self._primary_path(episode)
+        refs = (
+            self._episode_ref(s, episode)
             for s in series
             for season in s.seasons
             for episode in season.episodes
         )
-        return self._collect_unprocessed(episodes, subdir, limit)
+        return self._collect_unprocessed(refs, subdir, limit)
 
     @staticmethod
-    def _collect_unprocessed(sources: Iterable[Path | None], subdir: str, limit: int) -> list[Path]:
+    def _collect_unprocessed(
+        refs: Iterable[MediaFileRef | None], subdir: str, limit: int
+    ) -> list[MediaFileRef]:
         """Take the first ``limit`` on-disk files that lack a done marker."""
-        out: list[Path] = []
-        for source in sources:
-            if source is None or not source.is_file():
+        out: list[MediaFileRef] = []
+        for ref in refs:
+            if ref is None or not ref.path.is_file():
                 continue
-            if (ocr_subtitle_output_dir(source, subdir) / OCR_DONE_MARKER).exists():
+            if (ocr_subtitle_output_dir(ref.path, subdir) / OCR_DONE_MARKER).exists():
                 continue
-            out.append(source)
+            out.append(ref)
             if len(out) >= limit:
                 break
         return out
+
+    @classmethod
+    def _movie_ref(cls, movie: Movie) -> MediaFileRef | None:
+        path = cls._primary_path(movie)
+        if path is None or movie.id is None:
+            return None
+        return MediaFileRef(
+            kind="movie", media_id=str(movie.id), title=movie.title.value, path=path
+        )
+
+    @classmethod
+    def _episode_ref(cls, series: Series, episode: Episode) -> MediaFileRef | None:
+        path = cls._primary_path(episode)
+        if path is None or episode.id is None:
+            return None
+        label = (
+            f"{series.title.value} "
+            f"S{episode.season_number.value:02d}E{episode.episode_number.value:02d}"
+        )
+        return MediaFileRef(kind="episode", media_id=str(episode.id), title=label, path=path)
 
     @staticmethod
     def _primary_path(entity: Movie | Episode) -> Path | None:
@@ -161,40 +205,69 @@ class SubtitleOcrBackfillJob:
 
     async def _process_file(
         self,
-        source: Path,
+        ref: MediaFileRef,
         config: SubtitleOcrConfig,
         options: SubtitleOcrOptions,
     ) -> None:
-        """OCR a single file's image subtitles, then mark it processed.
+        """OCR a single file, mark it processed, and record the run.
 
-        Runs off the event loop (probe + OCR are synchronous, CPU/IO
-        bound). Best-effort: any failure is logged and the file is still
-        marked processed (the marker means "attempted"), so one bad file
-        never wedges the queue — the operator deletes the marker to retry.
+        Best-effort: any failure is logged and the file is still marked
+        processed (the marker means "attempted"), so one bad file never
+        wedges the queue — the operator deletes the marker to retry.
         """
+        started_at = datetime.now(UTC)
+        output_dir = ocr_subtitle_output_dir(ref.path, config.subdir)
+        language_filter = _language_filter(config.languages)
+        error: str | None = None
         try:
-            await asyncio.to_thread(self._ocr_file, source, config, options)
-        except Exception:
-            _logger.exception(
-                "[subtitle-ocr] failed to process file", extra={"source": str(source)}
+            report = await asyncio.to_thread(
+                self._processor.process_file,
+                str(ref.path),
+                output_dir,
+                options,
+                language_filter,
             )
-        self._write_marker(source, config.subdir)
+        except Exception as exc:
+            _logger.exception(
+                "[subtitle-ocr] failed to process file", extra={"source": str(ref.path)}
+            )
+            report = FileOcrReport(outcome=SubtitleOcrOutcome.FAILED)
+            error = f"{type(exc).__name__}: {exc}"[:2000]
+        self._write_marker(ref.path, config.subdir)
+        await self._record_run(ref, report, error, started_at)
 
-    def _ocr_file(
+    async def _record_run(
         self,
-        source: Path,
-        config: SubtitleOcrConfig,
-        options: SubtitleOcrOptions,
+        ref: MediaFileRef,
+        report: FileOcrReport,
+        error: str | None,
+        started_at: datetime,
     ) -> None:
-        """Probe ``source`` and OCR each image subtitle track (sync)."""
-        probe = self._probe.probe(str(source))
-        image_tracks = [t for t in probe.all_subtitles if t.is_image_based]
-        wanted = _language_filter(config.languages)
-        output_dir = ocr_subtitle_output_dir(source, config.subdir)
-        for track in image_tracks:
-            if wanted is not None and track.language.value.lower() not in wanted:
-                continue
-            self._ocr_service.ocr_track(str(source), track, output_dir, options)
+        """Append an audit row for a processed file (best-effort).
+
+        Files with no image subtitles are skipped (they would flood the
+        log) unless they failed; recording never breaks the tick.
+        """
+        if report.image_track_count == 0 and report.outcome != SubtitleOcrOutcome.FAILED:
+            return
+        run = SubtitleOcrRun(
+            media_kind=ref.kind,
+            media_id=ref.media_id,
+            media_title=ref.title,
+            file_path=str(ref.path),
+            outcome=report.outcome,
+            image_track_count=report.image_track_count,
+            extracted_count=report.extracted_count,
+            track_results=report.track_results,
+            error=error,
+            started_at=started_at,
+            finished_at=datetime.now(UTC),
+        )
+        try:
+            async with self._media_uow_factory() as uow:
+                await uow.subtitle_ocr_runs.add(run)
+        except Exception:
+            _logger.exception("[subtitle-ocr] failed to record run")
 
     @staticmethod
     def _write_marker(source: Path, subdir: str) -> None:
@@ -210,4 +283,4 @@ def _language_filter(languages: tuple[str, ...]) -> frozenset[str] | None:
     return frozenset(lang.lower() for lang in languages)
 
 
-__all__ = ["OCR_DONE_MARKER", "SubtitleOcrBackfillJob"]
+__all__ = ["OCR_DONE_MARKER", "MediaFileRef", "SubtitleOcrBackfillJob"]

--- a/src/main.py
+++ b/src/main.py
@@ -240,6 +240,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 minutes=scan_dedup_cfg.sweep_interval_minutes,
                 job_id="homeflix:scan-dedup-sweep",
             )
+        subtitle_ocr_cfg = await runtime_settings.subtitle_ocr()
+        if subtitle_ocr_cfg.enabled:
+            subtitle_ocr_job = await container.subtitle_ocr_job()
+            scheduler.add_interval_job(
+                subtitle_ocr_job.run,
+                minutes=subtitle_ocr_cfg.interval_minutes,
+                job_id="homeflix:subtitle-ocr",
+            )
         app.state.scheduler = scheduler
 
     logger.info("Application ready")

--- a/src/main.py
+++ b/src/main.py
@@ -40,6 +40,7 @@ from src.modules.media.presentation.routes import (
     admin_overview_router,
     admin_relink_router,
     admin_scan_router,
+    admin_subtitle_ocr_router,
     admin_system_router,
     catalog_router,
     collection_router,
@@ -72,6 +73,7 @@ WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.media.presentation.routes.admin_overview_routes",
     "src.modules.media.presentation.routes.admin_relink_routes",
     "src.modules.media.presentation.routes.admin_scan_routes",
+    "src.modules.media.presentation.routes.admin_subtitle_ocr_routes",
     "src.modules.media.presentation.routes.admin_system_routes",
     "src.modules.media.presentation.routes.catalog_routes",
     "src.modules.media.presentation.routes.collection_routes",
@@ -464,6 +466,7 @@ def create_app() -> FastAPI:
     app.include_router(admin_intro_detection_router)
     app.include_router(admin_jobs_router)
     app.include_router(admin_credits_router)
+    app.include_router(admin_subtitle_ocr_router)
     app.include_router(admin_system_router)
     app.include_router(catalog_router)
     app.include_router(collection_router)

--- a/src/modules/media/application/dtos/subtitle_ocr_run_dtos.py
+++ b/src/modules/media/application/dtos/subtitle_ocr_run_dtos.py
@@ -1,0 +1,87 @@
+"""DTOs for the subtitle-OCR run (audit) use cases."""
+
+from dataclasses import dataclass, field
+
+from src.modules.media.domain.entities.subtitle_ocr_run import SubtitleOcrRun
+
+
+@dataclass(frozen=True)
+class SubtitleTrackOcrResultOutput:
+    """One image subtitle track's OCR outcome within a run."""
+
+    track_index: int
+    language: str
+    outcome: str
+    cue_count: int
+
+
+@dataclass(frozen=True)
+class SubtitleOcrRunOutput:
+    """API projection of a :class:`SubtitleOcrRun`."""
+
+    id: str
+    media_kind: str
+    media_id: str
+    media_title: str
+    file_path: str
+    outcome: str
+    image_track_count: int
+    extracted_count: int
+    error: str | None
+    started_at: str
+    finished_at: str
+    track_results: list[SubtitleTrackOcrResultOutput] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ListSubtitleOcrRunsInput:
+    """Filters + pagination for listing subtitle-OCR runs."""
+
+    media_kind: str | None = None
+    media_id: str | None = None
+    limit: int = 50
+    offset: int = 0
+
+
+@dataclass(frozen=True)
+class GetSubtitleOcrRunInput:
+    """Input for fetching a single run by id."""
+
+    run_id: str
+
+
+def subtitle_ocr_run_to_output(run: SubtitleOcrRun) -> SubtitleOcrRunOutput:
+    """Project a persisted run aggregate to its API output DTO."""
+    if run.id is None:
+        raise ValueError("Cannot project an unpersisted SubtitleOcrRun to output")
+    return SubtitleOcrRunOutput(
+        id=str(run.id),
+        media_kind=run.media_kind,
+        media_id=run.media_id,
+        media_title=run.media_title,
+        file_path=run.file_path,
+        outcome=run.outcome.value,
+        image_track_count=run.image_track_count,
+        extracted_count=run.extracted_count,
+        error=run.error,
+        started_at=run.started_at.isoformat(),
+        finished_at=run.finished_at.isoformat(),
+        track_results=[
+            SubtitleTrackOcrResultOutput(
+                track_index=r.track_index,
+                language=r.language,
+                outcome=r.outcome.value,
+                cue_count=r.cue_count,
+            )
+            for r in run.track_results
+        ],
+    )
+
+
+__all__ = [
+    "GetSubtitleOcrRunInput",
+    "ListSubtitleOcrRunsInput",
+    "SubtitleOcrRunOutput",
+    "SubtitleTrackOcrResultOutput",
+    "subtitle_ocr_run_to_output",
+]

--- a/src/modules/media/application/dtos/subtitle_ocr_run_dtos.py
+++ b/src/modules/media/application/dtos/subtitle_ocr_run_dtos.py
@@ -50,6 +50,19 @@ class GetSubtitleOcrRunInput:
     run_id: str
 
 
+@dataclass(frozen=True)
+class RunSubtitleOcrInput:
+    """Input for the manual "OCR this title now" trigger.
+
+    Attributes:
+        media_kind: ``movie`` or ``episode``.
+        media_id: External id of the movie/episode to OCR.
+    """
+
+    media_kind: str
+    media_id: str
+
+
 def subtitle_ocr_run_to_output(run: SubtitleOcrRun) -> SubtitleOcrRunOutput:
     """Project a persisted run aggregate to its API output DTO."""
     if run.id is None:
@@ -81,6 +94,7 @@ def subtitle_ocr_run_to_output(run: SubtitleOcrRun) -> SubtitleOcrRunOutput:
 __all__ = [
     "GetSubtitleOcrRunInput",
     "ListSubtitleOcrRunsInput",
+    "RunSubtitleOcrInput",
     "SubtitleOcrRunOutput",
     "SubtitleTrackOcrResultOutput",
     "subtitle_ocr_run_to_output",

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -63,6 +63,10 @@ from src.modules.media.application.ports.scheduler_inspector_port import (
 from src.modules.media.application.ports.scrub_preview_locator_port import (
     ScrubPreviewLocatorPort,
 )
+from src.modules.media.application.ports.subtitle_ocr_port import (
+    SubtitleOcrOptions,
+    SubtitleOcrPort,
+)
 from src.modules.media.application.ports.variant_detector_port import (
     VariantDetectorPort,
 )
@@ -107,5 +111,7 @@ __all__ = [
     "ScrubPreviewLocatorPort",
     "SearchCandidate",
     "SeasonMetadata",
+    "SubtitleOcrOptions",
+    "SubtitleOcrPort",
     "VariantDetectorPort",
 ]

--- a/src/modules/media/application/ports/runtime_config_ports.py
+++ b/src/modules/media/application/ports/runtime_config_ports.py
@@ -42,6 +42,22 @@ class SubtitleOcrConfigPort(Protocol):
         ...
 
 
+class SubtitleOcrRunConfigPort(Protocol):
+    """Async config access the manual subtitle-OCR trigger needs.
+
+    ``RuntimeSettings`` satisfies this structurally, so the composition
+    root injects it unchanged.
+    """
+
+    async def subtitle_ocr(self) -> SubtitleOcrConfig:
+        """Return the current ``SubtitleOcrConfig``."""
+        ...
+
+    async def streaming(self) -> StreamingConfig:
+        """Return the current ``StreamingConfig`` (for ``ffmpeg_threads``)."""
+        ...
+
+
 class HlsRuntimeConfigPort(StreamingConfigPort, SubtitleOcrConfigPort, Protocol):
     """Combined sync config access the HLS service needs.
 
@@ -72,5 +88,6 @@ __all__ = [
     "ScanDedupConfigPort",
     "StreamingConfigPort",
     "SubtitleOcrConfigPort",
+    "SubtitleOcrRunConfigPort",
     "ThumbnailConfigPort",
 ]

--- a/src/modules/media/application/ports/runtime_config_ports.py
+++ b/src/modules/media/application/ports/runtime_config_ports.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from src.modules.settings.domain.value_objects import (
         ScanDedupConfig,
         StreamingConfig,
+        SubtitleOcrConfig,
         ThumbnailBackfillConfig,
     )
 
@@ -31,6 +32,23 @@ class StreamingConfigPort(Protocol):
     def streaming_snapshot_sync(self) -> StreamingConfig:
         """Return the latest ``StreamingConfig`` without awaiting a refresh."""
         ...
+
+
+class SubtitleOcrConfigPort(Protocol):
+    """Synchronous access to the current subtitle-OCR config snapshot."""
+
+    def subtitle_ocr_snapshot_sync(self) -> SubtitleOcrConfig:
+        """Return the latest ``SubtitleOcrConfig`` without awaiting a refresh."""
+        ...
+
+
+class HlsRuntimeConfigPort(StreamingConfigPort, SubtitleOcrConfigPort, Protocol):
+    """Combined sync config access the HLS service needs.
+
+    ``RuntimeSettings`` satisfies this structurally (it exposes both
+    snapshot getters), so the composition root keeps injecting it
+    unchanged while the HLS service names only the getters it calls.
+    """
 
 
 class ThumbnailConfigPort(Protocol):
@@ -50,7 +68,9 @@ class ScanDedupConfigPort(Protocol):
 
 
 __all__ = [
+    "HlsRuntimeConfigPort",
     "ScanDedupConfigPort",
     "StreamingConfigPort",
+    "SubtitleOcrConfigPort",
     "ThumbnailConfigPort",
 ]

--- a/src/modules/media/application/ports/subtitle_ocr_port.py
+++ b/src/modules/media/application/ports/subtitle_ocr_port.py
@@ -51,6 +51,17 @@ class SubtitleOcrPort(ABC):
     """OCR a single image-based subtitle track into a WebVTT sidecar."""
 
     @abstractmethod
+    def available_languages(self, tesseract_binary: str) -> frozenset[str]:
+        """Return the OCR language models installed for ``tesseract_binary``.
+
+        Lets the orchestrating job skip an entire tick when OCR is
+        non-functional (no models installed) instead of marking files as
+        processed and never retrying once the operator installs tesseract.
+        An empty set means OCR cannot run.
+        """
+        ...
+
+    @abstractmethod
     def ocr_track(
         self,
         source_file: str,

--- a/src/modules/media/application/ports/subtitle_ocr_port.py
+++ b/src/modules/media/application/ports/subtitle_ocr_port.py
@@ -20,6 +20,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+        SubtitleTrackOutcome,
+    )
     from src.shared_kernel.value_objects.tracks import SubtitleTrack
 
 
@@ -47,6 +50,23 @@ class SubtitleOcrOptions:
     ffmpeg_threads: int | None = None
 
 
+@dataclass(frozen=True)
+class OcrTrackResult:
+    """Outcome of OCR-ing a single image subtitle track.
+
+    Attributes:
+        outcome: What happened to the track (extracted, no text,
+            unsupported format, no language model, failed).
+        vtt_path: Path to the written sidecar when ``outcome`` is
+            ``EXTRACTED``; ``None`` otherwise.
+        cue_count: Number of cues written (``0`` unless extracted).
+    """
+
+    outcome: SubtitleTrackOutcome
+    vtt_path: Path | None = None
+    cue_count: int = 0
+
+
 class SubtitleOcrPort(ABC):
     """OCR a single image-based subtitle track into a WebVTT sidecar."""
 
@@ -68,17 +88,17 @@ class SubtitleOcrPort(ABC):
         track: SubtitleTrack,
         output_dir: Path,
         options: SubtitleOcrOptions,
-    ) -> Path | None:
+    ) -> OcrTrackResult:
         """OCR one image-based subtitle track to a WebVTT file on disk.
 
         Implementations own the full pipeline: demux/read the bitmap
         stream (from ``source_file`` at ``track.index`` for embedded
         tracks, or from ``track.file_path`` for external ones), decode
         it, OCR each cue, and write a ``.vtt`` into ``output_dir`` at a
-        deterministic name derived from the track. Degrades to ``None``
-        rather than raising when the track cannot be processed (missing
-        source, unsupported bitmap format, no installed language model,
-        empty OCR result).
+        deterministic name derived from the track. Never raises for an
+        unprocessable track — the returned :class:`OcrTrackResult`
+        ``outcome`` reports why (unsupported format, no language model,
+        empty result, failure).
 
         Args:
             source_file: Absolute path to the source media file.
@@ -90,10 +110,10 @@ class SubtitleOcrPort(ABC):
             options: OCR knobs snapshotted from runtime settings.
 
         Returns:
-            The path to the written WebVTT sidecar, or ``None`` if the
-            track could not be OCR'd.
+            An :class:`OcrTrackResult` describing the outcome, with the
+            sidecar path + cue count when extraction succeeded.
         """
         ...
 
 
-__all__ = ["SubtitleOcrOptions", "SubtitleOcrPort"]
+__all__ = ["OcrTrackResult", "SubtitleOcrOptions", "SubtitleOcrPort"]

--- a/src/modules/media/application/ports/subtitle_ocr_port.py
+++ b/src/modules/media/application/ports/subtitle_ocr_port.py
@@ -1,0 +1,88 @@
+"""Port for OCR-ing an image-based subtitle track into a text sidecar.
+
+The subtitle-OCR backfill job (ADR-027) hands the port a source media
+file plus one image-based subtitle track and receives, on success, the
+path to a WebVTT sidecar it wrote. The implementation owns the full
+pipeline — demuxing the bitmap stream, decoding it, running OCR — behind
+this single abstraction, so the orchestrating job never binds to a
+particular OCR engine.
+
+The concrete implementation lives in the infrastructure layer
+(:class:`TesseractPgsOcrService`).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+
+@dataclass(frozen=True)
+class SubtitleOcrOptions:
+    """Per-call OCR knobs forwarded by the job from runtime settings.
+
+    Passed per :meth:`SubtitleOcrPort.ocr_track` call so the
+    implementation stays stateless with respect to configuration — the
+    job snapshots :class:`SubtitleOcrConfig` and forwards the relevant
+    fields, letting admin edits apply on the next tick.
+
+    Attributes:
+        tesseract_binary: Name or absolute path of the tesseract
+            executable.
+        per_cue_timeout_seconds: Hard timeout for a single tesseract
+            invocation (one cue image).
+        ffmpeg_threads: Cap forwarded to the extraction ffmpeg call, or
+            ``None`` for ffmpeg's default. Mirrors the shared streaming
+            thread cap so OCR extraction respects the same limit.
+    """
+
+    tesseract_binary: str = "tesseract"
+    per_cue_timeout_seconds: int = 30
+    ffmpeg_threads: int | None = None
+
+
+class SubtitleOcrPort(ABC):
+    """OCR a single image-based subtitle track into a WebVTT sidecar."""
+
+    @abstractmethod
+    def ocr_track(
+        self,
+        source_file: str,
+        track: SubtitleTrack,
+        output_dir: Path,
+        options: SubtitleOcrOptions,
+    ) -> Path | None:
+        """OCR one image-based subtitle track to a WebVTT file on disk.
+
+        Implementations own the full pipeline: demux/read the bitmap
+        stream (from ``source_file`` at ``track.index`` for embedded
+        tracks, or from ``track.file_path`` for external ones), decode
+        it, OCR each cue, and write a ``.vtt`` into ``output_dir`` at a
+        deterministic name derived from the track. Degrades to ``None``
+        rather than raising when the track cannot be processed (missing
+        source, unsupported bitmap format, no installed language model,
+        empty OCR result).
+
+        Args:
+            source_file: Absolute path to the source media file.
+            track: The image-based subtitle track to OCR. Its
+                ``language`` selects the OCR model and its ``index`` /
+                external ``file_path`` locate the bitmap stream.
+            output_dir: Directory the sidecar is written into (created if
+                absent).
+            options: OCR knobs snapshotted from runtime settings.
+
+        Returns:
+            The path to the written WebVTT sidecar, or ``None`` if the
+            track could not be OCR'd.
+        """
+        ...
+
+
+__all__ = ["SubtitleOcrOptions", "SubtitleOcrPort"]

--- a/src/modules/media/application/services/subtitle_ocr_paths.py
+++ b/src/modules/media/application/services/subtitle_ocr_paths.py
@@ -1,0 +1,53 @@
+"""Deterministic on-disk paths for OCR subtitle sidecars (ADR-027).
+
+Pure path helpers shared by the OCR service, the surfacing step, the
+backfill job, and the manual-trigger use case. Kept here (application)
+rather than in the infrastructure OCR service so the application layer
+can compute the sidecar location without importing infrastructure.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+#: Sentinel written into a file's OCR output dir once it has been
+#: processed by the backfill job, so subsequent ticks skip it.
+OCR_DONE_MARKER = ".ocr_done"
+
+
+def ocr_subtitle_output_dir(source: Path, subdir: str) -> Path:
+    """Return the deterministic per-stem OCR sidecar directory for a source.
+
+    Mirrors ``scrub_preview_output_dir`` — ``<source-dir>/<subdir>/<stem>/``,
+    one folder per media stem so episodes sharing a season directory don't
+    collide. Centralised so the surfacing step (ADR-027) can predict an
+    already-generated sidecar's location and the backfill job's per-file
+    ``.ocr_done`` marker lives in a stable spot.
+
+    Args:
+        source: Absolute path to the source media file.
+        subdir: Configured OCR sub-directory (e.g. ``.homeflix/subtitles``).
+
+    Returns:
+        The directory that holds (or would hold) this file's OCR sidecars.
+    """
+    return source.parent / subdir / source.stem
+
+
+def ocr_sidecar_filename(track: SubtitleTrack) -> str:
+    """Return the deterministic sidecar filename for an OCR'd track.
+
+    Keyed by the source track's ``index`` and language so the surfacing
+    step (ADR-027) can predict the path from the probed image track and
+    check whether the OCR has already been produced. Example:
+    ``ocr_s4_pt.vtt``.
+    """
+    return f"ocr_s{track.index}_{track.language.value.lower()}.vtt"
+
+
+__all__ = ["OCR_DONE_MARKER", "ocr_sidecar_filename", "ocr_subtitle_output_dir"]

--- a/src/modules/media/application/services/subtitle_ocr_processor.py
+++ b/src/modules/media/application/services/subtitle_ocr_processor.py
@@ -1,0 +1,116 @@
+"""Application service: OCR one media file's image subtitles (ADR-027).
+
+Shared by the periodic backfill job and the manual trigger so both
+produce the same per-track report (which feeds the ``subtitle_ocr_runs``
+audit log). Synchronous — probe + OCR are subprocess-bound — so callers
+dispatch it via ``asyncio.to_thread``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from src.modules.media.domain.entities.subtitle_ocr_run import SubtitleTrackOcrResult
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+    SubtitleOcrOutcome,
+    SubtitleTrackOutcome,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.modules.media.application.ports.media_probe_port import MediaProbePort
+    from src.modules.media.application.ports.subtitle_ocr_port import (
+        SubtitleOcrOptions,
+        SubtitleOcrPort,
+    )
+
+
+@dataclass(frozen=True)
+class FileOcrReport:
+    """Result of OCR-ing one media file's image subtitle tracks.
+
+    Attributes:
+        outcome: ``NO_IMAGE_SUBTITLES`` when the file carries none;
+            ``COMPLETED`` when image tracks were processed.
+        image_track_count: How many image subtitle tracks the file had.
+        track_results: Per-track OCR detail (empty when no image tracks).
+    """
+
+    outcome: SubtitleOcrOutcome
+    image_track_count: int = 0
+    track_results: list[SubtitleTrackOcrResult] = field(default_factory=list)
+
+    @property
+    def extracted_count(self) -> int:
+        """Tracks that produced a text sidecar."""
+        return sum(1 for r in self.track_results if r.outcome == SubtitleTrackOutcome.EXTRACTED)
+
+
+class SubtitleOcrProcessor:
+    """OCR every image subtitle track of a single file (best-effort).
+
+    Args:
+        probe_service: Discovers the file's subtitle tracks.
+        ocr_service: The OCR engine.
+    """
+
+    def __init__(self, probe_service: MediaProbePort, ocr_service: SubtitleOcrPort) -> None:
+        self._probe = probe_service
+        self._ocr = ocr_service
+
+    def process_file(
+        self,
+        source_file: str,
+        output_dir: Path,
+        options: SubtitleOcrOptions,
+        language_filter: frozenset[str] | None,
+    ) -> FileOcrReport:
+        """Probe ``source_file`` and OCR each image subtitle track.
+
+        Args:
+            source_file: Absolute path to the media file.
+            output_dir: Directory sidecars are written into.
+            options: OCR knobs.
+            language_filter: Lowercased ISO codes to OCR, or ``None`` for
+                every mappable language. Tracks outside the set are
+                recorded as ``SKIPPED_LANGUAGE`` without running OCR.
+
+        Returns:
+            A :class:`FileOcrReport` with the per-track outcomes.
+        """
+        probe = self._probe.probe(source_file)
+        image_tracks = [t for t in probe.all_subtitles if t.is_image_based]
+        if not image_tracks:
+            return FileOcrReport(outcome=SubtitleOcrOutcome.NO_IMAGE_SUBTITLES)
+
+        results: list[SubtitleTrackOcrResult] = []
+        for track in image_tracks:
+            language = track.language.value
+            if language_filter is not None and language.lower() not in language_filter:
+                results.append(
+                    SubtitleTrackOcrResult(
+                        track_index=track.index,
+                        language=language,
+                        outcome=SubtitleTrackOutcome.SKIPPED_LANGUAGE,
+                    )
+                )
+                continue
+            result = self._ocr.ocr_track(source_file, track, output_dir, options)
+            results.append(
+                SubtitleTrackOcrResult(
+                    track_index=track.index,
+                    language=language,
+                    outcome=result.outcome,
+                    cue_count=result.cue_count,
+                )
+            )
+        return FileOcrReport(
+            outcome=SubtitleOcrOutcome.COMPLETED,
+            image_track_count=len(image_tracks),
+            track_results=results,
+        )
+
+
+__all__ = ["FileOcrReport", "SubtitleOcrProcessor"]

--- a/src/modules/media/application/unit_of_work.py
+++ b/src/modules/media/application/unit_of_work.py
@@ -15,6 +15,7 @@ from src.modules.media.domain.repositories import (
     MovieRepository,
     ScanRunRepository,
     SeriesRepository,
+    SubtitleOcrRunRepository,
 )
 
 
@@ -34,6 +35,7 @@ class MediaUnitOfWork(UnitOfWork):
     series: SeriesRepository
     scan_runs: ScanRunRepository
     intro_detection_runs: IntroDetectionRunRepository
+    subtitle_ocr_runs: SubtitleOcrRunRepository
     media_conflicts: MediaConflictRepository
     job_runs: JobRunRepository
 

--- a/src/modules/media/application/use_cases/get_subtitle_ocr_run.py
+++ b/src/modules/media/application/use_cases/get_subtitle_ocr_run.py
@@ -1,0 +1,29 @@
+"""GetSubtitleOcrRunUseCase — fetch a single subtitle-OCR run."""
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.subtitle_ocr_run_dtos import (
+    GetSubtitleOcrRunInput,
+    SubtitleOcrRunOutput,
+    subtitle_ocr_run_to_output,
+)
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.value_objects.subtitle_ocr_run_id import SubtitleOcrRunId
+
+
+class GetSubtitleOcrRunUseCase:
+    """Fetch one subtitle-OCR run by id, with full per-track detail."""
+
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
+
+    async def execute(self, input_dto: GetSubtitleOcrRunInput) -> SubtitleOcrRunOutput:
+        """Return the run with the given id, or raise if absent."""
+        run_id = SubtitleOcrRunId(input_dto.run_id)
+        async with self._media_uow_factory() as uow:
+            run = await uow.subtitle_ocr_runs.find_by_id(run_id)
+        if run is None:
+            raise ResourceNotFoundException.for_resource("SubtitleOcrRun", input_dto.run_id)
+        return subtitle_ocr_run_to_output(run)
+
+
+__all__ = ["GetSubtitleOcrRunUseCase"]

--- a/src/modules/media/application/use_cases/list_subtitle_ocr_runs.py
+++ b/src/modules/media/application/use_cases/list_subtitle_ocr_runs.py
@@ -1,0 +1,32 @@
+"""ListSubtitleOcrRunsUseCase — audit history of subtitle-OCR runs."""
+
+from src.modules.media.application.dtos.subtitle_ocr_run_dtos import (
+    ListSubtitleOcrRunsInput,
+    SubtitleOcrRunOutput,
+    subtitle_ocr_run_to_output,
+)
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+
+class ListSubtitleOcrRunsUseCase:
+    """Return subtitle-OCR run records newest-first, with filters."""
+
+    def __init__(self, media_uow_factory: MediaUnitOfWorkFactory) -> None:
+        self._media_uow_factory = media_uow_factory
+
+    async def execute(
+        self,
+        input_dto: ListSubtitleOcrRunsInput,
+    ) -> list[SubtitleOcrRunOutput]:
+        """Return matching runs newest-first as output DTOs."""
+        async with self._media_uow_factory() as uow:
+            runs = await uow.subtitle_ocr_runs.list_paginated(
+                media_kind=input_dto.media_kind,
+                media_id=input_dto.media_id,
+                limit=input_dto.limit,
+                offset=input_dto.offset,
+            )
+        return [subtitle_ocr_run_to_output(run) for run in runs]
+
+
+__all__ = ["ListSubtitleOcrRunsUseCase"]

--- a/src/modules/media/application/use_cases/run_subtitle_ocr_for_media.py
+++ b/src/modules/media/application/use_cases/run_subtitle_ocr_for_media.py
@@ -1,0 +1,203 @@
+"""RunSubtitleOcrForMediaUseCase — manual "OCR this title now" trigger.
+
+Runs the OCR pipeline on a single movie/episode on demand, records an
+audit run, and returns it. Unlike the periodic job it ignores the
+per-file ``.ocr_done`` marker (it always re-processes) and the operator's
+``languages`` allow-list (it OCRs every mappable track), since the admin
+explicitly asked for this title. It does not require the periodic job to
+be enabled — but it does need tesseract on the host.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.config.logging import get_logger
+from src.modules.media.application.dtos.subtitle_ocr_run_dtos import (
+    RunSubtitleOcrInput,
+    SubtitleOcrRunOutput,
+    subtitle_ocr_run_to_output,
+)
+from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrOptions
+from src.modules.media.application.services.subtitle_ocr_paths import (
+    OCR_DONE_MARKER,
+    ocr_subtitle_output_dir,
+)
+from src.modules.media.application.services.subtitle_ocr_processor import FileOcrReport
+from src.modules.media.domain.entities.subtitle_ocr_run import SubtitleOcrRun
+from src.modules.media.domain.value_objects import EpisodeId, MovieId
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import SubtitleOcrOutcome
+
+if TYPE_CHECKING:
+    from src.modules.media.application.ports.runtime_config_ports import (
+        SubtitleOcrRunConfigPort,
+    )
+    from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrPort
+    from src.modules.media.application.services.subtitle_ocr_processor import (
+        SubtitleOcrProcessor,
+    )
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+
+_logger = get_logger()
+
+_MOVIE = "movie"
+_EPISODE = "episode"
+
+
+@dataclass(frozen=True)
+class _MediaRef:
+    kind: str
+    media_id: str
+    title: str
+    path: Path
+
+
+class RunSubtitleOcrForMediaUseCase:
+    """OCR one movie/episode on demand and record the run.
+
+    Args:
+        media_uow_factory: Loads the entity and records the run.
+        processor: Shared OCR-one-file service.
+        ocr_service: Used to check tesseract availability up front.
+        config: Async access to the subtitle-OCR + streaming config.
+    """
+
+    def __init__(
+        self,
+        media_uow_factory: MediaUnitOfWorkFactory,
+        processor: SubtitleOcrProcessor,
+        ocr_service: SubtitleOcrPort,
+        config: SubtitleOcrRunConfigPort,
+    ) -> None:
+        self._media_uow_factory = media_uow_factory
+        self._processor = processor
+        self._ocr_service = ocr_service
+        self._config = config
+
+    async def execute(self, input_dto: RunSubtitleOcrInput) -> SubtitleOcrRunOutput:
+        """Run OCR for the given media and return the recorded run.
+
+        Raises:
+            ResourceNotFoundException: If the movie/episode does not exist
+                or has no primary file.
+            ValueError: If ``media_kind`` is neither ``movie`` nor
+                ``episode``.
+        """
+        ref = await self._resolve(input_dto)
+        config = await self._config.subtitle_ocr()
+        started_at = datetime.now(UTC)
+
+        if not self._ocr_service.available_languages(config.tesseract_binary):
+            return await self._record(
+                ref,
+                FileOcrReport(outcome=SubtitleOcrOutcome.FAILED),
+                "No tesseract language models installed on the host",
+                started_at,
+            )
+
+        streaming = await self._config.streaming()
+        options = SubtitleOcrOptions(
+            tesseract_binary=config.tesseract_binary,
+            per_cue_timeout_seconds=config.per_cue_timeout_seconds,
+            ffmpeg_threads=streaming.ffmpeg_threads,
+        )
+        output_dir = ocr_subtitle_output_dir(ref.path, config.subdir)
+
+        error: str | None = None
+        try:
+            # language_filter=None: a manual trigger OCRs every mappable track.
+            report = await asyncio.to_thread(
+                self._processor.process_file, str(ref.path), output_dir, options, None
+            )
+        except Exception as exc:  # — surface as a FAILED run, not a 500
+            _logger.exception("[subtitle-ocr] manual run failed", extra={"source": str(ref.path)})
+            report = FileOcrReport(outcome=SubtitleOcrOutcome.FAILED)
+            error = f"{type(exc).__name__}: {exc}"[:2000]
+
+        if report.outcome == SubtitleOcrOutcome.COMPLETED:
+            self._write_marker(output_dir)
+        return await self._record(ref, report, error, started_at)
+
+    async def _resolve(self, input_dto: RunSubtitleOcrInput) -> _MediaRef:
+        if input_dto.media_kind == _MOVIE:
+            return await self._resolve_movie(input_dto.media_id)
+        if input_dto.media_kind == _EPISODE:
+            return await self._resolve_episode(input_dto.media_id)
+        msg = f"Unknown media_kind: {input_dto.media_kind!r}"
+        raise ValueError(msg)
+
+    async def _resolve_movie(self, media_id: str) -> _MediaRef:
+        async with self._media_uow_factory() as uow:
+            movie = await uow.movies.find_by_id(MovieId(media_id))
+        if movie is None or movie.primary_file is None:
+            raise ResourceNotFoundException.for_resource("Movie", media_id)
+        return _MediaRef(
+            kind=_MOVIE,
+            media_id=str(movie.id),
+            title=movie.title.value,
+            path=Path(movie.primary_file.file_path.value),
+        )
+
+    async def _resolve_episode(self, media_id: str) -> _MediaRef:
+        async with self._media_uow_factory() as uow:
+            series = await uow.series.find_by_episode_id(EpisodeId(media_id))
+        episode = None
+        if series is not None:
+            episode = next(
+                (
+                    e
+                    for season in series.seasons
+                    for e in season.episodes
+                    if e.id is not None and str(e.id) == media_id
+                ),
+                None,
+            )
+        if series is None or episode is None or episode.primary_file is None:
+            raise ResourceNotFoundException.for_resource("Episode", media_id)
+        label = (
+            f"{series.title.value} "
+            f"S{episode.season_number.value:02d}E{episode.episode_number.value:02d}"
+        )
+        return _MediaRef(
+            kind=_EPISODE,
+            media_id=str(episode.id),
+            title=label,
+            path=Path(episode.primary_file.file_path.value),
+        )
+
+    async def _record(
+        self,
+        ref: _MediaRef,
+        report: FileOcrReport,
+        error: str | None,
+        started_at: datetime,
+    ) -> SubtitleOcrRunOutput:
+        run = SubtitleOcrRun(
+            media_kind=ref.kind,
+            media_id=ref.media_id,
+            media_title=ref.title,
+            file_path=str(ref.path),
+            outcome=report.outcome,
+            image_track_count=report.image_track_count,
+            extracted_count=report.extracted_count,
+            track_results=report.track_results,
+            error=error,
+            started_at=started_at,
+            finished_at=datetime.now(UTC),
+        )
+        async with self._media_uow_factory() as uow:
+            saved = await uow.subtitle_ocr_runs.add(run)
+        return subtitle_ocr_run_to_output(saved)
+
+    @staticmethod
+    def _write_marker(output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / OCR_DONE_MARKER).write_text("", encoding="utf-8")
+
+
+__all__ = ["RunSubtitleOcrForMediaUseCase"]

--- a/src/modules/media/application/use_cases/run_subtitle_ocr_for_media.py
+++ b/src/modules/media/application/use_cases/run_subtitle_ocr_for_media.py
@@ -2,10 +2,12 @@
 
 Runs the OCR pipeline on a single movie/episode on demand, records an
 audit run, and returns it. Unlike the periodic job it ignores the
-per-file ``.ocr_done`` marker (it always re-processes) and the operator's
-``languages`` allow-list (it OCRs every mappable track), since the admin
-explicitly asked for this title. It does not require the periodic job to
-be enabled — but it does need tesseract on the host.
+per-file ``.ocr_done`` marker (it always re-processes), but it *does*
+honour the operator's ``languages`` allow-list — some Blu-ray remuxes
+carry 20+ PGS tracks, and OCR-ing every one would take hours, so the
+scope is bounded by the configured languages (empty = every mappable
+track). It does not require the periodic job to be enabled — but it does
+need tesseract on the host.
 """
 
 from __future__ import annotations
@@ -107,12 +109,18 @@ class RunSubtitleOcrForMediaUseCase:
             ffmpeg_threads=streaming.ffmpeg_threads,
         )
         output_dir = ocr_subtitle_output_dir(ref.path, config.subdir)
+        # Honour the configured languages so a 20+ track remux doesn't OCR
+        # everything; empty means every mappable track.
+        language_filter = frozenset(lang.lower() for lang in config.languages) or None
 
         error: str | None = None
         try:
-            # language_filter=None: a manual trigger OCRs every mappable track.
             report = await asyncio.to_thread(
-                self._processor.process_file, str(ref.path), output_dir, options, None
+                self._processor.process_file,
+                str(ref.path),
+                output_dir,
+                options,
+                language_filter,
             )
         except Exception as exc:  # — surface as a FAILED run, not a 500
             _logger.exception("[subtitle-ocr] manual run failed", extra={"source": str(ref.path)})

--- a/src/modules/media/domain/entities/subtitle_ocr_run.py
+++ b/src/modules/media/domain/entities/subtitle_ocr_run.py
@@ -1,0 +1,76 @@
+"""SubtitleOcrRun aggregate — per-file subtitle-OCR audit row (ADR-027).
+
+One row is appended each time the OCR job (or the manual trigger)
+processes a media file that carries image-based subtitles, so operators
+can see which titles were processed and, per track, what was extracted
+(language + cue count + outcome). Append-only: records are never mutated.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import Field
+
+from src.building_blocks.domain import AggregateRoot, CompoundValueObject
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+    SubtitleOcrOutcome,  # noqa: TCH001 — runtime field type (pydantic resolves it)
+    SubtitleTrackOutcome,  # noqa: TCH001 — runtime field type
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_run_id import SubtitleOcrRunId
+
+
+class SubtitleTrackOcrResult(CompoundValueObject):
+    """One image subtitle track's OCR outcome within a run.
+
+    Attributes:
+        track_index: The source subtitle stream index (0-based).
+        language: The track language (ISO 639-1).
+        outcome: What happened to this track.
+        cue_count: Number of subtitle cues OCR'd (``0`` unless the
+            outcome is ``EXTRACTED``) — the "how much did we get out"
+            signal for the observability page.
+    """
+
+    track_index: int
+    language: str
+    outcome: SubtitleTrackOutcome
+    cue_count: int = 0
+
+
+class SubtitleOcrRun(AggregateRoot[SubtitleOcrRunId]):
+    """A single media file's subtitle-OCR run record.
+
+    Attributes:
+        id: External id (sor_xxx); assigned by the repository on insert.
+        media_kind: ``movie`` or ``episode``.
+        media_id: External id of the processed movie/episode.
+        media_title: Human label, denormalized at write time so the audit
+            row stays self-contained (survives rename/delete).
+        file_path: Absolute path to the processed source file.
+        outcome: ``COMPLETED`` or ``FAILED``.
+        image_track_count: How many image-based subtitle tracks the file
+            carried.
+        extracted_count: How many tracks produced a text sidecar
+            (outcome ``EXTRACTED``).
+        track_results: Per-track OCR detail.
+        error: Failure message when ``outcome`` is ``FAILED``.
+        started_at: When processing the file began.
+        finished_at: When the run was recorded.
+    """
+
+    id: SubtitleOcrRunId | None = Field(default=None)
+    media_kind: str
+    media_id: str
+    media_title: str = ""
+    file_path: str
+    outcome: SubtitleOcrOutcome
+    image_track_count: int = 0
+    extracted_count: int = 0
+    track_results: list[SubtitleTrackOcrResult] = Field(default_factory=list)
+    error: str | None = None
+    started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    finished_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+__all__ = ["SubtitleOcrRun", "SubtitleTrackOcrResult"]

--- a/src/modules/media/domain/repositories/__init__.py
+++ b/src/modules/media/domain/repositories/__init__.py
@@ -10,6 +10,9 @@ from src.modules.media.domain.repositories.media_conflict_repository import (
 from src.modules.media.domain.repositories.movie_repository import MovieRepository
 from src.modules.media.domain.repositories.scan_run_repository import ScanRunRepository
 from src.modules.media.domain.repositories.series_repository import SeriesRepository
+from src.modules.media.domain.repositories.subtitle_ocr_run_repository import (
+    SubtitleOcrRunRepository,
+)
 
 __all__ = [
     "IntroDetectionRunRepository",
@@ -18,4 +21,5 @@ __all__ = [
     "MovieRepository",
     "ScanRunRepository",
     "SeriesRepository",
+    "SubtitleOcrRunRepository",
 ]

--- a/src/modules/media/domain/repositories/subtitle_ocr_run_repository.py
+++ b/src/modules/media/domain/repositories/subtitle_ocr_run_repository.py
@@ -1,0 +1,50 @@
+"""SubtitleOcrRun repository interface."""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from src.modules.media.domain.entities.subtitle_ocr_run import SubtitleOcrRun
+from src.modules.media.domain.value_objects.subtitle_ocr_run_id import SubtitleOcrRunId
+
+
+class SubtitleOcrRunRepository(ABC):
+    """Append-only store of per-file subtitle-OCR run records.
+
+    Records are written once by the OCR job / manual trigger and read
+    back by the admin audit endpoints; there is no update path.
+    """
+
+    @abstractmethod
+    async def add(self, run: SubtitleOcrRun) -> SubtitleOcrRun:
+        """Insert a new run, assigning an id, and return the saved row."""
+        ...
+
+    @abstractmethod
+    async def find_by_id(self, run_id: SubtitleOcrRunId) -> SubtitleOcrRun | None:
+        """Look up a non-deleted run by external id."""
+        ...
+
+    @abstractmethod
+    async def list_paginated(
+        self,
+        *,
+        media_kind: str | None = None,
+        media_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Sequence[SubtitleOcrRun]:
+        """List runs newest-first, optionally filtered by media kind/id."""
+        ...
+
+    @abstractmethod
+    async def count(
+        self,
+        *,
+        media_kind: str | None = None,
+        media_id: str | None = None,
+    ) -> int:
+        """Count non-deleted runs matching the filter."""
+        ...
+
+
+__all__ = ["SubtitleOcrRunRepository"]

--- a/src/modules/media/domain/value_objects/subtitle_ocr_outcome.py
+++ b/src/modules/media/domain/value_objects/subtitle_ocr_outcome.py
@@ -1,0 +1,50 @@
+"""Outcome enums for subtitle-OCR audit runs (ADR-027)."""
+
+from enum import StrEnum
+
+
+class SubtitleOcrOutcome(StrEnum):
+    """Terminal outcome of OCR-ing one media file.
+
+    Only files that carry image-based subtitles (or that fail) are
+    recorded, so ``NO_IMAGE_SUBTITLES`` is not persisted — it exists to
+    describe the in-memory result before the job decides whether to write
+    an audit row.
+
+    Attributes:
+        COMPLETED: The file had image subtitles and each was processed
+            (see per-track results for what actually extracted).
+        NO_IMAGE_SUBTITLES: The file had no image subtitles — nothing to
+            do. Not persisted as a run.
+        FAILED: An unexpected error aborted processing the file.
+    """
+
+    COMPLETED = "completed"
+    NO_IMAGE_SUBTITLES = "no_image_subtitles"
+    FAILED = "failed"
+
+
+class SubtitleTrackOutcome(StrEnum):
+    """Per-track result of an OCR attempt.
+
+    Attributes:
+        EXTRACTED: OCR produced a text sidecar with at least one cue.
+        NO_TEXT: OCR ran but produced no readable text (empty result).
+        UNSUPPORTED_FORMAT: The bitmap format is not decodable (e.g.
+            VOBSUB/IDX).
+        NO_LANGUAGE_MODEL: The track language has no mappable / installed
+            tesseract model.
+        SKIPPED_LANGUAGE: The track language is outside the operator's
+            configured ``languages`` allow-list.
+        FAILED: Demux/parse/OCR raised for this track.
+    """
+
+    EXTRACTED = "extracted"
+    NO_TEXT = "no_text"
+    UNSUPPORTED_FORMAT = "unsupported_format"
+    NO_LANGUAGE_MODEL = "no_language_model"
+    SKIPPED_LANGUAGE = "skipped_language"
+    FAILED = "failed"
+
+
+__all__ = ["SubtitleOcrOutcome", "SubtitleTrackOutcome"]

--- a/src/modules/media/domain/value_objects/subtitle_ocr_run_id.py
+++ b/src/modules/media/domain/value_objects/subtitle_ocr_run_id.py
@@ -1,0 +1,19 @@
+"""SubtitleOcrRunId external id."""
+
+from typing import ClassVar
+
+from src.building_blocks.domain.external_id import ExternalId
+
+
+class SubtitleOcrRunId(ExternalId):
+    """External ID for subtitle-OCR audit runs.
+
+    One row is appended per media file the OCR job (or manual trigger)
+    processes that carries image-based subtitles. Format:
+    ``sor_{base62_12chars}``.
+    """
+
+    EXPECTED_PREFIX: ClassVar[str] = "sor"
+
+
+__all__ = ["SubtitleOcrRunId"]

--- a/src/modules/media/infrastructure/persistence/mappers/__init__.py
+++ b/src/modules/media/infrastructure/persistence/mappers/__init__.py
@@ -18,6 +18,9 @@ from src.modules.media.infrastructure.persistence.mappers.series_mapper import (
     SeasonMapper,
     SeriesMapper,
 )
+from src.modules.media.infrastructure.persistence.mappers.subtitle_ocr_run_mapper import (
+    SubtitleOcrRunMapper,
+)
 
 __all__ = [
     "EpisodeMapper",
@@ -28,4 +31,5 @@ __all__ = [
     "ScanRunMapper",
     "SeasonMapper",
     "SeriesMapper",
+    "SubtitleOcrRunMapper",
 ]

--- a/src/modules/media/infrastructure/persistence/mappers/subtitle_ocr_run_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/subtitle_ocr_run_mapper.py
@@ -1,0 +1,69 @@
+"""Mapper between SubtitleOcrRun aggregate and its ORM model."""
+
+from src.modules.media.domain.entities.subtitle_ocr_run import (
+    SubtitleOcrRun,
+    SubtitleTrackOcrResult,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+    SubtitleOcrOutcome,
+    SubtitleTrackOutcome,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_run_id import SubtitleOcrRunId
+from src.modules.media.infrastructure.persistence.models.subtitle_ocr_run import (
+    SubtitleOcrRunModel,
+)
+
+
+class SubtitleOcrRunMapper:
+    """Translate SubtitleOcrRun ↔ SubtitleOcrRunModel."""
+
+    @staticmethod
+    def to_entity(model: SubtitleOcrRunModel) -> SubtitleOcrRun:
+        """Hydrate the aggregate from a persisted row."""
+        return SubtitleOcrRun(
+            id=SubtitleOcrRunId(model.external_id),
+            media_kind=model.media_kind,
+            media_id=model.media_id,
+            media_title=model.media_title,
+            file_path=model.file_path,
+            outcome=SubtitleOcrOutcome(model.outcome),
+            image_track_count=model.image_track_count,
+            extracted_count=model.extracted_count,
+            track_results=[
+                SubtitleTrackOcrResult(
+                    track_index=int(item["track_index"]),
+                    language=str(item["language"]),
+                    outcome=SubtitleTrackOutcome(item["outcome"]),
+                    cue_count=int(item["cue_count"]),
+                )
+                for item in (model.track_results or [])
+            ],
+            error=model.error,
+            started_at=model.started_at,
+            finished_at=model.finished_at,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+    @staticmethod
+    def to_model(entity: SubtitleOcrRun) -> SubtitleOcrRunModel:
+        """Build a fresh model from a brand-new aggregate."""
+        if entity.id is None:
+            raise ValueError("SubtitleOcrRun must have an id before mapping to model")
+        return SubtitleOcrRunModel(
+            external_id=str(entity.id),
+            media_kind=entity.media_kind,
+            media_id=entity.media_id,
+            media_title=entity.media_title,
+            file_path=entity.file_path,
+            outcome=entity.outcome.value,
+            image_track_count=entity.image_track_count,
+            extracted_count=entity.extracted_count,
+            track_results=[result.model_dump() for result in entity.track_results],
+            error=entity.error,
+            started_at=entity.started_at,
+            finished_at=entity.finished_at,
+        )
+
+
+__all__ = ["SubtitleOcrRunMapper"]

--- a/src/modules/media/infrastructure/persistence/models/__init__.py
+++ b/src/modules/media/infrastructure/persistence/models/__init__.py
@@ -13,6 +13,9 @@ from src.modules.media.infrastructure.persistence.models.movie import MovieModel
 from src.modules.media.infrastructure.persistence.models.scan_run import ScanRunModel
 from src.modules.media.infrastructure.persistence.models.season import SeasonModel
 from src.modules.media.infrastructure.persistence.models.series import SeriesModel
+from src.modules.media.infrastructure.persistence.models.subtitle_ocr_run import (
+    SubtitleOcrRunModel,
+)
 
 __all__ = [
     "EpisodeModel",
@@ -24,4 +27,5 @@ __all__ = [
     "ScanRunModel",
     "SeasonModel",
     "SeriesModel",
+    "SubtitleOcrRunModel",
 ]

--- a/src/modules/media/infrastructure/persistence/models/subtitle_ocr_run.py
+++ b/src/modules/media/infrastructure/persistence/models/subtitle_ocr_run.py
@@ -1,0 +1,46 @@
+"""SubtitleOcrRun ORM model — per-file subtitle-OCR audit row."""
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.infrastructure.persistence.base import Base
+
+
+class SubtitleOcrRunModel(Base):
+    """SQLAlchemy model for the ``subtitle_ocr_runs`` table.
+
+    Append-only audit log: one row per media file with image-based
+    subtitles processed by the OCR job / manual trigger. Per-track detail
+    (language, outcome, cue count) lives in the ``track_results`` JSON
+    column so the wide-but-sparse alternative is avoided.
+
+    Attributes:
+        media_kind: ``movie`` or ``episode``.
+        media_id: External id of the processed movie/episode.
+        media_title: Human label, denormalized for display.
+        file_path: Absolute path to the processed source file.
+        outcome: ``completed`` | ``failed``.
+        image_track_count: Image subtitle tracks the file carried.
+        extracted_count: Tracks that produced a text sidecar.
+        track_results: Per-track OCR detail (JSON list).
+        error: Failure message when ``outcome`` is ``failed``.
+        started_at / finished_at: Processing window for the file.
+    """
+
+    media_kind: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    media_id: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    media_title: Mapped[str] = mapped_column(String(500), nullable=False, default="")
+    file_path: Mapped[str] = mapped_column(String(1000), nullable=False)
+    outcome: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    image_track_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    extracted_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    track_results: Mapped[list[dict[str, Any]]] = mapped_column(JSON, nullable=False, default=list)
+    error: Mapped[str | None] = mapped_column(String(2000), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    finished_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+__all__ = ["SubtitleOcrRunModel"]

--- a/src/modules/media/infrastructure/persistence/repositories/__init__.py
+++ b/src/modules/media/infrastructure/persistence/repositories/__init__.py
@@ -15,6 +15,9 @@ from src.modules.media.infrastructure.persistence.repositories.scan_run_reposito
 from src.modules.media.infrastructure.persistence.repositories.series_repository import (
     SQLAlchemySeriesRepository,
 )
+from src.modules.media.infrastructure.persistence.repositories.subtitle_ocr_run_repository import (
+    SqlAlchemySubtitleOcrRunRepository,
+)
 
 __all__ = [
     "SQLAlchemyMovieRepository",
@@ -22,4 +25,5 @@ __all__ = [
     "SqlAlchemyIntroDetectionRunRepository",
     "SqlAlchemyMediaConflictRepository",
     "SqlAlchemyScanRunRepository",
+    "SqlAlchemySubtitleOcrRunRepository",
 ]

--- a/src/modules/media/infrastructure/persistence/repositories/subtitle_ocr_run_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/subtitle_ocr_run_repository.py
@@ -1,0 +1,82 @@
+"""SQLAlchemy implementation of SubtitleOcrRunRepository."""
+
+from collections.abc import Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.domain.entities.subtitle_ocr_run import SubtitleOcrRun
+from src.modules.media.domain.repositories.subtitle_ocr_run_repository import (
+    SubtitleOcrRunRepository,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_run_id import SubtitleOcrRunId
+from src.modules.media.infrastructure.persistence.mappers.subtitle_ocr_run_mapper import (
+    SubtitleOcrRunMapper,
+)
+from src.modules.media.infrastructure.persistence.models.subtitle_ocr_run import (
+    SubtitleOcrRunModel,
+)
+
+
+class SqlAlchemySubtitleOcrRunRepository(SubtitleOcrRunRepository):
+    """Append-only store backed by the ``subtitle_ocr_runs`` table."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def add(self, run: SubtitleOcrRun) -> SubtitleOcrRun:
+        """Insert a new run with a fresh id, then re-read it."""
+        run_id = SubtitleOcrRunId.generate_if_absent(run.id)
+        self._session.add(SubtitleOcrRunMapper.to_model(run.with_updates(id=run_id)))
+        await self._session.flush()
+        saved = await self.find_by_id(run_id)
+        if saved is None:
+            raise RuntimeError(f"SubtitleOcrRun {run_id} disappeared after insert")
+        return saved
+
+    async def find_by_id(self, run_id: SubtitleOcrRunId) -> SubtitleOcrRun | None:
+        """Look up a non-deleted run by external id."""
+        stmt = select(SubtitleOcrRunModel).where(
+            SubtitleOcrRunModel.external_id == str(run_id),
+            SubtitleOcrRunModel.deleted_at.is_(None),
+        )
+        model = (await self._session.execute(stmt)).scalar_one_or_none()
+        return None if model is None else SubtitleOcrRunMapper.to_entity(model)
+
+    async def list_paginated(
+        self,
+        *,
+        media_kind: str | None = None,
+        media_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Sequence[SubtitleOcrRun]:
+        """List non-deleted runs newest-first with optional filters."""
+        stmt = select(SubtitleOcrRunModel).where(SubtitleOcrRunModel.deleted_at.is_(None))
+        if media_kind is not None:
+            stmt = stmt.where(SubtitleOcrRunModel.media_kind == media_kind)
+        if media_id is not None:
+            stmt = stmt.where(SubtitleOcrRunModel.media_id == media_id)
+        stmt = stmt.order_by(SubtitleOcrRunModel.started_at.desc()).limit(limit).offset(offset)
+        result = await self._session.execute(stmt)
+        return [SubtitleOcrRunMapper.to_entity(m) for m in result.scalars().all()]
+
+    async def count(
+        self,
+        *,
+        media_kind: str | None = None,
+        media_id: str | None = None,
+    ) -> int:
+        """Count non-deleted runs matching the filter."""
+        stmt = select(func.count(SubtitleOcrRunModel.id)).where(
+            SubtitleOcrRunModel.deleted_at.is_(None)
+        )
+        if media_kind is not None:
+            stmt = stmt.where(SubtitleOcrRunModel.media_kind == media_kind)
+        if media_id is not None:
+            stmt = stmt.where(SubtitleOcrRunModel.media_id == media_id)
+        result = await self._session.execute(stmt)
+        return int(result.scalar_one())
+
+
+__all__ = ["SqlAlchemySubtitleOcrRunRepository"]

--- a/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
+++ b/src/modules/media/infrastructure/persistence/sqlalchemy_unit_of_work.py
@@ -25,6 +25,9 @@ from src.modules.media.infrastructure.persistence.repositories.scan_run_reposito
 from src.modules.media.infrastructure.persistence.repositories.series_repository import (
     SQLAlchemySeriesRepository,
 )
+from src.modules.media.infrastructure.persistence.repositories.subtitle_ocr_run_repository import (
+    SqlAlchemySubtitleOcrRunRepository,
+)
 
 
 class SqlAlchemyMediaUnitOfWork(SqlAlchemyUnitOfWork, MediaUnitOfWork):
@@ -41,6 +44,7 @@ class SqlAlchemyMediaUnitOfWork(SqlAlchemyUnitOfWork, MediaUnitOfWork):
         self.series = SQLAlchemySeriesRepository(session)
         self.scan_runs = SqlAlchemyScanRunRepository(session)
         self.intro_detection_runs = SqlAlchemyIntroDetectionRunRepository(session)
+        self.subtitle_ocr_runs = SqlAlchemySubtitleOcrRunRepository(session)
         self.media_conflicts = SqlAlchemyMediaConflictRepository(session)
         self.job_runs = SqlAlchemyJobRunRepository(session)
 

--- a/src/modules/media/infrastructure/streaming/__init__.py
+++ b/src/modules/media/infrastructure/streaming/__init__.py
@@ -3,9 +3,13 @@
 from src.modules.media.infrastructure.streaming.file_streamer import LocalFileStreamer
 from src.modules.media.infrastructure.streaming.hls_service import HlsService
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
+from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
+    TesseractPgsOcrService,
+)
 
 __all__ = [
     "HlsService",
     "LocalFileStreamer",
     "MediaProbeService",
+    "TesseractPgsOcrService",
 ]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -63,9 +63,12 @@ from src.modules.media.infrastructure.streaming._subprocess import (
     with_ffmpeg_threads,
 )
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
+from src.modules.media.infrastructure.streaming.subtitle_ocr_surfacing import (
+    attach_ocr_subtitles,
+)
 
 if TYPE_CHECKING:
-    from src.modules.media.application.ports.runtime_config_ports import StreamingConfigPort
+    from src.modules.media.application.ports.runtime_config_ports import HlsRuntimeConfigPort
     from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 _logger = logging.getLogger(__name__)
@@ -179,7 +182,7 @@ class HlsService(HlsPlaylistPort):
 
     def __init__(
         self,
-        runtime_settings: StreamingConfigPort,
+        runtime_settings: HlsRuntimeConfigPort,
         cache_dir: str = "./hls_cache",
         probe_service: MediaProbeService | None = None,
         idle_timeout: float = _DEFAULT_IDLE_TIMEOUT,
@@ -611,12 +614,19 @@ class HlsService(HlsPlaylistPort):
         raise RuntimeError(msg)
 
     def probe_tracks(self, file_path: str) -> ProbeResult:
-        """Probe a file for tracks, using cache when available."""
+        """Probe a file for tracks, using cache when available.
+
+        Image-based subtitles that have an OCR sidecar on disk are
+        surfaced as external text tracks (ADR-027); a no-op when subtitle
+        OCR is disabled. Applied on the base probe (cached without OCR
+        tracks) so the derivation stays idempotent across cache hits.
+        """
         path_hash = self.get_path_hash(file_path)
         cached = self.get_cached_tracks(path_hash)
-        if cached:
-            return self._deserialize_probe(cached)
-        return self._probe.probe(file_path)
+        base = self._deserialize_probe(cached) if cached else self._probe.probe(file_path)
+        return attach_ocr_subtitles(
+            base, file_path, self._runtime_settings.subtitle_ocr_snapshot_sync()
+        )
 
     def clear_cache(self, file_path: str | None = None) -> None:
         """Clear cached HLS segments.
@@ -760,6 +770,14 @@ class HlsService(HlsPlaylistPort):
 
         # Probe outside the lock (potentially slow I/O)
         probe_result = self._probe.probe(safe_path)
+        # Read-time view with OCR text tracks surfaced for image subtitles
+        # that already have a sidecar (ADR-027). The base ``probe_result``
+        # is what gets cached; ``probe_view`` (which may carry the derived
+        # OCR tracks) drives subtitle rendition + master playlist so the
+        # ``sub_N`` indices match ``probe_tracks``. A no-op when disabled.
+        probe_view = attach_ocr_subtitles(
+            probe_result, safe_path, self._runtime_settings.subtitle_ocr_snapshot_sync()
+        )
 
         # Snapshot ffmpeg_threads once per generation start so every
         # command spawned for this path sees the same cap, even if
@@ -772,7 +790,7 @@ class HlsService(HlsPlaylistPort):
         # the file route would block on indefinitely.
         text_subs: list[SubtitleTrack] = [
             s
-            for s in probe_result.all_subtitles
+            for s in probe_view.all_subtitles
             if s.is_text_based and (not s.is_external or s.file_path is not None)
         ]
 
@@ -837,8 +855,10 @@ class HlsService(HlsPlaylistPort):
             # paths that get filled in by the background subtitle extraction
             # below. The player only fetches those URIs when the user enables
             # a subtitle (all entries are emitted as DEFAULT=NO,AUTOSELECT=NO),
-            # so racing them against playback start is safe.
-            self._build_master_playlist(output_dir, probe_result)
+            # so racing them against playback start is safe. Uses ``probe_view``
+            # so surfaced OCR text tracks (ADR-027) get a ``sub_N`` rendition
+            # matching ``text_subs``.
+            self._build_master_playlist(output_dir, probe_view)
 
             # 4. Pre-create per-subtitle readiness events. They MUST be
             # registered before _start_generation returns so the file

--- a/src/modules/media/infrastructure/streaming/pgs_parser.py
+++ b/src/modules/media/infrastructure/streaming/pgs_parser.py
@@ -1,0 +1,276 @@
+"""Parser for HDMV PGS (Presentation Graphic Stream) subtitles.
+
+PGS is the bitmap subtitle format carried on Blu-ray and, muxed, in many
+MKV remuxes (ffmpeg codec ``hdmv_pgs_subtitle``). A ``.sup`` file — or a
+demuxed PGS elementary stream — is a flat sequence of *segments*; a run
+of segments terminated by an END segment forms a *display set* that
+either shows a subtitle (a composition with objects) or clears the
+previous one (an empty composition).
+
+This module turns that byte stream into timed bitmaps
+(:class:`PgsCue`): it decodes each object's RLE-compressed, palette-index
+pixels, maps them through the YCbCr palette to RGBA, and pairs each
+"show" set with the following "clear" set to recover cue timing. The
+result feeds an OCR step (see :mod:`subtitle_ocr_service`); this module
+itself is pure — only Pillow, no ffmpeg or tesseract — so it is fully
+unit-testable from synthetic byte streams.
+
+Reference: the PGS/SUP segment layout is documented at
+https://blog.thescorpius.com/index.php/2017/07/15/presentation-graphic-stream-sup-files-bluray-subtitle-format/
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from PIL import Image
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_MAGIC = b"PG"
+_HEADER_LEN = 13  # magic(2) + pts(4) + dts(4) + type(1) + size(2)
+
+# Segment type identifiers.
+_SEG_PDS = 0x14  # Palette Definition Segment
+_SEG_ODS = 0x15  # Object Definition Segment (the RLE bitmap)
+_SEG_PCS = 0x16  # Presentation Composition Segment
+_SEG_WDS = 0x17  # Window Definition Segment
+_SEG_END = 0x80  # End of display set
+
+# ODS sequence flags (an object may span several ODS segments).
+_ODS_FIRST = 0x80
+_ODS_LAST = 0x40
+
+_PTS_HZ = 90_000  # PGS timestamps are in a 90 kHz clock.
+
+
+@dataclass(frozen=True)
+class PgsCue:
+    """A single subtitle occurrence: its bitmap and on-screen timing.
+
+    Attributes:
+        start_ms: When the subtitle appears, in milliseconds.
+        end_ms: When it is cleared, in milliseconds. Always greater than
+            ``start_ms`` for cues returned by :func:`parse_pgs`.
+        image: The rendered subtitle as an ``RGBA`` image (transparent
+            background, coloured glyphs) ready for OCR preprocessing.
+    """
+
+    start_ms: int
+    end_ms: int
+    image: Image.Image
+
+
+@dataclass
+class _Segment:
+    pts: int
+    type: int
+    data: bytes
+
+
+def _iter_segments(raw: bytes) -> Iterator[_Segment]:
+    """Yield each :class:`_Segment` from a raw PGS/SUP byte stream.
+
+    Raises:
+        ValueError: If a segment does not start with the ``PG`` magic,
+            i.e. the stream is not PGS or is misaligned/truncated.
+    """
+    off = 0
+    n = len(raw)
+    while off + _HEADER_LEN <= n:
+        if raw[off : off + 2] != _MAGIC:
+            msg = f"Not a PGS stream: bad magic at offset {off}"
+            raise ValueError(msg)
+        pts = struct.unpack(">I", raw[off + 2 : off + 6])[0]
+        seg_type = raw[off + 10]
+        seg_size = struct.unpack(">H", raw[off + 11 : off + 13])[0]
+        payload = raw[off + _HEADER_LEN : off + _HEADER_LEN + seg_size]
+        off += _HEADER_LEN + seg_size
+        yield _Segment(pts=pts, type=seg_type, data=payload)
+
+
+def _parse_palette(data: bytes) -> dict[int, tuple[int, int, int, int]]:
+    """Decode a PDS payload into ``{palette_index: (R, G, B, A)}``.
+
+    Palette entries are stored as YCbCr + alpha; they are converted to
+    RGBA with the BT.601 coefficients (PGS is standard-definition-derived).
+    """
+    palette: dict[int, tuple[int, int, int, int]] = {}
+    # data[0]=palette id, data[1]=version, then 5-byte entries.
+    body = data[2:]
+    for i in range(0, len(body) - 4, 5):
+        idx, y, cr, cb, alpha = body[i : i + 5]
+        c = y - 16
+        d = cb - 128
+        e = cr - 128
+        r = max(0, min(255, round(1.164 * c + 1.596 * e)))
+        g = max(0, min(255, round(1.164 * c - 0.392 * d - 0.813 * e)))
+        b = max(0, min(255, round(1.164 * c + 2.017 * d)))
+        palette[idx] = (r, g, b, alpha)
+    return palette
+
+
+@dataclass
+class _ObjectDef:
+    obj_id: int
+    width: int
+    height: int
+    rle: bytes = b""
+
+
+def _decode_rle(rle: bytes, width: int, height: int) -> bytearray:
+    """Decode PGS run-length data into a ``width * height`` index buffer.
+
+    The PGS RLE encoding (per the format spec): a non-zero byte is a
+    single pixel of that palette index; a zero byte introduces a run
+    whose length and colour are encoded in the following one or two
+    bytes, with ``0x00 0x00`` marking end-of-line (padding to the next
+    row boundary).
+    """
+    out = bytearray(width * height)
+    pos = 0
+    i = 0
+    n = len(rle)
+    while i < n:
+        first = rle[i]
+        i += 1
+        if first != 0:
+            if pos < len(out):
+                out[pos] = first
+            pos += 1
+            continue
+        if i >= n:
+            break
+        second = rle[i]
+        i += 1
+        if second == 0:
+            if width:  # end of line: pad to the row boundary
+                pos += (width - (pos % width)) % width
+            continue
+        run_len = second & 0x3F
+        if second & 0x40:
+            run_len = (run_len << 8) | rle[i]
+            i += 1
+        color = 0
+        if second & 0x80:
+            color = rle[i]
+            i += 1
+        end = min(pos + run_len, len(out))
+        for p in range(pos, end):
+            out[p] = color
+        pos = end
+    return out
+
+
+def _num_composition_objects(pcs: bytes) -> int:
+    """Return the object count from a PCS payload (0 => a clear set).
+
+    Layout up to the count: width(2) height(2) framerate(1)
+    composition_number(2) composition_state(1) palette_update_flag(1)
+    palette_id(1) number_of_composition_objects(1).
+    """
+    return pcs[10] if len(pcs) > 10 else 0
+
+
+@dataclass
+class _DisplaySet:
+    pts: int
+    has_composition: bool = False
+    palette: dict[int, tuple[int, int, int, int]] = field(default_factory=dict)
+    objects: dict[int, _ObjectDef] = field(default_factory=dict)
+
+
+def _render(display_set: _DisplaySet) -> Image.Image:
+    """Render a display set's first object to an RGBA image.
+
+    Builds a flat RGBA byte buffer and hands it to ``Image.frombytes``
+    rather than per-pixel ``load()`` assignment — faster and avoids the
+    Optional ``PixelAccess`` load returns.
+    """
+    obj = next(iter(display_set.objects.values()))
+    indices = _decode_rle(obj.rle, obj.width, obj.height)
+    palette = display_set.palette
+    transparent = (0, 0, 0, 0)
+    raw = bytearray(len(indices) * 4)
+    for i, idx in enumerate(indices):
+        raw[i * 4 : i * 4 + 4] = bytes(palette.get(idx, transparent))
+    return Image.frombytes("RGBA", (obj.width, obj.height), bytes(raw))
+
+
+def parse_pgs(raw: bytes) -> list[PgsCue]:
+    """Parse a PGS/SUP byte stream into timed subtitle bitmaps.
+
+    Walks the display sets, pairing each "show" set (a composition that
+    carries objects) with the next "clear" set (an empty composition) to
+    recover ``start_ms``/``end_ms``. Sets without objects, palette, or a
+    matching clear are skipped, so every returned cue has a renderable
+    image and a positive duration.
+
+    Args:
+        raw: The raw PGS elementary stream (e.g. the bytes of a ``.sup``
+            file, or a demuxed PGS subtitle stream).
+
+    Returns:
+        Cues in stream order. Empty if the stream carries no subtitles.
+
+    Raises:
+        ValueError: If ``raw`` is not a valid PGS stream (bad magic).
+    """
+    cues: list[PgsCue] = []
+    current = _DisplaySet(pts=0)
+    pending_obj: _ObjectDef | None = None
+    open_start: int | None = None
+    open_image: Image.Image | None = None
+
+    for seg in _iter_segments(raw):
+        if seg.type == _SEG_PCS:
+            current = _DisplaySet(
+                pts=seg.pts,
+                has_composition=_num_composition_objects(seg.data) > 0,
+            )
+        elif seg.type == _SEG_PDS:
+            current.palette.update(_parse_palette(seg.data))
+        elif seg.type == _SEG_ODS:
+            pending_obj = _accumulate_object(seg.data, pending_obj, current)
+        elif seg.type == _SEG_END:
+            pts_ms = current.pts // (_PTS_HZ // 1000)
+            if current.has_composition and current.objects and current.palette:
+                open_start = pts_ms
+                open_image = _render(current)
+            elif not current.has_composition:
+                if open_start is not None and open_image is not None and pts_ms > open_start:
+                    cues.append(PgsCue(open_start, pts_ms, open_image))
+                open_start, open_image = None, None
+    return cues
+
+
+def _accumulate_object(
+    data: bytes,
+    pending: _ObjectDef | None,
+    display_set: _DisplaySet,
+) -> _ObjectDef | None:
+    """Fold one ODS segment into the object being assembled.
+
+    A large object spans several ODS segments: the first carries the
+    dimensions + a leading RLE chunk, continuations carry more RLE, and
+    the one flagged "last" is committed to the display set.
+    """
+    seq_flag = data[3]
+    if seq_flag & _ODS_FIRST:
+        obj_id = struct.unpack(">H", data[0:2])[0]
+        # object_data_length(3) width(2) height(2) then RLE.
+        width = struct.unpack(">H", data[7:9])[0]
+        height = struct.unpack(">H", data[9:11])[0]
+        pending = _ObjectDef(obj_id, width, height, data[11:])
+    elif pending is not None:
+        pending.rle += data[4:]
+    if seq_flag & _ODS_LAST and pending is not None:
+        display_set.objects[pending.obj_id] = pending
+        return None
+    return pending
+
+
+__all__ = ["PgsCue", "parse_pgs"]

--- a/src/modules/media/infrastructure/streaming/subtitle_ocr_service.py
+++ b/src/modules/media/infrastructure/streaming/subtitle_ocr_service.py
@@ -86,6 +86,10 @@ class TesseractPgsOcrService(SubtitleOcrPort):
     def __init__(self) -> None:
         self._installed_langs: dict[str, frozenset[str]] = {}
 
+    def available_languages(self, tesseract_binary: str) -> frozenset[str]:
+        """See :meth:`SubtitleOcrPort.available_languages`."""
+        return self._available_langs(tesseract_binary)
+
     def ocr_track(
         self,
         source_file: str,

--- a/src/modules/media/infrastructure/streaming/subtitle_ocr_service.py
+++ b/src/modules/media/infrastructure/streaming/subtitle_ocr_service.py
@@ -26,9 +26,11 @@ from typing import TYPE_CHECKING
 from PIL import Image, ImageOps
 
 from src.modules.media.application.ports.subtitle_ocr_port import (
+    OcrTrackResult,
     SubtitleOcrOptions,
     SubtitleOcrPort,
 )
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import SubtitleTrackOutcome
 from src.modules.media.infrastructure.streaming._subprocess import (
     SUBPROCESS_TEXT_KWARGS,
     with_ffmpeg_threads,
@@ -96,11 +98,11 @@ class TesseractPgsOcrService(SubtitleOcrPort):
         track: SubtitleTrack,
         output_dir: Path,
         options: SubtitleOcrOptions,
-    ) -> Path | None:
+    ) -> OcrTrackResult:
         """See :meth:`SubtitleOcrPort.ocr_track`."""
         decoded = self._decode_cues(source_file, track, output_dir, options)
-        if decoded is None:
-            return None
+        if isinstance(decoded, SubtitleTrackOutcome):
+            return OcrTrackResult(outcome=decoded)
         model, cues = decoded
 
         vtt_cues = self._ocr_cues(cues, model, options)
@@ -109,7 +111,7 @@ class TesseractPgsOcrService(SubtitleOcrPort):
                 "[subtitle-ocr] OCR produced no text; skipping",
                 extra={"index": track.index, "source": source_file},
             )
-            return None
+            return OcrTrackResult(outcome=SubtitleTrackOutcome.NO_TEXT)
 
         output_dir.mkdir(parents=True, exist_ok=True)
         vtt_path = output_dir / ocr_sidecar_filename(track)
@@ -118,7 +120,11 @@ class TesseractPgsOcrService(SubtitleOcrPort):
             "[subtitle-ocr] wrote OCR sidecar",
             extra={"cues": len(vtt_cues), "path": str(vtt_path)},
         )
-        return vtt_path
+        return OcrTrackResult(
+            outcome=SubtitleTrackOutcome.EXTRACTED,
+            vtt_path=vtt_path,
+            cue_count=len(vtt_cues),
+        )
 
     def _decode_cues(
         self,
@@ -126,27 +132,28 @@ class TesseractPgsOcrService(SubtitleOcrPort):
         track: SubtitleTrack,
         output_dir: Path,
         options: SubtitleOcrOptions,
-    ) -> tuple[str, list[PgsCue]] | None:
+    ) -> tuple[str, list[PgsCue]] | SubtitleTrackOutcome:
         """Resolve the OCR model and decode the track's bitmap cues.
 
         Returns ``(model, cues)`` when the track is a supported bitmap
         format with an installed language model and at least one decodable
-        cue; ``None`` (logged) at the first guard that fails.
+        cue; otherwise a :class:`SubtitleTrackOutcome` (logged) naming the
+        first guard that failed.
         """
         if track.format.lower() not in _SUPPORTED_FORMATS:
             _logger.debug(
                 "[subtitle-ocr] unsupported bitmap format; skipping",
                 extra={"format": track.format, "index": track.index},
             )
-            return None
+            return SubtitleTrackOutcome.UNSUPPORTED_FORMAT
 
         model = self._resolve_model(track, options.tesseract_binary)
         if model is None:
-            return None
+            return SubtitleTrackOutcome.NO_LANGUAGE_MODEL
 
         raw = self._read_pgs_bytes(source_file, track, output_dir, options.ffmpeg_threads)
         if raw is None:
-            return None
+            return SubtitleTrackOutcome.FAILED
 
         try:
             cues = parse_pgs(raw)
@@ -155,9 +162,9 @@ class TesseractPgsOcrService(SubtitleOcrPort):
                 "[subtitle-ocr] not a valid PGS stream; skipping",
                 extra={"index": track.index, "source": source_file},
             )
-            return None
+            return SubtitleTrackOutcome.FAILED
         if not cues:
-            return None
+            return SubtitleTrackOutcome.NO_TEXT
         return model, cues
 
     # -- language models -------------------------------------------------------

--- a/src/modules/media/infrastructure/streaming/subtitle_ocr_service.py
+++ b/src/modules/media/infrastructure/streaming/subtitle_ocr_service.py
@@ -30,6 +30,10 @@ from src.modules.media.application.ports.subtitle_ocr_port import (
     SubtitleOcrOptions,
     SubtitleOcrPort,
 )
+from src.modules.media.application.services.subtitle_ocr_paths import (
+    ocr_sidecar_filename,
+    ocr_subtitle_output_dir,
+)
 from src.modules.media.domain.value_objects.subtitle_ocr_outcome import SubtitleTrackOutcome
 from src.modules.media.infrastructure.streaming._subprocess import (
     SUBPROCESS_TEXT_KWARGS,
@@ -317,36 +321,6 @@ class TesseractPgsOcrService(SubtitleOcrPort):
             _logger.exception("[subtitle-ocr] tesseract invocation failed")
             return ""
         return _clean_ocr_text(result.stdout.decode("utf-8", errors="replace"))
-
-
-def ocr_subtitle_output_dir(source: Path, subdir: str) -> Path:
-    """Return the deterministic per-stem OCR sidecar directory for a source.
-
-    Mirrors ``scrub_preview_output_dir`` — ``<source-dir>/<subdir>/<stem>/``,
-    one folder per media stem so episodes sharing a season directory don't
-    collide. Centralised so the surfacing step (ADR-027) can predict an
-    already-generated sidecar's location and the backfill job's per-file
-    ``.ocr_done`` marker lives in a stable spot.
-
-    Args:
-        source: Absolute path to the source media file.
-        subdir: Configured OCR sub-directory (e.g. ``.homeflix/subtitles``).
-
-    Returns:
-        The directory that holds (or would hold) this file's OCR sidecars.
-    """
-    return source.parent / subdir / source.stem
-
-
-def ocr_sidecar_filename(track: SubtitleTrack) -> str:
-    """Return the deterministic sidecar filename for an OCR'd track.
-
-    Keyed by the source track's ``index`` and language so the surfacing
-    step (ADR-027) can predict the path from the probed image track and
-    check whether the OCR has already been produced. Example:
-    ``ocr_s4_pt.vtt``.
-    """
-    return f"ocr_s{track.index}_{track.language.value.lower()}.vtt"
 
 
 def _read_file(path: str) -> bytes:

--- a/src/modules/media/infrastructure/streaming/subtitle_ocr_service.py
+++ b/src/modules/media/infrastructure/streaming/subtitle_ocr_service.py
@@ -1,0 +1,394 @@
+"""Tesseract-backed OCR of image-based (PGS) subtitles into WebVTT.
+
+Implements :class:`SubtitleOcrPort` (ADR-027). Given a source media file
+and one image-based subtitle track, it demuxes the PGS bitmap stream
+with ffmpeg, decodes it (:mod:`pgs_parser`), OCRs each cue with tesseract,
+and writes a WebVTT sidecar next to the media at a deterministic path.
+
+Synchronous (subprocess-based), like :class:`ThumbnailGenerationService`;
+callers that must not block the event loop dispatch it via
+``asyncio.to_thread``. Every failure mode degrades to ``None`` rather
+than raising — OCR is best-effort and must never break the calling job.
+
+Only PGS/SUP bitmap subtitles are supported. VOBSUB/IDX use a different
+bitmap layout and return ``None`` (logged) for now.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PIL import Image, ImageOps
+
+from src.modules.media.application.ports.subtitle_ocr_port import (
+    SubtitleOcrOptions,
+    SubtitleOcrPort,
+)
+from src.modules.media.infrastructure.streaming._subprocess import (
+    SUBPROCESS_TEXT_KWARGS,
+    with_ffmpeg_threads,
+)
+from src.modules.media.infrastructure.streaming.pgs_parser import parse_pgs
+
+if TYPE_CHECKING:
+    from src.modules.media.infrastructure.streaming.pgs_parser import PgsCue
+    from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+_logger = logging.getLogger(__name__)
+
+# Seconds allowed for the demux of one subtitle stream. The demux reads
+# through the whole container, so this is generous.
+_EXTRACT_TIMEOUT = 1800
+
+# PGS/SUP formats this service can decode. Others (vobsub/idx) are a
+# different bitmap layout and skipped.
+_SUPPORTED_FORMATS = frozenset({"pgs", "sup"})
+
+# ISO 639-1 (LanguageCode) → tesseract 639-2/T model name. Only the
+# common subtitle languages; unmapped codes are skipped (logged).
+_ISO_TO_TESSERACT: dict[str, str] = {
+    "en": "eng",
+    "pt": "por",
+    "fr": "fra",
+    "es": "spa",
+    "de": "deu",
+    "it": "ita",
+    "nl": "nld",
+    "pl": "pol",
+    "ru": "rus",
+    "sv": "swe",
+    "no": "nor",
+    "da": "dan",
+    "fi": "fin",
+    "tr": "tur",
+    "cs": "ces",
+    "ja": "jpn",
+    "ko": "kor",
+    "zh": "chi_sim",
+    "ar": "ara",
+    "hi": "hin",
+}
+
+
+class TesseractPgsOcrService(SubtitleOcrPort):
+    """OCR PGS subtitle tracks to WebVTT sidecars with tesseract.
+
+    Caches the set of installed tesseract language models per binary so
+    a track whose language model is missing is skipped cheaply without
+    running OCR that would only yield garbage.
+    """
+
+    def __init__(self) -> None:
+        self._installed_langs: dict[str, frozenset[str]] = {}
+
+    def ocr_track(
+        self,
+        source_file: str,
+        track: SubtitleTrack,
+        output_dir: Path,
+        options: SubtitleOcrOptions,
+    ) -> Path | None:
+        """See :meth:`SubtitleOcrPort.ocr_track`."""
+        decoded = self._decode_cues(source_file, track, output_dir, options)
+        if decoded is None:
+            return None
+        model, cues = decoded
+
+        vtt_cues = self._ocr_cues(cues, model, options)
+        if not vtt_cues:
+            _logger.info(
+                "[subtitle-ocr] OCR produced no text; skipping",
+                extra={"index": track.index, "source": source_file},
+            )
+            return None
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        vtt_path = output_dir / ocr_sidecar_filename(track)
+        vtt_path.write_text(_render_vtt(vtt_cues), encoding="utf-8")
+        _logger.info(
+            "[subtitle-ocr] wrote OCR sidecar",
+            extra={"cues": len(vtt_cues), "path": str(vtt_path)},
+        )
+        return vtt_path
+
+    def _decode_cues(
+        self,
+        source_file: str,
+        track: SubtitleTrack,
+        output_dir: Path,
+        options: SubtitleOcrOptions,
+    ) -> tuple[str, list[PgsCue]] | None:
+        """Resolve the OCR model and decode the track's bitmap cues.
+
+        Returns ``(model, cues)`` when the track is a supported bitmap
+        format with an installed language model and at least one decodable
+        cue; ``None`` (logged) at the first guard that fails.
+        """
+        if track.format.lower() not in _SUPPORTED_FORMATS:
+            _logger.debug(
+                "[subtitle-ocr] unsupported bitmap format; skipping",
+                extra={"format": track.format, "index": track.index},
+            )
+            return None
+
+        model = self._resolve_model(track, options.tesseract_binary)
+        if model is None:
+            return None
+
+        raw = self._read_pgs_bytes(source_file, track, output_dir, options.ffmpeg_threads)
+        if raw is None:
+            return None
+
+        try:
+            cues = parse_pgs(raw)
+        except ValueError:
+            _logger.warning(
+                "[subtitle-ocr] not a valid PGS stream; skipping",
+                extra={"index": track.index, "source": source_file},
+            )
+            return None
+        if not cues:
+            return None
+        return model, cues
+
+    # -- language models -------------------------------------------------------
+
+    def _resolve_model(self, track: SubtitleTrack, binary: str) -> str | None:
+        """Map the track language to an installed tesseract model, or None."""
+        model = _ISO_TO_TESSERACT.get(track.language.value.lower())
+        if model is None:
+            _logger.info(
+                "[subtitle-ocr] no tesseract model for language; skipping",
+                extra={"language": track.language.value, "index": track.index},
+            )
+            return None
+        if model not in self._available_langs(binary):
+            _logger.warning(
+                "[subtitle-ocr] tesseract model not installed; skipping",
+                extra={"model": model, "language": track.language.value},
+            )
+            return None
+        return model
+
+    def _available_langs(self, binary: str) -> frozenset[str]:
+        """Installed tesseract models for ``binary`` (cached per process)."""
+        cached = self._installed_langs.get(binary)
+        if cached is not None:
+            return cached
+        langs: frozenset[str] = frozenset()
+        try:
+            result = subprocess.run(
+                [binary, "--list-langs"],
+                **SUBPROCESS_TEXT_KWARGS,
+                check=False,
+                timeout=30,
+            )
+            # tesseract prints a header line then one model per line;
+            # some builds emit it on stderr. Keep bare model tokens.
+            combined = f"{result.stdout}\n{result.stderr}"
+            langs = frozenset(
+                line.strip()
+                for line in combined.splitlines()
+                if re.fullmatch(r"[a-z_]{2,}", line.strip())
+            )
+        except (OSError, subprocess.SubprocessError):
+            _logger.exception("[subtitle-ocr] could not list tesseract languages")
+        self._installed_langs[binary] = langs
+        return langs
+
+    # -- bitmap source ---------------------------------------------------------
+
+    def _read_pgs_bytes(
+        self,
+        source_file: str,
+        track: SubtitleTrack,
+        output_dir: Path,
+        ffmpeg_threads: int | None,
+    ) -> bytes | None:
+        """Return the raw PGS stream for the track, demuxing if embedded."""
+        if track.is_external:
+            if track.file_path is None:
+                return None
+            try:
+                return _read_file(track.file_path.value)
+            except OSError:
+                _logger.warning(
+                    "[subtitle-ocr] external subtitle unreadable; skipping",
+                    extra={"path": track.file_path.value},
+                )
+                return None
+        return self._demux_embedded(source_file, track.index, output_dir, ffmpeg_threads)
+
+    def _demux_embedded(
+        self,
+        source_file: str,
+        stream_index: int,
+        output_dir: Path,
+        ffmpeg_threads: int | None,
+    ) -> bytes | None:
+        """Copy an embedded PGS stream to a temp ``.sup`` and read it back."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+        temp_sup = output_dir / f"_extract_s{stream_index}.sup"
+        cmd = with_ffmpeg_threads(
+            [
+                "ffmpeg",
+                "-i",
+                source_file,
+                "-map",
+                f"0:s:{stream_index}",
+                "-c:s",
+                "copy",
+                "-f",
+                "sup",
+                "-loglevel",
+                "error",
+                "-y",
+                str(temp_sup),
+            ],
+            ffmpeg_threads,
+        )
+        try:
+            result = subprocess.run(
+                cmd,
+                **SUBPROCESS_TEXT_KWARGS,
+                check=False,
+                timeout=_EXTRACT_TIMEOUT,
+            )
+            if result.returncode != 0 or not temp_sup.is_file():
+                _logger.warning(
+                    "[subtitle-ocr] PGS demux failed; skipping",
+                    extra={"index": stream_index, "source": source_file},
+                )
+                return None
+            return temp_sup.read_bytes()
+        except subprocess.TimeoutExpired:
+            _logger.warning(
+                "[subtitle-ocr] PGS demux timed out; skipping",
+                extra={"index": stream_index, "source": source_file},
+            )
+            return None
+        finally:
+            temp_sup.unlink(missing_ok=True)
+
+    # -- OCR -------------------------------------------------------------------
+
+    def _ocr_cues(
+        self,
+        cues: list[PgsCue],
+        model: str,
+        options: SubtitleOcrOptions,
+    ) -> list[tuple[int, int, str]]:
+        """OCR each cue, dropping ones that yield no text."""
+        out: list[tuple[int, int, str]] = []
+        for cue in cues:
+            text = self._ocr_one(cue, model, options)
+            if text:
+                out.append((cue.start_ms, cue.end_ms, text))
+        return out
+
+    def _ocr_one(self, cue: PgsCue, model: str, options: SubtitleOcrOptions) -> str:
+        """Run tesseract on a single cue image, returning cleaned text."""
+        png = _to_ocr_png(cue.image)
+        try:
+            result = subprocess.run(
+                [options.tesseract_binary, "stdin", "stdout", "-l", model, "--psm", "6"],
+                input=png,
+                capture_output=True,
+                check=False,
+                timeout=options.per_cue_timeout_seconds,
+            )
+        except (OSError, subprocess.SubprocessError):
+            _logger.exception("[subtitle-ocr] tesseract invocation failed")
+            return ""
+        return _clean_ocr_text(result.stdout.decode("utf-8", errors="replace"))
+
+
+def ocr_subtitle_output_dir(source: Path, subdir: str) -> Path:
+    """Return the deterministic per-stem OCR sidecar directory for a source.
+
+    Mirrors ``scrub_preview_output_dir`` — ``<source-dir>/<subdir>/<stem>/``,
+    one folder per media stem so episodes sharing a season directory don't
+    collide. Centralised so the surfacing step (ADR-027) can predict an
+    already-generated sidecar's location and the backfill job's per-file
+    ``.ocr_done`` marker lives in a stable spot.
+
+    Args:
+        source: Absolute path to the source media file.
+        subdir: Configured OCR sub-directory (e.g. ``.homeflix/subtitles``).
+
+    Returns:
+        The directory that holds (or would hold) this file's OCR sidecars.
+    """
+    return source.parent / subdir / source.stem
+
+
+def ocr_sidecar_filename(track: SubtitleTrack) -> str:
+    """Return the deterministic sidecar filename for an OCR'd track.
+
+    Keyed by the source track's ``index`` and language so the surfacing
+    step (ADR-027) can predict the path from the probed image track and
+    check whether the OCR has already been produced. Example:
+    ``ocr_s4_pt.vtt``.
+    """
+    return f"ocr_s{track.index}_{track.language.value.lower()}.vtt"
+
+
+def _read_file(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+
+def _to_ocr_png(image: Image.Image) -> bytes:
+    """Composite the RGBA subtitle over black and invert to dark-on-light.
+
+    PGS glyphs are light with a dark outline on a transparent
+    background; compositing over black then inverting yields black text
+    on white, which tesseract reads best.
+    """
+    background = Image.new("RGB", image.size, (0, 0, 0))
+    background.paste(image, mask=image.split()[3])
+    prepared = ImageOps.invert(ImageOps.grayscale(background))
+    buffer = io.BytesIO()
+    prepared.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+# tesseract reads a standalone "I" as a pipe; in subtitle text a pipe is
+# almost always a misread I, so normalise it back.
+_PIPE_RE = re.compile(r"\|")
+
+
+def _clean_ocr_text(text: str) -> str:
+    """Trim tesseract output and fix its standard ``I`` → ``|`` misread."""
+    fixed = _PIPE_RE.sub("I", text)
+    lines = [line.strip() for line in fixed.splitlines() if line.strip()]
+    return "\n".join(lines)
+
+
+def _ms_to_vtt(ms: int) -> str:
+    """Format milliseconds as a WebVTT timestamp ``HH:MM:SS.mmm``."""
+    hours, ms = divmod(ms, 3_600_000)
+    minutes, ms = divmod(ms, 60_000)
+    seconds, ms = divmod(ms, 1_000)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{ms:03d}"
+
+
+def _render_vtt(cues: list[tuple[int, int, str]]) -> str:
+    """Render OCR'd cues as a WebVTT document."""
+    blocks = ["WEBVTT", ""]
+    for start_ms, end_ms, text in cues:
+        blocks.append(f"{_ms_to_vtt(start_ms)} --> {_ms_to_vtt(end_ms)}")
+        blocks.append(text)
+        blocks.append("")
+    return "\n".join(blocks)
+
+
+__all__ = [
+    "TesseractPgsOcrService",
+    "ocr_sidecar_filename",
+    "ocr_subtitle_output_dir",
+]

--- a/src/modules/media/infrastructure/streaming/subtitle_ocr_surfacing.py
+++ b/src/modules/media/infrastructure/streaming/subtitle_ocr_surfacing.py
@@ -1,0 +1,108 @@
+"""Surface already-OCR'd image subtitles as external text tracks (ADR-027).
+
+The OCR backfill job writes a text WebVTT sidecar next to each media
+file for every image-based subtitle it processes. This module is the
+read-time bridge: given a probe result, it appends — for each image
+track whose sidecar exists on disk — a sibling *external text* track
+pointing at that sidecar. The original image track is left untouched
+(still filtered out downstream); the new text track flows through the
+existing ``/tracks`` serialization, the HLS external-subtitle branch and
+the ADR-026 default-subtitle selection unchanged.
+
+Pure and idempotent: it reads only the base probe (which never carries
+OCR tracks — the cache stores the base) plus the filesystem, and derives
+the text tracks fresh each call, so applying it to ``/tracks`` and to the
+HLS master playlist yields the same stable ``sub_N`` indices. Gated on
+``SubtitleOcrConfig.enabled`` so it is a no-op until the operator turns
+OCR on.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
+    ocr_sidecar_filename,
+    ocr_subtitle_output_dir,
+)
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+if TYPE_CHECKING:
+    from src.modules.media.application.ports.media_probe_port import ProbeResult
+    from src.modules.settings.domain.value_objects import SubtitleOcrConfig
+
+_logger = logging.getLogger(__name__)
+
+
+def attach_ocr_subtitles(
+    probe: ProbeResult,
+    source_file: str,
+    config: SubtitleOcrConfig,
+) -> ProbeResult:
+    """Return ``probe`` augmented with OCR text tracks for image subtitles.
+
+    For each image-based subtitle whose deterministic OCR sidecar exists
+    on disk, appends an external text ``SubtitleTrack`` (``format="vtt"``,
+    ``is_external=True``, ``file_path`` = the sidecar) with a fresh index
+    past every existing track, so it never collides with an existing
+    ``sub_N`` rendition. The original image track is preserved.
+
+    Args:
+        probe: The base probe result (must not already carry OCR tracks).
+        source_file: Absolute path to the source media file, used to
+            locate the deterministic sidecar directory.
+        config: Current subtitle-OCR config. When ``enabled`` is false,
+            or no image track has a sidecar, ``probe`` is returned
+            unchanged.
+
+    Returns:
+        Either ``probe`` itself or a copy with the OCR text tracks added
+        to ``external_subtitles``.
+    """
+    if not config.enabled:
+        return probe
+
+    image_tracks = [t for t in probe.all_subtitles if t.is_image_based]
+    if not image_tracks:
+        return probe
+
+    output_dir = ocr_subtitle_output_dir(Path(source_file), config.subdir)
+    existing_indices = [t.index for t in probe.all_subtitles]
+    next_index = max(existing_indices) + 1 if existing_indices else 0
+
+    ocr_tracks: list[SubtitleTrack] = []
+    for track in image_tracks:
+        sidecar = output_dir / ocr_sidecar_filename(track)
+        if not sidecar.is_file():
+            continue
+        ocr_tracks.append(
+            SubtitleTrack(
+                index=next_index,
+                language=track.language,
+                format="vtt",
+                title=track.title,
+                is_forced=track.is_forced,
+                is_external=True,
+                file_path=FilePath(str(sidecar)),
+            )
+        )
+        next_index += 1
+
+    if not ocr_tracks:
+        return probe
+
+    _logger.debug(
+        "[subtitle-ocr] surfacing OCR text tracks",
+        extra={"count": len(ocr_tracks), "source": source_file},
+    )
+    return replace(
+        probe,
+        external_subtitles=[*probe.external_subtitles, *ocr_tracks],
+    )
+
+
+__all__ = ["attach_ocr_subtitles"]

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -21,6 +21,9 @@ from src.modules.media.presentation.routes.admin_relink_routes import (
 from src.modules.media.presentation.routes.admin_scan_routes import (
     router as admin_scan_router,
 )
+from src.modules.media.presentation.routes.admin_subtitle_ocr_routes import (
+    router as admin_subtitle_ocr_router,
+)
 from src.modules.media.presentation.routes.admin_system_routes import (
     router as admin_system_router,
 )
@@ -46,6 +49,7 @@ __all__ = [
     "admin_overview_router",
     "admin_relink_router",
     "admin_scan_router",
+    "admin_subtitle_ocr_router",
     "admin_system_router",
     "catalog_router",
     "collection_router",

--- a/src/modules/media/presentation/routes/admin_subtitle_ocr_routes.py
+++ b/src/modules/media/presentation/routes/admin_subtitle_ocr_routes.py
@@ -1,5 +1,6 @@
-"""Admin REST routes for subtitle-OCR run history (audit)."""
+"""Admin REST routes for subtitle-OCR runs (audit + manual trigger)."""
 
+import asyncio
 from dataclasses import asdict
 from typing import Any
 
@@ -8,10 +9,12 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
+from src.config.logging import get_logger
 from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.subtitle_ocr_run_dtos import (
     GetSubtitleOcrRunInput,
     ListSubtitleOcrRunsInput,
+    RunSubtitleOcrInput,
 )
 from src.modules.media.application.use_cases.get_subtitle_ocr_run import (
     GetSubtitleOcrRunUseCase,
@@ -19,8 +22,42 @@ from src.modules.media.application.use_cases.get_subtitle_ocr_run import (
 from src.modules.media.application.use_cases.list_subtitle_ocr_runs import (
     ListSubtitleOcrRunsUseCase,
 )
+from src.modules.media.application.use_cases.run_subtitle_ocr_for_media import (
+    RunSubtitleOcrForMediaUseCase,
+)
+
+_logger = get_logger()
 
 router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Subtitle OCR"])
+
+# Strong references to in-flight manual-OCR tasks so the event loop's weak
+# reference doesn't GC a running OCR (mirrors the eager-thumbnail pattern).
+_manual_ocr_tasks: set[asyncio.Task[Any]] = set()
+
+
+def _fire_manual_ocr(
+    use_case: RunSubtitleOcrForMediaUseCase, media_kind: str, media_id: str
+) -> None:
+    """Launch a manual OCR run in the background (fire-and-forget).
+
+    OCR takes minutes, so the request returns 202 immediately; the run is
+    recorded on completion and surfaced via the runs list. Exceptions are
+    logged — a not-found media never reaches here (the UI triggers only on
+    titles it displays), and OCR failures are recorded as FAILED runs.
+    """
+
+    async def _run() -> None:
+        try:
+            await use_case.execute(RunSubtitleOcrInput(media_kind=media_kind, media_id=media_id))
+        except Exception:
+            _logger.exception(
+                "[subtitle-ocr] manual trigger failed",
+                extra={"media_kind": media_kind, "media_id": media_id},
+            )
+
+    task = asyncio.create_task(_run())
+    _manual_ocr_tasks.add(task)
+    task.add_done_callback(_manual_ocr_tasks.discard)
 
 
 @router.get("/subtitle-ocr/runs")
@@ -59,6 +96,40 @@ async def get_subtitle_ocr_run(
     """Fetch one subtitle-OCR run with full per-track detail."""
     output = await use_case.execute(GetSubtitleOcrRunInput(run_id=run_id))
     return api_single("subtitle_ocr_run", asdict(output))
+
+
+@router.post("/subtitle-ocr/movies/{movie_id}/run", status_code=202)
+@inject
+async def run_movie_subtitle_ocr(
+    movie_id: str,
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
+    use_case: RunSubtitleOcrForMediaUseCase = Depends(
+        Provide[ApplicationContainer.media.run_subtitle_ocr_for_media],
+    ),
+) -> dict[str, Any]:
+    """Trigger OCR for one movie now (best-effort, runs in the background)."""
+    _fire_manual_ocr(use_case, "movie", movie_id)
+    return api_single(
+        "subtitle_ocr_trigger",
+        {"media_kind": "movie", "media_id": movie_id, "triggered": True},
+    )
+
+
+@router.post("/subtitle-ocr/episodes/{episode_id}/run", status_code=202)
+@inject
+async def run_episode_subtitle_ocr(
+    episode_id: str,
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
+    use_case: RunSubtitleOcrForMediaUseCase = Depends(
+        Provide[ApplicationContainer.media.run_subtitle_ocr_for_media],
+    ),
+) -> dict[str, Any]:
+    """Trigger OCR for one episode now (best-effort, runs in the background)."""
+    _fire_manual_ocr(use_case, "episode", episode_id)
+    return api_single(
+        "subtitle_ocr_trigger",
+        {"media_kind": "episode", "media_id": episode_id, "triggered": True},
+    )
 
 
 __all__ = ["router"]

--- a/src/modules/media/presentation/routes/admin_subtitle_ocr_routes.py
+++ b/src/modules/media/presentation/routes/admin_subtitle_ocr_routes.py
@@ -1,0 +1,64 @@
+"""Admin REST routes for subtitle-OCR run history (audit)."""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.presentation import api_list, api_single
+from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.media.application.dtos.subtitle_ocr_run_dtos import (
+    GetSubtitleOcrRunInput,
+    ListSubtitleOcrRunsInput,
+)
+from src.modules.media.application.use_cases.get_subtitle_ocr_run import (
+    GetSubtitleOcrRunUseCase,
+)
+from src.modules.media.application.use_cases.list_subtitle_ocr_runs import (
+    ListSubtitleOcrRunsUseCase,
+)
+
+router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Subtitle OCR"])
+
+
+@router.get("/subtitle-ocr/runs")
+@inject
+async def list_subtitle_ocr_runs(
+    media_kind: str | None = None,
+    media_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
+    use_case: ListSubtitleOcrRunsUseCase = Depends(
+        Provide[ApplicationContainer.media.list_subtitle_ocr_runs],
+    ),
+) -> dict[str, Any]:
+    """List subtitle-OCR runs newest-first (optionally per media kind/id)."""
+    rows = await use_case.execute(
+        ListSubtitleOcrRunsInput(
+            media_kind=media_kind,
+            media_id=media_id,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+    return api_list([asdict(row) for row in rows])
+
+
+@router.get("/subtitle-ocr/runs/{run_id}")
+@inject
+async def get_subtitle_ocr_run(
+    run_id: str,
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
+    use_case: GetSubtitleOcrRunUseCase = Depends(
+        Provide[ApplicationContainer.media.get_subtitle_ocr_run],
+    ),
+) -> dict[str, Any]:
+    """Fetch one subtitle-OCR run with full per-track detail."""
+    output = await use_case.execute(GetSubtitleOcrRunInput(run_id=run_id))
+    return api_single("subtitle_ocr_run", asdict(output))
+
+
+__all__ = ["router"]

--- a/src/modules/media/presentation/routes/admin_subtitle_ocr_routes.py
+++ b/src/modules/media/presentation/routes/admin_subtitle_ocr_routes.py
@@ -33,18 +33,29 @@ router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Subtitle OCR"])
 # Strong references to in-flight manual-OCR tasks so the event loop's weak
 # reference doesn't GC a running OCR (mirrors the eager-thumbnail pattern).
 _manual_ocr_tasks: set[asyncio.Task[Any]] = set()
+# Single-flight guard: media keys currently being OCR'd, so a repeat click
+# doesn't launch a second full-file OCR of the same title.
+_inflight_media: set[str] = set()
 
 
 def _fire_manual_ocr(
     use_case: RunSubtitleOcrForMediaUseCase, media_kind: str, media_id: str
-) -> None:
+) -> bool:
     """Launch a manual OCR run in the background (fire-and-forget).
 
     OCR takes minutes, so the request returns 202 immediately; the run is
     recorded on completion and surfaced via the runs list. Exceptions are
     logged — a not-found media never reaches here (the UI triggers only on
     titles it displays), and OCR failures are recorded as FAILED runs.
+
+    Single-flighted per title: a repeat trigger for a title already being
+    OCR'd is ignored (returns ``False``) so double-clicks don't stack
+    duplicate full-file OCR runs.
     """
+    key = f"{media_kind}:{media_id}"
+    if key in _inflight_media:
+        return False
+    _inflight_media.add(key)
 
     async def _run() -> None:
         try:
@@ -54,10 +65,13 @@ def _fire_manual_ocr(
                 "[subtitle-ocr] manual trigger failed",
                 extra={"media_kind": media_kind, "media_id": media_id},
             )
+        finally:
+            _inflight_media.discard(key)
 
     task = asyncio.create_task(_run())
     _manual_ocr_tasks.add(task)
     task.add_done_callback(_manual_ocr_tasks.discard)
+    return True
 
 
 @router.get("/subtitle-ocr/runs")
@@ -108,10 +122,10 @@ async def run_movie_subtitle_ocr(
     ),
 ) -> dict[str, Any]:
     """Trigger OCR for one movie now (best-effort, runs in the background)."""
-    _fire_manual_ocr(use_case, "movie", movie_id)
+    triggered = _fire_manual_ocr(use_case, "movie", movie_id)
     return api_single(
         "subtitle_ocr_trigger",
-        {"media_kind": "movie", "media_id": movie_id, "triggered": True},
+        {"media_kind": "movie", "media_id": movie_id, "triggered": triggered},
     )
 
 
@@ -125,10 +139,10 @@ async def run_episode_subtitle_ocr(
     ),
 ) -> dict[str, Any]:
     """Trigger OCR for one episode now (best-effort, runs in the background)."""
-    _fire_manual_ocr(use_case, "episode", episode_id)
+    triggered = _fire_manual_ocr(use_case, "episode", episode_id)
     return api_single(
         "subtitle_ocr_trigger",
-        {"media_kind": "episode", "media_id": episode_id, "triggered": True},
+        {"media_kind": "episode", "media_id": episode_id, "triggered": triggered},
     )
 
 

--- a/src/modules/settings/domain/value_objects/__init__.py
+++ b/src/modules/settings/domain/value_objects/__init__.py
@@ -28,6 +28,7 @@ from src.modules.settings.domain.value_objects.streaming_config import (
     HardwareAccel,
     StreamingConfig,
 )
+from src.modules.settings.domain.value_objects.subtitle_ocr_config import SubtitleOcrConfig
 from src.modules.settings.domain.value_objects.thumbnail_backfill_config import (
     ThumbnailBackfillConfig,
 )
@@ -40,6 +41,7 @@ ConfigVO = (
     | StreamingConfig
     | AvatarConfig
     | ScanDedupConfig
+    | SubtitleOcrConfig
 )
 """Union of all configuration VOs persisted in ``app_settings``."""
 
@@ -58,6 +60,7 @@ __all__ = [
     "SettingKey",
     "SettingSource",
     "StreamingConfig",
+    "SubtitleOcrConfig",
     "ThumbnailBackfillConfig",
     "vo_type_for",
 ]

--- a/src/modules/settings/domain/value_objects/setting_key.py
+++ b/src/modules/settings/domain/value_objects/setting_key.py
@@ -22,6 +22,7 @@ class SettingKey(StrEnum):
     STREAMING = "streaming"
     AVATAR = "avatar"
     SCAN_DEDUP = "scan_dedup"
+    SUBTITLE_OCR = "subtitle_ocr"
 
 
 __all__ = ["SettingKey"]

--- a/src/modules/settings/domain/value_objects/setting_vo_registry.py
+++ b/src/modules/settings/domain/value_objects/setting_vo_registry.py
@@ -24,6 +24,7 @@ from src.modules.settings.domain.value_objects.scan_dedup_config import ScanDedu
 from src.modules.settings.domain.value_objects.scheduler_config import SchedulerConfig
 from src.modules.settings.domain.value_objects.setting_key import SettingKey
 from src.modules.settings.domain.value_objects.streaming_config import StreamingConfig
+from src.modules.settings.domain.value_objects.subtitle_ocr_config import SubtitleOcrConfig
 from src.modules.settings.domain.value_objects.thumbnail_backfill_config import (
     ThumbnailBackfillConfig,
 )
@@ -37,6 +38,7 @@ SETTING_VO_TYPES: Final[Mapping[SettingKey, type[CompoundValueObject]]] = Mappin
         SettingKey.STREAMING: StreamingConfig,
         SettingKey.AVATAR: AvatarConfig,
         SettingKey.SCAN_DEDUP: ScanDedupConfig,
+        SettingKey.SUBTITLE_OCR: SubtitleOcrConfig,
     }
 )
 """Read-only map from setting bucket to the VO type its row carries."""

--- a/src/modules/settings/domain/value_objects/subtitle_ocr_config.py
+++ b/src/modules/settings/domain/value_objects/subtitle_ocr_config.py
@@ -1,0 +1,55 @@
+"""Subtitle OCR tunables — image-subtitle → text sidecar job (ADR-027 bucket)."""
+
+from pydantic import Field
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+
+
+class SubtitleOcrConfig(CompoundValueObject):
+    """Operational knobs for the image-subtitle OCR backfill job (ADR-027).
+
+    Image-based subtitles (PGS/SUP) are not selectable in the player
+    because HLS serves text WebVTT only. This job OCRs them to text
+    sidecars that the probe then surfaces as external text tracks. OCR is
+    expensive (tens of seconds per track) and best-effort, so the job is
+    off by default and processes a small batch per tick.
+
+    ``languages`` is a tuple (not a list) so the VO stays hashable like
+    every other ``CompoundValueObject``. Empty means "OCR any track whose
+    language maps to an installed tesseract model"; a non-empty tuple
+    restricts to those ISO 639-1 codes.
+
+    Attributes:
+        enabled: Toggle for the periodic job. Off by default; requires
+            ffmpeg + tesseract (with the relevant language data) on the
+            host. See ADR-027.
+        batch_size: Max media files processed per OCR tick. Each file may
+            hold several image tracks and each OCRs hundreds of cues, so
+            keep this small.
+        interval_minutes: How often the OCR job runs.
+        subdir: Subdirectory (relative to each media file's parent folder)
+            where OCR sidecars + the per-file ``.ocr_done`` marker are
+            written, nested under a per-stem leaf so episodes sharing a
+            season folder do not collide.
+        languages: ISO 639-1 codes to OCR. Empty = every track with a
+            mappable, installed tesseract model.
+        tesseract_binary: Name or absolute path of the tesseract
+            executable (shelled out to like ffmpeg).
+        per_cue_timeout_seconds: Hard timeout for a single tesseract
+            invocation (one subtitle cue image). Bounds a stuck OCR call.
+
+    Example:
+        >>> cfg = SubtitleOcrConfig()
+        >>> on = cfg.with_updates(enabled=True, languages=("en", "pt"))
+    """
+
+    enabled: bool = Field(default=False)
+    batch_size: int = Field(default=2, ge=1)
+    interval_minutes: int = Field(default=60, ge=1)
+    subdir: str = Field(default=".homeflix/subtitles", min_length=1)
+    languages: tuple[str, ...] = Field(default=())
+    tesseract_binary: str = Field(default="tesseract", min_length=1)
+    per_cue_timeout_seconds: int = Field(default=30, ge=1)
+
+
+__all__ = ["SubtitleOcrConfig"]

--- a/src/modules/settings/infrastructure/runtime_settings.py
+++ b/src/modules/settings/infrastructure/runtime_settings.py
@@ -38,6 +38,7 @@ from src.modules.settings.domain.value_objects import (
     SchedulerConfig,
     SettingKey,
     StreamingConfig,
+    SubtitleOcrConfig,
     ThumbnailBackfillConfig,
 )
 
@@ -171,6 +172,11 @@ class RuntimeSettings:
         """Return the current :class:`ScanDedupConfig` snapshot."""
         await self._ensure_fresh()
         return cast(ScanDedupConfig, self._snapshot[SettingKey.SCAN_DEDUP])
+
+    async def subtitle_ocr(self) -> SubtitleOcrConfig:
+        """Return the current :class:`SubtitleOcrConfig` snapshot."""
+        await self._ensure_fresh()
+        return cast(SubtitleOcrConfig, self._snapshot[SettingKey.SUBTITLE_OCR])
 
 
 __all__ = ["RuntimeSettings"]

--- a/src/modules/settings/infrastructure/runtime_settings.py
+++ b/src/modules/settings/infrastructure/runtime_settings.py
@@ -178,5 +178,16 @@ class RuntimeSettings:
         await self._ensure_fresh()
         return cast(SubtitleOcrConfig, self._snapshot[SettingKey.SUBTITLE_OCR])
 
+    def subtitle_ocr_snapshot_sync(self) -> SubtitleOcrConfig:
+        """Return the cached :class:`SubtitleOcrConfig` *without* refreshing.
+
+        Escape hatch for synchronous contexts (the HLS probe/generation
+        path) that cannot ``await``. Like :meth:`streaming_snapshot_sync`,
+        it returns whatever the async path last saw; the OCR ``enabled``
+        flag and ``subdir`` change rarely, so a slightly stale read is
+        acceptable — it converges on the next async refresh.
+        """
+        return cast(SubtitleOcrConfig, self._snapshot[SettingKey.SUBTITLE_OCR])
+
 
 __all__ = ["RuntimeSettings"]

--- a/src/modules/settings/presentation/routes/admin_settings_routes.py
+++ b/src/modules/settings/presentation/routes/admin_settings_routes.py
@@ -29,6 +29,7 @@ from src.modules.settings.domain.value_objects import (
     SchedulerConfig,
     SettingKey,
     StreamingConfig,
+    SubtitleOcrConfig,
     ThumbnailBackfillConfig,
 )
 
@@ -186,6 +187,26 @@ async def update_scan_dedup_settings(
     detail = await use_case.execute(
         UpdateSettingInput(
             key=SettingKey.SCAN_DEDUP.value,
+            value=body.model_dump(mode="json"),
+            acting_admin_id=admin.external_id,
+        ),
+    )
+    return api_single("setting", asdict(detail))
+
+
+@router.patch("/subtitle-ocr")
+@inject
+async def update_subtitle_ocr_settings(
+    body: SubtitleOcrConfig,
+    admin: AuthenticatedUser = Depends(authenticated_admin),
+    use_case: UpdateSettingUseCase = Depends(
+        Provide[ApplicationContainer.settings.update_setting],
+    ),
+) -> dict[str, Any]:
+    """Replace the persisted :class:`SubtitleOcrConfig`."""
+    detail = await use_case.execute(
+        UpdateSettingInput(
+            key=SettingKey.SUBTITLE_OCR.value,
             value=body.model_dump(mode="json"),
             acting_admin_id=admin.external_id,
         ),

--- a/tests/infrastructure/scheduling/test_subtitle_ocr_job.py
+++ b/tests/infrastructure/scheduling/test_subtitle_ocr_job.py
@@ -1,0 +1,213 @@
+"""Tests for SubtitleOcrBackfillJob.
+
+Stubs the media UoW, probe, and OCR service so the tests exercise the
+job's orchestration — the enabled/availability gates, the marker-based
+discovery, the batch budget, and the language filter — without touching
+the database, ffmpeg, or tesseract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.infrastructure.scheduling.subtitle_ocr_job import (
+    OCR_DONE_MARKER,
+    SubtitleOcrBackfillJob,
+)
+from src.modules.media.application.ports.media_probe_port import ProbeResult
+from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrPort
+from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
+    ocr_subtitle_output_dir,
+)
+from src.modules.settings.domain.value_objects import StreamingConfig, SubtitleOcrConfig
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+_SUBDIR = ".homeflix/subtitles"
+
+
+def _entity(path: Path | None) -> SimpleNamespace:
+    if path is None:
+        return SimpleNamespace(primary_file=None)
+    return SimpleNamespace(primary_file=SimpleNamespace(file_path=SimpleNamespace(value=str(path))))
+
+
+def _series(episode_paths: Iterable[Path]) -> SimpleNamespace:
+    episodes = [_entity(p) for p in episode_paths]
+    return SimpleNamespace(seasons=[SimpleNamespace(episodes=episodes)])
+
+
+def _build_uow(*, movies: list, series: list) -> AsyncMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.movies = AsyncMock()
+    uow.movies.list_all = AsyncMock(return_value=movies)
+    uow.series = AsyncMock()
+    uow.series.list_all = AsyncMock(return_value=series)
+    return uow
+
+
+def _runtime_settings(config: SubtitleOcrConfig) -> AsyncMock:
+    runtime = AsyncMock()
+    runtime.subtitle_ocr = AsyncMock(return_value=config)
+    runtime.streaming = AsyncMock(return_value=StreamingConfig())
+    return runtime
+
+
+def _ocr_service(*, langs: frozenset[str] = frozenset({"eng", "por"})) -> MagicMock:
+    service = MagicMock(spec=SubtitleOcrPort)
+    service.available_languages.return_value = langs
+    service.ocr_track.return_value = None
+    return service
+
+
+def _probe_with(*tracks: SubtitleTrack) -> MagicMock:
+    probe = MagicMock()
+    probe.probe.return_value = ProbeResult(subtitle_tracks=list(tracks))
+    return probe
+
+
+def _image(index: int = 0, lang: str = "en") -> SubtitleTrack:
+    return SubtitleTrack(index=index, language=LanguageCode(lang), format="pgs")
+
+
+def _text(index: int = 0, lang: str = "en") -> SubtitleTrack:
+    return SubtitleTrack(index=index, language=LanguageCode(lang), format="srt")
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"")
+    return path
+
+
+def _marker(source: Path) -> Path:
+    return ocr_subtitle_output_dir(source, _SUBDIR) / OCR_DONE_MARKER
+
+
+def _make_job(uow: AsyncMock, config: SubtitleOcrConfig, probe: MagicMock, ocr: MagicMock):
+    return SubtitleOcrBackfillJob(
+        media_uow_factory=MagicMock(return_value=uow),
+        runtime_settings=_runtime_settings(config),
+        ocr_service=ocr,
+        probe_service=probe,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSubtitleOcrBackfillJob:
+    async def test_disabled_does_nothing(self, tmp_path: Path) -> None:
+        movie = _touch(tmp_path / "m.mkv")
+        uow = _build_uow(movies=[_entity(movie)], series=[])
+        probe, ocr = _probe_with(_image()), _ocr_service()
+        job = _make_job(uow, SubtitleOcrConfig(enabled=False), probe, ocr)
+
+        await job.run()
+
+        probe.probe.assert_not_called()
+        ocr.ocr_track.assert_not_called()
+        assert not _marker(movie).exists()
+
+    async def test_no_installed_languages_skips_tick(self, tmp_path: Path) -> None:
+        movie = _touch(tmp_path / "m.mkv")
+        uow = _build_uow(movies=[_entity(movie)], series=[])
+        probe = _probe_with(_image())
+        ocr = _ocr_service(langs=frozenset())
+        job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
+
+        await job.run()
+
+        probe.probe.assert_not_called()
+        ocr.ocr_track.assert_not_called()
+        assert not _marker(movie).exists()
+
+    async def test_ocrs_image_track_and_writes_marker(self, tmp_path: Path) -> None:
+        movie = _touch(tmp_path / "m.mkv")
+        uow = _build_uow(movies=[_entity(movie)], series=[])
+        image = _image(lang="pt")
+        probe, ocr = _probe_with(image), _ocr_service()
+        job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
+
+        await job.run()
+
+        ocr.ocr_track.assert_called_once()
+        assert ocr.ocr_track.call_args.args[1] is image
+        assert _marker(movie).exists()
+
+    async def test_marked_file_is_skipped(self, tmp_path: Path) -> None:
+        movie = _touch(tmp_path / "m.mkv")
+        _touch(_marker(movie))  # already processed
+        uow = _build_uow(movies=[_entity(movie)], series=[])
+        probe, ocr = _probe_with(_image()), _ocr_service()
+        job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
+
+        await job.run()
+
+        probe.probe.assert_not_called()
+        ocr.ocr_track.assert_not_called()
+
+    async def test_batch_size_bounds_files_processed(self, tmp_path: Path) -> None:
+        movies = [_touch(tmp_path / f"m{i}.mkv") for i in range(3)]
+        uow = _build_uow(movies=[_entity(m) for m in movies], series=[])
+        probe, ocr = _probe_with(_image()), _ocr_service()
+        job = _make_job(uow, SubtitleOcrConfig(enabled=True, batch_size=2), probe, ocr)
+
+        await job.run()
+
+        assert sum(_marker(m).exists() for m in movies) == 2
+
+    async def test_language_filter_skips_other_languages_but_marks(self, tmp_path: Path) -> None:
+        movie = _touch(tmp_path / "m.mkv")
+        uow = _build_uow(movies=[_entity(movie)], series=[])
+        probe = _probe_with(_image(lang="en"))  # only English image track
+        ocr = _ocr_service()
+        job = _make_job(uow, SubtitleOcrConfig(enabled=True, languages=("pt",)), probe, ocr)
+
+        await job.run()
+
+        ocr.ocr_track.assert_not_called()  # en filtered out
+        assert _marker(movie).exists()  # still marked attempted
+
+    async def test_non_image_tracks_are_ignored_but_file_marked(self, tmp_path: Path) -> None:
+        movie = _touch(tmp_path / "m.mkv")
+        uow = _build_uow(movies=[_entity(movie)], series=[])
+        probe, ocr = _probe_with(_text()), _ocr_service()
+        job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
+
+        await job.run()
+
+        ocr.ocr_track.assert_not_called()
+        assert _marker(movie).exists()
+
+    async def test_episodes_processed_when_budget_remains(self, tmp_path: Path) -> None:
+        episode = _touch(tmp_path / "e1.mkv")
+        uow = _build_uow(movies=[], series=[_series([episode])])
+        image = _image()
+        probe, ocr = _probe_with(image), _ocr_service()
+        job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
+
+        await job.run()
+
+        ocr.ocr_track.assert_called_once()
+        assert _marker(episode).exists()
+
+    async def test_missing_source_file_is_skipped(self, tmp_path: Path) -> None:
+        missing = tmp_path / "gone.mkv"  # never created
+        uow = _build_uow(movies=[_entity(missing)], series=[])
+        probe, ocr = _probe_with(_image()), _ocr_service()
+        job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
+
+        await job.run()
+
+        probe.probe.assert_not_called()
+        assert not _marker(missing).exists()

--- a/tests/infrastructure/scheduling/test_subtitle_ocr_job.py
+++ b/tests/infrastructure/scheduling/test_subtitle_ocr_job.py
@@ -2,8 +2,8 @@
 
 Stubs the media UoW, probe, and OCR service so the tests exercise the
 job's orchestration — the enabled/availability gates, the marker-based
-discovery, the batch budget, and the language filter — without touching
-the database, ffmpeg, or tesseract.
+discovery, the batch budget, the language filter, and the audit-run
+recording — without touching the database, ffmpeg, or tesseract.
 """
 
 from __future__ import annotations
@@ -19,7 +19,14 @@ from src.infrastructure.scheduling.subtitle_ocr_job import (
     SubtitleOcrBackfillJob,
 )
 from src.modules.media.application.ports.media_probe_port import ProbeResult
-from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrPort
+from src.modules.media.application.ports.subtitle_ocr_port import (
+    OcrTrackResult,
+    SubtitleOcrPort,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+    SubtitleOcrOutcome,
+    SubtitleTrackOutcome,
+)
 from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
     ocr_subtitle_output_dir,
 )
@@ -34,15 +41,24 @@ if TYPE_CHECKING:
 _SUBDIR = ".homeflix/subtitles"
 
 
-def _entity(path: Path | None) -> SimpleNamespace:
-    if path is None:
-        return SimpleNamespace(primary_file=None)
-    return SimpleNamespace(primary_file=SimpleNamespace(file_path=SimpleNamespace(value=str(path))))
+def _movie(path: Path | None, *, media_id: str = "mov_1", title: str = "Movie") -> SimpleNamespace:
+    primary = None if path is None else SimpleNamespace(file_path=SimpleNamespace(value=str(path)))
+    return SimpleNamespace(id=media_id, title=SimpleNamespace(value=title), primary_file=primary)
 
 
-def _series(episode_paths: Iterable[Path]) -> SimpleNamespace:
-    episodes = [_entity(p) for p in episode_paths]
-    return SimpleNamespace(seasons=[SimpleNamespace(episodes=episodes)])
+def _series(episode_paths: Iterable[Path], *, title: str = "Show") -> SimpleNamespace:
+    episodes = [
+        SimpleNamespace(
+            id=f"epi_{i}",
+            season_number=SimpleNamespace(value=1),
+            episode_number=SimpleNamespace(value=i + 1),
+            primary_file=SimpleNamespace(file_path=SimpleNamespace(value=str(p))),
+        )
+        for i, p in enumerate(episode_paths)
+    ]
+    return SimpleNamespace(
+        title=SimpleNamespace(value=title), seasons=[SimpleNamespace(episodes=episodes)]
+    )
 
 
 def _build_uow(*, movies: list, series: list) -> AsyncMock:
@@ -53,6 +69,7 @@ def _build_uow(*, movies: list, series: list) -> AsyncMock:
     uow.movies.list_all = AsyncMock(return_value=movies)
     uow.series = AsyncMock()
     uow.series.list_all = AsyncMock(return_value=series)
+    uow.subtitle_ocr_runs = AsyncMock()
     return uow
 
 
@@ -63,10 +80,15 @@ def _runtime_settings(config: SubtitleOcrConfig) -> AsyncMock:
     return runtime
 
 
-def _ocr_service(*, langs: frozenset[str] = frozenset({"eng", "por"})) -> MagicMock:
+def _ocr_service(
+    *,
+    langs: frozenset[str] = frozenset({"eng", "por"}),
+    outcome: SubtitleTrackOutcome = SubtitleTrackOutcome.EXTRACTED,
+    cue_count: int = 12,
+) -> MagicMock:
     service = MagicMock(spec=SubtitleOcrPort)
     service.available_languages.return_value = langs
-    service.ocr_track.return_value = None
+    service.ocr_track.return_value = OcrTrackResult(outcome=outcome, cue_count=cue_count)
     return service
 
 
@@ -94,6 +116,10 @@ def _marker(source: Path) -> Path:
     return ocr_subtitle_output_dir(source, _SUBDIR) / OCR_DONE_MARKER
 
 
+def _recorded_runs(uow: AsyncMock) -> list:
+    return [call.args[0] for call in uow.subtitle_ocr_runs.add.call_args_list]
+
+
 def _make_job(uow: AsyncMock, config: SubtitleOcrConfig, probe: MagicMock, ocr: MagicMock):
     return SubtitleOcrBackfillJob(
         media_uow_factory=MagicMock(return_value=uow),
@@ -108,7 +134,7 @@ def _make_job(uow: AsyncMock, config: SubtitleOcrConfig, probe: MagicMock, ocr: 
 class TestSubtitleOcrBackfillJob:
     async def test_disabled_does_nothing(self, tmp_path: Path) -> None:
         movie = _touch(tmp_path / "m.mkv")
-        uow = _build_uow(movies=[_entity(movie)], series=[])
+        uow = _build_uow(movies=[_movie(movie)], series=[])
         probe, ocr = _probe_with(_image()), _ocr_service()
         job = _make_job(uow, SubtitleOcrConfig(enabled=False), probe, ocr)
 
@@ -120,7 +146,7 @@ class TestSubtitleOcrBackfillJob:
 
     async def test_no_installed_languages_skips_tick(self, tmp_path: Path) -> None:
         movie = _touch(tmp_path / "m.mkv")
-        uow = _build_uow(movies=[_entity(movie)], series=[])
+        uow = _build_uow(movies=[_movie(movie)], series=[])
         probe = _probe_with(_image())
         ocr = _ocr_service(langs=frozenset())
         job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
@@ -131,11 +157,11 @@ class TestSubtitleOcrBackfillJob:
         ocr.ocr_track.assert_not_called()
         assert not _marker(movie).exists()
 
-    async def test_ocrs_image_track_and_writes_marker(self, tmp_path: Path) -> None:
+    async def test_ocrs_image_track_writes_marker_and_records_run(self, tmp_path: Path) -> None:
         movie = _touch(tmp_path / "m.mkv")
-        uow = _build_uow(movies=[_entity(movie)], series=[])
+        uow = _build_uow(movies=[_movie(movie, media_id="mov_42", title="Nausicaa")], series=[])
         image = _image(lang="pt")
-        probe, ocr = _probe_with(image), _ocr_service()
+        probe, ocr = _probe_with(image), _ocr_service(cue_count=99)
         job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
 
         await job.run()
@@ -144,10 +170,22 @@ class TestSubtitleOcrBackfillJob:
         assert ocr.ocr_track.call_args.args[1] is image
         assert _marker(movie).exists()
 
+        runs = _recorded_runs(uow)
+        assert len(runs) == 1
+        run = runs[0]
+        assert run.media_kind == "movie"
+        assert run.media_id == "mov_42"
+        assert run.media_title == "Nausicaa"
+        assert run.outcome == SubtitleOcrOutcome.COMPLETED
+        assert run.image_track_count == 1
+        assert run.extracted_count == 1
+        assert run.track_results[0].language == "pt"
+        assert run.track_results[0].cue_count == 99
+
     async def test_marked_file_is_skipped(self, tmp_path: Path) -> None:
         movie = _touch(tmp_path / "m.mkv")
         _touch(_marker(movie))  # already processed
-        uow = _build_uow(movies=[_entity(movie)], series=[])
+        uow = _build_uow(movies=[_movie(movie)], series=[])
         probe, ocr = _probe_with(_image()), _ocr_service()
         job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
 
@@ -155,10 +193,13 @@ class TestSubtitleOcrBackfillJob:
 
         probe.probe.assert_not_called()
         ocr.ocr_track.assert_not_called()
+        assert _recorded_runs(uow) == []
 
     async def test_batch_size_bounds_files_processed(self, tmp_path: Path) -> None:
         movies = [_touch(tmp_path / f"m{i}.mkv") for i in range(3)]
-        uow = _build_uow(movies=[_entity(m) for m in movies], series=[])
+        uow = _build_uow(
+            movies=[_movie(m, media_id=f"mov_{i}") for i, m in enumerate(movies)], series=[]
+        )
         probe, ocr = _probe_with(_image()), _ocr_service()
         job = _make_job(uow, SubtitleOcrConfig(enabled=True, batch_size=2), probe, ocr)
 
@@ -166,9 +207,9 @@ class TestSubtitleOcrBackfillJob:
 
         assert sum(_marker(m).exists() for m in movies) == 2
 
-    async def test_language_filter_skips_other_languages_but_marks(self, tmp_path: Path) -> None:
+    async def test_language_filter_records_skipped_and_does_not_ocr(self, tmp_path: Path) -> None:
         movie = _touch(tmp_path / "m.mkv")
-        uow = _build_uow(movies=[_entity(movie)], series=[])
+        uow = _build_uow(movies=[_movie(movie)], series=[])
         probe = _probe_with(_image(lang="en"))  # only English image track
         ocr = _ocr_service()
         job = _make_job(uow, SubtitleOcrConfig(enabled=True, languages=("pt",)), probe, ocr)
@@ -176,11 +217,15 @@ class TestSubtitleOcrBackfillJob:
         await job.run()
 
         ocr.ocr_track.assert_not_called()  # en filtered out
-        assert _marker(movie).exists()  # still marked attempted
+        assert _marker(movie).exists()
+        run = _recorded_runs(uow)[0]
+        assert run.image_track_count == 1
+        assert run.extracted_count == 0
+        assert run.track_results[0].outcome == SubtitleTrackOutcome.SKIPPED_LANGUAGE
 
-    async def test_non_image_tracks_are_ignored_but_file_marked(self, tmp_path: Path) -> None:
+    async def test_no_image_tracks_marks_but_records_no_run(self, tmp_path: Path) -> None:
         movie = _touch(tmp_path / "m.mkv")
-        uow = _build_uow(movies=[_entity(movie)], series=[])
+        uow = _build_uow(movies=[_movie(movie)], series=[])
         probe, ocr = _probe_with(_text()), _ocr_service()
         job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
 
@@ -188,10 +233,11 @@ class TestSubtitleOcrBackfillJob:
 
         ocr.ocr_track.assert_not_called()
         assert _marker(movie).exists()
+        assert _recorded_runs(uow) == []  # nothing to observe -> no audit noise
 
     async def test_episodes_processed_when_budget_remains(self, tmp_path: Path) -> None:
         episode = _touch(tmp_path / "e1.mkv")
-        uow = _build_uow(movies=[], series=[_series([episode])])
+        uow = _build_uow(movies=[], series=[_series([episode], title="Show")])
         image = _image()
         probe, ocr = _probe_with(image), _ocr_service()
         job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
@@ -200,10 +246,13 @@ class TestSubtitleOcrBackfillJob:
 
         ocr.ocr_track.assert_called_once()
         assert _marker(episode).exists()
+        run = _recorded_runs(uow)[0]
+        assert run.media_kind == "episode"
+        assert run.media_title == "Show S01E01"
 
     async def test_missing_source_file_is_skipped(self, tmp_path: Path) -> None:
         missing = tmp_path / "gone.mkv"  # never created
-        uow = _build_uow(movies=[_entity(missing)], series=[])
+        uow = _build_uow(movies=[_movie(missing)], series=[])
         probe, ocr = _probe_with(_image()), _ocr_service()
         job = _make_job(uow, SubtitleOcrConfig(enabled=True), probe, ocr)
 

--- a/tests/modules/media/integration/persistence/repositories/test_subtitle_ocr_run_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_subtitle_ocr_run_repository.py
@@ -1,0 +1,100 @@
+"""Integration tests for SqlAlchemySubtitleOcrRunRepository."""
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.domain.entities.subtitle_ocr_run import (
+    SubtitleOcrRun,
+    SubtitleTrackOcrResult,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+    SubtitleOcrOutcome,
+    SubtitleTrackOutcome,
+)
+from src.modules.media.infrastructure.persistence.repositories.subtitle_ocr_run_repository import (
+    SqlAlchemySubtitleOcrRunRepository,
+)
+
+
+def _run(
+    *,
+    media_id: str,
+    media_kind: str = "movie",
+    outcome: SubtitleOcrOutcome = SubtitleOcrOutcome.COMPLETED,
+    track_results: list[SubtitleTrackOcrResult] | None = None,
+) -> SubtitleOcrRun:
+    now = datetime(2026, 7, 4, 12, 0, tzinfo=UTC)
+    return SubtitleOcrRun(
+        media_kind=media_kind,
+        media_id=media_id,
+        media_title="Nausicaa",
+        file_path="G:/movies/nausicaa.mkv",
+        outcome=outcome,
+        image_track_count=len(track_results or []),
+        extracted_count=sum(
+            1 for r in (track_results or []) if r.outcome == SubtitleTrackOutcome.EXTRACTED
+        ),
+        track_results=track_results or [],
+        started_at=now,
+        finished_at=now,
+    )
+
+
+@pytest.mark.integration
+class TestSqlAlchemySubtitleOcrRunRepository:
+    async def test_add_assigns_id_and_round_trips(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemySubtitleOcrRunRepository(db_session)
+        run = _run(
+            media_id="mov_aaaaaaaaaaaa",
+            track_results=[
+                SubtitleTrackOcrResult(
+                    track_index=0,
+                    language="en",
+                    outcome=SubtitleTrackOutcome.EXTRACTED,
+                    cue_count=1079,
+                ),
+                SubtitleTrackOcrResult(
+                    track_index=2,
+                    language="fr",
+                    outcome=SubtitleTrackOutcome.SKIPPED_LANGUAGE,
+                ),
+            ],
+        )
+
+        saved = await repo.add(run)
+
+        assert saved.id is not None
+        assert str(saved.id).startswith("sor_")
+        found = await repo.find_by_id(saved.id)
+        assert found is not None
+        assert found.media_kind == "movie"
+        assert found.media_title == "Nausicaa"
+        assert found.outcome is SubtitleOcrOutcome.COMPLETED
+        assert found.image_track_count == 2
+        assert found.extracted_count == 1
+        assert len(found.track_results) == 2
+        extracted = next(
+            r for r in found.track_results if r.outcome == SubtitleTrackOutcome.EXTRACTED
+        )
+        assert extracted.language == "en"
+        assert extracted.cue_count == 1079
+
+    async def test_list_paginated_newest_first_and_filter(self, db_session: AsyncSession) -> None:
+        repo = SqlAlchemySubtitleOcrRunRepository(db_session)
+        await repo.add(_run(media_id="mov_a", media_kind="movie"))
+        await repo.add(_run(media_id="epi_b", media_kind="episode"))
+        await repo.add(_run(media_id="mov_a", media_kind="movie"))
+
+        assert len(await repo.list_paginated()) == 3
+
+        only_movies = await repo.list_paginated(media_kind="movie")
+        assert len(only_movies) == 2
+        assert all(r.media_kind == "movie" for r in only_movies)
+
+        only_a = await repo.list_paginated(media_id="mov_a")
+        assert len(only_a) == 2
+
+        assert await repo.count() == 3
+        assert await repo.count(media_kind="episode") == 1

--- a/tests/modules/media/unit/application/services/test_subtitle_ocr_processor.py
+++ b/tests/modules/media/unit/application/services/test_subtitle_ocr_processor.py
@@ -1,0 +1,96 @@
+"""Tests for SubtitleOcrProcessor (OCR one file's image subtitles)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.modules.media.application.ports.media_probe_port import ProbeResult
+from src.modules.media.application.ports.subtitle_ocr_port import (
+    OcrTrackResult,
+    SubtitleOcrOptions,
+    SubtitleOcrPort,
+)
+from src.modules.media.application.services.subtitle_ocr_processor import (
+    SubtitleOcrProcessor,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+    SubtitleOcrOutcome,
+    SubtitleTrackOutcome,
+)
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+_OPTS = SubtitleOcrOptions()
+_OUT = Path("/tmp/out")
+
+
+def _image(index: int, lang: str) -> SubtitleTrack:
+    return SubtitleTrack(index=index, language=LanguageCode(lang), format="pgs")
+
+
+def _text(index: int, lang: str) -> SubtitleTrack:
+    return SubtitleTrack(index=index, language=LanguageCode(lang), format="srt")
+
+
+def _processor(probe_tracks: list[SubtitleTrack], ocr_result: OcrTrackResult) -> tuple:
+    probe = MagicMock()
+    probe.probe.return_value = ProbeResult(subtitle_tracks=probe_tracks)
+    ocr = MagicMock(spec=SubtitleOcrPort)
+    ocr.ocr_track.return_value = ocr_result
+    return SubtitleOcrProcessor(probe, ocr), ocr
+
+
+@pytest.mark.unit
+class TestSubtitleOcrProcessor:
+    def test_no_image_tracks(self) -> None:
+        proc, ocr = _processor(
+            [_text(0, "en")], OcrTrackResult(outcome=SubtitleTrackOutcome.EXTRACTED)
+        )
+
+        report = proc.process_file("m.mkv", _OUT, _OPTS, None)
+
+        assert report.outcome == SubtitleOcrOutcome.NO_IMAGE_SUBTITLES
+        assert report.image_track_count == 0
+        assert report.track_results == []
+        ocr.ocr_track.assert_not_called()
+
+    def test_extracts_each_image_track(self) -> None:
+        proc, ocr = _processor(
+            [_image(0, "en"), _image(1, "pt")],
+            OcrTrackResult(outcome=SubtitleTrackOutcome.EXTRACTED, cue_count=50),
+        )
+
+        report = proc.process_file("m.mkv", _OUT, _OPTS, None)
+
+        assert report.outcome == SubtitleOcrOutcome.COMPLETED
+        assert report.image_track_count == 2
+        assert report.extracted_count == 2
+        assert [r.language for r in report.track_results] == ["en", "pt"]
+        assert report.track_results[0].cue_count == 50
+
+    def test_language_filter_marks_skipped_without_ocr(self) -> None:
+        proc, ocr = _processor(
+            [_image(0, "en"), _image(1, "pt")],
+            OcrTrackResult(outcome=SubtitleTrackOutcome.EXTRACTED, cue_count=10),
+        )
+
+        report = proc.process_file("m.mkv", _OUT, _OPTS, frozenset({"pt"}))
+
+        assert ocr.ocr_track.call_count == 1  # only the pt track
+        by_lang = {r.language: r.outcome for r in report.track_results}
+        assert by_lang["en"] == SubtitleTrackOutcome.SKIPPED_LANGUAGE
+        assert by_lang["pt"] == SubtitleTrackOutcome.EXTRACTED
+        assert report.extracted_count == 1
+
+    def test_non_extracted_outcome_flows_through(self) -> None:
+        proc, _ = _processor(
+            [_image(0, "en")],
+            OcrTrackResult(outcome=SubtitleTrackOutcome.NO_TEXT),
+        )
+
+        report = proc.process_file("m.mkv", _OUT, _OPTS, None)
+
+        assert report.outcome == SubtitleOcrOutcome.COMPLETED
+        assert report.extracted_count == 0
+        assert report.track_results[0].outcome == SubtitleTrackOutcome.NO_TEXT

--- a/tests/modules/media/unit/application/use_cases/test_run_subtitle_ocr_for_media.py
+++ b/tests/modules/media/unit/application/use_cases/test_run_subtitle_ocr_for_media.py
@@ -1,0 +1,180 @@
+"""Tests for RunSubtitleOcrForMediaUseCase (manual OCR trigger)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.subtitle_ocr_run_dtos import RunSubtitleOcrInput
+from src.modules.media.application.services.subtitle_ocr_paths import (
+    OCR_DONE_MARKER,
+    ocr_subtitle_output_dir,
+)
+from src.modules.media.application.services.subtitle_ocr_processor import FileOcrReport
+from src.modules.media.application.use_cases.run_subtitle_ocr_for_media import (
+    RunSubtitleOcrForMediaUseCase,
+)
+from src.modules.media.domain.entities.subtitle_ocr_run import SubtitleTrackOcrResult
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+    SubtitleOcrOutcome,
+    SubtitleTrackOutcome,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_run_id import SubtitleOcrRunId
+from src.modules.settings.domain.value_objects import StreamingConfig, SubtitleOcrConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _movie(
+    path: Path, *, media_id: str = "mov_aaaaaaaaaaaa", title: str = "Nausicaa"
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=media_id,
+        title=SimpleNamespace(value=title),
+        primary_file=SimpleNamespace(file_path=SimpleNamespace(value=str(path))),
+    )
+
+
+def _series_with_episode(path: Path, *, episode_id: str = "epi_bbbbbbbbbbbb") -> SimpleNamespace:
+    episode = SimpleNamespace(
+        id=episode_id,
+        season_number=SimpleNamespace(value=1),
+        episode_number=SimpleNamespace(value=3),
+        primary_file=SimpleNamespace(file_path=SimpleNamespace(value=str(path))),
+    )
+    return SimpleNamespace(
+        title=SimpleNamespace(value="Show"),
+        seasons=[SimpleNamespace(episodes=[episode])],
+    )
+
+
+def _uow(
+    *, movie: SimpleNamespace | None = None, series: SimpleNamespace | None = None
+) -> AsyncMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.movies = AsyncMock()
+    uow.movies.find_by_id = AsyncMock(return_value=movie)
+    uow.series = AsyncMock()
+    uow.series.find_by_episode_id = AsyncMock(return_value=series)
+    uow.subtitle_ocr_runs = AsyncMock()
+    uow.subtitle_ocr_runs.add = AsyncMock(
+        side_effect=lambda run: run.with_updates(id=SubtitleOcrRunId.generate())
+    )
+    return uow
+
+
+def _config() -> AsyncMock:
+    config = AsyncMock()
+    config.subtitle_ocr = AsyncMock(return_value=SubtitleOcrConfig())
+    config.streaming = AsyncMock(return_value=StreamingConfig())
+    return config
+
+
+def _ocr_service(*, langs: frozenset[str] = frozenset({"eng", "por"})) -> MagicMock:
+    service = MagicMock()
+    service.available_languages.return_value = langs
+    return service
+
+
+def _processor(report: FileOcrReport) -> MagicMock:
+    proc = MagicMock()
+    proc.process_file.return_value = report
+    return proc
+
+
+def _use_case(
+    uow: AsyncMock, processor: MagicMock, ocr: MagicMock
+) -> RunSubtitleOcrForMediaUseCase:
+    return RunSubtitleOcrForMediaUseCase(
+        media_uow_factory=MagicMock(return_value=uow),
+        processor=processor,
+        ocr_service=ocr,
+        config=_config(),
+    )
+
+
+_COMPLETED = FileOcrReport(
+    outcome=SubtitleOcrOutcome.COMPLETED,
+    image_track_count=1,
+    track_results=[
+        SubtitleTrackOcrResult(
+            track_index=0, language="pt", outcome=SubtitleTrackOutcome.EXTRACTED, cue_count=42
+        )
+    ],
+)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestRunSubtitleOcrForMedia:
+    async def test_movie_ocr_records_completed_run_and_marker(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.mkv"
+        uow = _uow(movie=_movie(path, media_id="mov_cccccccccccc", title="Nausicaa"))
+        proc = _processor(_COMPLETED)
+        use_case = _use_case(uow, proc, _ocr_service())
+
+        out = await use_case.execute(
+            RunSubtitleOcrInput(media_kind="movie", media_id="mov_cccccccccccc")
+        )
+
+        assert out.media_kind == "movie"
+        assert out.media_title == "Nausicaa"
+        assert out.outcome == SubtitleOcrOutcome.COMPLETED.value
+        assert out.extracted_count == 1
+        assert out.track_results[0].cue_count == 42
+        # manual trigger OCRs all languages (no filter)
+        assert proc.process_file.call_args.args[3] is None
+        # COMPLETED writes the done marker
+        assert (ocr_subtitle_output_dir(path, ".homeflix/subtitles") / OCR_DONE_MARKER).exists()
+
+    async def test_tesseract_unavailable_records_failed_run(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.mkv"
+        uow = _uow(movie=_movie(path))
+        proc = _processor(_COMPLETED)
+        use_case = _use_case(uow, proc, _ocr_service(langs=frozenset()))
+
+        out = await use_case.execute(
+            RunSubtitleOcrInput(media_kind="movie", media_id="mov_aaaaaaaaaaaa")
+        )
+
+        assert out.outcome == SubtitleOcrOutcome.FAILED.value
+        assert out.error is not None
+        proc.process_file.assert_not_called()
+        # FAILED does not write the done marker (so it can be retried)
+        assert not (ocr_subtitle_output_dir(path, ".homeflix/subtitles") / OCR_DONE_MARKER).exists()
+
+    async def test_movie_not_found_raises(self, tmp_path: Path) -> None:
+        uow = _uow(movie=None)
+        use_case = _use_case(uow, _processor(_COMPLETED), _ocr_service())
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(
+                RunSubtitleOcrInput(media_kind="movie", media_id="mov_dddddddddddd")
+            )
+
+    async def test_episode_ocr_uses_series_label(self, tmp_path: Path) -> None:
+        path = tmp_path / "e.mkv"
+        uow = _uow(series=_series_with_episode(path, episode_id="epi_eeeeeeeeeeee"))
+        use_case = _use_case(uow, _processor(_COMPLETED), _ocr_service())
+
+        out = await use_case.execute(
+            RunSubtitleOcrInput(media_kind="episode", media_id="epi_eeeeeeeeeeee")
+        )
+
+        assert out.media_kind == "episode"
+        assert out.media_title == "Show S01E03"
+
+    async def test_unknown_kind_raises(self, tmp_path: Path) -> None:
+        use_case = _use_case(_uow(), _processor(_COMPLETED), _ocr_service())
+
+        with pytest.raises(ValueError, match="Unknown media_kind"):
+            await use_case.execute(
+                RunSubtitleOcrInput(media_kind="bogus", media_id="mov_ffffffffffff")
+            )

--- a/tests/modules/media/unit/application/use_cases/test_run_subtitle_ocr_for_media.py
+++ b/tests/modules/media/unit/application/use_cases/test_run_subtitle_ocr_for_media.py
@@ -70,9 +70,9 @@ def _uow(
     return uow
 
 
-def _config() -> AsyncMock:
+def _config(languages: tuple[str, ...] = ()) -> AsyncMock:
     config = AsyncMock()
-    config.subtitle_ocr = AsyncMock(return_value=SubtitleOcrConfig())
+    config.subtitle_ocr = AsyncMock(return_value=SubtitleOcrConfig(languages=languages))
     config.streaming = AsyncMock(return_value=StreamingConfig())
     return config
 
@@ -90,13 +90,16 @@ def _processor(report: FileOcrReport) -> MagicMock:
 
 
 def _use_case(
-    uow: AsyncMock, processor: MagicMock, ocr: MagicMock
+    uow: AsyncMock,
+    processor: MagicMock,
+    ocr: MagicMock,
+    languages: tuple[str, ...] = (),
 ) -> RunSubtitleOcrForMediaUseCase:
     return RunSubtitleOcrForMediaUseCase(
         media_uow_factory=MagicMock(return_value=uow),
         processor=processor,
         ocr_service=ocr,
-        config=_config(),
+        config=_config(languages),
     )
 
 
@@ -129,8 +132,19 @@ class TestRunSubtitleOcrForMedia:
         assert out.outcome == SubtitleOcrOutcome.COMPLETED.value
         assert out.extracted_count == 1
         assert out.track_results[0].cue_count == 42
-        # manual trigger OCRs all languages (no filter)
+        # empty config languages -> no filter (every mappable track)
         assert proc.process_file.call_args.args[3] is None
+
+    async def test_honours_configured_languages(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.mkv"
+        uow = _uow(movie=_movie(path, media_id="mov_cccccccccccc"))
+        proc = _processor(_COMPLETED)
+        # a 20+ track remux must not OCR everything — scope by config
+        use_case = _use_case(uow, proc, _ocr_service(), languages=("pt", "en"))
+
+        await use_case.execute(RunSubtitleOcrInput(media_kind="movie", media_id="mov_cccccccccccc"))
+
+        assert proc.process_file.call_args.args[3] == frozenset({"pt", "en"})
         # COMPLETED writes the done marker
         assert (ocr_subtitle_output_dir(path, ".homeflix/subtitles") / OCR_DONE_MARKER).exists()
 

--- a/tests/modules/media/unit/application/use_cases/test_subtitle_ocr_run_use_cases.py
+++ b/tests/modules/media/unit/application/use_cases/test_subtitle_ocr_run_use_cases.py
@@ -1,0 +1,104 @@
+"""Tests for the subtitle-OCR run (audit) use cases."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.subtitle_ocr_run_dtos import (
+    GetSubtitleOcrRunInput,
+    ListSubtitleOcrRunsInput,
+)
+from src.modules.media.application.use_cases.get_subtitle_ocr_run import (
+    GetSubtitleOcrRunUseCase,
+)
+from src.modules.media.application.use_cases.list_subtitle_ocr_runs import (
+    ListSubtitleOcrRunsUseCase,
+)
+from src.modules.media.domain.entities.subtitle_ocr_run import (
+    SubtitleOcrRun,
+    SubtitleTrackOcrResult,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import (
+    SubtitleOcrOutcome,
+    SubtitleTrackOutcome,
+)
+from src.modules.media.domain.value_objects.subtitle_ocr_run_id import SubtitleOcrRunId
+
+
+def _run() -> SubtitleOcrRun:
+    now = datetime(2026, 7, 4, 12, 0, tzinfo=UTC)
+    return SubtitleOcrRun(
+        id=SubtitleOcrRunId.generate(),
+        media_kind="movie",
+        media_id="mov_test00000001",
+        media_title="Nausicaa",
+        file_path="G:/movies/nausicaa.mkv",
+        outcome=SubtitleOcrOutcome.COMPLETED,
+        image_track_count=2,
+        extracted_count=1,
+        track_results=[
+            SubtitleTrackOcrResult(
+                track_index=0,
+                language="en",
+                outcome=SubtitleTrackOutcome.EXTRACTED,
+                cue_count=1079,
+            ),
+        ],
+        started_at=now,
+        finished_at=now,
+    )
+
+
+def _uow(
+    *, runs: list[SubtitleOcrRun] | None = None, found: SubtitleOcrRun | None = None
+) -> AsyncMock:
+    uow = AsyncMock()
+    uow.__aenter__.return_value = uow
+    uow.__aexit__.return_value = None
+    uow.subtitle_ocr_runs = AsyncMock()
+    uow.subtitle_ocr_runs.list_paginated = AsyncMock(return_value=runs or [])
+    uow.subtitle_ocr_runs.find_by_id = AsyncMock(return_value=found)
+    return uow
+
+
+@pytest.mark.unit
+class TestSubtitleOcrRunUseCases:
+    @pytest.mark.asyncio
+    async def test_list_projects_runs_to_output(self) -> None:
+        run = _run()
+        uow = _uow(runs=[run])
+        use_case = ListSubtitleOcrRunsUseCase(media_uow_factory=MagicMock(return_value=uow))
+
+        rows = await use_case.execute(ListSubtitleOcrRunsInput(media_kind="movie"))
+
+        assert len(rows) == 1
+        assert rows[0].id == str(run.id)
+        assert rows[0].outcome == SubtitleOcrOutcome.COMPLETED.value
+        assert rows[0].extracted_count == 1
+        assert rows[0].track_results[0].outcome == SubtitleTrackOutcome.EXTRACTED.value
+        assert rows[0].track_results[0].cue_count == 1079
+        uow.subtitle_ocr_runs.list_paginated.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_returns_run_when_found(self) -> None:
+        run = _run()
+        uow = _uow(found=run)
+        use_case = GetSubtitleOcrRunUseCase(media_uow_factory=MagicMock(return_value=uow))
+
+        output = await use_case.execute(GetSubtitleOcrRunInput(run_id=str(run.id)))
+
+        assert output.id == str(run.id)
+        assert output.media_title == "Nausicaa"
+        assert output.image_track_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_raises_when_not_found(self) -> None:
+        uow = _uow(found=None)
+        use_case = GetSubtitleOcrRunUseCase(media_uow_factory=MagicMock(return_value=uow))
+
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(GetSubtitleOcrRunInput(run_id=str(SubtitleOcrRunId.generate())))

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -20,7 +20,11 @@ from src.modules.media.infrastructure.streaming.hls_service import (
     _shift_webvtt_to_bucket_local,
 )
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
-from src.modules.settings.domain.value_objects import HardwareAccel, StreamingConfig
+from src.modules.settings.domain.value_objects import (
+    HardwareAccel,
+    StreamingConfig,
+    SubtitleOcrConfig,
+)
 from src.shared_kernel.value_objects.language_code import LanguageCode
 from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
@@ -30,11 +34,14 @@ def _fake_runtime_settings(
     ffmpeg_threads: int | None = None,
     hls_cache_max_size_mb: int = 5120,
     hw_accel: HardwareAccel = HardwareAccel.OFF,
+    subtitle_ocr: SubtitleOcrConfig | None = None,
 ) -> MagicMock:
-    """Build a fake :class:`RuntimeSettings` exposing the sync streaming snapshot.
+    """Build a fake :class:`RuntimeSettings` exposing the sync snapshots.
 
     ``hw_accel`` defaults to ``OFF`` so command-building tests stay on
     the deterministic software path and never spawn the NVENC probe.
+    ``subtitle_ocr`` defaults to a disabled config so OCR surfacing is a
+    no-op unless a test opts in.
     """
     runtime = MagicMock()
     runtime.streaming_snapshot_sync.return_value = StreamingConfig(
@@ -42,6 +49,7 @@ def _fake_runtime_settings(
         hls_cache_max_size_mb=hls_cache_max_size_mb,
         hw_accel=hw_accel,
     )
+    runtime.subtitle_ocr_snapshot_sync.return_value = subtitle_ocr or SubtitleOcrConfig()
     return runtime
 
 

--- a/tests/modules/media/unit/infrastructure/streaming/test_pgs_parser.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_pgs_parser.py
@@ -1,0 +1,114 @@
+"""Tests for the pure PGS subtitle parser.
+
+Builds synthetic PGS byte streams segment-by-segment so decode + timing
+are validated without a binary fixture.
+"""
+
+import struct
+
+import pytest
+
+from src.modules.media.infrastructure.streaming.pgs_parser import parse_pgs
+
+_SEG_PDS = 0x14
+_SEG_ODS = 0x15
+_SEG_PCS = 0x16
+_SEG_END = 0x80
+
+
+def _segment(pts_90khz: int, seg_type: int, payload: bytes) -> bytes:
+    """Assemble one PGS segment with its 13-byte header."""
+    return (
+        b"PG"
+        + struct.pack(">I", pts_90khz)
+        + struct.pack(">I", 0)  # dts (unused)
+        + bytes([seg_type])
+        + struct.pack(">H", len(payload))
+        + payload
+    )
+
+
+def _pcs(num_objects: int) -> bytes:
+    """A Presentation Composition Segment declaring ``num_objects``."""
+    # width(2) height(2) framerate(1) compnum(2) compstate(1) palupd(1)
+    # palid(1) num_objects(1) [+ per-object entries the parser ignores].
+    return struct.pack(">HHBHBBBB", 2, 1, 0x10, 0, 0x80, 0, 0, num_objects)
+
+
+def _pds() -> bytes:
+    """A palette mapping index 1 -> opaque white (Y=235, Cr=Cb=128)."""
+    return bytes([0, 0]) + bytes([1, 235, 128, 128, 255])
+
+
+def _ods_2x1() -> bytes:
+    """One 2x1 object, both pixels palette index 1."""
+    rle = bytes([0x01, 0x01, 0x00, 0x00])  # px1, px2, end-of-line
+    obj_data_len = 2 + 2 + len(rle)  # width + height + rle
+    return (
+        struct.pack(">H", 0)  # object id
+        + bytes([0])  # version
+        + bytes([0xC0])  # first + last in sequence
+        + struct.pack(">I", obj_data_len)[1:]  # 3-byte data length
+        + struct.pack(">H", 2)  # width
+        + struct.pack(">H", 1)  # height
+        + rle
+    )
+
+
+def _show_then_clear(show_pts: int, clear_pts: int) -> bytes:
+    """A full show display set followed by a clear one."""
+    return (
+        _segment(show_pts, _SEG_PCS, _pcs(num_objects=1))
+        + _segment(show_pts, _SEG_PDS, _pds())
+        + _segment(show_pts, _SEG_ODS, _ods_2x1())
+        + _segment(show_pts, _SEG_END, b"")
+        + _segment(clear_pts, _SEG_PCS, _pcs(num_objects=0))
+        + _segment(clear_pts, _SEG_END, b"")
+    )
+
+
+@pytest.mark.unit
+class TestParsePgs:
+    def test_pairs_show_and_clear_into_one_timed_cue(self) -> None:
+        stream = _show_then_clear(show_pts=90_000, clear_pts=180_000)
+
+        cues = parse_pgs(stream)
+
+        assert len(cues) == 1
+        assert cues[0].start_ms == 1000  # 90_000 / 90
+        assert cues[0].end_ms == 2000  # 180_000 / 90
+
+    def test_decodes_object_bitmap_through_palette(self) -> None:
+        cues = parse_pgs(_show_then_clear(90_000, 180_000))
+
+        image = cues[0].image
+        assert image.size == (2, 1)
+        assert image.mode == "RGBA"
+        # both pixels are palette index 1 -> opaque white
+        assert image.getpixel((0, 0)) == (255, 255, 255, 255)
+        assert image.getpixel((1, 0)) == (255, 255, 255, 255)
+
+    def test_multiple_cues_preserved_in_order(self) -> None:
+        stream = _show_then_clear(90_000, 180_000) + _show_then_clear(270_000, 360_000)
+
+        cues = parse_pgs(stream)
+
+        assert [(c.start_ms, c.end_ms) for c in cues] == [(1000, 2000), (3000, 4000)]
+
+    def test_show_without_matching_clear_is_dropped(self) -> None:
+        # A show set with no following clear yields no completed cue.
+        stream = (
+            _segment(90_000, _SEG_PCS, _pcs(num_objects=1))
+            + _segment(90_000, _SEG_PDS, _pds())
+            + _segment(90_000, _SEG_ODS, _ods_2x1())
+            + _segment(90_000, _SEG_END, b"")
+        )
+
+        assert parse_pgs(stream) == []
+
+    def test_empty_stream_yields_no_cues(self) -> None:
+        assert parse_pgs(b"") == []
+
+    def test_non_pgs_stream_raises(self) -> None:
+        with pytest.raises(ValueError, match="Not a PGS stream"):
+            parse_pgs(b"NOTPGSDATA___________")

--- a/tests/modules/media/unit/infrastructure/streaming/test_subtitle_ocr_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_subtitle_ocr_service.py
@@ -1,0 +1,154 @@
+"""Tests for the tesseract PGS OCR service (ADR-027).
+
+The real tesseract/ffmpeg binaries are never invoked: the parse step,
+the language probe, the bitmap read, and the per-cue OCR are stubbed so
+the orchestration (filtering, VTT assembly, degradation to ``None``) is
+verified deterministically.
+"""
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrOptions
+from src.modules.media.infrastructure.streaming import subtitle_ocr_service as svc
+from src.modules.media.infrastructure.streaming.pgs_parser import PgsCue
+from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
+    TesseractPgsOcrService,
+    ocr_sidecar_filename,
+    ocr_subtitle_output_dir,
+)
+from src.shared_kernel.value_objects.file_path import FilePath
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+_OPTS = SubtitleOcrOptions(tesseract_binary="tesseract", per_cue_timeout_seconds=5)
+
+
+def _pgs_track(index: int = 4, lang: str = "pt") -> SubtitleTrack:
+    return SubtitleTrack(index=index, language=LanguageCode(lang), format="pgs")
+
+
+def _cue(start_ms: int, end_ms: int) -> PgsCue:
+    return PgsCue(start_ms, end_ms, Image.new("RGBA", (2, 1)))
+
+
+@pytest.mark.unit
+class TestOcrTrack:
+    def test_unsupported_bitmap_format_is_skipped(self, tmp_path: Path) -> None:
+        track = SubtitleTrack(index=1, language=LanguageCode("en"), format="vobsub")
+        service = TesseractPgsOcrService()
+
+        assert service.ocr_track("movie.mkv", track, tmp_path, _OPTS) is None
+
+    def test_unmappable_language_is_skipped(self, tmp_path: Path) -> None:
+        # "th" (Thai) is a valid ISO code but not in the model map.
+        service = TesseractPgsOcrService()
+
+        result = service.ocr_track("m.mkv", _pgs_track(lang="th"), tmp_path, _OPTS)
+
+        assert result is None
+
+    def test_missing_language_model_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = TesseractPgsOcrService()
+        monkeypatch.setattr(service, "_available_langs", lambda _binary: frozenset())
+
+        result = service.ocr_track("m.mkv", _pgs_track(), tmp_path, _OPTS)
+
+        assert result is None
+
+    def test_writes_vtt_sidecar_on_success(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = TesseractPgsOcrService()
+        monkeypatch.setattr(service, "_available_langs", lambda _binary: frozenset({"por"}))
+        monkeypatch.setattr(service, "_read_pgs_bytes", lambda *a: b"rawpgs")
+        monkeypatch.setattr(svc, "parse_pgs", lambda _raw: [_cue(1000, 2000), _cue(3000, 4000)])
+        texts = iter(["Olá mundo", "Segunda linha"])
+        monkeypatch.setattr(service, "_ocr_one", lambda *a: next(texts))
+
+        track = _pgs_track(index=4, lang="pt")
+        result = service.ocr_track("m.mkv", track, tmp_path, _OPTS)
+
+        assert result == tmp_path / "ocr_s4_pt.vtt"
+        content = result.read_text(encoding="utf-8")
+        assert content.startswith("WEBVTT")
+        assert "00:00:01.000 --> 00:00:02.000" in content
+        assert "Olá mundo" in content
+        assert "00:00:03.000 --> 00:00:04.000" in content
+
+    def test_all_empty_ocr_yields_no_sidecar(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = TesseractPgsOcrService()
+        monkeypatch.setattr(service, "_available_langs", lambda _binary: frozenset({"por"}))
+        monkeypatch.setattr(service, "_read_pgs_bytes", lambda *a: b"rawpgs")
+        monkeypatch.setattr(svc, "parse_pgs", lambda _raw: [_cue(1000, 2000)])
+        monkeypatch.setattr(service, "_ocr_one", lambda *a: "")
+
+        result = service.ocr_track("m.mkv", _pgs_track(), tmp_path, _OPTS)
+
+        assert result is None
+        assert list(tmp_path.glob("*.vtt")) == []
+
+    def test_no_cues_parsed_yields_no_sidecar(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        service = TesseractPgsOcrService()
+        monkeypatch.setattr(service, "_available_langs", lambda _binary: frozenset({"por"}))
+        monkeypatch.setattr(service, "_read_pgs_bytes", lambda *a: b"rawpgs")
+        monkeypatch.setattr(svc, "parse_pgs", lambda _raw: [])
+
+        assert service.ocr_track("m.mkv", _pgs_track(), tmp_path, _OPTS) is None
+
+    def test_external_sup_reads_file_directly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sup = tmp_path / "sub.sup"
+        sup.write_bytes(b"rawpgs")
+        track = SubtitleTrack(
+            index=7,
+            language=LanguageCode("en"),
+            format="sup",
+            is_external=True,
+            file_path=FilePath(str(sup)),
+        )
+        service = TesseractPgsOcrService()
+        monkeypatch.setattr(service, "_available_langs", lambda _binary: frozenset({"eng"}))
+        captured: dict[str, bytes] = {}
+        monkeypatch.setattr(svc, "parse_pgs", lambda raw: captured.setdefault("raw", raw) and [])
+
+        service.ocr_track("m.mkv", track, tmp_path, _OPTS)
+
+        assert captured["raw"] == b"rawpgs"
+
+
+@pytest.mark.unit
+class TestHelpers:
+    def test_sidecar_filename_is_deterministic_from_track(self) -> None:
+        assert ocr_sidecar_filename(_pgs_track(index=4, lang="pt")) == "ocr_s4_pt.vtt"
+
+    def test_output_dir_mirrors_scrub_preview_layout(self) -> None:
+        source = Path("/media/Movies/Film (2020)/Film (2020).mkv")
+
+        out = ocr_subtitle_output_dir(source, ".homeflix/subtitles")
+
+        assert out == source.parent / ".homeflix/subtitles" / "Film (2020)"
+
+    def test_clean_text_fixes_pipe_misread(self) -> None:
+        assert svc._clean_ocr_text("| wonder if | can go") == "I wonder if I can go"
+
+    def test_clean_text_drops_blank_lines_and_trims(self) -> None:
+        assert svc._clean_ocr_text("\n  Hello  \n\n world \n") == "Hello\nworld"
+
+    def test_ms_to_vtt_formats_timestamp(self) -> None:
+        assert svc._ms_to_vtt(3_661_007) == "01:01:01.007"
+
+    def test_render_vtt_has_header_and_blank_separated_cues(self) -> None:
+        out = svc._render_vtt([(1000, 2000, "A"), (3000, 4000, "B")])
+
+        assert out.startswith("WEBVTT\n\n")
+        assert "00:00:01.000 --> 00:00:02.000\nA\n" in out

--- a/tests/modules/media/unit/infrastructure/streaming/test_subtitle_ocr_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_subtitle_ocr_service.py
@@ -12,6 +12,7 @@ import pytest
 from PIL import Image
 
 from src.modules.media.application.ports.subtitle_ocr_port import SubtitleOcrOptions
+from src.modules.media.domain.value_objects.subtitle_ocr_outcome import SubtitleTrackOutcome
 from src.modules.media.infrastructure.streaming import subtitle_ocr_service as svc
 from src.modules.media.infrastructure.streaming.pgs_parser import PgsCue
 from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
@@ -40,7 +41,10 @@ class TestOcrTrack:
         track = SubtitleTrack(index=1, language=LanguageCode("en"), format="vobsub")
         service = TesseractPgsOcrService()
 
-        assert service.ocr_track("movie.mkv", track, tmp_path, _OPTS) is None
+        result = service.ocr_track("movie.mkv", track, tmp_path, _OPTS)
+
+        assert result.outcome == SubtitleTrackOutcome.UNSUPPORTED_FORMAT
+        assert result.vtt_path is None
 
     def test_unmappable_language_is_skipped(self, tmp_path: Path) -> None:
         # "th" (Thai) is a valid ISO code but not in the model map.
@@ -48,7 +52,7 @@ class TestOcrTrack:
 
         result = service.ocr_track("m.mkv", _pgs_track(lang="th"), tmp_path, _OPTS)
 
-        assert result is None
+        assert result.outcome == SubtitleTrackOutcome.NO_LANGUAGE_MODEL
 
     def test_missing_language_model_is_skipped(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -58,7 +62,7 @@ class TestOcrTrack:
 
         result = service.ocr_track("m.mkv", _pgs_track(), tmp_path, _OPTS)
 
-        assert result is None
+        assert result.outcome == SubtitleTrackOutcome.NO_LANGUAGE_MODEL
 
     def test_writes_vtt_sidecar_on_success(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -73,8 +77,10 @@ class TestOcrTrack:
         track = _pgs_track(index=4, lang="pt")
         result = service.ocr_track("m.mkv", track, tmp_path, _OPTS)
 
-        assert result == tmp_path / "ocr_s4_pt.vtt"
-        content = result.read_text(encoding="utf-8")
+        assert result.outcome == SubtitleTrackOutcome.EXTRACTED
+        assert result.vtt_path == tmp_path / "ocr_s4_pt.vtt"
+        assert result.cue_count == 2
+        content = result.vtt_path.read_text(encoding="utf-8")
         assert content.startswith("WEBVTT")
         assert "00:00:01.000 --> 00:00:02.000" in content
         assert "Olá mundo" in content
@@ -91,7 +97,8 @@ class TestOcrTrack:
 
         result = service.ocr_track("m.mkv", _pgs_track(), tmp_path, _OPTS)
 
-        assert result is None
+        assert result.outcome == SubtitleTrackOutcome.NO_TEXT
+        assert result.vtt_path is None
         assert list(tmp_path.glob("*.vtt")) == []
 
     def test_no_cues_parsed_yields_no_sidecar(
@@ -102,7 +109,9 @@ class TestOcrTrack:
         monkeypatch.setattr(service, "_read_pgs_bytes", lambda *a: b"rawpgs")
         monkeypatch.setattr(svc, "parse_pgs", lambda _raw: [])
 
-        assert service.ocr_track("m.mkv", _pgs_track(), tmp_path, _OPTS) is None
+        result = service.ocr_track("m.mkv", _pgs_track(), tmp_path, _OPTS)
+
+        assert result.outcome == SubtitleTrackOutcome.NO_TEXT
 
     def test_external_sup_reads_file_directly(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/modules/media/unit/infrastructure/streaming/test_subtitle_ocr_surfacing.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_subtitle_ocr_surfacing.py
@@ -1,0 +1,120 @@
+"""Tests for surfacing OCR sidecars as external text tracks (ADR-027)."""
+
+from pathlib import Path
+
+import pytest
+
+from src.modules.media.application.ports.media_probe_port import ProbeResult
+from src.modules.media.infrastructure.streaming.subtitle_ocr_service import (
+    ocr_sidecar_filename,
+    ocr_subtitle_output_dir,
+)
+from src.modules.media.infrastructure.streaming.subtitle_ocr_surfacing import (
+    attach_ocr_subtitles,
+)
+from src.modules.settings.domain.value_objects import SubtitleOcrConfig
+from src.shared_kernel.value_objects.language_code import LanguageCode
+from src.shared_kernel.value_objects.tracks import SubtitleTrack
+
+_SUBDIR = ".homeflix/subtitles"
+
+
+def _text(index: int, lang: str = "en") -> SubtitleTrack:
+    return SubtitleTrack(index=index, language=LanguageCode(lang), format="srt")
+
+
+def _image(index: int, lang: str = "pt", *, forced: bool = False) -> SubtitleTrack:
+    return SubtitleTrack(index=index, language=LanguageCode(lang), format="pgs", is_forced=forced)
+
+
+def _probe(*subs: SubtitleTrack) -> ProbeResult:
+    embedded = [s for s in subs if not s.is_external]
+    external = [s for s in subs if s.is_external]
+    return ProbeResult(subtitle_tracks=list(embedded), external_subtitles=list(external))
+
+
+def _write_sidecar(source: Path, track: SubtitleTrack) -> Path:
+    out = ocr_subtitle_output_dir(source, _SUBDIR)
+    out.mkdir(parents=True, exist_ok=True)
+    sidecar = out / ocr_sidecar_filename(track)
+    sidecar.write_text("WEBVTT\n", encoding="utf-8")
+    return sidecar
+
+
+def _source(tmp_path: Path) -> Path:
+    source = tmp_path / "Movie (2020)" / "Movie (2020).mkv"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    return source
+
+
+@pytest.mark.unit
+class TestAttachOcrSubtitles:
+    def test_disabled_is_a_noop(self, tmp_path: Path) -> None:
+        source = _source(tmp_path)
+        image = _image(1)
+        _write_sidecar(source, image)  # sidecar exists but OCR is off
+        probe = _probe(_text(0), image)
+
+        result = attach_ocr_subtitles(probe, str(source), SubtitleOcrConfig(enabled=False))
+
+        assert result is probe
+
+    def test_surfaces_image_track_with_existing_sidecar(self, tmp_path: Path) -> None:
+        source = _source(tmp_path)
+        image = _image(1, lang="pt", forced=True)
+        sidecar = _write_sidecar(source, image)
+        probe = _probe(_text(0), image)
+
+        result = attach_ocr_subtitles(probe, str(source), SubtitleOcrConfig(enabled=True))
+
+        ocr = [t for t in result.all_subtitles if t.format == "vtt"]
+        assert len(ocr) == 1
+        assert ocr[0].index == 2  # max(0, 1) + 1
+        assert ocr[0].is_external is True
+        assert ocr[0].file_path is not None
+        assert ocr[0].file_path.value == str(sidecar)
+        assert ocr[0].language.value == "pt"
+        assert ocr[0].is_forced is True
+        # original image track is preserved untouched
+        assert any(t.format == "pgs" for t in result.all_subtitles)
+
+    def test_image_track_without_sidecar_is_unchanged(self, tmp_path: Path) -> None:
+        source = _source(tmp_path)
+        probe = _probe(_text(0), _image(1))
+
+        result = attach_ocr_subtitles(probe, str(source), SubtitleOcrConfig(enabled=True))
+
+        assert result is probe
+
+    def test_no_image_tracks_is_unchanged(self, tmp_path: Path) -> None:
+        source = _source(tmp_path)
+        probe = _probe(_text(0), _text(1, "pt"))
+
+        result = attach_ocr_subtitles(probe, str(source), SubtitleOcrConfig(enabled=True))
+
+        assert result is probe
+
+    def test_multiple_sidecars_get_distinct_indices_past_max(self, tmp_path: Path) -> None:
+        source = _source(tmp_path)
+        img_pt = _image(3, lang="pt")
+        img_en = _image(4, lang="en")
+        for track in (img_pt, img_en):
+            _write_sidecar(source, track)
+        probe = _probe(_text(0), img_pt, img_en)
+
+        result = attach_ocr_subtitles(probe, str(source), SubtitleOcrConfig(enabled=True))
+
+        ocr_indices = sorted(t.index for t in result.all_subtitles if t.format == "vtt")
+        assert ocr_indices == [5, 6]  # max(0,3,4)+1, +2 — no collision with sub_N
+
+    def test_only_tracks_with_sidecars_are_surfaced(self, tmp_path: Path) -> None:
+        source = _source(tmp_path)
+        img_with = _image(1, lang="pt")
+        img_without = _image(2, lang="en")
+        _write_sidecar(source, img_with)
+        probe = _probe(img_with, img_without)
+
+        result = attach_ocr_subtitles(probe, str(source), SubtitleOcrConfig(enabled=True))
+
+        ocr = [t for t in result.all_subtitles if t.format == "vtt"]
+        assert [t.language.value for t in ocr] == ["pt"]

--- a/tests/modules/media/unit/presentation/routes/test_admin_subtitle_ocr_routes.py
+++ b/tests/modules/media/unit/presentation/routes/test_admin_subtitle_ocr_routes.py
@@ -1,0 +1,45 @@
+"""Tests for the manual subtitle-OCR trigger's single-flight guard."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.modules.media.presentation.routes import admin_subtitle_ocr_routes as mod
+
+
+async def _drain() -> None:
+    """Wait for all in-flight manual-OCR tasks to finish."""
+    while mod._manual_ocr_tasks:
+        await asyncio.gather(*list(mod._manual_ocr_tasks), return_exceptions=True)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_single_flight_ignores_repeat_trigger_for_same_title() -> None:
+    gate = asyncio.Event()
+
+    async def _slow_execute(_input: object) -> None:
+        await gate.wait()
+
+    use_case = MagicMock()
+    use_case.execute = _slow_execute
+
+    try:
+        # first trigger starts a run
+        assert mod._fire_manual_ocr(use_case, "movie", "mov_aaaaaaaaaaaa") is True
+        # repeat while still running is ignored
+        assert mod._fire_manual_ocr(use_case, "movie", "mov_aaaaaaaaaaaa") is False
+        # a different title still starts
+        assert mod._fire_manual_ocr(use_case, "movie", "mov_bbbbbbbbbbbb") is True
+
+        gate.set()
+        await _drain()
+
+        # once finished, the same title can be triggered again
+        assert mod._fire_manual_ocr(use_case, "movie", "mov_aaaaaaaaaaaa") is True
+        await _drain()
+    finally:
+        gate.set()
+        await _drain()
+        mod._inflight_media.clear()

--- a/tests/modules/settings/e2e/test_admin_settings_routes.py
+++ b/tests/modules/settings/e2e/test_admin_settings_routes.py
@@ -95,6 +95,7 @@ class TestAdminSettingsList:
                 "streaming",
                 "avatar",
                 "scan_dedup",
+                "subtitle_ocr",
             ]
         )
         for entry in body["data"]:

--- a/tests/modules/settings/e2e/test_admin_settings_routes.py
+++ b/tests/modules/settings/e2e/test_admin_settings_routes.py
@@ -9,6 +9,7 @@ from src.modules.settings.domain.value_objects import (
     IntroDetectionConfig,
     ScanDedupConfig,
     SchedulerConfig,
+    SubtitleOcrConfig,
 )
 from tests.modules.settings.e2e.conftest import SeededUser
 
@@ -227,3 +228,26 @@ class TestAdminSettingsPatch:
         response = await client.patch(f"{SETTINGS_ROOT}/scan-dedup", json=body)
 
         assert response.status_code == 422
+
+    async def test_subtitle_ocr_full_replace_persists(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await _login_as_admin(client, seed_user_with_profile)
+
+        body = SubtitleOcrConfig(
+            enabled=True,
+            batch_size=3,
+            languages=("en", "pt"),
+        ).model_dump(mode="json")
+        response = await client.patch(f"{SETTINGS_ROOT}/subtitle-ocr", json=body)
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["key"] == "subtitle_ocr"
+        assert payload["source"] == "admin"
+        assert payload["updated_by_user_id"] == admin.user_external_id
+        assert payload["value"]["enabled"] is True
+        assert payload["value"]["batch_size"] == 3
+        assert payload["value"]["languages"] == ["en", "pt"]

--- a/tests/modules/settings/unit/domain/value_objects/test_subtitle_ocr_config.py
+++ b/tests/modules/settings/unit/domain/value_objects/test_subtitle_ocr_config.py
@@ -1,0 +1,49 @@
+"""Tests for the SubtitleOcrConfig VO (ADR-027 bucket)."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.settings.domain.value_objects import SubtitleOcrConfig
+
+
+@pytest.mark.unit
+class TestSubtitleOcrConfig:
+    def test_defaults_are_conservative(self) -> None:
+        cfg = SubtitleOcrConfig()
+
+        assert cfg.enabled is False
+        assert cfg.batch_size == 2
+        assert cfg.interval_minutes == 60
+        assert cfg.subdir == ".homeflix/subtitles"
+        assert cfg.languages == ()
+        assert cfg.tesseract_binary == "tesseract"
+        assert cfg.per_cue_timeout_seconds == 30
+
+    def test_with_updates_returns_a_modified_copy(self) -> None:
+        cfg = SubtitleOcrConfig()
+
+        updated = cfg.with_updates(enabled=True, languages=("en", "pt"))
+
+        assert updated.enabled is True
+        assert updated.languages == ("en", "pt")
+        assert cfg.enabled is False  # original untouched
+
+    def test_languages_is_hashable_so_the_vo_is_hashable(self) -> None:
+        # languages must be a tuple, not a list, or the VO can't be hashed
+        # like every other CompoundValueObject.
+        cfg = SubtitleOcrConfig(languages=("en",))
+
+        assert hash(cfg) == hash(SubtitleOcrConfig(languages=("en",)))
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_batch_size_must_be_positive(self, bad: int) -> None:
+        with pytest.raises(DomainValidationException):
+            SubtitleOcrConfig(batch_size=bad)
+
+    def test_interval_must_be_positive(self) -> None:
+        with pytest.raises(DomainValidationException):
+            SubtitleOcrConfig(interval_minutes=0)
+
+    def test_per_cue_timeout_must_be_positive(self) -> None:
+        with pytest.raises(DomainValidationException):
+            SubtitleOcrConfig(per_cue_timeout_seconds=0)


### PR DESCRIPTION
## Summary

Image-based subtitles (PGS/SUP, common in Blu-ray remuxes) are OCR'd to
text WebVTT sidecars and surfaced as selectable text tracks (ADR-027).
Backend-only; the frontend already trusts `/tracks` (ADR-026).

- **Pipeline** — `SubtitleOcrPort` + `TesseractPgsOcrService` (own PGS
  parser → tesseract → deterministic `.vtt` sidecar) + `SubtitleOcrConfig`
  runtime-settings bucket (off by default).
- **Surfacing** — `attach_ocr_subtitles` in `probe_tracks` + HLS
  `_start_generation`; an image track with a sidecar becomes an external
  text track. Gated on `enabled`, so with OCR off the player is
  byte-for-byte unchanged.
- **Generation** — background job `homeflix:subtitle-ocr` (batched,
  `.ocr_done` marker, tesseract-availability gate) + manual trigger
  `POST /admin/subtitle-ocr/movies|episodes/{id}/run` (fire-and-forget
  202, single-flight, honours the configured `languages`).
- **Observability** — `subtitle_ocr_runs` audit table (per file, per-track
  detail) + `GET /admin/subtitle-ocr/runs` (+ `/{id}`), mirroring
  `intro_detection_runs`.
- **Docs** — `docs/standards/subtitle-ocr-guide.md` (install, config,
  trigger, observability, troubleshooting); ADR-027.

Commits are granular (one per phase) for commit-by-commit review.

## Test plan

- [ ] `make migrate` applies (revision `5d0b7e1c9a3f`, `subtitle_ocr_runs`)
- [ ] `make test` green (unit + integration + e2e)
- [ ] `make lint` (ruff check + format) clean
- [ ] Smoke: enable `subtitle_ocr` + set `languages`, trigger a PGS movie,
      confirm a run is recorded and the subtitle is selectable in the player

## Migration steps

- `make migrate` — adds `subtitle_ocr_runs`. (If the dev server created the
  table via `create_all` first: `alembic stamp 5d0b7e1c9a3f`.)
- Host prerequisite: `tesseract` + the language `*.traineddata` on PATH
  (see the guide).
