### PR TITLE
fix(app): source app version from package metadata

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 from fastapi import FastAPI, Request
@@ -61,6 +62,26 @@ from src.modules.preferences.presentation.routes.preferences_routes import (
 )
 from src.modules.settings.presentation.routes import admin_settings_router
 from src.modules.watch_progress.presentation.routes import progress_router
+
+
+def _resolve_version() -> str:
+    """Resolve the app version from installed package metadata.
+
+    Single source of truth is ``pyproject.toml`` (``tool.poetry.version``),
+    exposed at runtime via the installed distribution's metadata so the
+    OpenAPI schema and health endpoints never drift from the released
+    version. Falls back to ``"0.0.0"`` when the package isn't installed
+    as a distribution (e.g. some ad-hoc script runs), which is a clearer
+    signal than a stale hardcoded number.
+    """
+    try:
+        return version("homeflix")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+#: Application version, sourced from package metadata (see ``pyproject.toml``).
+APP_VERSION = _resolve_version()
 
 #: Module paths whose ``@inject``-decorated callables are wired to the
 #: dependency-injector container. Extracted as a module constant so e2e
@@ -441,7 +462,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title=settings.app_name,
         description="Personal streaming platform for local media",
-        version="0.1.0",
+        version=APP_VERSION,
         docs_url="/docs" if settings.debug else None,
         redoc_url="/redoc" if settings.debug else None,
         lifespan=lifespan,
@@ -525,7 +546,7 @@ def register_health_routes(app: FastAPI) -> None:
         return {
             "status": "healthy",
             "timestamp": datetime.now(UTC).isoformat(),
-            "version": "0.1.0",
+            "version": APP_VERSION,
         }
 
     @app.get("/health/ready", tags=["Health"])  # type: ignore[misc]
@@ -577,7 +598,7 @@ def register_health_routes(app: FastAPI) -> None:
         """Root endpoint with API information."""
         return {
             "name": "HomeFlix API",
-            "version": "0.1.0",
+            "version": APP_VERSION,
             "docs": "/docs",
         }
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,25 @@
+"""Tests for the application entry point (src.main)."""
+
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
+import pytest
+
+from src.main import _resolve_version
+
+
+@pytest.mark.unit
+class TestResolveVersion:
+    """Tests for the app-version resolver backing OpenAPI + health."""
+
+    def test_should_return_package_metadata_version(self) -> None:
+        # The version is sourced from installed distribution metadata so
+        # the OpenAPI schema and /health never drift from pyproject.
+        with patch("src.main.version", return_value="1.2.3"):
+            assert _resolve_version() == "1.2.3"
+
+    def test_should_fall_back_when_package_not_installed(self) -> None:
+        # Running as a bare script (no installed distribution) resolves to
+        # a clear sentinel rather than a stale hardcoded number.
+        with patch("src.main.version", side_effect=PackageNotFoundError):
+            assert _resolve_version() == "0.0.0"


### PR DESCRIPTION
## Summary

- The FastAPI app `version` and the `/health` and `/` endpoints returned a hardcoded `"0.1.0"`, drifting from `pyproject.toml` (now `0.4.0`).
- Resolve the version once from installed package metadata (`importlib.metadata.version("homeflix")`) into `APP_VERSION`, reused by all three sites, with a `"0.0.0"` fallback when the package isn't installed as a distribution.
- Behavior change: OpenAPI schema `version` and the `/health` + `/` `version` fields now report the real released version instead of the stale `0.1.0`.

## Test plan

- [x] `pytest tests/test_main.py` — happy path + `PackageNotFoundError` fallback
- [x] `ruff check` + `ruff format` clean
- [x] `create_app()` smoke-imports; `APP_VERSION` resolves from metadata

## Summary by Sourcery

Source the FastAPI application version from installed package metadata and reuse it across OpenAPI and health/root endpoints to keep reported versions in sync with releases.

Bug Fixes:
- Ensure OpenAPI schema and health/root endpoints report the actual released app version instead of a stale hardcoded value.

Tests:
- Add unit tests for the version resolver to verify metadata-based version lookup and the fallback when the package is not installed.