### PR TITLE
refactor(watch-progress): extract PlaybackPosition value object

### DIFF
--- a/src/modules/watch_progress/domain/entities/watch_progress.py
+++ b/src/modules/watch_progress/domain/entities/watch_progress.py
@@ -9,6 +9,7 @@ from pydantic import Field, model_validator
 
 from src.building_blocks.domain import AggregateRoot
 from src.modules.watch_progress.domain.value_objects import (
+    PlaybackPosition,
     ProgressId,
     SubtitlePreference,
     WatchableMediaId,
@@ -56,9 +57,9 @@ class WatchProgress(AggregateRoot[ProgressId]):
             )
         return self
 
-    # Position tracking
-    position_seconds: int = Field(ge=0)
-    duration_seconds: int = Field(gt=0)
+    # Position tracking — position + duration bundled so the progress
+    # arithmetic (ratio/percentage/completion) lives on the value object.
+    position: PlaybackPosition
     status: WatchStatus = Field(default=WatchStatus.IN_PROGRESS)
 
     # Track preferences
@@ -69,26 +70,20 @@ class WatchProgress(AggregateRoot[ProgressId]):
     last_watched_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     completed_at: datetime | None = None
 
-    @staticmethod
-    def _watched_ratio(position_seconds: int, duration_seconds: int | None) -> float:
-        """Fraction of the media watched (0.0+); 0.0 when duration is unknown.
+    @property
+    def position_seconds(self) -> int:
+        """Current playback position in seconds (from the position VO)."""
+        return self.position.position_seconds
 
-        Single source of the position/duration formula shared by
-        ``percentage`` and the completion check so the two never drift.
-        """
-        if not duration_seconds:
-            return 0.0
-        return position_seconds / duration_seconds
-
-    @classmethod
-    def _reaches_completion(cls, position_seconds: int, duration_seconds: int | None) -> bool:
-        """Whether the watched ratio crosses the completion threshold."""
-        return cls._watched_ratio(position_seconds, duration_seconds) >= _COMPLETION_THRESHOLD
+    @property
+    def duration_seconds(self) -> int:
+        """Total media duration in seconds (from the position VO)."""
+        return self.position.duration_seconds
 
     @property
     def percentage(self) -> float:
         """Calculate watch percentage (0-100)."""
-        return min(100.0, self._watched_ratio(self.position_seconds, self.duration_seconds) * 100)
+        return self.position.percentage
 
     @property
     def is_completed(self) -> bool:
@@ -119,15 +114,17 @@ class WatchProgress(AggregateRoot[ProgressId]):
         """
         now = datetime.now(UTC)
         effective_duration = duration_seconds or self.duration_seconds
-        is_complete = self._reaches_completion(position_seconds, effective_duration)
+        new_position = PlaybackPosition(
+            position_seconds=position_seconds,
+            duration_seconds=effective_duration,
+        )
+        is_complete = new_position.reaches_completion(_COMPLETION_THRESHOLD)
 
         updates: dict[str, object] = {
-            "position_seconds": position_seconds,
+            "position": new_position,
             "last_watched_at": now,
         }
 
-        if duration_seconds is not None:
-            updates["duration_seconds"] = duration_seconds
         if audio_track is not None:
             updates["audio_track"] = audio_track
         if subtitle_track is not None:
@@ -169,15 +166,18 @@ class WatchProgress(AggregateRoot[ProgressId]):
             A new WatchProgress instance.
         """
         now = datetime.now(UTC)
-        is_complete = cls._reaches_completion(position_seconds, duration_seconds)
+        position = PlaybackPosition(
+            position_seconds=position_seconds,
+            duration_seconds=duration_seconds,
+        )
+        is_complete = position.reaches_completion(_COMPLETION_THRESHOLD)
 
         return cls(
             id=ProgressId.generate(),
             profile_id=profile_id,
             media_id=media_id,
             media_type=media_type,
-            position_seconds=position_seconds,
-            duration_seconds=duration_seconds,
+            position=position,
             status=WatchStatus.COMPLETED if is_complete else WatchStatus.IN_PROGRESS,
             audio_track=audio_track,
             subtitle_track=subtitle_track,

--- a/src/modules/watch_progress/domain/value_objects/__init__.py
+++ b/src/modules/watch_progress/domain/value_objects/__init__.py
@@ -3,6 +3,9 @@
 from src.modules.watch_progress.domain.value_objects.episode_candidate import (
     EpisodeCandidate,
 )
+from src.modules.watch_progress.domain.value_objects.playback_position import (
+    PlaybackPosition,
+)
 from src.modules.watch_progress.domain.value_objects.progress_id import ProgressId
 from src.modules.watch_progress.domain.value_objects.subtitle_preference import (
     SubtitlePreference,
@@ -17,6 +20,7 @@ from src.modules.watch_progress.domain.value_objects.watchable_media_type import
 
 __all__ = [
     "EpisodeCandidate",
+    "PlaybackPosition",
     "ProgressId",
     "SubtitlePreference",
     "WatchStatus",

--- a/src/modules/watch_progress/domain/value_objects/playback_position.py
+++ b/src/modules/watch_progress/domain/value_objects/playback_position.py
@@ -1,0 +1,49 @@
+"""PlaybackPosition value object — the playhead within a media's duration."""
+
+from pydantic import Field
+
+from src.building_blocks.domain import CompoundValueObject
+
+
+class PlaybackPosition(CompoundValueObject):
+    """Where playback sits within the media, as ``(position, duration)``.
+
+    Bundles the current playhead and the total duration into one value so
+    the progress arithmetic (watched ratio, percentage, completion check)
+    lives on the data instead of in stateless helpers. Both components are
+    seconds measured from the start of the media.
+
+    ``position_seconds`` may legitimately exceed ``duration_seconds`` for a
+    beat: the player can report a position against a stale duration before
+    the corrected duration arrives (see ``WatchProgress.update_position``),
+    so the ratio is clamped by the caller rather than rejected here. The
+    only hard invariants are non-negative position and positive duration.
+
+    Attributes:
+        position_seconds: Current playhead in seconds. Must be ``>= 0``.
+        duration_seconds: Total media duration in seconds. Must be ``>= 1``.
+
+    Example:
+        >>> PlaybackPosition(position_seconds=3600, duration_seconds=7200).percentage
+        50.0
+    """
+
+    position_seconds: int = Field(ge=0)
+    duration_seconds: int = Field(ge=1)
+
+    @property
+    def ratio(self) -> float:
+        """Fraction of the media watched (``0.0``+), unclamped."""
+        return self.position_seconds / self.duration_seconds
+
+    @property
+    def percentage(self) -> float:
+        """Watched percentage, clamped to ``0-100``."""
+        return min(100.0, self.ratio * 100)
+
+    def reaches_completion(self, threshold: float) -> bool:
+        """Whether the watched ratio crosses ``threshold`` (e.g. ``0.9``)."""
+        return self.ratio >= threshold
+
+
+__all__ = ["PlaybackPosition"]

--- a/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
+++ b/src/modules/watch_progress/infrastructure/persistence/mappers/watch_progress_mapper.py
@@ -2,6 +2,7 @@
 
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import (
+    PlaybackPosition,
     ProgressId,
     SubtitlePreference,
     WatchableMediaId,
@@ -55,8 +56,10 @@ class WatchProgressMapper:
             profile_id=ProfileId(model.profile_id),
             media_id=WatchableMediaId(model.media_id),
             media_type=WatchableMediaType(model.media_type),
-            position_seconds=model.position_seconds,
-            duration_seconds=model.duration_seconds,
+            position=PlaybackPosition(
+                position_seconds=model.position_seconds,
+                duration_seconds=model.duration_seconds,
+            ),
             status=WatchStatus(model.status),
             audio_track=model.audio_track,
             subtitle_track=SubtitlePreference.from_wire(model.subtitle_track),

--- a/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
+++ b/tests/modules/watch_progress/unit/application/use_cases/test_get_continue_watching.py
@@ -16,7 +16,10 @@ from src.modules.watch_progress.application.ports import (
 )
 from src.modules.watch_progress.application.use_cases import GetContinueWatchingUseCase
 from src.modules.watch_progress.domain.entities import WatchProgress
-from src.modules.watch_progress.domain.value_objects import WatchableMediaType
+from src.modules.watch_progress.domain.value_objects import (
+    PlaybackPosition,
+    WatchableMediaType,
+)
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from tests.modules.watch_progress.unit.conftest import (
     WatchProgressUoWMocks,
@@ -44,8 +47,7 @@ def _make_progress(
         profile_id=_PROFILE_ID,
         media_id=media_id,
         media_type=media_type,
-        position_seconds=position,
-        duration_seconds=3600,
+        position=PlaybackPosition(position_seconds=position, duration_seconds=3600),
         status=status,
         last_watched_at=last_watched or datetime(2026, 4, 9, tzinfo=UTC),
     )

--- a/tests/modules/watch_progress/unit/domain/services/test_continue_watching_selector.py
+++ b/tests/modules/watch_progress/unit/domain/services/test_continue_watching_selector.py
@@ -11,6 +11,7 @@ from src.modules.watch_progress.domain.services import (
 )
 from src.modules.watch_progress.domain.value_objects import (
     EpisodeCandidate,
+    PlaybackPosition,
     WatchableMediaType,
     WatchStatus,
 )
@@ -29,8 +30,7 @@ def _progress(
         profile_id=_PROFILE_ID,
         media_id=media_id,
         media_type=WatchableMediaType.EPISODE,
-        position_seconds=900,
-        duration_seconds=3600,
+        position=PlaybackPosition(position_seconds=900, duration_seconds=3600),
         status=status,
         last_watched_at=last_watched_at or datetime(2026, 4, 9, tzinfo=UTC),
     )

--- a/tests/modules/watch_progress/unit/domain/value_objects/test_playback_position.py
+++ b/tests/modules/watch_progress/unit/domain/value_objects/test_playback_position.py
@@ -1,0 +1,55 @@
+"""Tests for the PlaybackPosition value object."""
+
+import pytest
+
+from src.building_blocks.domain.errors import DomainValidationException
+from src.modules.watch_progress.domain.value_objects import PlaybackPosition
+
+
+@pytest.mark.unit
+class TestPlaybackPositionValidation:
+    """Invariants enforced at construction."""
+
+    def test_accepts_zero_position(self) -> None:
+        assert PlaybackPosition(position_seconds=0, duration_seconds=7200).position_seconds == 0
+
+    def test_rejects_negative_position(self) -> None:
+        with pytest.raises(DomainValidationException):
+            PlaybackPosition(position_seconds=-1, duration_seconds=7200)
+
+    def test_rejects_zero_duration(self) -> None:
+        with pytest.raises(DomainValidationException):
+            PlaybackPosition(position_seconds=10, duration_seconds=0)
+
+    def test_allows_position_beyond_duration(self) -> None:
+        # A stale-duration report can momentarily exceed the total; the VO
+        # accepts it and the percentage clamps rather than rejecting.
+        pos = PlaybackPosition(position_seconds=9000, duration_seconds=7200)
+        assert pos.percentage == 100.0
+
+
+@pytest.mark.unit
+class TestPlaybackPositionMath:
+    """Ratio / percentage / completion arithmetic lives on the VO."""
+
+    def test_ratio_is_unclamped(self) -> None:
+        assert PlaybackPosition(position_seconds=3600, duration_seconds=7200).ratio == 0.5
+
+    def test_percentage_half(self) -> None:
+        assert PlaybackPosition(position_seconds=3600, duration_seconds=7200).percentage == 50.0
+
+    def test_percentage_clamped_to_100(self) -> None:
+        assert PlaybackPosition(position_seconds=8000, duration_seconds=7200).percentage == 100.0
+
+    def test_reaches_completion_at_threshold(self) -> None:
+        pos = PlaybackPosition(position_seconds=6480, duration_seconds=7200)  # 0.9
+        assert pos.reaches_completion(0.9) is True
+
+    def test_below_threshold_is_not_complete(self) -> None:
+        pos = PlaybackPosition(position_seconds=6479, duration_seconds=7200)
+        assert pos.reaches_completion(0.9) is False
+
+    def test_equality_by_value(self) -> None:
+        a = PlaybackPosition(position_seconds=100, duration_seconds=200)
+        b = PlaybackPosition(position_seconds=100, duration_seconds=200)
+        assert a == b

--- a/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
+++ b/tests/modules/watch_progress/unit/infrastructure/persistence/mappers/test_watch_progress_mapper.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.modules.watch_progress.domain.entities import WatchProgress
 from src.modules.watch_progress.domain.value_objects import (
+    PlaybackPosition,
     ProgressId,
     SubtitlePreference,
     WatchableMediaType,
@@ -33,8 +34,7 @@ def _make_progress(
         profile_id=_PROFILE_ID,
         media_id=media_id,
         media_type=media_type,
-        position_seconds=position,
-        duration_seconds=duration,
+        position=PlaybackPosition(position_seconds=position, duration_seconds=duration),
     )
 
 
@@ -48,8 +48,7 @@ class TestWatchProgressMapperToModel:
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
-            position_seconds=100,
-            duration_seconds=7200,
+            position=PlaybackPosition(position_seconds=100, duration_seconds=7200),
         )
 
         with pytest.raises(ValueError, match="Cannot map entity without ID"):
@@ -75,8 +74,7 @@ class TestWatchProgressMapperToModel:
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
-            position_seconds=100,
-            duration_seconds=7200,
+            position=PlaybackPosition(position_seconds=100, duration_seconds=7200),
             audio_track=1,
             subtitle_track=SubtitlePreference.track(2),
         )
@@ -92,8 +90,7 @@ class TestWatchProgressMapperToModel:
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
-            position_seconds=100,
-            duration_seconds=7200,
+            position=PlaybackPosition(position_seconds=100, duration_seconds=7200),
             subtitle_track=SubtitlePreference.off(),
         )
 
@@ -108,8 +105,7 @@ class TestWatchProgressMapperToModel:
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
-            position_seconds=7200,
-            duration_seconds=7200,
+            position=PlaybackPosition(position_seconds=7200, duration_seconds=7200),
             status="completed",
             completed_at=now,
         )
@@ -219,8 +215,7 @@ class TestWatchProgressMapperUpdateModel:
             profile_id=_PROFILE_ID,
             media_id="mov_abc123def456",
             media_type=WatchableMediaType.MOVIE,
-            position_seconds=6500,
-            duration_seconds=7200,
+            position=PlaybackPosition(position_seconds=6500, duration_seconds=7200),
             status="completed",
             audio_track=1,
             subtitle_track=SubtitlePreference.track(2),
@@ -255,8 +250,7 @@ class TestWatchProgressMapperUpdateModel:
             profile_id=_PROFILE_ID,
             media_id="mov_different000",
             media_type=WatchableMediaType.MOVIE,
-            position_seconds=200,
-            duration_seconds=7200,
+            position=PlaybackPosition(position_seconds=200, duration_seconds=7200),
         )
 
         result = WatchProgressMapper.update_model(model, updated)


### PR DESCRIPTION
## Summary

Continues the **2.2 Primitive Obsession** cleanup, this time in the `watch_progress` bounded context.

- The `WatchProgress` aggregate held `position_seconds` and `duration_seconds` as two raw `int` fields, with the progress arithmetic (watched ratio, percentage, completion check) sitting in `@staticmethod`/`@classmethod` helpers that took the two ints and never touched `self` — behaviour living away from its data, over a pair that travelled together through every signature (Data Clumps + Feature Envy).
- Introduce a `PlaybackPosition` compound value object (`position_seconds`, `duration_seconds`) that **owns** `.ratio`, `.percentage`, and `.reaches_completion(threshold)`, and enforces the invariants in one place (`position >= 0`, `duration >= 1`).
- The aggregate now carries a single `position: PlaybackPosition` field; `position_seconds` / `duration_seconds` / `percentage` remain reachable as thin delegating read properties, and `create()` / `update_position()` keep their `int` parameters at the boundary. Net result: **persistence columns, DTOs, and callers are unchanged** — only the domain model got tighter.

### Deliberately not changed
- No `position <= duration` invariant: `update_position` intentionally corrects a stale duration, so a position momentarily exceeding it is valid; the percentage clamps to 100 instead of rejecting.
- `audio_track: int` stays raw for now (asymmetric with the `subtitle_track` VO) — noted as a small separate follow-up to keep this PR focused.

## Test plan

- [x] `mypy src` — 0 errors (770 files)
- [x] `ruff check` / `ruff format` — clean
- [x] New `test_playback_position.py` covers validation, ratio/percentage/clamp, and the completion threshold
- [x] `pytest tests/modules/watch_progress` — 129 passed
- [x] Full suite — 3514 passed, 3 skipped (only the pre-existing Windows-only symlink test deselected; green on CI Linux)

## Summary by Sourcery

Introduce a PlaybackPosition value object to encapsulate watch progress position and duration and move progress calculations onto it, updating the WatchProgress aggregate and mappers to use the new type while keeping external interfaces stable.

New Features:
- Add a PlaybackPosition compound value object that encapsulates playback position, duration, and progress calculations.

Enhancements:
- Refactor WatchProgress to store a PlaybackPosition instead of raw position and duration fields while preserving existing public properties and completion logic.

Tests:
- Add unit tests for the PlaybackPosition value object covering validation, ratio/percentage behavior, clamping, and completion thresholds.
- Update existing watch_progress tests and mappers to construct WatchProgress using the new PlaybackPosition value object.