### PR TITLE
chore: release 0.5.0

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -29,6 +29,11 @@ Para os requisitos completos (incluindo o que ainda é planejado), veja
 - **Variantes de arquivo** — múltiplas versões do mesmo título (720p/1080p/4K,
   HDR) agrupadas como uma mídia com vários arquivos
   ([ADR-006](adr/ADR-006-media-file-variants.md)).
+- **Arquivos multi-episódio** — o caso inverso das variantes: um único arquivo
+  físico que contém vários episódios (minisséries antigas). Cada episódio aponta
+  para uma janela de tempo `[início, fim)` do arquivo compartilhado, reproduzida
+  clampada via HLS sem cortar o arquivo no disco. Um endpoint admin define os
+  cortes por episódio ([ADR-030](adr/ADR-030-multi-episode-file-segments.md)).
 - **Detecção de abertura (intro)** por frame-hash de vídeo, plugável
   ([ADR-020](adr/ADR-020-pluggable-intro-detector-frame-hash.md)).
 - **Detecção de créditos** por sinais visuais (borda + movimento), por arquivo
@@ -71,11 +76,16 @@ Para os requisitos completos (incluindo o que ainda é planejado), veja
 
 - **Watchlist**, **favoritos** e **listas personalizadas** (com reordenação),
   todos escopo por perfil.
+- **Compartilhamento e follow de listas** — uma lista personalizada pode ser
+  compartilhada por um token opaco; outros perfis passam a segui-la, com o
+  follow idempotente e reversível.
 
 ## Busca e navegação
 
 - **Busca full-text** (SQLite FTS5) sobre campos localizados, com navegação por
   gênero e por ator, ordenados pelo título localizado.
+- **Ordenação na listagem por gênero** — opções de ordenação (por título, ano,
+  data de adição) com paginação por cursor.
 
 ## Multi-usuário e identidade
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "homeflix"
-version = "0.4.0"
+version = "0.5.0"
 description = "Personal streaming platform for local media"
 authors = ["Lucas"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version `0.4.0` → `0.5.0`.
- Document the release's new capabilities in `docs/features.md`: multi-episode file segments (ADR-030), custom-list sharing & following, and sort options on the by-genre listing.

Release scope since v0.4.0 (PRs #372–#375). The GitHub release + tag are cut after this merges.

## Test plan

- [x] `check-toml` / pre-commit hooks pass
- [ ] CI green (docs strict build validates the features page)

## Summary by Sourcery

Prepare the 0.5.0 release by updating the documented feature set and bumping the project version.

New Features:
- Document multi-episode file segment support, including admin-defined per-episode time windows.
- Document sharing and following of custom lists via opaque tokens with reversible follows.
- Document sort options for the by-genre listing, including title, year, and added date.

Enhancements:
- Update project version metadata from 0.4.0 to 0.5.0 in the packaging configuration.

Documentation:
- Expand the features overview page to cover multi-episode files, list sharing/following, and genre listing sort options.