### PR TITLE
feat(catalog): add sort options to by-genre listing

### DIFF
--- a/src/building_blocks/application/pagination.py
+++ b/src/building_blocks/application/pagination.py
@@ -153,6 +153,99 @@ def decode_title_cursor(cursor: str | None) -> TitleCursorValue | None:
         return None
 
 
+@dataclass(frozen=True)
+class SortCursorValue:
+    """Decoded cursor for a sort-parametrized listing.
+
+    Generalizes :class:`TitleCursorValue` to any single-column sort key
+    plus the ``id`` tie-breaker, and additionally carries the ``sort``
+    discriminant the cursor was minted under. The catalog by-genre
+    endpoint accepts a ``?sort=`` union (title / year / recently-added);
+    each order expresses one composite ``(sort_key, id)`` position, and
+    the encoded ``sort`` lets the decoder reject a cursor replayed under
+    a *different* sort instead of silently reinterpreting its ``key`` in
+    the wrong order.
+
+    Attributes:
+        sort: The ``CatalogSort`` value (its string form) the cursor was
+            minted under.
+        key: The primary sort key rendered as a string —
+            ``LOWER(title)`` for title sorts, ``str(year)`` for year
+            sorts, and empty for ``recently_added`` (which orders on
+            ``id`` alone).
+        id: Internal autoincrement id of the last row of the previous
+            page — the final tie-breaker for every sort.
+    """
+
+    sort: str
+    key: str
+    id: int
+
+
+# Separator used inside the sort cursor's encoded payload. Same
+# rationale as `_TITLE_CURSOR_SEP` — a control character can't collide
+# with any realistic sort key or sort name.
+_SORT_CURSOR_SEP = "\x1f"
+
+
+def encode_sort_cursor(sort: str, key: str, internal_id: int) -> str:
+    """Encode a ``(sort, key, id)`` triple as an opaque sort cursor.
+
+    The caller is responsible for rendering ``key`` in the exact form
+    the SQL ``ORDER BY`` compares against (e.g. lowercasing a title, or
+    stringifying a year) — pagination must use the same comparison the
+    query uses or rows can be skipped or repeated across pages.
+
+    Args:
+        sort: The sort discriminant (a ``CatalogSort`` value's string).
+        key: The primary sort key of the last row, already normalized to
+            match the SQL comparison. Empty when the sort orders on
+            ``id`` alone.
+        internal_id: The internal autoincrement id of the same row.
+
+    Returns:
+        URL-safe base64 string suitable for use as a query parameter.
+    """
+    raw = f"{sort}{_SORT_CURSOR_SEP}{key}{_SORT_CURSOR_SEP}{internal_id}"
+    return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii")
+
+
+def decode_sort_cursor(cursor: str | None, *, expected_sort: str) -> SortCursorValue | None:
+    """Decode a sort cursor, rejecting one minted under a different sort.
+
+    Returns ``None`` — "no cursor, start from the first page" — for an
+    absent, malformed, or *sort-mismatched* token. The sort-mismatch
+    rule keeps a stale cursor from a previous ``?sort=`` value from being
+    reinterpreted under the new sort (whose ``key`` means something
+    different), which would otherwise dupe or skip rows; the frontend
+    already restarts from page 1 on a sort change, so dropping the cursor
+    is the correct, invisible fallback.
+
+    Args:
+        cursor: The opaque cursor string, or ``None``.
+        expected_sort: The sort the current request is running under. A
+            decoded cursor whose embedded sort differs is discarded.
+
+    Returns:
+        A ``SortCursorValue`` on success, or ``None`` when the input is
+        empty, malformed, or was minted under a different sort.
+    """
+    if not cursor:
+        return None
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+        # Split the sort off the front and the id off the back so a key
+        # that itself contains the separator can't corrupt the parse.
+        sort, rest = raw.split(_SORT_CURSOR_SEP, 1)
+        key, id_str = rest.rsplit(_SORT_CURSOR_SEP, 1)
+        cursor_id = int(id_str)
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+    if sort != expected_sort:
+        return None
+    return SortCursorValue(sort=sort, key=key, id=cursor_id)
+
+
 # Separator for the dual-cursor wire format. Same rationale as
 # `_TITLE_CURSOR_SEP` — using a control character keeps the parser
 # robust against any payload bytes the inner stream cursors might
@@ -227,11 +320,14 @@ __all__ = [
     "MAX_PAGE_SIZE",
     "CursorValue",
     "DualCursorValue",
+    "SortCursorValue",
     "TitleCursorValue",
     "decode_cursor",
     "decode_dual_cursor",
+    "decode_sort_cursor",
     "decode_title_cursor",
     "encode_cursor",
     "encode_dual_cursor",
+    "encode_sort_cursor",
     "encode_title_cursor",
 ]

--- a/src/modules/media/application/dtos/catalog_dtos.py
+++ b/src/modules/media/application/dtos/catalog_dtos.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE
+from src.modules.media.domain.value_objects import CatalogSort
 
 if TYPE_CHECKING:
     from src.shared_kernel.value_objects import MediaType
@@ -109,12 +110,15 @@ class ListByGenreInput:
         genre: Canonical English genre id — same value the frontend
             received from ``ListGenresOutput.genres[*].id``.
         cursor: Opaque dual-stream cursor from the previous page, or
-            ``None`` for the first page.
+            ``None`` for the first page. A cursor minted under a
+            different ``sort`` is rejected and treated as the first page.
         limit: Page size. Routes clamp to ``[1, MAX_PAGE_SIZE]``.
         lang: Language for localized titles / synopses / genres.
         media_type: Optional filter — when set the use case only
             pulls from the matching stream (movie or series). ``None``
             (default) merges both streams as usual.
+        sort: Ordering for the merged listing (see :class:`CatalogSort`).
+            Defaults to ``TITLE_ASC``.
     """
 
     profile_id: str
@@ -123,6 +127,7 @@ class ListByGenreInput:
     limit: int = DEFAULT_PAGE_SIZE
     lang: str = "en"
     media_type: MediaType | None = None
+    sort: CatalogSort = CatalogSort.TITLE_ASC
 
 
 @dataclass(frozen=True)
@@ -131,7 +136,7 @@ class ListByGenreOutput:
 
     Attributes:
         items: Mixed list of movies and series for the requested
-            genre, sorted alphabetically by title.
+            genre, ordered by the requested ``sort``.
         next_cursor: Opaque dual-stream cursor for the next page, or
             ``None`` when both streams are exhausted.
         has_more: Convenience flag matching ``next_cursor is not None``.

--- a/src/modules/media/application/use_cases/list_by_genre.py
+++ b/src/modules/media/application/use_cases/list_by_genre.py
@@ -1,9 +1,10 @@
 """ListByGenreUseCase - paginated mixed (movies + series) listing per genre."""
 
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import TypeVar
+from functools import cmp_to_key
+from typing import Any, TypeVar
 
 from src.building_blocks.application.pagination import (
     DualCursorValue,
@@ -21,11 +22,66 @@ from src.modules.media.application.ports.profile_library_access_port import (
 )
 from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
 from src.modules.media.domain.entities import Movie, Series
-from src.modules.media.domain.value_objects import Genre
+from src.modules.media.domain.value_objects import CatalogSort, Genre
 from src.shared_kernel.value_objects import MediaType
 from src.shared_kernel.value_objects.library_id import LibraryId
 
 _T = TypeVar("_T")
+
+# Sorts whose primary key descends. Kept as a set so the merge
+# comparator and any future reader agree on the direction of each sort
+# in one place.
+_DESCENDING_SORTS = frozenset(
+    {CatalogSort.TITLE_DESC, CatalogSort.YEAR_DESC, CatalogSort.RECENTLY_ADDED}
+)
+
+
+def _merge_primary_key(entity: Movie | Series, sort: CatalogSort, lang: str) -> Any:
+    """Primary sort key for one entity, matching the SQL ORDER BY key.
+
+    Mirrors ``_GenreSortSpec`` on the repository side: title sorts
+    compare the lowercased localized title, year sorts the release year
+    (movie ``year`` / series ``start_year``), and ``recently_added`` the
+    ``created_at`` timestamp — the cross-stream analogue of each stream's
+    ``id DESC`` order (ids from the two tables aren't comparable, so a
+    real timestamp is required; same rationale as
+    ``ListRecentlyAddedCatalogUseCase``).
+    """
+    if sort in (CatalogSort.TITLE_ASC, CatalogSort.TITLE_DESC):
+        return (entity.get_title(lang) or "").lower()
+    if sort in (CatalogSort.YEAR_ASC, CatalogSort.YEAR_DESC):
+        return entity.year.value if isinstance(entity, Movie) else entity.start_year.value
+    return entity.created_at
+
+
+def _merge_comparator(
+    sort: CatalogSort, lang: str
+) -> Callable[["_MergedItem", "_MergedItem"], int]:
+    """Build a stable comparator matching each stream's own SQL order.
+
+    Compares the primary key in the sort's direction and breaks ties on
+    ``source_index`` *ascending* regardless of direction. Each stream
+    arrives already in its SQL order, so preserving source order on a
+    primary-key tie keeps the merged sequence consistent with each
+    stream's per-item cursor. A descending primary must NOT simply
+    reverse the whole sort key — that would flip the source-order
+    tie-break too and dupe/skip rows across the page boundary (the bug
+    only surfaces on page 2+). When both the primary key and the source
+    index tie (two streams contributing the same key at the same depth),
+    the comparator returns 0 and Python's stable sort keeps movies before
+    series — deterministic across pages.
+    """
+    descending = sort in _DESCENDING_SORTS
+
+    def compare(a: "_MergedItem", b: "_MergedItem") -> int:
+        ka = _merge_primary_key(a.entity, sort, lang)
+        kb = _merge_primary_key(b.entity, sort, lang)
+        if ka != kb:
+            base = -1 if ka < kb else 1
+            return -base if descending else base
+        return (a.source_index > b.source_index) - (a.source_index < b.source_index)
+
+    return compare
 
 
 def _empty_page(_element_type: type[_T]) -> PaginatedResult[_T]:
@@ -64,10 +120,14 @@ class ListByGenreUseCase:
     """Paginated mixed listing of movies + series for a single genre.
 
     Both repositories are queried in parallel via their own
-    ``list_paginated_by_genre`` method (sorted by ``LOWER(title), id``),
-    the two streams are merged in Python by title, the merged result
-    is trimmed to the requested page size, and a dual cursor is
-    composed from the position each stream is left at.
+    ``list_paginated_by_genre`` method under the requested ``sort``
+    (title / year / recently-added, each ending in ``id`` as the
+    tie-breaker); the two streams are merged in Python by the same sort
+    key, the merged result is trimmed to the requested page size, and a
+    dual cursor is composed from the position each stream is left at. The
+    Python merge key and its direction mirror the SQL order exactly (see
+    ``_merge_comparator``) so partial-prefix cursor advancement stays
+    correct for every sort.
 
     Cursor advancement is "consumed-aware": each repository populates
     a parallel ``item_cursors`` list on its ``PaginatedResult`` with
@@ -127,6 +187,7 @@ class ListByGenreUseCase:
             decoded=decoded,
             limit=input_dto.limit,
             media_type=input_dto.media_type,
+            sort=input_dto.sort,
             lang=input_dto.lang,
             allowed_library_ids=allowed,
         )
@@ -140,17 +201,12 @@ class ListByGenreUseCase:
             _MergedItem(kind=MediaType.SERIES, source_index=index, entity=item)
             for index, item in enumerate(series_page.items)
         ]
-        # Sort by (lowercase localized title, source index) — the source
-        # index tie-breaker matches the SQL
-        # `(LOWER(COALESCE(localized[lang].title, title)), id) ASC` order
-        # within each stream and gives a stable cross-stream order when
-        # two rows share a title.
-        tagged.sort(
-            key=lambda mi: (
-                (mi.entity.get_title(input_dto.lang) or "").lower(),
-                mi.source_index,
-            )
-        )
+        # Merge the two already-sorted streams under the requested order.
+        # The comparator applies the sort's direction to the primary key
+        # and breaks ties on ``source_index`` (ascending) so each stream
+        # stays in the exact order its SQL query — and therefore its
+        # per-item cursor — produced. See ``_merge_comparator``.
+        tagged.sort(key=cmp_to_key(_merge_comparator(input_dto.sort, input_dto.lang)))
 
         page_items = tagged[: input_dto.limit]
 
@@ -196,6 +252,7 @@ class ListByGenreUseCase:
         decoded: DualCursorValue,
         limit: int,
         media_type: MediaType | None,
+        sort: CatalogSort,
         lang: str,
         allowed_library_ids: Sequence[LibraryId],
     ) -> tuple[PaginatedResult[Movie], PaginatedResult[Series]]:
@@ -217,6 +274,7 @@ class ListByGenreUseCase:
                     genre=genre,
                     cursor=decoded.movies,
                     limit=limit,
+                    sort=sort,
                     lang=lang,
                     allowed_library_ids=allowed_library_ids,
                 )
@@ -227,6 +285,7 @@ class ListByGenreUseCase:
                     genre=genre,
                     cursor=decoded.series,
                     limit=limit,
+                    sort=sort,
                     lang=lang,
                     allowed_library_ids=allowed_library_ids,
                 )
@@ -236,6 +295,7 @@ class ListByGenreUseCase:
                 genre=genre,
                 cursor=decoded.movies,
                 limit=limit,
+                sort=sort,
                 lang=lang,
                 allowed_library_ids=allowed_library_ids,
             ),
@@ -243,6 +303,7 @@ class ListByGenreUseCase:
                 genre=genre,
                 cursor=decoded.series,
                 limit=limit,
+                sort=sort,
                 lang=lang,
                 allowed_library_ids=allowed_library_ids,
             ),
@@ -254,6 +315,7 @@ class ListByGenreUseCase:
         genre: Genre,
         cursor: str | None,
         limit: int,
+        sort: CatalogSort,
         lang: str,
         allowed_library_ids: Sequence[LibraryId],
     ) -> PaginatedResult[Movie]:
@@ -262,6 +324,7 @@ class ListByGenreUseCase:
                 genre=genre,
                 cursor=cursor,
                 limit=limit,
+                sort=sort,
                 lang=lang,
                 allowed_library_ids=allowed_library_ids,
             )
@@ -272,6 +335,7 @@ class ListByGenreUseCase:
         genre: Genre,
         cursor: str | None,
         limit: int,
+        sort: CatalogSort,
         lang: str,
         allowed_library_ids: Sequence[LibraryId],
     ) -> PaginatedResult[Series]:
@@ -280,6 +344,7 @@ class ListByGenreUseCase:
                 genre=genre,
                 cursor=cursor,
                 limit=limit,
+                sort=sort,
                 lang=lang,
                 allowed_library_ids=allowed_library_ids,
             )

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -8,6 +8,7 @@ from src.building_blocks.domain.pagination import PaginatedResult
 from src.modules.media.domain.entities.movie import Movie
 from src.modules.media.domain.value_objects import (
     ArtworkColumns,
+    CatalogSort,
     CreditsDetectionState,
     CreditsMarker,
     EpisodeId,
@@ -264,17 +265,21 @@ class MovieRepository(ABC):
         cursor: str | None,
         limit: int,
         *,
+        sort: CatalogSort = CatalogSort.TITLE_ASC,
         lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Movie]:
         """List movies belonging to a specific genre, paginated.
 
-        Sorted by ``(LOWER(COALESCE(localized[lang].title, title)) ASC,
-        id ASC)`` so the catalog carousel renders alphabetically in the
-        viewer's language (falling back to the canonical title). The
-        cursor is a ``(title, id)`` composite (see ``encode_title_cursor``
-        in the pagination building block) — the ``id`` tie-breaker keeps
-        pagination stable when two rows share a title.
+        The ordering is chosen by ``sort`` (see :class:`CatalogSort`) and
+        always ends in the internal ``id`` as its tie-breaker so
+        pagination stays stable when two rows share the primary key. The
+        default ``TITLE_ASC`` orders by
+        ``(LOWER(COALESCE(localized[lang].title, title)) ASC, id ASC)`` so
+        the catalog carousel renders alphabetically in the viewer's
+        language (falling back to the canonical title). The cursor is a
+        sort-bound ``(sort, key, id)`` token (see ``encode_sort_cursor``
+        in the pagination building block).
 
         The genre filter matches the canonical English genre name
         stored in ``MovieModel.genres`` (a comma-separated string).
@@ -285,13 +290,17 @@ class MovieRepository(ABC):
 
         Args:
             genre: The canonical (English) genre to filter by.
-            cursor: Opaque title cursor from the previous page, or
-                ``None`` for the first page. Invalid cursors silently
-                fall back to the first page.
+            cursor: Opaque sort cursor from the previous page, or
+                ``None`` for the first page. Invalid cursors — including
+                one minted under a different ``sort`` — silently fall
+                back to the first page.
             limit: Page size. The repository fetches ``limit + 1``
                 rows and trims the sentinel to detect ``has_more``.
-            lang: Language whose localized title drives the sort order
-                (falls back to the canonical ``title`` when absent).
+            sort: Ordering to apply. Defaults to ``TITLE_ASC``, which is
+                byte-identical to the pre-sort behavior.
+            lang: Language whose localized title drives the title sort
+                order (falls back to the canonical ``title`` when
+                absent).
             allowed_library_ids: Optional per-profile ACL filter. When
                 non-``None``, results are restricted to rows whose
                 ``library_id`` is in the supplied set. ``None``

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -15,6 +15,7 @@ from src.modules.media.domain.repositories.movie_repository import (
 )
 from src.modules.media.domain.value_objects import (
     ArtworkColumns,
+    CatalogSort,
     CreditsDetectionState,
     CreditsMarker,
     EpisodeId,
@@ -221,16 +222,19 @@ class SeriesRepository(ABC):
         cursor: str | None,
         limit: int,
         *,
+        sort: CatalogSort = CatalogSort.TITLE_ASC,
         lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Series]:
         """List series belonging to a specific genre, paginated.
 
-        Sorted by ``(LOWER(COALESCE(localized[lang].title, title)) ASC,
-        id ASC)``. Same contract as
+        Ordering is chosen by ``sort`` (see :class:`CatalogSort`),
+        defaulting to ``(LOWER(COALESCE(localized[lang].title, title))
+        ASC, id ASC)``. For ``year_*`` sorts the series ``start_year``
+        is the release-year key. Same contract as
         ``MovieRepository.list_paginated_by_genre`` — see that method
-        for the full description of the cursor format and the genre
-        filter (whole-word LIKE on the comma-separated ``genres``
+        for the full description of the sort-bound cursor format and the
+        genre filter (whole-word LIKE on the comma-separated ``genres``
         column).
         """
         ...

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -4,6 +4,7 @@ from src.modules.media.domain.value_objects.air_date import AirDate
 from src.modules.media.domain.value_objects.artwork_columns import ArtworkColumns
 from src.modules.media.domain.value_objects.artwork_key import ArtworkKey
 from src.modules.media.domain.value_objects.cast_member import CastMember
+from src.modules.media.domain.value_objects.catalog_sort import CatalogSort
 from src.modules.media.domain.value_objects.collection import Collection
 from src.modules.media.domain.value_objects.conflict_candidate import ConflictCandidate
 from src.modules.media.domain.value_objects.content_rating import ContentRating
@@ -53,6 +54,7 @@ __all__ = [
     "ArtworkKey",
     "AudioTrack",
     "CastMember",
+    "CatalogSort",
     "Collection",
     "ConflictCandidate",
     "ContentRating",

--- a/src/modules/media/domain/value_objects/catalog_sort.py
+++ b/src/modules/media/domain/value_objects/catalog_sort.py
@@ -1,0 +1,46 @@
+"""Sort order for the catalog by-genre listing."""
+
+from enum import StrEnum
+
+
+class CatalogSort(StrEnum):
+    """Ordering options for ``GET /api/v1/catalog/by-genre/{genre}``.
+
+    Part of the repository port vocabulary: the sort choice reaches
+    ``MovieRepository.list_paginated_by_genre`` /
+    ``SeriesRepository.list_paginated_by_genre`` because it drives the
+    SQL ``ORDER BY`` and the cursor shape, so it belongs in the domain
+    alongside the ports rather than in the application layer. Uses
+    ``StrEnum`` (like :class:`~src.shared_kernel.value_objects.MediaType`)
+    so the value serializes directly as a query-string / cursor token.
+
+    Every order ultimately falls back to the internal autoincrement
+    ``id`` as its final tie-breaker; without it the merged movie+series
+    stream would be unstable and cursor pagination could duplicate or
+    skip rows.
+
+    Members:
+        TITLE_ASC: ``LOWER(localized title)`` A→Z. The default — keeps
+            the pre-sort behavior of the endpoint.
+        TITLE_DESC: ``LOWER(localized title)`` Z→A.
+        YEAR_DESC: Release year (movie ``year`` / series ``start_year``)
+            newest first.
+        YEAR_ASC: Release year oldest first.
+        RECENTLY_ADDED: Insertion order, newest first (by ``created_at``
+            across the merge, ``id DESC`` within each stream).
+
+    Example:
+        >>> CatalogSort.TITLE_ASC.value
+        'title_asc'
+        >>> CatalogSort("year_desc")
+        <CatalogSort.YEAR_DESC: 'year_desc'>
+    """
+
+    TITLE_ASC = "title_asc"
+    TITLE_DESC = "title_desc"
+    YEAR_DESC = "year_desc"
+    YEAR_ASC = "year_asc"
+    RECENTLY_ADDED = "recently_added"
+
+
+__all__ = ["CatalogSort"]

--- a/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
@@ -22,19 +22,20 @@ the column format changes.
 import json
 import re
 from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, TypeVar
+from dataclasses import dataclass
+from typing import Any, Literal, TypeVar
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.strategy_options import _AbstractLoad
 
 from src.building_blocks.application.pagination import (
-    decode_title_cursor,
-    encode_title_cursor,
+    decode_sort_cursor,
+    encode_sort_cursor,
 )
 from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.repositories.movie_repository import GenreRow
-from src.modules.media.domain.value_objects import Genre, LocalizedField
+from src.modules.media.domain.value_objects import CatalogSort, Genre, LocalizedField
 from src.shared_kernel.value_objects.library_id import LibraryId
 
 TModel = TypeVar("TModel")
@@ -153,6 +154,73 @@ async def fetch_genre_rows(
     ]
 
 
+# The kind of primary sort key a CatalogSort orders on. ``"id"`` means
+# the sort orders on the internal autoincrement id alone (no separate
+# primary column) — used by ``recently_added``.
+_SortKeyKind = Literal["title", "year", "id"]
+
+
+@dataclass(frozen=True)
+class _GenreSortSpec:
+    """How one :class:`CatalogSort` maps onto SQL for the by-genre page.
+
+    Keeping the ORDER BY direction and the primary-key kind in a single
+    record — from which the ORDER BY, the cursor ``WHERE`` and the
+    per-item cursor key are all derived — guarantees the three stay in
+    lockstep. A mismatch between them silently dupes or skips rows across
+    pages (the failure only surfaces on page 2+).
+
+    Attributes:
+        descending: Whether the primary key (and its ``id`` tie-breaker)
+            sort ``DESC``. Flips both the ORDER BY direction and the
+            cursor comparison operator.
+        key_kind: What the primary key is — ``"title"`` (lowercased
+            localized title), ``"year"`` (release year column), or
+            ``"id"`` (``recently_added``: order on ``id`` alone).
+    """
+
+    descending: bool
+    key_kind: _SortKeyKind
+
+
+# One spec per sort. ``recently_added`` orders on the internal
+# autoincrement ``id`` alone (newest first) — id is monotonic with
+# insertion within a table, so it matches "newest by created_at" without
+# the SQLite ``func.now()`` precision quirk documented in
+# ``building_blocks/application/pagination.py``; the cross-stream merge
+# in the use case re-orders the two id-DESC streams by ``created_at``.
+_GENRE_SORT_SPECS: dict[CatalogSort, _GenreSortSpec] = {
+    CatalogSort.TITLE_ASC: _GenreSortSpec(descending=False, key_kind="title"),
+    CatalogSort.TITLE_DESC: _GenreSortSpec(descending=True, key_kind="title"),
+    CatalogSort.YEAR_ASC: _GenreSortSpec(descending=False, key_kind="year"),
+    CatalogSort.YEAR_DESC: _GenreSortSpec(descending=True, key_kind="year"),
+    CatalogSort.RECENTLY_ADDED: _GenreSortSpec(descending=True, key_kind="id"),
+}
+
+
+def _primary_sort_column(model: Any, year_column: Any, lang: str, key_kind: _SortKeyKind) -> Any:
+    """Primary ORDER BY / cursor column for ``key_kind`` (``None`` for id-only).
+
+    Returns a SQLAlchemy ``ColumnElement`` (untyped ``Any`` here to match
+    the surrounding query builders) or ``None`` when the sort orders on
+    ``id`` alone.
+    """
+    if key_kind == "title":
+        return localized_title_sort_key(model, lang)
+    if key_kind == "year":
+        return year_column
+    return None
+
+
+def _row_sort_key(row: Any, year_column: Any, lang: str, key_kind: _SortKeyKind) -> str:
+    """Render a fetched row's primary key to the cursor's string form."""
+    if key_kind == "title":
+        return localized_title_for(row.localized, row.title, lang).lower()
+    if key_kind == "year":
+        return str(getattr(row, year_column.key))
+    return ""
+
+
 async def fetch_genre_paginated_page(
     *,
     session: AsyncSession,
@@ -162,17 +230,23 @@ async def fetch_genre_paginated_page(
     genre: Genre,
     cursor: str | None,
     limit: int,
+    year_column: Any,
+    sort: CatalogSort = CatalogSort.TITLE_ASC,
     lang: str = "en",
     allowed_library_ids: Sequence[LibraryId] | None = None,
 ) -> PaginatedResult[TEntity]:
-    """Run one page of the title-sorted by-genre listing for ``model``.
+    """Run one page of the by-genre listing for ``model`` under ``sort``.
 
     Wraps the duplicated SQL boilerplate that ``list_paginated_by_genre``
     needs in both repositories: the delimited LIKE filter that avoids
-    substring matches, the ``LOWER(title), id`` cursor, the N+1 fetch
-    trick to detect ``has_more``, and the parallel ``item_cursors``
-    list that the catalog by-genre use case needs to advance partial
-    consumption.
+    substring matches, the sort-aware composite ``(sort_key, id)`` cursor,
+    the N+1 fetch trick to detect ``has_more``, and the parallel
+    ``item_cursors`` list that the catalog by-genre use case needs to
+    advance partial consumption.
+
+    The ORDER BY, the cursor ``WHERE`` and the per-item cursor key all
+    derive from a single :class:`_GenreSortSpec` keyed by ``sort`` so the
+    three can't drift out of lockstep.
 
     Args:
         session: AsyncSession to execute against.
@@ -186,12 +260,17 @@ async def fetch_genre_paginated_page(
             (e.g. ``selectinload`` of relationships). Empty sequence
             is fine.
         genre: Canonical genre value object to filter by.
-        cursor: Opaque title cursor from the previous page, or
-            ``None`` for the first page. Invalid cursors silently
-            fall back to the first page.
+        cursor: Opaque sort cursor from the previous page, or ``None``
+            for the first page. Invalid cursors — including one minted
+            under a different ``sort`` — silently fall back to the first
+            page.
         limit: Page size. The query fetches ``limit + 1`` rows and
             trims the sentinel.
-        lang: Language whose localized title drives the sort order
+        year_column: The model's release-year column (``MovieModel.year``
+            / ``SeriesModel.start_year``) used by the ``year_*`` sorts.
+        sort: The ordering to apply. Defaults to ``TITLE_ASC`` so the
+            behavior is byte-identical to the pre-sort endpoint.
+        lang: Language whose localized title drives the title sort order
             (falls back to the canonical ``title`` when absent).
         allowed_library_ids: Optional per-profile ACL filter. When
             non-``None``, rows are restricted to those whose
@@ -202,14 +281,14 @@ async def fetch_genre_paginated_page(
         ``PaginatedResult`` with mapped entities, pagination
         metadata, and the per-item cursor list.
     """
-    decoded = decode_title_cursor(cursor)
+    spec = _GENRE_SORT_SPECS[sort]
+    decoded = decode_sort_cursor(cursor, expected_sort=sort.value)
 
     # Wrap the column with delimiters so a substring search can't
     # false-positive: "Action" must NOT match "Reaction" or
     # "Action Adventure". The matching pattern wraps the genre value
     # the same way.
     delimited_genres = func.concat(",", func.coalesce(model.genres, ""), ",")
-    title_lower = localized_title_sort_key(model, lang)
 
     stmt = (
         select(model)
@@ -225,19 +304,18 @@ async def fetch_genre_paginated_page(
             model.library_id.in_([library_id.value for library_id in allowed_library_ids])
         )
 
-    if decoded is not None:
-        # Composite ascending: anything strictly after the cursor
-        # row in the (title, id) merge order. The OR + tie-breaker
-        # is the same shape as a stable cursor for any composite
-        # sort.
-        stmt = stmt.where(
-            or_(
-                title_lower > decoded.title,
-                and_(title_lower == decoded.title, model.id > decoded.id),
-            )
-        )
+    primary = _primary_sort_column(model, year_column, lang, spec.key_kind)
 
-    stmt = stmt.order_by(title_lower.asc(), model.id.asc()).limit(limit + 1)
+    if decoded is not None:
+        stmt = stmt.where(_cursor_predicate(model, primary, spec, decoded))
+
+    if primary is None:
+        stmt = stmt.order_by(model.id.desc())
+    elif spec.descending:
+        stmt = stmt.order_by(primary.desc(), model.id.desc())
+    else:
+        stmt = stmt.order_by(primary.asc(), model.id.asc())
+    stmt = stmt.limit(limit + 1)
 
     result = await session.execute(stmt)
     rows = list(result.scalars().all())
@@ -250,7 +328,7 @@ async def fetch_genre_paginated_page(
     # consume only a prefix of this page after merging with the
     # other media stream, so each item carries its own resume token.
     item_cursors = [
-        encode_title_cursor(localized_title_for(row.localized, row.title, lang), row.id)
+        encode_sort_cursor(sort.value, _row_sort_key(row, year_column, lang, spec.key_kind), row.id)
         for row in rows
     ]
 
@@ -264,6 +342,36 @@ async def fetch_genre_paginated_page(
         total_count=None,
         item_cursors=item_cursors,
     )
+
+
+def _cursor_predicate(
+    model: Any,
+    primary: Any,
+    spec: _GenreSortSpec,
+    decoded: Any,
+) -> Any:
+    """Build the "strictly after the cursor row" predicate for one sort.
+
+    For an ``id``-only sort (``recently_added``) this is a bare
+    ``id < cursor_id``. For a composite ``(key, id)`` sort it is the
+    standard row-value comparison expanded into an OR with the ``id``
+    tie-breaker, direction-aware. A cursor ``key`` that fails to parse
+    (tampered) degrades to "no predicate" so the request restarts from
+    page 1 rather than raising mid-scroll.
+    """
+    if primary is None:
+        # recently_added: id DESC, so "after" means a smaller id.
+        return model.id < decoded.id
+    try:
+        pivot: Any = int(decoded.key) if spec.key_kind == "year" else decoded.key
+    except ValueError:
+        # Tampered/unparseable key — ignore the cursor (a no-op TRUE
+        # predicate) so the request restarts from page 1 rather than
+        # raising mid-scroll.
+        return true()
+    if spec.descending:
+        return or_(primary < pivot, and_(primary == pivot, model.id < decoded.id))
+    return or_(primary > pivot, and_(primary == pivot, model.id > decoded.id))
 
 
 __all__ = [

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -23,6 +23,7 @@ from src.modules.media.domain.repositories.movie_repository import (
 )
 from src.modules.media.domain.value_objects import (
     ArtworkColumns,
+    CatalogSort,
     CreditsDetectionState,
     CreditsMarker,
     EpisodeId,
@@ -373,16 +374,18 @@ class SQLAlchemyMovieRepository(MovieRepository):
         cursor: str | None,
         limit: int,
         *,
+        sort: CatalogSort = CatalogSort.TITLE_ASC,
         lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Movie]:
-        """List movies for a single genre, paginated and sorted by title.
+        """List movies for a single genre, paginated under ``sort``.
 
         Delegates the SQL boilerplate (delimited LIKE filter,
-        localized ``LOWER(COALESCE(localized[lang].title, title))``
-        cursor, fetch N+1 trick, per-item cursor population) to the
-        shared ``fetch_genre_paginated_page`` helper so this method and
-        its series counterpart can't drift apart.
+        sort-aware ``(key, id)`` cursor, fetch N+1 trick, per-item
+        cursor population) to the shared ``fetch_genre_paginated_page``
+        helper so this method and its series counterpart can't drift
+        apart. ``MovieModel.year`` is the release-year key for the
+        ``year_*`` sorts.
         """
         return await fetch_genre_paginated_page(
             session=self._session,
@@ -392,6 +395,8 @@ class SQLAlchemyMovieRepository(MovieRepository):
             genre=genre,
             cursor=cursor,
             limit=limit,
+            year_column=MovieModel.year,
+            sort=sort,
             lang=lang,
             allowed_library_ids=allowed_library_ids,
         )

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -22,6 +22,7 @@ from src.modules.media.domain.repositories.movie_repository import (
 )
 from src.modules.media.domain.value_objects import (
     ArtworkColumns,
+    CatalogSort,
     CreditsDetectionState,
     CreditsMarker,
     EpisodeId,
@@ -426,17 +427,19 @@ class SQLAlchemySeriesRepository(SeriesRepository):
         cursor: str | None,
         limit: int,
         *,
+        sort: CatalogSort = CatalogSort.TITLE_ASC,
         lang: str = "en",
         allowed_library_ids: Sequence[LibraryId] | None = None,
     ) -> PaginatedResult[Series]:
-        """List series for a single genre, paginated and sorted by title.
+        """List series for a single genre, paginated under ``sort``.
 
         Delegates the SQL boilerplate to the shared
         ``fetch_genre_paginated_page`` helper so this method and its
-        movie counterpart stay in lockstep. The full season / episode
-        hierarchy is loaded via the existing ``_series_load_options``
-        because consumers may want to render episode counts on the
-        carousel card.
+        movie counterpart stay in lockstep. ``SeriesModel.start_year`` is
+        the release-year key for the ``year_*`` sorts. The full season /
+        episode hierarchy is loaded via the existing
+        ``_series_load_options`` because consumers may want to render
+        episode counts on the carousel card.
         """
         return await fetch_genre_paginated_page(
             session=self._session,
@@ -446,6 +449,8 @@ class SQLAlchemySeriesRepository(SeriesRepository):
             genre=genre,
             cursor=cursor,
             limit=limit,
+            year_column=SeriesModel.start_year,
+            sort=sort,
             lang=lang,
             allowed_library_ids=allowed_library_ids,
         )

--- a/src/modules/media/presentation/routes/catalog_routes.py
+++ b/src/modules/media/presentation/routes/catalog_routes.py
@@ -23,6 +23,7 @@ from src.modules.media.application.use_cases.list_movies_by_actor import (
 from src.modules.media.application.use_cases.list_recently_added_catalog import (
     ListRecentlyAddedCatalogUseCase,
 )
+from src.modules.media.domain.value_objects import CatalogSort
 from src.modules.media.presentation.dependencies import resolve_profile_id
 from src.shared_kernel.value_objects import MediaType
 
@@ -36,6 +37,17 @@ _MEDIA_TYPE_QUERY: MediaType | None = Query(
     description=(
         "Optional filter — restrict the result to a single media type. "
         "Accepts 'movie' or 'series'; omit to aggregate both."
+    ),
+)
+
+# OpenAPI/validation config for the by-genre `?sort=` query param. An
+# unknown value is rejected with 422 (the frontend narrows to this union
+# before sending, so a 422 only ever signals contract drift).
+_SORT_QUERY: CatalogSort = Query(
+    default=CatalogSort.TITLE_ASC,
+    description=(
+        "Ordering for the merged listing. One of: title_asc (default), "
+        "title_desc, year_desc, year_asc, recently_added."
     ),
 )
 
@@ -82,6 +94,7 @@ async def list_by_genre(
     limit: int = DEFAULT_PAGE_SIZE,
     lang: str = "en",
     type: MediaType | None = _MEDIA_TYPE_QUERY,
+    sort: CatalogSort = _SORT_QUERY,
     profile_id: str = Depends(resolve_profile_id),
     use_case: ListByGenreUseCase = Depends(
         Provide[ApplicationContainer.media.list_by_genre],
@@ -91,14 +104,15 @@ async def list_by_genre(
 
     The ``genre`` path parameter is the canonical English id from
     ``GET /api/v1/catalog/genres``. Items are merged from both media
-    types, sorted alphabetically by title, and paginated with an
+    types, ordered by the requested ``sort``, and paginated with an
     opaque dual-stream cursor.
 
     Query params:
         cursor: Opaque token returned by the previous page's
             ``metadata.pagination.next_cursor``. Omit on the first
-            request. Invalid / tampered cursors silently start over
-            from the beginning.
+            request. Invalid / tampered cursors — including one carried
+            over after changing ``sort`` — silently start over from the
+            beginning.
         limit: Page size, clamped to ``[1, MAX_PAGE_SIZE]``.
         lang: Language code for localized titles, synopses, and
             genre names returned in each item.
@@ -106,6 +120,9 @@ async def list_by_genre(
             only the matching stream is queried so the Movies and
             Series tabs can show a genre restricted to their side of
             the catalog without mixing in the other.
+        sort: Ordering for the merged listing — ``title_asc`` (default),
+            ``title_desc``, ``year_desc``, ``year_asc`` or
+            ``recently_added``. An unknown value is rejected with 422.
     """
     clamped_limit = max(1, min(limit, MAX_PAGE_SIZE))
     result = await use_case.execute(
@@ -116,6 +133,7 @@ async def list_by_genre(
             limit=clamped_limit,
             lang=lang,
             media_type=type,
+            sort=sort,
         )
     )
     return api_list(

--- a/tests/building_blocks/unit/application/test_pagination.py
+++ b/tests/building_blocks/unit/application/test_pagination.py
@@ -9,12 +9,15 @@ from src.building_blocks.application.pagination import (
     MAX_PAGE_SIZE,
     CursorValue,
     DualCursorValue,
+    SortCursorValue,
     TitleCursorValue,
     decode_cursor,
     decode_dual_cursor,
+    decode_sort_cursor,
     decode_title_cursor,
     encode_cursor,
     encode_dual_cursor,
+    encode_sort_cursor,
     encode_title_cursor,
 )
 from src.building_blocks.domain.pagination import PaginatedResult, Pagination
@@ -201,6 +204,64 @@ class TestTitleCursor:
     def test_should_return_none_when_id_part_is_not_an_integer(self) -> None:
         bogus = base64.urlsafe_b64encode(b"title\x1fnot_an_int").decode("ascii")
         assert decode_title_cursor(bogus) is None
+
+
+@pytest.mark.unit
+class TestSortCursor:
+    """Tests for the sort-bound ``(sort, key, id)`` cursor."""
+
+    def test_should_roundtrip_a_title_cursor(self) -> None:
+        encoded = encode_sort_cursor("title_asc", "inception", 42)
+
+        decoded = decode_sort_cursor(encoded, expected_sort="title_asc")
+
+        assert decoded == SortCursorValue(sort="title_asc", key="inception", id=42)
+
+    def test_should_roundtrip_a_year_cursor(self) -> None:
+        encoded = encode_sort_cursor("year_desc", "2010", 7)
+
+        decoded = decode_sort_cursor(encoded, expected_sort="year_desc")
+
+        assert decoded == SortCursorValue(sort="year_desc", key="2010", id=7)
+
+    def test_should_roundtrip_an_empty_key_for_id_only_sorts(self) -> None:
+        # recently_added orders on id alone, so its key is empty.
+        encoded = encode_sort_cursor("recently_added", "", 99)
+
+        decoded = decode_sort_cursor(encoded, expected_sort="recently_added")
+
+        assert decoded == SortCursorValue(sort="recently_added", key="", id=99)
+
+    def test_should_reject_a_cursor_minted_under_a_different_sort(self) -> None:
+        # A cursor from one sort replayed under another must decode to
+        # "no cursor" so the listing restarts from page 1 instead of
+        # reinterpreting the key in the wrong order.
+        encoded = encode_sort_cursor("title_asc", "inception", 42)
+
+        assert decode_sort_cursor(encoded, expected_sort="year_desc") is None
+
+    def test_should_preserve_a_key_containing_the_separator(self) -> None:
+        # The parser splits the sort off the front and the id off the
+        # back, so a separator byte inside the key survives intact.
+        weird_key = "a\x1fb"
+        encoded = encode_sort_cursor("title_asc", weird_key, 5)
+
+        decoded = decode_sort_cursor(encoded, expected_sort="title_asc")
+
+        assert decoded == SortCursorValue(sort="title_asc", key=weird_key, id=5)
+
+    def test_should_return_none_for_empty_or_invalid_cursor(self) -> None:
+        assert decode_sort_cursor(None, expected_sort="title_asc") is None
+        assert decode_sort_cursor("", expected_sort="title_asc") is None
+        assert decode_sort_cursor("not-valid-base64!!!", expected_sort="title_asc") is None
+
+    def test_should_return_none_when_payload_lacks_separators(self) -> None:
+        bogus = base64.urlsafe_b64encode(b"missing-separators").decode("ascii")
+        assert decode_sort_cursor(bogus, expected_sort="title_asc") is None
+
+    def test_should_return_none_when_id_part_is_not_an_integer(self) -> None:
+        bogus = base64.urlsafe_b64encode(b"title_asc\x1fkey\x1fnot_an_int").decode("ascii")
+        assert decode_sort_cursor(bogus, expected_sort="title_asc") is None
 
 
 @pytest.mark.unit

--- a/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_movie_repository.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
+    CatalogSort,
     Duration,
     FilePath,
     Genre,
@@ -993,6 +994,139 @@ class TestSQLAlchemyMovieRepositoryListPaginatedByGenre:
 
         assert len(page.items) == 1
         assert page.items[0].title.value == "B"
+
+
+@pytest.mark.integration
+class TestSQLAlchemyMovieRepositoryListPaginatedByGenreSort:
+    """The ``sort`` parameter drives ORDER BY and cursor stability."""
+
+    async def test_year_desc_orders_newest_first(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        for title, year in [("Old", 2000), ("New", 2020), ("Mid", 2010)]:
+            await repo.save(
+                _create_movie(title=title, year=year, file_path=f"/m/{title}.mkv").with_genre(
+                    Genre("Action")
+                )
+            )
+
+        page = await repo.list_paginated_by_genre(
+            genre=Genre("Action"), cursor=None, limit=10, sort=CatalogSort.YEAR_DESC
+        )
+
+        assert [m.year.value for m in page.items] == [2020, 2010, 2000]
+
+    async def test_year_asc_orders_oldest_first(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        for title, year in [("Old", 2000), ("New", 2020), ("Mid", 2010)]:
+            await repo.save(
+                _create_movie(title=title, year=year, file_path=f"/m/{title}.mkv").with_genre(
+                    Genre("Action")
+                )
+            )
+
+        page = await repo.list_paginated_by_genre(
+            genre=Genre("Action"), cursor=None, limit=10, sort=CatalogSort.YEAR_ASC
+        )
+
+        assert [m.year.value for m in page.items] == [2000, 2010, 2020]
+
+    async def test_recently_added_orders_by_insertion_desc(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # Saved in order A, B, C — recently_added (id DESC) surfaces the
+        # last-inserted first.
+        for title in ["A", "B", "C"]:
+            await repo.save(
+                _create_movie(title=title, file_path=f"/m/{title}.mkv").with_genre(Genre("Action"))
+            )
+
+        page = await repo.list_paginated_by_genre(
+            genre=Genre("Action"), cursor=None, limit=10, sort=CatalogSort.RECENTLY_ADDED
+        )
+
+        assert [m.title.value for m in page.items] == ["C", "B", "A"]
+
+    async def test_walks_all_pages_under_year_desc_without_dupes(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        years = [2001, 2005, 2010, 2015, 2020]
+        for i, year in enumerate(years):
+            await repo.save(
+                _create_movie(title=f"M{i}", year=year, file_path=f"/m/m{i}.mkv").with_genre(
+                    Genre("Action")
+                )
+            )
+
+        seen: list[int] = []
+        cursor: str | None = None
+        for _ in range(10):  # generous upper bound; breaks when exhausted
+            page = await repo.list_paginated_by_genre(
+                genre=Genre("Action"), cursor=cursor, limit=2, sort=CatalogSort.YEAR_DESC
+            )
+            seen.extend(m.year.value for m in page.items)
+            if not page.pagination.has_more:
+                break
+            cursor = page.pagination.next_cursor
+
+        # Every year exactly once, newest-first, no dupes or skips.
+        assert seen == sorted(years, reverse=True)
+
+    async def test_year_ties_break_by_id_and_stay_stable_across_pages(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        # Three movies share a year — the id tie-breaker must keep them
+        # all visible across pages under a year sort.
+        for path in ["/m/t1.mkv", "/m/t2.mkv", "/m/t3.mkv"]:
+            await repo.save(
+                _create_movie(title="Tie", year=2010, file_path=path).with_genre(Genre("Action"))
+            )
+
+        page1 = await repo.list_paginated_by_genre(
+            genre=Genre("Action"), cursor=None, limit=2, sort=CatalogSort.YEAR_ASC
+        )
+        page2 = await repo.list_paginated_by_genre(
+            genre=Genre("Action"),
+            cursor=page1.pagination.next_cursor,
+            limit=2,
+            sort=CatalogSort.YEAR_ASC,
+        )
+
+        ids = [m.id for m in page1.items] + [m.id for m in page2.items]
+        assert len(page1.items) == 2
+        assert len(page2.items) == 1
+        assert len(set(ids)) == 3  # no duplicates across the page boundary
+
+    async def test_cursor_from_another_sort_is_rejected(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemyMovieRepository(db_session)
+        for title, year in [("Old", 2000), ("New", 2020), ("Mid", 2010)]:
+            await repo.save(
+                _create_movie(title=title, year=year, file_path=f"/m/{title}.mkv").with_genre(
+                    Genre("Action")
+                )
+            )
+
+        year_page = await repo.list_paginated_by_genre(
+            genre=Genre("Action"), cursor=None, limit=1, sort=CatalogSort.YEAR_DESC
+        )
+        assert year_page.pagination.next_cursor is not None
+
+        # Replay the YEAR_DESC cursor under TITLE_ASC: it must be rejected
+        # and the listing restart from the first title-sorted page.
+        title_page = await repo.list_paginated_by_genre(
+            genre=Genre("Action"),
+            cursor=year_page.pagination.next_cursor,
+            limit=10,
+            sort=CatalogSort.TITLE_ASC,
+        )
+        fresh_title_page = await repo.list_paginated_by_genre(
+            genre=Genre("Action"), cursor=None, limit=10, sort=CatalogSort.TITLE_ASC
+        )
+
+        assert [m.title.value for m in title_page.items] == [
+            m.title.value for m in fresh_title_page.items
+        ]
+        assert [m.title.value for m in title_page.items] == ["Mid", "New", "Old"]
 
 
 @pytest.mark.integration

--- a/tests/modules/media/integration/persistence/repositories/test_series_repository.py
+++ b/tests/modules/media/integration/persistence/repositories/test_series_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
+    CatalogSort,
     Duration,
     EpisodeId,
     FilePath,
@@ -1115,6 +1116,80 @@ class TestSQLAlchemySeriesRepositoryListPaginatedByGenre:
 
         assert len(page.items) == 1
         assert page.items[0].title.value == "B"
+
+
+@pytest.mark.integration
+class TestSQLAlchemySeriesRepositoryListPaginatedByGenreSort:
+    """The ``sort`` parameter uses ``start_year`` and stays cursor-stable."""
+
+    async def test_year_desc_orders_by_start_year_newest_first(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        for title, start_year in [("Old", 2000), ("New", 2020), ("Mid", 2010)]:
+            await repo.save(
+                _create_series(title=title, start_year=start_year, genres=[Genre("Drama")])
+            )
+
+        page = await repo.list_paginated_by_genre(
+            genre=Genre("Drama"), cursor=None, limit=10, sort=CatalogSort.YEAR_DESC
+        )
+
+        assert [s.start_year.value for s in page.items] == [2020, 2010, 2000]
+
+    async def test_recently_added_orders_by_insertion_desc(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        for title in ["A", "B", "C"]:
+            await repo.save(_create_series(title=title, genres=[Genre("Drama")]))
+
+        page = await repo.list_paginated_by_genre(
+            genre=Genre("Drama"), cursor=None, limit=10, sort=CatalogSort.RECENTLY_ADDED
+        )
+
+        assert [s.title.value for s in page.items] == ["C", "B", "A"]
+
+    async def test_walks_all_pages_under_year_desc_without_dupes(
+        self, db_session: AsyncSession
+    ) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        years = [2001, 2005, 2010, 2015, 2020]
+        for i, year in enumerate(years):
+            await repo.save(_create_series(title=f"S{i}", start_year=year, genres=[Genre("Drama")]))
+
+        seen: list[int] = []
+        cursor: str | None = None
+        for _ in range(10):
+            page = await repo.list_paginated_by_genre(
+                genre=Genre("Drama"), cursor=cursor, limit=2, sort=CatalogSort.YEAR_DESC
+            )
+            seen.extend(s.start_year.value for s in page.items)
+            if not page.pagination.has_more:
+                break
+            cursor = page.pagination.next_cursor
+
+        assert seen == sorted(years, reverse=True)
+
+    async def test_cursor_from_another_sort_is_rejected(self, db_session: AsyncSession) -> None:
+        repo = SQLAlchemySeriesRepository(db_session)
+        for title, start_year in [("Old", 2000), ("New", 2020), ("Mid", 2010)]:
+            await repo.save(
+                _create_series(title=title, start_year=start_year, genres=[Genre("Drama")])
+            )
+
+        year_page = await repo.list_paginated_by_genre(
+            genre=Genre("Drama"), cursor=None, limit=1, sort=CatalogSort.YEAR_DESC
+        )
+        assert year_page.pagination.next_cursor is not None
+
+        title_page = await repo.list_paginated_by_genre(
+            genre=Genre("Drama"),
+            cursor=year_page.pagination.next_cursor,
+            limit=10,
+            sort=CatalogSort.TITLE_ASC,
+        )
+
+        # The stale YEAR_DESC cursor is rejected → full title-sorted page.
+        assert [s.title.value for s in title_page.items] == ["Mid", "New", "Old"]
 
 
 def _series_with_episode_paths(

--- a/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
+++ b/tests/modules/media/unit/application/use_cases/test_list_by_genre.py
@@ -1,5 +1,7 @@
 """Tests for ListByGenreUseCase."""
 
+from datetime import UTC, datetime
+from typing import Any
 
 import pytest
 
@@ -12,6 +14,7 @@ from src.modules.media.application.dtos.catalog_dtos import (
 )
 from src.modules.media.application.use_cases.list_by_genre import ListByGenreUseCase
 from src.modules.media.domain.entities import Movie, Series
+from src.modules.media.domain.value_objects import CatalogSort
 from src.shared_kernel.value_objects import MediaType
 from tests.modules.media.unit.conftest import (
     FakeProfileLibraryAccessPort,
@@ -23,20 +26,39 @@ _LIBRARY_ID_OTHER = "lib_otherlibrary"
 _PROFILE_ID = "prf_test12345678"
 
 
-def _movie(title: str, *, library_id: str = _LIBRARY_ID) -> Movie:
+def _movie(
+    title: str,
+    *,
+    year: int = 2020,
+    created_at: datetime | None = None,
+    library_id: str = _LIBRARY_ID,
+) -> Movie:
+    kwargs: dict[str, Any] = {}
+    if created_at is not None:
+        kwargs["created_at"] = created_at
     return Movie.create(
         library_id=library_id,
         title=title,
-        year=2020,
+        year=year,
         duration=7200,
         file_path=f"/movies/{title.lower().replace(' ', '_')}.mkv",
         file_size=1_000_000_000,
         resolution="1080p",
+        **kwargs,
     )
 
 
-def _series(title: str, *, library_id: str = _LIBRARY_ID) -> Series:
-    return Series.create(library_id=library_id, title=title, start_year=2020)
+def _series(
+    title: str,
+    *,
+    start_year: int = 2020,
+    created_at: datetime | None = None,
+    library_id: str = _LIBRARY_ID,
+) -> Series:
+    kwargs: dict[str, Any] = {}
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    return Series.create(library_id=library_id, title=title, start_year=start_year, **kwargs)
 
 
 def _movies_page(
@@ -349,3 +371,143 @@ class TestListByGenreUseCase:
         assert list(movie_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
         assert list(series_kwargs["allowed_library_ids"]) == [_LIBRARY_ID]
         assert _LIBRARY_ID_OTHER not in list(movie_kwargs["allowed_library_ids"])
+
+
+@pytest.mark.unit
+class TestListByGenreSort:
+    """The merge respects the requested ``sort`` across both streams."""
+
+    @pytest.mark.asyncio
+    async def test_should_default_to_title_ascending(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Avatar"), _movie("Cyrano")]
+        )
+        mocks.series.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
+        use_case = _make_use_case(mocks)
+
+        result = await use_case.execute(ListByGenreInput(profile_id=_PROFILE_ID, genre="Action"))
+
+        assert [item.title for item in result.items] == ["Avatar", "Breaking Bad", "Cyrano"]
+        # The default input forwards TITLE_ASC to both repositories.
+        assert (
+            mocks.movies.list_paginated_by_genre.await_args.kwargs["sort"] is CatalogSort.TITLE_ASC
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_sort_by_title_descending(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Avatar"), _movie("Cyrano")]
+        )
+        mocks.series.list_paginated_by_genre.return_value = _series_page([_series("Breaking Bad")])
+        use_case = _make_use_case(mocks)
+
+        result = await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", sort=CatalogSort.TITLE_DESC)
+        )
+
+        assert [item.title for item in result.items] == ["Cyrano", "Breaking Bad", "Avatar"]
+
+    @pytest.mark.asyncio
+    async def test_should_sort_by_year_descending(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Old", year=2000), _movie("Mid", year=2010)]
+        )
+        mocks.series.list_paginated_by_genre.return_value = _series_page(
+            [_series("New", start_year=2020)]
+        )
+        use_case = _make_use_case(mocks)
+
+        result = await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", sort=CatalogSort.YEAR_DESC)
+        )
+
+        assert [item.title for item in result.items] == ["New", "Mid", "Old"]
+        assert [item.year for item in result.items] == [2020, 2010, 2000]
+
+    @pytest.mark.asyncio
+    async def test_should_sort_by_year_ascending(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("Old", year=2000), _movie("Mid", year=2010)]
+        )
+        mocks.series.list_paginated_by_genre.return_value = _series_page(
+            [_series("New", start_year=2020)]
+        )
+        use_case = _make_use_case(mocks)
+
+        result = await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", sort=CatalogSort.YEAR_ASC)
+        )
+
+        assert [item.year for item in result.items] == [2000, 2010, 2020]
+
+    @pytest.mark.asyncio
+    async def test_should_sort_by_recently_added_using_created_at(self) -> None:
+        # Cross-stream "newest first" orders by created_at (movie ids and
+        # series ids come from independent sequences and aren't
+        # comparable), matching ListRecentlyAddedCatalogUseCase.
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
+            [
+                _movie("Newest", created_at=datetime(2024, 1, 3, tzinfo=UTC)),
+                _movie("Oldest", created_at=datetime(2024, 1, 1, tzinfo=UTC)),
+            ]
+        )
+        mocks.series.list_paginated_by_genre.return_value = _series_page(
+            [_series("Middle", created_at=datetime(2024, 1, 2, tzinfo=UTC))]
+        )
+        use_case = _make_use_case(mocks)
+
+        result = await use_case.execute(
+            ListByGenreInput(
+                profile_id=_PROFILE_ID, genre="Action", sort=CatalogSort.RECENTLY_ADDED
+            )
+        )
+
+        assert [item.title for item in result.items] == ["Newest", "Middle", "Oldest"]
+
+    @pytest.mark.asyncio
+    async def test_should_forward_sort_to_both_repositories(self) -> None:
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page([])
+        mocks.series.list_paginated_by_genre.return_value = _series_page([])
+        use_case = _make_use_case(mocks)
+
+        await use_case.execute(
+            ListByGenreInput(profile_id=_PROFILE_ID, genre="Action", sort=CatalogSort.YEAR_DESC)
+        )
+
+        assert (
+            mocks.movies.list_paginated_by_genre.await_args.kwargs["sort"] is CatalogSort.YEAR_DESC
+        )
+        assert (
+            mocks.series.list_paginated_by_genre.await_args.kwargs["sort"] is CatalogSort.YEAR_DESC
+        )
+
+    @pytest.mark.asyncio
+    async def test_should_break_year_ties_by_source_order_within_a_stream(self) -> None:
+        # Two movies share a year: the merge must keep them in the
+        # stream's own (year, id) order — a descending primary must not
+        # flip the source-order tie-break — and the consumed-aware
+        # cursor must advance to the last consumed row.
+        mocks = make_media_uow_mock()
+        mocks.movies.list_paginated_by_genre.return_value = _movies_page(
+            [_movie("A", year=2010), _movie("B", year=2010)],
+            has_more=True,
+        )
+        mocks.series.list_paginated_by_genre.return_value = _series_page([])
+        use_case = _make_use_case(mocks)
+
+        result = await use_case.execute(
+            ListByGenreInput(
+                profile_id=_PROFILE_ID, genre="Action", limit=1, sort=CatalogSort.YEAR_ASC
+            )
+        )
+
+        assert [item.title for item in result.items] == ["A"]
+        assert result.has_more is True
+        decoded = decode_dual_cursor(result.next_cursor)
+        assert decoded.movies == "m-cursor-0"


### PR DESCRIPTION
## Summary

- Add an optional `?sort=` query param to `GET /api/v1/catalog/by-genre/{genre}`: `title_asc` (default), `title_desc`, `year_desc`, `year_asc`, `recently_added`. Unknown values are rejected with 422.
- The chosen order drives the SQL `ORDER BY`, the per-item cursor, and the in-memory movie+series merge from a single `_GenreSortSpec` / `_merge_comparator` pair so all three stay in lockstep across cursor pages (a descending primary flips only the primary key, never the `source_index` tie-break).
- Cursors are **sort-bound**: `encode_sort_cursor`/`decode_sort_cursor` embed the sort discriminant, so a cursor minted under one sort and replayed under another is rejected and the listing restarts from page 1.
- `recently_added` merges the two streams by `created_at` (movie/series ids come from independent sequences and aren't comparable), mirroring `ListRecentlyAddedCatalogUseCase`; each stream still queries `id DESC`.
- The default (`title_asc`, no cursor) is behaviorally identical to the previous endpoint — verified by a regression test.

### Notes / deviations
- `year` (movie) and `start_year` (series) are `nullable=False` at both DB and domain level, so the spec's null-year-last case is not reachable and intentionally not implemented.
- Frontend enablement is a one-line `SORT_ENABLED` flip in `homeflix-web` — no further backend work.

## Test plan

- [x] Unit: each of the 5 sorts orders the merged movie+series stream correctly, sort forwarded to both repos, year/source tie-break, default is title_asc.
- [x] Building block: sort-cursor roundtrip, sort-mismatch rejection, malformed/empty-key handling.
- [x] Integration (movie + series): `year_desc`/`year_asc`/`recently_added` ordering, walking all pages under a sort yields every row once, id tie-break stable across pages, cross-sort cursor rejected.
- [x] Regression: existing by-genre unit + integration tests unchanged and green.
- [x] `ruff` clean on all changed files; changed files are `mypy`-clean.

## Summary by Sourcery

Add sort options and sort-bound cursor handling to the catalog by-genre listing while keeping default behavior unchanged.

New Features:
- Introduce CatalogSort value object and wire it through by-genre use case, repositories, and HTTP route as a ?sort= query parameter supporting title, year, and recently-added orderings.
- Add a general sort cursor format that embeds the sort discriminant, ensuring cursors are bound to the sort they were minted under.

Enhancements:
- Align movie and series by-genre SQL helpers and in-memory merge logic around shared sort specifications so ORDER BY, cursor predicates, and per-item cursors stay consistent across pages.

Tests:
- Extend unit and integration tests for pagination, movie/series repositories, and ListByGenreUseCase to cover all supported sort modes, cursor stability, and cross-sort cursor rejection.