### PR TITLE
chore: gitignore mirrored artwork directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,11 @@ uploads/
 # Generated thumbnails
 thumbnails/
 
+# Mirrored catalog artwork (ADR-029). Runtime durability cache created by the
+# ArtworkMirrorJob under ARTWORK_STORAGE_DIRECTORY (default ./artwork). It is
+# regenerable from the provider, so it must never be committed.
+artwork/
+
 # Alembic versions (keep template)
 backend/src/infrastructure/persistence/migrations/versions/*.py
 !backend/src/infrastructure/persistence/migrations/versions/.gitkeep


### PR DESCRIPTION
## Summary

- Add `artwork/` to `.gitignore`. The `ArtworkMirrorJob` (ADR-029) writes a regenerable durability cache under `ARTWORK_STORAGE_DIRECTORY`, whose default `./artwork` lands at the repo root.
- A dev run started from the repo without the storage override (as happened during the ADR-030 live validation) mirrors provider images into `./artwork` and leaves ~76 binary files staged-ready at the repo root. Ignoring the directory prevents that from ever being committed.
- No durability impact: the real store lives elsewhere (e.g. an absolute path on a persistent volume), the cache is regenerable from the provider, and the serving route falls back to the origin URL when an object is absent.

## Test plan

- [x] `git status` clean after removing the leftover `./artwork` and ignoring it
- [x] `.env.example` already documents `ARTWORK_STORAGE_DIRECTORY` — no config change needed

## Summary by Sourcery

Chores:
- Add the mirrored artwork cache directory to .gitignore to prevent committing regenerated binary assets.