### PR TITLE
feat(settings): add admin PATCH route for artwork-mirror bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Key entry points:
 streaming server with profile ACLs, automatic intro detection,
 trickplay scrub thumbnails, and a scheduled scan/enrichment pipeline.
 
-- 138 REST API endpoints across 9 bounded contexts
+- 139 REST API endpoints across 9 bounded contexts
 - 3,200+ tests
 - Responsive React frontend with HLS player and per-profile UI
 

--- a/docs/standards/artwork-mirroring-guide.md
+++ b/docs/standards/artwork-mirroring-guide.md
@@ -201,11 +201,9 @@ Runtime setting persistido em banco, por bucket (ADR-013/014). Definido em
 | `max_bytes` | `10485760` (10 MiB) | Teto de uma imagem baixada. Maiores são puladas (mantêm URL remota). |
 
 O bucket aparece no agregado `GET /api/v1/admin/settings` (junto dos demais
-buckets, com `source='default'` se nunca foi editado).
-
-<!-- TODO(docs): não há endpoint PATCH dedicado (`/admin/settings/artwork-mirror`)
-     como o de subtitle-ocr; hoje o bucket só é editável via app_settings
-     no banco. Documentar aqui quando/se a rota de edição for adicionada. -->
+buckets, com `source='default'` se nunca foi editado) e é editável por
+`PATCH /api/v1/admin/settings/artwork-mirror` (full-replace, body = o
+`ArtworkMirrorConfig`; admin-only), no mesmo padrão dos outros buckets.
 
 > `batch_size` e `max_bytes` são lidos **por tick** (edição vale no próximo
 > run). `enabled` e `interval_minutes` são lidos **no boot** ao registrar o

--- a/src/modules/settings/presentation/routes/admin_settings_routes.py
+++ b/src/modules/settings/presentation/routes/admin_settings_routes.py
@@ -22,6 +22,7 @@ from src.modules.settings.application.use_cases import (
     UpdateSettingUseCase,
 )
 from src.modules.settings.domain.value_objects import (
+    ArtworkMirrorConfig,
     AvatarConfig,
     CreditsDetectionConfig,
     IntroDetectionConfig,
@@ -207,6 +208,26 @@ async def update_subtitle_ocr_settings(
     detail = await use_case.execute(
         UpdateSettingInput(
             key=SettingKey.SUBTITLE_OCR.value,
+            value=body.model_dump(mode="json"),
+            acting_admin_id=admin.external_id,
+        ),
+    )
+    return api_single("setting", asdict(detail))
+
+
+@router.patch("/artwork-mirror")
+@inject
+async def update_artwork_mirror_settings(
+    body: ArtworkMirrorConfig,
+    admin: AuthenticatedUser = Depends(authenticated_admin),
+    use_case: UpdateSettingUseCase = Depends(
+        Provide[ApplicationContainer.settings.update_setting],
+    ),
+) -> dict[str, Any]:
+    """Replace the persisted :class:`ArtworkMirrorConfig`."""
+    detail = await use_case.execute(
+        UpdateSettingInput(
+            key=SettingKey.ARTWORK_MIRROR.value,
             value=body.model_dump(mode="json"),
             acting_admin_id=admin.external_id,
         ),

--- a/tests/modules/settings/e2e/test_admin_settings_routes.py
+++ b/tests/modules/settings/e2e/test_admin_settings_routes.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import AsyncClient
 
 from src.modules.settings.domain.value_objects import (
+    ArtworkMirrorConfig,
     IntroDetectionConfig,
     ScanDedupConfig,
     SchedulerConfig,
@@ -252,3 +253,39 @@ class TestAdminSettingsPatch:
         assert payload["value"]["enabled"] is True
         assert payload["value"]["batch_size"] == 3
         assert payload["value"]["languages"] == ["en", "pt"]
+
+    async def test_artwork_mirror_full_replace_persists(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        admin = await _login_as_admin(client, seed_user_with_profile)
+
+        body = ArtworkMirrorConfig(
+            enabled=False,
+            batch_size=50,
+            interval_minutes=15,
+        ).model_dump(mode="json")
+        response = await client.patch(f"{SETTINGS_ROOT}/artwork-mirror", json=body)
+
+        assert response.status_code == 200
+        payload = response.json()["data"]
+        assert payload["key"] == "artwork_mirror"
+        assert payload["source"] == "admin"
+        assert payload["updated_by_user_id"] == admin.user_external_id
+        assert payload["value"]["enabled"] is False
+        assert payload["value"]["batch_size"] == 50
+        assert payload["value"]["interval_minutes"] == 15
+
+    async def test_artwork_mirror_rejects_non_positive_batch_size(
+        self,
+        client: AsyncClient,
+        seed_user_with_profile: Callable[..., Awaitable[SeededUser]],
+    ) -> None:
+        await _login_as_admin(client, seed_user_with_profile)
+
+        body = ArtworkMirrorConfig().model_dump(mode="json")
+        body["batch_size"] = 0
+        response = await client.patch(f"{SETTINGS_ROOT}/artwork-mirror", json=body)
+
+        assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Add `PATCH /api/v1/admin/settings/artwork-mirror` (full-replace, admin-only, body = `ArtworkMirrorConfig`) so the `artwork_mirror` settings bucket is editable from the admin UI, mirroring the other buckets. Until now it was only surfaced by the aggregate `GET /admin/settings` and editable via `app_settings` directly.
- Update the artwork-mirroring guide (route now exists) and the README endpoint count (138 → 139).

Unblocks the frontend settings screen for the artwork mirror.

## Test plan

- [x] e2e: full-replace persists (`enabled`/`batch_size`/`interval_minutes`), and a non-positive `batch_size` is rejected (422)
- [x] `ruff check` + `format --check` clean; `mkdocs build --strict` passes; endpoint count recomputed (139)

## Summary by Sourcery

Add an admin-only PATCH endpoint to update the artwork mirror settings bucket and adjust docs and metadata to reflect the new route.

New Features:
- Expose an admin PATCH /api/v1/admin/settings/artwork-mirror endpoint to fully replace the persisted ArtworkMirrorConfig settings bucket.

Enhancements:
- Update the artwork mirroring guide to document the new editable artwork-mirror settings bucket endpoint and its behavior.
- Refresh the README API endpoint count to include the new artwork-mirror admin route.

Tests:
- Add e2e tests covering successful full-replace updates for artwork-mirror settings and validation rejecting non-positive batch_size values.