### PR TITLE
ci: enforce mypy in the type-check gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
 
       - name: Run MyPy
         run: poetry run mypy src --ignore-missing-imports
-        continue-on-error: true
 
   test:
     name: Test
@@ -188,6 +187,7 @@ jobs:
       - name: Check all jobs passed
         run: |
           if [[ "${{ needs.lint.result }}" != "success" ]] || \
+             [[ "${{ needs.type-check.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.docs.result }}" != "success" ]]; then
             echo "Required jobs failed"


### PR DESCRIPTION
Drop continue-on-error on the MyPy step and add type-check to the ci-success required jobs, so a type regression fails the build. The tree is already mypy-clean (see #376).

## Summary by Sourcery

Enforce MyPy type checking as a required CI gate so type regressions fail the pipeline.

CI:
- Make the MyPy type-check step fail the CI job on errors instead of continuing.
- Require the type-check job to pass alongside lint, test, and docs in the ci-success aggregate job.