### PR TITLE
feat(media): mirror season posters (ADR-029 PR 3b)

### DIFF
--- a/docs/standards/artwork-mirroring-guide.md
+++ b/docs/standards/artwork-mirroring-guide.md
@@ -37,9 +37,10 @@ tick seguinte — a URL remota autoritativa nunca é descartada.
 
 - ✅ Campos top-level **poster / backdrop / logo** de **Movie** e
   **Series** (`ArtworkColumns`).
-- ⏳ Poster de Season, stills de episódio, artes localizadas por locale e
-  fotos de elenco: **planejados** (follow-ups do ADR-029 §5), ainda não
-  implementados.
+- ✅ **Poster de Season** — mirrorado por coluna direta (`seasons.poster_path`),
+  sem round-trip do agregado.
+- ⏳ Stills de episódio, artes localizadas por locale e fotos de elenco:
+  **planejados** (follow-ups do ADR-029 §5), ainda não implementados.
 
 ---
 

--- a/src/infrastructure/scheduling/artwork_mirror_job.py
+++ b/src/infrastructure/scheduling/artwork_mirror_job.py
@@ -27,7 +27,7 @@ from src.modules.media.domain.value_objects.artwork_key import (
     SUPPORTED_ARTWORK_CONTENT_TYPES,
 )
 from src.shared_kernel.value_objects.image_url import ImageUrl
-from src.shared_kernel.value_objects.media_id import MovieId, SeriesId
+from src.shared_kernel.value_objects.media_id import MovieId, SeasonId, SeriesId
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -98,6 +98,13 @@ class ArtworkMirrorJob:
                 find=lambda uow, limit: uow.series.find_with_remote_artwork(limit),
                 update=lambda uow, media_id, cols: uow.series.update_series_artwork(
                     SeriesId(media_id), cols
+                ),
+            ),
+            _Kind(
+                label="seasons",
+                find=lambda uow, limit: uow.series.find_seasons_with_remote_poster(limit),
+                update=lambda uow, media_id, cols: uow.series.update_season_artwork(
+                    SeasonId(media_id), cols
                 ),
             ),
         )

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -457,6 +457,26 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_seasons_with_remote_poster(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` seasons whose poster is still a remote URL.
+
+        ``RemoteArtworkRow.media_id`` is the season external id (``ssn_xxx``)
+        and only ``artwork.poster`` is populated — seasons carry no
+        backdrop/logo column.
+        """
+        ...
+
+    @abstractmethod
+    async def update_season_artwork(self, season_id: SeasonId, artwork: ArtworkColumns) -> None:
+        """Set a single season's poster column by external id.
+
+        Direct column update on the ``seasons`` table — the mirror job
+        never round-trips the ``Series`` aggregate. Only ``artwork.poster``
+        is written; the other fields are ignored (no such columns).
+        """
+        ...
+
+    @abstractmethod
     async def find_seasons_pending_intro_detection(
         self,
         limit: int,

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -745,6 +745,37 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             .values(**artwork_column_values(artwork))
         )
 
+    async def find_seasons_with_remote_poster(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` seasons whose poster is still a remote URL.
+
+        Projects the season external id + poster column (seasons have no
+        backdrop/logo). Seasons carry no soft-delete column of their own;
+        a season of a soft-deleted series is harmless to mirror and the
+        row still exists.
+        """
+        stmt = (
+            select(SeasonModel.external_id, SeasonModel.poster_path)
+            .where(SeasonModel.poster_path.like("http%"))
+            .order_by(SeasonModel.id.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [
+            RemoteArtworkRow(
+                media_id=row.external_id,
+                artwork=to_artwork_columns(row.poster_path, None, None),
+            )
+            for row in result.all()
+        ]
+
+    async def update_season_artwork(self, season_id: SeasonId, artwork: ArtworkColumns) -> None:
+        """Set a single season's poster column by external id."""
+        await self._session.execute(
+            update(SeasonModel)
+            .where(SeasonModel.external_id == season_id.value)
+            .values(poster_path=artwork.poster.value if artwork.poster else None)
+        )
+
     async def find_seasons_pending_intro_detection(
         self,
         limit: int,

--- a/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
+++ b/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
@@ -180,3 +180,64 @@ class TestSeriesArtwork:
         # must survive an artwork update untouched.
         assert len(reloaded.seasons) == 1
         assert len(reloaded.seasons[0].episodes) == 1
+
+
+def _series_with_season_poster(poster: str) -> tuple[Series, SeasonId, SeriesId]:
+    sid = SeriesId.generate()
+    season_id = SeasonId.generate()
+    episode = Episode(
+        id=EpisodeId.generate(),
+        series_id=sid,
+        season_number=1,
+        episode_number=1,
+        title=Title("E1"),
+        duration=Duration(2700),
+        files=[
+            MediaFile(
+                file_path=FilePath("/series/s01e01.mkv"),
+                file_size=500_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            )
+        ],
+    )
+    season = Season(
+        id=season_id,
+        series_id=sid,
+        season_number=1,
+        title=Title("Season 1"),
+        poster_path=ImageUrl(poster),
+        episodes=[episode],
+    )
+    series = Series(
+        library_id="lib_test12345678",
+        id=sid,
+        title=Title("With Season"),
+        start_year=Year(2020),
+        seasons=[season],
+    )
+    return series, season_id, sid
+
+
+@pytest.mark.integration
+class TestSeasonArtwork:
+    async def test_should_find_and_update_season_poster(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series, season_id, series_id = _series_with_season_poster(_REMOTE)
+        await repo.save(series)
+
+        rows = await repo.find_seasons_with_remote_poster(limit=10)
+        assert len(rows) == 1
+        assert rows[0].media_id == str(season_id)
+        assert rows[0].artwork.poster == ImageUrl(_REMOTE)
+
+        await repo.update_season_artwork(
+            season_id, ArtworkColumns(poster=ImageUrl(_LOCAL), backdrop=None, logo=None)
+        )
+
+        assert await repo.find_seasons_with_remote_poster(limit=10) == []
+        reloaded = await repo.find_by_id(series_id)
+        assert reloaded is not None
+        assert reloaded.seasons[0].poster_path == ImageUrl(_LOCAL)
+        # The episode survives a season-poster update untouched.
+        assert len(reloaded.seasons[0].episodes) == 1

--- a/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
+++ b/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
@@ -23,6 +23,7 @@ REMOTE_B = "https://image.tmdb.org/t/p/original/b.jpg"
 LOCAL = "/api/v1/artwork/deadbeef.jpg"
 MOVIE_ID = "mov_abc123def456"
 SERIES_ID = "ser_abc123def456"
+SEASON_ID = "ssn_abc123def456"
 
 
 def _row(media_id: str, *, poster=None, backdrop=None, logo=None) -> RemoteArtworkRow:
@@ -51,8 +52,23 @@ class _FakeMovieRepo(_FakeRepo):
 
 
 class _FakeSeriesRepo(_FakeRepo):
+    def __init__(
+        self,
+        rows: list[RemoteArtworkRow],
+        season_rows: list[RemoteArtworkRow] | None = None,
+    ) -> None:
+        super().__init__(rows)
+        self._season_rows = season_rows or []
+        self.season_updates: list[tuple[str, ArtworkColumns]] = []
+
     async def update_series_artwork(self, series_id, artwork: ArtworkColumns) -> None:
         self.updates.append((str(series_id), artwork))
+
+    async def find_seasons_with_remote_poster(self, limit: int) -> list[RemoteArtworkRow]:
+        return self._season_rows[:limit]
+
+    async def update_season_artwork(self, season_id, artwork: ArtworkColumns) -> None:
+        self.season_updates.append((str(season_id), artwork))
 
 
 @dataclass
@@ -124,12 +140,13 @@ def _make(
     *,
     movie_rows: list[RemoteArtworkRow] | None = None,
     series_rows: list[RemoteArtworkRow] | None = None,
+    season_rows: list[RemoteArtworkRow] | None = None,
     config: ArtworkMirrorConfig | None = None,
     fail_urls: set[str] = frozenset(),
     nonimage_urls: set[str] = frozenset(),
 ) -> _Harness:
     movies = _FakeMovieRepo(list(movie_rows or []))
-    series = _FakeSeriesRepo(list(series_rows or []))
+    series = _FakeSeriesRepo(list(series_rows or []), season_rows=list(season_rows or []))
     uow = _FakeUow(movies=movies, series=series)
     downloader = _FakeDownloader(fail_urls=fail_urls, nonimage_urls=nonimage_urls)
     storage = _FakeStorage()
@@ -200,6 +217,16 @@ class TestRun:
         _, cols = h.series.updates[0]
         assert cols.poster.value.startswith("/api/v1/artwork/")
         assert cols.backdrop.value.startswith("/api/v1/artwork/")
+
+    async def test_should_mirror_season_posters(self) -> None:
+        h = _make(season_rows=[_row(SEASON_ID, poster=REMOTE)])
+
+        await h.job.run()
+
+        assert len(h.series.season_updates) == 1
+        media_id, cols = h.series.season_updates[0]
+        assert media_id == SEASON_ID
+        assert cols.poster.value.startswith("/api/v1/artwork/")
 
     async def test_should_split_budget_between_kinds(self) -> None:
         # batch_size 1 → the single slot goes to the movie; series is not


### PR DESCRIPTION
## Summary

- Extend the artwork mirror to **season posters**: `SeriesRepository.find_seasons_with_remote_poster` + `update_season_artwork` (direct column update on the `seasons` table — no aggregate round-trip, episodes untouched).
- `ArtworkMirrorJob` registers a `seasons` `_Kind` next to movies and series; seasons carry only a poster, which fits the `ArtworkColumns` carrier (backdrop/logo stay `None`).
- Guide's delivered-scope list updated (season poster now ✅).

Follow-ups still deferred: episode stills, localized art, cast photos.

## Test plan

- [x] Unit: job mirrors season posters via the new `_Kind`
- [x] Integration: `find_seasons_with_remote_poster` + `update_season_artwork` (poster swapped, episode survives)
- [x] `ruff check` + `ruff format --check` + domain-exceptions gate clean; `mkdocs build --strict` passes

## Summary by Sourcery

Support mirroring of season poster artwork by introducing season-aware repository methods, wiring seasons into the artwork mirror job, and updating tests and documentation accordingly.

New Features:
- Mirror season poster artwork alongside movies and series via the ArtworkMirrorJob.
- Expose repository operations to find seasons with remote posters and update their mirrored poster artwork.

Enhancements:
- Extend the series repository interface and SQLAlchemy implementation to handle season-level poster artwork without affecting episodes.

Documentation:
- Update the artwork mirroring guide to mark season posters as supported and clarify their mirroring behavior.

Tests:
- Add integration tests for finding and updating season posters in the series repository.
- Add unit tests for mirroring season posters through the artwork mirror job.