### PR TITLE
feat(media): mirror provider artwork into local storage (ADR-029)

### DIFF
--- a/docs/adr/ADR-029-artwork-mirroring-storage.md
+++ b/docs/adr/ADR-029-artwork-mirroring-storage.md
@@ -150,7 +150,7 @@ class ArtworkStoragePort(ABC):
 
 Pontos de toque no código (blast radius): endpoint novo `GET /api/v1/artwork/{key}` na presentation de `media`; use case `MirrorArtwork` + registro no scheduler; `ArtworkStoragePort` + `LocalArtworkStorage` + registro no container de `media`; config `artwork_storage_directory` em `settings.py`. `ImageUrl`, mappers e schemas de presentation **não** mudam.
 
-Faseamento (1 PR por item): **PR 1** entrega a fundação — port, `LocalArtworkStorage`, endpoint de proxy, config e fiação (sem mudar o enrichment); **PR 2** o mirror dos campos top-level `ImageUrl` (use case + job em background); **PR 3** estende a stills, artes localizadas e elenco.
+Faseamento (1 PR por item): **PR 1** entrega a fundação — port, `LocalArtworkStorage`, endpoint de proxy, config e fiação (sem mudar o enrichment); **PR 2** o mirror dos campos top-level `ImageUrl` de **Movie e Series** (poster/backdrop/logo) via job em background (`ArtworkMirrorJob` + downloader httpx + bucket `ArtworkMirrorConfig` + finder/update direto por coluna, sem round-trip de aggregate); **PR 3** estende a **poster de Season**, episode stills, artes localizadas e elenco — todos arte de coleção-filha, alcançados por update direto/aggregate à parte.
 
 Docs a sincronizar ao implementar (docs-maintainer): página do módulo `media` (novo endpoint + fluxo de mirror), `README.md` da raiz (contagem de endpoints), e este ADR promovido de **Proposto → Aceito**.
 

--- a/docs/adr/ADR-029-artwork-mirroring-storage.md
+++ b/docs/adr/ADR-029-artwork-mirroring-storage.md
@@ -1,0 +1,162 @@
+# ADR-029: Mirror de Artwork de Provider via Port de Storage
+
+**Status:** Proposto
+**Data:** 2026-07-18
+**Deciders:** Lucas
+**Technical Story:** Durabilidade de artes do catálogo — hoje poster/backdrop/logo/still são URLs absolutas do TMDB servidas verbatim ao frontend; se o TMDB remove a imagem, aplica rate limit, o CDN cai, ou o uso é offline, a arte some.
+
+---
+
+## Contexto
+
+Toda arte de catálogo (poster/cover, backdrop/fanart, logo de título, still de episódio, foto de elenco) é hoje armazenada como **URL absoluta do TMDB** e servida **sem alteração** ao cliente. O caminho é:
+
+- `TmdbClient._image_url` (`media/infrastructure/metadata/tmdb_client.py:161`) monta `https://image.tmdb.org/t/p/original/<file_path>` a partir de `_TMDB_IMAGE_BASE` (linha 65). **O fragmento `file_path` cru e o tamanho (`original`) são descartados na fronteira do adapter** — só a URL montada sobrevive downstream.
+- A application traduz essas strings em VOs de domínio: `_metadata_field_merge.py:COMMON_FILL_IF_EMPTY` mapeia `poster_url/backdrop_url/logo_url → ImageUrl`; `enrich_series_metadata` embrulha `still_url → ImageUrl(thumbnail_path)`; as artes **localizadas** viram `str` cru dentro do JSON blob de `LocalizedMetadata` (ADR-023), **não** `ImageUrl`.
+- A persistência guarda tudo como `String(1000)`/`Text`. A presentation devolve a string **como está** (as DTOs de application são a wire shape) — o browser baixa direto de `image.tmdb.org`.
+
+Isso acopla a **disponibilidade do catálogo à disponibilidade de um terceiro**. Cenários concretos de perda: imagem removida/trocada no TMDB (comum em títulos menos populares), rate limit / indisponibilidade do CDN, e **uso offline** — que para um media manager pessoal servindo mídia de HD local é requisito implícito, não hipótese remota.
+
+Fatos do código que orientam o design:
+
+- **`ImageUrl` (shared_kernel) já é dual-mode.** Aceita URL http(s) **ou** path local absoluto e expõe `is_remote`. O `scrub_preview_path` (sprite VTT gerado localmente) já usa esse mesmo VO com path local — ou seja, há precedente de campo de imagem carregando referência local. **O VO não precisa mudar** para carregar uma referência mirrorada.
+- **Já existe um port de storage no projeto.** `AvatarStoragePort` + `LocalAvatarStorage` (módulo identity) esconde o backend, retorna uma **URL relativa `/api/...`** (não path de filesystem), processa bytes com Pillow em `asyncio.to_thread`, é idempotente no delete e usa dir config-driven. O docstring dele antecipa este ADR: *"A future S3 / object-store implementation would just be another adapter satisfying the same contract."* É o template a seguir.
+- **Não há storage de artwork** (buscas por `blob`/`minio`/`s3`/storage de imagem de catálogo não acharam nada).
+
+## Decisão
+
+Nós iremos **mirrorar as artes de provider em storage próprio** e servi-las pela nossa API, mantendo a URL remota apenas como fonte de origem e fallback. Concretamente:
+
+**1. Port de storage na application do módulo `media`.**
+Introduzir `ArtworkStoragePort` (ABC) em `media/application/ports/`, com adapter concreto em `media/infrastructure/storage/`. A implementação **default é local-disk** (`LocalArtworkStorage`), escrevendo os arquivos sob um diretório configurável (`artwork_storage_directory`, mesmo estilo bootstrap de `hls_cache_directory`) — espelha o precedente `LocalAvatarStorage`. O port é a fronteira; o adapter esconde o backend e **não decide política** (ADR-009: infra via port+adapter; ADR-025: tradução/orquestração de fonte externa é concern de application, a borda não decide). Um adapter de **object storage (MinIO / S3)** é uma implementação válida do mesmo contrato para um cenário multi-node / prod, mas **não é o default** — para escala pessoal single-node o disco local basta e evita a dependência operacional (ver Alternativa 3).
+
+**2. Mirror assíncrono, desacoplado do enrichment.**
+O `EnrichMovie/SeriesMetadataUseCase` continua gravando a **URL remota** do TMDB (comportamento atual, inalterado). Um **job de background** (scheduler da infra compartilhada) reconcilia depois: para cada `ImageUrl.is_remote`, baixa os bytes, faz `storage.save(...)`, e substitui o campo por um `ImageUrl` apontando para a referência própria. O enrich **não** fica mais lento nem acoplado à disponibilidade da imagem naquele instante.
+
+**3. Serving via proxy da API (URL estável `/api/...`).**
+Os campos de imagem passam a guardar uma referência própria que resolve para um endpoint nosso (ex.: `/api/v1/artwork/{key}`). A API serve os bytes lendo do storage via port. O frontend **nunca** fala com o backend de storage direto — trocar filesystem por object-store não vaza pro cliente. Como a presentation já devolve a string armazenada como está, **a superfície da API muda sem editar schemas** (só entra o passo de resolução chave → URL e o endpoint de serve).
+
+**4. Fallback gracioso — o mirror nunca bloqueia.**
+Enquanto uma arte não foi mirrorada (job ainda não rodou, download falhou, TMDB indisponível no momento), o campo mantém a **URL remota** e o cliente continua funcionando exatamente como hoje. O mirror é uma melhoria de durabilidade sobreposta, não um caminho crítico. Falha de mirror é logada e re-tentada, não propagada.
+
+**5. Escopo v1 — todas as artes.**
+Top-level (`poster_path`, `backdrop_path`, `logo_path` de Movie/Series + poster de Season), **episode stills** (`thumbnail_path`), **artes localizadas por locale** (`LocalizedFields.{poster,backdrop,logo}_path` — tratadas à parte por serem `str` cru no JSON, não `ImageUrl`) e **fotos de elenco** (`profile_path`). O `scrub_preview_path` **fica fora** — é asset gerado localmente, não vem de provider.
+
+**6. Chave de armazenamento determinística e content-addressed.**
+A chave do objeto deriva de `(tipo de entidade, id, tipo de arte, locale, hash do conteúdo)`. Content-hash dá dedup natural (mesmo poster referenciado por vários títulos ocupa um objeto) e cache-busting embutido (mudou a arte → muda a chave → o cliente refetcha), espelhando o `?v=...` do avatar.
+
+## Consequências
+
+### Positivas
+
+- O catálogo deixa de depender do TMDB em runtime para exibir artes: remoção upstream, rate limit, CDN fora do ar e **uso offline** passam a ser tolerados assim que a arte foi mirrorada uma vez.
+- O `ImageUrl` VO absorve a mudança **sem alteração** (já dual-mode); a presentation muda "de graça" (devolve a string armazenada). O blast radius fica nos dois choke points já conhecidos: construção (`TmdbClient._image_url`) e atribuição (`_metadata_field_merge` + localized helpers).
+- A fronteira fica nítida e discoverable: port de storage (infra, ADR-009), orquestração do mirror (application, ADR-025), invariantes e VO (domínio). Reaproveita o padrão já ratificado pelo `AvatarStoragePort`.
+- Proxy via API desacopla o cliente do backend de storage: o disco fica privado, e uma futura troca (MinIO/S3, outro backend) não vaza pro frontend.
+- **Zero dependência operacional nova**: o default local-disk não adiciona container, credenciais nem bucket — só um diretório, backupável copiando a pasta. Cabe na escala pessoal single-node sem infra extra.
+
+### Negativas
+
+- A durabilidade da arte passa a depender do **mesmo disco** do resto do app (não há redundância que um object-store daria) e o diretório **cresce** com o catálogo — o backup precisa incluí-lo. Aceitável na escala pessoal; se virar prod multi-node, trocar pelo adapter de object storage (mesmo port).
+- Passa a existir **cópia de bytes** e um job de reconciliação com estado (o que já foi mirrorado, o que falhou, retry/backoff) — mais partes móveis que o "só guarda a URL" atual.
+- As artes **localizadas** exigem um caminho de código separado do mirror dos campos `ImageUrl` (são `str` no JSON blob), duplicando a lógica de "é remoto? baixa, troca por local".
+- **Custo de armazenamento e staleness**: mirrorar tudo (incluindo stills por episódio e fotos de elenco, que têm bastante churn) consome espaço e pode reter arte desatualizada se o provider trocar a imagem sem trocar o `file_path` — mitigado só parcialmente pelo content-hash.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| O job de background nunca roda / falha silenciosa e nada é mirrorado — falsa sensação de durabilidade | Média | Alto | Observabilidade explícita (contagem de pendentes/mirrorados/falhos por execução, log estruturado); fallback gracioso garante que o produto segue funcional mesmo com o job parado |
+| Diretório de artwork perdido (disco corrompido / reset) leva junto todo o mirror | Baixa | Médio | Fallback gracioso: o serve degrada para redirect à URL remota de origem quando o arquivo não existe; incluir o diretório no backup; re-mirror reconstrói a partir das URLs remotas ainda armazenadas |
+| `file_path` cru do TMDB descartado no adapter dificulta re-derivar tamanho/original para o download | Alta | Baixo | O mirror baixa a partir da **URL já montada** armazenada (é o que existe); não precisa do fragmento cru — a URL absoluta é suficiente para o GET |
+| Explosão de armazenamento com stills + elenco em catálogo grande | Baixa | Médio | Content-hash deduplica; escopo é revisável — stills/elenco podem virar opt-in por config se o custo doer |
+| Arte trocada upstream com mesmo `file_path` → mirror retém versão velha | Baixa | Baixo | Re-mirror periódico opcional; content-hash detecta mudança quando o `file_path` também muda (caso comum) |
+
+## Alternativas Consideradas
+
+### 1. Manter a URL do TMDB (status quo / não fazer nada)
+
+Continuar guardando e servindo a URL absoluta do provider.
+
+**Rejeitado porque:** é exatamente a fonte do problema — acopla a exibição do catálogo à disponibilidade de um terceiro e **quebra o uso offline**, que é implícito num media manager de HD local.
+
+### 2. Mirror síncrono durante o enrichment
+
+Baixar e subir a imagem dentro do `EnrichMovie/SeriesMetadataUseCase`, na hora.
+
+**Rejeitado porque:** lentifica o enrich (I/O de rede por arte, N artes por título+temporadas+episódios) e o acopla à disponibilidade da imagem **naquele instante** — se o download falha no meio do enrich, ou o enrich vira caminho crítico de imagem, ou some a arte. O mirror assíncrono desacopla as duas preocupações e mantém o enrich como está.
+
+### 3. Object storage (MinIO / S3) como default
+
+Subir MinIO (ou apontar pra um bucket S3) e implementar o adapter S3-compatible como backend default, em vez do disco local.
+
+**Rejeitado (como default, por ora) porque:** adiciona uma dependência operacional (container + credenciais + bucket + config) desproporcional à escala pessoal single-node do HomeFlix, que hoje roda com SQLite/filesystem. O disco local cobre o caso e o backup é copiar uma pasta. **Continua sendo um adapter válido do mesmo `ArtworkStoragePort`** — é exatamente o ponto de troca se o deploy virar multi-node / prod, sem tocar em domínio, use case ou rota.
+
+### 4. URL direta / presigned do backend para o browser
+
+Guardar a URL do objeto no backend de storage (arquivo servido por outro host, ou presigned de object-store) e o cliente baixa direto de lá.
+
+**Rejeitado porque:** acopla o cliente ao endpoint do backend, exige-o acessível externamente, e faz uma troca de backend vazar pro frontend. O proxy via API mantém o backend privado e a URL do cliente estável (`/api/...`), consistente com o `AvatarStoragePort`.
+
+### 5. Mirror lazy no primeiro acesso
+
+Baixar-e-cachear na primeira vez que a arte é servida pelo proxy.
+
+**Rejeitado porque:** se o TMDB já ficou indisponível **antes** do primeiro acesso, a arte se perde — justamente o cenário que o ADR quer cobrir. Além disso o primeiro request fica lento. O job de background mirrora proativamente, sem depender de alguém ter aberto o título.
+
+## Referências
+
+- ADR-009 (Cross-BC Read Ports + ACL) — port+adapter para infra externa
+- ADR-025 (Reconciliação de Metadados de Provider é Concern de Application) — a orquestração do mirror é application; a borda não decide
+- ADR-023 (Metadados Localizados como Value Object) — as artes localizadas vivem no JSON blob como `str`, tratadas à parte
+- ADR-006 (Variantes de Arquivo de Mídia), ADR-017 (Invariantes na camada de domínio)
+- `src/modules/identity/application/ports/avatar_storage_port.py` + `src/modules/identity/infrastructure/storage/local_avatar_storage.py` — template do par port/adapter
+- `src/shared_kernel/value_objects/image_url.py` — VO dual-mode (URL remota / path local), `is_remote`
+- `src/modules/media/infrastructure/metadata/tmdb_client.py` (`_image_url`, `_TMDB_IMAGE_BASE`) — choke point de construção da URL
+- `src/modules/media/application/use_cases/_metadata_field_merge.py` — choke point de atribuição `str → ImageUrl`
+- `src/config/settings.py` — `thumbnails_directory` / `hls_cache_directory` (padrão de dir config-driven a estender)
+
+---
+
+## Notas de Implementação
+
+```python
+# media/application/ports/artwork_storage_port.py
+class ArtworkStoragePort(ABC):
+    """Persiste bytes de arte e resolve chave -> URL servível pela API.
+
+    O adapter esconde o backend (disco local default; MinIO/S3 alternativo) e
+    NÃO decide política — só armazena, recupera e remove.
+    """
+
+    async def save(self, *, content: bytes, content_type: str, key: str) -> str:
+        """Armazena os bytes sob `key`; retorna a URL relativa /api/... servível."""
+
+    async def open(self, key: str) -> StoredArtwork | None:
+        """Bytes + content-type (StoredArtwork) para o proxy; None se ausente."""
+
+    async def delete(self, key: str) -> None: ...  # idempotente
+
+
+# media/application/use_cases/mirror_artwork.py  (rodado pelo scheduler)
+#   para cada entidade com ImageUrl.is_remote:
+#     bytes, ctype = await http.get(image_url.value)
+#     key = artwork_key(kind, entity_id, art_kind, locale, sha256(bytes))
+#     served_url = await storage.save(content=bytes, content_type=ctype, key=key)
+#     entity = entity.with_poster_path(ImageUrl(served_url))   # troca remoto -> local
+#   falha de download/save -> log + retry; mantém a URL remota (fallback gracioso)
+#   artes localizadas: mesmo fluxo sobre LocalizedFields.{poster,backdrop,logo}_path (str)
+```
+
+Pontos de toque no código (blast radius): endpoint novo `GET /api/v1/artwork/{key}` na presentation de `media`; use case `MirrorArtwork` + registro no scheduler; `ArtworkStoragePort` + `LocalArtworkStorage` + registro no container de `media`; config `artwork_storage_directory` em `settings.py`. `ImageUrl`, mappers e schemas de presentation **não** mudam.
+
+Faseamento (1 PR por item): **PR 1** entrega a fundação — port, `LocalArtworkStorage`, endpoint de proxy, config e fiação (sem mudar o enrichment); **PR 2** o mirror dos campos top-level `ImageUrl` (use case + job em background); **PR 3** estende a stills, artes localizadas e elenco.
+
+Docs a sincronizar ao implementar (docs-maintainer): página do módulo `media` (novo endpoint + fluxo de mirror), `README.md` da raiz (contagem de endpoints), e este ADR promovido de **Proposto → Aceito**.
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-07-18 | Lucas | Criação inicial (Proposto) |
+| 2026-07-18 | Lucas | Default de storage passa de object-store (MinIO) para disco local; MinIO/S3 vira adapter plugável (Alternativa 3) |

--- a/docs/adr/ADR-029-artwork-mirroring-storage.md
+++ b/docs/adr/ADR-029-artwork-mirroring-storage.md
@@ -42,8 +42,8 @@ Enquanto uma arte não foi mirrorada (job ainda não rodou, download falhou, TMD
 **5. Escopo v1 — todas as artes.**
 Top-level (`poster_path`, `backdrop_path`, `logo_path` de Movie/Series + poster de Season), **episode stills** (`thumbnail_path`), **artes localizadas por locale** (`LocalizedFields.{poster,backdrop,logo}_path` — tratadas à parte por serem `str` cru no JSON, não `ImageUrl`) e **fotos de elenco** (`profile_path`). O `scrub_preview_path` **fica fora** — é asset gerado localmente, não vem de provider.
 
-**6. Chave de armazenamento determinística e content-addressed.**
-A chave do objeto deriva de `(tipo de entidade, id, tipo de arte, locale, hash do conteúdo)`. Content-hash dá dedup natural (mesmo poster referenciado por vários títulos ocupa um objeto) e cache-busting embutido (mudou a arte → muda a chave → o cliente refetcha), espelhando o `?v=...` do avatar.
+**6. Chave de armazenamento content-addressed.**
+A chave (`ArtworkKey`) é `sha256(bytes) + extensão` — content-address puro. Dá dedup natural (mesmo poster referenciado por vários títulos ocupa um objeto) e cache-busting embutido (mudou a arte → muda a chave → o cliente refetcha), espelhando o `?v=...` do avatar. Não é preciso codificar tipo/id/locale na chave: o hash já deduplica, e o `ArtworkKey` guarda o charset (`ARTWORK_KEY_PATTERN`) tanto na escrita (job) quanto na leitura (rota).
 
 ## Consequências
 
@@ -138,17 +138,20 @@ class ArtworkStoragePort(ABC):
     async def delete(self, key: str) -> None: ...  # idempotente
 
 
-# media/application/use_cases/mirror_artwork.py  (rodado pelo scheduler)
-#   para cada entidade com ImageUrl.is_remote:
-#     bytes, ctype = await http.get(image_url.value)
-#     key = artwork_key(kind, entity_id, art_kind, locale, sha256(bytes))
-#     served_url = await storage.save(content=bytes, content_type=ctype, key=key)
-#     entity = entity.with_poster_path(ImageUrl(served_url))   # troca remoto -> local
-#   falha de download/save -> log + retry; mantém a URL remota (fallback gracioso)
-#   artes localizadas: mesmo fluxo sobre LocalizedFields.{poster,backdrop,logo}_path (str)
+# infrastructure/scheduling/artwork_mirror_job.py  (ArtworkMirrorJob.run, no scheduler)
+#   segue a convenção dos jobs irmãos (ThumbnailBackfillJob et al.): a
+#   orquestração vive no job de infra, não num use case dedicado.
+#   para cada título com coluna LIKE 'http%':
+#     img = await downloader.fetch(url, max_bytes=cfg.max_bytes)   # https + host allow-list
+#     if not is_supported_image(img.content_type): continuar (mantém remoto)
+#     key = ArtworkKey.for_content(img.content, content_type=img.content_type, source_url=url)
+#     served = await storage.save(content=img.content, content_type=img.content_type, key=str(key))
+#     update direto da coluna (sem save de aggregate → não apaga filhos)
+#   falha de download/store ou não-imagem -> log + mantém a URL remota (fallback gracioso)
+#   artes localizadas: mesmo fluxo sobre LocalizedFields.{poster,backdrop,logo}_path (str) — PR 3
 ```
 
-Pontos de toque no código (blast radius): endpoint novo `GET /api/v1/artwork/{key}` na presentation de `media`; use case `MirrorArtwork` + registro no scheduler; `ArtworkStoragePort` + `LocalArtworkStorage` + registro no container de `media`; config `artwork_storage_directory` em `settings.py`. `ImageUrl`, mappers e schemas de presentation **não** mudam.
+Pontos de toque no código (blast radius): endpoint novo `GET /api/v1/artwork/{key}` na presentation de `media` (PR 1); `ArtworkStoragePort` + `LocalArtworkStorage` + config `artwork_storage_directory` (PR 1); `ArtworkMirrorJob` + `ArtworkDownloaderPort`/`HttpxArtworkDownloader` + `ArtworkKey` + bucket `ArtworkMirrorConfig` + finders/updaters de coluna + registro no scheduler (PR 2). A orquestração é do **job de infra** (convenção ratificada dos jobs irmãos), não de um use case de application. `ImageUrl`, mappers e schemas de presentation **não** mudam.
 
 Faseamento (1 PR por item): **PR 1** entrega a fundação — port, `LocalArtworkStorage`, endpoint de proxy, config e fiação (sem mudar o enrichment); **PR 2** o mirror dos campos top-level `ImageUrl` de **Movie e Series** (poster/backdrop/logo) via job em background (`ArtworkMirrorJob` + downloader httpx + bucket `ArtworkMirrorConfig` + finder/update direto por coluna, sem round-trip de aggregate); **PR 3** estende a **poster de Season**, episode stills, artes localizadas e elenco — todos arte de coleção-filha, alcançados por update direto/aggregate à parte.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,6 +38,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-026](./ADR-026-server-authoritative-track-selection.md) | Seleção de Faixa Default Autoritativa no Servidor a partir de Preferência por Usuário | ✅ Aceito | 2026-06-30 |
 | [ADR-027](./ADR-027-ocr-image-based-subtitles.md) | OCR de Legendas Baseadas em Imagem (PGS/VOBSUB) para Faixas de Texto Selecionáveis | ✅ Aceito | 2026-07-04 |
 | [ADR-028](./ADR-028-domain-exception-semantics.md) | Semântica de uso da hierarquia de exceções de domínio | ✅ Aceito | 2026-07-07 |
+| [ADR-029](./ADR-029-artwork-mirroring-storage.md) | Mirror de Artwork de Provider via Port de Storage | 🟡 Proposto | 2026-07-18 |
 
 ## Como Criar um Novo ADR
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,3 +112,4 @@ nav:
       - adr/ADR-026-server-authoritative-track-selection.md
       - adr/ADR-027-ocr-image-based-subtitles.md
       - adr/ADR-028-domain-exception-semantics.md
+      - adr/ADR-029-artwork-mirroring-storage.md

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -225,6 +225,7 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         tmdb_api_key=config.provided.tmdb_api_key,
         supported_locales=config.provided.supported_locales,
         hls_cache_directory=config.provided.hls_cache_directory,
+        artwork_storage_directory=config.provided.artwork_storage_directory,
         runtime_settings=settings.runtime_settings,
     )
 

--- a/src/config/containers/main.py
+++ b/src/config/containers/main.py
@@ -21,6 +21,7 @@ from src.config.containers.watch_progress import WatchProgressContainer
 from src.config.settings import Settings
 from src.infrastructure.health import DatabaseProbe, FilesystemProbe
 from src.infrastructure.scheduling import (
+    ArtworkMirrorJob,
     CreditsDetectionJob,
     IntroDetectionJob,
     LibraryScanScheduler,
@@ -308,6 +309,14 @@ class ApplicationContainer(containers.DeclarativeContainer):  # type: ignore[mis
         media_uow_factory=media.media_unit_of_work_factory,
         runtime_settings=settings.runtime_settings,
         thumbnail_service=media.thumbnail_generation_service,
+    )
+
+    artwork_mirror_job = providers.Singleton(
+        ArtworkMirrorJob,
+        media_uow_factory=media.media_unit_of_work_factory,
+        runtime_settings=settings.runtime_settings,
+        downloader=media.artwork_image_downloader,
+        storage=media.artwork_storage,
     )
 
     intro_detection_job = providers.Singleton(

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -174,6 +174,9 @@ from src.modules.media.infrastructure.audio import (
 )
 from src.modules.media.infrastructure.file_system.scanner import LocalFileSystemScanner
 from src.modules.media.infrastructure.file_system.variant_detector import VariantDetector
+from src.modules.media.infrastructure.metadata.artwork_downloader import (
+    HttpxArtworkDownloader,
+)
 from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
 from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyMediaUnitOfWorkFactory,
@@ -551,6 +554,10 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         LocalArtworkStorage,
         root_directory=artwork_storage_directory,
     )
+
+    # Downloads still-remote provider artwork for the mirror job (ADR-029).
+    # Singleton so one pooled httpx client is shared across ticks.
+    artwork_image_downloader = providers.Singleton(HttpxArtworkDownloader)
 
     # =========================================================================
     # Use Cases — Streaming

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -178,6 +178,7 @@ from src.modules.media.infrastructure.metadata.tmdb_client import TmdbClient
 from src.modules.media.infrastructure.persistence.sqlalchemy_unit_of_work import (
     SqlAlchemyMediaUnitOfWorkFactory,
 )
+from src.modules.media.infrastructure.storage import LocalArtworkStorage
 from src.modules.media.infrastructure.streaming import (
     HlsService,
     MediaProbeService,
@@ -260,6 +261,11 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     # and ``hls_cache_max_size_mb`` moved to ``StreamingConfig`` in
     # ADR-013 phase 3 and are read from ``RuntimeSettings``.
     hls_cache_directory = providers.Dependency(default="./hls_cache")
+
+    # Artwork mirror directory (ADR-029), wired from
+    # ``Settings.artwork_storage_directory`` at the composition root.
+    # Bootstrap filesystem path, same style as ``hls_cache_directory``.
+    artwork_storage_directory = providers.Dependency(default="./artwork")
 
     # RuntimeSettings facade — needed by HlsService, AudioExtractor,
     # ThumbnailGenerationService for streaming config + by
@@ -537,6 +543,14 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
     )
 
     file_streamer = providers.Factory(LocalFileStreamer)
+
+    # Local-disk storage for mirrored catalog artwork (ADR-029).
+    # Singleton so the proxy route and the mirror job share one
+    # instance (it is stateless apart from the root path).
+    artwork_storage = providers.Singleton(
+        LocalArtworkStorage,
+        root_directory=artwork_storage_directory,
+    )
 
     # =========================================================================
     # Use Cases — Streaming

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -90,6 +90,14 @@ class Settings(BaseSettings):  # type: ignore[misc]
         description="Directory to store cached HLS segments",
     )
 
+    # Artwork mirror storage (ADR-029). Local-disk directory holding
+    # mirrored catalog artwork, in the same bootstrap-config style as
+    # ``thumbnails_directory`` / ``hls_cache_directory`` above.
+    artwork_storage_directory: str = Field(
+        default="./artwork",
+        description="Directory to store mirrored catalog artwork",
+    )
+
     # ``hls_cache_max_size_mb`` and the ``avatar_*`` knobs moved to
     # ``app_settings`` in ADR-013 phase 3. Set them via the admin
     # panel or ``UPDATE app_settings SET value_json=...``. The legacy

--- a/src/infrastructure/scheduling/__init__.py
+++ b/src/infrastructure/scheduling/__init__.py
@@ -5,6 +5,7 @@ thumbnail backfill, intro detection, scan-dedup sweep) without coupling
 the domain or application layers to any specific scheduling backend.
 """
 
+from src.infrastructure.scheduling.artwork_mirror_job import ArtworkMirrorJob
 from src.infrastructure.scheduling.credits_detection_job import CreditsDetectionJob
 from src.infrastructure.scheduling.intro_detection_job import IntroDetectionJob
 from src.infrastructure.scheduling.scan_dedup_sweep_job import ScanDedupSweepJob
@@ -13,6 +14,7 @@ from src.infrastructure.scheduling.subtitle_ocr_job import SubtitleOcrBackfillJo
 from src.infrastructure.scheduling.thumbnail_backfill_job import ThumbnailBackfillJob
 
 __all__ = [
+    "ArtworkMirrorJob",
     "CreditsDetectionJob",
     "IntroDetectionJob",
     "LibraryScanScheduler",

--- a/src/infrastructure/scheduling/artwork_mirror_job.py
+++ b/src/infrastructure/scheduling/artwork_mirror_job.py
@@ -1,0 +1,219 @@
+"""Periodic mirror of provider artwork into local storage (ADR-029).
+
+Finds movies and series whose poster/backdrop/logo is still a remote
+TMDB URL, downloads the bytes, persists them via
+:class:`ArtworkStoragePort`, and swaps the column for the local
+``/api/v1/artwork/{key}`` reference. The catalog then serves art from
+storage the deployment controls, tolerating TMDB removal, rate limits,
+CDN outages, and offline use.
+
+Each tick processes at most ``batch_size`` titles split between movies
+and series. Network I/O never happens while a DB session is held: rows
+are fetched in one short UoW, mirrored without a session, and the
+column update runs in a fresh per-title UoW. A download failure is
+logged and leaves the remote URL untouched (graceful fallback), so a
+flaky provider only defers mirroring to a later tick.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.building_blocks.infrastructure.errors import GatewayException
+from src.config.logging import get_logger
+from src.modules.media.domain.value_objects import ArtworkKey
+from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from src.modules.media.application.ports.artwork_downloader_port import (
+        ArtworkDownloaderPort,
+    )
+    from src.modules.media.application.ports.artwork_storage_port import ArtworkStoragePort
+    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.domain.repositories.movie_repository import RemoteArtworkRow
+    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
+
+_logger = get_logger()
+
+# The top-level artwork columns this job mirrors. Season posters, episode
+# stills, localized art and cast photos are out of scope here (PR 3).
+_ARTWORK_FIELDS = ("poster_path", "backdrop_path", "logo_path")
+
+
+class ArtworkMirrorJob:
+    """Download still-remote artwork and replace it with local references.
+
+    Args:
+        media_uow_factory: Builds fresh media UoWs. Fetch and each
+            per-title update open their own UoW so a single failure
+            rolls back only that title.
+        runtime_settings: Snapshot facade for :class:`ArtworkMirrorConfig`
+            (batch size + max download size), read per ``run()`` so admin
+            edits apply on the next tick (ADR-013).
+        downloader: Fetches the remote image bytes.
+        storage: Persists the bytes and returns the served URL.
+    """
+
+    def __init__(
+        self,
+        media_uow_factory: MediaUnitOfWorkFactory,
+        runtime_settings: RuntimeSettings,
+        downloader: ArtworkDownloaderPort,
+        storage: ArtworkStoragePort,
+    ) -> None:
+        self._media_uow_factory = media_uow_factory
+        self._runtime_settings = runtime_settings
+        self._downloader = downloader
+        self._storage = storage
+
+    async def run(self) -> None:
+        """Mirror one batch of titles with still-remote artwork.
+
+        Splits the per-tick budget between movies and series: movies
+        first, remaining slots go to series. Logs how many titles were
+        updated and how many individual images were mirrored vs. failed.
+        """
+        config = await self._runtime_settings.artwork_mirror()
+        budget = config.batch_size
+
+        movies = await self._fetch_movies(budget)
+        movies_updated, movies_mirrored, movies_failed = await self._process(
+            movies, is_movie=True, max_bytes=config.max_bytes
+        )
+        budget -= len(movies)
+
+        series_updated = series_mirrored = series_failed = 0
+        if budget > 0:
+            series = await self._fetch_series(budget)
+            series_updated, series_mirrored, series_failed = await self._process(
+                series, is_movie=False, max_bytes=config.max_bytes
+            )
+
+        if movies_mirrored or series_mirrored or movies_failed or series_failed:
+            _logger.info(
+                "[artwork-mirror] tick complete",
+                movies_updated=movies_updated,
+                movies_mirrored=movies_mirrored,
+                movies_failed=movies_failed,
+                series_updated=series_updated,
+                series_mirrored=series_mirrored,
+                series_failed=series_failed,
+                batch_size=config.batch_size,
+            )
+
+    async def _fetch_movies(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        async with self._media_uow_factory() as uow:
+            return await uow.movies.find_with_remote_artwork(limit)
+
+    async def _fetch_series(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        async with self._media_uow_factory() as uow:
+            return await uow.series.find_with_remote_artwork(limit)
+
+    async def _process(
+        self,
+        rows: Sequence[RemoteArtworkRow],
+        *,
+        is_movie: bool,
+        max_bytes: int,
+    ) -> tuple[int, int, int]:
+        """Mirror every row's artwork; return (titles_updated, mirrored, failed)."""
+        titles_updated = 0
+        mirrored = 0
+        failed = 0
+        for row in rows:
+            values, hits, misses = await self._mirror_row(row, max_bytes)
+            mirrored += hits
+            failed += misses
+            if hits:
+                await self._persist(row.media_id, values, is_movie=is_movie)
+                titles_updated += 1
+        return titles_updated, mirrored, failed
+
+    async def _mirror_row(
+        self,
+        row: RemoteArtworkRow,
+        max_bytes: int,
+    ) -> tuple[dict[str, str | None], int, int]:
+        """Mirror each remote field of ``row``.
+
+        Returns the final value for all three columns (local URL where a
+        mirror succeeded, the original value otherwise) plus the count of
+        successful and failed downloads.
+        """
+        values: dict[str, str | None] = {}
+        hits = 0
+        misses = 0
+        for field in _ARTWORK_FIELDS:
+            current = getattr(row, field)
+            mirrored_url = await self._mirror_one(current, max_bytes)
+            if mirrored_url is None:
+                values[field] = current
+                if _is_remote(current):
+                    misses += 1  # was remote but the download failed
+            else:
+                values[field] = mirrored_url
+                hits += 1
+        return values, hits, misses
+
+    async def _mirror_one(self, url: str | None, max_bytes: int) -> str | None:
+        """Download + store one image; return its served URL, or None.
+
+        None means "leave the column unchanged" — either the value was
+        not a remote URL, or the download/store failed (logged).
+        """
+        if not _is_remote(url):
+            return None
+        assert url is not None  # narrowed by _is_remote
+        try:
+            image = await self._downloader.fetch(url, max_bytes=max_bytes)
+        except GatewayException as exc:
+            _logger.warning(
+                "[artwork-mirror] download failed; keeping remote URL",
+                url=url,
+                error=str(exc),
+            )
+            return None
+        key = ArtworkKey.for_content(
+            image.content,
+            content_type=image.content_type,
+            source_url=url,
+        )
+        return await self._storage.save(
+            content=image.content,
+            content_type=image.content_type,
+            key=str(key),
+        )
+
+    async def _persist(
+        self,
+        media_id: str,
+        values: dict[str, str | None],
+        *,
+        is_movie: bool,
+    ) -> None:
+        """Write the mirrored artwork columns in a fresh UoW."""
+        async with self._media_uow_factory() as uow:
+            if is_movie:
+                await uow.movies.update_movie_artwork(
+                    MovieId(media_id),
+                    poster_path=values["poster_path"],
+                    backdrop_path=values["backdrop_path"],
+                    logo_path=values["logo_path"],
+                )
+            else:
+                await uow.series.update_series_artwork(
+                    SeriesId(media_id),
+                    poster_path=values["poster_path"],
+                    backdrop_path=values["backdrop_path"],
+                    logo_path=values["logo_path"],
+                )
+
+
+def _is_remote(url: str | None) -> bool:
+    """Whether ``url`` is a value the job should mirror (an http(s) URL)."""
+    return bool(url) and url.startswith("http")  # type: ignore[union-attr]
+
+
+__all__ = ["ArtworkMirrorJob"]

--- a/src/infrastructure/scheduling/artwork_mirror_job.py
+++ b/src/infrastructure/scheduling/artwork_mirror_job.py
@@ -7,42 +7,57 @@ TMDB URL, downloads the bytes, persists them via
 storage the deployment controls, tolerating TMDB removal, rate limits,
 CDN outages, and offline use.
 
-Each tick processes at most ``batch_size`` titles split between movies
-and series. Network I/O never happens while a DB session is held: rows
-are fetched in one short UoW, mirrored without a session, and the
-column update runs in a fresh per-title UoW. A download failure is
-logged and leaves the remote URL untouched (graceful fallback), so a
-flaky provider only defers mirroring to a later tick.
+Each tick processes at most ``batch_size`` titles split between the
+title kinds. Network I/O never happens while a DB session is held: rows
+are fetched in one short UoW, mirrored without a session, and the column
+update runs in a fresh per-title UoW. A download failure (or a non-image
+response) is logged and leaves the remote URL untouched (graceful
+fallback), so a flaky provider only defers mirroring to a later tick.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from src.building_blocks.infrastructure.errors import GatewayException
 from src.config.logging import get_logger
-from src.modules.media.domain.value_objects import ArtworkKey
+from src.modules.media.domain.value_objects import ArtworkColumns, ArtworkKey
 from src.modules.media.domain.value_objects.artwork_key import (
     SUPPORTED_ARTWORK_CONTENT_TYPES,
 )
+from src.shared_kernel.value_objects.image_url import ImageUrl
 from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Awaitable, Callable, Sequence
 
     from src.modules.media.application.ports.artwork_downloader_port import (
         ArtworkDownloaderPort,
     )
     from src.modules.media.application.ports.artwork_storage_port import ArtworkStoragePort
-    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.application.unit_of_work import (
+        MediaUnitOfWork,
+        MediaUnitOfWorkFactory,
+    )
     from src.modules.media.domain.repositories.movie_repository import RemoteArtworkRow
     from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = get_logger()
 
-# The top-level artwork columns this job mirrors. Season posters, episode
-# stills, localized art and cast photos are out of scope here (PR 3).
-_ARTWORK_FIELDS = ("poster_path", "backdrop_path", "logo_path")
+
+@dataclass(frozen=True)
+class _Kind:
+    """One artwork-bearing title kind the job mirrors (movie / series).
+
+    Bundles how to find candidates and how to write them back, so the
+    job loops over kinds instead of branching on a boolean flag. Adding
+    season/episode art later is a new ``_Kind``, not a new ``if``.
+    """
+
+    label: str
+    find: Callable[[MediaUnitOfWork, int], Awaitable[Sequence[RemoteArtworkRow]]]
+    update: Callable[[MediaUnitOfWork, str, ArtworkColumns], Awaitable[None]]
 
 
 class ArtworkMirrorJob:
@@ -70,180 +85,169 @@ class ArtworkMirrorJob:
         self._runtime_settings = runtime_settings
         self._downloader = downloader
         self._storage = storage
+        self._kinds: tuple[_Kind, ...] = (
+            _Kind(
+                label="movies",
+                find=lambda uow, limit: uow.movies.find_with_remote_artwork(limit),
+                update=lambda uow, media_id, cols: uow.movies.update_movie_artwork(
+                    MovieId(media_id), cols
+                ),
+            ),
+            _Kind(
+                label="series",
+                find=lambda uow, limit: uow.series.find_with_remote_artwork(limit),
+                update=lambda uow, media_id, cols: uow.series.update_series_artwork(
+                    SeriesId(media_id), cols
+                ),
+            ),
+        )
 
     async def run(self) -> None:
         """Mirror one batch of titles with still-remote artwork.
 
-        Splits the per-tick budget between movies and series: movies
-        first, remaining slots go to series. Logs how many titles were
-        updated and how many individual images were mirrored vs. failed.
+        Splits the per-tick budget across the title kinds in order, and
+        logs how many titles were updated and how many images were
+        mirrored vs. left remote per kind.
         """
         config = await self._runtime_settings.artwork_mirror()
         budget = config.batch_size
+        stats: dict[str, int] = {}
+        active = False
+        for kind in self._kinds:
+            if budget <= 0:
+                break
+            rows = await self._fetch(kind, budget)
+            budget -= len(rows)
+            updated, mirrored, failed = await self._process(kind, rows, config.max_bytes)
+            stats[f"{kind.label}_updated"] = updated
+            stats[f"{kind.label}_mirrored"] = mirrored
+            stats[f"{kind.label}_failed"] = failed
+            active = active or bool(mirrored or failed)
 
-        movies = await self._fetch_movies(budget)
-        movies_updated, movies_mirrored, movies_failed = await self._process(
-            movies, is_movie=True, max_bytes=config.max_bytes
-        )
-        budget -= len(movies)
-
-        series_updated = series_mirrored = series_failed = 0
-        if budget > 0:
-            series = await self._fetch_series(budget)
-            series_updated, series_mirrored, series_failed = await self._process(
-                series, is_movie=False, max_bytes=config.max_bytes
-            )
-
-        if movies_mirrored or series_mirrored or movies_failed or series_failed:
+        if active:
             _logger.info(
                 "[artwork-mirror] tick complete",
-                movies_updated=movies_updated,
-                movies_mirrored=movies_mirrored,
-                movies_failed=movies_failed,
-                series_updated=series_updated,
-                series_mirrored=series_mirrored,
-                series_failed=series_failed,
                 batch_size=config.batch_size,
+                **stats,
             )
 
-    async def _fetch_movies(self, limit: int) -> Sequence[RemoteArtworkRow]:
+    async def _fetch(self, kind: _Kind, limit: int) -> Sequence[RemoteArtworkRow]:
         async with self._media_uow_factory() as uow:
-            return await uow.movies.find_with_remote_artwork(limit)
-
-    async def _fetch_series(self, limit: int) -> Sequence[RemoteArtworkRow]:
-        async with self._media_uow_factory() as uow:
-            return await uow.series.find_with_remote_artwork(limit)
+            return await kind.find(uow, limit)
 
     async def _process(
         self,
+        kind: _Kind,
         rows: Sequence[RemoteArtworkRow],
-        *,
-        is_movie: bool,
         max_bytes: int,
     ) -> tuple[int, int, int]:
-        """Mirror every row's artwork; return (titles_updated, mirrored, failed)."""
-        titles_updated = 0
+        """Mirror every row; return (titles_updated, mirrored, failed)."""
+        updated = 0
         mirrored = 0
         failed = 0
         for row in rows:
-            values, hits, misses = await self._mirror_row(row, max_bytes)
+            columns, hits, misses = await self._mirror_row(row, max_bytes)
             mirrored += hits
             failed += misses
             if hits:
-                await self._persist(row.media_id, values, is_movie=is_movie)
-                titles_updated += 1
-        return titles_updated, mirrored, failed
+                await self._persist(kind, row.media_id, columns)
+                updated += 1
+        return updated, mirrored, failed
+
+    async def _persist(self, kind: _Kind, media_id: str, artwork: ArtworkColumns) -> None:
+        """Write the mirrored artwork columns in a fresh UoW.
+
+        A blind last-writer-wins column update from the fetch-time
+        snapshot: a concurrent re-enrichment in the small fetch→persist
+        window could be reverted, but the 30-min cadence and self-healing
+        re-mirror on the next tick make that acceptable over guarding
+        every column value in the WHERE clause.
+        """
+        async with self._media_uow_factory() as uow:
+            await kind.update(uow, media_id, artwork)
 
     async def _mirror_row(
         self,
         row: RemoteArtworkRow,
         max_bytes: int,
-    ) -> tuple[dict[str, str | None], int, int]:
-        """Mirror each remote field of ``row``.
+    ) -> tuple[ArtworkColumns, int, int]:
+        """Mirror each remote reference of ``row``.
 
-        Returns the final value for all three columns (local URL where a
-        mirror succeeded, the original value otherwise) plus the count of
-        successful and failed downloads.
+        Returns the final columns (local reference where a mirror
+        succeeded, the original value otherwise) plus the count of
+        successful and failed mirrors.
         """
-        values: dict[str, str | None] = {}
-        hits = 0
-        misses = 0
-        for field in _ARTWORK_FIELDS:
-            current = getattr(row, field)
-            mirrored_url = await self._mirror_one(current, max_bytes)
-            if mirrored_url is None:
-                values[field] = current
-                if _is_remote(current):
-                    misses += 1  # was remote but the download failed
-            else:
-                values[field] = mirrored_url
-                hits += 1
-        return values, hits, misses
+        poster, hp, mp = await self._mirror_field(row.artwork.poster, max_bytes)
+        backdrop, hb, mb = await self._mirror_field(row.artwork.backdrop, max_bytes)
+        logo, hl, ml = await self._mirror_field(row.artwork.logo, max_bytes)
+        return (
+            ArtworkColumns(poster=poster, backdrop=backdrop, logo=logo),
+            hp + hb + hl,
+            mp + mb + ml,
+        )
 
-    async def _mirror_one(self, url: str | None, max_bytes: int) -> str | None:
-        """Download + store one image; return its served URL, or None.
+    async def _mirror_field(
+        self,
+        current: ImageUrl | None,
+        max_bytes: int,
+    ) -> tuple[ImageUrl | None, int, int]:
+        """Mirror one reference; return (final value, hit, miss).
 
-        None means "leave the column unchanged": the value was not a
-        remote URL, the response was not a supported image type, or the
-        download/store failed. Every non-mirror path keeps the original
-        remote URL so a later tick can retry — a bad response never
-        overwrites the authoritative provider URL.
+        A non-remote value (local or None) is returned unchanged with no
+        hit/miss. A remote value that mirrors returns the local reference
+        and one hit; one that fails returns the original and one miss —
+        the authoritative remote URL is never dropped.
         """
-        if not _is_remote(url):
-            return None
-        assert url is not None  # narrowed by _is_remote
+        if current is None or not current.is_remote:
+            return current, 0, 0
+        mirrored = await self._mirror_one(current, max_bytes)
+        if mirrored is None:
+            return current, 0, 1
+        return mirrored, 1, 0
+
+    async def _mirror_one(self, url: ImageUrl, max_bytes: int) -> ImageUrl | None:
+        """Download + store one remote image; return the local reference.
+
+        None means the mirror did not happen — the response was not a
+        supported image, or the download/store failed (all logged). The
+        caller keeps the remote URL so a later tick can retry.
+        """
         try:
-            image = await self._downloader.fetch(url, max_bytes=max_bytes)
+            image = await self._downloader.fetch(url.value, max_bytes=max_bytes)
             if not _is_supported_image(image.content_type):
                 # A 200 serving HTML (rate-limit/geoblock page) or an
                 # svg/unknown type must not be stored over the remote URL.
                 _logger.warning(
                     "[artwork-mirror] non-image response; keeping remote URL",
-                    url=url,
+                    url=url.value,
                     content_type=image.content_type,
                 )
                 return None
             key = ArtworkKey.for_content(
                 image.content,
                 content_type=image.content_type,
-                source_url=url,
+                source_url=url.value,
             )
-            return await self._storage.save(
+            served = await self._storage.save(
                 content=image.content,
                 content_type=image.content_type,
                 key=str(key),
             )
+            return ImageUrl(served)
         except GatewayException as exc:
             _logger.warning(
                 "[artwork-mirror] download failed; keeping remote URL",
-                url=url,
+                url=url.value,
                 error=str(exc),
             )
             return None
         except OSError as exc:
             _logger.warning(
                 "[artwork-mirror] storage failed; keeping remote URL",
-                url=url,
+                url=url.value,
                 error=str(exc),
             )
             return None
-
-    async def _persist(
-        self,
-        media_id: str,
-        values: dict[str, str | None],
-        *,
-        is_movie: bool,
-    ) -> None:
-        """Write the mirrored artwork columns in a fresh UoW.
-
-        Writes all three columns from the fetch-time snapshot (mirrored
-        where produced, original otherwise). This is a blind
-        last-writer-wins update: a concurrent re-enrichment in the small
-        fetch→persist window could be reverted, but the 30-min cadence
-        and self-healing re-mirror on the next tick make that acceptable
-        over guarding every column value in the WHERE clause.
-        """
-        async with self._media_uow_factory() as uow:
-            if is_movie:
-                await uow.movies.update_movie_artwork(
-                    MovieId(media_id),
-                    poster_path=values["poster_path"],
-                    backdrop_path=values["backdrop_path"],
-                    logo_path=values["logo_path"],
-                )
-            else:
-                await uow.series.update_series_artwork(
-                    SeriesId(media_id),
-                    poster_path=values["poster_path"],
-                    backdrop_path=values["backdrop_path"],
-                    logo_path=values["logo_path"],
-                )
-
-
-def _is_remote(url: str | None) -> bool:
-    """Whether ``url`` is a value the job should mirror (an http(s) URL)."""
-    return bool(url) and url.startswith("http")  # type: ignore[union-attr]
 
 
 def _is_supported_image(content_type: str | None) -> bool:

--- a/src/infrastructure/scheduling/artwork_mirror_job.py
+++ b/src/infrastructure/scheduling/artwork_mirror_job.py
@@ -22,6 +22,9 @@ from typing import TYPE_CHECKING
 from src.building_blocks.infrastructure.errors import GatewayException
 from src.config.logging import get_logger
 from src.modules.media.domain.value_objects import ArtworkKey
+from src.modules.media.domain.value_objects.artwork_key import (
+    SUPPORTED_ARTWORK_CONTENT_TYPES,
+)
 from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
 
 if TYPE_CHECKING:
@@ -160,14 +163,36 @@ class ArtworkMirrorJob:
     async def _mirror_one(self, url: str | None, max_bytes: int) -> str | None:
         """Download + store one image; return its served URL, or None.
 
-        None means "leave the column unchanged" — either the value was
-        not a remote URL, or the download/store failed (logged).
+        None means "leave the column unchanged": the value was not a
+        remote URL, the response was not a supported image type, or the
+        download/store failed. Every non-mirror path keeps the original
+        remote URL so a later tick can retry — a bad response never
+        overwrites the authoritative provider URL.
         """
         if not _is_remote(url):
             return None
         assert url is not None  # narrowed by _is_remote
         try:
             image = await self._downloader.fetch(url, max_bytes=max_bytes)
+            if not _is_supported_image(image.content_type):
+                # A 200 serving HTML (rate-limit/geoblock page) or an
+                # svg/unknown type must not be stored over the remote URL.
+                _logger.warning(
+                    "[artwork-mirror] non-image response; keeping remote URL",
+                    url=url,
+                    content_type=image.content_type,
+                )
+                return None
+            key = ArtworkKey.for_content(
+                image.content,
+                content_type=image.content_type,
+                source_url=url,
+            )
+            return await self._storage.save(
+                content=image.content,
+                content_type=image.content_type,
+                key=str(key),
+            )
         except GatewayException as exc:
             _logger.warning(
                 "[artwork-mirror] download failed; keeping remote URL",
@@ -175,16 +200,13 @@ class ArtworkMirrorJob:
                 error=str(exc),
             )
             return None
-        key = ArtworkKey.for_content(
-            image.content,
-            content_type=image.content_type,
-            source_url=url,
-        )
-        return await self._storage.save(
-            content=image.content,
-            content_type=image.content_type,
-            key=str(key),
-        )
+        except OSError as exc:
+            _logger.warning(
+                "[artwork-mirror] storage failed; keeping remote URL",
+                url=url,
+                error=str(exc),
+            )
+            return None
 
     async def _persist(
         self,
@@ -193,7 +215,15 @@ class ArtworkMirrorJob:
         *,
         is_movie: bool,
     ) -> None:
-        """Write the mirrored artwork columns in a fresh UoW."""
+        """Write the mirrored artwork columns in a fresh UoW.
+
+        Writes all three columns from the fetch-time snapshot (mirrored
+        where produced, original otherwise). This is a blind
+        last-writer-wins update: a concurrent re-enrichment in the small
+        fetch→persist window could be reverted, but the 30-min cadence
+        and self-healing re-mirror on the next tick make that acceptable
+        over guarding every column value in the WHERE clause.
+        """
         async with self._media_uow_factory() as uow:
             if is_movie:
                 await uow.movies.update_movie_artwork(
@@ -214,6 +244,13 @@ class ArtworkMirrorJob:
 def _is_remote(url: str | None) -> bool:
     """Whether ``url`` is a value the job should mirror (an http(s) URL)."""
     return bool(url) and url.startswith("http")  # type: ignore[union-attr]
+
+
+def _is_supported_image(content_type: str | None) -> bool:
+    """Whether a response content type is an artwork image we will store."""
+    if not content_type:
+        return False
+    return content_type.split(";", 1)[0].strip().lower() in SUPPORTED_ARTWORK_CONTENT_TYPES
 
 
 __all__ = ["ArtworkMirrorJob"]

--- a/src/main.py
+++ b/src/main.py
@@ -155,7 +155,7 @@ def _warn_about_deprecated_env_vars(logger: Any) -> None:
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: PLR0915 — sequential startup script (sweeps + per-job scheduler registration)
     """Application lifespan handler.
 
     Handles startup and shutdown logic:
@@ -251,6 +251,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 subtitle_ocr_job.run,
                 minutes=subtitle_ocr_cfg.interval_minutes,
                 job_id="homeflix:subtitle-ocr",
+            )
+        artwork_mirror_cfg = await runtime_settings.artwork_mirror()
+        if artwork_mirror_cfg.enabled:
+            artwork_mirror_job = await container.artwork_mirror_job()
+            scheduler.add_interval_job(
+                artwork_mirror_job.run,
+                minutes=artwork_mirror_cfg.interval_minutes,
+                job_id="homeflix:artwork-mirror",
             )
         app.state.scheduler = scheduler
 

--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,7 @@ from src.modules.media.presentation.routes import (
     admin_scan_router,
     admin_subtitle_ocr_router,
     admin_system_router,
+    artwork_router,
     catalog_router,
     collection_router,
     enrichment_router,
@@ -75,6 +76,7 @@ WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.media.presentation.routes.admin_scan_routes",
     "src.modules.media.presentation.routes.admin_subtitle_ocr_routes",
     "src.modules.media.presentation.routes.admin_system_routes",
+    "src.modules.media.presentation.routes.artwork_routes",
     "src.modules.media.presentation.routes.catalog_routes",
     "src.modules.media.presentation.routes.collection_routes",
     "src.modules.media.presentation.routes.search_routes",
@@ -468,6 +470,7 @@ def create_app() -> FastAPI:
     app.include_router(admin_credits_router)
     app.include_router(admin_subtitle_ocr_router)
     app.include_router(admin_system_router)
+    app.include_router(artwork_router)
     app.include_router(catalog_router)
     app.include_router(collection_router)
     app.include_router(search_router)

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -1,5 +1,9 @@
 """Media application ports (interfaces for infrastructure and external BCs)."""
 
+from src.modules.media.application.ports.artwork_storage_port import (
+    ArtworkStoragePort,
+    StoredArtwork,
+)
 from src.modules.media.application.ports.catalog_request_lookup_port import (
     CatalogRequestLookupPort,
     CatalogRequestStatus,
@@ -72,6 +76,7 @@ from src.modules.media.application.ports.variant_detector_port import (
 )
 
 __all__ = [
+    "ArtworkStoragePort",
     "CatalogRequestLookupPort",
     "CatalogRequestStatus",
     "CollectionDetailMetadata",
@@ -111,6 +116,7 @@ __all__ = [
     "ScrubPreviewLocatorPort",
     "SearchCandidate",
     "SeasonMetadata",
+    "StoredArtwork",
     "SubtitleOcrOptions",
     "SubtitleOcrPort",
     "VariantDetectorPort",

--- a/src/modules/media/application/ports/__init__.py
+++ b/src/modules/media/application/ports/__init__.py
@@ -1,5 +1,9 @@
 """Media application ports (interfaces for infrastructure and external BCs)."""
 
+from src.modules.media.application.ports.artwork_downloader_port import (
+    ArtworkDownloaderPort,
+    DownloadedImage,
+)
 from src.modules.media.application.ports.artwork_storage_port import (
     ArtworkStoragePort,
     StoredArtwork,
@@ -76,6 +80,7 @@ from src.modules.media.application.ports.variant_detector_port import (
 )
 
 __all__ = [
+    "ArtworkDownloaderPort",
     "ArtworkStoragePort",
     "CatalogRequestLookupPort",
     "CatalogRequestStatus",
@@ -88,6 +93,7 @@ __all__ = [
     "CreditsSignal",
     "DetectedCredits",
     "DetectedIntro",
+    "DownloadedImage",
     "EpisodeMediaRef",
     "EpisodeMetadata",
     "FileStreamerPort",

--- a/src/modules/media/application/ports/artwork_downloader_port.py
+++ b/src/modules/media/application/ports/artwork_downloader_port.py
@@ -13,6 +13,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+#: Provider image hosts artwork may be downloaded from (and, in the read
+#: route, redirected to). Downloading is a server-side fetch of a
+#: DB-stored URL, so it MUST be constrained to known provider CDNs — an
+#: unconstrained fetch is an SSRF primitive. TMDB is the only image
+#: provider today; extend as providers are added. Shared by the
+#: downloader adapter (write path) and the proxy route (redirect path).
+ALLOWED_ARTWORK_HOSTS = frozenset({"image.tmdb.org"})
+
 
 @dataclass(frozen=True, slots=True)
 class DownloadedImage:
@@ -20,12 +28,14 @@ class DownloadedImage:
 
     Attributes:
         content: The raw image bytes.
-        content_type: The response ``Content-Type`` (e.g. ``image/jpeg``),
-            used to pick the stored key's extension.
+        content_type: The response ``Content-Type`` (e.g. ``image/jpeg``)
+            exactly as the provider sent it, or ``None`` when the header
+            was absent — the caller decides how to treat a missing type
+            rather than the adapter fabricating one.
     """
 
     content: bytes
-    content_type: str
+    content_type: str | None
 
 
 class ArtworkDownloaderPort(ABC):

--- a/src/modules/media/application/ports/artwork_downloader_port.py
+++ b/src/modules/media/application/ports/artwork_downloader_port.py
@@ -1,0 +1,56 @@
+"""Port for downloading provider artwork bytes (ADR-029).
+
+The mirror job needs the raw bytes of a remote poster/backdrop/logo so
+it can persist them via :class:`ArtworkStoragePort`. Fetching over HTTP
+is infrastructure; the job talks to this port and an adapter under
+``media/infrastructure/`` owns the HTTP client. Keeping it behind a
+port lets the job be tested with an in-memory fake and keeps transport
+concerns out of the orchestration.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DownloadedImage:
+    """Bytes plus content type of a fetched image.
+
+    Attributes:
+        content: The raw image bytes.
+        content_type: The response ``Content-Type`` (e.g. ``image/jpeg``),
+            used to pick the stored key's extension.
+    """
+
+    content: bytes
+    content_type: str
+
+
+class ArtworkDownloaderPort(ABC):
+    """Fetch the bytes of a remote artwork URL."""
+
+    @abstractmethod
+    async def fetch(self, url: str, *, max_bytes: int) -> DownloadedImage:
+        """Download the image at ``url``.
+
+        Args:
+            url: Absolute http(s) URL of the provider image.
+            max_bytes: Hard ceiling on the response body. The adapter
+                MUST abort (raising) rather than buffer a larger payload,
+                so a mis-sized or hostile URL cannot exhaust memory.
+
+        Returns:
+            The downloaded bytes and content type.
+
+        Raises:
+            GatewayException: On timeout, transport error, non-2xx
+                status, or a body exceeding ``max_bytes``. The caller
+                (mirror job) catches these and leaves the remote URL in
+                place, retrying on a later tick.
+        """
+        ...
+
+
+__all__ = ["ArtworkDownloaderPort", "DownloadedImage"]

--- a/src/modules/media/application/ports/artwork_storage_port.py
+++ b/src/modules/media/application/ports/artwork_storage_port.py
@@ -1,0 +1,92 @@
+"""Port for persisting catalog artwork outside the domain.
+
+Poster / backdrop / logo / still images come from an external
+metadata provider (TMDB) as remote URLs. Serving them straight from
+``image.tmdb.org`` couples the catalog's availability to a third
+party — a removed image, a rate limit, a CDN outage, or plain
+offline use all make the art disappear (see ADR-029).
+
+This port lets the application **mirror** those bytes into storage
+the deployment controls. The use case talks to this port; the
+adapter under ``media/infrastructure/storage/`` knows how to reach
+the backing store — a local-disk directory by default, with an
+S3 / MinIO adapter possible behind the same contract. The adapter
+deliberately returns a **relative URL** (``/api/v1/artwork/{key}``)
+rather than a store-specific URL so the domain and the frontend
+never learn where the bytes actually live — swapping the backend is
+an adapter change, invisible to callers (ADR-009 / ADR-025).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class StoredArtwork:
+    """Bytes plus content type of a single stored artwork object.
+
+    Returned by :meth:`ArtworkStoragePort.open` so the read-only
+    proxy route can stream the object back with the right media type
+    without the route knowing anything about the storage backend.
+
+    Attributes:
+        content: The raw image bytes as stored.
+        content_type: The MIME type to serve them with (e.g.
+            ``image/jpeg``). Persisted alongside the object at save
+            time so the proxy never has to sniff it.
+    """
+
+    content: bytes
+    content_type: str
+
+
+class ArtworkStoragePort(ABC):
+    """Persist, read back, or remove mirrored catalog artwork."""
+
+    @abstractmethod
+    async def save(self, *, content: bytes, content_type: str, key: str) -> str:
+        """Store ``content`` under ``key`` and return its served URL.
+
+        Args:
+            content: Raw image bytes fetched from the provider.
+            content_type: MIME type to persist and later serve with.
+            key: Stable, storage-safe object key. Callers derive it
+                deterministically (e.g. a content hash) so re-saving
+                identical bytes is idempotent and de-duplicated. Must
+                match ``[A-Za-z0-9._-]+`` — it is embedded verbatim in
+                the served URL path.
+
+        Returns:
+            The relative URL the catalog should embed in place of the
+            provider URL (e.g. ``/api/v1/artwork/ab12cd.jpg``).
+            Returning a URL keeps the domain unaware of the backend.
+        """
+        ...
+
+    @abstractmethod
+    async def open(self, key: str) -> StoredArtwork | None:
+        """Read the object back for the proxy route.
+
+        Args:
+            key: The object key previously returned via the served URL.
+
+        Returns:
+            The stored bytes and content type, or ``None`` when no
+            object exists for ``key`` (the route turns that into a
+            404 / remote-origin redirect).
+        """
+        ...
+
+    @abstractmethod
+    async def delete(self, key: str) -> None:
+        """Remove the object for ``key``.
+
+        Idempotent — a missing object is not an error, so callers can
+        delete on every artwork change without a prior existence check.
+        """
+        ...
+
+
+__all__ = ["ArtworkStoragePort", "StoredArtwork"]

--- a/src/modules/media/application/ports/artwork_storage_port.py
+++ b/src/modules/media/application/ports/artwork_storage_port.py
@@ -34,8 +34,10 @@ class StoredArtwork:
     Attributes:
         content: The raw image bytes as stored.
         content_type: The MIME type to serve them with (e.g.
-            ``image/jpeg``). Persisted alongside the object at save
-            time so the proxy never has to sniff it.
+            ``image/jpeg``). How it is resolved is backend-specific:
+            an object store persists it as object metadata at save
+            time, while the local-disk adapter derives it from the
+            key's file extension on read.
     """
 
     content: bytes
@@ -51,12 +53,17 @@ class ArtworkStoragePort(ABC):
 
         Args:
             content: Raw image bytes fetched from the provider.
-            content_type: MIME type to persist and later serve with.
+            content_type: MIME type to serve the bytes with. Whether it
+                is stored (object-store metadata) or re-derived from the
+                key's extension on read (local-disk adapter) is
+                backend-specific, so callers MUST give ``key`` a
+                type-bearing extension that matches ``content_type``.
             key: Stable, storage-safe object key. Callers derive it
-                deterministically (e.g. a content hash) so re-saving
-                identical bytes is idempotent and de-duplicated. Must
-                match ``[A-Za-z0-9._-]+`` — it is embedded verbatim in
-                the served URL path.
+                deterministically (e.g. a content hash + extension) so
+                re-saving identical bytes is idempotent and
+                de-duplicated. Must match ``[A-Za-z0-9._-]+`` (and not
+                be all dots) — it is embedded verbatim in the served
+                URL path.
 
         Returns:
             The relative URL the catalog should embed in place of the

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -55,6 +55,24 @@ class CreditsStatusRow:
     episode_number: int | None = None
 
 
+@dataclass(frozen=True)
+class RemoteArtworkRow:
+    """Lightweight projection of a title's artwork URL columns.
+
+    Used by the artwork-mirror job (ADR-029) to find titles whose
+    poster/backdrop/logo is still a remote provider URL and update just
+    those columns directly — without loading the aggregate, which a full
+    ``save`` would risk persisting with unloaded children (file variants,
+    seasons). ``media_id`` is the external id (``mov_xxx`` / ``ser_xxx``).
+    Reused for both movies and series (same three columns).
+    """
+
+    media_id: str
+    poster_path: str | None
+    backdrop_path: str | None
+    logo_path: str | None
+
+
 class MovieRepository(ABC):
     """Repository interface for Movie aggregate.
 
@@ -592,6 +610,36 @@ class MovieRepository(ABC):
 
         Returns:
             Sequence of movies whose ``scrub_preview_path`` is null.
+        """
+        ...
+
+    @abstractmethod
+    async def find_with_remote_artwork(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` movies with a still-remote artwork URL.
+
+        A row is returned when any of ``poster_path`` / ``backdrop_path``
+        / ``logo_path`` is still an ``http(s)`` provider URL (not yet
+        mirrored). Soft-deleted rows are excluded and results are ordered
+        by id so the mirror job makes steady forward progress.
+        """
+        ...
+
+    @abstractmethod
+    async def update_movie_artwork(
+        self,
+        movie_id: MovieId,
+        *,
+        poster_path: str | None,
+        backdrop_path: str | None,
+        logo_path: str | None,
+    ) -> None:
+        """Set the three artwork columns directly (mirror job).
+
+        A targeted column update rather than an aggregate ``save`` so the
+        mirror job never risks persisting the movie with unloaded file
+        variants. Callers pass the final value for every column (the
+        mirrored local URL where one was produced, the original value
+        otherwise).
         """
         ...
 

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from src.building_blocks.domain.pagination import PaginatedResult
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.value_objects import (
+    ArtworkColumns,
     CreditsDetectionState,
     CreditsMarker,
     EpisodeId,
@@ -57,20 +58,20 @@ class CreditsStatusRow:
 
 @dataclass(frozen=True)
 class RemoteArtworkRow:
-    """Lightweight projection of a title's artwork URL columns.
+    """Lightweight projection of a title's artwork references.
 
     Used by the artwork-mirror job (ADR-029) to find titles whose
     poster/backdrop/logo is still a remote provider URL and update just
     those columns directly — without loading the aggregate, which a full
     ``save`` would risk persisting with unloaded children (file variants,
-    seasons). ``media_id`` is the external id (``mov_xxx`` / ``ser_xxx``).
-    Reused for both movies and series (same three columns).
+    seasons). ``media_id`` is the external id (``mov_xxx`` / ``ser_xxx``);
+    ``artwork`` carries the three references as ``ImageUrl`` values, so
+    ``.is_remote`` is available without re-parsing strings. Reused for
+    both movies and series (same three columns).
     """
 
     media_id: str
-    poster_path: str | None
-    backdrop_path: str | None
-    logo_path: str | None
+    artwork: ArtworkColumns
 
 
 class MovieRepository(ABC):
@@ -625,21 +626,14 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
-    async def update_movie_artwork(
-        self,
-        movie_id: MovieId,
-        *,
-        poster_path: str | None,
-        backdrop_path: str | None,
-        logo_path: str | None,
-    ) -> None:
+    async def update_movie_artwork(self, movie_id: MovieId, artwork: ArtworkColumns) -> None:
         """Set the three artwork columns directly (mirror job).
 
         A targeted column update rather than an aggregate ``save`` so the
         mirror job never risks persisting the movie with unloaded file
-        variants. Callers pass the final value for every column (the
-        mirrored local URL where one was produced, the original value
-        otherwise).
+        variants. ``artwork`` carries the final value for every column
+        (the mirrored local reference where one was produced, the
+        original value otherwise).
         """
         ...
 

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -14,6 +14,7 @@ from src.modules.media.domain.repositories.movie_repository import (
     RemoteArtworkRow,
 )
 from src.modules.media.domain.value_objects import (
+    ArtworkColumns,
     CreditsDetectionState,
     CreditsMarker,
     EpisodeId,
@@ -445,19 +446,13 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def update_series_artwork(
-        self,
-        series_id: SeriesId,
-        *,
-        poster_path: str | None,
-        backdrop_path: str | None,
-        logo_path: str | None,
-    ) -> None:
+    async def update_series_artwork(self, series_id: SeriesId, artwork: ArtworkColumns) -> None:
         """Set the three artwork columns for one series by external id.
 
         A targeted column update rather than an aggregate ``save`` so the
         mirror job never risks persisting the series with its seasons and
-        episodes unloaded. Callers pass the final value for every column.
+        episodes unloaded. ``artwork`` carries the final value for every
+        column.
         """
         ...
 

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -8,7 +8,11 @@ from src.building_blocks.domain.pagination import PaginatedResult
 from src.modules.media.domain.entities.episode import Episode
 from src.modules.media.domain.entities.season import Season
 from src.modules.media.domain.entities.series import Series
-from src.modules.media.domain.repositories.movie_repository import CreditsStatusRow, GenreRow
+from src.modules.media.domain.repositories.movie_repository import (
+    CreditsStatusRow,
+    GenreRow,
+    RemoteArtworkRow,
+)
 from src.modules.media.domain.value_objects import (
     CreditsDetectionState,
     CreditsMarker,
@@ -427,6 +431,33 @@ class SeriesRepository(ABC):
         Returns:
             ``True`` if a row was updated, ``False`` if no episode with
             that id exists.
+        """
+        ...
+
+    @abstractmethod
+    async def find_with_remote_artwork(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` series with a still-remote artwork URL.
+
+        Mirror of ``MovieRepository.find_with_remote_artwork`` over
+        series ``poster_path`` / ``backdrop_path`` / ``logo_path``. Season
+        posters and episode stills are handled separately (ADR-029 PR 3).
+        """
+        ...
+
+    @abstractmethod
+    async def update_series_artwork(
+        self,
+        series_id: SeriesId,
+        *,
+        poster_path: str | None,
+        backdrop_path: str | None,
+        logo_path: str | None,
+    ) -> None:
+        """Set the three artwork columns for one series by external id.
+
+        A targeted column update rather than an aggregate ``save`` so the
+        mirror job never risks persisting the series with its seasons and
+        episodes unloaded. Callers pass the final value for every column.
         """
         ...
 

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -1,6 +1,7 @@
 """Media domain value objects."""
 
 from src.modules.media.domain.value_objects.air_date import AirDate
+from src.modules.media.domain.value_objects.artwork_columns import ArtworkColumns
 from src.modules.media.domain.value_objects.artwork_key import ArtworkKey
 from src.modules.media.domain.value_objects.cast_member import CastMember
 from src.modules.media.domain.value_objects.collection import Collection
@@ -48,6 +49,7 @@ from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 __all__ = [
     "AirDate",
+    "ArtworkColumns",
     "ArtworkKey",
     "AudioTrack",
     "CastMember",

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -1,6 +1,7 @@
 """Media domain value objects."""
 
 from src.modules.media.domain.value_objects.air_date import AirDate
+from src.modules.media.domain.value_objects.artwork_key import ArtworkKey
 from src.modules.media.domain.value_objects.cast_member import CastMember
 from src.modules.media.domain.value_objects.collection import Collection
 from src.modules.media.domain.value_objects.conflict_candidate import ConflictCandidate
@@ -47,6 +48,7 @@ from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
 
 __all__ = [
     "AirDate",
+    "ArtworkKey",
     "AudioTrack",
     "CastMember",
     "Collection",

--- a/src/modules/media/domain/value_objects/artwork_columns.py
+++ b/src/modules/media/domain/value_objects/artwork_columns.py
@@ -1,0 +1,38 @@
+"""The trio of top-level artwork references for a title (ADR-029).
+
+Poster / backdrop / logo travel together everywhere the mirror flows —
+the repository projection, the job's per-field result, and the update
+signature. Bundling them into one value object replaces a three-argument
+data clump (and a stringly-keyed ``dict``) with a single typed value,
+and gives later phases (season posters, stills) one place to grow.
+
+Each reference is an :class:`ImageUrl` — dual-mode, so it carries either
+a remote provider URL or a local ``/api/v1/artwork/...`` path — which
+keeps the ``is_remote`` decision on the value object rather than on
+loose strings.
+"""
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+from src.shared_kernel.value_objects.image_url import ImageUrl
+
+
+class ArtworkColumns(CompoundValueObject):
+    """Poster / backdrop / logo references for one title.
+
+    Attributes:
+        poster: Poster reference, or ``None``.
+        backdrop: Backdrop reference, or ``None``.
+        logo: Title-logo reference, or ``None``.
+
+    Example:
+        >>> cols = ArtworkColumns(poster=ImageUrl("/api/v1/artwork/ab.jpg"))
+        >>> cols.poster.is_remote
+        False
+    """
+
+    poster: ImageUrl | None = None
+    backdrop: ImageUrl | None = None
+    logo: ImageUrl | None = None
+
+
+__all__ = ["ArtworkColumns"]

--- a/src/modules/media/domain/value_objects/artwork_key.py
+++ b/src/modules/media/domain/value_objects/artwork_key.py
@@ -1,0 +1,120 @@
+"""Value object for a mirrored-artwork storage key (ADR-029).
+
+The key is the stable, storage-safe token embedded verbatim in the
+served URL ``/api/v1/artwork/{key}`` and used as the object name in
+:class:`ArtworkStoragePort`. It is content-addressed — the SHA-256 of
+the image bytes plus a type-bearing extension — so re-mirroring the
+same image de-duplicates naturally and a changed image yields a new
+key (cache-busting).
+
+This VO is the single source of truth for the key charset: the proxy
+route validates untrusted input against :data:`ARTWORK_KEY_PATTERN`,
+and the mirror job constructs keys via :meth:`ArtworkKey.for_content`,
+so the write path is guarded too — not just the read route.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from urllib.parse import urlsplit
+
+from pydantic import model_validator
+
+from src.building_blocks.domain.value_objects import StringValueObject
+
+#: Charset a storage key may use. Kept here so the route and the job
+#: share one definition instead of restating the rule.
+ARTWORK_KEY_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Explicit MIME -> extension map for the image types providers serve.
+# Preferred over ``mimetypes.guess_extension``, which is unreliable
+# across platforms (e.g. ``image/webp`` is unregistered on some Windows
+# installs and ``image/jpeg`` can yield ``.jpe``).
+_CONTENT_TYPE_EXTENSIONS = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+    "image/avif": ".avif",
+}
+
+# Fallback extension when neither the content type nor the source URL
+# yields one. Artwork is always an image, so a generic image extension
+# keeps the served content type sensible.
+_FALLBACK_EXTENSION = ".jpg"
+
+
+class ArtworkKey(StringValueObject):
+    """A validated, content-addressed artwork storage key.
+
+    Example:
+        >>> key = ArtworkKey.for_content(
+        ...     b"...bytes...",
+        ...     content_type="image/png",
+        ...     source_url="https://image.tmdb.org/t/p/original/x.png",
+        ... )
+        >>> str(key).endswith(".png")
+        True
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_key(cls, value: str) -> str:
+        """Reject anything outside the safe charset or that is all dots."""
+        if not isinstance(value, str):
+            raise ValueError("ArtworkKey must be a string")
+        value = value.strip()
+        if not ARTWORK_KEY_PATTERN.match(value) or set(value) <= {"."}:
+            raise ValueError(
+                "ArtworkKey must match [A-Za-z0-9._-]+ and not be all dots"
+            )
+        return value
+
+    @classmethod
+    def for_content(
+        cls,
+        content: bytes,
+        *,
+        content_type: str | None,
+        source_url: str,
+    ) -> ArtworkKey:
+        """Build a content-addressed key from image bytes.
+
+        Args:
+            content: The downloaded image bytes.
+            content_type: The response MIME type, used to pick the
+                extension (``image/png`` -> ``.png``). Falls back to the
+                source URL's suffix, then to ``.jpg``.
+            source_url: The remote URL the bytes came from, used for the
+                extension when ``content_type`` is missing/unknown.
+
+        Returns:
+            An ``ArtworkKey`` of the form ``<sha256-hex><ext>``.
+        """
+        digest = hashlib.sha256(content).hexdigest()
+        return cls(f"{digest}{_extension_for(content_type, source_url)}")
+
+
+def _extension_for(content_type: str | None, source_url: str) -> str:
+    """Pick a file extension from the content type, else the URL, else jpg."""
+    if content_type:
+        # Strip any ``; charset=...`` suffix before the lookup.
+        mime = content_type.split(";", 1)[0].strip().lower()
+        if mime in _CONTENT_TYPE_EXTENSIONS:
+            return _CONTENT_TYPE_EXTENSIONS[mime]
+    suffix = _clean_suffix(urlsplit(source_url).path)
+    return suffix or _FALLBACK_EXTENSION
+
+
+def _clean_suffix(path: str) -> str:
+    """Return a charset-safe extension from a URL path, or empty string."""
+    dot = path.rfind(".")
+    if dot == -1:
+        return ""
+    suffix = path[dot:]
+    return suffix if ARTWORK_KEY_PATTERN.match(suffix.lstrip(".")) else ""
+
+
+__all__ = ["ARTWORK_KEY_PATTERN", "ArtworkKey"]

--- a/src/modules/media/domain/value_objects/artwork_key.py
+++ b/src/modules/media/domain/value_objects/artwork_key.py
@@ -40,6 +40,16 @@ _CONTENT_TYPE_EXTENSIONS = {
     "image/avif": ".avif",
 }
 
+#: Content types the mirror will accept as artwork. Exposed so the job
+#: can reject a non-image response (e.g. an HTML rate-limit page served
+#: with 200, or an ``image/svg+xml`` XSS vector) before storing it.
+SUPPORTED_ARTWORK_CONTENT_TYPES = frozenset(_CONTENT_TYPE_EXTENSIONS)
+
+# Extensions accepted when derived from a source URL's path. Restricted
+# to the raster set above (plus the ``.jpeg`` spelling) so a URL ending
+# in ``.svg`` or an arbitrary suffix can never mint a dangerous key.
+_SAFE_URL_EXTENSIONS = frozenset(_CONTENT_TYPE_EXTENSIONS.values()) | {".jpeg"}
+
 # Fallback extension when neither the content type nor the source URL
 # yields one. Artwork is always an image, so a generic image extension
 # keeps the served content type sensible.
@@ -67,9 +77,7 @@ class ArtworkKey(StringValueObject):
             raise ValueError("ArtworkKey must be a string")
         value = value.strip()
         if not ARTWORK_KEY_PATTERN.match(value) or set(value) <= {"."}:
-            raise ValueError(
-                "ArtworkKey must match [A-Za-z0-9._-]+ and not be all dots"
-            )
+            raise ValueError("ArtworkKey must match [A-Za-z0-9._-]+ and not be all dots")
         return value
 
     @classmethod
@@ -109,12 +117,12 @@ def _extension_for(content_type: str | None, source_url: str) -> str:
 
 
 def _clean_suffix(path: str) -> str:
-    """Return a charset-safe extension from a URL path, or empty string."""
+    """Return a safe raster extension from a URL path, or empty string."""
     dot = path.rfind(".")
     if dot == -1:
         return ""
-    suffix = path[dot:]
-    return suffix if ARTWORK_KEY_PATTERN.match(suffix.lstrip(".")) else ""
+    suffix = path[dot:].lower()
+    return suffix if suffix in _SAFE_URL_EXTENSIONS else ""
 
 
-__all__ = ["ARTWORK_KEY_PATTERN", "ArtworkKey"]
+__all__ = ["ARTWORK_KEY_PATTERN", "SUPPORTED_ARTWORK_CONTENT_TYPES", "ArtworkKey"]

--- a/src/modules/media/infrastructure/metadata/artwork_downloader.py
+++ b/src/modules/media/infrastructure/metadata/artwork_downloader.py
@@ -1,0 +1,96 @@
+"""httpx implementation of ``ArtworkDownloaderPort`` (ADR-029).
+
+Streams the response and aborts as soon as the accumulated body would
+exceed ``max_bytes``, so a mis-sized or hostile URL can never buffer an
+unbounded payload into memory. Transport failures are translated into
+the shared gateway exception hierarchy, mirroring ``TmdbClient``'s
+error handling so the mirror job sees one exception family.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from src.building_blocks.infrastructure.errors import (
+    GatewayBadResponseException,
+    GatewayTimeoutException,
+    GatewayUnavailableException,
+)
+from src.config.logging import get_logger
+from src.modules.media.application.ports.artwork_downloader_port import (
+    ArtworkDownloaderPort,
+    DownloadedImage,
+)
+
+_logger = get_logger()
+
+_GATEWAY_NAME = "artwork-cdn"
+_DEFAULT_CONTENT_TYPE = "application/octet-stream"
+
+
+class HttpxArtworkDownloader(ArtworkDownloaderPort):
+    """Download artwork bytes over HTTP with a hard size ceiling.
+
+    Owns a single long-lived ``httpx.AsyncClient`` (thread-safe, pooled),
+    constructed with ``follow_redirects=True`` because provider image
+    CDNs commonly 30x to a resized variant.
+
+    Args:
+        timeout_seconds: Per-request timeout. Defaults to 30s, matching
+            the metadata client.
+    """
+
+    def __init__(self, *, timeout_seconds: float = 30.0) -> None:
+        self._client = httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=True)
+
+    async def fetch(self, url: str, *, max_bytes: int) -> DownloadedImage:
+        """Stream ``url`` into memory, aborting past ``max_bytes``."""
+        try:
+            async with self._client.stream("GET", url) as response:
+                response.raise_for_status()
+                content = await self._read_capped(response, max_bytes, url)
+                content_type = response.headers.get("content-type", _DEFAULT_CONTENT_TYPE)
+                return DownloadedImage(content=content, content_type=content_type)
+        except httpx.TimeoutException as exc:
+            raise GatewayTimeoutException(
+                message="Artwork download timed out",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=f"Timeout fetching {url}",
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            raise GatewayBadResponseException(
+                message="Artwork provider returned an error status",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=f"HTTP {exc.response.status_code} fetching {url}",
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise GatewayUnavailableException(
+                message="Artwork provider is unavailable",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=f"Transport error fetching {url}: {exc}",
+            ) from exc
+
+    async def _read_capped(
+        self,
+        response: httpx.Response,
+        max_bytes: int,
+        url: str,
+    ) -> bytes:
+        """Accumulate the streamed body, raising once it passes the cap."""
+        buffer = bytearray()
+        async for chunk in response.aiter_bytes():
+            buffer.extend(chunk)
+            if len(buffer) > max_bytes:
+                raise GatewayBadResponseException(
+                    message="Artwork exceeds the maximum allowed size",
+                    gateway_name=_GATEWAY_NAME,
+                    internal_message=f"Body over {max_bytes} bytes fetching {url}",
+                )
+        return bytes(buffer)
+
+    async def aclose(self) -> None:
+        """Close the underlying client (called on app shutdown)."""
+        await self._client.aclose()
+
+
+__all__ = ["HttpxArtworkDownloader"]

--- a/src/modules/media/infrastructure/metadata/artwork_downloader.py
+++ b/src/modules/media/infrastructure/metadata/artwork_downloader.py
@@ -5,9 +5,16 @@ exceed ``max_bytes``, so a mis-sized or hostile URL can never buffer an
 unbounded payload into memory. Transport failures are translated into
 the shared gateway exception hierarchy, mirroring ``TmdbClient``'s
 error handling so the mirror job sees one exception family.
+
+Because the URLs come from the database (a server-side fetch), the
+target is constrained to ``https`` on an allow-listed provider host and
+redirects are NOT followed — an unconstrained fetch of a DB-controlled
+URL would be an SSRF primitive.
 """
 
 from __future__ import annotations
+
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -18,6 +25,7 @@ from src.building_blocks.infrastructure.errors import (
 )
 from src.config.logging import get_logger
 from src.modules.media.application.ports.artwork_downloader_port import (
+    ALLOWED_ARTWORK_HOSTS,
     ArtworkDownloaderPort,
     DownloadedImage,
 )
@@ -25,31 +33,51 @@ from src.modules.media.application.ports.artwork_downloader_port import (
 _logger = get_logger()
 
 _GATEWAY_NAME = "artwork-cdn"
-_DEFAULT_CONTENT_TYPE = "application/octet-stream"
 
 
 class HttpxArtworkDownloader(ArtworkDownloaderPort):
     """Download artwork bytes over HTTP with a hard size ceiling.
 
     Owns a single long-lived ``httpx.AsyncClient`` (thread-safe, pooled),
-    constructed with ``follow_redirects=True`` because provider image
-    CDNs commonly 30x to a resized variant.
+    with ``follow_redirects=False`` so a 30x cannot bounce the fetch to an
+    internal target (provider image URLs are direct 200s).
 
     Args:
         timeout_seconds: Per-request timeout. Defaults to 30s, matching
             the metadata client.
+        client: Optional injected client (tests pass a fake). Defaults to
+            a redirect-disabled ``httpx.AsyncClient``.
     """
 
-    def __init__(self, *, timeout_seconds: float = 30.0) -> None:
-        self._client = httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=True)
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 30.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._client = client or httpx.AsyncClient(timeout=timeout_seconds, follow_redirects=False)
 
     async def fetch(self, url: str, *, max_bytes: int) -> DownloadedImage:
-        """Stream ``url`` into memory, aborting past ``max_bytes``."""
+        """Stream ``url`` into memory, aborting past ``max_bytes``.
+
+        The URL must be ``https`` on an allow-listed provider host, else
+        it is rejected before any request is made (SSRF guard).
+        """
+        self._reject_disallowed(url)
         try:
             async with self._client.stream("GET", url) as response:
                 response.raise_for_status()
+                if response.is_redirect:
+                    # Redirects are disabled; a 3xx here means the CDN
+                    # tried to bounce us — refuse rather than store the
+                    # redirect body or chase the target.
+                    raise GatewayBadResponseException(
+                        message="Artwork provider attempted a redirect",
+                        gateway_name=_GATEWAY_NAME,
+                        internal_message=f"Unexpected {response.status_code} redirect for {url}",
+                    )
                 content = await self._read_capped(response, max_bytes, url)
-                content_type = response.headers.get("content-type", _DEFAULT_CONTENT_TYPE)
+                content_type = response.headers.get("content-type")
                 return DownloadedImage(content=content, content_type=content_type)
         except httpx.TimeoutException as exc:
             raise GatewayTimeoutException(
@@ -70,6 +98,16 @@ class HttpxArtworkDownloader(ArtworkDownloaderPort):
                 internal_message=f"Transport error fetching {url}: {exc}",
             ) from exc
 
+    def _reject_disallowed(self, url: str) -> None:
+        """Raise unless ``url`` is https on an allow-listed provider host."""
+        parts = urlsplit(url)
+        if parts.scheme != "https" or parts.hostname not in ALLOWED_ARTWORK_HOSTS:
+            raise GatewayBadResponseException(
+                message="Artwork URL is not an allowed provider host",
+                gateway_name=_GATEWAY_NAME,
+                internal_message=f"Refusing to fetch disallowed URL {url}",
+            )
+
     async def _read_capped(
         self,
         response: httpx.Response,
@@ -89,7 +127,13 @@ class HttpxArtworkDownloader(ArtworkDownloaderPort):
         return bytes(buffer)
 
     async def aclose(self) -> None:
-        """Close the underlying client (called on app shutdown)."""
+        """Close the underlying httpx client.
+
+        Not wired to a shutdown hook today (the singleton's sockets are
+        reclaimed at process exit); provided so a future
+        ``providers.Resource`` finalizer, or a test, can close it
+        deterministically.
+        """
         await self._client.aclose()
 
 

--- a/src/modules/media/infrastructure/persistence/repositories/_artwork_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_artwork_helpers.py
@@ -1,0 +1,35 @@
+"""Column <-> ArtworkColumns conversion for the mirror finders (ADR-029).
+
+Shared by the movie and series repositories so the raw poster/backdrop/
+logo string columns are wrapped into (and unwrapped from) an
+``ArtworkColumns`` value object in exactly one place.
+"""
+
+from __future__ import annotations
+
+from src.modules.media.domain.value_objects import ArtworkColumns, ImageUrl
+
+
+def to_artwork_columns(
+    poster: str | None,
+    backdrop: str | None,
+    logo: str | None,
+) -> ArtworkColumns:
+    """Wrap raw column strings into an ``ArtworkColumns`` value object."""
+    return ArtworkColumns(
+        poster=ImageUrl(poster) if poster else None,
+        backdrop=ImageUrl(backdrop) if backdrop else None,
+        logo=ImageUrl(logo) if logo else None,
+    )
+
+
+def artwork_column_values(artwork: ArtworkColumns) -> dict[str, str | None]:
+    """Unwrap an ``ArtworkColumns`` into a ``{column: value}`` update map."""
+    return {
+        "poster_path": artwork.poster.value if artwork.poster else None,
+        "backdrop_path": artwork.backdrop.value if artwork.backdrop else None,
+        "logo_path": artwork.logo.value if artwork.logo else None,
+    }
+
+
+__all__ = ["artwork_column_values", "to_artwork_columns"]

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -16,7 +16,11 @@ from src.building_blocks.application.pagination import (
 from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.repositories import MovieRepository
-from src.modules.media.domain.repositories.movie_repository import CreditsStatusRow, GenreRow
+from src.modules.media.domain.repositories.movie_repository import (
+    CreditsStatusRow,
+    GenreRow,
+    RemoteArtworkRow,
+)
 from src.modules.media.domain.value_objects import (
     CreditsDetectionState,
     CreditsMarker,
@@ -751,6 +755,62 @@ class SQLAlchemyMovieRepository(MovieRepository):
         )
         result = await self._session.execute(stmt)
         return [MovieMapper.to_entity(model) for model in result.scalars().all()]
+
+    async def find_with_remote_artwork(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` movies whose artwork is still a remote URL.
+
+        Projects just the four columns the mirror job needs (external id +
+        the three artwork URLs) so it never loads entities or their file
+        variants. ``LIKE 'http%'`` matches the persisted full provider
+        URLs; already-mirrored ``/api/v1/artwork/...`` paths don't match.
+        """
+        stmt = (
+            select(
+                MovieModel.external_id,
+                MovieModel.poster_path,
+                MovieModel.backdrop_path,
+                MovieModel.logo_path,
+            )
+            .where(
+                MovieModel.deleted_at.is_(None),
+                or_(
+                    MovieModel.poster_path.like("http%"),
+                    MovieModel.backdrop_path.like("http%"),
+                    MovieModel.logo_path.like("http%"),
+                ),
+            )
+            .order_by(MovieModel.id.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [
+            RemoteArtworkRow(
+                media_id=row.external_id,
+                poster_path=row.poster_path,
+                backdrop_path=row.backdrop_path,
+                logo_path=row.logo_path,
+            )
+            for row in result.all()
+        ]
+
+    async def update_movie_artwork(
+        self,
+        movie_id: MovieId,
+        *,
+        poster_path: str | None,
+        backdrop_path: str | None,
+        logo_path: str | None,
+    ) -> None:
+        """Set the three artwork columns for one movie by external id."""
+        await self._session.execute(
+            update(MovieModel)
+            .where(MovieModel.external_id == movie_id.value)
+            .values(
+                poster_path=poster_path,
+                backdrop_path=backdrop_path,
+                logo_path=logo_path,
+            )
+        )
 
     async def count_credits_states(self) -> dict[str, int]:
         """Return ``{credits_detection_state: count}`` over non-deleted movies."""

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -22,6 +22,7 @@ from src.modules.media.domain.repositories.movie_repository import (
     RemoteArtworkRow,
 )
 from src.modules.media.domain.value_objects import (
+    ArtworkColumns,
     CreditsDetectionState,
     CreditsMarker,
     EpisodeId,
@@ -34,6 +35,10 @@ from src.modules.media.infrastructure.persistence.models import (
     EpisodeModel,
     MediaFileModel,
     MovieModel,
+)
+from src.modules.media.infrastructure.persistence.repositories._artwork_helpers import (
+    artwork_column_values,
+    to_artwork_columns,
 )
 from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
     fetch_genre_paginated_page,
@@ -786,30 +791,17 @@ class SQLAlchemyMovieRepository(MovieRepository):
         return [
             RemoteArtworkRow(
                 media_id=row.external_id,
-                poster_path=row.poster_path,
-                backdrop_path=row.backdrop_path,
-                logo_path=row.logo_path,
+                artwork=to_artwork_columns(row.poster_path, row.backdrop_path, row.logo_path),
             )
             for row in result.all()
         ]
 
-    async def update_movie_artwork(
-        self,
-        movie_id: MovieId,
-        *,
-        poster_path: str | None,
-        backdrop_path: str | None,
-        logo_path: str | None,
-    ) -> None:
+    async def update_movie_artwork(self, movie_id: MovieId, artwork: ArtworkColumns) -> None:
         """Set the three artwork columns for one movie by external id."""
         await self._session.execute(
             update(MovieModel)
             .where(MovieModel.external_id == movie_id.value)
-            .values(
-                poster_path=poster_path,
-                backdrop_path=backdrop_path,
-                logo_path=logo_path,
-            )
+            .values(**artwork_column_values(artwork))
         )
 
     async def count_credits_states(self) -> dict[str, int]:

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -745,7 +745,7 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         """Set the three artwork columns for one series by external id."""
         await self._session.execute(
             update(SeriesModel)
-            .where(SeriesModel.external_id == str(series_id))
+            .where(SeriesModel.external_id == series_id.value)
             .values(
                 poster_path=poster_path,
                 backdrop_path=backdrop_path,

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -21,6 +21,7 @@ from src.modules.media.domain.repositories.movie_repository import (
     RemoteArtworkRow,
 )
 from src.modules.media.domain.value_objects import (
+    ArtworkColumns,
     CreditsDetectionState,
     CreditsMarker,
     EpisodeId,
@@ -43,6 +44,10 @@ from src.modules.media.infrastructure.persistence.models import (
     MediaFileModel,
     SeasonModel,
     SeriesModel,
+)
+from src.modules.media.infrastructure.persistence.repositories._artwork_helpers import (
+    artwork_column_values,
+    to_artwork_columns,
 )
 from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
     fetch_genre_paginated_page,
@@ -727,30 +732,17 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         return [
             RemoteArtworkRow(
                 media_id=row.external_id,
-                poster_path=row.poster_path,
-                backdrop_path=row.backdrop_path,
-                logo_path=row.logo_path,
+                artwork=to_artwork_columns(row.poster_path, row.backdrop_path, row.logo_path),
             )
             for row in result.all()
         ]
 
-    async def update_series_artwork(
-        self,
-        series_id: SeriesId,
-        *,
-        poster_path: str | None,
-        backdrop_path: str | None,
-        logo_path: str | None,
-    ) -> None:
+    async def update_series_artwork(self, series_id: SeriesId, artwork: ArtworkColumns) -> None:
         """Set the three artwork columns for one series by external id."""
         await self._session.execute(
             update(SeriesModel)
             .where(SeriesModel.external_id == series_id.value)
-            .values(
-                poster_path=poster_path,
-                backdrop_path=backdrop_path,
-                logo_path=logo_path,
-            )
+            .values(**artwork_column_values(artwork))
         )
 
     async def find_seasons_pending_intro_detection(

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -15,7 +15,11 @@ from src.building_blocks.application.pagination import (
 from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.repositories import SeriesRepository
-from src.modules.media.domain.repositories.movie_repository import CreditsStatusRow, GenreRow
+from src.modules.media.domain.repositories.movie_repository import (
+    CreditsStatusRow,
+    GenreRow,
+    RemoteArtworkRow,
+)
 from src.modules.media.domain.value_objects import (
     CreditsDetectionState,
     CreditsMarker,
@@ -692,6 +696,62 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         )
         result = await self._session.execute(stmt)
         return bool(result.rowcount)
+
+    async def find_with_remote_artwork(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` series whose artwork is still a remote URL.
+
+        Projects only the external id + three artwork columns so the
+        mirror job never loads the series aggregate (seasons + episodes).
+        ``LIKE 'http%'`` matches persisted provider URLs; already-mirrored
+        ``/api/v1/artwork/...`` paths do not.
+        """
+        stmt = (
+            select(
+                SeriesModel.external_id,
+                SeriesModel.poster_path,
+                SeriesModel.backdrop_path,
+                SeriesModel.logo_path,
+            )
+            .where(
+                SeriesModel.deleted_at.is_(None),
+                or_(
+                    SeriesModel.poster_path.like("http%"),
+                    SeriesModel.backdrop_path.like("http%"),
+                    SeriesModel.logo_path.like("http%"),
+                ),
+            )
+            .order_by(SeriesModel.id.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [
+            RemoteArtworkRow(
+                media_id=row.external_id,
+                poster_path=row.poster_path,
+                backdrop_path=row.backdrop_path,
+                logo_path=row.logo_path,
+            )
+            for row in result.all()
+        ]
+
+    async def update_series_artwork(
+        self,
+        series_id: SeriesId,
+        *,
+        poster_path: str | None,
+        backdrop_path: str | None,
+        logo_path: str | None,
+    ) -> None:
+        """Set the three artwork columns for one series by external id."""
+        await self._session.execute(
+            update(SeriesModel)
+            .where(SeriesModel.external_id == str(series_id))
+            .values(
+                poster_path=poster_path,
+                backdrop_path=backdrop_path,
+                logo_path=logo_path,
+            )
+        )
 
     async def find_seasons_pending_intro_detection(
         self,

--- a/src/modules/media/infrastructure/storage/__init__.py
+++ b/src/modules/media/infrastructure/storage/__init__.py
@@ -1,0 +1,7 @@
+"""Storage adapters for the media bounded context."""
+
+from src.modules.media.infrastructure.storage.local_artwork_storage import (
+    LocalArtworkStorage,
+)
+
+__all__ = ["LocalArtworkStorage"]

--- a/src/modules/media/infrastructure/storage/local_artwork_storage.py
+++ b/src/modules/media/infrastructure/storage/local_artwork_storage.py
@@ -1,0 +1,120 @@
+"""Local-disk implementation of ``ArtworkStoragePort``.
+
+Stores mirrored catalog artwork as plain files under a configured
+directory and serves the bytes back through the API proxy route
+(ADR-029). For a personal, single-node deployment this needs no extra
+infrastructure — backing up the artwork is just copying the folder —
+which is why it is the default backend over an object store.
+
+The port stays backend-agnostic: a future S3 / MinIO adapter would
+satisfy the same contract without touching callers. Filesystem I/O is
+deferred to a worker thread via ``asyncio.to_thread`` — the same
+pattern ``LocalAvatarStorage`` uses — so a slow disk never blocks the
+event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+from pathlib import Path
+
+from src.config.logging import get_logger
+from src.modules.media.application.ports.artwork_storage_port import (
+    ArtworkStoragePort,
+    StoredArtwork,
+)
+
+_logger = get_logger()
+
+
+class LocalArtworkStorage(ArtworkStoragePort):
+    """Persist mirrored artwork as files under ``root_directory``.
+
+    Keys are flat, storage-safe tokens ending in a file extension
+    (e.g. ``ab12cd.jpg``) — the content type is derived from that
+    extension on read, so no sidecar metadata is needed. The
+    resolved path is confined to ``root_directory`` as defence in
+    depth even though the route already validates the key charset.
+
+    Args:
+        root_directory: Directory that holds every artwork file. It
+            (and any parents) is created on first write.
+    """
+
+    def __init__(self, *, root_directory: str) -> None:
+        self._root = Path(root_directory)
+
+    async def save(
+        self,
+        *,
+        content: bytes,
+        content_type: str,  # noqa: ARG002 — kept for port parity; local derives type from ext
+        key: str,
+    ) -> str:
+        """Write ``content`` to ``{root}/{key}`` and return the proxy URL.
+
+        ``content_type`` is accepted for contract parity with
+        object-store backends but not persisted — it is re-derived
+        from the key's extension on ``open``.
+        """
+        target = self._path_for(key)
+        await asyncio.to_thread(self._write, target, content)
+        return f"/api/v1/artwork/{key}"
+
+    async def open(self, key: str) -> StoredArtwork | None:
+        """Read the file back, or ``None`` when it does not exist."""
+        target = self._path_for(key)
+        data = await asyncio.to_thread(self._read, target)
+        if data is None:
+            return None
+        return StoredArtwork(content=data, content_type=self._content_type(key))
+
+    async def delete(self, key: str) -> None:
+        """Remove the file. Idempotent — a missing file is a no-op."""
+        target = self._path_for(key)
+        try:
+            await asyncio.to_thread(target.unlink)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            _logger.warning(
+                "[artwork-storage] failed to remove file",
+                key=key,
+                path=str(target),
+                error=str(exc),
+            )
+
+    def _path_for(self, key: str) -> Path:
+        """Resolve ``key`` under the root, rejecting any escape.
+
+        The route already constrains keys to ``[A-Za-z0-9._-]+``; this
+        containment check is belt-and-suspenders so a key like ``..``
+        can never resolve outside the artwork directory.
+        """
+        root = self._root.resolve()
+        target = (root / key).resolve()
+        if not target.is_relative_to(root):
+            raise ValueError(f"artwork key {key!r} escapes the storage root")
+        return target
+
+    @staticmethod
+    def _write(target: Path, content: bytes) -> None:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+
+    @staticmethod
+    def _read(target: Path) -> bytes | None:
+        try:
+            return target.read_bytes()
+        except FileNotFoundError:
+            return None
+
+    @staticmethod
+    def _content_type(key: str) -> str:
+        """MIME type inferred from the key's file extension."""
+        guessed, _ = mimetypes.guess_type(key)
+        return guessed or "application/octet-stream"
+
+
+__all__ = ["LocalArtworkStorage"]

--- a/src/modules/media/infrastructure/storage/local_artwork_storage.py
+++ b/src/modules/media/infrastructure/storage/local_artwork_storage.py
@@ -109,6 +109,12 @@ class LocalArtworkStorage(ArtworkStoragePort):
             return target.read_bytes()
         except FileNotFoundError:
             return None
+        except OSError:
+            # Target exists but is not a readable file — e.g. a key of
+            # ``.`` resolves to the root directory (``IsADirectoryError``),
+            # or a permission issue. Treat as absent rather than letting
+            # the exception surface as a 500 through the proxy route.
+            return None
 
     @staticmethod
     def _content_type(key: str) -> str:

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -27,6 +27,7 @@ from src.modules.media.presentation.routes.admin_subtitle_ocr_routes import (
 from src.modules.media.presentation.routes.admin_system_routes import (
     router as admin_system_router,
 )
+from src.modules.media.presentation.routes.artwork_routes import router as artwork_router
 from src.modules.media.presentation.routes.catalog_routes import router as catalog_router
 from src.modules.media.presentation.routes.collection_routes import router as collection_router
 from src.modules.media.presentation.routes.enrichment_routes import router as enrichment_router
@@ -51,6 +52,7 @@ __all__ = [
     "admin_scan_router",
     "admin_subtitle_ocr_router",
     "admin_system_router",
+    "artwork_router",
     "catalog_router",
     "collection_router",
     "enrichment_router",

--- a/src/modules/media/presentation/routes/artwork_routes.py
+++ b/src/modules/media/presentation/routes/artwork_routes.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse, Response
 
 from src.config.containers import ApplicationContainer
+from src.modules.media.application.ports.artwork_downloader_port import ALLOWED_ARTWORK_HOSTS
 from src.modules.media.application.ports.artwork_storage_port import ArtworkStoragePort
 from src.modules.media.domain.value_objects.artwork_key import ARTWORK_KEY_PATTERN
 
@@ -30,13 +31,6 @@ router = APIRouter(prefix="/api/v1/artwork", tags=["Artwork"])
 # object and would otherwise reach the storage adapter as a directory /
 # traversal-shaped path.
 
-# Hosts a fallback ``origin`` is allowed to redirect to. Only provider
-# image CDNs the mirror legitimately stores may be echoed into a
-# ``Location`` header — otherwise the public, unauthenticated endpoint
-# would be an open redirect (bounce a victim to any URL). TMDB is the
-# only image provider today; extend this set as providers are added.
-_ALLOWED_ORIGIN_HOSTS = frozenset({"image.tmdb.org"})
-
 # Cache mirrored art aggressively — a content-hashed key is immutable,
 # so a long-lived immutable cache is safe and spares the proxy on every
 # repeat view.
@@ -44,9 +38,14 @@ _CACHE_CONTROL = "public, max-age=31536000, immutable"
 
 
 def _is_allowed_origin(origin: str) -> bool:
-    """Whether ``origin`` is an https URL on an allow-listed provider host."""
+    """Whether ``origin`` is an https URL on an allow-listed provider host.
+
+    Reuses ``ALLOWED_ARTWORK_HOSTS`` (the same set the downloader fetches
+    from) so the redirect fallback can only bounce to a real provider
+    CDN — the public endpoint is never an open redirect.
+    """
     parts = urlsplit(origin)
-    return parts.scheme == "https" and parts.hostname in _ALLOWED_ORIGIN_HOSTS
+    return parts.scheme == "https" and parts.hostname in ALLOWED_ARTWORK_HOSTS
 
 
 @router.get("/{key}")  # type: ignore[misc]
@@ -90,7 +89,12 @@ async def get_artwork(
     return Response(
         content=stored.content,
         media_type=stored.content_type,
-        headers={"Cache-Control": _CACHE_CONTROL},
+        headers={
+            "Cache-Control": _CACHE_CONTROL,
+            # Never let the browser MIME-sniff a stored object into an
+            # executable type (defense-in-depth against a mis-typed asset).
+            "X-Content-Type-Options": "nosniff",
+        },
     )
 
 

--- a/src/modules/media/presentation/routes/artwork_routes.py
+++ b/src/modules/media/presentation/routes/artwork_routes.py
@@ -11,7 +11,6 @@ supplied it redirects there, otherwise 404. That keeps the catalog
 functional while the background mirror job is still catching up.
 """
 
-import re
 from typing import Annotated
 from urllib.parse import urlsplit
 
@@ -21,16 +20,15 @@ from fastapi.responses import RedirectResponse, Response
 
 from src.config.containers import ApplicationContainer
 from src.modules.media.application.ports.artwork_storage_port import ArtworkStoragePort
+from src.modules.media.domain.value_objects.artwork_key import ARTWORK_KEY_PATTERN
 
 router = APIRouter(prefix="/api/v1/artwork", tags=["Artwork"])
 
-# Keys are derived server-side (content hash + extension) and embedded
-# verbatim in the path. Reject anything outside the safe charset so a
-# crafted key can never escape the bucket namespace or the path param.
-# The charset admits dots, so an all-dots key (``.``/``..``) is rejected
-# separately below — it is not a valid object and would otherwise reach
-# the storage adapter as a directory / traversal-shaped path.
-_KEY_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+# Key charset is defined once on ``ArtworkKey`` (the write path) and
+# reused here for the read path. The charset admits dots, so an all-dots
+# key (``.``/``..``) is rejected separately below — it is not a valid
+# object and would otherwise reach the storage adapter as a directory /
+# traversal-shaped path.
 
 # Hosts a fallback ``origin`` is allowed to redirect to. Only provider
 # image CDNs the mirror legitimately stores may be echoed into a
@@ -71,7 +69,7 @@ async def get_artwork(
     the key charset + all-dots check; the ``origin`` fallback only
     redirects to allow-listed provider hosts (no open redirect).
     """
-    if not _KEY_PATTERN.match(key) or set(key) <= {"."}:
+    if not ARTWORK_KEY_PATTERN.match(key) or set(key) <= {"."}:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="invalid artwork key",

--- a/src/modules/media/presentation/routes/artwork_routes.py
+++ b/src/modules/media/presentation/routes/artwork_routes.py
@@ -1,8 +1,8 @@
 """Read-only proxy that serves mirrored catalog artwork (ADR-029).
 
 The catalog stores a relative ``/api/v1/artwork/{key}`` URL once an
-image has been mirrored into object storage. This route reads the
-object back through :class:`ArtworkStoragePort` and streams it to the
+image has been mirrored into storage. This route reads the object
+back through :class:`ArtworkStoragePort` and streams it to the
 client, so the browser never talks to the storage backend directly.
 
 When the object is not in storage (mirror hasn't run yet, or the key
@@ -13,6 +13,7 @@ functional while the background mirror job is still catching up.
 
 import re
 from typing import Annotated
+from urllib.parse import urlsplit
 
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -26,12 +27,28 @@ router = APIRouter(prefix="/api/v1/artwork", tags=["Artwork"])
 # Keys are derived server-side (content hash + extension) and embedded
 # verbatim in the path. Reject anything outside the safe charset so a
 # crafted key can never escape the bucket namespace or the path param.
+# The charset admits dots, so an all-dots key (``.``/``..``) is rejected
+# separately below — it is not a valid object and would otherwise reach
+# the storage adapter as a directory / traversal-shaped path.
 _KEY_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Hosts a fallback ``origin`` is allowed to redirect to. Only provider
+# image CDNs the mirror legitimately stores may be echoed into a
+# ``Location`` header — otherwise the public, unauthenticated endpoint
+# would be an open redirect (bounce a victim to any URL). TMDB is the
+# only image provider today; extend this set as providers are added.
+_ALLOWED_ORIGIN_HOSTS = frozenset({"image.tmdb.org"})
 
 # Cache mirrored art aggressively — a content-hashed key is immutable,
 # so a long-lived immutable cache is safe and spares the proxy on every
 # repeat view.
 _CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+def _is_allowed_origin(origin: str) -> bool:
+    """Whether ``origin`` is an https URL on an allow-listed provider host."""
+    parts = urlsplit(origin)
+    return parts.scheme == "https" and parts.hostname in _ALLOWED_ORIGIN_HOSTS
 
 
 @router.get("/{key}")  # type: ignore[misc]
@@ -51,9 +68,10 @@ async def get_artwork(
     Not auth-gated: artwork is public catalog imagery embedded in
     pages and ``<img>`` tags that cannot carry auth headers, mirroring
     how the TMDB URLs were served before. Path traversal is blocked by
-    the key charset check.
+    the key charset + all-dots check; the ``origin`` fallback only
+    redirects to allow-listed provider hosts (no open redirect).
     """
-    if not _KEY_PATTERN.match(key):
+    if not _KEY_PATTERN.match(key) or set(key) <= {"."}:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="invalid artwork key",
@@ -61,9 +79,10 @@ async def get_artwork(
 
     stored = await storage.open(key)
     if stored is None:
-        if origin:
-            # Not mirrored yet — bounce the client to the provider so
-            # the image still renders while the job catches up.
+        # Not mirrored yet — bounce the client to the provider so the
+        # image still renders while the job catches up, but only when the
+        # origin is an allow-listed provider host (else behave as a miss).
+        if origin and _is_allowed_origin(origin):
             return RedirectResponse(url=origin, status_code=status.HTTP_302_FOUND)
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/modules/media/presentation/routes/artwork_routes.py
+++ b/src/modules/media/presentation/routes/artwork_routes.py
@@ -1,0 +1,80 @@
+"""Read-only proxy that serves mirrored catalog artwork (ADR-029).
+
+The catalog stores a relative ``/api/v1/artwork/{key}`` URL once an
+image has been mirrored into object storage. This route reads the
+object back through :class:`ArtworkStoragePort` and streams it to the
+client, so the browser never talks to the storage backend directly.
+
+When the object is not in storage (mirror hasn't run yet, or the key
+is unknown) the route degrades gracefully: if a remote origin URL was
+supplied it redirects there, otherwise 404. That keeps the catalog
+functional while the background mirror job is still catching up.
+"""
+
+import re
+from typing import Annotated
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse, Response
+
+from src.config.containers import ApplicationContainer
+from src.modules.media.application.ports.artwork_storage_port import ArtworkStoragePort
+
+router = APIRouter(prefix="/api/v1/artwork", tags=["Artwork"])
+
+# Keys are derived server-side (content hash + extension) and embedded
+# verbatim in the path. Reject anything outside the safe charset so a
+# crafted key can never escape the bucket namespace or the path param.
+_KEY_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Cache mirrored art aggressively — a content-hashed key is immutable,
+# so a long-lived immutable cache is safe and spares the proxy on every
+# repeat view.
+_CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+@router.get("/{key}")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def get_artwork(
+    key: str,
+    origin: Annotated[
+        str | None,
+        Query(description="Remote origin URL to fall back to when not yet mirrored"),
+    ] = None,
+    storage: ArtworkStoragePort = Depends(
+        Provide[ApplicationContainer.media.artwork_storage],
+    ),
+) -> Response:
+    """Serve a mirrored artwork object, or fall back to its origin.
+
+    Not auth-gated: artwork is public catalog imagery embedded in
+    pages and ``<img>`` tags that cannot carry auth headers, mirroring
+    how the TMDB URLs were served before. Path traversal is blocked by
+    the key charset check.
+    """
+    if not _KEY_PATTERN.match(key):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="invalid artwork key",
+        )
+
+    stored = await storage.open(key)
+    if stored is None:
+        if origin:
+            # Not mirrored yet — bounce the client to the provider so
+            # the image still renders while the job catches up.
+            return RedirectResponse(url=origin, status_code=status.HTTP_302_FOUND)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="artwork not found",
+        )
+
+    return Response(
+        content=stored.content,
+        media_type=stored.content_type,
+        headers={"Cache-Control": _CACHE_CONTROL},
+    )
+
+
+__all__ = ["router"]

--- a/src/modules/settings/domain/value_objects/__init__.py
+++ b/src/modules/settings/domain/value_objects/__init__.py
@@ -6,6 +6,9 @@ persisted row in ``app_settings`` carries; :class:`SettingSource` marks
 the row's provenance for audit.
 """
 
+from src.modules.settings.domain.value_objects.artwork_mirror_config import (
+    ArtworkMirrorConfig,
+)
 from src.modules.settings.domain.value_objects.avatar_config import AvatarConfig
 from src.modules.settings.domain.value_objects.credits_detection_config import (
     CreditsDetectionConfig,
@@ -42,10 +45,12 @@ ConfigVO = (
     | AvatarConfig
     | ScanDedupConfig
     | SubtitleOcrConfig
+    | ArtworkMirrorConfig
 )
 """Union of all configuration VOs persisted in ``app_settings``."""
 
 __all__ = [
+    "ArtworkMirrorConfig",
     "AvatarConfig",
     "ChromaprintTuningConfig",
     "ConfigVO",

--- a/src/modules/settings/domain/value_objects/artwork_mirror_config.py
+++ b/src/modules/settings/domain/value_objects/artwork_mirror_config.py
@@ -1,0 +1,34 @@
+"""Artwork mirror tunables — cadence, batch size, size ceiling (ADR-029)."""
+
+from pydantic import Field
+
+from src.building_blocks.domain.value_objects import CompoundValueObject
+
+
+class ArtworkMirrorConfig(CompoundValueObject):
+    """Operational knobs for the periodic artwork-mirror job.
+
+    Attributes:
+        enabled: Toggle for the periodic job that downloads still-remote
+            poster/backdrop/logo images (TMDB URLs) and mirrors them into
+            local storage, replacing the stored field with the local
+            reference so the catalog stops depending on the provider CDN.
+        batch_size: Maximum media items (movies + series) processed per
+            tick. Bounds network + disk work per run on a large catalog.
+        interval_minutes: How often the mirror job runs.
+        max_bytes: Hard ceiling on a single downloaded image. Larger
+            responses are skipped (kept as remote URLs) so a hostile or
+            mis-sized URL cannot exhaust memory during the download.
+
+    Example:
+        >>> cfg = ArtworkMirrorConfig()
+        >>> faster = cfg.with_updates(batch_size=50, interval_minutes=15)
+    """
+
+    enabled: bool = Field(default=True)
+    batch_size: int = Field(default=20, ge=1)
+    interval_minutes: int = Field(default=30, ge=1)
+    max_bytes: int = Field(default=10 * 1024 * 1024, ge=1)
+
+
+__all__ = ["ArtworkMirrorConfig"]

--- a/src/modules/settings/domain/value_objects/setting_key.py
+++ b/src/modules/settings/domain/value_objects/setting_key.py
@@ -23,6 +23,7 @@ class SettingKey(StrEnum):
     AVATAR = "avatar"
     SCAN_DEDUP = "scan_dedup"
     SUBTITLE_OCR = "subtitle_ocr"
+    ARTWORK_MIRROR = "artwork_mirror"
 
 
 __all__ = ["SettingKey"]

--- a/src/modules/settings/domain/value_objects/setting_vo_registry.py
+++ b/src/modules/settings/domain/value_objects/setting_vo_registry.py
@@ -13,6 +13,9 @@ from types import MappingProxyType
 from typing import Final
 
 from src.building_blocks.domain.value_objects import CompoundValueObject
+from src.modules.settings.domain.value_objects.artwork_mirror_config import (
+    ArtworkMirrorConfig,
+)
 from src.modules.settings.domain.value_objects.avatar_config import AvatarConfig
 from src.modules.settings.domain.value_objects.credits_detection_config import (
     CreditsDetectionConfig,
@@ -39,6 +42,7 @@ SETTING_VO_TYPES: Final[Mapping[SettingKey, type[CompoundValueObject]]] = Mappin
         SettingKey.AVATAR: AvatarConfig,
         SettingKey.SCAN_DEDUP: ScanDedupConfig,
         SettingKey.SUBTITLE_OCR: SubtitleOcrConfig,
+        SettingKey.ARTWORK_MIRROR: ArtworkMirrorConfig,
     }
 )
 """Read-only map from setting bucket to the VO type its row carries."""

--- a/src/modules/settings/infrastructure/runtime_settings.py
+++ b/src/modules/settings/infrastructure/runtime_settings.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, cast
 
 from src.modules.settings.domain.value_objects import (
     SETTING_VO_TYPES,
+    ArtworkMirrorConfig,
     AvatarConfig,
     ConfigVO,
     CreditsDetectionConfig,
@@ -128,6 +129,14 @@ class RuntimeSettings:
         return cast(
             ThumbnailBackfillConfig,
             self._snapshot[SettingKey.THUMBNAIL_BACKFILL],
+        )
+
+    async def artwork_mirror(self) -> ArtworkMirrorConfig:
+        """Return the current :class:`ArtworkMirrorConfig` snapshot."""
+        await self._ensure_fresh()
+        return cast(
+            ArtworkMirrorConfig,
+            self._snapshot[SettingKey.ARTWORK_MIRROR],
         )
 
     async def intro_detection(self) -> IntroDetectionConfig:

--- a/tests/modules/media/e2e/test_artwork_routes.py
+++ b/tests/modules/media/e2e/test_artwork_routes.py
@@ -72,7 +72,7 @@ class TestGetArtwork:
 
         assert resp.status_code == 404
 
-    async def test_should_redirect_to_origin_when_not_mirrored(
+    async def test_should_redirect_to_allowed_origin_when_not_mirrored(
         self, client: AsyncClient, storage: _FakeArtworkStorage
     ) -> None:
         origin = "https://image.tmdb.org/t/p/original/x.jpg"
@@ -86,12 +86,71 @@ class TestGetArtwork:
         assert resp.status_code == 302
         assert resp.headers["location"] == origin
 
+    async def test_should_404_not_redirect_when_origin_host_not_allowed(
+        self, client: AsyncClient, storage: _FakeArtworkStorage
+    ) -> None:
+        # An arbitrary origin host must never be echoed into Location —
+        # that would make this public endpoint an open redirect.
+        resp = await client.get(
+            ARTWORK_PATH.format(key="missing.jpg"),
+            params={"origin": "https://evil.example.com/x.jpg"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 404
+
+    async def test_should_serve_stored_bytes_even_when_origin_supplied(
+        self, client: AsyncClient, storage: _FakeArtworkStorage
+    ) -> None:
+        # Precedence: a mirrored object wins over the origin fallback —
+        # never redirect away from a good local image.
+        await storage.save(content=b"local", content_type="image/jpeg", key="ab12.jpg")
+
+        resp = await client.get(
+            ARTWORK_PATH.format(key="ab12.jpg"),
+            params={"origin": "https://image.tmdb.org/t/p/original/x.jpg"},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 200
+        assert resp.content == b"local"
+
+    async def test_should_serve_without_authentication(
+        self, client: AsyncClient, storage: _FakeArtworkStorage
+    ) -> None:
+        # Deliberate design: artwork is public <img> imagery that cannot
+        # carry auth headers. This pins the invariant so adding an auth
+        # dependency to the router would fail here by name.
+        await storage.save(content=b"x", content_type="image/png", key="pub.png")
+
+        resp = await client.get(ARTWORK_PATH.format(key="pub.png"))
+
+        assert resp.status_code == 200
+
     async def test_should_400_on_invalid_key(
         self, client: AsyncClient, storage: _FakeArtworkStorage
     ) -> None:
         # A slash-bearing key can't even reach the handler as one path
-        # segment, so probe the charset guard with a traversal attempt
-        # that stays within a single segment.
+        # segment, so probe the charset guard with a space (percent-
+        # encoded) that stays within a single path segment.
         resp = await client.get(ARTWORK_PATH.format(key="bad%20key"))
 
         assert resp.status_code == 400
+        # Assert the 400 came from the charset guard specifically, not
+        # some other validation, so the test can't pass for a wrong reason.
+        # The HTTPException detail lands in the envelope's ``message``.
+        assert resp.json()["message"] == "invalid artwork key"
+
+    async def test_should_400_on_all_dots_key(
+        self, client: AsyncClient, storage: _FakeArtworkStorage
+    ) -> None:
+        # All-dots keys pass the charset regex (dots are allowed) but are
+        # not valid objects and would reach storage as a directory /
+        # traversal-shaped path — must be rejected up front, not 500.
+        # ``...`` is used (not ``.``/``..``) because the server URL-
+        # normalizes the latter before routing, so they never reach the
+        # handler; ``...`` is an ordinary segment that does.
+        resp = await client.get(ARTWORK_PATH.format(key="..."))
+
+        assert resp.status_code == 400
+        assert resp.json()["message"] == "invalid artwork key"

--- a/tests/modules/media/e2e/test_artwork_routes.py
+++ b/tests/modules/media/e2e/test_artwork_routes.py
@@ -1,0 +1,97 @@
+"""End-to-end tests for the artwork proxy route (ADR-029).
+
+Drives ``GET /api/v1/artwork/{key}`` over the in-process ASGI
+transport with an in-memory fake :class:`ArtworkStoragePort` swapped
+into the media container. Covers the hit, the not-yet-mirrored miss
+(404 vs. redirect-to-origin), and the invalid-key guard. The route is
+deliberately unauthenticated, so no login is needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import (  # noqa: TCH003 — used by runtime fixture annotations
+    AsyncGenerator,
+)
+
+import pytest
+from dependency_injector import providers
+from fastapi import FastAPI  # noqa: TCH002 — used by runtime fixture annotations
+from httpx import AsyncClient  # noqa: TCH002 — used by runtime fixture annotations
+
+from src.modules.media.application.ports.artwork_storage_port import (
+    ArtworkStoragePort,
+    StoredArtwork,
+)
+
+ARTWORK_PATH = "/api/v1/artwork/{key}"
+
+
+class _FakeArtworkStorage(ArtworkStoragePort):
+    """In-memory port double keyed by object key."""
+
+    def __init__(self) -> None:
+        self._objects: dict[str, StoredArtwork] = {}
+
+    async def save(self, *, content: bytes, content_type: str, key: str) -> str:
+        self._objects[key] = StoredArtwork(content=content, content_type=content_type)
+        return f"/api/v1/artwork/{key}"
+
+    async def open(self, key: str) -> StoredArtwork | None:
+        return self._objects.get(key)
+
+    async def delete(self, key: str) -> None:
+        self._objects.pop(key, None)
+
+
+@pytest.fixture(scope="function")
+async def storage(app: FastAPI) -> AsyncGenerator[_FakeArtworkStorage, None]:
+    """Override the media container's artwork storage with a fake."""
+    fake = _FakeArtworkStorage()
+    app.state.container.media.artwork_storage.override(providers.Object(fake))
+    yield fake
+    app.state.container.media.artwork_storage.reset_override()
+
+
+class TestGetArtwork:
+    async def test_should_serve_stored_bytes_with_content_type(
+        self, client: AsyncClient, storage: _FakeArtworkStorage
+    ) -> None:
+        await storage.save(content=b"poster-bytes", content_type="image/jpeg", key="ab12.jpg")
+
+        resp = await client.get(ARTWORK_PATH.format(key="ab12.jpg"))
+
+        assert resp.status_code == 200
+        assert resp.content == b"poster-bytes"
+        assert resp.headers["content-type"] == "image/jpeg"
+        assert "immutable" in resp.headers["cache-control"]
+
+    async def test_should_404_when_not_mirrored_and_no_origin(
+        self, client: AsyncClient, storage: _FakeArtworkStorage
+    ) -> None:
+        resp = await client.get(ARTWORK_PATH.format(key="missing.jpg"))
+
+        assert resp.status_code == 404
+
+    async def test_should_redirect_to_origin_when_not_mirrored(
+        self, client: AsyncClient, storage: _FakeArtworkStorage
+    ) -> None:
+        origin = "https://image.tmdb.org/t/p/original/x.jpg"
+
+        resp = await client.get(
+            ARTWORK_PATH.format(key="missing.jpg"),
+            params={"origin": origin},
+            follow_redirects=False,
+        )
+
+        assert resp.status_code == 302
+        assert resp.headers["location"] == origin
+
+    async def test_should_400_on_invalid_key(
+        self, client: AsyncClient, storage: _FakeArtworkStorage
+    ) -> None:
+        # A slash-bearing key can't even reach the handler as one path
+        # segment, so probe the charset guard with a traversal attempt
+        # that stays within a single segment.
+        resp = await client.get(ARTWORK_PATH.format(key="bad%20key"))
+
+        assert resp.status_code == 400

--- a/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
+++ b/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
@@ -9,18 +9,24 @@ column update swaps the URL without touching the rest of the row.
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.value_objects import (
     Duration,
+    EpisodeId,
     FilePath,
     ImageUrl,
     MediaFile,
     MovieId,
     Resolution,
+    SeasonId,
+    SeriesId,
     Title,
     Year,
 )
-from src.modules.media.infrastructure.persistence.repositories import SQLAlchemyMovieRepository
+from src.modules.media.infrastructure.persistence.repositories import (
+    SQLAlchemyMovieRepository,
+    SQLAlchemySeriesRepository,
+)
 
 _REMOTE = "https://image.tmdb.org/t/p/original/poster.jpg"
 _LOCAL = "/api/v1/artwork/deadbeefdeadbeef.jpg"
@@ -81,9 +87,7 @@ class TestFindWithRemoteArtwork:
 
 @pytest.mark.integration
 class TestUpdateMovieArtwork:
-    async def test_should_swap_remote_columns_for_local(
-        self, db_session: AsyncSession
-    ) -> None:
+    async def test_should_swap_remote_columns_for_local(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyMovieRepository(db_session)
         movie = _movie(
             "Remote",
@@ -114,3 +118,66 @@ class TestUpdateMovieArtwork:
 def _id(movie: Movie) -> MovieId:
     assert movie.id is not None
     return movie.id
+
+
+def _series_with_one_episode(title: str, **kwargs: object) -> Series:
+    sid = SeriesId.generate()
+    episode = Episode(
+        id=EpisodeId.generate(),
+        series_id=sid,
+        season_number=1,
+        episode_number=1,
+        title=Title("E1"),
+        duration=Duration(2700),
+        files=[
+            MediaFile(
+                file_path=FilePath("/series/s01e01.mkv"),
+                file_size=500_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            )
+        ],
+    )
+    season = Season(
+        id=SeasonId.generate(),
+        series_id=sid,
+        season_number=1,
+        title=Title("Season 1"),
+        episodes=[episode],
+    )
+    return Series(
+        library_id="lib_test12345678",
+        id=sid,
+        title=Title(title),
+        start_year=Year(2020),
+        seasons=[season],
+        **kwargs,
+    )
+
+
+@pytest.mark.integration
+class TestSeriesArtwork:
+    async def test_should_find_and_update_without_touching_children(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series = _series_with_one_episode("Remote", poster_path=ImageUrl(_REMOTE))
+        await repo.save(series)
+        assert series.id is not None
+
+        rows = await repo.find_with_remote_artwork(limit=10)
+        assert len(rows) == 1
+        assert rows[0].media_id == str(series.id)
+
+        await repo.update_series_artwork(
+            series.id, poster_path=_LOCAL, backdrop_path=None, logo_path=None
+        )
+
+        assert await repo.find_with_remote_artwork(limit=10) == []
+        reloaded = await repo.find_by_id(series.id)
+        assert reloaded is not None
+        assert reloaded.poster_path == ImageUrl(_LOCAL)
+        # The whole reason for the direct column update: seasons/episodes
+        # must survive an artwork update untouched.
+        assert len(reloaded.seasons) == 1
+        assert len(reloaded.seasons[0].episodes) == 1

--- a/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
+++ b/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
@@ -1,0 +1,116 @@
+"""Integration tests for the artwork-mirror repo methods (ADR-029).
+
+Exercises ``find_with_remote_artwork`` + ``update_movie_artwork`` on the
+real SQLite-backed ``SQLAlchemyMovieRepository``: the LIKE-``http%``
+filter selects only titles with a still-remote URL, and the targeted
+column update swaps the URL without touching the rest of the row.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.modules.media.domain.entities import Movie
+from src.modules.media.domain.value_objects import (
+    Duration,
+    FilePath,
+    ImageUrl,
+    MediaFile,
+    MovieId,
+    Resolution,
+    Title,
+    Year,
+)
+from src.modules.media.infrastructure.persistence.repositories import SQLAlchemyMovieRepository
+
+_REMOTE = "https://image.tmdb.org/t/p/original/poster.jpg"
+_LOCAL = "/api/v1/artwork/deadbeefdeadbeef.jpg"
+
+
+def _movie(title: str, path: str, **kwargs: object) -> Movie:
+    return Movie(
+        library_id="lib_test12345678",
+        id=MovieId.generate(),
+        title=Title(title),
+        year=Year(2024),
+        duration=Duration(7200),
+        files=[
+            MediaFile(
+                file_path=FilePath(path),
+                file_size=1_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            )
+        ],
+        **kwargs,
+    )
+
+
+@pytest.mark.integration
+class TestFindWithRemoteArtwork:
+    async def test_should_return_only_titles_with_a_remote_url(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        remote = _movie(
+            "Remote",
+            "/movies/a.mkv",
+            poster_path=ImageUrl(_REMOTE),
+            backdrop_path=ImageUrl(_LOCAL),  # already local
+        )
+        local_only = _movie("Local", "/movies/b.mkv", poster_path=ImageUrl(_LOCAL))
+        no_art = _movie("Bare", "/movies/c.mkv")
+        for movie in (remote, local_only, no_art):
+            await repo.save(movie)
+
+        rows = await repo.find_with_remote_artwork(limit=10)
+
+        assert len(rows) == 1
+        assert rows[0].media_id == str(remote.id)
+        assert rows[0].poster_path == _REMOTE
+        assert rows[0].backdrop_path == _LOCAL
+
+    async def test_should_respect_the_limit(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        for i in range(3):
+            await repo.save(_movie(f"M{i}", f"/movies/m{i}.mkv", poster_path=ImageUrl(_REMOTE)))
+
+        rows = await repo.find_with_remote_artwork(limit=2)
+
+        assert len(rows) == 2
+
+
+@pytest.mark.integration
+class TestUpdateMovieArtwork:
+    async def test_should_swap_remote_columns_for_local(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        movie = _movie(
+            "Remote",
+            "/movies/a.mkv",
+            poster_path=ImageUrl(_REMOTE),
+            backdrop_path=ImageUrl(_REMOTE),
+        )
+        await repo.save(movie)
+
+        await repo.update_movie_artwork(
+            _id(movie),
+            poster_path=_LOCAL,
+            backdrop_path=_LOCAL,
+            logo_path=None,
+        )
+
+        # The title now has no remote artwork, and the reloaded entity
+        # carries the local references + an intact title.
+        assert await repo.find_with_remote_artwork(limit=10) == []
+        reloaded = await repo.find_by_id(_id(movie))
+        assert reloaded is not None
+        assert reloaded.poster_path == ImageUrl(_LOCAL)
+        assert reloaded.backdrop_path == ImageUrl(_LOCAL)
+        assert reloaded.logo_path is None
+        assert reloaded.title == Title("Remote")
+
+
+def _id(movie: Movie) -> MovieId:
+    assert movie.id is not None
+    return movie.id

--- a/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
+++ b/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.media.domain.entities import Episode, Movie, Season, Series
 from src.modules.media.domain.value_objects import (
+    ArtworkColumns,
     Duration,
     EpisodeId,
     FilePath,
@@ -72,8 +73,8 @@ class TestFindWithRemoteArtwork:
 
         assert len(rows) == 1
         assert rows[0].media_id == str(remote.id)
-        assert rows[0].poster_path == _REMOTE
-        assert rows[0].backdrop_path == _LOCAL
+        assert rows[0].artwork.poster == ImageUrl(_REMOTE)
+        assert rows[0].artwork.backdrop == ImageUrl(_LOCAL)
 
     async def test_should_respect_the_limit(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemyMovieRepository(db_session)
@@ -99,9 +100,7 @@ class TestUpdateMovieArtwork:
 
         await repo.update_movie_artwork(
             _id(movie),
-            poster_path=_LOCAL,
-            backdrop_path=_LOCAL,
-            logo_path=None,
+            ArtworkColumns(poster=ImageUrl(_LOCAL), backdrop=ImageUrl(_LOCAL), logo=None),
         )
 
         # The title now has no remote artwork, and the reloaded entity
@@ -170,7 +169,7 @@ class TestSeriesArtwork:
         assert rows[0].media_id == str(series.id)
 
         await repo.update_series_artwork(
-            series.id, poster_path=_LOCAL, backdrop_path=None, logo_path=None
+            series.id, ArtworkColumns(poster=ImageUrl(_LOCAL), backdrop=None, logo=None)
         )
 
         assert await repo.find_with_remote_artwork(limit=10) == []

--- a/tests/modules/media/unit/domain/value_objects/test_artwork_key.py
+++ b/tests/modules/media/unit/domain/value_objects/test_artwork_key.py
@@ -1,0 +1,81 @@
+"""Unit tests for the :class:`ArtworkKey` value object (ADR-029)."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.media.domain.value_objects.artwork_key import ArtworkKey
+
+
+class TestForContent:
+    def test_should_be_content_addressed_sha256_plus_extension(self) -> None:
+        content = b"poster-bytes"
+        expected_digest = hashlib.sha256(content).hexdigest()
+
+        key = ArtworkKey.for_content(
+            content, content_type="image/jpeg", source_url="https://x/y.jpg"
+        )
+
+        assert str(key) == f"{expected_digest}.jpg"
+
+    def test_should_derive_extension_from_content_type(self) -> None:
+        key = ArtworkKey.for_content(
+            b"x", content_type="image/png", source_url="https://x/y"
+        )
+
+        assert str(key).endswith(".png")
+
+    def test_should_ignore_charset_suffix_on_content_type(self) -> None:
+        key = ArtworkKey.for_content(
+            b"x", content_type="image/webp; charset=binary", source_url="https://x/y"
+        )
+
+        assert str(key).endswith(".webp")
+
+    def test_should_fall_back_to_url_suffix_when_content_type_unknown(self) -> None:
+        key = ArtworkKey.for_content(
+            b"x", content_type=None, source_url="https://image.tmdb.org/t/p/original/z.png"
+        )
+
+        assert str(key).endswith(".png")
+
+    def test_should_fall_back_to_jpg_when_no_extension_anywhere(self) -> None:
+        key = ArtworkKey.for_content(
+            b"x", content_type="application/octet-stream", source_url="https://x/no-ext"
+        )
+
+        assert str(key).endswith(".jpg")
+
+    def test_should_be_deterministic_for_identical_bytes(self) -> None:
+        a = ArtworkKey.for_content(b"same", content_type="image/jpeg", source_url="https://a/x.jpg")
+        b = ArtworkKey.for_content(b"same", content_type="image/jpeg", source_url="https://b/z.jpg")
+
+        assert str(a) == str(b)
+
+    def test_should_change_when_bytes_change(self) -> None:
+        a = ArtworkKey.for_content(b"one", content_type="image/jpeg", source_url="https://a/x.jpg")
+        b = ArtworkKey.for_content(b"two", content_type="image/jpeg", source_url="https://a/x.jpg")
+
+        assert str(a) != str(b)
+
+    def test_should_produce_a_key_matching_the_route_charset(self) -> None:
+        from src.modules.media.domain.value_objects.artwork_key import ARTWORK_KEY_PATTERN
+
+        key = ArtworkKey.for_content(
+            b"x", content_type="image/jpeg", source_url="https://x/y.jpg"
+        )
+
+        assert ARTWORK_KEY_PATTERN.match(str(key))
+
+
+class TestValidation:
+    @pytest.mark.parametrize("bad", ["", "..", ".", "a/b", "a b", "a?b", "../x"])
+    def test_should_reject_unsafe_or_all_dots_keys(self, bad: str) -> None:
+        with pytest.raises(DomainValidationException):
+            ArtworkKey(bad)
+
+    def test_should_accept_a_hash_and_extension_token(self) -> None:
+        assert str(ArtworkKey("ab12CD._-def.jpg")) == "ab12CD._-def.jpg"

--- a/tests/modules/media/unit/domain/value_objects/test_artwork_key.py
+++ b/tests/modules/media/unit/domain/value_objects/test_artwork_key.py
@@ -22,9 +22,7 @@ class TestForContent:
         assert str(key) == f"{expected_digest}.jpg"
 
     def test_should_derive_extension_from_content_type(self) -> None:
-        key = ArtworkKey.for_content(
-            b"x", content_type="image/png", source_url="https://x/y"
-        )
+        key = ArtworkKey.for_content(b"x", content_type="image/png", source_url="https://x/y")
 
         assert str(key).endswith(".png")
 
@@ -64,9 +62,7 @@ class TestForContent:
     def test_should_produce_a_key_matching_the_route_charset(self) -> None:
         from src.modules.media.domain.value_objects.artwork_key import ARTWORK_KEY_PATTERN
 
-        key = ArtworkKey.for_content(
-            b"x", content_type="image/jpeg", source_url="https://x/y.jpg"
-        )
+        key = ArtworkKey.for_content(b"x", content_type="image/jpeg", source_url="https://x/y.jpg")
 
         assert ARTWORK_KEY_PATTERN.match(str(key))
 

--- a/tests/modules/media/unit/infrastructure/metadata/test_artwork_downloader.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_artwork_downloader.py
@@ -1,0 +1,132 @@
+"""Unit tests for :class:`HttpxArtworkDownloader` (ADR-029).
+
+The httpx client is replaced with a fake that yields controlled chunks
+and errors, so the tests exercise the adapter's streaming size cap and
+its translation of transport failures into gateway exceptions without
+real network I/O.
+"""
+
+from __future__ import annotations
+
+from collections.abc import (  # noqa: TCH003 — runtime annotations on fakes
+    AsyncIterator,
+    Sequence,
+)
+
+import httpx
+import pytest
+
+from src.building_blocks.infrastructure.errors import (
+    GatewayBadResponseException,
+    GatewayTimeoutException,
+    GatewayUnavailableException,
+)
+from src.modules.media.infrastructure.metadata.artwork_downloader import (
+    HttpxArtworkDownloader,
+)
+
+
+class _FakeStreamResponse:
+    def __init__(
+        self,
+        chunks: Sequence[bytes],
+        headers: dict[str, str],
+        status_error: Exception | None = None,
+    ) -> None:
+        self._chunks = chunks
+        self.headers = headers
+        self._status_error = status_error
+
+    def raise_for_status(self) -> None:
+        if self._status_error is not None:
+            raise self._status_error
+
+    async def aiter_bytes(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeStreamCtx:
+    def __init__(
+        self,
+        response: _FakeStreamResponse | None = None,
+        enter_error: Exception | None = None,
+    ) -> None:
+        self._response = response
+        self._enter_error = enter_error
+
+    async def __aenter__(self) -> _FakeStreamResponse:
+        if self._enter_error is not None:
+            raise self._enter_error
+        assert self._response is not None
+        return self._response
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+class _FakeClient:
+    def __init__(self, ctx: _FakeStreamCtx) -> None:
+        self._ctx = ctx
+
+    def stream(self, _method: str, _url: str) -> _FakeStreamCtx:
+        return self._ctx
+
+
+def _downloader_with(ctx: _FakeStreamCtx) -> HttpxArtworkDownloader:
+    downloader = HttpxArtworkDownloader()
+    downloader._client = _FakeClient(ctx)  # type: ignore[assignment]
+    return downloader
+
+
+class TestFetch:
+    async def test_should_return_bytes_and_content_type(self) -> None:
+        ctx = _FakeStreamCtx(
+            _FakeStreamResponse([b"ab", b"cd"], {"content-type": "image/png"})
+        )
+        downloader = _downloader_with(ctx)
+
+        result = await downloader.fetch("https://x/y.png", max_bytes=1024)
+
+        assert result.content == b"abcd"
+        assert result.content_type == "image/png"
+
+    async def test_should_raise_when_body_exceeds_max_bytes(self) -> None:
+        ctx = _FakeStreamCtx(
+            _FakeStreamResponse([b"x" * 6, b"y" * 6], {"content-type": "image/jpeg"})
+        )
+        downloader = _downloader_with(ctx)
+
+        with pytest.raises(GatewayBadResponseException):
+            await downloader.fetch("https://x/big.jpg", max_bytes=8)
+
+    async def test_should_translate_timeout(self) -> None:
+        ctx = _FakeStreamCtx(enter_error=httpx.TimeoutException("slow"))
+        downloader = _downloader_with(ctx)
+
+        with pytest.raises(GatewayTimeoutException):
+            await downloader.fetch("https://x/y.jpg", max_bytes=1024)
+
+    async def test_should_translate_http_status_error(self) -> None:
+        request = httpx.Request("GET", "https://x/y.jpg")
+        response = httpx.Response(404, request=request)
+        ctx = _FakeStreamCtx(
+            _FakeStreamResponse(
+                [],
+                {"content-type": "text/html"},
+                status_error=httpx.HTTPStatusError(
+                    "not found", request=request, response=response
+                ),
+            )
+        )
+        downloader = _downloader_with(ctx)
+
+        with pytest.raises(GatewayBadResponseException):
+            await downloader.fetch("https://x/y.jpg", max_bytes=1024)
+
+    async def test_should_translate_transport_error(self) -> None:
+        ctx = _FakeStreamCtx(enter_error=httpx.ConnectError("refused"))
+        downloader = _downloader_with(ctx)
+
+        with pytest.raises(GatewayUnavailableException):
+            await downloader.fetch("https://x/y.jpg", max_bytes=1024)

--- a/tests/modules/media/unit/infrastructure/metadata/test_artwork_downloader.py
+++ b/tests/modules/media/unit/infrastructure/metadata/test_artwork_downloader.py
@@ -32,10 +32,14 @@ class _FakeStreamResponse:
         chunks: Sequence[bytes],
         headers: dict[str, str],
         status_error: Exception | None = None,
+        is_redirect: bool = False,
+        status_code: int = 200,
     ) -> None:
         self._chunks = chunks
         self.headers = headers
         self._status_error = status_error
+        self.is_redirect = is_redirect
+        self.status_code = status_code
 
     def raise_for_status(self) -> None:
         if self._status_error is not None:
@@ -74,22 +78,57 @@ class _FakeClient:
 
 
 def _downloader_with(ctx: _FakeStreamCtx) -> HttpxArtworkDownloader:
-    downloader = HttpxArtworkDownloader()
-    downloader._client = _FakeClient(ctx)  # type: ignore[assignment]
-    return downloader
+    # Inject the fake through the constructor seam so a renamed internal
+    # client can't silently bypass the fake into real network I/O.
+    return HttpxArtworkDownloader(client=_FakeClient(ctx))  # type: ignore[arg-type]
+
+
+_URL = "https://image.tmdb.org/t/p/original/x.png"
 
 
 class TestFetch:
     async def test_should_return_bytes_and_content_type(self) -> None:
-        ctx = _FakeStreamCtx(
-            _FakeStreamResponse([b"ab", b"cd"], {"content-type": "image/png"})
-        )
+        ctx = _FakeStreamCtx(_FakeStreamResponse([b"ab", b"cd"], {"content-type": "image/png"}))
         downloader = _downloader_with(ctx)
 
-        result = await downloader.fetch("https://x/y.png", max_bytes=1024)
+        result = await downloader.fetch(_URL, max_bytes=1024)
 
         assert result.content == b"abcd"
         assert result.content_type == "image/png"
+
+    async def test_should_return_none_content_type_when_header_absent(self) -> None:
+        ctx = _FakeStreamCtx(_FakeStreamResponse([b"ab"], {}))
+        downloader = _downloader_with(ctx)
+
+        result = await downloader.fetch(_URL, max_bytes=1024)
+
+        # Absent header -> None, not a fabricated octet-stream.
+        assert result.content_type is None
+
+    async def test_should_reject_disallowed_host_before_any_request(self) -> None:
+        # A URL on a non-allow-listed host is refused before the client is
+        # ever touched (SSRF guard). The fake would raise if reached.
+        ctx = _FakeStreamCtx(enter_error=AssertionError("must not be requested"))
+        downloader = _downloader_with(ctx)
+
+        with pytest.raises(GatewayBadResponseException):
+            await downloader.fetch("https://evil.example.com/x.png", max_bytes=1024)
+
+    async def test_should_reject_plaintext_http(self) -> None:
+        ctx = _FakeStreamCtx(enter_error=AssertionError("must not be requested"))
+        downloader = _downloader_with(ctx)
+
+        with pytest.raises(GatewayBadResponseException):
+            await downloader.fetch("http://image.tmdb.org/x.png", max_bytes=1024)
+
+    async def test_should_reject_a_redirect_response(self) -> None:
+        ctx = _FakeStreamCtx(
+            _FakeStreamResponse([], {"location": "https://image.tmdb.org/z"}, is_redirect=True)
+        )
+        downloader = _downloader_with(ctx)
+
+        with pytest.raises(GatewayBadResponseException):
+            await downloader.fetch(_URL, max_bytes=1024)
 
     async def test_should_raise_when_body_exceeds_max_bytes(self) -> None:
         ctx = _FakeStreamCtx(
@@ -98,35 +137,33 @@ class TestFetch:
         downloader = _downloader_with(ctx)
 
         with pytest.raises(GatewayBadResponseException):
-            await downloader.fetch("https://x/big.jpg", max_bytes=8)
+            await downloader.fetch(_URL, max_bytes=8)
 
     async def test_should_translate_timeout(self) -> None:
         ctx = _FakeStreamCtx(enter_error=httpx.TimeoutException("slow"))
         downloader = _downloader_with(ctx)
 
         with pytest.raises(GatewayTimeoutException):
-            await downloader.fetch("https://x/y.jpg", max_bytes=1024)
+            await downloader.fetch(_URL, max_bytes=1024)
 
     async def test_should_translate_http_status_error(self) -> None:
-        request = httpx.Request("GET", "https://x/y.jpg")
+        request = httpx.Request("GET", _URL)
         response = httpx.Response(404, request=request)
         ctx = _FakeStreamCtx(
             _FakeStreamResponse(
                 [],
                 {"content-type": "text/html"},
-                status_error=httpx.HTTPStatusError(
-                    "not found", request=request, response=response
-                ),
+                status_error=httpx.HTTPStatusError("not found", request=request, response=response),
             )
         )
         downloader = _downloader_with(ctx)
 
         with pytest.raises(GatewayBadResponseException):
-            await downloader.fetch("https://x/y.jpg", max_bytes=1024)
+            await downloader.fetch(_URL, max_bytes=1024)
 
     async def test_should_translate_transport_error(self) -> None:
         ctx = _FakeStreamCtx(enter_error=httpx.ConnectError("refused"))
         downloader = _downloader_with(ctx)
 
         with pytest.raises(GatewayUnavailableException):
-            await downloader.fetch("https://x/y.jpg", max_bytes=1024)
+            await downloader.fetch(_URL, max_bytes=1024)

--- a/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
+++ b/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
@@ -18,6 +18,7 @@ from src.modules.media.domain.repositories.movie_repository import RemoteArtwork
 from src.modules.settings.domain.value_objects import ArtworkMirrorConfig
 
 REMOTE = "https://image.tmdb.org/t/p/original/x.jpg"
+REMOTE_B = "https://image.tmdb.org/t/p/original/b.jpg"
 LOCAL = "/api/v1/artwork/deadbeef.jpg"
 
 
@@ -84,15 +85,22 @@ class _FakeRuntimeSettings:
 
 
 class _FakeDownloader:
-    def __init__(self, *, fail_urls: set[str] = frozenset()) -> None:
+    def __init__(
+        self,
+        *,
+        fail_urls: set[str] = frozenset(),
+        nonimage_urls: set[str] = frozenset(),
+    ) -> None:
         self._fail_urls = fail_urls
+        self._nonimage_urls = nonimage_urls
         self.fetched: list[str] = []
 
     async def fetch(self, url: str, *, max_bytes: int) -> DownloadedImage:
         self.fetched.append(url)
         if url in self._fail_urls:
             raise GatewayUnavailableException(message="down", gateway_name="artwork-cdn")
-        return DownloadedImage(content=b"image-bytes", content_type="image/jpeg")
+        content_type = "text/html" if url in self._nonimage_urls else "image/jpeg"
+        return DownloadedImage(content=b"image-bytes", content_type=content_type)
 
 
 class _FakeStorage:
@@ -119,11 +127,12 @@ def _make(
     series_rows: list[RemoteArtworkRow] | None = None,
     config: ArtworkMirrorConfig | None = None,
     fail_urls: set[str] = frozenset(),
+    nonimage_urls: set[str] = frozenset(),
 ) -> _Harness:
     movies = _FakeMovieRepo(list(movie_rows or []))
     series = _FakeSeriesRepo(list(series_rows or []))
     uow = _FakeUow(movies=movies, series=series)
-    downloader = _FakeDownloader(fail_urls=fail_urls)
+    downloader = _FakeDownloader(fail_urls=fail_urls, nonimage_urls=nonimage_urls)
     storage = _FakeStorage()
     job = ArtworkMirrorJob(
         media_uow_factory=_FakeUowFactory(uow),
@@ -176,6 +185,49 @@ class TestRun:
         assert h.movies.updates == []
         assert h.storage.saved == []
 
+    async def test_should_keep_remote_url_when_response_is_not_an_image(self) -> None:
+        # A 200 serving HTML (rate-limit page) must never overwrite the
+        # authoritative remote URL with a broken "artwork".
+        h = _make(
+            movie_rows=[
+                RemoteArtworkRow(
+                    media_id="mov_abc123def456",
+                    poster_path=REMOTE,
+                    backdrop_path=None,
+                    logo_path=None,
+                )
+            ],
+            nonimage_urls={REMOTE},
+        )
+
+        await h.job.run()
+
+        assert h.movies.updates == []
+        assert h.storage.saved == []
+
+    async def test_should_persist_partial_when_one_field_fails(self) -> None:
+        # Two remote fields, one download fails: the winner is mirrored,
+        # the loser keeps its remote URL, and the title is still updated.
+        h = _make(
+            movie_rows=[
+                RemoteArtworkRow(
+                    media_id="mov_abc123def456",
+                    poster_path=REMOTE,
+                    backdrop_path=REMOTE_B,
+                    logo_path=None,
+                )
+            ],
+            fail_urls={REMOTE_B},
+        )
+
+        await h.job.run()
+
+        assert len(h.movies.updates) == 1
+        update = h.movies.updates[0]
+        assert update.poster_path.startswith("/api/v1/artwork/")
+        assert update.backdrop_path == REMOTE_B  # failed → kept remote
+        assert len(h.storage.saved) == 1
+
     async def test_should_mirror_series_too(self) -> None:
         h = _make(
             series_rows=[
@@ -201,12 +253,18 @@ class TestRun:
         h = _make(
             movie_rows=[
                 RemoteArtworkRow(
-                    media_id="mov_abc123def456", poster_path=REMOTE, backdrop_path=None, logo_path=None
+                    media_id="mov_abc123def456",
+                    poster_path=REMOTE,
+                    backdrop_path=None,
+                    logo_path=None,
                 )
             ],
             series_rows=[
                 RemoteArtworkRow(
-                    media_id="ser_abc123def456", poster_path=REMOTE, backdrop_path=None, logo_path=None
+                    media_id="ser_abc123def456",
+                    poster_path=REMOTE,
+                    backdrop_path=None,
+                    logo_path=None,
                 )
             ],
             config=ArtworkMirrorConfig(batch_size=1),

--- a/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
+++ b/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
@@ -2,9 +2,9 @@
 
 Drives the job with in-memory fakes for the UoW/repositories, the
 downloader and the storage, so the orchestration is verified without a
-DB or network: which fields get mirrored, which are left as-is, that a
-download failure keeps the remote URL, and the movies/series budget
-split.
+DB or network: which references get mirrored, which are left as-is, that
+a download failure or a non-image response keeps the remote URL, and the
+per-kind budget split.
 """
 
 from __future__ import annotations
@@ -15,45 +15,44 @@ from src.building_blocks.infrastructure.errors import GatewayUnavailableExceptio
 from src.infrastructure.scheduling.artwork_mirror_job import ArtworkMirrorJob
 from src.modules.media.application.ports.artwork_downloader_port import DownloadedImage
 from src.modules.media.domain.repositories.movie_repository import RemoteArtworkRow
+from src.modules.media.domain.value_objects import ArtworkColumns, ImageUrl
 from src.modules.settings.domain.value_objects import ArtworkMirrorConfig
 
 REMOTE = "https://image.tmdb.org/t/p/original/x.jpg"
 REMOTE_B = "https://image.tmdb.org/t/p/original/b.jpg"
 LOCAL = "/api/v1/artwork/deadbeef.jpg"
+MOVIE_ID = "mov_abc123def456"
+SERIES_ID = "ser_abc123def456"
 
 
-@dataclass
-class _Update:
-    media_id: str
-    poster_path: str | None
-    backdrop_path: str | None
-    logo_path: str | None
+def _row(media_id: str, *, poster=None, backdrop=None, logo=None) -> RemoteArtworkRow:
+    return RemoteArtworkRow(
+        media_id=media_id,
+        artwork=ArtworkColumns(
+            poster=ImageUrl(poster) if poster else None,
+            backdrop=ImageUrl(backdrop) if backdrop else None,
+            logo=ImageUrl(logo) if logo else None,
+        ),
+    )
 
 
 class _FakeRepo:
     def __init__(self, rows: list[RemoteArtworkRow]) -> None:
         self._rows = rows
-        self.updates: list[_Update] = []
+        self.updates: list[tuple[str, ArtworkColumns]] = []
 
     async def find_with_remote_artwork(self, limit: int) -> list[RemoteArtworkRow]:
         return self._rows[:limit]
 
-    async def _record(self, media_id: str, poster_path, backdrop_path, logo_path) -> None:
-        self.updates.append(_Update(media_id, poster_path, backdrop_path, logo_path))
-
 
 class _FakeMovieRepo(_FakeRepo):
-    async def update_movie_artwork(
-        self, movie_id, *, poster_path, backdrop_path, logo_path
-    ) -> None:
-        await self._record(str(movie_id), poster_path, backdrop_path, logo_path)
+    async def update_movie_artwork(self, movie_id, artwork: ArtworkColumns) -> None:
+        self.updates.append((str(movie_id), artwork))
 
 
 class _FakeSeriesRepo(_FakeRepo):
-    async def update_series_artwork(
-        self, series_id, *, poster_path, backdrop_path, logo_path
-    ) -> None:
-        await self._record(str(series_id), poster_path, backdrop_path, logo_path)
+    async def update_series_artwork(self, series_id, artwork: ArtworkColumns) -> None:
+        self.updates.append((str(series_id), artwork))
 
 
 @dataclass
@@ -145,39 +144,20 @@ def _make(
 
 class TestRun:
     async def test_should_mirror_remote_fields_and_leave_others(self) -> None:
-        h = _make(
-            movie_rows=[
-                RemoteArtworkRow(
-                    media_id="mov_abc123def456",
-                    poster_path=REMOTE,
-                    backdrop_path=LOCAL,  # already local — untouched
-                    logo_path=None,  # absent — untouched
-                )
-            ]
-        )
+        h = _make(movie_rows=[_row(MOVIE_ID, poster=REMOTE, backdrop=LOCAL, logo=None)])
 
         await h.job.run()
 
         assert len(h.movies.updates) == 1
-        update = h.movies.updates[0]
-        assert update.media_id == "mov_abc123def456"
-        assert update.poster_path.startswith("/api/v1/artwork/")
-        assert update.backdrop_path == LOCAL
-        assert update.logo_path is None
+        media_id, cols = h.movies.updates[0]
+        assert media_id == MOVIE_ID
+        assert cols.poster.value.startswith("/api/v1/artwork/")  # mirrored
+        assert cols.backdrop == ImageUrl(LOCAL)  # already local — untouched
+        assert cols.logo is None  # absent — untouched
         assert h.storage.saved  # one object stored
 
     async def test_should_keep_remote_url_when_download_fails(self) -> None:
-        h = _make(
-            movie_rows=[
-                RemoteArtworkRow(
-                    media_id="mov_abc123def456",
-                    poster_path=REMOTE,
-                    backdrop_path=None,
-                    logo_path=None,
-                )
-            ],
-            fail_urls={REMOTE},
-        )
+        h = _make(movie_rows=[_row(MOVIE_ID, poster=REMOTE)], fail_urls={REMOTE})
 
         await h.job.run()
 
@@ -188,17 +168,7 @@ class TestRun:
     async def test_should_keep_remote_url_when_response_is_not_an_image(self) -> None:
         # A 200 serving HTML (rate-limit page) must never overwrite the
         # authoritative remote URL with a broken "artwork".
-        h = _make(
-            movie_rows=[
-                RemoteArtworkRow(
-                    media_id="mov_abc123def456",
-                    poster_path=REMOTE,
-                    backdrop_path=None,
-                    logo_path=None,
-                )
-            ],
-            nonimage_urls={REMOTE},
-        )
+        h = _make(movie_rows=[_row(MOVIE_ID, poster=REMOTE)], nonimage_urls={REMOTE})
 
         await h.job.run()
 
@@ -209,64 +179,34 @@ class TestRun:
         # Two remote fields, one download fails: the winner is mirrored,
         # the loser keeps its remote URL, and the title is still updated.
         h = _make(
-            movie_rows=[
-                RemoteArtworkRow(
-                    media_id="mov_abc123def456",
-                    poster_path=REMOTE,
-                    backdrop_path=REMOTE_B,
-                    logo_path=None,
-                )
-            ],
+            movie_rows=[_row(MOVIE_ID, poster=REMOTE, backdrop=REMOTE_B)],
             fail_urls={REMOTE_B},
         )
 
         await h.job.run()
 
         assert len(h.movies.updates) == 1
-        update = h.movies.updates[0]
-        assert update.poster_path.startswith("/api/v1/artwork/")
-        assert update.backdrop_path == REMOTE_B  # failed → kept remote
+        _, cols = h.movies.updates[0]
+        assert cols.poster.value.startswith("/api/v1/artwork/")
+        assert cols.backdrop == ImageUrl(REMOTE_B)  # failed → kept remote
         assert len(h.storage.saved) == 1
 
     async def test_should_mirror_series_too(self) -> None:
-        h = _make(
-            series_rows=[
-                RemoteArtworkRow(
-                    media_id="ser_abc123def456",
-                    poster_path=REMOTE,
-                    backdrop_path=REMOTE,
-                    logo_path=None,
-                )
-            ]
-        )
+        h = _make(series_rows=[_row(SERIES_ID, poster=REMOTE, backdrop=REMOTE)])
 
         await h.job.run()
 
         assert len(h.series.updates) == 1
-        update = h.series.updates[0]
-        assert update.poster_path.startswith("/api/v1/artwork/")
-        assert update.backdrop_path.startswith("/api/v1/artwork/")
+        _, cols = h.series.updates[0]
+        assert cols.poster.value.startswith("/api/v1/artwork/")
+        assert cols.backdrop.value.startswith("/api/v1/artwork/")
 
-    async def test_should_split_budget_between_movies_and_series(self) -> None:
+    async def test_should_split_budget_between_kinds(self) -> None:
         # batch_size 1 → the single slot goes to the movie; series is not
         # fetched this tick.
         h = _make(
-            movie_rows=[
-                RemoteArtworkRow(
-                    media_id="mov_abc123def456",
-                    poster_path=REMOTE,
-                    backdrop_path=None,
-                    logo_path=None,
-                )
-            ],
-            series_rows=[
-                RemoteArtworkRow(
-                    media_id="ser_abc123def456",
-                    poster_path=REMOTE,
-                    backdrop_path=None,
-                    logo_path=None,
-                )
-            ],
+            movie_rows=[_row(MOVIE_ID, poster=REMOTE)],
+            series_rows=[_row(SERIES_ID, poster=REMOTE)],
             config=ArtworkMirrorConfig(batch_size=1),
         )
 

--- a/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
+++ b/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
@@ -1,0 +1,218 @@
+"""Unit tests for :class:`ArtworkMirrorJob` (ADR-029).
+
+Drives the job with in-memory fakes for the UoW/repositories, the
+downloader and the storage, so the orchestration is verified without a
+DB or network: which fields get mirrored, which are left as-is, that a
+download failure keeps the remote URL, and the movies/series budget
+split.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.building_blocks.infrastructure.errors import GatewayUnavailableException
+from src.infrastructure.scheduling.artwork_mirror_job import ArtworkMirrorJob
+from src.modules.media.application.ports.artwork_downloader_port import DownloadedImage
+from src.modules.media.domain.repositories.movie_repository import RemoteArtworkRow
+from src.modules.settings.domain.value_objects import ArtworkMirrorConfig
+
+REMOTE = "https://image.tmdb.org/t/p/original/x.jpg"
+LOCAL = "/api/v1/artwork/deadbeef.jpg"
+
+
+@dataclass
+class _Update:
+    media_id: str
+    poster_path: str | None
+    backdrop_path: str | None
+    logo_path: str | None
+
+
+class _FakeRepo:
+    def __init__(self, rows: list[RemoteArtworkRow]) -> None:
+        self._rows = rows
+        self.updates: list[_Update] = []
+
+    async def find_with_remote_artwork(self, limit: int) -> list[RemoteArtworkRow]:
+        return self._rows[:limit]
+
+    async def _record(self, media_id: str, poster_path, backdrop_path, logo_path) -> None:
+        self.updates.append(_Update(media_id, poster_path, backdrop_path, logo_path))
+
+
+class _FakeMovieRepo(_FakeRepo):
+    async def update_movie_artwork(
+        self, movie_id, *, poster_path, backdrop_path, logo_path
+    ) -> None:
+        await self._record(str(movie_id), poster_path, backdrop_path, logo_path)
+
+
+class _FakeSeriesRepo(_FakeRepo):
+    async def update_series_artwork(
+        self, series_id, *, poster_path, backdrop_path, logo_path
+    ) -> None:
+        await self._record(str(series_id), poster_path, backdrop_path, logo_path)
+
+
+@dataclass
+class _FakeUow:
+    movies: _FakeMovieRepo
+    series: _FakeSeriesRepo
+
+    async def __aenter__(self) -> _FakeUow:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+class _FakeUowFactory:
+    def __init__(self, uow: _FakeUow) -> None:
+        self._uow = uow
+
+    def __call__(self) -> _FakeUow:
+        return self._uow
+
+
+class _FakeRuntimeSettings:
+    def __init__(self, config: ArtworkMirrorConfig) -> None:
+        self._config = config
+
+    async def artwork_mirror(self) -> ArtworkMirrorConfig:
+        return self._config
+
+
+class _FakeDownloader:
+    def __init__(self, *, fail_urls: set[str] = frozenset()) -> None:
+        self._fail_urls = fail_urls
+        self.fetched: list[str] = []
+
+    async def fetch(self, url: str, *, max_bytes: int) -> DownloadedImage:
+        self.fetched.append(url)
+        if url in self._fail_urls:
+            raise GatewayUnavailableException(message="down", gateway_name="artwork-cdn")
+        return DownloadedImage(content=b"image-bytes", content_type="image/jpeg")
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self.saved: list[str] = []
+
+    async def save(self, *, content: bytes, content_type: str, key: str) -> str:
+        self.saved.append(key)
+        return f"/api/v1/artwork/{key}"
+
+
+@dataclass
+class _Harness:
+    job: ArtworkMirrorJob
+    movies: _FakeMovieRepo
+    series: _FakeSeriesRepo
+    downloader: _FakeDownloader
+    storage: _FakeStorage
+
+
+def _make(
+    *,
+    movie_rows: list[RemoteArtworkRow] | None = None,
+    series_rows: list[RemoteArtworkRow] | None = None,
+    config: ArtworkMirrorConfig | None = None,
+    fail_urls: set[str] = frozenset(),
+) -> _Harness:
+    movies = _FakeMovieRepo(list(movie_rows or []))
+    series = _FakeSeriesRepo(list(series_rows or []))
+    uow = _FakeUow(movies=movies, series=series)
+    downloader = _FakeDownloader(fail_urls=fail_urls)
+    storage = _FakeStorage()
+    job = ArtworkMirrorJob(
+        media_uow_factory=_FakeUowFactory(uow),
+        runtime_settings=_FakeRuntimeSettings(config or ArtworkMirrorConfig()),
+        downloader=downloader,
+        storage=storage,
+    )
+    return _Harness(job=job, movies=movies, series=series, downloader=downloader, storage=storage)
+
+
+class TestRun:
+    async def test_should_mirror_remote_fields_and_leave_others(self) -> None:
+        h = _make(
+            movie_rows=[
+                RemoteArtworkRow(
+                    media_id="mov_abc123def456",
+                    poster_path=REMOTE,
+                    backdrop_path=LOCAL,  # already local — untouched
+                    logo_path=None,  # absent — untouched
+                )
+            ]
+        )
+
+        await h.job.run()
+
+        assert len(h.movies.updates) == 1
+        update = h.movies.updates[0]
+        assert update.media_id == "mov_abc123def456"
+        assert update.poster_path.startswith("/api/v1/artwork/")
+        assert update.backdrop_path == LOCAL
+        assert update.logo_path is None
+        assert h.storage.saved  # one object stored
+
+    async def test_should_keep_remote_url_when_download_fails(self) -> None:
+        h = _make(
+            movie_rows=[
+                RemoteArtworkRow(
+                    media_id="mov_abc123def456",
+                    poster_path=REMOTE,
+                    backdrop_path=None,
+                    logo_path=None,
+                )
+            ],
+            fail_urls={REMOTE},
+        )
+
+        await h.job.run()
+
+        # Nothing changed → no update issued, remote URL stays for a retry.
+        assert h.movies.updates == []
+        assert h.storage.saved == []
+
+    async def test_should_mirror_series_too(self) -> None:
+        h = _make(
+            series_rows=[
+                RemoteArtworkRow(
+                    media_id="ser_abc123def456",
+                    poster_path=REMOTE,
+                    backdrop_path=REMOTE,
+                    logo_path=None,
+                )
+            ]
+        )
+
+        await h.job.run()
+
+        assert len(h.series.updates) == 1
+        update = h.series.updates[0]
+        assert update.poster_path.startswith("/api/v1/artwork/")
+        assert update.backdrop_path.startswith("/api/v1/artwork/")
+
+    async def test_should_split_budget_between_movies_and_series(self) -> None:
+        # batch_size 1 → the single slot goes to the movie; series is not
+        # fetched this tick.
+        h = _make(
+            movie_rows=[
+                RemoteArtworkRow(
+                    media_id="mov_abc123def456", poster_path=REMOTE, backdrop_path=None, logo_path=None
+                )
+            ],
+            series_rows=[
+                RemoteArtworkRow(
+                    media_id="ser_abc123def456", poster_path=REMOTE, backdrop_path=None, logo_path=None
+                )
+            ],
+            config=ArtworkMirrorConfig(batch_size=1),
+        )
+
+        await h.job.run()
+
+        assert len(h.movies.updates) == 1
+        assert h.series.updates == []

--- a/tests/modules/media/unit/infrastructure/storage/test_local_artwork_storage.py
+++ b/tests/modules/media/unit/infrastructure/storage/test_local_artwork_storage.py
@@ -1,0 +1,95 @@
+"""Unit tests for :class:`LocalArtworkStorage`.
+
+Exercises the adapter against a real temp directory (``tmp_path``) —
+no mocking needed since the backend is the filesystem. Covers the
+save → open round-trip, content-type derived from the key extension,
+the not-found miss, idempotent delete, and the traversal guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TCH003 — used by runtime fixture annotations
+
+import pytest
+
+from src.modules.media.infrastructure.storage.local_artwork_storage import (
+    LocalArtworkStorage,
+)
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> LocalArtworkStorage:
+    """Adapter rooted at a test-scoped temp directory."""
+    return LocalArtworkStorage(root_directory=str(tmp_path / "artwork"))
+
+
+class TestSave:
+    async def test_should_return_proxy_url_for_the_key(
+        self, storage: LocalArtworkStorage
+    ) -> None:
+        url = await storage.save(content=b"bytes", content_type="image/jpeg", key="ab12.jpg")
+
+        assert url == "/api/v1/artwork/ab12.jpg"
+
+    async def test_should_write_bytes_under_the_root(
+        self, storage: LocalArtworkStorage, tmp_path: Path
+    ) -> None:
+        await storage.save(content=b"poster", content_type="image/jpeg", key="k.jpg")
+
+        assert (tmp_path / "artwork" / "k.jpg").read_bytes() == b"poster"
+
+
+class TestOpen:
+    async def test_should_round_trip_bytes_with_derived_content_type(
+        self, storage: LocalArtworkStorage
+    ) -> None:
+        await storage.save(content=b"image-bytes", content_type="ignored", key="pic.png")
+
+        result = await storage.open("pic.png")
+
+        assert result is not None
+        assert result.content == b"image-bytes"
+        # Content type comes from the ``.png`` extension, not the
+        # ``content_type`` passed to ``save``.
+        assert result.content_type == "image/png"
+
+    async def test_should_return_none_when_file_missing(
+        self, storage: LocalArtworkStorage
+    ) -> None:
+        assert await storage.open("gone.jpg") is None
+
+    async def test_should_fall_back_to_octet_stream_for_unknown_extension(
+        self, storage: LocalArtworkStorage
+    ) -> None:
+        await storage.save(content=b"x", content_type="whatever", key="blob.unknownext")
+
+        result = await storage.open("blob.unknownext")
+
+        assert result is not None
+        assert result.content_type == "application/octet-stream"
+
+
+class TestDelete:
+    async def test_should_remove_the_file(
+        self, storage: LocalArtworkStorage, tmp_path: Path
+    ) -> None:
+        await storage.save(content=b"x", content_type="image/jpeg", key="k.jpg")
+
+        await storage.delete("k.jpg")
+
+        assert not (tmp_path / "artwork" / "k.jpg").exists()
+        assert await storage.open("k.jpg") is None
+
+    async def test_should_be_idempotent_when_file_missing(
+        self, storage: LocalArtworkStorage
+    ) -> None:
+        # Must not raise.
+        await storage.delete("never-existed.jpg")
+
+
+class TestTraversalGuard:
+    async def test_should_reject_key_escaping_the_root(
+        self, storage: LocalArtworkStorage
+    ) -> None:
+        with pytest.raises(ValueError, match="escapes the storage root"):
+            await storage.open("../secret.txt")

--- a/tests/modules/media/unit/infrastructure/storage/test_local_artwork_storage.py
+++ b/tests/modules/media/unit/infrastructure/storage/test_local_artwork_storage.py
@@ -24,9 +24,7 @@ def storage(tmp_path: Path) -> LocalArtworkStorage:
 
 
 class TestSave:
-    async def test_should_return_proxy_url_for_the_key(
-        self, storage: LocalArtworkStorage
-    ) -> None:
+    async def test_should_return_proxy_url_for_the_key(self, storage: LocalArtworkStorage) -> None:
         url = await storage.save(content=b"bytes", content_type="image/jpeg", key="ab12.jpg")
 
         assert url == "/api/v1/artwork/ab12.jpg"
@@ -53,9 +51,7 @@ class TestOpen:
         # ``content_type`` passed to ``save``.
         assert result.content_type == "image/png"
 
-    async def test_should_return_none_when_file_missing(
-        self, storage: LocalArtworkStorage
-    ) -> None:
+    async def test_should_return_none_when_file_missing(self, storage: LocalArtworkStorage) -> None:
         assert await storage.open("gone.jpg") is None
 
     async def test_should_fall_back_to_octet_stream_for_unknown_extension(
@@ -67,6 +63,18 @@ class TestOpen:
 
         assert result is not None
         assert result.content_type == "application/octet-stream"
+
+    async def test_should_return_none_when_key_resolves_to_a_directory(
+        self, storage: LocalArtworkStorage, tmp_path: Path
+    ) -> None:
+        # A key pointing at a directory (read_bytes → IsADirectoryError,
+        # an OSError) must be treated as absent, not surface as a crash
+        # through the proxy route. Relevant on the direct-call path (the
+        # PR-2 mirror job), where no route regex guards the key.
+        (tmp_path / "artwork").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "artwork" / "adir").mkdir()
+
+        assert await storage.open("adir") is None
 
 
 class TestDelete:
@@ -86,10 +94,20 @@ class TestDelete:
         # Must not raise.
         await storage.delete("never-existed.jpg")
 
+    async def test_should_swallow_oserror_when_target_is_a_directory(
+        self, storage: LocalArtworkStorage, tmp_path: Path
+    ) -> None:
+        # Unlinking a directory raises OSError on most platforms; delete
+        # logs and swallows it rather than propagating (idempotent by
+        # contract). Exercises the OSError branch.
+        (tmp_path / "artwork").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "artwork" / "adir").mkdir()
+
+        # Must not raise.
+        await storage.delete("adir")
+
 
 class TestTraversalGuard:
-    async def test_should_reject_key_escaping_the_root(
-        self, storage: LocalArtworkStorage
-    ) -> None:
+    async def test_should_reject_key_escaping_the_root(self, storage: LocalArtworkStorage) -> None:
         with pytest.raises(ValueError, match="escapes the storage root"):
             await storage.open("../secret.txt")

--- a/tests/modules/settings/e2e/test_admin_settings_routes.py
+++ b/tests/modules/settings/e2e/test_admin_settings_routes.py
@@ -97,6 +97,7 @@ class TestAdminSettingsList:
                 "avatar",
                 "scan_dedup",
                 "subtitle_ocr",
+                "artwork_mirror",
             ]
         )
         for entry in body["data"]:

--- a/tests/modules/settings/unit/domain/value_objects/test_artwork_mirror_config.py
+++ b/tests/modules/settings/unit/domain/value_objects/test_artwork_mirror_config.py
@@ -1,0 +1,39 @@
+"""Tests for the ArtworkMirrorConfig VO (ADR-029 bucket)."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.settings.domain.value_objects import ArtworkMirrorConfig
+
+
+@pytest.mark.unit
+class TestArtworkMirrorConfig:
+    def test_defaults(self) -> None:
+        cfg = ArtworkMirrorConfig()
+
+        assert cfg.enabled is True
+        assert cfg.batch_size == 20
+        assert cfg.interval_minutes == 30
+        assert cfg.max_bytes == 10 * 1024 * 1024
+
+    def test_with_updates_returns_a_modified_copy(self) -> None:
+        cfg = ArtworkMirrorConfig()
+
+        updated = cfg.with_updates(batch_size=50, interval_minutes=15)
+
+        assert updated.batch_size == 50
+        assert updated.interval_minutes == 15
+        assert cfg.batch_size == 20  # original untouched
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_batch_size_must_be_positive(self, bad: int) -> None:
+        with pytest.raises(DomainValidationException):
+            ArtworkMirrorConfig(batch_size=bad)
+
+    def test_interval_must_be_positive(self) -> None:
+        with pytest.raises(DomainValidationException):
+            ArtworkMirrorConfig(interval_minutes=0)
+
+    def test_max_bytes_must_be_positive(self) -> None:
+        with pytest.raises(DomainValidationException):
+            ArtworkMirrorConfig(max_bytes=0)


### PR DESCRIPTION
## Summary

- **Storage foundation (PR 1):** `ArtworkStoragePort` + local-disk adapter (`LocalArtworkStorage`, dir `artwork_storage_directory`) and a `GET /api/v1/artwork/{key}` proxy route that serves stored art and degrades to a redirect/404 when not yet mirrored. Default is local disk; MinIO/S3 stays a pluggable adapter behind the same port (ADR-029).
- **Background mirror (PR 2):** `ArtworkMirrorJob` (APScheduler interval) finds movies/series whose poster/backdrop/logo is still a remote TMDB URL, downloads the bytes via `ArtworkDownloaderPort`/`HttpxArtworkDownloader`, stores them under a content-addressed `ArtworkKey`, and swaps the column for the local reference via a direct column update (no aggregate round-trip, so children aren't wiped). New `ArtworkMirrorConfig` settings bucket.
- **Modeling (PR 3a):** the poster/backdrop/logo trio is an `ArtworkColumns` value object (`ImageUrl` fields); the job iterates title kinds via a strategy object instead of a boolean flag.
- **Hardening:** downloader constrained to https on an allow-listed provider host with redirects disabled (SSRF); non-image responses rejected before storing so a bad 200 never overwrites the authoritative URL; key extension restricted to raster types; `X-Content-Type-Options: nosniff` on the proxy; graceful fallback keeps the remote URL on any failure.

Behaviour: `ImageUrl`, mappers and presentation schemas are unchanged. Season posters, episode stills, localized art and cast photos are deferred to follow-ups.

## Test plan

- [x] `make test` (full suite) green
- [x] `ruff check` + `ruff format` clean; `mkdocs build --strict` passes
- [x] Unit: `ArtworkKey`, `HttpxArtworkDownloader` (size cap, SSRF/redirect reject, error translation), `ArtworkMirrorJob` (mirror/keep-on-failure/non-image/partial/budget), `ArtworkMirrorConfig`
- [x] Integration: movie + series `find_with_remote_artwork` / `update_*_artwork` (incl. seasons untouched)
- [x] e2e: `GET /api/v1/artwork/{key}` (serve / 404 / origin redirect / disallowed-origin / bad key)
- [x] Manual smoke: ran the mirror once against the dev catalog — 20 titles mirrored, 0 failures, files written as valid JPEG/PNG, `storage.open` round-trips, DB columns swapped to `/api/v1/artwork/...`
- [ ] Manual: serve a mirrored key over HTTP with the app running

## Summary by Sourcery

Introduce a configurable artwork mirroring pipeline that downloads provider images into local storage and serves them via a new API proxy, improving catalog resilience to remote outages while preserving existing ImageUrl behaviour.

New Features:
- Add ArtworkStoragePort with a default LocalArtworkStorage adapter backed by a configured filesystem directory and expose mirrored images via GET /api/v1/artwork/{key}.
- Introduce ArtworkDownloaderPort and HttpxArtworkDownloader to safely fetch provider artwork bytes with host allow-listing, HTTPS-only and size limits.
- Add ArtworkMirrorJob, wired into the scheduler via ArtworkMirrorConfig runtime settings, to periodically mirror movie and series poster/backdrop/logo images and update their artwork columns to local references.
- Model poster/backdrop/logo triples as an ArtworkColumns value object and define content-addressed ArtworkKey to generate safe, stable storage keys for mirrored artwork.

Enhancements:
- Extend movie and series repositories with lightweight projections for titles that still reference remote artwork and targeted column update methods to swap artwork paths without reloading aggregates.
- Wire artwork storage and downloader into the media/application container and expose new artwork-related settings (artwork_storage_directory, artwork_mirror bucket) through RuntimeSettings.
- Add helpers and value objects to centralize artwork column handling and key validation, including charset and traversal guards in the proxy route.

Documentation:
- Add ADR-029 documenting the decision to mirror provider artwork via a storage port and reference it from the ADR index and MkDocs navigation.

Tests:
- Add unit tests for ArtworkMirrorJob orchestration, ArtworkKey generation and validation, HttpxArtworkDownloader error handling, LocalArtworkStorage behaviour, and ArtworkMirrorConfig validation.
- Add integration tests for movie/series repository artwork finders and updaters to ensure only still-remote rows are selected and children remain intact.
- Add end-to-end tests for the artwork proxy route covering stored hits, origin redirect fallback, disallowed origins, invalid keys and public access invariants.

Chores:
- Extend admin settings routes and tests to surface the new artwork_mirror configuration bucket alongside existing runtime settings.