### PR TITLE
feat(preferences): add extra-large subtitle size

### DIFF
--- a/src/modules/preferences/domain/value_objects/subtitle_font_size.py
+++ b/src/modules/preferences/domain/value_objects/subtitle_font_size.py
@@ -6,15 +6,16 @@ from enum import StrEnum
 class SubtitleFontSize(StrEnum):
     """Relative subtitle text size the player maps to a concrete size.
 
-    Kept as three relative steps rather than a pixel value so the player
-    can scale them to the viewport (the same tier renders larger on a TV
-    than on a phone). String values are the canonical ones persisted on
-    the ``preferences`` table.
+    Kept as relative steps rather than a pixel value so the player can
+    scale them to the viewport (the same tier renders larger on a TV than
+    on a phone). String values are the canonical ones persisted on the
+    ``preferences`` table.
     """
 
     SMALL = "small"
     MEDIUM = "medium"
     LARGE = "large"
+    XLARGE = "xlarge"
 
 
 __all__ = ["SubtitleFontSize"]

--- a/src/modules/preferences/presentation/schemas/preferences_schemas.py
+++ b/src/modules/preferences/presentation/schemas/preferences_schemas.py
@@ -10,7 +10,7 @@ class SubtitleAppearanceRequest(BaseModel):
 
     color: str | None = None
     background: str | None = None
-    font_size: Literal["small", "medium", "large"] | None = None
+    font_size: Literal["small", "medium", "large", "xlarge"] | None = None
     text_edge: Literal["none", "shadow", "outline"] | None = None
 
 

--- a/tests/modules/preferences/unit/domain/value_objects/test_subtitle_appearance.py
+++ b/tests/modules/preferences/unit/domain/value_objects/test_subtitle_appearance.py
@@ -35,6 +35,13 @@ class TestSubtitleAppearance:
         assert appearance.font_size is SubtitleFontSize.LARGE
         assert appearance.text_edge is SubtitleTextEdge.OUTLINE
 
+    def test_accepts_xlarge_font_size(self) -> None:
+        appearance = SubtitleAppearance(
+            color="#FFFFFF", background="#000000", font_size="xlarge", text_edge="none"
+        )
+
+        assert appearance.font_size is SubtitleFontSize.XLARGE
+
     def test_rejects_invalid_color(self) -> None:
         with pytest.raises(DomainValidationException):
             SubtitleAppearance(


### PR DESCRIPTION
## Summary

Add an **extra-large** subtitle size tier.

- `SubtitleFontSize` enum gains `XLARGE = "xlarge"`.
- The update schema's `font_size` Literal widens to include `xlarge`.
- No migration: `subtitle_font_size` is a free `String` column, so existing rows are untouched and only the accepted value set grows. The player (frontend PR) maps `xlarge` to a larger CSS size.

## Test plan

- [x] `mypy src` — 0 errors (774 files)
- [x] `ruff` — clean
- [x] Unit: `SubtitleAppearance` accepts `font_size="xlarge"`
- [x] `pytest tests/modules/preferences` — 69 passed

## Summary by Sourcery

Introduce an extra-large subtitle font size tier and wire it through the preferences domain model and request schema.

New Features:
- Add support for an extra-large subtitle font size option in preferences and API requests.

Enhancements:
- Clarify subtitle font size enum documentation to describe relative scaling without implying a fixed number of steps.

Tests:
- Add a unit test ensuring SubtitleAppearance accepts and normalizes the new xlarge font size option.