### PR TITLE
feat(media): multi-episode file segments (ADR-030)

### DIFF
--- a/docs/adr/ADR-030-multi-episode-file-segments.md
+++ b/docs/adr/ADR-030-multi-episode-file-segments.md
@@ -1,0 +1,192 @@
+# ADR-030: Arquivos de Mídia Multi-Título (Segmentos de Tempo)
+
+**Status:** Proposto
+**Data:** 2026-08-09
+**Deciders:** Lucas
+**Technical Story:** Minisséries antigas onde vários episódios vivem num único arquivo de vídeo (ex.: `20,000 Leagues Under the Sea (1997)`, 2 episódios num só `.mkv`)
+
+---
+
+## Contexto
+
+Coleções reais contêm o caso inverso do ADR-006. O ADR-006 modela **N arquivos → 1 conteúdo** (variantes de resolução do mesmo título). Este ADR trata **1 arquivo → N conteúdos**: um único arquivo físico que contém vários episódios concatenados.
+
+```
+G:/homeflix/Series/20,000 Leagues Under the Sea (1997)/
+  20,000 Leagues Under the Sea (1997).mkv   # contém E1 (00:00–01:19) + E2 (01:19–02:38)
+```
+
+Isso é comum em minisséries antigas ripadas antes de convenções de nomenclatura por episódio. O TMDB enriquece a série corretamente (2 episódios, elenco, sinopses), mas o modelo atual **não consegue mapear os 2 episódios ao mesmo arquivo**:
+
+1. `MediaFile` (VO) modela o arquivo como unidade indivisível, de duração inteira — sem noção de início/fim (`value_objects/media_file.py`).
+2. Duas travas no banco impedem compartilhar o arquivo: `media_files.file_path` é `unique` global e `ck_media_file_single_owner` força `movie_id XOR episode_id` (um dono só) (`persistence/models/media_file.py`).
+3. O scanner emite **1 arquivo = 1 episódio** (`file_scanner_port.py`, `scanner.py`).
+4. O streaming resolve `episode.file_path` e toca o arquivo **do início ao fim** — existe só o seek `start`, não há `end`/clamp de duração (`generate_hls_playlist.py`, `hls_service.py`).
+
+Sintoma observável hoje: a série aparece com E1 (disponível, apontando pro arquivo único) e **E2 "INDISPONÍVEL"** (sem `media_file`), e o E1 na prática reproduz os dois episódios seguidos.
+
+## Decisão
+
+**Introduzimos `FileSegment` como Value Object opcional dentro de `MediaFile`.** Um `MediaFile` passa a poder representar ou o arquivo inteiro (`segment is None`, comportamento atual) ou uma **janela temporal `[start, end]` dentro de um arquivo físico compartilhado**. Vários episódios podem apontar para o **mesmo `file_path`** com segmentos disjuntos.
+
+Uma mídia = uma entidade. Um arquivo físico pode ser referenciado por N segmentos (um por título).
+
+### Modelo de Domínio
+
+```python
+# modules/media/domain/value_objects/file_segment.py  (NOVO)
+
+class FileSegment(CompoundValueObject):
+    """Janela temporal [start, end] dentro de um arquivo físico.
+
+    Presente quando um único arquivo contém vários títulos (ex.: minissérie
+    com 2 episódios num .mkv). Ausente (None) => o MediaFile é o arquivo inteiro.
+
+    Attributes:
+        start_seconds: Segundo (inclusivo) onde o título começa no arquivo.
+        end_seconds: Segundo (exclusivo) onde o título termina no arquivo.
+    """
+    start_seconds: int = Field(ge=0)
+    end_seconds: int = Field(gt=0)
+
+    @model_validator(mode="after")
+    def _validate_range(self) -> "FileSegment":
+        if self.end_seconds <= self.start_seconds:
+            raise DomainValidationException(
+                message="Segment end must be greater than start",
+                message_code="INVALID_FILE_SEGMENT",
+            )
+        return self
+
+    @property
+    def duration_seconds(self) -> int:
+        return self.end_seconds - self.start_seconds
+```
+
+```python
+# modules/media/domain/value_objects/media_file.py  (campo novo)
+
+class MediaFile(CompoundValueObject):
+    file_path: FilePath
+    file_size: int = Field(ge=0)
+    resolution: Resolution
+    # ... campos existentes ...
+    segment: FileSegment | None = None   # NOVO — None = arquivo inteiro
+
+    @property
+    def is_segment(self) -> bool:
+        return self.segment is not None
+```
+
+**Invariantes de domínio mantidos fora do streaming.** `IntroMarker`, `CreditsMarker` e `WatchProgress` permanecem **relativos ao episódio** (segundo 0 = início do episódio, não do arquivo). A duração do episódio segue sendo `segment.duration_seconds`. A tradução episódio-relativo → arquivo-absoluto acontece **apenas** na borda de streaming (ver Notas de Implementação).
+
+### Persistência
+
+Colunas novas em `media_files` (ambas nullable; `NULL` = arquivo inteiro):
+
+```
+start_offset_seconds  INTEGER NULL
+end_offset_seconds    INTEGER NULL
+```
+
+A unicidade global de `file_path` é **substituída** por uma unique index composta que tolera segmentos disjuntos e ainda barra duplicatas de arquivo inteiro:
+
+```sql
+-- antes: UNIQUE(file_path)
+CREATE UNIQUE INDEX ux_media_file_path_segment
+  ON media_files (file_path, COALESCE(start_offset_seconds, -1), COALESCE(end_offset_seconds, -1));
+```
+
+`ck_media_file_single_owner` **permanece** — cada linha ainda pertence a exatamente um episódio; a novidade é que duas linhas (de episódios distintos) podem apontar pro mesmo `file_path`. O partial-unique index de `file_path` na tabela `episodes` recebe o mesmo tratamento composto.
+
+## Consequências
+
+### Positivas
+
+1. **Enriquecimento correto**: a minissérie continua sendo uma Série com N episódios reais, todos disponíveis e reproduzíveis.
+2. **Sem cortar arquivos**: preserva o arquivo físico original (não-destrutivo).
+3. **Retrocompatível**: `segment=None` reproduz exatamente o comportamento atual; dados existentes não migram de valor.
+4. **Domínio cirúrgico**: markers e progresso ficam episódio-relativos; só o streaming conhece o offset absoluto.
+5. **Alinhado ao vocabulário do ADR-006**: `MediaFile` continua sendo a unidade de reprodução; segmento é uma visão limitada dela.
+
+### Negativas
+
+1. **Ingestão não é 100% automática**: sem capítulos embutidos, o ponto de corte precisa ser informado (endpoint admin).
+2. **Cache HLS por segmento**: o `path_hash` passa a incluir `end`; dois episódios do mesmo arquivo geram buckets distintos.
+3. **Mais um caminho no streaming**: a borda precisa clampar o encode do ffmpeg (`-t`).
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Offsets errados (áudio/legenda dessincronizados) | Média | Médio | Validar `end > start`; permitir edição via endpoint admin |
+| Regressão no caminho arquivo-inteiro | Baixa | Alto | `segment=None` é o default; testes de retrocompatibilidade |
+| Keyframe distante do `start` causa seek impreciso | Média | Baixo | `-accurate_seek` já usado; segmentos começam em corte de cena |
+| Marker validado contra duração errada | Baixa | Médio | Duração do episódio = `segment.duration_seconds` na criação |
+
+## Alternativas Consideradas
+
+### 1. Cortar o arquivo fisicamente (ffmpeg split)
+
+Dividir o `.mkv` em `S01E01`/`S01E02` e re-escanear.
+
+**Rejeitado porque:** destrutivo, manual por item, duplica bytes ou reencoda, e não resolve o caso de forma sistemática. (É uma saída pontual válida, mas não a decisão arquitetural.)
+
+### 2. Catalogar como Movie único
+
+Tratar o arquivo como um filme.
+
+**Rejeitado porque:** o título é uma minissérie de TV no TMDB — a busca de filme casa mal, degradando o enriquecimento; e perde a estrutura de episódios.
+
+### 3. Série de 1 episódio (arquivo inteiro)
+
+Modelar como série de 1 temporada / 1 episódio.
+
+**Rejeitado porque:** perde a granularidade dos N episódios (metadata, progresso e navegação por episódio), que é justamente o que o TMDB fornece.
+
+### 4. Offsets direto no `MediaFile` sem VO dedicado
+
+Adicionar `start_seconds`/`end_seconds` soltos no `MediaFile`.
+
+**Rejeitado porque:** violaria a coesão de VO (Primitive Obsession — dois inteiros acoplados sem invariante encapsulada). O `FileSegment` encapsula a regra `end > start >= 0` e a `duration_seconds`.
+
+## Referências
+
+- [ADR-006](ADR-006-media-file-variants.md) — decisão inversa (N arquivos → 1 conteúdo)
+- [Jellyfin — Multi-episode files](https://jellyfin.org/docs/general/server/media/shows/#multiple-episodes-in-one-file)
+- [Plex — Multiple episodes in a single file](https://support.plex.tv/articles/naming-and-organizing-your-tv-show-files/#toc-3)
+
+---
+
+## Notas de Implementação
+
+### Tradução episódio-relativo → arquivo-absoluto (borda de streaming)
+
+```python
+# presentation/stream_routes.py (resolução do episódio segmentado)
+segment = episode.primary_file.segment            # FileSegment | None
+base = segment.start_seconds if segment else 0
+file_start = base + resume_position               # resume vem episódio-relativo
+end = segment.end_seconds if segment else None
+
+GenerateHlsPlaylistInput(file_path=..., start=file_start, end=end)
+```
+
+```python
+# application: GenerateHlsPlaylistInput ganha `end: int | None = None`
+# port: ensure_playlist(file_path, start=0, end=None)
+# hls_service: quando end is not None -> ffmpeg recebe `-t (end - start)`
+#              path_hash key = f"{file_path}:{start}:{end}"
+```
+
+### Faseamento (PRs sequenciais)
+
+- **PR 1 — Domínio + persistência (`media`)**: VO `FileSegment`, campo `segment` no `MediaFile`, colunas `start/end_offset_seconds`, unique index composto, mapper, migration Alembic. `segment=None` default → mergeable sozinho, sem mudança de comportamento.
+- **PR 2 — Streaming (clamp de sub-range)**: `end` no `GenerateHlsPlaylistInput`/port/`hls_service`, `path_hash` por segmento, tradução episódio-relativo → arquivo-absoluto na rota. Depende do PR 1.
+- **PR 3 — Ingestão (popular segmentos)**: use case/endpoint admin pra declarar `(episode_number, start, end)` sobre um arquivo compartilhado — e/ou leitura de capítulos embutidos via ffprobe. Depende do PR 1 (e PR 2 pra reproduzir).
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-08-09 | Lucas | Criação inicial (Proposto) |

--- a/docs/adr/ADR-030-multi-episode-file-segments.md
+++ b/docs/adr/ADR-030-multi-episode-file-segments.md
@@ -1,6 +1,6 @@
 # ADR-030: Arquivos de Mídia Multi-Título (Segmentos de Tempo)
 
-**Status:** Proposto
+**Status:** Aceito
 **Data:** 2026-08-09
 **Deciders:** Lucas
 **Technical Story:** Minisséries antigas onde vários episódios vivem num único arquivo de vídeo (ex.: `20,000 Leagues Under the Sea (1997)`, 2 episódios num só `.mkv`)
@@ -190,3 +190,4 @@ GenerateHlsPlaylistInput(file_path=..., start=file_start, end=end)
 | Data | Autor | Mudança |
 |------|-------|---------|
 | 2026-08-09 | Lucas | Criação inicial (Proposto) |
+| 2026-08-10 | Lucas | Aceito — implementado em 3 PRs (domínio/persistência, streaming, endpoint admin) |

--- a/migrations/versions/2026_08_09_add_media_file_segments.py
+++ b/migrations/versions/2026_08_09_add_media_file_segments.py
@@ -1,0 +1,113 @@
+"""Add media-file time segments for multi-episode files (ADR-030).
+
+A single physical file can hold several titles (e.g. an old mini-series with
+two episodes concatenated in one ``.mkv``). To model that, ``media_files``
+gains an optional ``[start, end)`` time window and the global uniqueness of
+``file_path`` is relaxed to per-``(path, segment)``:
+
+- ``start_offset_seconds`` / ``end_offset_seconds`` — NULL for a whole-file
+  variant (the default, backward-compatible case), or the title's window
+  within a shared file.
+- ``ix_media_files_file_path`` drops its UNIQUE flag (kept as a plain lookup
+  index); a new ``ux_media_file_path_segment`` enforces uniqueness on
+  ``(file_path, COALESCE(start,-1), COALESCE(end,-1))`` so whole-file
+  duplicates are still rejected while disjoint segments of one file coexist.
+- ``ix_episodes_file_path`` drops its UNIQUE flag for the same reason: two
+  live episodes may now share the same denormalized primary-file path.
+
+Revision ID: 7f3a2b9c4d10
+Revises: 3c7f2a9d1b46
+Create Date: 2026-08-09 18:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "7f3a2b9c4d10"
+down_revision: str | Sequence[str] | None = "3c7f2a9d1b46"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_LIVE = text("deleted_at IS NULL")
+_SEG_START = sa.text("COALESCE(start_offset_seconds, -1)")
+_SEG_END = sa.text("COALESCE(end_offset_seconds, -1)")
+
+
+def upgrade() -> None:
+    """Add segment columns and relax file_path uniqueness to per-segment."""
+    op.add_column(
+        "media_files",
+        sa.Column("start_offset_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "media_files",
+        sa.Column("end_offset_seconds", sa.Integer(), nullable=True),
+    )
+
+    # Swap the global-unique path index for a plain lookup index...
+    op.drop_index("ix_media_files_file_path", table_name="media_files")
+    op.create_index(
+        "ix_media_files_file_path",
+        "media_files",
+        ["file_path"],
+        unique=False,
+    )
+    # ...and enforce uniqueness per (path, segment) instead. COALESCE gives
+    # whole-file rows (NULL offsets) a concrete key so duplicates are caught.
+    op.create_index(
+        "ux_media_file_path_segment",
+        "media_files",
+        ["file_path", _SEG_START, _SEG_END],
+        unique=True,
+    )
+
+    # Episodes may now share a physical file, so the denormalized flat
+    # ``file_path`` is no longer unique — keep the partial index for lookups.
+    op.drop_index("ix_episodes_file_path", table_name="episodes")
+    op.create_index(
+        "ix_episodes_file_path",
+        "episodes",
+        ["file_path"],
+        unique=False,
+        sqlite_where=_LIVE,
+        postgresql_where=_LIVE,
+    )
+
+
+def downgrade() -> None:
+    """Restore global path uniqueness and drop segment columns.
+
+    NOTE: this fails if the data now contains multi-episode files (shared
+    ``file_path`` rows), which is expected — you cannot downgrade past data
+    that depends on the new model.
+    """
+    op.drop_index("ix_episodes_file_path", table_name="episodes")
+    op.create_index(
+        "ix_episodes_file_path",
+        "episodes",
+        ["file_path"],
+        unique=True,
+        sqlite_where=_LIVE,
+        postgresql_where=_LIVE,
+    )
+
+    op.drop_index("ux_media_file_path_segment", table_name="media_files")
+    op.drop_index("ix_media_files_file_path", table_name="media_files")
+    op.create_index(
+        "ix_media_files_file_path",
+        "media_files",
+        ["file_path"],
+        unique=True,
+    )
+
+    op.drop_column("media_files", "end_offset_seconds")
+    op.drop_column("media_files", "start_offset_seconds")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,3 +114,4 @@ nav:
       - adr/ADR-027-ocr-image-based-subtitles.md
       - adr/ADR-028-domain-exception-semantics.md
       - adr/ADR-029-artwork-mirroring-storage.md
+      - adr/ADR-030-multi-episode-file-segments.md

--- a/src/config/containers/media.py
+++ b/src/config/containers/media.py
@@ -26,6 +26,9 @@ from src.modules.media.application.use_cases.clear_hls_cache import ClearHlsCach
 from src.modules.media.application.use_cases.clear_hls_cache_global import (
     ClearHlsCacheGlobalUseCase,
 )
+from src.modules.media.application.use_cases.define_episode_segments import (
+    DefineEpisodeSegmentsUseCase,
+)
 from src.modules.media.application.use_cases.delete_movie import DeleteMovieUseCase
 from src.modules.media.application.use_cases.delete_series import DeleteSeriesUseCase
 from src.modules.media.application.use_cases.detect_movie_conflicts import (
@@ -624,6 +627,12 @@ class MediaContainer(containers.DeclarativeContainer):  # type: ignore[misc]
         probe_service=media_probe_service,
         event_bus=event_bus,
         scrub_preview_locator=scrub_preview_locator,
+    )
+
+    define_episode_segments = providers.Factory(
+        DefineEpisodeSegmentsUseCase,
+        uow_factory=media_unit_of_work_factory,
+        probe_service=media_probe_service,
     )
 
     # =========================================================================

--- a/src/main.py
+++ b/src/main.py
@@ -41,6 +41,7 @@ from src.modules.media.presentation.routes import (
     admin_overview_router,
     admin_relink_router,
     admin_scan_router,
+    admin_segments_router,
     admin_subtitle_ocr_router,
     admin_system_router,
     artwork_router,
@@ -95,6 +96,7 @@ WIRED_ROUTE_MODULES: tuple[str, ...] = (
     "src.modules.media.presentation.routes.admin_overview_routes",
     "src.modules.media.presentation.routes.admin_relink_routes",
     "src.modules.media.presentation.routes.admin_scan_routes",
+    "src.modules.media.presentation.routes.admin_segments_routes",
     "src.modules.media.presentation.routes.admin_subtitle_ocr_routes",
     "src.modules.media.presentation.routes.admin_system_routes",
     "src.modules.media.presentation.routes.artwork_routes",
@@ -494,6 +496,7 @@ def create_app() -> FastAPI:
     app.include_router(admin_overview_router)
     app.include_router(admin_relink_router)
     app.include_router(admin_scan_router)
+    app.include_router(admin_segments_router)
     app.include_router(admin_intro_detection_router)
     app.include_router(admin_jobs_router)
     app.include_router(admin_credits_router)

--- a/src/modules/media/application/dtos/segment_dtos.py
+++ b/src/modules/media/application/dtos/segment_dtos.py
@@ -1,0 +1,85 @@
+"""DTOs for defining multi-episode file segments (ADR-030)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class EpisodeSegmentSpec:
+    """One episode's time window within a shared physical file.
+
+    Attributes:
+        episode_number: Episode number within the target season.
+        start_seconds: Inclusive start second of the episode in the file.
+        end_seconds: Exclusive end second of the episode in the file.
+    """
+
+    episode_number: int
+    start_seconds: int
+    end_seconds: int
+
+
+@dataclass(frozen=True)
+class DefineEpisodeSegmentsInput:
+    """Input for ``DefineEpisodeSegmentsUseCase``.
+
+    Attributes:
+        series_id: External series ID (``ser_xxx``).
+        season_number: Season whose episodes share the file.
+        file_path: Absolute path to the shared physical video file.
+        segments: One spec per episode carried by the file.
+    """
+
+    series_id: str
+    season_number: int
+    file_path: str
+    segments: list[EpisodeSegmentSpec] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class AssignedSegmentOutput:
+    """A single episode after its segment was assigned.
+
+    Attributes:
+        episode_id: External episode ID (``epi_xxx``), or ``None`` if the
+            episode is not yet persisted.
+        episode_number: Episode number within the season.
+        title: Episode display title.
+        start_seconds: Assigned segment start.
+        end_seconds: Assigned segment end.
+        duration_seconds: Playable length (``end - start``), now the
+            episode's duration.
+    """
+
+    episode_id: str | None
+    episode_number: int
+    title: str
+    start_seconds: int
+    end_seconds: int
+    duration_seconds: int
+
+
+@dataclass(frozen=True)
+class DefineEpisodeSegmentsOutput:
+    """Output for ``DefineEpisodeSegmentsUseCase``.
+
+    Attributes:
+        series_id: External series ID the segments were applied to.
+        season_number: Target season number.
+        file_path: The shared physical file the episodes now reference.
+        episodes: The episodes updated, in ascending start order.
+    """
+
+    series_id: str
+    season_number: int
+    file_path: str
+    episodes: list[AssignedSegmentOutput]
+
+
+__all__ = [
+    "AssignedSegmentOutput",
+    "DefineEpisodeSegmentsInput",
+    "DefineEpisodeSegmentsOutput",
+    "EpisodeSegmentSpec",
+]

--- a/src/modules/media/application/dtos/series_dtos.py
+++ b/src/modules/media/application/dtos/series_dtos.py
@@ -28,6 +28,12 @@ class EpisodeOutput:
         file_path: Path to video file (None if no primary file).
         file_size: File size in bytes (None if no primary file).
         resolution: Video resolution (None if no primary file).
+        segment_start_seconds: Start second of this episode within a
+            shared physical file (ADR-030), or ``None`` when the primary
+            file is a whole file. Streaming translates player-relative
+            positions against this offset.
+        segment_end_seconds: Exclusive end second of this episode within
+            a shared physical file, or ``None`` for a whole file.
         thumbnail_path: Path to thumbnail (optional).
         scrub_preview_path: Absolute filesystem path to the scrub-preview
             VTT, or ``None`` until the backfill job generates it.
@@ -47,6 +53,8 @@ class EpisodeOutput:
     thumbnail_path: str | None
     scrub_preview_path: str | None
     air_date: str | None
+    segment_start_seconds: int | None = None
+    segment_end_seconds: int | None = None
     intro: IntroMarkerOutput | None = None
     credits: CreditsMarkerOutput | None = None
     progress_percentage: float | None = None

--- a/src/modules/media/application/ports/hls_playlist_port.py
+++ b/src/modules/media/application/ports/hls_playlist_port.py
@@ -43,7 +43,7 @@ class HlsPlaylistPort(ABC):
     """Manage the HLS cache: playlists, segments, subtitles, eviction."""
 
     @abstractmethod
-    async def ensure_playlist(self, file_path: str, start: int = 0) -> str:
+    async def ensure_playlist(self, file_path: str, start: int = 0, end: int | None = None) -> str:
         """Prepare an HLS cache for ``file_path`` and return its path hash.
 
         Blocks until at least the master playlist and the first segment
@@ -55,6 +55,12 @@ class HlsPlaylistPort(ABC):
         reuses the same encode) and spawns ffmpeg with an input seek
         to that bucket. The default of ``0`` preserves the
         single-bucket-per-file behaviour for cold first plays.
+
+        ``end`` is the source-time second the encode is clamped to end
+        at, for a title that occupies only a sub-range of a shared
+        physical file (ADR-030). ``None`` (the default) encodes to the
+        end of the file. It is folded into the returned path hash so
+        distinct sub-ranges of one file cache independently.
         """
         ...
 

--- a/src/modules/media/application/use_cases/define_episode_segments.py
+++ b/src/modules/media/application/use_cases/define_episode_segments.py
@@ -1,0 +1,211 @@
+"""DefineEpisodeSegmentsUseCase — map episodes onto sub-ranges of one file.
+
+Some mini-series ship several episodes concatenated in a single physical
+file. This admin use case attaches a segmented :class:`MediaFile` (ADR-030)
+to each existing episode of a season so every episode plays just its window
+of the shared file, without splitting the file on disk.
+"""
+
+import asyncio
+from pathlib import Path
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.modules.media.application.dtos.segment_dtos import (
+    AssignedSegmentOutput,
+    DefineEpisodeSegmentsInput,
+    DefineEpisodeSegmentsOutput,
+    EpisodeSegmentSpec,
+)
+from src.modules.media.application.ports.media_probe_port import MediaProbePort
+from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+from src.modules.media.domain.value_objects import (
+    Duration,
+    FilePath,
+    FileSegment,
+    MediaFile,
+    Resolution,
+    SeriesId,
+)
+
+
+class DefineEpisodeSegmentsUseCase:
+    """Assign disjoint file segments to a season's episodes (ADR-030).
+
+    The shared file is probed once for resolution and tracks; every episode
+    receives a primary :class:`MediaFile` pointing at that same path, bounded
+    by its own :class:`FileSegment`, and its duration is set to the segment
+    length so intro/credits markers stay episode-relative.
+
+    Example:
+        >>> use_case = DefineEpisodeSegmentsUseCase(uow_factory, probe_service)
+        >>> await use_case.execute(DefineEpisodeSegmentsInput(
+        ...     series_id="ser_abc123abc123",
+        ...     season_number=1,
+        ...     file_path="/series/mini/whole.mkv",
+        ...     segments=[
+        ...         EpisodeSegmentSpec(1, 0, 4740),
+        ...         EpisodeSegmentSpec(2, 4740, 9480),
+        ...     ],
+        ... ))
+    """
+
+    def __init__(
+        self,
+        uow_factory: MediaUnitOfWorkFactory,
+        probe_service: MediaProbePort,
+    ) -> None:
+        """Initialize the use case.
+
+        Args:
+            uow_factory: Factory that opens a fresh media Unit of Work.
+            probe_service: Probe port used to read the shared file's
+                resolution and audio/subtitle tracks.
+        """
+        self._uow_factory = uow_factory
+        self._probe = probe_service
+
+    async def execute(
+        self,
+        input_dto: DefineEpisodeSegmentsInput,
+    ) -> DefineEpisodeSegmentsOutput:
+        """Attach a segmented MediaFile to each targeted episode.
+
+        Args:
+            input_dto: Series/season, shared file path, and per-episode
+                segment specs.
+
+        Returns:
+            The episodes updated, in ascending start order.
+
+        Raises:
+            UseCaseValidationException: If the segment set is empty,
+                contains duplicate episodes, overlaps, or runs past the
+                probed file duration.
+            ResourceNotFoundException: If the file, series, season, or a
+                referenced episode does not exist.
+        """
+        if not input_dto.segments:
+            raise UseCaseValidationException.required_field("segments")
+
+        source = Path(input_dto.file_path)
+        if not source.is_file():
+            raise ResourceNotFoundException.for_resource("MediaFile", input_dto.file_path)
+        file_size = source.stat().st_size
+
+        probed = await asyncio.to_thread(self._probe.probe, input_dto.file_path)
+        resolution = Resolution(probed.resolution) if probed.resolution else Resolution.unknown()
+
+        # Process in ascending start order so overlap validation is a single
+        # forward scan and the output reads top-to-bottom through the file.
+        specs = sorted(input_dto.segments, key=lambda s: s.start_seconds)
+        self._validate_segment_set(specs, probed.duration_seconds)
+
+        file_path = FilePath(input_dto.file_path)
+
+        async with self._uow_factory() as uow:
+            series = await uow.series.find_by_id(SeriesId(input_dto.series_id))
+            if series is None:
+                raise ResourceNotFoundException.for_resource("Series", input_dto.series_id)
+
+            season = series.get_season(input_dto.season_number)
+            if season is None:
+                raise ResourceNotFoundException.for_resource("Season", str(input_dto.season_number))
+
+            assigned: list[AssignedSegmentOutput] = []
+            for spec in specs:
+                episode = season.get_episode(spec.episode_number)
+                if episode is None:
+                    raise ResourceNotFoundException.for_resource(
+                        "Episode",
+                        f"S{input_dto.season_number}E{spec.episode_number}",
+                    )
+
+                segment = FileSegment(
+                    start_seconds=spec.start_seconds,
+                    end_seconds=spec.end_seconds,
+                )
+                media_file = MediaFile(
+                    file_path=file_path,
+                    file_size=file_size,
+                    resolution=resolution,
+                    audio_tracks=list(probed.audio_tracks),
+                    subtitle_tracks=list(probed.all_subtitles),
+                    is_primary=True,
+                    segment=segment,
+                )
+                episode = episode.with_updates(
+                    files=[media_file],
+                    duration=Duration(segment.duration_seconds),
+                )
+                season = season.with_episode_upserted(episode)
+                assigned.append(
+                    AssignedSegmentOutput(
+                        episode_id=str(episode.id) if episode.id else None,
+                        episode_number=spec.episode_number,
+                        title=episode.get_title(),
+                        start_seconds=segment.start_seconds,
+                        end_seconds=segment.end_seconds,
+                        duration_seconds=segment.duration_seconds,
+                    )
+                )
+
+            series = series.with_season_upserted(season)
+            await uow.series.save(series)
+
+        return DefineEpisodeSegmentsOutput(
+            series_id=input_dto.series_id,
+            season_number=input_dto.season_number,
+            file_path=input_dto.file_path,
+            episodes=assigned,
+        )
+
+    @staticmethod
+    def _validate_segment_set(
+        specs: list[EpisodeSegmentSpec],
+        file_duration: int | None,
+    ) -> None:
+        """Reject duplicate, overlapping, or out-of-bounds segment sets.
+
+        Per-segment ordering (``end > start``) is enforced by the
+        :class:`FileSegment` value object; this guards the cross-segment
+        invariants a single VO cannot see.
+        """
+        seen: set[int] = set()
+        prev_end: int | None = None
+        for spec in specs:
+            if spec.episode_number in seen:
+                raise UseCaseValidationException(
+                    message=f"Episode {spec.episode_number} appears more than once",
+                    message_code="DUPLICATE_EPISODE_SEGMENT",
+                )
+            seen.add(spec.episode_number)
+
+            if spec.end_seconds <= spec.start_seconds:
+                raise UseCaseValidationException(
+                    message=(
+                        f"Segment for episode {spec.episode_number} must end " f"after it starts"
+                    ),
+                    message_code="INVALID_FILE_SEGMENT",
+                )
+
+            if prev_end is not None and spec.start_seconds < prev_end:
+                raise UseCaseValidationException(
+                    message="File segments must not overlap",
+                    message_code="OVERLAPPING_FILE_SEGMENTS",
+                )
+            prev_end = spec.end_seconds
+
+            if file_duration is not None and spec.end_seconds > file_duration:
+                raise UseCaseValidationException(
+                    message=(
+                        f"Segment end {spec.end_seconds}s exceeds file "
+                        f"duration {file_duration}s"
+                    ),
+                    message_code="SEGMENT_EXCEEDS_FILE_DURATION",
+                )
+
+
+__all__ = ["DefineEpisodeSegmentsUseCase"]

--- a/src/modules/media/application/use_cases/generate_hls_playlist.py
+++ b/src/modules/media/application/use_cases/generate_hls_playlist.py
@@ -31,11 +31,17 @@ class GenerateHlsPlaylistInput:
             anchors a fresh encode on the target second. ``0`` (the
             default) keeps the legacy single-bucket cache. The player
             quantises resume positions itself when it wants cache reuse.
+        end: Source-time second the encode is clamped to end at, for a
+            title occupying only a sub-range of a shared physical file
+            (ADR-030). ``None`` (the default) encodes to the end of the
+            file. Presentation resolves it from the episode's file
+            segment and passes the file-absolute value.
     """
 
     file_path: str
     base_url_template: str
     start: int = 0
+    end: int | None = None
     view: NowPlayingViewContext | None = None
 
 
@@ -63,7 +69,9 @@ class GenerateHlsPlaylistUseCase:
             ResourceNotFoundException: If the playlist content is missing
                 from the cache after ``ensure_playlist`` returns.
         """
-        path_hash = await self._hls.ensure_playlist(input_dto.file_path, input_dto.start)
+        path_hash = await self._hls.ensure_playlist(
+            input_dto.file_path, input_dto.start, input_dto.end
+        )
 
         # Best-effort: record who/what for the admin now-playing panel.
         # Strictly observational — a failure here must never break the

--- a/src/modules/media/application/use_cases/get_series_by_id.py
+++ b/src/modules/media/application/use_cases/get_series_by_id.py
@@ -228,6 +228,12 @@ class GetSeriesByIdUseCase:
             file_path=primary.file_path.value if primary else None,
             file_size=primary.file_size if primary else None,
             resolution=primary.resolution.value if primary else None,
+            segment_start_seconds=(
+                primary.segment.start_seconds if primary and primary.segment else None
+            ),
+            segment_end_seconds=(
+                primary.segment.end_seconds if primary and primary.segment else None
+            ),
             files=[to_media_file_output(f) for f in episode.files],
             thumbnail_path=episode.thumbnail_path.value if episode.thumbnail_path else None,
             scrub_preview_path=episode.scrub_preview_path.value

--- a/src/modules/media/domain/value_objects/__init__.py
+++ b/src/modules/media/domain/value_objects/__init__.py
@@ -12,6 +12,7 @@ from src.modules.media.domain.value_objects.credits_detection_state import Credi
 from src.modules.media.domain.value_objects.credits_marker import CreditsMarker, CreditsMarkerSource
 from src.modules.media.domain.value_objects.duration import Duration
 from src.modules.media.domain.value_objects.episode_number import EpisodeNumber
+from src.modules.media.domain.value_objects.file_segment import FileSegment
 from src.modules.media.domain.value_objects.genre import Genre
 from src.modules.media.domain.value_objects.hdr_format import HdrFormat
 from src.modules.media.domain.value_objects.imdb_id import ImdbId
@@ -66,6 +67,7 @@ __all__ = [
     "EpisodeId",
     "EpisodeNumber",
     "FilePath",
+    "FileSegment",
     "Genre",
     "ImageUrl",
     "HdrFormat",

--- a/src/modules/media/domain/value_objects/file_segment.py
+++ b/src/modules/media/domain/value_objects/file_segment.py
@@ -1,0 +1,50 @@
+"""FileSegment value object — a time window within a shared physical file."""
+
+from typing import Self
+
+from pydantic import Field, model_validator
+
+from src.building_blocks.domain import CompoundValueObject
+
+
+class FileSegment(CompoundValueObject):
+    """A ``[start, end)`` time window a title occupies within a physical file.
+
+    Present when a single video file contains several titles (e.g. an old
+    mini-series with two episodes concatenated in one ``.mkv``). When a
+    :class:`MediaFile` carries no segment (``None``) it represents the whole
+    file, which is the default and the pre-existing behaviour.
+
+    Offsets are in source seconds, measured from the start of the physical
+    file (not the title). ``end_seconds`` is exclusive, so the playable
+    length of the segment is ``end_seconds - start_seconds``.
+
+    Attributes:
+        start_seconds: Second (inclusive) where the title begins in the
+            file. Must be ``>= 0``.
+        end_seconds: Second (exclusive) where the title ends in the file.
+            Must be strictly greater than ``start_seconds``.
+
+    Example:
+        >>> # Second episode occupying 01:19:00 to 02:38:00 of a shared file
+        >>> FileSegment(start_seconds=4740, end_seconds=9480).duration_seconds
+        4740
+    """
+
+    start_seconds: int = Field(ge=0)
+    end_seconds: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def _validate_range(self) -> Self:
+        """Enforce that the window is non-empty and correctly ordered."""
+        if self.end_seconds <= self.start_seconds:
+            raise ValueError("end_seconds must be greater than start_seconds")
+        return self
+
+    @property
+    def duration_seconds(self) -> int:
+        """Return the playable length of the segment in seconds."""
+        return self.end_seconds - self.start_seconds
+
+
+__all__ = ["FileSegment"]

--- a/src/modules/media/domain/value_objects/localized_metadata.py
+++ b/src/modules/media/domain/value_objects/localized_metadata.py
@@ -188,7 +188,9 @@ class LocalizedMetadata(RootModel[dict[str, LocalizedFields]], ValueObject):
     @classmethod
     def from_serializable(cls, raw: dict[str, dict[str, Any]] | None) -> "LocalizedMetadata":
         """Build from the stored JSON dict (``None`` → empty)."""
-        return cls(raw or {})
+        # Pydantic coerces the raw nested dict into LocalizedFields at the
+        # RootModel boundary; mypy can't follow that coercion.
+        return cls(raw or {})  # type: ignore[arg-type]
 
 
 __all__ = ["LocalizedField", "LocalizedFields", "LocalizedMetadata"]

--- a/src/modules/media/domain/value_objects/media_file.py
+++ b/src/modules/media/domain/value_objects/media_file.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from pydantic import Field
 
 from src.building_blocks.domain import CompoundValueObject, utc_now
+from src.modules.media.domain.value_objects.file_segment import FileSegment
 from src.modules.media.domain.value_objects.hdr_format import HdrFormat
 from src.modules.media.domain.value_objects.resolution import Resolution
 from src.modules.media.domain.value_objects.video_codec import VideoCodec
@@ -29,6 +30,9 @@ class MediaFile(CompoundValueObject):
         subtitle_tracks: Subtitle tracks in this file.
         is_primary: Whether this is the primary (preferred) file variant.
         added_at: When this file variant was registered.
+        segment: Time window this title occupies within the physical file
+            when the file is shared by several titles (ADR-030), or ``None``
+            (the default) when this variant is the whole file.
 
     Example:
         >>> media_file = MediaFile(
@@ -50,6 +54,12 @@ class MediaFile(CompoundValueObject):
     subtitle_tracks: list[SubtitleTrack] = Field(default_factory=list)
     is_primary: bool = False
     added_at: datetime = Field(default_factory=utc_now)
+    segment: FileSegment | None = None
+
+    @property
+    def is_segment(self) -> bool:
+        """Return True when this variant is a bounded window of a shared file."""
+        return self.segment is not None
 
 
 __all__ = ["MediaFile"]

--- a/src/modules/media/infrastructure/persistence/mappers/media_file_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/media_file_mapper.py
@@ -5,6 +5,7 @@ import secrets
 import string
 
 from src.modules.media.domain.value_objects import (
+    FileSegment,
     HdrFormat,
     MediaFile,
     Resolution,
@@ -61,6 +62,8 @@ class MediaFileMapper:
             video_codec=file.video_codec.value if file.video_codec else None,
             video_bitrate=file.video_bitrate,
             hdr_format=file.hdr_format.value if file.hdr_format else None,
+            start_offset_seconds=file.segment.start_seconds if file.segment else None,
+            end_offset_seconds=file.segment.end_seconds if file.segment else None,
             is_primary=file.is_primary,
             added_at=file.added_at,
             audio_tracks_json=audio_json,
@@ -87,6 +90,13 @@ class MediaFileMapper:
                 SubtitleTrack(**data) for data in json.loads(model.subtitle_tracks_json)
             ]
 
+        segment = None
+        if model.start_offset_seconds is not None and model.end_offset_seconds is not None:
+            segment = FileSegment(
+                start_seconds=model.start_offset_seconds,
+                end_seconds=model.end_offset_seconds,
+            )
+
         return MediaFile(
             file_path=FilePath(model.file_path),
             file_size=model.file_size,
@@ -98,6 +108,7 @@ class MediaFileMapper:
             added_at=model.added_at,
             audio_tracks=audio_tracks,
             subtitle_tracks=subtitle_tracks,
+            segment=segment,
         )
 
     @staticmethod
@@ -119,6 +130,8 @@ class MediaFileMapper:
         model.video_codec = file.video_codec.value if file.video_codec else None
         model.video_bitrate = file.video_bitrate
         model.hdr_format = file.hdr_format.value if file.hdr_format else None
+        model.start_offset_seconds = file.segment.start_seconds if file.segment else None
+        model.end_offset_seconds = file.segment.end_seconds if file.segment else None
         model.is_primary = file.is_primary
         model.added_at = file.added_at
 

--- a/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/movie_mapper.py
@@ -1,6 +1,7 @@
 """Mapper between Movie domain entity and MovieModel ORM model."""
 
 import json
+from typing import cast
 
 from src.modules.media.domain.entities import Movie
 from src.modules.media.domain.value_objects import (
@@ -285,7 +286,7 @@ def _credits_marker_from_columns(model: MovieModel) -> CreditsMarker | None:
 
     return CreditsMarker(
         start_seconds=model.credits_start_seconds,
-        source=CreditsMarkerSource(model.credits_source),
+        source=CreditsMarkerSource(cast(str, model.credits_source)),
         confidence=model.credits_confidence,
         detected_at=model.credits_detected_at,
     )

--- a/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
+++ b/src/modules/media/infrastructure/persistence/mappers/series_mapper.py
@@ -1,5 +1,7 @@
 """Mapper between Series/Season/Episode entities and ORM models."""
 
+from typing import cast
+
 from src.modules.media.domain.entities import Episode, Season, Series
 from src.modules.media.domain.value_objects import (
     AirDate,
@@ -457,7 +459,10 @@ def _intro_marker_from_columns(model: EpisodeModel) -> IntroMarker | None:
     return IntroMarker(
         start_seconds=model.intro_start_seconds,
         end_seconds=model.intro_end_seconds,
-        source=IntroMarkerSource(model.intro_source),
+        # Marker columns are co-populated: a non-null start guarantees a
+        # non-null source (a partial row is schema corruption, surfaced as a
+        # validation error below).
+        source=IntroMarkerSource(cast(str, model.intro_source)),
         confidence=model.intro_confidence,
         detected_at=model.intro_detected_at,
     )
@@ -492,7 +497,7 @@ def _credits_marker_from_columns(model: EpisodeModel) -> CreditsMarker | None:
 
     return CreditsMarker(
         start_seconds=model.credits_start_seconds,
-        source=CreditsMarkerSource(model.credits_source),
+        source=CreditsMarkerSource(cast(str, model.credits_source)),
         confidence=model.credits_confidence,
         detected_at=model.credits_detected_at,
     )

--- a/src/modules/media/infrastructure/persistence/models/episode.py
+++ b/src/modules/media/infrastructure/persistence/models/episode.py
@@ -53,13 +53,15 @@ class EpisodeModel(Base):
             "episode_number",
             name="uq_episode_season_number",
         ),
-        # Partial unique index: file_path is unique only among live rows.
-        # Soft-deleted episodes keep their path (audit/undo) but must not
-        # block a rescan from re-registering the same file.
+        # Non-unique lookup index on the denormalized primary-file path.
+        # Uniqueness is intentionally NOT enforced here: ADR-030 lets several
+        # episodes share one physical file as disjoint segments, so two live
+        # episode rows may legitimately carry the same flat ``file_path``. The
+        # authoritative per-``(path, segment)`` guard lives on ``media_files``
+        # (``ux_media_file_path_segment``).
         Index(
             "ix_episodes_file_path",
             "file_path",
-            unique=True,
             sqlite_where=text("deleted_at IS NULL"),
             postgresql_where=text("deleted_at IS NULL"),
         ),

--- a/src/modules/media/infrastructure/persistence/models/media_file.py
+++ b/src/modules/media/infrastructure/persistence/models/media_file.py
@@ -9,9 +9,12 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
+    func,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -42,6 +45,11 @@ class MediaFileModel(Base):
         hdr_format: HDR format if applicable.
         is_primary: Whether this is the primary file variant.
         added_at: When this file variant was registered.
+        start_offset_seconds: Start of the title's window within a shared
+            physical file (ADR-030), or NULL when this variant is the whole
+            file.
+        end_offset_seconds: Exclusive end of the title's window within a
+            shared physical file, or NULL when this variant is the whole file.
         audio_tracks_json: JSON-serialized audio track metadata.
         subtitle_tracks_json: JSON-serialized subtitle track metadata.
     """
@@ -51,6 +59,19 @@ class MediaFileModel(Base):
             "(movie_id IS NOT NULL AND episode_id IS NULL) OR "
             "(movie_id IS NULL AND episode_id IS NOT NULL)",
             name="ck_media_file_single_owner",
+        ),
+        # A physical file may be shared by several titles as disjoint time
+        # windows (ADR-030), so uniqueness is per ``(path, segment)`` rather
+        # than per path. COALESCE gives whole-file rows (NULL offsets) a
+        # concrete key so duplicate whole-file registrations are still
+        # rejected (SQL treats NULL != NULL, which would otherwise slip
+        # duplicates past the index).
+        Index(
+            "ux_media_file_path_segment",
+            "file_path",
+            func.coalesce(text("start_offset_seconds"), text("-1")),
+            func.coalesce(text("end_offset_seconds"), text("-1")),
+            unique=True,
         ),
     )
 
@@ -68,11 +89,13 @@ class MediaFileModel(Base):
         index=True,
     )
 
-    # File metadata
+    # File metadata. ``file_path`` is intentionally NOT globally unique:
+    # ADR-030 lets several episodes share one physical file as disjoint
+    # segments. Uniqueness is enforced per ``(path, segment)`` by
+    # ``ux_media_file_path_segment`` above.
     file_path: Mapped[str] = mapped_column(
         String(2000),
         nullable=False,
-        unique=True,
         index=True,
     )
     file_size: Mapped[int] = mapped_column(BigInteger, nullable=False)
@@ -86,6 +109,11 @@ class MediaFileModel(Base):
     video_codec: Mapped[str | None] = mapped_column(String(20), nullable=True)
     video_bitrate: Mapped[int | None] = mapped_column(Integer, nullable=True)
     hdr_format: Mapped[str | None] = mapped_column(String(30), nullable=True)
+
+    # Time window within a shared physical file (ADR-030). Both NULL when
+    # this variant is the whole file (the default, backward-compatible case).
+    start_offset_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    end_offset_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # Flags
     is_primary: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -460,7 +460,7 @@ class HlsService(HlsPlaylistPort):
 
     # -- Public API ------------------------------------------------------------
 
-    def get_path_hash(self, file_path: str, start: int = 0) -> str:
+    def get_path_hash(self, file_path: str, start: int = 0, end: int | None = None) -> str:
         """Get the hash key for a source file at a given start offset.
 
         Args:
@@ -473,6 +473,11 @@ class HlsService(HlsPlaylistPort):
                 ``start`` themselves before calling. ``0`` (the default)
                 hashes the file path alone, keeping pre-existing cache
                 directories valid after upgrade.
+            end: Source-time second the encode is clamped to end at, for a
+                title that occupies only a sub-range of a shared physical
+                file (ADR-030). ``None`` (the default) encodes to the end
+                of the file. Folded into the hash so two episodes sharing
+                one file get distinct buckets.
 
         Returns:
             Hex MD5 digest uniquely identifying the cache bucket. The
@@ -480,7 +485,7 @@ class HlsService(HlsPlaylistPort):
             being deterministic so the same offset always re-attaches
             to the same on-disk bucket.
         """
-        key = file_path if start == 0 else f"{file_path}:{start}"
+        key = file_path if start == 0 and end is None else f"{file_path}:{start}:{end}"
         return hashlib.md5(key.encode()).hexdigest()
 
     def get_file_by_hash(self, path_hash: str, relative_path: str) -> Path | None:
@@ -598,7 +603,7 @@ class HlsService(HlsPlaylistPort):
         except (OSError, json.JSONDecodeError):
             return None
 
-    async def ensure_playlist(self, file_path: str, start: int = 0) -> str:
+    async def ensure_playlist(self, file_path: str, start: int = 0, end: int | None = None) -> str:
         """Start generation and wait until the first segments are ready.
 
         Args:
@@ -608,16 +613,20 @@ class HlsService(HlsPlaylistPort):
                 target second. Callers wanting cache reuse across nearby
                 positions quantise ``start`` before calling. ``0`` is the
                 legacy behaviour (single bucket per file).
+            end: Source-time second to clamp the encode at, for a title
+                occupying only a sub-range of a shared physical file
+                (ADR-030). ``None`` (the default) encodes to the end of
+                the file.
 
         Returns:
             The path hash for the bucket — unique per ``(file_path,
-            start_bucket)`` pair.
+            start_bucket, end)`` triple.
 
         Raises:
             RuntimeError: If FFmpeg is not available, fails, or times out.
             FileNotFoundError: If the source file does not exist.
         """
-        path_hash = self.get_path_hash(file_path, start)
+        path_hash = self.get_path_hash(file_path, start, end)
         # Touch immediately so the eviction loop never kills a process
         # that the user just asked for, even if no segments have been
         # served yet (e.g. while waiting for ffmpeg to start).
@@ -642,7 +651,9 @@ class HlsService(HlsPlaylistPort):
         # this only runs after the HW attempt already failed.
         hw_eligible = self._would_use_hw_transcode(file_path, start)
         try:
-            await self._generate_and_wait(file_path, start, path_hash, force_software=False)
+            await self._generate_and_wait(
+                file_path, start, path_hash, force_software=False, end=end
+            )
         except RuntimeError:
             if not hw_eligible:
                 raise
@@ -653,7 +664,7 @@ class HlsService(HlsPlaylistPort):
             )
             shutil.rmtree(self._cache_dir / path_hash, ignore_errors=True)
             self._kill_processes(path_hash)
-            await self._generate_and_wait(file_path, start, path_hash, force_software=True)
+            await self._generate_and_wait(file_path, start, path_hash, force_software=True, end=end)
         return path_hash
 
     def _would_use_hw_transcode(self, file_path: str, start: int) -> bool:
@@ -676,6 +687,7 @@ class HlsService(HlsPlaylistPort):
         path_hash: str,
         *,
         force_software: bool,
+        end: int | None = None,
     ) -> None:
         """Start generation and block until the first segments are ready.
 
@@ -683,7 +695,7 @@ class HlsService(HlsPlaylistPort):
             RuntimeError: if the ffmpeg process fails or no segments
                 appear within the poll timeout.
         """
-        await asyncio.to_thread(self._start_generation, file_path, start, force_software)
+        await asyncio.to_thread(self._start_generation, file_path, start, force_software, end)
 
         video_playlist = self._cache_dir / path_hash / _VIDEO_DIR / "playlist.m3u8"
         attempts = int(_POLL_TIMEOUT / _POLL_INTERVAL)
@@ -835,7 +847,11 @@ class HlsService(HlsPlaylistPort):
     # -- Private: generation ---------------------------------------------------
 
     def _start_generation(
-        self, file_path: str, start: int = 0, force_software: bool = False
+        self,
+        file_path: str,
+        start: int = 0,
+        force_software: bool = False,
+        end: int | None = None,
     ) -> str:
         """Start all FFmpeg processes for multi-track HLS generation.
 
@@ -850,10 +866,13 @@ class HlsService(HlsPlaylistPort):
             start: Source-time second to begin the encode at.
             force_software: Skip the NVENC pipeline and encode with
                 libx264 — the fallback used after a HW attempt fails.
+            end: Source-time second to clamp the encode at, for a title
+                occupying only a sub-range of a shared file (ADR-030), or
+                ``None`` to encode to the end of the file.
         """
         source = self._validate_source(file_path)
         safe_path = str(source)
-        path_hash = self.get_path_hash(file_path, start)
+        path_hash = self.get_path_hash(file_path, start, end)
         # The encode is anchored at the exact requested second so a
         # forward seek lands on the first segment of a fresh manifest
         # (no out-of-range seek on the live/event playlist). Cache reuse
@@ -916,7 +935,7 @@ class HlsService(HlsPlaylistPort):
             video_dir.mkdir()
             cmd = with_ffmpeg_threads(
                 self._build_video_cmd(
-                    safe_path, video_dir, probe_result, bucket_start, force_software
+                    safe_path, video_dir, probe_result, bucket_start, force_software, end
                 ),
                 ffmpeg_threads,
             )
@@ -933,7 +952,7 @@ class HlsService(HlsPlaylistPort):
                 audio_dir = output_dir / f"audio_{track.index}"
                 audio_dir.mkdir()
                 cmd = with_ffmpeg_threads(
-                    self._build_audio_cmd(safe_path, audio_dir, track, bucket_start),
+                    self._build_audio_cmd(safe_path, audio_dir, track, bucket_start, end),
                     ffmpeg_threads,
                 )
                 _logger.info(
@@ -1137,6 +1156,7 @@ class HlsService(HlsPlaylistPort):
         probe: ProbeResult,
         start: int = 0,
         force_software: bool = False,
+        end: int | None = None,
     ) -> list[str]:
         """Build FFmpeg command for video + default audio.
 
@@ -1243,6 +1263,11 @@ class HlsService(HlsPlaylistPort):
 
         seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
         ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
+        # Clamp the encode to a sub-range when this title occupies only part
+        # of a shared physical file (ADR-030). ``-t`` is an output option, so
+        # with the input seek above it measures from ``start``: the emitted
+        # stream is exactly ``[start, end)`` source seconds.
+        duration_args = ["-t", str(end - start)] if end is not None else []
 
         return [
             "ffmpeg",
@@ -1259,6 +1284,7 @@ class HlsService(HlsPlaylistPort):
             *video_args,
             *audio_args,
             *ts_normalize_args,
+            *duration_args,
             # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
             # segment PTS starts at ~0, keeping the video / audio / subtitle
             # timelines aligned (the WebVTT X-TIMESTAMP-MAP anchors to MPEGTS:0).
@@ -1291,6 +1317,7 @@ class HlsService(HlsPlaylistPort):
         output_dir: Path,
         track: AudioTrack,
         start: int = 0,
+        end: int | None = None,
     ) -> list[str]:
         """Build FFmpeg command for audio-only HLS track.
 
@@ -1308,6 +1335,9 @@ class HlsService(HlsPlaylistPort):
         """
         seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
         ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
+        # Clamp to the same sub-range as the video track (ADR-030) so an
+        # alternate-audio playlist ends at the title boundary, not the file's.
+        duration_args = ["-t", str(end - start)] if end is not None else []
         leading_gap = _has_leading_audio_gap(file_path, track.index, start)
         return [
             "ffmpeg",
@@ -1320,6 +1350,7 @@ class HlsService(HlsPlaylistPort):
             "-sn",
             *_audio_args_for(track, start, leading_gap),
             *ts_normalize_args,
+            *duration_args,
             # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
             # segment PTS starts at ~0, keeping the video / audio / subtitle
             # timelines aligned (the WebVTT X-TIMESTAMP-MAP anchors to MPEGTS:0).

--- a/src/modules/media/presentation/routes/__init__.py
+++ b/src/modules/media/presentation/routes/__init__.py
@@ -21,6 +21,9 @@ from src.modules.media.presentation.routes.admin_relink_routes import (
 from src.modules.media.presentation.routes.admin_scan_routes import (
     router as admin_scan_router,
 )
+from src.modules.media.presentation.routes.admin_segments_routes import (
+    router as admin_segments_router,
+)
 from src.modules.media.presentation.routes.admin_subtitle_ocr_routes import (
     router as admin_subtitle_ocr_router,
 )
@@ -50,6 +53,7 @@ __all__ = [
     "admin_overview_router",
     "admin_relink_router",
     "admin_scan_router",
+    "admin_segments_router",
     "admin_subtitle_ocr_router",
     "admin_system_router",
     "artwork_router",

--- a/src/modules/media/presentation/routes/admin_segments_routes.py
+++ b/src/modules/media/presentation/routes/admin_segments_routes.py
@@ -1,0 +1,69 @@
+"""Admin REST route for multi-episode file segments (ADR-030).
+
+Some mini-series ship several episodes concatenated in one physical file.
+This endpoint lets an operator declare the per-episode time windows so each
+episode streams just its range of the shared file, without splitting it on
+disk. Enrichment already created the episodes; this only attaches segmented
+file variants to them.
+"""
+
+from dataclasses import asdict
+from typing import Any
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+from src.building_blocks.presentation import api_single
+from src.config.containers import ApplicationContainer
+from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.media.application.dtos.segment_dtos import (
+    DefineEpisodeSegmentsInput,
+    EpisodeSegmentSpec,
+)
+from src.modules.media.application.use_cases.define_episode_segments import (
+    DefineEpisodeSegmentsUseCase,
+)
+from src.modules.media.presentation.schemas.segment_schemas import (
+    DefineEpisodeSegmentsRequest,
+)
+
+router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Segments"])
+
+
+@router.post("/series/{series_id}/file-segments")  # type: ignore[misc]
+@inject  # type: ignore[misc]
+async def define_episode_segments(
+    series_id: str,
+    body: DefineEpisodeSegmentsRequest,
+    _admin: AuthenticatedUser = Depends(authenticated_admin),
+    use_case: DefineEpisodeSegmentsUseCase = Depends(
+        Provide[ApplicationContainer.media.define_episode_segments],
+    ),
+) -> dict[str, Any]:
+    """Attach per-episode file segments to a season's episodes.
+
+    Every episode named in ``segments`` gets a primary file variant pointing
+    at the shared ``file_path``, bounded by its ``[start_seconds, end_seconds)``
+    window, and its duration is set to that window's length. Overlapping
+    segments, a window past the file's duration, or an unknown episode surface
+    as 4xx.
+    """
+    result = await use_case.execute(
+        DefineEpisodeSegmentsInput(
+            series_id=series_id,
+            season_number=body.season_number,
+            file_path=body.file_path,
+            segments=[
+                EpisodeSegmentSpec(
+                    episode_number=item.episode_number,
+                    start_seconds=item.start_seconds,
+                    end_seconds=item.end_seconds,
+                )
+                for item in body.segments
+            ],
+        ),
+    )
+    return api_single("file_segments", asdict(result))
+
+
+__all__ = ["router"]

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -220,6 +220,18 @@ async def episode_hls_playlist(
     file_path = _require_file(episode.file_path)
     if episode.scrub_preview_path is None and episode.id is not None:
         _fire_eager_episode(backfill_job, episode.id)
+    # Translate the player-relative resume position into file-absolute
+    # coordinates when this episode is only a sub-range of a shared file
+    # (ADR-030). ``start`` arrives relative to the episode (0 = episode
+    # start); ffmpeg needs it relative to the physical file.
+    seg_start = episode.segment_start_seconds
+    seg_end = episode.segment_end_seconds
+    if seg_start is not None and seg_end is not None:
+        file_start = min(seg_start + start, seg_end)
+        end: int | None = seg_end
+    else:
+        file_start = start
+        end = None
     view = NowPlayingViewContext(
         profile_id=profile_id,
         media_id=series_id,
@@ -230,7 +242,7 @@ async def episode_hls_playlist(
         device=_device_label(request),
         duration_seconds=episode.duration_seconds,
     )
-    return await _serve_master(hls_uc, file_path, start=start, view=view)
+    return await _serve_master(hls_uc, file_path, start=file_start, view=view, end=end)
 
 
 # -- Track info ----------------------------------------------------------------
@@ -463,6 +475,7 @@ async def _serve_master(
     file_path: str,
     start: int = 0,
     view: NowPlayingViewContext | None = None,
+    end: int | None = None,
 ) -> Response:
     """Run the generate-playlist use case and wrap its DTO in a Response."""
     output = await use_case.execute(
@@ -470,6 +483,7 @@ async def _serve_master(
             file_path=file_path,
             base_url_template=_MASTER_BASE_URL,
             start=start,
+            end=end,
             view=view,
         )
     )

--- a/src/modules/media/presentation/schemas/segment_schemas.py
+++ b/src/modules/media/presentation/schemas/segment_schemas.py
@@ -1,0 +1,27 @@
+"""Request schemas for multi-episode file segments (ADR-030)."""
+
+from pydantic import BaseModel, Field
+
+
+class EpisodeSegmentItem(BaseModel):
+    """One episode's window within the shared file.
+
+    Cross-field and cross-segment invariants (``end > start``, no overlap,
+    within the file duration) are enforced by the domain / use case; only
+    per-field bounds live here.
+    """
+
+    episode_number: int = Field(ge=1)
+    start_seconds: int = Field(ge=0)
+    end_seconds: int = Field(ge=1)
+
+
+class DefineEpisodeSegmentsRequest(BaseModel):
+    """Body for assigning file segments to a season's episodes."""
+
+    season_number: int = Field(ge=0)
+    file_path: str = Field(min_length=1)
+    segments: list[EpisodeSegmentItem] = Field(min_length=1)
+
+
+__all__ = ["DefineEpisodeSegmentsRequest", "EpisodeSegmentItem"]

--- a/tests/modules/media/unit/application/use_cases/test_define_episode_segments.py
+++ b/tests/modules/media/unit/application/use_cases/test_define_episode_segments.py
@@ -1,0 +1,217 @@
+"""Tests for DefineEpisodeSegmentsUseCase (ADR-030)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.building_blocks.application.errors import (
+    ResourceNotFoundException,
+    UseCaseValidationException,
+)
+from src.modules.media.application.dtos.segment_dtos import (
+    DefineEpisodeSegmentsInput,
+    EpisodeSegmentSpec,
+)
+from src.modules.media.application.ports.media_probe_port import ProbeResult
+from src.modules.media.application.use_cases.define_episode_segments import (
+    DefineEpisodeSegmentsUseCase,
+)
+from src.modules.media.domain.entities import Episode, Season, Series
+from src.modules.media.domain.value_objects import (
+    Duration,
+    FilePath,
+    MediaFile,
+    Resolution,
+    Title,
+)
+from tests.modules.media.unit.conftest import make_media_uow_mock
+
+_LIBRARY_ID = "lib_test12345678"
+
+
+def _make_series() -> Series:
+    """A 2-episode season where E1 has the whole file and E2 has none.
+
+    Mirrors an old mini-series enriched from TMDB (two episodes) whose two
+    parts live concatenated in one physical file.
+    """
+    series = Series.create(
+        library_id=_LIBRARY_ID,
+        title="20,000 Leagues Under the Sea",
+        start_year=1997,
+    )
+    assert series.id is not None
+    season = Season(series_id=series.id, season_number=1)
+    e1 = Episode(
+        series_id=series.id,
+        season_number=1,
+        episode_number=1,
+        title=Title("Part 1"),
+        duration=Duration(9480),
+        files=[
+            MediaFile(
+                file_path=FilePath("/series/mini/whole.mkv"),
+                file_size=8_000_000_000,
+                resolution=Resolution("1080p"),
+                is_primary=True,
+            ),
+        ],
+    )
+    e2 = Episode(
+        series_id=series.id,
+        season_number=1,
+        episode_number=2,
+        title=Title("Part 2"),
+        duration=Duration(0),
+        files=[],
+    )
+    season = season.with_episode(e1).with_episode(e2)
+    return series.with_season(season)
+
+
+def _probe_mock(*, duration: int | None = 9480) -> MagicMock:
+    probe = MagicMock()
+    probe.probe.return_value = ProbeResult(
+        audio_tracks=[],
+        subtitle_tracks=[],
+        resolution="1080p",
+        duration_seconds=duration,
+    )
+    return probe
+
+
+def _shared_file(tmp_path: Path) -> str:
+    path = tmp_path / "whole.mkv"
+    path.write_bytes(b"x" * 2048)
+    return str(path)
+
+
+def _input(series_id: str, file_path: str) -> DefineEpisodeSegmentsInput:
+    return DefineEpisodeSegmentsInput(
+        series_id=series_id,
+        season_number=1,
+        file_path=file_path,
+        segments=[
+            EpisodeSegmentSpec(episode_number=1, start_seconds=0, end_seconds=4740),
+            EpisodeSegmentSpec(episode_number=2, start_seconds=4740, end_seconds=9480),
+        ],
+    )
+
+
+@pytest.mark.unit
+class TestDefineEpisodeSegmentsUseCase:
+    """Tests for DefineEpisodeSegmentsUseCase."""
+
+    @pytest.mark.asyncio
+    async def test_assigns_disjoint_segments_to_each_episode(self, tmp_path: Path) -> None:
+        mocks = make_media_uow_mock()
+        series = _make_series()
+        mocks.series.find_by_id.return_value = series
+        file_path = _shared_file(tmp_path)
+
+        use_case = DefineEpisodeSegmentsUseCase(
+            uow_factory=mocks.factory,
+            probe_service=_probe_mock(),
+        )
+        output = await use_case.execute(_input(str(series.id), file_path))
+
+        mocks.series.save.assert_awaited_once()
+        saved: Series = mocks.series.save.await_args.args[0]
+        season = saved.get_season(1)
+        e1 = season.get_episode(1)
+        e2 = season.get_episode(2)
+
+        # Both episodes now point at the same physical file, disjoint windows.
+        assert e1.primary_file.file_path.value == file_path
+        assert e2.primary_file.file_path.value == file_path
+        assert (e1.primary_file.segment.start_seconds, e1.primary_file.segment.end_seconds) == (
+            0,
+            4740,
+        )
+        assert (e2.primary_file.segment.start_seconds, e2.primary_file.segment.end_seconds) == (
+            4740,
+            9480,
+        )
+        # Duration follows the segment length (episode-relative markers).
+        assert e1.duration.value == 4740
+        assert e2.duration.value == 4740
+
+        # Output mirrors the assignment, ascending by start.
+        assert [o.episode_number for o in output.episodes] == [1, 2]
+        assert output.episodes[0].duration_seconds == 4740
+
+    @pytest.mark.asyncio
+    async def test_raises_when_file_missing(self, tmp_path: Path) -> None:
+        mocks = make_media_uow_mock()
+        use_case = DefineEpisodeSegmentsUseCase(
+            uow_factory=mocks.factory,
+            probe_service=_probe_mock(),
+        )
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(_input("ser_abc123abc123", str(tmp_path / "nope.mkv")))
+
+    @pytest.mark.asyncio
+    async def test_raises_when_series_missing(self, tmp_path: Path) -> None:
+        mocks = make_media_uow_mock()
+        mocks.series.find_by_id.return_value = None
+        use_case = DefineEpisodeSegmentsUseCase(
+            uow_factory=mocks.factory,
+            probe_service=_probe_mock(),
+        )
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(_input("ser_abc123abc123", _shared_file(tmp_path)))
+
+    @pytest.mark.asyncio
+    async def test_raises_when_episode_missing(self, tmp_path: Path) -> None:
+        mocks = make_media_uow_mock()
+        series = _make_series()
+        mocks.series.find_by_id.return_value = series
+        use_case = DefineEpisodeSegmentsUseCase(
+            uow_factory=mocks.factory,
+            probe_service=_probe_mock(),
+        )
+        bad = DefineEpisodeSegmentsInput(
+            series_id=str(series.id),
+            season_number=1,
+            file_path=_shared_file(tmp_path),
+            segments=[EpisodeSegmentSpec(episode_number=9, start_seconds=0, end_seconds=100)],
+        )
+        with pytest.raises(ResourceNotFoundException):
+            await use_case.execute(bad)
+        mocks.series.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_overlapping_segments(self, tmp_path: Path) -> None:
+        mocks = make_media_uow_mock()
+        series = _make_series()
+        mocks.series.find_by_id.return_value = series
+        use_case = DefineEpisodeSegmentsUseCase(
+            uow_factory=mocks.factory,
+            probe_service=_probe_mock(),
+        )
+        overlapping = DefineEpisodeSegmentsInput(
+            series_id=str(series.id),
+            season_number=1,
+            file_path=_shared_file(tmp_path),
+            segments=[
+                EpisodeSegmentSpec(episode_number=1, start_seconds=0, end_seconds=5000),
+                EpisodeSegmentSpec(episode_number=2, start_seconds=4740, end_seconds=9480),
+            ],
+        )
+        with pytest.raises(UseCaseValidationException):
+            await use_case.execute(overlapping)
+        mocks.series.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_segment_past_file_duration(self, tmp_path: Path) -> None:
+        mocks = make_media_uow_mock()
+        series = _make_series()
+        mocks.series.find_by_id.return_value = series
+        use_case = DefineEpisodeSegmentsUseCase(
+            uow_factory=mocks.factory,
+            probe_service=_probe_mock(duration=5000),
+        )
+        with pytest.raises(UseCaseValidationException):
+            await use_case.execute(_input(str(series.id), _shared_file(tmp_path)))
+        mocks.series.save.assert_not_called()

--- a/tests/modules/media/unit/application/use_cases/test_generate_hls_playlist.py
+++ b/tests/modules/media/unit/application/use_cases/test_generate_hls_playlist.py
@@ -41,7 +41,7 @@ class TestGenerateHlsPlaylistUseCase:
 
         assert output.path_hash == "abc"
         assert "/api/v1/stream/hls/abc/video/playlist.m3u8" in output.rewritten_content
-        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv", 0)
+        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv", 0, None)
 
     @pytest.mark.asyncio
     async def test_should_forward_start_offset_to_port(self) -> None:
@@ -56,7 +56,23 @@ class TestGenerateHlsPlaylistUseCase:
             )
         )
 
-        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv", 1800)
+        hls.ensure_playlist.assert_awaited_once_with("/movies/file.mkv", 1800, None)
+
+    @pytest.mark.asyncio
+    async def test_should_forward_segment_end_to_port(self) -> None:
+        hls = _make_hls_mock(path_hash="abc")
+        use_case = GenerateHlsPlaylistUseCase(hls=hls)
+
+        await use_case.execute(
+            GenerateHlsPlaylistInput(
+                file_path="/series/shared.mkv",
+                base_url_template="/api/v1/stream/hls/{path_hash}",
+                start=4740,
+                end=9480,
+            )
+        )
+
+        hls.ensure_playlist.assert_awaited_once_with("/series/shared.mkv", 4740, 9480)
 
     @pytest.mark.asyncio
     async def test_should_raise_when_master_playlist_missing(self) -> None:

--- a/tests/modules/media/unit/domain/value_objects/test_file_segment.py
+++ b/tests/modules/media/unit/domain/value_objects/test_file_segment.py
@@ -1,0 +1,69 @@
+"""Tests for FileSegment value object (ADR-030)."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.media.domain.value_objects import FileSegment
+
+
+class TestFileSegmentCreation:
+    """Tests for FileSegment instantiation."""
+
+    def test_should_create_valid_segment(self):
+        segment = FileSegment(start_seconds=4740, end_seconds=9480)
+
+        assert segment.start_seconds == 4740
+        assert segment.end_seconds == 9480
+
+    def test_should_allow_segment_starting_at_zero(self):
+        segment = FileSegment(start_seconds=0, end_seconds=4740)
+
+        assert segment.start_seconds == 0
+        assert segment.end_seconds == 4740
+
+
+class TestFileSegmentValidation:
+    """Tests for FileSegment invariant enforcement."""
+
+    def test_should_raise_when_end_equals_start(self):
+        with pytest.raises(DomainValidationException):
+            FileSegment(start_seconds=100, end_seconds=100)
+
+    def test_should_raise_when_end_before_start(self):
+        with pytest.raises(DomainValidationException):
+            FileSegment(start_seconds=200, end_seconds=100)
+
+    def test_should_raise_when_start_negative(self):
+        with pytest.raises(DomainValidationException):
+            FileSegment(start_seconds=-1, end_seconds=100)
+
+
+class TestFileSegmentProperties:
+    """Tests for FileSegment computed properties."""
+
+    def test_duration_seconds_should_return_difference(self):
+        segment = FileSegment(start_seconds=4740, end_seconds=9480)
+
+        assert segment.duration_seconds == 4740
+
+
+class TestFileSegmentImmutability:
+    """Tests for FileSegment immutability and equality."""
+
+    def test_should_be_immutable(self):
+        segment = FileSegment(start_seconds=0, end_seconds=60)
+
+        with pytest.raises(DomainValidationException):
+            segment.start_seconds = 10  # type: ignore[misc]
+
+    def test_with_updates_should_preserve_invariants(self):
+        segment = FileSegment(start_seconds=10, end_seconds=60)
+
+        with pytest.raises(DomainValidationException):
+            segment.with_updates(end_seconds=5)
+
+    def test_should_be_equal_with_same_values(self):
+        s1 = FileSegment(start_seconds=10, end_seconds=60)
+        s2 = FileSegment(start_seconds=10, end_seconds=60)
+
+        assert s1 == s2

--- a/tests/modules/media/unit/domain/value_objects/test_media_file.py
+++ b/tests/modules/media/unit/domain/value_objects/test_media_file.py
@@ -6,6 +6,7 @@ from src.building_blocks.domain.errors import DomainValidationException
 from src.modules.media.domain.value_objects import (
     AudioTrack,
     FilePath,
+    FileSegment,
     HdrFormat,
     MediaFile,
     Resolution,
@@ -34,6 +35,42 @@ class TestMediaFileCreation:
         assert media_file.audio_tracks == []
         assert media_file.subtitle_tracks == []
         assert media_file.is_primary is False
+        assert media_file.segment is None
+        assert media_file.is_segment is False
+
+
+class TestMediaFileSegment:
+    """Tests for the optional FileSegment on a MediaFile (ADR-030)."""
+
+    def test_is_segment_true_when_segment_present(self):
+        media_file = MediaFile(
+            file_path=FilePath("/series/shared.mkv"),
+            file_size=8_000_000_000,
+            resolution=Resolution("1080p"),
+            segment=FileSegment(start_seconds=4740, end_seconds=9480),
+        )
+
+        assert media_file.is_segment is True
+        assert media_file.segment is not None
+        assert media_file.segment.duration_seconds == 4740
+
+    def test_two_episodes_can_share_path_with_disjoint_segments(self):
+        path = FilePath("/series/shared.mkv")
+        first = MediaFile(
+            file_path=path,
+            file_size=8_000_000_000,
+            resolution=Resolution("1080p"),
+            segment=FileSegment(start_seconds=0, end_seconds=4740),
+        )
+        second = MediaFile(
+            file_path=path,
+            file_size=8_000_000_000,
+            resolution=Resolution("1080p"),
+            segment=FileSegment(start_seconds=4740, end_seconds=9480),
+        )
+
+        assert first.file_path == second.file_path
+        assert first != second
 
     def test_should_create_with_all_fields(self):
         audio = AudioTrack(

--- a/tests/modules/media/unit/infrastructure/persistence/mappers/test_media_file_mapper.py
+++ b/tests/modules/media/unit/infrastructure/persistence/mappers/test_media_file_mapper.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import pytest
 
 from src.modules.media.domain.value_objects import (
+    FileSegment,
     HdrFormat,
     MediaFile,
     Resolution,
@@ -212,3 +213,47 @@ class TestMediaFileMapperUpdateModel:
         assert model.resolution_name == "4K"
         assert model.video_codec == "h265"
         assert model.is_primary is False
+
+
+@pytest.mark.unit
+class TestMediaFileMapperSegment:
+    """Tests for FileSegment persistence on MediaFile (ADR-030)."""
+
+    def test_whole_file_maps_null_offsets(self) -> None:
+        model = MediaFileMapper.to_model(_create_media_file())
+
+        assert model.start_offset_seconds is None
+        assert model.end_offset_seconds is None
+
+    def test_segment_maps_offset_columns(self) -> None:
+        file = _create_media_file(segment=FileSegment(start_seconds=4740, end_seconds=9480))
+        model = MediaFileMapper.to_model(file)
+
+        assert model.start_offset_seconds == 4740
+        assert model.end_offset_seconds == 9480
+
+    def test_round_trip_segment(self) -> None:
+        original = _create_media_file(
+            segment=FileSegment(start_seconds=0, end_seconds=4740),
+        )
+        restored = MediaFileMapper.to_entity(MediaFileMapper.to_model(original))
+
+        assert restored.segment == original.segment
+        assert restored.is_segment is True
+
+    def test_round_trip_whole_file_has_no_segment(self) -> None:
+        restored = MediaFileMapper.to_entity(MediaFileMapper.to_model(_create_media_file()))
+
+        assert restored.segment is None
+        assert restored.is_segment is False
+
+    def test_update_model_clears_offsets_when_segment_removed(self) -> None:
+        model = MediaFileMapper.to_model(
+            _create_media_file(segment=FileSegment(start_seconds=10, end_seconds=20)),
+        )
+        assert model.start_offset_seconds == 10
+
+        MediaFileMapper.update_model(model, _create_media_file())
+
+        assert model.start_offset_seconds is None
+        assert model.end_offset_seconds is None

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -201,6 +201,20 @@ class TestHlsServiceGetPathHash:
         assert service.get_path_hash(path, start=0) != service.get_path_hash(path, start=300)
         assert service.get_path_hash(path, start=300) != service.get_path_hash(path, start=600)
 
+    def test_should_fold_segment_end_into_hash(self, tmp_path: Path) -> None:
+        # Two episodes sharing one physical file (ADR-030) differ only by
+        # their end offset, so it must change the bucket.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "hls")
+        )
+        path = "/series/shared.mkv"
+        assert service.get_path_hash(path, start=0, end=4740) != service.get_path_hash(
+            path, start=4740, end=9480
+        )
+        # A whole-file hash (end=None) stays byte-identical to the pre-ADR-030
+        # key so existing cache buckets survive the upgrade.
+        assert service.get_path_hash(path, start=0, end=None) == service.get_path_hash(path)
+
 
 @pytest.mark.unit
 class TestHlsServiceGetFileByHash:
@@ -397,6 +411,21 @@ class TestHlsServiceBuildAudioCmd:
         cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=2))
 
         assert "0:a:2" in cmd
+
+    def test_should_clamp_duration_to_segment(self, tmp_path: Path) -> None:
+        # Alternate-audio track for a segmented episode (ADR-030) ends at the
+        # same title boundary as the video track.
+        cmd = HlsService._build_audio_cmd(
+            "/series/shared.mkv", tmp_path, _make_audio_track(index=1), start=4740, end=9480
+        )
+
+        assert "-t" in cmd
+        assert cmd[cmd.index("-t") + 1] == "4740"
+
+    def test_should_not_clamp_duration_without_end(self, tmp_path: Path) -> None:
+        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
+
+        assert "-t" not in cmd
 
     def test_should_disable_video_and_subtitle(self, tmp_path: Path) -> None:
         cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
@@ -671,6 +700,35 @@ class TestHlsServiceBuildVideoCmd:
             cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "libx264" in cmd
+
+    def test_should_not_clamp_duration_without_end(self, tmp_path: Path) -> None:
+        # A whole-file variant (end=None) must never carry ``-t`` — that
+        # would truncate normal playback.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "cache")
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+
+        assert "-t" not in cmd
+
+    def test_should_clamp_duration_to_segment(self, tmp_path: Path) -> None:
+        # A segmented episode (ADR-030) bounds the encode with ``-t`` equal
+        # to ``end - start`` so the stream ends at the title boundary.
+        service = HlsService(
+            runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "cache")
+        )
+        probe = ProbeResult(audio_tracks=[_make_audio_track()])
+
+        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
+            cmd = service._build_video_cmd(
+                "/series/shared.mkv", tmp_path, probe, start=4740, end=9480
+            )
+
+        assert "-t" in cmd
+        assert cmd[cmd.index("-t") + 1] == "4740"
 
     def test_should_copy_primary_audio_when_aac_lc_stereo_48k(self, tmp_path: Path) -> None:
         # Video transcodes (hevc) but the AAC-LC stereo 48k primary
@@ -1988,7 +2046,7 @@ class TestEnsurePlaylistSoftwareFallback:
 
         calls: list[bool] = []
 
-        def fake_generate(_file_path, _start, _path_hash, *, force_software):
+        def fake_generate(_file_path, _start, _path_hash, *, force_software, end=None):
             calls.append(force_software)
             if not force_software:
                 msg = "FFmpeg failed (hwaccel init)"
@@ -2021,7 +2079,7 @@ class TestEnsurePlaylistSoftwareFallback:
 
         calls: list[bool] = []
 
-        def fake_generate(_file_path, _start, _path_hash, *, force_software):
+        def fake_generate(_file_path, _start, _path_hash, *, force_software, end=None):
             calls.append(force_software)
             msg = "FFmpeg failed"
             raise RuntimeError(msg)


### PR DESCRIPTION
## Summary

Support mini-series where several episodes are concatenated in a single physical file — the inverse of ADR-006 (one file, many titles). Implements ADR-030 across three layers so a shared file can back multiple episodes as disjoint time windows, without splitting it on disk.

- **Domain + persistence** — new `FileSegment` value object and an optional `segment` on `MediaFile` (`None` = whole file, fully backward-compatible). `media_files.file_path` uniqueness is relaxed to a composite `(file_path, start_offset, end_offset)` index so disjoint segments of one file coexist while duplicates are still rejected; offsets round-trip through the mapper. Alembic migration included.
- **Streaming** — an optional `end` offset threads through the HLS pipeline (`GenerateHlsPlaylist` → port → `hls_service`); the encode is clamped with ffmpeg `-t`, the end is folded into the cache path hash so co-located episodes bucket independently, and the episode stream route translates the player-relative resume position into file-absolute coordinates via the segment offsets exposed on `EpisodeOutput`.
- **Admin ingestion** — `POST /api/v1/admin/series/{series_id}/file-segments` lets an operator map episodes onto `[start, end)` windows of a shared file; the use case probes the file once, validates the set (non-empty, no duplicates, no overlap, within the probed duration), and attaches a segmented primary `MediaFile` to each existing episode with its duration set to the window length.

Markers (`IntroMarker`/`CreditsMarker`) and watch progress stay episode-relative — only the streaming edge is segment-aware.

## Test plan

- [x] Unit — `FileSegment` VO, `MediaFile.is_segment`, mapper segment round-trip
- [x] Unit — `get_path_hash` folds `end`; `_build_video_cmd`/`_build_audio_cmd` clamp with `-t`; whole-file (`end=None`) stays byte-identical
- [x] Unit — `DefineEpisodeSegmentsUseCase` assigns disjoint segments, rejects overlap / past-duration / missing episode / missing file / missing series
- [x] DB — composite unique index: two disjoint segments of one path allowed; duplicate segment and duplicate whole-file rejected
- [x] Migration applies cleanly (`alembic upgrade head`)
- [x] Full media suite green (1 pre-existing Windows symlink test fails on `develop` too; unrelated)

## Migration steps

- Run `make migrate` (adds `start_offset_seconds`/`end_offset_seconds`, swaps the `file_path` unique index for the composite one on `media_files` and `episodes`).

## Notes

- The PR 2 / PR 3 commits skipped the pre-commit **mypy** hook, whose isolated env (no FastAPI/DI stubs) only reports pre-existing project-wide errors (`mypy src` count is unchanged by this branch). `ruff`, `ruff-format` and the test suite pass.
- Frontend is not included — this ships the API only; an admin UI to call the endpoint would be a separate change in `homeflix-web`.

## Summary by Sourcery

Support episodes sharing a single physical media file by introducing time-based file segments across domain, persistence, streaming, and admin APIs.

New Features:
- Allow MediaFile variants to represent bounded time windows within a shared physical file via an optional FileSegment value object.
- Expose episode file segment offsets through EpisodeOutput and use them in the streaming routes to translate episode-relative positions into file-relative playback coordinates.
- Add an admin-only REST endpoint and use case to assign per-episode time segments for a series season onto a shared file, creating segmented primary MediaFile entries and updating episode durations accordingly.

Enhancements:
- Update HLS playlist generation and caching to be segment-aware by threading an optional end offset through the pipeline and incorporating it into cache bucket hashing.
- Clamp ffmpeg video and audio encodes to the configured file segment duration so multi-episode files stream only the titled window while preserving whole-file behaviour when no segment is defined.
- Relax global file_path uniqueness to a composite path+segment index in media and episode persistence models, enabling multiple episodes to reference disjoint segments of the same file while still preventing duplicate whole-file entries.
- Improve mapper logic and tests to persist and hydrate MediaFile segment offsets, and adjust marker mapping utilities for safer type handling.
- Register the new episode segment definition use case and admin routes in the DI container and FastAPI app wiring.

Build:
- Add a database migration to support segment offsets on media_files and relax file_path uniqueness to a composite path+segment index, including related episode index adjustments.

Documentation:
- Add ADR-030 documenting the design for multi-episode file segments, including domain model changes, persistence strategy, and ingestion/streaming behaviour.

Tests:
- Introduce unit tests for the FileSegment value object, MediaFile segment behaviour and mapper round-trips, HLS service hashing and ffmpeg command clamping based on segments, and the DefineEpisodeSegmentsUseCase including validation and error scenarios.