### PR TITLE
ci: enforce ADR-028 raw DomainException gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run Ruff formatter check
         run: poetry run ruff format --check src tests
 
+      - name: Enforce ADR-028 domain exception semantics
+        run: bash scripts/check_domain_exceptions.sh
+
   type-check:
     name: Type Check
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ test-cov:
 lint:
 	poetry run ruff check src tests
 	poetry run ruff format --check src tests
+	bash scripts/check_domain_exceptions.sh
+
+check-domain-exceptions:
+	bash scripts/check_domain_exceptions.sh
 
 format:
 	poetry run ruff check --fix src tests

--- a/docs/adr/ADR-028-domain-exception-semantics.md
+++ b/docs/adr/ADR-028-domain-exception-semantics.md
@@ -137,7 +137,9 @@ exceção; caso de uso com falha esperada = retorno).
 **Enforcement:**
 - **Determinístico (CI):** `raise DomainException(` (a base) fora de
   `src/building_blocks/domain/` falha o pipeline — ratchet que mantém o 0 atual.
-  <!-- TODO(Lucas): adicionar step de grep/ruff-custom no job de lint da CI -->
+  Implementado em `scripts/check_domain_exceptions.sh`, rodado no job `lint` da CI
+  e localmente via `make lint` (ou `make check-domain-exceptions`). O grep casa só
+  a base; as subclasses semânticas não disparam.
 - **Semântico (code review de MR):** escolha da subclasse e presença/reuso de
   `rule_code`, usando a árvore de decisão deste ADR como critério — já coberto
   pelo subagente de code-smell/arch do fluxo `mr-review`.

--- a/scripts/check_domain_exceptions.sh
+++ b/scripts/check_domain_exceptions.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# ADR-028 enforcement (deterministic gate).
+#
+# The base `DomainException` is reserved for domain-framework invariants and
+# must only be raised from within `src/building_blocks/domain/`. Everywhere else
+# in `src/`, code MUST use the semantically specific subclass
+# (DomainValidationException / BusinessRuleViolationException /
+# DomainNotFoundException / DomainConflictException). See
+# docs/adr/ADR-028-domain-exception-semantics.md.
+#
+# This check fails the pipeline if a raw `raise DomainException(...)` appears in
+# production code outside the allowlisted directory. It matches only the base
+# class — `raise DomainNotFoundException(` and the other subclasses do not match.
+#
+# Runs in CI (ci.yml lint job) and locally via `make lint`.
+
+set -euo pipefail
+
+# Match `raise DomainException(` with flexible whitespace; the trailing `(`
+# excludes bare re-raises and ensures we only catch instantiations of the base.
+PATTERN='raise[[:space:]]+DomainException[[:space:]]*\('
+ALLOWED_DIR='src/building_blocks/domain/'
+
+# grep exits 1 when there are no matches — that's the success case here, so guard it.
+offenders="$(grep -rEn --include='*.py' "${PATTERN}" src/ | grep -v "${ALLOWED_DIR}" || true)"
+
+if [[ -n "${offenders}" ]]; then
+  echo "ADR-028 violation: raw 'raise DomainException(...)' found outside ${ALLOWED_DIR}"
+  echo "The base DomainException is reserved for domain-framework invariants."
+  echo "Use the specific subclass (DomainValidationException / BusinessRuleViolationException /"
+  echo "DomainNotFoundException / DomainConflictException). See docs/adr/ADR-028-domain-exception-semantics.md"
+  echo
+  echo "${offenders}"
+  exit 1
+fi
+
+echo "ADR-028 gate OK: no raw base DomainException raises outside ${ALLOWED_DIR}"


### PR DESCRIPTION
## Summary

- Implements the **deterministic enforcement** promised by ADR-028: a raw `raise DomainException(` (the base class) outside `src/building_blocks/domain/` now fails the pipeline.
- The base class is reserved for domain-framework invariants; everywhere else must use the semantic subclass (`DomainValidationException` / `BusinessRuleViolationException` / `DomainNotFoundException` / `DomainConflictException`).
- `scripts/check_domain_exceptions.sh` runs in the CI **lint** job and locally via `make lint` (or standalone `make check-domain-exceptions`), so drift is caught before push — not just in CI.
- The regex matches only the base (`raise DomainException(`); the subclasses do **not** trip it (verified).
- Updates ADR-028 to point at the script and drop the now-resolved TODO.

Current baseline is **0** raw base raises outside the allowlist, so this is a green ratchet that keeps it there.

## Test plan

- [x] Script passes on current `src/` (0 offenders).
- [x] Script fails (exit 1) on an injected `raise DomainException(...)` in a module.
- [x] Script does **not** false-positive on `raise DomainNotFoundException(...)` / other subclasses.
- [x] `ci.yml` YAML parses; new lint step present.
- [x] `mkdocs build --strict` still passes after the ADR edit.
- [ ] This PR's CI is green.

## Related issues

Implements the enforcement TODO from ADR-028 (docs/adr/ADR-028-domain-exception-semantics.md). Follows #360/#361/#362.

## Summary by Sourcery

Add a CI and local lint gate that enforces ADR-028 by forbidding raw DomainException raises outside the domain building blocks and document the enforcement mechanism.

New Features:
- Introduce a check-domain-exceptions Makefile target for running the domain exception enforcement script locally.

Enhancements:
- Add a bash script that scans src/ for raw DomainException raises outside the allowed domain directory and fails on violations.
- Integrate the domain exception enforcement script into the existing lint workflow in CI and local lint runs.
- Update ADR-028 documentation to describe the implemented enforcement script and its execution points.