### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "homeflix"
-version = "0.3.0"
+version = "0.4.0"
 description = "Personal streaming platform for local media"
 authors = ["Lucas"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump project version 0.3.0 → 0.4.0 for the **Artwork Mirroring & HLS audio fix** release.

## Test plan

- [x] Version bump only; CI (lint/test/type/docs) must stay green.