### PR TITLE
fix(media): pad leading audio silence in HLS transcode

### DIFF
--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -116,6 +116,80 @@ def _primary_audio_index(probe: ProbeResult) -> int:
     return probe.audio_tracks[0].index if probe.audio_tracks else 0
 
 
+# A leading audio offset above this many seconds is treated as a gap that
+# must be padded with silence (see ``_first_audio_pts``). The threshold is
+# generous — normal muxing jitter is a few milliseconds, so anything past a
+# quarter-second is a real hole at the head of the track, not noise.
+_AUDIO_LEADING_GAP_THRESHOLD = 0.25
+
+
+def _first_audio_pts(file_path: str, audio_index: int) -> float | None:
+    """Return the PTS (seconds) of the first packet of one audio stream.
+
+    Some source files carry an audio track whose first sample lands well
+    after t=0 (e.g. an 11-second silent hole at the head of the stream).
+    Muxed into HLS from t=0, the leading segments then declare an audio
+    stream that has *no* frames yet, and hls.js — which needs the audio
+    codec from the first fragment — stalls forever on that phantom track
+    instead of ever appending a buffer. Detecting the offset lets the
+    caller pad it with silence and keep the copy fast-path off files that
+    would otherwise ship an empty-audio first segment.
+
+    Args:
+        file_path: Absolute path to the source video file.
+        audio_index: Stream index *within the audio streams* (the ``N`` in
+            ffmpeg's ``0:a:N``), matching how the transcode maps it.
+
+    Returns:
+        The first packet's presentation timestamp in seconds, or ``None``
+        if ffprobe fails or reports no readable timestamp (caller then
+        assumes no gap).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                f"a:{audio_index}",
+                "-read_intervals",
+                "%+#1",
+                "-show_entries",
+                "packet=pts_time",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                file_path,
+            ],
+            **SUBPROCESS_TEXT_KWARGS,
+            check=False,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    raw = result.stdout.strip().splitlines()
+    if not raw:
+        return None
+    try:
+        return float(raw[0])
+    except ValueError:
+        return None
+
+
+def _has_leading_audio_gap(file_path: str, audio_index: int, start: int) -> bool:
+    """Whether a mapped audio stream begins meaningfully after t=0.
+
+    Only meaningful for the initial (``start == 0``) bucket — a seek
+    bucket lands mid-stream where audio already exists and normalises its
+    own timestamps, so we skip the probe there and never treat it as a
+    gap. See :func:`_first_audio_pts` for why the gap matters.
+    """
+    if start != 0:
+        return False
+    pts = _first_audio_pts(file_path, audio_index)
+    return pts is not None and pts > _AUDIO_LEADING_GAP_THRESHOLD
+
+
 def _manifest_track_name(language: str, version: TrackVersion | None) -> str:
     """Compose a fallback ``NAME=`` for a manifest rendition.
 
@@ -129,7 +203,11 @@ def _manifest_track_name(language: str, version: TrackVersion | None) -> str:
     return f"{base} · {token}" if token else base
 
 
-def _audio_args_for(track: AudioTrack | None, start: int) -> list[str]:
+def _audio_args_for(
+    track: AudioTrack | None,
+    start: int,
+    leading_gap: bool = False,
+) -> list[str]:
     """Pick the ffmpeg audio args for one HLS track: copy or re-encode.
 
     Re-encoding every audio track to AAC stereo 48 kHz is wasted work
@@ -146,20 +224,38 @@ def _audio_args_for(track: AudioTrack | None, start: int) -> list[str]:
     - **start == 0** — a non-zero resume offset re-encodes the video with
       ``-accurate_seek``; copying the audio there would land it at the
       nearest packet instead of the exact second and drift out of sync.
+    - **no leading gap** — a track whose first sample lands after t=0
+      (``leading_gap``) must be re-encoded so the silence filter below
+      can backfill the hole; copying would preserve it and ship an
+      empty-audio first segment that stalls hls.js.
 
     Anything else (unknown profile/rate, non-AAC, surround, mid-stream
-    seek) falls back to the safe AAC re-encode.
+    seek, leading gap) falls back to the safe AAC re-encode.
+
+    On the re-encode path for an initial (``start == 0``) bucket we add
+    ``aresample=async=1:first_pts=0``. It pads any leading offset with
+    silence so the audio starts at t=0 and the first HLS segment carries
+    decodable frames — without it, a file whose audio begins late (a real
+    silent intro) yields a first segment with a declared-but-empty audio
+    stream, and hls.js hangs on "preparing" forever. It is a no-op for a
+    track that already starts at zero. The seek path (``start > 0``)
+    already normalises timestamps via ``-avoid_negative_ts make_zero`` and
+    is left untouched.
     """
     if (
         track is not None
         and start == 0
+        and not leading_gap
         and track.codec == "aac"
         and track.is_stereo
         and track.sample_rate == 48000
         and (track.profile or "").strip().upper() == "LC"
     ):
         return ["-c:a", "copy"]
-    return ["-c:a", "aac", "-ac", "2", "-ar", "48000"]
+    args = ["-c:a", "aac", "-ac", "2", "-ar", "48000"]
+    if start == 0:
+        args += ["-af", "aresample=async=1:first_pts=0"]
+    return args
 
 
 class HlsService(HlsPlaylistPort):
@@ -1142,7 +1238,8 @@ class HlsService(HlsPlaylistPort):
         primary_idx = _primary_audio_index(probe)
         audio_map = f"0:a:{primary_idx}"
         primary_track = probe.audio_tracks[0] if probe.audio_tracks else None
-        audio_args = _audio_args_for(primary_track, start)
+        leading_gap = _has_leading_audio_gap(file_path, primary_idx, start)
+        audio_args = _audio_args_for(primary_track, start, leading_gap)
 
         seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
         ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
@@ -1211,6 +1308,7 @@ class HlsService(HlsPlaylistPort):
         """
         seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
         ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
+        leading_gap = _has_leading_audio_gap(file_path, track.index, start)
         return [
             "ffmpeg",
             *seek_args,
@@ -1220,7 +1318,7 @@ class HlsService(HlsPlaylistPort):
             f"0:a:{track.index}",
             "-vn",
             "-sn",
-            *_audio_args_for(track, start),
+            *_audio_args_for(track, start, leading_gap),
             *ts_normalize_args,
             # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
             # segment PTS starts at ~0, keeping the video / audio / subtitle

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -376,6 +376,17 @@ class TestHlsServiceGetCachedTracks:
 class TestHlsServiceBuildAudioCmd:
     """Tests for _build_audio_cmd."""
 
+    @pytest.fixture(autouse=True)
+    def _no_leading_gap_probe(self):  # type: ignore[no-untyped-def]
+        # Keep the command-building tests hermetic: without this, every
+        # start==0 build shells out to a real ffprobe on the fake path.
+        # Default to "no gap"; the gap-specific tests patch it themselves.
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            return_value=None,
+        ):
+            yield
+
     def test_should_include_input_file(self, tmp_path: Path) -> None:
         cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
 
@@ -558,6 +569,16 @@ class TestLeadingAudioGap:
         ):
             assert _first_audio_pts("/movies/test.mkv", 0) is None
 
+    def test_first_pts_returns_none_on_non_numeric_output(self) -> None:
+        # ffprobe emits "N/A" for pts_time on some containers; the parse
+        # must degrade to None (no gap) instead of raising ValueError.
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="N/A\n")
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service.subprocess.run",
+            return_value=completed,
+        ):
+            assert _first_audio_pts("/movies/test.mkv", 0) is None
+
     def test_gap_detected_above_threshold(self) -> None:
         with patch(
             "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
@@ -584,6 +605,16 @@ class TestLeadingAudioGap:
 @pytest.mark.unit
 class TestHlsServiceBuildVideoCmd:
     """Tests for _build_video_cmd with mocked codec probe."""
+
+    @pytest.fixture(autouse=True)
+    def _no_leading_gap_probe(self):  # type: ignore[no-untyped-def]
+        # Keep these hermetic — otherwise each start==0 build spawns a
+        # real ffprobe on the fake path. The gap test patches it itself.
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            return_value=None,
+        ):
+            yield
 
     def test_should_copy_video_for_h264(self, tmp_path: Path) -> None:
         service = HlsService(

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -14,8 +14,11 @@ from src.modules.media.infrastructure.streaming.hls_service import (
     HlsService,
     _append_endlist_atomic,
     _atomic_write_text,
+    _audio_args_for,
     _ensure_vtt_timestamp_map,
+    _first_audio_pts,
     _has_endlist,
+    _has_leading_audio_gap,
     _primary_audio_index,
     _shift_webvtt_to_bucket_local,
 )
@@ -483,6 +486,100 @@ class TestHlsServiceBuildAudioCmd:
         assert "copy" not in cmd
         assert cmd[cmd.index("-c:a") + 1] == "aac"
 
+    def test_should_reencode_alt_track_with_leading_gap(self, tmp_path: Path) -> None:
+        # An alternate audio track whose first sample lands after t=0 is
+        # re-encoded (not copied) so the silence pad can backfill the hole
+        # even though it is otherwise copy-eligible AAC-LC stereo 48k.
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            return_value=11.0,
+        ):
+            cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _aac_lc_stereo_48k())
+
+        assert "copy" not in cmd
+        assert cmd[cmd.index("-c:a") + 1] == "aac"
+        assert cmd[cmd.index("-af") + 1] == "aresample=async=1:first_pts=0"
+
+
+@pytest.mark.unit
+class TestAudioArgsFor:
+    """Tests for the _audio_args_for copy/re-encode + silence-pad decision."""
+
+    def test_should_copy_when_browser_ready_and_no_gap(self) -> None:
+        assert _audio_args_for(_aac_lc_stereo_48k(), start=0) == ["-c:a", "copy"]
+
+    def test_should_reencode_and_pad_silence_at_start_zero(self) -> None:
+        # The re-encode path for the initial bucket aligns audio to t=0 so
+        # a late-starting track still fills the first HLS segment.
+        args = _audio_args_for(_make_audio_track(codec="ac3"), start=0)
+
+        assert args[:2] == ["-c:a", "aac"]
+        assert args[args.index("-af") + 1] == "aresample=async=1:first_pts=0"
+
+    def test_should_skip_copy_when_leading_gap(self) -> None:
+        # Copy-eligible audio still re-encodes when it opens after t=0.
+        args = _audio_args_for(_aac_lc_stereo_48k(), start=0, leading_gap=True)
+
+        assert "copy" not in args
+        assert "-af" in args
+
+    def test_should_not_pad_silence_when_seeking(self) -> None:
+        # The seek path (start > 0) normalises timestamps itself; the
+        # leading-silence filter is left off to avoid touching it.
+        args = _audio_args_for(_make_audio_track(codec="ac3"), start=1800)
+
+        assert "-af" not in args
+
+
+@pytest.mark.unit
+class TestLeadingAudioGap:
+    """Tests for _first_audio_pts and _has_leading_audio_gap."""
+
+    def test_first_pts_parses_ffprobe_output(self) -> None:
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="11.000000\n")
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service.subprocess.run",
+            return_value=completed,
+        ):
+            assert _first_audio_pts("/movies/test.mkv", 0) == pytest.approx(11.0)
+
+    def test_first_pts_returns_none_on_empty_output(self) -> None:
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service.subprocess.run",
+            return_value=completed,
+        ):
+            assert _first_audio_pts("/movies/test.mkv", 0) is None
+
+    def test_first_pts_returns_none_when_ffprobe_missing(self) -> None:
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            assert _first_audio_pts("/movies/test.mkv", 0) is None
+
+    def test_gap_detected_above_threshold(self) -> None:
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            return_value=11.0,
+        ):
+            assert _has_leading_audio_gap("/movies/test.mkv", 0, start=0) is True
+
+    def test_no_gap_within_threshold(self) -> None:
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            return_value=0.02,
+        ):
+            assert _has_leading_audio_gap("/movies/test.mkv", 0, start=0) is False
+
+    def test_no_gap_probe_skipped_when_seeking(self) -> None:
+        # A seek bucket lands mid-stream; never probe or treat it as a gap.
+        with patch(
+            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+        ) as probe:
+            assert _has_leading_audio_gap("/movies/test.mkv", 0, start=1800) is False
+            probe.assert_not_called()
+
 
 @pytest.mark.unit
 class TestHlsServiceBuildVideoCmd:
@@ -557,6 +654,28 @@ class TestHlsServiceBuildVideoCmd:
 
         assert cmd[cmd.index("-c:a") + 1] == "copy"
         assert "libx264" in cmd  # video still re-encoded
+
+    def test_should_reencode_primary_audio_with_leading_gap(self, tmp_path: Path) -> None:
+        # A copy-eligible primary audio track that opens after t=0 is
+        # re-encoded with the silence pad so the first segment carries
+        # decodable audio instead of a phantom empty stream that hangs
+        # hls.js on "preparing" forever.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "cache")
+        )
+        probe = ProbeResult(audio_tracks=[_aac_lc_stereo_48k()])
+
+        with (
+            patch.object(HlsService, "_probe_video_codec", return_value="h264"),
+            patch(
+                "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+                return_value=11.0,
+            ),
+        ):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert cmd[cmd.index("-c:a") + 1] == "aac"
+        assert cmd[cmd.index("-af") + 1] == "aresample=async=1:first_pts=0"
 
     def test_should_use_nvenc_when_available(self, tmp_path: Path) -> None:
         # AUTO + a passing functional probe → full-GPU NVENC pipeline.


### PR DESCRIPTION
## Summary

- Fix HLS playback hang ("Preparando vídeo...") for movies whose **default audio track begins after t=0** (a silent gap at the head of the stream). Example: `Suzume (2022).mkv` — the PT-BR audio's first packet is at PTS 11s.
- Such a track, muxed into HLS from t=0, produced a first segment with a **declared-but-empty audio stream** (0 channels / 0 Hz). hls.js 1.6.15 needs the audio codec from the first fragment, so it stalled indefinitely without ever appending a buffer.
- Fix: on the initial (`start == 0`) bucket, re-encode audio with `-af aresample=async=1:first_pts=0` to backfill the leading gap with silence, and detect the offset (`_first_audio_pts` / `_has_leading_audio_gap`) to skip the `-c:a copy` fast path when a copied track would otherwise preserve the hole.
- Fixes the whole bug class, not just Suzume: any title whose default audio opens late was affected.

## Test plan

- [x] `pytest tests/modules/media/unit/infrastructure/streaming/test_hls_service.py` — 149 passed
- [x] `ruff check` + `ruff format` clean
- [x] End-to-end: cleared Suzume HLS cache, regenerated via the server — fresh `segment_0000.ts` now carries valid audio (`aac, 48000, 2`, first packet ~0s), and the movie plays in-browser (readyState 4, 1920×802, buffering ahead).
- [ ] Manual smoke test by reviewer (play Suzume + one normal multi-audio title to confirm no regression on the copy fast-path)

## Summary by Sourcery

Handle HLS audio tracks that start after t=0 by detecting leading gaps and re-encoding initial segments to pad silence, preventing playback hangs for affected titles.

Bug Fixes:
- Fix HLS playback hangs caused by initial segments declaring but not carrying decodable audio when the default track begins significantly after t=0.

Enhancements:
- Introduce audio gap probing and configurable threshold to decide when an audio track must be re-encoded instead of copied for HLS.
- Centralize ffmpeg audio argument selection in a helper that accounts for start time and leading audio gaps.
- Ensure initial HLS audio buckets are padded with silence via resampling when re-encoded so their first segment always carries valid audio frames.

Tests:
- Add unit tests for audio argument selection, leading-gap detection, and ffprobe-based first-PTS probing, including edge cases and hermetic fixtures in command-building tests.