### PR TITLE
docs: add ADR-028 to mkdocs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,3 +111,4 @@ nav:
       - adr/ADR-025-provider-metadata-reconciliation-in-application.md
       - adr/ADR-026-server-authoritative-track-selection.md
       - adr/ADR-027-ocr-image-based-subtitles.md
+      - adr/ADR-028-domain-exception-semantics.md


### PR DESCRIPTION
## Summary

- Registers `adr/ADR-028-domain-exception-semantics.md` in the `mkdocs.yml` nav.
- Fixes the `mkdocs build --strict` failure (page-exists-but-not-in-nav warning) introduced when ADR-028 was merged in #360 without the nav entry.

## Test plan

- [x] `poetry run mkdocs build --strict` passes locally (0 warnings).
- [ ] CI docs build green.

## Related issues

Follow-up to #360.

## Summary by Sourcery

Register ADR-028 in the MkDocs navigation to restore a clean strict documentation build.

Build:
- Resolve MkDocs strict build warning by including the new ADR page in the nav configuration.

Documentation:
- Add ADR-028 domain exception semantics ADR page to the documentation navigation.