### PR TITLE
feat(preferences): add subtitle text-edge style

### DIFF
--- a/migrations/versions/2026_08_16_add_subtitle_text_edge.py
+++ b/migrations/versions/2026_08_16_add_subtitle_text_edge.py
@@ -1,0 +1,39 @@
+"""Add subtitle text-edge column to preferences (2.4 follow-up).
+
+Adds a per-profile subtitle text-edge style (``none`` / ``shadow`` /
+``outline``) the player's overlay maps to a CSS treatment. Defaults to
+``shadow`` so existing rows keep the current soft-shadow look unchanged.
+
+Revision ID: c3a9d4e1f072
+Revises: b2f1c8a4e6d3
+Create Date: 2026-08-16 21:30:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+revision: str = "c3a9d4e1f072"
+down_revision: str | Sequence[str] | None = "b2f1c8a4e6d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the subtitle text-edge column with the shadow default."""
+    op.add_column(
+        "preferences",
+        sa.Column("subtitle_text_edge", sa.String(10), nullable=False, server_default="shadow"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the subtitle text-edge column."""
+    op.drop_column("preferences", "subtitle_text_edge")

--- a/src/modules/preferences/application/dtos/preferences_dtos.py
+++ b/src/modules/preferences/application/dtos/preferences_dtos.py
@@ -23,6 +23,7 @@ class SubtitleAppearanceDto:
     color: str
     background: str
     font_size: str
+    text_edge: str
 
 
 @dataclass(frozen=True)
@@ -50,6 +51,7 @@ class PreferencesOutput:
                 color=appearance.color.value,
                 background=appearance.background.value,
                 font_size=appearance.font_size.value,
+                text_edge=appearance.text_edge.value,
             ),
         )
 

--- a/src/modules/preferences/domain/value_objects/__init__.py
+++ b/src/modules/preferences/domain/value_objects/__init__.py
@@ -8,10 +8,14 @@ from src.modules.preferences.domain.value_objects.subtitle_appearance import (
     DEFAULT_SUBTITLE_BACKGROUND,
     DEFAULT_SUBTITLE_COLOR,
     DEFAULT_SUBTITLE_FONT_SIZE,
+    DEFAULT_SUBTITLE_TEXT_EDGE,
     SubtitleAppearance,
 )
 from src.modules.preferences.domain.value_objects.subtitle_font_size import (
     SubtitleFontSize,
+)
+from src.modules.preferences.domain.value_objects.subtitle_text_edge import (
+    SubtitleTextEdge,
 )
 from src.shared_kernel.value_objects.subtitle_mode import SubtitleMode
 
@@ -19,6 +23,7 @@ __all__ = [
     "DEFAULT_SUBTITLE_BACKGROUND",
     "DEFAULT_SUBTITLE_COLOR",
     "DEFAULT_SUBTITLE_FONT_SIZE",
+    "DEFAULT_SUBTITLE_TEXT_EDGE",
     "CssColor",
     "PreferencesId",
     "Quality",
@@ -26,4 +31,5 @@ __all__ = [
     "SubtitleAppearance",
     "SubtitleFontSize",
     "SubtitleMode",
+    "SubtitleTextEdge",
 ]

--- a/src/modules/preferences/domain/value_objects/subtitle_appearance.py
+++ b/src/modules/preferences/domain/value_objects/subtitle_appearance.py
@@ -5,25 +5,31 @@ from src.modules.preferences.domain.value_objects.css_color import CssColor
 from src.modules.preferences.domain.value_objects.subtitle_font_size import (
     SubtitleFontSize,
 )
+from src.modules.preferences.domain.value_objects.subtitle_text_edge import (
+    SubtitleTextEdge,
+)
 
 DEFAULT_SUBTITLE_COLOR = "#FFFFFF"
 DEFAULT_SUBTITLE_BACKGROUND = "rgba(0, 0, 0, 0.75)"
 DEFAULT_SUBTITLE_FONT_SIZE = SubtitleFontSize.MEDIUM
+DEFAULT_SUBTITLE_TEXT_EDGE = SubtitleTextEdge.DROP_SHADOW
 
 
 class SubtitleAppearance(CompoundValueObject):
     """Per-profile styling for the subtitle overlay in the player.
 
-    Bundles the three knobs the player's custom subtitle overlay reads —
-    text color, background color, and relative size — into one value so
-    they travel and validate together. Account-level styling that syncs
-    across devices, mirroring how Netflix/YouTube persist caption style.
+    Bundles the knobs the player's custom subtitle overlay reads — text
+    color, background color, relative size, and text-edge style — into one
+    value so they travel and validate together. Account-level styling that
+    syncs across devices, mirroring how Netflix/YouTube persist caption style.
 
     Attributes:
         color: Subtitle text color (validated CSS color).
         background: Subtitle background color, typically semi-transparent
             (validated CSS color).
         font_size: Relative size tier the player scales to the viewport.
+        text_edge: How the glyphs are outlined for legibility (none / drop
+            shadow / hard outline).
 
     Example:
         >>> a = SubtitleAppearance.default()
@@ -36,6 +42,7 @@ class SubtitleAppearance(CompoundValueObject):
     color: CssColor
     background: CssColor
     font_size: SubtitleFontSize
+    text_edge: SubtitleTextEdge
 
     @classmethod
     def default(cls) -> "SubtitleAppearance":
@@ -44,6 +51,7 @@ class SubtitleAppearance(CompoundValueObject):
             color=CssColor(DEFAULT_SUBTITLE_COLOR),
             background=CssColor(DEFAULT_SUBTITLE_BACKGROUND),
             font_size=DEFAULT_SUBTITLE_FONT_SIZE,
+            text_edge=DEFAULT_SUBTITLE_TEXT_EDGE,
         )
 
 
@@ -51,5 +59,6 @@ __all__ = [
     "DEFAULT_SUBTITLE_BACKGROUND",
     "DEFAULT_SUBTITLE_COLOR",
     "DEFAULT_SUBTITLE_FONT_SIZE",
+    "DEFAULT_SUBTITLE_TEXT_EDGE",
     "SubtitleAppearance",
 ]

--- a/src/modules/preferences/domain/value_objects/subtitle_text_edge.py
+++ b/src/modules/preferences/domain/value_objects/subtitle_text_edge.py
@@ -1,0 +1,21 @@
+"""Subtitle text-edge enumeration."""
+
+from enum import StrEnum
+
+
+class SubtitleTextEdge(StrEnum):
+    """How the subtitle text is outlined for legibility over the picture.
+
+    The player maps each tier to a concrete CSS treatment: ``NONE`` draws the
+    glyphs flat, ``DROP_SHADOW`` (the default, matching the pre-existing look)
+    adds a soft shadow, and ``OUTLINE`` traces a hard contour that stays
+    readable over bright frames. String values are the canonical ones
+    persisted on the ``preferences`` table.
+    """
+
+    NONE = "none"
+    DROP_SHADOW = "shadow"
+    OUTLINE = "outline"
+
+
+__all__ = ["SubtitleTextEdge"]

--- a/src/modules/preferences/infrastructure/persistence/mappers/preferences_mapper.py
+++ b/src/modules/preferences/infrastructure/persistence/mappers/preferences_mapper.py
@@ -32,6 +32,7 @@ class PreferencesMapper:
                 color=model.subtitle_color,
                 background=model.subtitle_background,
                 font_size=model.subtitle_font_size,
+                text_edge=model.subtitle_text_edge,
             ),
             created_at=model.created_at,
             updated_at=model.updated_at,
@@ -54,6 +55,7 @@ class PreferencesMapper:
             subtitle_color=entity.subtitle_appearance.color.value,
             subtitle_background=entity.subtitle_appearance.background.value,
             subtitle_font_size=entity.subtitle_appearance.font_size.value,
+            subtitle_text_edge=entity.subtitle_appearance.text_edge.value,
         )
 
     @staticmethod
@@ -75,6 +77,7 @@ class PreferencesMapper:
         model.subtitle_color = entity.subtitle_appearance.color.value
         model.subtitle_background = entity.subtitle_appearance.background.value
         model.subtitle_font_size = entity.subtitle_appearance.font_size.value
+        model.subtitle_text_edge = entity.subtitle_appearance.text_edge.value
         return model
 
 

--- a/src/modules/preferences/infrastructure/persistence/models/preferences_model.py
+++ b/src/modules/preferences/infrastructure/persistence/models/preferences_model.py
@@ -35,6 +35,7 @@ class PreferencesModel(Base):
         default="rgba(0, 0, 0, 0.75)",
     )
     subtitle_font_size: Mapped[str] = mapped_column(String(10), nullable=False, default="medium")
+    subtitle_text_edge: Mapped[str] = mapped_column(String(10), nullable=False, default="shadow")
 
 
 __all__ = ["PreferencesModel"]

--- a/src/modules/preferences/presentation/schemas/preferences_schemas.py
+++ b/src/modules/preferences/presentation/schemas/preferences_schemas.py
@@ -6,11 +6,12 @@ from pydantic import BaseModel, Field
 
 
 class SubtitleAppearanceRequest(BaseModel):
-    """Partial subtitle-styling update. Any subset of the three knobs."""
+    """Partial subtitle-styling update. Any subset of the knobs."""
 
     color: str | None = None
     background: str | None = None
     font_size: Literal["small", "medium", "large"] | None = None
+    text_edge: Literal["none", "shadow", "outline"] | None = None
 
 
 class UpdatePreferencesRequest(BaseModel):

--- a/tests/modules/preferences/integration/persistence/test_preferences_repository.py
+++ b/tests/modules/preferences/integration/persistence/test_preferences_repository.py
@@ -87,7 +87,11 @@ class TestSQLAlchemyPreferencesRepository:
         repo = SQLAlchemyPreferencesRepository(db_session)
         await repo.save(
             PlaybackPreferences.default_for(_PROFILE_ID).apply_updates(
-                subtitle_appearance={"color": "yellow", "font_size": "large"},
+                subtitle_appearance={
+                    "color": "yellow",
+                    "font_size": "large",
+                    "text_edge": "outline",
+                },
             ),
         )
 
@@ -96,5 +100,6 @@ class TestSQLAlchemyPreferencesRepository:
         assert found is not None
         assert found.subtitle_appearance.color.value == "yellow"
         assert found.subtitle_appearance.font_size.value == "large"
+        assert found.subtitle_appearance.text_edge.value == "outline"
         # Untouched knob kept its default through the DB round-trip.
         assert found.subtitle_appearance.background.value == "rgba(0, 0, 0, 0.75)"

--- a/tests/modules/preferences/unit/domain/entities/test_playback_preferences.py
+++ b/tests/modules/preferences/unit/domain/entities/test_playback_preferences.py
@@ -25,6 +25,7 @@ class TestDefaultFactory:
         assert prefs.subtitle_appearance.color.value == "#FFFFFF"
         assert prefs.subtitle_appearance.background.value == "rgba(0, 0, 0, 0.75)"
         assert prefs.subtitle_appearance.font_size.value == "medium"
+        assert prefs.subtitle_appearance.text_edge.value == "shadow"
         assert prefs.id is not None
         assert prefs.id.value == _PROFILE_ID.value
 
@@ -92,10 +93,11 @@ class TestSubtitleAppearanceUpdates:
 
         updated = prefs.apply_updates(subtitle_appearance={"color": "yellow"})
 
-        # Only color changed; background and size keep their defaults.
+        # Only color changed; background, size, and edge keep their defaults.
         assert updated.subtitle_appearance.color.value == "yellow"
         assert updated.subtitle_appearance.background.value == "rgba(0, 0, 0, 0.75)"
         assert updated.subtitle_appearance.font_size.value == "medium"
+        assert updated.subtitle_appearance.text_edge.value == "shadow"
         # Immutable per ADR-007 — the original is untouched.
         assert prefs.subtitle_appearance.color.value == "#FFFFFF"
 
@@ -107,11 +109,13 @@ class TestSubtitleAppearanceUpdates:
                 "color": "#00FF00",
                 "background": "rgba(0, 0, 0, 0.5)",
                 "font_size": "large",
+                "text_edge": "outline",
             },
         )
 
         assert updated.subtitle_appearance.color.value == "#00FF00"
         assert updated.subtitle_appearance.font_size.value == "large"
+        assert updated.subtitle_appearance.text_edge.value == "outline"
 
     def test_rejects_invalid_color(self) -> None:
         prefs = PlaybackPreferences.default_for(_PROFILE_ID)

--- a/tests/modules/preferences/unit/domain/value_objects/test_subtitle_appearance.py
+++ b/tests/modules/preferences/unit/domain/value_objects/test_subtitle_appearance.py
@@ -7,6 +7,7 @@ from src.modules.preferences.domain.value_objects import (
     CssColor,
     SubtitleAppearance,
     SubtitleFontSize,
+    SubtitleTextEdge,
 )
 
 
@@ -14,32 +15,49 @@ from src.modules.preferences.domain.value_objects import (
 class TestSubtitleAppearance:
     """Construction, defaults, and coercion."""
 
-    def test_default_is_white_on_dim_medium(self) -> None:
+    def test_default_is_white_on_dim_medium_shadow(self) -> None:
         appearance = SubtitleAppearance.default()
 
         assert appearance.color == CssColor("#FFFFFF")
         assert appearance.background == CssColor("rgba(0, 0, 0, 0.75)")
         assert appearance.font_size is SubtitleFontSize.MEDIUM
+        assert appearance.text_edge is SubtitleTextEdge.DROP_SHADOW
 
     def test_coerces_raw_strings(self) -> None:
         appearance = SubtitleAppearance(
             color="yellow",
             background="#000000",
             font_size="large",
+            text_edge="outline",
         )
 
         assert appearance.color.value == "yellow"
         assert appearance.font_size is SubtitleFontSize.LARGE
+        assert appearance.text_edge is SubtitleTextEdge.OUTLINE
 
     def test_rejects_invalid_color(self) -> None:
         with pytest.raises(DomainValidationException):
-            SubtitleAppearance(color="#GGG", background="#000000", font_size="small")
+            SubtitleAppearance(
+                color="#GGG", background="#000000", font_size="small", text_edge="none"
+            )
 
     def test_rejects_unknown_font_size(self) -> None:
         with pytest.raises((DomainValidationException, ValueError)):
-            SubtitleAppearance(color="#FFFFFF", background="#000000", font_size="huge")
+            SubtitleAppearance(
+                color="#FFFFFF", background="#000000", font_size="huge", text_edge="none"
+            )
+
+    def test_rejects_unknown_text_edge(self) -> None:
+        with pytest.raises((DomainValidationException, ValueError)):
+            SubtitleAppearance(
+                color="#FFFFFF", background="#000000", font_size="medium", text_edge="glow"
+            )
 
     def test_equality_by_value(self) -> None:
-        a = SubtitleAppearance(color="#FFFFFF", background="#000000", font_size="medium")
-        b = SubtitleAppearance(color="#FFFFFF", background="#000000", font_size="medium")
+        a = SubtitleAppearance(
+            color="#FFFFFF", background="#000000", font_size="medium", text_edge="shadow"
+        )
+        b = SubtitleAppearance(
+            color="#FFFFFF", background="#000000", font_size="medium", text_edge="shadow"
+        )
         assert a == b


### PR DESCRIPTION
## Summary

Follow-up to the subtitle-appearance feature, adding the **text-edge** knob (inspired by HBO Max's caption-style screen, which follows the CEA-608 / FCC caption model).

- Extend the `SubtitleAppearance` compound VO with `text_edge` — a new `SubtitleTextEdge` enum (`none` / `shadow` / `outline`). Defaults to `shadow` so existing rows keep the current soft-shadow look unchanged.
- Column `subtitle_text_edge` + Alembic migration (default `shadow`), threaded through the mapper, Output DTO, and the partial-update HTTP schema. `apply_updates` merges it field-by-field like the other knobs.

The player maps each tier to a CSS `text-shadow` treatment (frontend PR).

## Test plan

- [x] `mypy src` — 0 errors (774 files)
- [x] `ruff check` / `ruff format` — clean
- [x] Unit: VO default/coercion/rejection incl. `text_edge`; entity partial-merge keeps edge default, full-replace sets it
- [x] Integration: `text_edge` round-trips through the SQLite repository
- [x] Migration applies cleanly on a scratch DB (chain b2f1c8a4e6d3 → c3a9d4e1f072)
- [x] Full suite — 3541 passed, 3 skipped

## Summary by Sourcery

Add a configurable subtitle text-edge style to playback preferences and persist it across API, domain, and storage layers.

New Features:
- Introduce SubtitleTextEdge enum and add text_edge to SubtitleAppearance so profiles can control subtitle outlining (none / shadow / outline).

Enhancements:
- Wire subtitle text_edge through playback preferences entities, DTOs, request schemas, and SQLAlchemy mappers so partial and full updates handle the new knob consistently.

Tests:
- Extend unit and integration tests to cover default text_edge behavior, validation of invalid values, partial-merge semantics, and repository round-trips.