### PR TITLE
docs: add features page and bump to v0.3.0

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,91 @@
+# Funcionalidades
+
+O que o HomeFlix oferece hoje, por área. Esta página descreve **capacidades já
+implementadas** — cada item se apoia num módulo do código ou num ADR aceito.
+Para os requisitos completos (incluindo o que ainda é planejado), veja
+[Requisitos](homeflix-requirements.md); para o que vem a seguir, o
+[Roadmap](roadmap.md).
+
+## Bibliotecas e configuração
+
+- **Múltiplas bibliotecas** (filmes, séries ou misto), cada uma com suas fontes
+  de diretório e idioma de metadados. A biblioteca é a entidade de configuração
+  do sistema ([ADR-005](adr/ADR-005-library-as-configuration-entity.md)).
+- **Provedores de metadados ordenados** (TMDB, OMDb) com fallback por prioridade.
+- **Preferências de reprodução por biblioteca** — idioma de áudio/legenda e modo
+  de legenda (sempre, só se áudio estrangeiro, só forçadas, desligado).
+- **Scan agendado** por biblioteca via expressão cron ou apenas manual.
+- **Runtime settings** persistidos em banco, por bucket, ajustáveis em runtime
+  ([ADR-013](adr/ADR-013-runtime-settings-db-backed.md) /
+  [ADR-014](adr/ADR-014-settings-per-bucket-aggregate.md)).
+
+## Scan e detecção de mídia
+
+- **Scanner de filesystem** que detecta vídeos, remove entradas de arquivos
+  apagados e deduplica por identidade de conteúdo
+  ([ADR-015](adr/ADR-015-scanner-deduplication-by-content-identity.md)).
+- **Faixas de áudio e legenda** detectadas do container (via ffprobe) e de
+  legendas externas na mesma pasta.
+- **Variantes de arquivo** — múltiplas versões do mesmo título (720p/1080p/4K,
+  HDR) agrupadas como uma mídia com vários arquivos
+  ([ADR-006](adr/ADR-006-media-file-variants.md)).
+- **Detecção de abertura (intro)** por frame-hash de vídeo, plugável
+  ([ADR-020](adr/ADR-020-pluggable-intro-detector-frame-hash.md)).
+- **Detecção de créditos** por sinais visuais (borda + movimento), por arquivo
+  ([ADR-021](adr/ADR-021-credits-detector-per-file-visual.md)).
+- **Enriquecimento de metadados** via TMDB, localizado por locale
+  ([ADR-023](adr/ADR-023-localized-metadata-value-object.md)) e reconciliado na
+  camada de aplicação
+  ([ADR-025](adr/ADR-025-provider-metadata-reconciliation-in-application.md)).
+
+## Reprodução (player)
+
+- **Streaming HLS** no navegador, com **transcodificação por hardware**
+  (NVENC/NVDEC) e encoder selecionável por configuração
+  ([ADR-019](adr/ADR-019-hardware-accelerated-transcoding.md)).
+- **Seleção de faixa autoritativa no servidor** — o backend resolve a faixa
+  default de áudio/legenda a partir das preferências e o front confia no
+  `/tracks` ([ADR-026](adr/ADR-026-server-authoritative-track-selection.md)),
+  usando um serviço de domínio `TrackSelector`
+  ([ADR-005](adr/ADR-005-library-as-configuration-entity.md)).
+- **Multi-áudio e multi-legenda** com nomes de faixa normalizados.
+- **OCR de legendas baseadas em imagem** (PGS/VOBSUB) convertidas para faixas de
+  texto selecionáveis ([ADR-027](adr/ADR-027-ocr-image-based-subtitles.md)).
+- **Skip intro / skip créditos** a partir dos marcadores detectados, e
+  **trickplay** (thumbnails de scrub) na barra de progresso.
+
+## Progresso e histórico
+
+- **Salvamento automático de progresso**, com marcação de "completo" ao atingir
+  ~90% e retomada exata (*continue watching*). O progresso é **escopo por
+  perfil**.
+
+## Listas e coleções
+
+- **Watchlist**, **favoritos** e **listas personalizadas** (com reordenação),
+  todos escopo por perfil.
+
+## Busca e navegação
+
+- **Busca full-text** (SQLite FTS5) sobre campos localizados, com navegação por
+  gênero e por ator, ordenados pelo título localizado.
+
+## Multi-usuário e identidade
+
+- **Usuários, perfis e sessões** com autenticação por cookie
+  ([ADR-010](adr/ADR-010-identity-bounded-context.md) /
+  [ADR-011](adr/ADR-011-authentication-strategy.md)).
+- **ACL por perfil** — cada perfil enxerga apenas as bibliotecas permitidas
+  (`allowed_library_ids`), com flag de perfil infantil e avatares.
+- **Catalog Requests ("Em breve")** — pedidos de títulos ausentes com
+  **subscriptions multi-usuário e fanout**, resolvidos quando o scanner encontra
+  o título ([ADR-022](adr/ADR-022-catalog-requests-subscriptions-fanout.md)).
+- **Notificações** de eventos de catálogo e da casa.
+
+## Administração e operação
+
+- **Painel admin** com dashboard de tarefas (job runs), execuções de scan,
+  edição manual de marcadores de abertura e sinalização de mídia enriquecida
+  incorretamente para revisão.
+- **Contratos de presentation publicados** para imports cross-BC
+  ([ADR-024](adr/ADR-024-published-presentation-contracts-cross-bc.md)).

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ ferramenta funcional de gerenciamento de mídia.
 
 ## Como navegar
 
+- **[Funcionalidades](features.md)** — o que o sistema oferece hoje, por área.
 - **[Requisitos](homeflix-requirements.md)** — features e regras de negócio.
 - **[Roadmap](roadmap.md)** — priorização e próximos passos.
 - **Standards** — convenções transversais: formato de respostas da API,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ validation:
 
 nav:
   - Início: index.md
+  - Funcionalidades: features.md
   - Requisitos: homeflix-requirements.md
   - Roadmap: roadmap.md
   - Standards:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "homeflix"
-version = "0.2.0"
+version = "0.3.0"
 description = "Personal streaming platform for local media"
 authors = ["Lucas"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Add a **Funcionalidades** page to the MkDocs site describing what the system offers today, organized by area (libraries & config, scan/detection, player, progress, lists, search, multi-user & identity, admin). Every item is grounded in a module or an accepted ADR — no aspirational content.
- Wire the page into the `nav` (right after Início) and link it from the landing page.
- Bump the project version `0.2.0` → `0.3.0` ahead of the `v0.3.0` release.

## Test plan

- [x] `make docs-build` (`mkdocs build --strict`) exits 0 with 0 warnings
- [x] All 16 ADR links on the features page resolve
- [x] Nav + index link to the new page resolve
- [ ] Reviewer sanity-checks the rendered page

## Related

Follows #357 (the MkDocs site). After merge: tag `v0.3.0` + GitHub release with notes covering everything since v0.2.0 (Phases 5/6, 16 ADRs).

## Summary by Sourcery

Document current system capabilities in a new MkDocs "Funcionalidades" page, link it into the docs navigation and landing page, and bump the project version to 0.3.0.

Build:
- Update project version from 0.2.0 to 0.3.0 in pyproject.toml ahead of the v0.3.0 release.

Documentation:
- Add a "Funcionalidades" documentation page detailing implemented features by area and referencing relevant ADRs.
- Expose the new features page in the MkDocs navigation and from the docs landing page.