### PR TITLE
docs(media): make artwork storage location explicit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,12 @@ MEDIA_DIRECTORIES=/path/to/movies,/path/to/series
 # Where to store generated thumbnails
 THUMBNAILS_DIRECTORY=./thumbnails
 
+# Where mirrored catalog artwork is stored (ADR-029). A flat directory
+# of content-addressed <hash>.<ext> image files, served via
+# GET /api/v1/artwork/{key}. Use an absolute path on a persistent volume
+# in production so mirrored images survive redeploys.
+ARTWORK_STORAGE_DIRECTORY=./artwork
+
 # -----------------------------------------------------------------------------
 # HLS streaming cache
 # -----------------------------------------------------------------------------

--- a/docs/standards/artwork-mirroring-guide.md
+++ b/docs/standards/artwork-mirroring-guide.md
@@ -119,6 +119,26 @@ o content-type da extensão da chave na leitura, e confina o path resolvido
 ao diretório raiz (defesa em profundidade contra traversal). I/O de disco
 roda em `asyncio.to_thread` (não bloqueia o event loop).
 
+### Onde os arquivos ficam
+
+Um **store central e content-addressed**, não co-localizado por arquivo de
+mídia (diferente dos scrub-preview sprites, que ficam em `.homeflix/` ao
+lado do vídeo). Concretamente:
+
+- Todas as imagens vão **flat** dentro de um único diretório
+  (`artwork_storage_directory`, default `./artwork`), cada uma nomeada
+  `{sha256-do-conteúdo}.{ext}` (ex.: `010616cc…bd0.jpg`).
+- Content-addressed ⇒ **dedup natural**: o mesmo pôster referenciado por
+  vários títulos ocupa **um** arquivo só. Por isso o store é central (por
+  título, não por arquivo de vídeo), cobrindo uniformemente movie / series
+  / season / episode.
+- A coluna no banco guarda a referência própria `/api/v1/artwork/{key}`; a
+  rota proxy serve lendo desse mesmo diretório.
+
+Em **produção**, aponte o diretório para um **caminho absoluto num volume
+persistente** (ex.: `ARTWORK_STORAGE_DIRECTORY=/data/homeflix/artwork`) —
+assim os arquivos não somem em redeploy e o backup é copiar essa pasta.
+
 ### Configuração de bootstrap
 
 | Setting | Default | Onde |


### PR DESCRIPTION
## Summary

- Add a **"Where the files live"** section to `docs/standards/artwork-mirroring-guide.md`: a central, content-addressed store (`<sha256>.<ext>` flat files under `artwork_storage_directory`, default `./artwork`), **not** co-located per media file (unlike scrub-preview sprites) — this is by design for dedup + uniform coverage across movie/series/season/episode. Notes to use an absolute path on a persistent volume in production.
- Add `ARTWORK_STORAGE_DIRECTORY` to `.env.example` (it was missing, unlike `THUMBNAILS_DIRECTORY` / `HLS_CACHE_DIRECTORY`).

Pairs with the frontend PR that surfaces the same info in the Artwork mirror settings card.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] docs + `.env.example` only, no `src/` changes

## Summary by Sourcery

Document the centralized, content-addressed storage model for mirrored artwork and expose its configuration in environment examples.

Build:
- Add ARTWORK_STORAGE_DIRECTORY to the example environment configuration to document artwork storage setup.

Documentation:
- Clarify where mirrored artwork files are stored, including naming scheme, centralization rationale, and production deployment guidance.