### PR TITLE
feat(media): mirror episode stills (ADR-029 PR 3c)

### DIFF
--- a/docs/standards/artwork-mirroring-guide.md
+++ b/docs/standards/artwork-mirroring-guide.md
@@ -39,8 +39,10 @@ tick seguinte — a URL remota autoritativa nunca é descartada.
   **Series** (`ArtworkColumns`).
 - ✅ **Poster de Season** — mirrorado por coluna direta (`seasons.poster_path`),
   sem round-trip do agregado.
-- ⏳ Stills de episódio, artes localizadas por locale e fotos de elenco:
-  **planejados** (follow-ups do ADR-029 §5), ainda não implementados.
+- ✅ **Still de episódio** (`episodes.thumbnail_path`) — mesma via de coluna
+  direta; viaja no campo `still` do `ArtworkColumns`.
+- ⏳ Artes localizadas por locale e fotos de elenco: **planejados**
+  (follow-ups do ADR-029 §5), ainda não implementados.
 
 ---
 

--- a/src/infrastructure/scheduling/artwork_mirror_job.py
+++ b/src/infrastructure/scheduling/artwork_mirror_job.py
@@ -27,7 +27,7 @@ from src.modules.media.domain.value_objects.artwork_key import (
     SUPPORTED_ARTWORK_CONTENT_TYPES,
 )
 from src.shared_kernel.value_objects.image_url import ImageUrl
-from src.shared_kernel.value_objects.media_id import MovieId, SeasonId, SeriesId
+from src.shared_kernel.value_objects.media_id import EpisodeId, MovieId, SeasonId, SeriesId
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Sequence
@@ -105,6 +105,13 @@ class ArtworkMirrorJob:
                 find=lambda uow, limit: uow.series.find_seasons_with_remote_poster(limit),
                 update=lambda uow, media_id, cols: uow.series.update_season_artwork(
                     SeasonId(media_id), cols
+                ),
+            ),
+            _Kind(
+                label="episodes",
+                find=lambda uow, limit: uow.series.find_episodes_with_remote_thumbnail(limit),
+                update=lambda uow, media_id, cols: uow.series.update_episode_thumbnail(
+                    EpisodeId(media_id), cols
                 ),
             ),
         )
@@ -187,10 +194,11 @@ class ArtworkMirrorJob:
         poster, hp, mp = await self._mirror_field(row.artwork.poster, max_bytes)
         backdrop, hb, mb = await self._mirror_field(row.artwork.backdrop, max_bytes)
         logo, hl, ml = await self._mirror_field(row.artwork.logo, max_bytes)
+        still, hs, ms = await self._mirror_field(row.artwork.still, max_bytes)
         return (
-            ArtworkColumns(poster=poster, backdrop=backdrop, logo=logo),
-            hp + hb + hl,
-            mp + mb + ml,
+            ArtworkColumns(poster=poster, backdrop=backdrop, logo=logo, still=still),
+            hp + hb + hl + hs,
+            mp + mb + ml + ms,
         )
 
     async def _mirror_field(

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -477,6 +477,28 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
+    async def find_episodes_with_remote_thumbnail(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` episodes whose still is still a remote URL.
+
+        ``RemoteArtworkRow.media_id`` is the episode external id
+        (``epi_xxx``) and only ``artwork.still`` is populated — the
+        episode still is its single mirrorable image. Soft-deleted
+        episodes are excluded.
+        """
+        ...
+
+    @abstractmethod
+    async def update_episode_thumbnail(
+        self, episode_id: EpisodeId, artwork: ArtworkColumns
+    ) -> None:
+        """Set a single episode's still (``thumbnail_path``) by external id.
+
+        Direct column update on the ``episodes`` table — no aggregate
+        round-trip. Only ``artwork.still`` is written.
+        """
+        ...
+
+    @abstractmethod
     async def find_seasons_pending_intro_detection(
         self,
         limit: int,

--- a/src/modules/media/domain/value_objects/artwork_columns.py
+++ b/src/modules/media/domain/value_objects/artwork_columns.py
@@ -1,10 +1,14 @@
-"""The trio of top-level artwork references for a title (ADR-029).
+"""The mirrorable artwork references of a title (ADR-029).
 
-Poster / backdrop / logo travel together everywhere the mirror flows —
-the repository projection, the job's per-field result, and the update
-signature. Bundling them into one value object replaces a three-argument
-data clump (and a stringly-keyed ``dict``) with a single typed value,
-and gives later phases (season posters, stills) one place to grow.
+The image references a title exposes travel together everywhere the
+mirror flows — the repository projection, the job's per-field result,
+and the update signature. Bundling them into one value object replaces a
+data clump (and a stringly-keyed ``dict``) with a single typed value.
+
+Each kind populates the subset that applies to it: movies and series set
+``poster`` / ``backdrop`` / ``logo``; a season sets ``poster``; an
+episode sets ``still``. Unused references stay ``None`` and the mirror
+skips them.
 
 Each reference is an :class:`ImageUrl` — dual-mode, so it carries either
 a remote provider URL or a local ``/api/v1/artwork/...`` path — which
@@ -20,9 +24,10 @@ class ArtworkColumns(CompoundValueObject):
     """Poster / backdrop / logo references for one title.
 
     Attributes:
-        poster: Poster reference, or ``None``.
-        backdrop: Backdrop reference, or ``None``.
-        logo: Title-logo reference, or ``None``.
+        poster: Poster reference (movie / series / season), or ``None``.
+        backdrop: Backdrop reference (movie / series), or ``None``.
+        logo: Title-logo reference (movie / series), or ``None``.
+        still: Episode still reference, or ``None``.
 
     Example:
         >>> cols = ArtworkColumns(poster=ImageUrl("/api/v1/artwork/ab.jpg"))
@@ -33,6 +38,7 @@ class ArtworkColumns(CompoundValueObject):
     poster: ImageUrl | None = None
     backdrop: ImageUrl | None = None
     logo: ImageUrl | None = None
+    still: ImageUrl | None = None
 
 
 __all__ = ["ArtworkColumns"]

--- a/src/modules/media/infrastructure/persistence/repositories/_artwork_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_artwork_helpers.py
@@ -23,6 +23,11 @@ def to_artwork_columns(
     )
 
 
+def to_still_columns(thumbnail: str | None) -> ArtworkColumns:
+    """Wrap a raw episode-still string into an ``ArtworkColumns`` (``still`` set)."""
+    return ArtworkColumns(still=ImageUrl(thumbnail) if thumbnail else None)
+
+
 def artwork_column_values(artwork: ArtworkColumns) -> dict[str, str | None]:
     """Unwrap an ``ArtworkColumns`` into a ``{column: value}`` update map."""
     return {
@@ -32,4 +37,4 @@ def artwork_column_values(artwork: ArtworkColumns) -> dict[str, str | None]:
     }
 
 
-__all__ = ["artwork_column_values", "to_artwork_columns"]
+__all__ = ["artwork_column_values", "to_artwork_columns", "to_still_columns"]

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -48,6 +48,7 @@ from src.modules.media.infrastructure.persistence.models import (
 from src.modules.media.infrastructure.persistence.repositories._artwork_helpers import (
     artwork_column_values,
     to_artwork_columns,
+    to_still_columns,
 )
 from src.modules.media.infrastructure.persistence.repositories._genre_helpers import (
     fetch_genre_paginated_page,
@@ -774,6 +775,36 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             update(SeasonModel)
             .where(SeasonModel.external_id == season_id.value)
             .values(poster_path=artwork.poster.value if artwork.poster else None)
+        )
+
+    async def find_episodes_with_remote_thumbnail(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` episodes whose still is still a remote URL."""
+        stmt = (
+            select(EpisodeModel.external_id, EpisodeModel.thumbnail_path)
+            .where(
+                EpisodeModel.deleted_at.is_(None),
+                EpisodeModel.thumbnail_path.like("http%"),
+            )
+            .order_by(EpisodeModel.id.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [
+            RemoteArtworkRow(
+                media_id=row.external_id,
+                artwork=to_still_columns(row.thumbnail_path),
+            )
+            for row in result.all()
+        ]
+
+    async def update_episode_thumbnail(
+        self, episode_id: EpisodeId, artwork: ArtworkColumns
+    ) -> None:
+        """Set a single episode's ``thumbnail_path`` by external id."""
+        await self._session.execute(
+            update(EpisodeModel)
+            .where(EpisodeModel.external_id == episode_id.value)
+            .values(thumbnail_path=artwork.still.value if artwork.still else None)
         )
 
     async def find_seasons_pending_intro_detection(

--- a/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
+++ b/tests/modules/media/integration/persistence/repositories/test_artwork_finders.py
@@ -241,3 +241,60 @@ class TestSeasonArtwork:
         assert reloaded.seasons[0].poster_path == ImageUrl(_LOCAL)
         # The episode survives a season-poster update untouched.
         assert len(reloaded.seasons[0].episodes) == 1
+
+
+def _series_with_episode_thumbnail(thumb: str) -> tuple[Series, EpisodeId, SeriesId]:
+    sid = SeriesId.generate()
+    episode_id = EpisodeId.generate()
+    episode = Episode(
+        id=episode_id,
+        series_id=sid,
+        season_number=1,
+        episode_number=1,
+        title=Title("E1"),
+        duration=Duration(2700),
+        thumbnail_path=ImageUrl(thumb),
+        files=[
+            MediaFile(
+                file_path=FilePath("/series/s01e01.mkv"),
+                file_size=500_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            )
+        ],
+    )
+    season = Season(
+        id=SeasonId.generate(),
+        series_id=sid,
+        season_number=1,
+        title=Title("Season 1"),
+        episodes=[episode],
+    )
+    series = Series(
+        library_id="lib_test12345678",
+        id=sid,
+        title=Title("With Episode"),
+        start_year=Year(2020),
+        seasons=[season],
+    )
+    return series, episode_id, sid
+
+
+@pytest.mark.integration
+class TestEpisodeArtwork:
+    async def test_should_find_and_update_episode_thumbnail(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        series, episode_id, series_id = _series_with_episode_thumbnail(_REMOTE)
+        await repo.save(series)
+
+        rows = await repo.find_episodes_with_remote_thumbnail(limit=10)
+        assert len(rows) == 1
+        assert rows[0].media_id == str(episode_id)
+        assert rows[0].artwork.still == ImageUrl(_REMOTE)
+
+        await repo.update_episode_thumbnail(episode_id, ArtworkColumns(still=ImageUrl(_LOCAL)))
+
+        assert await repo.find_episodes_with_remote_thumbnail(limit=10) == []
+        reloaded = await repo.find_by_id(series_id)
+        assert reloaded is not None
+        assert reloaded.seasons[0].episodes[0].thumbnail_path == ImageUrl(_LOCAL)

--- a/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
+++ b/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
@@ -24,15 +24,17 @@ LOCAL = "/api/v1/artwork/deadbeef.jpg"
 MOVIE_ID = "mov_abc123def456"
 SERIES_ID = "ser_abc123def456"
 SEASON_ID = "ssn_abc123def456"
+EPISODE_ID = "epi_abc123def456"
 
 
-def _row(media_id: str, *, poster=None, backdrop=None, logo=None) -> RemoteArtworkRow:
+def _row(media_id: str, *, poster=None, backdrop=None, logo=None, still=None) -> RemoteArtworkRow:
     return RemoteArtworkRow(
         media_id=media_id,
         artwork=ArtworkColumns(
             poster=ImageUrl(poster) if poster else None,
             backdrop=ImageUrl(backdrop) if backdrop else None,
             logo=ImageUrl(logo) if logo else None,
+            still=ImageUrl(still) if still else None,
         ),
     )
 
@@ -56,10 +58,13 @@ class _FakeSeriesRepo(_FakeRepo):
         self,
         rows: list[RemoteArtworkRow],
         season_rows: list[RemoteArtworkRow] | None = None,
+        episode_rows: list[RemoteArtworkRow] | None = None,
     ) -> None:
         super().__init__(rows)
         self._season_rows = season_rows or []
+        self._episode_rows = episode_rows or []
         self.season_updates: list[tuple[str, ArtworkColumns]] = []
+        self.episode_updates: list[tuple[str, ArtworkColumns]] = []
 
     async def update_series_artwork(self, series_id, artwork: ArtworkColumns) -> None:
         self.updates.append((str(series_id), artwork))
@@ -69,6 +74,12 @@ class _FakeSeriesRepo(_FakeRepo):
 
     async def update_season_artwork(self, season_id, artwork: ArtworkColumns) -> None:
         self.season_updates.append((str(season_id), artwork))
+
+    async def find_episodes_with_remote_thumbnail(self, limit: int) -> list[RemoteArtworkRow]:
+        return self._episode_rows[:limit]
+
+    async def update_episode_thumbnail(self, episode_id, artwork: ArtworkColumns) -> None:
+        self.episode_updates.append((str(episode_id), artwork))
 
 
 @dataclass
@@ -141,12 +152,17 @@ def _make(
     movie_rows: list[RemoteArtworkRow] | None = None,
     series_rows: list[RemoteArtworkRow] | None = None,
     season_rows: list[RemoteArtworkRow] | None = None,
+    episode_rows: list[RemoteArtworkRow] | None = None,
     config: ArtworkMirrorConfig | None = None,
     fail_urls: set[str] = frozenset(),
     nonimage_urls: set[str] = frozenset(),
 ) -> _Harness:
     movies = _FakeMovieRepo(list(movie_rows or []))
-    series = _FakeSeriesRepo(list(series_rows or []), season_rows=list(season_rows or []))
+    series = _FakeSeriesRepo(
+        list(series_rows or []),
+        season_rows=list(season_rows or []),
+        episode_rows=list(episode_rows or []),
+    )
     uow = _FakeUow(movies=movies, series=series)
     downloader = _FakeDownloader(fail_urls=fail_urls, nonimage_urls=nonimage_urls)
     storage = _FakeStorage()
@@ -227,6 +243,16 @@ class TestRun:
         media_id, cols = h.series.season_updates[0]
         assert media_id == SEASON_ID
         assert cols.poster.value.startswith("/api/v1/artwork/")
+
+    async def test_should_mirror_episode_stills(self) -> None:
+        h = _make(episode_rows=[_row(EPISODE_ID, still=REMOTE)])
+
+        await h.job.run()
+
+        assert len(h.series.episode_updates) == 1
+        media_id, cols = h.series.episode_updates[0]
+        assert media_id == EPISODE_ID
+        assert cols.still.value.startswith("/api/v1/artwork/")
 
     async def test_should_split_budget_between_kinds(self) -> None:
         # batch_size 1 → the single slot goes to the movie; series is not


### PR DESCRIPTION
## Summary

- Extend the artwork mirror to **episode stills** (`episodes.thumbnail_path`): `SeriesRepository.find_episodes_with_remote_thumbnail` + `update_episode_thumbnail` (direct column update, soft-deleted rows excluded).
- Give `ArtworkColumns` a `still` reference — an episode carries a still, not a poster/backdrop/logo — so each kind populates the subset that applies (movies/series: poster/backdrop/logo; season: poster; episode: still).
- `ArtworkMirrorJob` registers an `episodes` `_Kind`; the still travels in `ArtworkColumns.still`.
- Guide's delivered-scope list updated.

Remaining follow-ups: localized art and cast photos (both live in JSON blobs, not columns — a different mirroring flow).

## Test plan

- [x] Unit: job mirrors episode stills via the new `_Kind` / `still` field
- [x] Integration: `find_episodes_with_remote_thumbnail` + `update_episode_thumbnail`
- [x] `ruff check` + `format --check` + domain-exceptions gate clean; `mkdocs build --strict` passes

## Summary by Sourcery

Extend the artwork mirroring pipeline to support episode stills and ensure they are mirrored from remote URLs into local artwork paths.

New Features:
- Add episode-level artwork mirroring using the `still` reference, flowing through repositories, the artwork mirror job, and value objects.

Enhancements:
- Expand `ArtworkColumns` to include a `still` field so different media kinds can populate only their applicable artwork references.
- Update series repository helpers and abstractions to handle episode stills as mirrorable artwork, including projection helpers for still-only rows.

Documentation:
- Update the artwork mirroring guide to document episode still mirroring and distinguish it from planned localized art and cast photos.

Tests:
- Add integration coverage for finding and updating episode thumbnails via the series repository.
- Extend artwork mirror job unit tests to cover mirroring of episode stills and tracking episode artwork updates.