### PR TITLE
docs: add live docs site badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🎬 HomeFlix
 
 [![CI](https://github.com/lucaschf/homeflix/actions/workflows/ci.yml/badge.svg)](https://github.com/lucaschf/homeflix/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-live-D97757.svg)](https://lucaschf.github.io/homeflix/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 


### PR DESCRIPTION
## Summary

- Add a peach `docs | live` badge to the README header linking to the published site (https://lucaschf.github.io/homeflix/).

## Test plan

- [x] Badge renders and links to the live GitHub Pages site

## Summary by Sourcery

Documentation:
- Document the live docs site in the README via a header badge linking to GitHub Pages.