### PR TITLE
docs(media): sync artwork mirroring docs and accept ADR-029

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ HomeFlix is a self-hosted media server that allows you to:
 - 📋 Create watchlists and custom collections per profile
 - ⏭️ Skip intros automatically (Chromaprint fingerprinting) and scrub with thumbnail trickplay
 - 🔍 Full-text search across the catalog
+- 🖼️ Mirror provider artwork into local storage so posters survive TMDB removal, rate limits, and offline use (ADR-029)
 
 ## Tech Stack
 
@@ -195,15 +196,15 @@ Key entry points:
 streaming server with profile ACLs, automatic intro detection,
 trickplay scrub thumbnails, and a scheduled scan/enrichment pipeline.
 
-- 137 REST API endpoints across 9 bounded contexts
-- 3,100+ tests
+- 138 REST API endpoints across 9 bounded contexts
+- 3,200+ tests
 - Responsive React frontend with HLS player and per-profile UI
 
 ### Modules
 
 | Module | Scope | Highlights |
 |--------|-------|------------|
-| **Media Catalog** | Movies, Series, Seasons, Episodes | File variants (ADR-006), HLS streaming, multi-audio/subtitle, FTS5 search, TMDB enrichment, filesystem scanner, intro markers, trickplay sprites |
+| **Media Catalog** | Movies, Series, Seasons, Episodes | File variants (ADR-006), HLS streaming, multi-audio/subtitle, FTS5 search, TMDB enrichment, filesystem scanner, intro markers, trickplay sprites, provider artwork mirrored to local storage (ADR-029) |
 | **Library** | Media source configuration | CRUD, metadata providers, scan settings, TrackSelector service (ADR-005) |
 | **Watch Progress** | Playback tracking, scoped per profile | Save/resume, continue watching, auto-complete at 90% |
 | **Collections** | Watchlist & Custom Lists, scoped per profile | Toggle watchlist, up to 10 custom lists with ordering |

--- a/docs/adr/ADR-029-artwork-mirroring-storage.md
+++ b/docs/adr/ADR-029-artwork-mirroring-storage.md
@@ -1,6 +1,6 @@
 # ADR-029: Mirror de Artwork de Provider via Port de Storage
 
-**Status:** Proposto
+**Status:** Aceito
 **Data:** 2026-07-18
 **Deciders:** Lucas
 **Technical Story:** Durabilidade de artes do catálogo — hoje poster/backdrop/logo/still são URLs absolutas do TMDB servidas verbatim ao frontend; se o TMDB remove a imagem, aplica rate limit, o CDN cai, ou o uso é offline, a arte some.
@@ -163,3 +163,4 @@ Docs a sincronizar ao implementar (docs-maintainer): página do módulo `media` 
 |------|-------|---------|
 | 2026-07-18 | Lucas | Criação inicial (Proposto) |
 | 2026-07-18 | Lucas | Default de storage passa de object-store (MinIO) para disco local; MinIO/S3 vira adapter plugável (Alternativa 3) |
+| 2026-07-19 | Lucas | **Aceito** — implementado e mergeado (PR #364): endpoint `GET /api/v1/artwork/{key}`, `ArtworkStoragePort` + `LocalArtworkStorage` (único adapter implementado; MinIO/S3 segue plugável, não implementado), `ArtworkMirrorJob` (`homeflix:artwork-mirror`), `HttpxArtworkDownloader` guardado contra SSRF, `ArtworkKey`/`ArtworkColumns` VOs e bucket `ArtworkMirrorConfig`. Escopo entregue: campos top-level (poster/backdrop/logo) de **Movie e Series**. Poster de Season, stills de episódio, artes localizadas e fotos de elenco ficam para follow-ups (§5 do escopo v1). |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,7 +38,7 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-026](./ADR-026-server-authoritative-track-selection.md) | Seleção de Faixa Default Autoritativa no Servidor a partir de Preferência por Usuário | ✅ Aceito | 2026-06-30 |
 | [ADR-027](./ADR-027-ocr-image-based-subtitles.md) | OCR de Legendas Baseadas em Imagem (PGS/VOBSUB) para Faixas de Texto Selecionáveis | ✅ Aceito | 2026-07-04 |
 | [ADR-028](./ADR-028-domain-exception-semantics.md) | Semântica de uso da hierarquia de exceções de domínio | ✅ Aceito | 2026-07-07 |
-| [ADR-029](./ADR-029-artwork-mirroring-storage.md) | Mirror de Artwork de Provider via Port de Storage | 🟡 Proposto | 2026-07-18 |
+| [ADR-029](./ADR-029-artwork-mirroring-storage.md) | Mirror de Artwork de Provider via Port de Storage | ✅ Aceito | 2026-07-18 |
 
 ## Como Criar um Novo ADR
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -37,6 +37,13 @@ Para os requisitos completos (incluindo o que ainda é planejado), veja
   ([ADR-023](adr/ADR-023-localized-metadata-value-object.md)) e reconciliado na
   camada de aplicação
   ([ADR-025](adr/ADR-025-provider-metadata-reconciliation-in-application.md)).
+- **Mirror de artwork do provider** — um job de background baixa poster,
+  backdrop e logo (hoje URLs do TMDB) para storage próprio e passa a servi-los
+  por um endpoint estável (`/api/v1/artwork/{key}`), com fallback gracioso para
+  a URL remota enquanto a arte ainda não foi espelhada. O catálogo deixa de
+  depender do CDN do TMDB para exibir artes
+  ([ADR-029](adr/ADR-029-artwork-mirroring-storage.md)). Detalhes operacionais no
+  [Guia de Mirror de Artwork](standards/artwork-mirroring-guide.md).
 
 ## Reprodução (player)
 

--- a/docs/standards/artwork-mirroring-guide.md
+++ b/docs/standards/artwork-mirroring-guide.md
@@ -1,0 +1,221 @@
+# Guia — Mirror de Artwork de Provider
+
+Este guia cobre a operação do **mirror de artwork** (ADR-029): o
+espelhamento das artes do catálogo (poster, backdrop, logo) — hoje URLs
+absolutas do TMDB — para storage que o deploy controla, servidas por um
+endpoint próprio e estável.
+
+> **Fonte da verdade da decisão:** [`docs/adr/ADR-029-artwork-mirroring-storage.md`](../adr/ADR-029-artwork-mirroring-storage.md).
+
+---
+
+## 1. Visão Geral
+
+Toda arte do catálogo é enriquecida como **URL absoluta do TMDB** e, por
+padrão, servida verbatim ao cliente. Isso acopla a exibição do catálogo à
+disponibilidade de um terceiro: imagem removida upstream, rate limit, CDN
+fora do ar ou **uso offline** fazem a arte sumir.
+
+O mirror sobrepõe uma camada de durabilidade **sem** alterar o enrichment:
+o `EnrichMovie/SeriesMetadataUseCase` continua gravando a URL remota, e um
+**job de background** reconcilia depois — baixa os bytes, guarda no
+storage e troca a coluna por uma referência local estável
+(`/api/v1/artwork/{key}`).
+
+Fluxo: **enrichment** grava URL remota → **job de background**
+(`homeflix:artwork-mirror`) encontra colunas ainda remotas → baixa
+(SSRF-guarded) → `ArtworkStoragePort.save` → **atualiza a coluna** com a
+referência local → o proxy `GET /api/v1/artwork/{key}` serve os bytes do
+storage.
+
+É **best-effort e não bloqueante**: enquanto a arte não foi espelhada, a
+coluna mantém a URL remota e o cliente funciona exatamente como antes
+(fallback gracioso). Uma falha de download/store é logada e re-tentada no
+tick seguinte — a URL remota autoritativa nunca é descartada.
+
+### Escopo entregue
+
+- ✅ Campos top-level **poster / backdrop / logo** de **Movie** e
+  **Series** (`ArtworkColumns`).
+- ⏳ Poster de Season, stills de episódio, artes localizadas por locale e
+  fotos de elenco: **planejados** (follow-ups do ADR-029 §5), ainda não
+  implementados.
+
+---
+
+## 2. Endpoint de serving (`GET /api/v1/artwork/{key}`)
+
+Proxy read-only definido em
+`src/modules/media/presentation/routes/artwork_routes.py`. O frontend
+**nunca** fala com o backend de storage direto — trocar disco por
+object-store não vaza para o cliente.
+
+**Auth:** nenhuma (arte de catálogo é imagem pública embutida em `<img>`,
+que não carrega header de auth — espelha como as URLs do TMDB eram
+servidas). · **Tenant-scoped:** não.
+
+| Param | Origem | Papel |
+|-------|--------|-------|
+| `key` (path) | URL armazenada na coluna | Nome do objeto no storage. Validado contra `ARTWORK_KEY_PATTERN` (`^[A-Za-z0-9._-]+$`) e rejeitado se for só pontos. |
+| `origin` (query, opcional) | URL remota de origem | Para onde redirecionar quando o objeto ainda não foi espelhado. |
+
+**Respostas**
+
+| Status | Quando |
+|--------|--------|
+| 200 | Objeto existe no storage — serve os bytes com `Cache-Control: public, max-age=31536000, immutable` e `X-Content-Type-Options: nosniff`. |
+| 302 | Objeto ausente **e** `origin` é uma URL `https` num host allow-listed (`ALLOWED_ARTWORK_HOSTS` = `{image.tmdb.org}`) — bounce para o provider enquanto o job não alcança. |
+| 400 | `key` fora do charset seguro ou só pontos. |
+| 404 | Objeto ausente e sem `origin` válido. |
+
+!!! warning "Sem open redirect"
+    O fallback `origin` só redireciona para hosts de provider
+    allow-listed (`ALLOWED_ARTWORK_HOSTS`, o **mesmo** conjunto de onde o
+    downloader baixa). Um `origin` para host arbitrário é tratado como
+    miss (404), não como redirect.
+
+!!! note "Cache imutável"
+    A chave é content-addressed (hash dos bytes), então o objeto é
+    imutável — daí o `Cache-Control` de 1 ano `immutable`. Arte trocada
+    upstream vira uma **chave nova**, então o cliente refetcha sozinho
+    (cache-busting embutido, sem invalidação manual).
+
+---
+
+## 3. Chave content-addressed (`ArtworkKey`)
+
+`src/modules/media/domain/value_objects/artwork_key.py`. A chave é
+`sha256(bytes) + extensão` (ex.: `ab12…ef.jpg`):
+
+- **Dedup natural** — o mesmo poster referenciado por vários títulos ocupa
+  um único objeto.
+- **Cache-busting** — arte diferente → hash diferente → chave diferente.
+- **Single source of truth do charset** — a rota valida input não-confiável
+  e o job constrói chaves via `ArtworkKey.for_content`, então tanto a
+  leitura quanto a escrita passam pela mesma regra.
+
+Extensão derivada do `Content-Type` (`image/jpeg→.jpg`, `png`, `webp`,
+`gif`, `avif`), com fallback para o sufixo da URL de origem e, por fim,
+`.jpg`.
+
+---
+
+## 4. Storage (`ArtworkStoragePort`)
+
+Port em `src/modules/media/application/ports/artwork_storage_port.py`
+(`save` / `open` / `delete`). O adapter esconde o backend e **não decide
+política** — só armazena, recupera e remove.
+
+| Backend | Adapter | Status |
+|---------|---------|--------|
+| **Disco local (default)** | `LocalArtworkStorage` (`infrastructure/storage/local_artwork_storage.py`) | **Implementado** — o único adapter que existe hoje. Escala pessoal single-node; zero dependência operacional, backup é copiar a pasta. |
+| Object storage (MinIO / S3) | — (mesmo port, ainda não implementado) | **Planejado** (ADR-029 Alternativa 3). Ponto de troca para multi-node / prod: basta um adapter novo satisfazendo o `ArtworkStoragePort`, sem tocar em domínio, job ou rota. |
+
+O `LocalArtworkStorage` grava arquivos flat sob `root_directory`, deriva
+o content-type da extensão da chave na leitura, e confina o path resolvido
+ao diretório raiz (defesa em profundidade contra traversal). I/O de disco
+roda em `asyncio.to_thread` (não bloqueia o event loop).
+
+### Configuração de bootstrap
+
+| Setting | Default | Onde |
+|---------|---------|------|
+| `artwork_storage_directory` | `./artwork` | `src/config/settings.py` (env/config de boot, no estilo de `hls_cache_directory` / `thumbnails_directory`). |
+
+> Diretório perdido (disco corrompido / reset) não quebra o produto: o
+> serve degrada para redirect à URL de origem, e o re-mirror reconstrói a
+> partir das URLs remotas ainda armazenadas. **Inclua o diretório no
+> backup** se quiser durabilidade real da cópia local.
+
+---
+
+## 5. Download (`ArtworkDownloaderPort`) — SSRF-guarded
+
+Port em `src/modules/media/application/ports/artwork_downloader_port.py`;
+adapter `HttpxArtworkDownloader` em `infrastructure/metadata/`. Como o job
+baixa uma **URL vinda do banco**, o fetch é uma primitiva de SSRF se não
+for restringido. As guardas:
+
+- **`https` + host allow-list** — só `ALLOWED_ARTWORK_HOSTS`
+  (`image.tmdb.org` hoje; estender conforme novos providers).
+- **Sem seguir redirects** — o alvo não pode desviar o fetch para um host
+  interno.
+- **Teto de tamanho (`max_bytes`)** — o adapter aborta em vez de bufferizar
+  um corpo maior, para uma URL hostil/mis-dimensionada não exaurir memória.
+
+Timeout, erro de transporte, status não-2xx ou corpo acima do teto viram
+`GatewayException` — o job captura, mantém a URL remota e re-tenta depois.
+
+---
+
+## 6. Job de background (`homeflix:artwork-mirror`)
+
+`src/infrastructure/scheduling/artwork_mirror_job.py`. Registrado no
+scheduler **no boot**, apenas quando o bucket `artwork_mirror` está
+`enabled=true` (default), com cadência `interval_minutes`.
+
+Por tick:
+
+1. Lê o snapshot `ArtworkMirrorConfig` (ADR-013) — edições valem no próximo
+   tick.
+2. Divide o orçamento `batch_size` entre os *kinds* (movies, series), em
+   ordem.
+3. Para cada título com coluna ainda remota (`find_with_remote_artwork`):
+   baixa cada campo remoto, valida que a resposta é uma **imagem suportada**
+   (senão mantém a URL remota — evita gravar uma página HTML de rate-limit
+   ou um `svg`), calcula a `ArtworkKey`, `storage.save`, e **atualiza a
+   coluna** com a referência local.
+4. Loga por *kind* quantos títulos foram atualizados e quantas imagens
+   foram espelhadas vs. mantidas remotas.
+
+!!! note "Sem round-trip de aggregate"
+    A escrita é um **update direto de coluna** numa UoW fresca por título
+    (não um save de aggregate) — não apaga coleções-filhas. É um
+    last-writer-wins a partir do snapshot de leitura; uma re-enrichment
+    concorrente na janela curta fetch→persist poderia ser revertida, mas a
+    cadência de 30 min e o re-mirror auto-curativo no tick seguinte tornam
+    isso aceitável.
+
+!!! warning "Falsa sensação de durabilidade"
+    Se o job nunca roda (bucket desligado, scheduler parado), **nada** é
+    espelhado e o catálogo segue dependendo do TMDB — sem quebrar, mas sem
+    a durabilidade prometida. Confirme `enabled=true` e acompanhe o log
+    `[artwork-mirror] tick complete` (contagens de `mirrored`/`failed` por
+    kind).
+
+---
+
+## 7. Configuração (bucket `artwork_mirror`)
+
+Runtime setting persistido em banco, por bucket (ADR-013/014). Definido em
+`src/modules/settings/domain/value_objects/artwork_mirror_config.py`.
+
+| Campo | Default | Descrição |
+|-------|---------|-----------|
+| `enabled` | `true` | Registra o job periódico no boot. |
+| `batch_size` | `20` | Máximo de títulos (movies + series) processados por tick. Limita trabalho de rede + disco por run num catálogo grande. |
+| `interval_minutes` | `30` | Cadência do job. |
+| `max_bytes` | `10485760` (10 MiB) | Teto de uma imagem baixada. Maiores são puladas (mantêm URL remota). |
+
+O bucket aparece no agregado `GET /api/v1/admin/settings` (junto dos demais
+buckets, com `source='default'` se nunca foi editado).
+
+<!-- TODO(docs): não há endpoint PATCH dedicado (`/admin/settings/artwork-mirror`)
+     como o de subtitle-ocr; hoje o bucket só é editável via app_settings
+     no banco. Documentar aqui quando/se a rota de edição for adicionada. -->
+
+> `batch_size` e `max_bytes` são lidos **por tick** (edição vale no próximo
+> run). `enabled` e `interval_minutes` são lidos **no boot** ao registrar o
+> job — mudá-los exige restart.
+
+---
+
+## 8. Diagnóstico Rápido
+
+| Sintoma | Causa provável | Ação |
+|---------|----------------|------|
+| Artes ainda apontam para `image.tmdb.org` | Job desligado ou ainda não alcançou o título | Confirmar bucket `enabled=true`; olhar o log `[artwork-mirror] tick complete`; baixar `batch_size`/`interval_minutes` se preciso |
+| `404` em `/api/v1/artwork/{key}` sem redirect | Objeto ausente **e** sem `origin` válido | Esperado antes do mirror rodar; garantir que o front passa `?origin=<url-remota>` para o fallback 302 |
+| Log `non-image response; keeping remote URL` | Provider serviu HTML (rate-limit/geoblock) ou tipo não suportado | Benigno — a URL remota é mantida e re-tentada; sem ação |
+| Diretório de artwork perdido | Disco corrompido / reset | Serve degrada para redirect à origem; re-mirror reconstrói; incluir o diretório no backup |
+| Arte não muda após troca upstream com mesmo `file_path` | Content-hash não detecta troca se o `file_path` não mudou | Re-mirror periódico opcional; caso comum (novo `file_path`) já é coberto |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
   - Standards:
       - standards/api-i18n-guide.md
       - standards/api-production-addons.md
+      - standards/artwork-mirroring-guide.md
       - standards/api-response-standard-rest-v3.md
       - standards/clean-architecture-decisions.md
       - standards/exception-hierarchy-clean-architecture.md


### PR DESCRIPTION
## Summary

- Promote **ADR-029** from Proposed → **Accepted** (implemented + merged in #364) and update the ADR index status.
- Refresh root `README.md`: endpoint count (→ 138), test count, and the Media Catalog row now notes provider artwork is mirrored to local storage (ADR-029).
- Add `docs/standards/artwork-mirroring-guide.md` — operational guide (proxy endpoint, content-addressed key, storage port + local adapter, SSRF-guarded downloader, `homeflix:artwork-mirror` job, `artwork_mirror` settings bucket, diagnostics) and wire it into the nav.
- Note the feature under scan/metadata in `docs/features.md`.

Docs-only — no `src/` changes. Local disk is documented as the only shipped storage adapter; MinIO/S3 is a pluggable (not yet implemented) option per ADR-029 Alternative 3.

## Test plan

- [x] `mkdocs build --strict` passes (0 warnings)
- [x] Counts recomputed from source (`grep @router` → 138)
- [x] No `src/` changes

## Summary by Sourcery

Accept ADR-029 for provider artwork mirroring and update documentation to describe the new artwork mirroring behavior and operational details.

New Features:
- Document the stable artwork proxy endpoint and background mirroring job as part of the media catalog feature set.

Enhancements:
- Clarify the delivered scope and planned follow-ups for artwork mirroring across catalog entities.

Documentation:
- Refresh README and feature documentation to note provider artwork is mirrored into local storage and to update endpoint and test counts.
- Mark ADR-029 as accepted in the ADR index and extend it with implementation notes and scope status.
- Add an artwork mirroring operational guide under Standards and wire it into the MkDocs navigation.