### PR TITLE
ci: gate PRs on mkdocs build --strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,17 +146,47 @@ jobs:
         run: pip-audit --require-hashes=false
         continue-on-error: true
 
+  docs:
+    name: Docs Build (strict)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # histórico completo p/ git-revision-date-localized
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: latest
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install docs dependencies
+        run: poetry install --with docs --no-root --no-interaction
+
+      - name: Build site (strict)
+        env:
+          CI: "true" # ativa o plugin git-revision-date-localized
+        run: poetry run mkdocs build --strict
+
   # Summary job that depends on all others
   ci-success:
     name: CI Success
-    needs: [lint, type-check, test, security]
+    needs: [lint, type-check, test, security, docs]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
-             [[ "${{ needs.test.result }}" != "success" ]]; then
+             [[ "${{ needs.test.result }}" != "success" ]] || \
+             [[ "${{ needs.docs.result }}" != "success" ]]; then
             echo "Required jobs failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Adds a **`docs` job** to `ci.yml` that runs `poetry run mkdocs build --strict` on every PR, and wires it into the required **`ci-success`** gate.
- Closes the gap that let #360 merge with a broken nav: until now the strict build only ran **post-merge** in `docs-deploy.yml`, so doc drift (page missing from nav, dead links, etc.) surfaced at deploy time instead of blocking the PR.
- Mirrors the deploy workflow's install/build (`poetry install --with docs --no-root`, `CI=true`, `fetch-depth: 0` for git-revision-date-localized) so PR and deploy validate identically.

## Test plan

- [x] `poetry run mkdocs build --strict` passes locally (0 warnings).
- [x] `ci.yml` YAML parses; `ci-success` needs now include `docs`.
- [ ] This PR's own `Docs Build (strict)` check is green.

## Related issues

Follow-up to #360 / #361 (ADR-028 merged without a nav entry, only caught at deploy).

## Summary by Sourcery

Add a strict MkDocs documentation build to the main CI workflow and gate PRs on its success.

CI:
- Introduce a docs job in the main CI workflow that runs a strict MkDocs build on every PR and mirrors the deploy-time doc build environment.
- Update the CI summary job to depend on the new docs job and fail if the docs build does not succeed.