### PR TITLE
refactor(catalog-requests): type poster_url as ImageUrl VO

### DIFF
--- a/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
+++ b/src/modules/catalog_requests/application/dtos/catalog_request_dtos.py
@@ -140,7 +140,7 @@ class CatalogRequestOutput:
             tmdb_id=entity.tmdb_id,
             media_type=entity.media_type.value,
             title=entity.get_title(lang) if lang is not None else entity.title,
-            poster_url=entity.poster_url,
+            poster_url=entity.poster_url.value if entity.poster_url else None,
             requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
             source=entity.source.value,

--- a/src/modules/catalog_requests/domain/entities/catalog_request.py
+++ b/src/modules/catalog_requests/domain/entities/catalog_request.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from src.building_blocks.domain import AggregateRoot
 from src.modules.catalog_requests.domain.value_objects import (
@@ -12,9 +12,7 @@ from src.modules.catalog_requests.domain.value_objects import (
     CatalogRequestSource,
     CatalogRequestStatus,
 )
-from src.shared_kernel.value_objects import (
-    MediaType,  # noqa: TCH001 — runtime for Pydantic
-)
+from src.shared_kernel.value_objects import ImageUrl, MediaType
 
 
 class CatalogRequest(AggregateRoot[CatalogRequestId]):
@@ -81,7 +79,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
     # "Em breve" feed renders in the viewer's language; falls back to
     # the English snapshot / ``title`` when a locale is missing.
     localized_titles: dict[str, str] = Field(default_factory=dict)
-    poster_url: str | None = None
+    poster_url: ImageUrl | None = None
     requester_user_id: str | None = None
     collection_tmdb_id: int | None = None
     source: CatalogRequestSource = CatalogRequestSource.HOUSEHOLD
@@ -89,13 +87,26 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
     requested_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     fulfilled_at: datetime | None = None
 
+    @field_validator("poster_url", mode="before")
+    @classmethod
+    def _convert_poster_url(cls, v: str | ImageUrl | None) -> ImageUrl | None:
+        """Accept a raw ``str`` at the boundary and normalize to ``ImageUrl``.
+
+        The TMDB snapshot arrives as a plain URL string from the use case;
+        typing the field as ``ImageUrl`` validates it once here and lets the
+        VO flow (with ``.is_remote`` etc.) through the domain (ADR-018).
+        """
+        if v is None or isinstance(v, ImageUrl):
+            return v
+        return ImageUrl(v)
+
     @classmethod
     def create(
         cls,
         tmdb_id: int,
         media_type: MediaType,
         title: str | None = None,
-        poster_url: str | None = None,
+        poster_url: str | ImageUrl | None = None,
         requester_user_id: str | None = None,
         collection_tmdb_id: int | None = None,
         notify_on_arrival: bool = False,
@@ -189,7 +200,7 @@ class CatalogRequest(AggregateRoot[CatalogRequestId]):
         self,
         *,
         title: str | None = None,
-        poster_url: str | None = None,
+        poster_url: str | ImageUrl | None = None,
         requester_user_id: str | None = None,
         notify: bool = False,
         localized_titles: dict[str, str] | None = None,

--- a/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
+++ b/src/modules/catalog_requests/infrastructure/persistence/mappers/catalog_request_mapper.py
@@ -46,7 +46,7 @@ class CatalogRequestMapper:
             localized_titles=json.dumps(entity.localized_titles, ensure_ascii=False)
             if entity.localized_titles
             else None,
-            poster_url=entity.poster_url,
+            poster_url=entity.poster_url.value if entity.poster_url else None,
             requester_user_id=entity.requester_user_id,
             collection_tmdb_id=entity.collection_tmdb_id,
             source=entity.source.value,
@@ -96,7 +96,7 @@ class CatalogRequestMapper:
             if entity.localized_titles
             else None
         )
-        model.poster_url = entity.poster_url
+        model.poster_url = entity.poster_url.value if entity.poster_url else None
         model.requester_user_id = entity.requester_user_id
         model.collection_tmdb_id = entity.collection_tmdb_id
         model.notify_on_arrival = entity.notify_on_arrival

--- a/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
+++ b/tests/modules/catalog_requests/unit/domain/test_catalog_request.py
@@ -10,7 +10,7 @@ from src.modules.catalog_requests.domain.value_objects import (
     CatalogRequestSource,
     CatalogRequestStatus,
 )
-from src.shared_kernel.value_objects import MediaType
+from src.shared_kernel.value_objects import ImageUrl, MediaType
 
 
 @pytest.mark.unit
@@ -160,13 +160,13 @@ class TestCatalogRequest:
             poster_url="https://image.tmdb.org/t/p/original/alien.jpg",
         )
 
-        assert request.poster_url == "https://image.tmdb.org/t/p/original/alien.jpg"
+        assert request.poster_url == ImageUrl("https://image.tmdb.org/t/p/original/alien.jpg")
 
     def test_reconcile_backfills_poster_first_owner_wins(self) -> None:
         without = CatalogRequest.create(tmdb_id=348, media_type=MediaType.MOVIE)
         backfilled = without.reconcile(poster_url="https://img/poster.jpg")
         assert backfilled is not None
-        assert backfilled.poster_url == "https://img/poster.jpg"
+        assert backfilled.poster_url == ImageUrl("https://img/poster.jpg")
 
         # A later poster never overwrites the first snapshot.
         assert backfilled.reconcile(poster_url="https://img/other.jpg") is None


### PR DESCRIPTION
## Summary

- Replace the primitive `poster_url: str` on the `CatalogRequest` aggregate with the `ImageUrl` value object, so the TMDB poster snapshot is validated once at the boundary and flows typed through the domain (roadmap 2.2 — Primitive Obsession; ADR-018).
- Add a `@field_validator("poster_url", mode="before")` that normalizes an incoming `str` to `ImageUrl`, mirroring the `CustomList` name-conversion pattern. `create()` / `reconcile()` accept `str | ImageUrl | None`.
- Keep the edges as `str`: the DB column, the application Input/Output DTOs, and the HTTP schemas are unchanged — the mapper and `from_entity` unwrap via `.value`.

## Test plan

- [x] `pytest tests/modules/catalog_requests` — 73 passed
- [x] `mypy src` — 0 errors (769 files)
- [x] `ruff check` / `ruff format --check` — clean
- [x] Round-trip: `reconcile()` backfills a raw poster `str` and it re-validates to `ImageUrl` via `with_updates`

## Summary by Sourcery

Refactor catalog request poster URLs to use a typed ImageUrl value object while keeping external interfaces unchanged.

Enhancements:
- Replace the CatalogRequest.poster_url primitive string with the ImageUrl value object and normalize inputs via a field validator.
- Update persistence mappers and application DTOs to unwrap ImageUrl back to raw strings at the boundaries.

Tests:
- Adjust catalog request domain tests to assert on ImageUrl instances for poster URLs.