### PR TITLE
refactor(media): remove type:ignore that masked real type issues

### DIFF
--- a/src/infrastructure/scheduling/credits_detection_job.py
+++ b/src/infrastructure/scheduling/credits_detection_job.py
@@ -31,13 +31,14 @@ from src.modules.media.domain.value_objects import (
     CreditsDetectionState,
     CreditsMarker,
     CreditsMarkerSource,
+    EpisodeId,
+    MovieId,
 )
 
 if TYPE_CHECKING:
     from src.modules.media.application.ports import CreditsDetectorPort, DetectedCredits
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
     from src.modules.media.domain.entities import Episode, Movie
-    from src.modules.media.domain.value_objects import EpisodeId, MovieId
     from src.modules.settings.domain.value_objects import CreditsDetectionConfig
     from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
@@ -163,9 +164,15 @@ class CreditsDetectionJob:
     ) -> None:
         async with self._media_uow_factory() as uow:
             if kind == _MOVIE:
-                await uow.movies.update_movie_credits(media_id, marker, state)  # type: ignore[arg-type]
+                # The kind/id invariant is coupled here: a movie kind must
+                # carry a MovieId, so the narrowing assert both satisfies the
+                # type checker and guards against ever writing an EpisodeId
+                # into the movies update (or vice versa).
+                assert isinstance(media_id, MovieId)
+                await uow.movies.update_movie_credits(media_id, marker, state)
             else:
-                await uow.series.update_episode_credits(media_id, marker, state)  # type: ignore[arg-type]
+                assert isinstance(media_id, EpisodeId)
+                await uow.series.update_episode_credits(media_id, marker, state)
 
 
 def _build_tuning(config: CreditsDetectionConfig) -> CreditsDetectorTuning:

--- a/src/modules/media/application/use_cases/detect_movie_conflicts.py
+++ b/src/modules/media/application/use_cases/detect_movie_conflicts.py
@@ -26,7 +26,10 @@ if TYPE_CHECKING:
         LibraryHealthPort,
     )
     from src.modules.media.application.ports.runtime_config_ports import ScanDedupConfigPort
-    from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
+    from src.modules.media.application.unit_of_work import (
+        MediaUnitOfWork,
+        MediaUnitOfWorkFactory,
+    )
     from src.modules.media.domain.entities.movie import Movie
     from src.modules.settings.domain.value_objects import ScanDedupConfig
 
@@ -215,7 +218,7 @@ class DetectMovieConflictsUseCase:
     async def _queue_conflict(
         self,
         *,
-        uow: object,
+        uow: MediaUnitOfWork,
         self_id: str,
         self_runtime: float | None,
         other: Movie,
@@ -233,7 +236,7 @@ class DetectMovieConflictsUseCase:
             abs_threshold_minutes=abs_threshold,
             relative_threshold=relative_threshold,
         )
-        persisted = await uow.media_conflicts.save(conflict)  # type: ignore[attr-defined]
+        persisted = await uow.media_conflicts.save(conflict)
         event = MediaConflictDetectedEvent(
             conflict_id=str(persisted.id),
             candidate_a_id=MovieId(persisted.candidate_a.id),
@@ -245,7 +248,7 @@ class DetectMovieConflictsUseCase:
 
     async def _collect_title_year_matches(
         self,
-        uow: object,
+        uow: MediaUnitOfWork,
         self_movie: Movie,
         *,
         exclude: set[str],
@@ -258,7 +261,7 @@ class DetectMovieConflictsUseCase:
         TMDB pass) are skipped to avoid double-queuing.
         """
         self_key = _normalized_identity_title(self_movie)
-        candidates = await uow.movies.find_all_by_year(self_movie.year.value)  # type: ignore[attr-defined]
+        candidates = await uow.movies.find_all_by_year(self_movie.year.value)
         return [
             m
             for m in candidates
@@ -284,16 +287,12 @@ class DetectMovieConflictsUseCase:
     async def _auto_merge_orphan(
         self,
         *,
-        uow: object,
+        uow: MediaUnitOfWork,
         self_movie: Movie,
         self_runtime: float | None,
         orphan: Movie,
     ) -> tuple[MediaConflict, MovieMergedEvent]:
         """Persist a resolved-AUTO conflict and soft-delete the orphan."""
-        # ``uow`` is typed ``object`` here because importing
-        # MediaUnitOfWork would form a runtime cycle through this
-        # module — the caller passes the live UoW from the same
-        # ``async with`` block above.
         conflict = MediaConflict.detect(
             candidate_a=ConflictCandidate(id=str(self_movie.id), type=MediaType.MOVIE),
             candidate_a_runtime_minutes=self_runtime,
@@ -306,7 +305,7 @@ class DetectMovieConflictsUseCase:
             winner_id=str(self_movie.id),
             source=ResolutionSource.AUTO,
         )
-        persisted = await uow.media_conflicts.save(resolved)  # type: ignore[attr-defined]
+        persisted = await uow.media_conflicts.save(resolved)
 
         loser_id = persisted.loser_id()
         if loser_id is None:  # pragma: no cover — guarded by aggregate
@@ -315,7 +314,7 @@ class DetectMovieConflictsUseCase:
         if winner_id is None:  # pragma: no cover — loaded from the repository
             raise RuntimeError("auto-merge winner movie missing id")
 
-        deleted = await uow.movies.delete(MovieId(loser_id))  # type: ignore[attr-defined]
+        deleted = await uow.movies.delete(MovieId(loser_id))
         if not deleted:
             _logger.warning(
                 "Orphan movie %s missing during auto-merge of %s",

--- a/src/modules/media/application/use_cases/search_tmdb_titles.py
+++ b/src/modules/media/application/use_cases/search_tmdb_titles.py
@@ -41,18 +41,37 @@ _TMDB_BARE_RE = re.compile(r"^\d+$")
 
 
 @dataclass(frozen=True)
-class _ParsedQuery:
-    """Outcome of input parsing — one of three branches."""
+class _TmdbIdQuery:
+    """A resolved TMDB numeric id, from a URL or a bare number.
 
-    kind: Literal["tmdb_id", "imdb_id", "text"]
-    # tmdb_id branch: the numeric id + which media type to fetch
-    # ("movie" / "tv" / None for ambiguous bare numeric).
-    tmdb_id: int | None = None
+    ``media_type`` is ``None`` for an ambiguous bare numeric (TMDB ids are
+    not unique across the movie / tv namespaces), so the caller fetches both.
+    """
+
+    tmdb_id: int
     media_type: Literal["movie", "tv"] | None = None
-    # imdb_id branch: the canonical "tt..." string.
-    imdb_id: str | None = None
-    # text branch: the cleaned free-text query.
-    text: str | None = None
+    kind: Literal["tmdb_id"] = "tmdb_id"
+
+
+@dataclass(frozen=True)
+class _ImdbIdQuery:
+    """A canonical IMDb id (``tt...``)."""
+
+    imdb_id: str
+    kind: Literal["imdb_id"] = "imdb_id"
+
+
+@dataclass(frozen=True)
+class _TextQuery:
+    """A cleaned free-text search query."""
+
+    text: str
+    kind: Literal["text"] = "text"
+
+
+# Discriminated union on ``kind`` — each branch carries only its own fields,
+# so mypy narrows the payload without per-branch ``| None`` widening.
+_ParsedQuery = _TmdbIdQuery | _ImdbIdQuery | _TextQuery
 
 
 def parse_lookup_query(raw: str) -> _ParsedQuery | None:
@@ -68,26 +87,22 @@ def parse_lookup_query(raw: str) -> _ParsedQuery | None:
 
     if url_match := _TMDB_URL_RE.search(cleaned):
         kind = url_match.group("kind").lower()
-        return _ParsedQuery(
-            kind="tmdb_id",
+        return _TmdbIdQuery(
             tmdb_id=int(url_match.group("id")),
             media_type="movie" if kind == "movie" else "tv",
         )
 
     if imdb_match := _IMDB_URL_RE.search(cleaned):
-        return _ParsedQuery(kind="imdb_id", imdb_id=imdb_match.group("id").lower())
+        return _ImdbIdQuery(imdb_id=imdb_match.group("id").lower())
 
     if _IMDB_BARE_RE.fullmatch(cleaned):
-        return _ParsedQuery(kind="imdb_id", imdb_id=cleaned.lower())
+        return _ImdbIdQuery(imdb_id=cleaned.lower())
 
     if _TMDB_BARE_RE.fullmatch(cleaned):
-        # Bare numeric — TMDB ids are not unique across the movie /
-        # tv namespaces, so the use case fetches both summaries and
-        # returns whichever exist. Leave media_type unset to flag
-        # "try both."
-        return _ParsedQuery(kind="tmdb_id", tmdb_id=int(cleaned))
+        # Bare numeric — media_type unset flags "try both" (see docstring).
+        return _TmdbIdQuery(tmdb_id=int(cleaned))
 
-    return _ParsedQuery(kind="text", text=cleaned)
+    return _TextQuery(text=cleaned)
 
 
 class SearchTmdbTitlesUseCase:
@@ -118,26 +133,25 @@ class SearchTmdbTitlesUseCase:
 
         if parsed.kind == "tmdb_id":
             candidates = await self._fetch_by_tmdb_id(
-                parsed.tmdb_id,  # type: ignore[arg-type]  # guaranteed non-None on this branch
+                parsed.tmdb_id,
                 parsed.media_type,
             )
-            display = parsed.text or input_dto.query.strip()
             return SearchTmdbTitlesOutput(
-                query=display,
+                query=input_dto.query.strip(),
                 kind="tmdb_id",
                 candidates=await self._mark_in_catalog(candidates),
             )
 
         if parsed.kind == "imdb_id":
-            results = await self._provider.find_by_imdb_id(parsed.imdb_id)  # type: ignore[arg-type]
+            results = await self._provider.find_by_imdb_id(parsed.imdb_id)
             return SearchTmdbTitlesOutput(
-                query=parsed.imdb_id or "",
+                query=parsed.imdb_id,
                 kind="imdb_id",
                 candidates=await self._mark_in_catalog([_to_dto(c) for c in results]),
             )
 
         # text branch
-        text = parsed.text or ""
+        text = parsed.text
         limit = max(1, min(input_dto.limit, 20))
         movies, series = await asyncio.gather(
             self._provider.find_movie_candidates(text, year=None, limit=limit),

--- a/src/modules/media/domain/entities/file_variant_mixin.py
+++ b/src/modules/media/domain/entities/file_variant_mixin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any, Self
 
 if TYPE_CHECKING:
     from src.modules.media.domain.value_objects import MediaFile, Resolution
@@ -19,6 +19,12 @@ class FileVariantMixin:
     """
 
     files: list[MediaFile]
+
+    if TYPE_CHECKING:
+
+        def with_updates(self, **changes: Any) -> Self:
+            """Return a copy with fields replaced (provided by DomainModel)."""
+            ...
 
     @property
     def primary_file(self) -> MediaFile | None:
@@ -57,7 +63,7 @@ class FileVariantMixin:
         """
         if any(f.file_path == file.file_path for f in self.files):
             return self
-        return self.with_updates(files=[*self.files, file])  # type: ignore[attr-defined, no-any-return]
+        return self.with_updates(files=[*self.files, file])
 
     def get_file_by_resolution(self, resolution: Resolution | str) -> MediaFile | None:
         """Find a file variant by resolution.

--- a/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
+++ b/src/modules/media/infrastructure/persistence/repositories/_genre_helpers.py
@@ -21,7 +21,7 @@ the column format changes.
 
 import json
 import re
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, TypeVar
 
@@ -225,7 +225,7 @@ async def fetch_genre_paginated_page(
     *,
     session: AsyncSession,
     model: Any,
-    mapper_to_entity: Callable[[Any], TEntity] | Callable[[Any], Awaitable[TEntity]],
+    mapper_to_entity: Callable[[Any], TEntity],
     options: Sequence[_AbstractLoad],
     genre: Genre,
     cursor: str | None,
@@ -337,7 +337,7 @@ async def fetch_genre_paginated_page(
         next_cursor = item_cursors[-1]
 
     return PaginatedResult(
-        items=[mapper_to_entity(row) for row in rows],  # type: ignore[misc]
+        items=[mapper_to_entity(row) for row in rows],
         pagination=Pagination(next_cursor=next_cursor, has_more=has_more),
         total_count=None,
         item_cursors=item_cursors,

--- a/src/modules/settings/infrastructure/persistence/mappers/setting_mapper.py
+++ b/src/modules/settings/infrastructure/persistence/mappers/setting_mapper.py
@@ -1,6 +1,6 @@
 """Bidirectional mapper between :class:`Setting` and :class:`SettingModel`."""
 
-from typing import Any
+from typing import Any, cast
 
 from src.modules.settings.domain.entities import Setting
 from src.modules.settings.domain.value_objects import (
@@ -46,7 +46,9 @@ class SettingMapper:
         key = SettingKey(model.key)
         vo_type = vo_type_for(key)
         payload: dict[str, Any] = dict(model.value_json or {})
-        value: ConfigVO = vo_type.model_validate(payload)  # type: ignore[assignment]
+        # vo_type_for(key) returns the concrete ConfigVO subtype for this key;
+        # model_validate yields that subtype, which mypy widens to the union.
+        value = cast(ConfigVO, vo_type.model_validate(payload))
         return Setting(
             id=key,
             value=value,


### PR DESCRIPTION
## Summary

**Onda 0** do plano de remediação de débito técnico. Elimina **11 `type: ignore`** substituindo supressão por tipagem correta (contagem no `src`: 53 → 42). Todos os pontos foram apontados pela auditoria como ignores mascarando problemas reais (não library gaps legítimos).

- **`detect_movie_conflicts`** — tipa `uow` como `MediaUnitOfWork` e remove os **4 `ignore[attr-defined]` no caminho destrutivo de auto-merge** (inclui `uow.movies.delete`). O comentário de "ciclo de import" era falso: o arquivo já tem `from __future__ import annotations` e importa o factory sob `TYPE_CHECKING`.
- **`credits_detection_job._set`** — `assert isinstance` narra `MovieId | EpisodeId` pelo `kind`, satisfazendo o mypy **e** guardando em runtime contra gravar um `EpisodeId` no update de movies; remove 2 ignores.
- **`search_tmdb_titles`** — `_ParsedQuery` vira **união discriminada** de 3 dataclasses (`_TmdbIdQuery`/`_ImdbIdQuery`/`_TextQuery`); o mypy estreita o payload por branch; remove 2 ignores.
- **LOW** — `_genre_helpers` mapper estreitado para `Callable` sync-only (a variante async nunca era awaited — hazard de coroutine solta); `file_variant_mixin` declara `with_updates` sob `TYPE_CHECKING`; `setting_mapper` usa `cast`.

## Test plan

- [x] `mypy src` — 0 errors (774 files)
- [x] `ruff check` / `ruff format` — clean
- [x] Tests dos afetados (parse_lookup_query, settings, media unit) — 104 passed
- [x] Suíte completa — via CI

## Summary by Sourcery

Tighten media-related type safety by replacing incorrect type suppressions with proper typing and runtime guarantees across parsing, conflict detection, credit updates, and settings mapping.

New Features:
- Introduce a discriminated union for TMDB/IMDb/text lookup queries to provide clearer structure and safer narrowing in search TMDB titles.

Bug Fixes:
- Ensure movie and episode credit updates use correctly typed IDs, guarding against cross-writing credits between movies and episodes.
- Prevent accidental acceptance of coroutine mappers in genre pagination by restricting mapper_to_entity to synchronous callables.
- Resolve potential misuse of the generic domain with_updates helper in file variants by declaring a typed signature for static checking.
- Guarantee settings value deserialization produces correctly typed ConfigVO instances via explicit casting instead of suppressed type errors.
- Eliminate unsafe unit-of-work typing in movie conflict detection, ensuring repositories are properly typed and removing attr-defined ignores on critical persistence paths.

Enhancements:
- Refine search TMDB titles output query handling to rely consistently on the original input while leveraging the new parsed query types for execution.