### PR TITLE
test(media): cover PGS RLE decoder and FrameHasher hash core

### DIFF
--- a/tests/modules/media/unit/infrastructure/streaming/test_pgs_parser.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_pgs_parser.py
@@ -8,7 +8,10 @@ import struct
 
 import pytest
 
-from src.modules.media.infrastructure.streaming.pgs_parser import parse_pgs
+from src.modules.media.infrastructure.streaming.pgs_parser import (
+    _decode_rle,
+    parse_pgs,
+)
 
 _SEG_PDS = 0x14
 _SEG_ODS = 0x15
@@ -112,3 +115,64 @@ class TestParsePgs:
     def test_non_pgs_stream_raises(self) -> None:
         with pytest.raises(ValueError, match="Not a PGS stream"):
             parse_pgs(b"NOTPGSDATA___________")
+
+
+@pytest.mark.unit
+class TestDecodeRle:
+    """Per-branch coverage of the PGS run-length decoder.
+
+    Real PGS subtitles are dominated by runs, not literal pixels — the
+    integration builder above only exercises the literal + end-of-line
+    path, so these cover every run-length branch explicitly.
+    """
+
+    def test_literal_pixels(self) -> None:
+        # Non-zero bytes are single pixels of that palette index.
+        assert list(_decode_rle(bytes([0x01, 0x02]), width=2, height=1)) == [1, 2]
+
+    def test_end_of_line_pads_to_row_boundary(self) -> None:
+        # 0x00 0x00 after one literal pads the rest of the 3-wide row with 0.
+        out = _decode_rle(bytes([0x05, 0x00, 0x00, 0x07]), width=3, height=2)
+        assert list(out) == [5, 0, 0, 7, 0, 0]
+
+    def test_short_run_background(self) -> None:
+        # 0x00 <len> with neither 0x40 nor 0x80: run of `len` zeros.
+        assert list(_decode_rle(bytes([0x00, 0x03]), width=3, height=1)) == [0, 0, 0]
+
+    def test_short_run_coloured(self) -> None:
+        # 0x80 set: the byte after carries the colour index. 0x83 -> len 3.
+        out = _decode_rle(bytes([0x00, 0x83, 0x05]), width=3, height=1)
+        assert list(out) == [5, 5, 5]
+
+    def test_extended_length_run(self) -> None:
+        # 0x40 set: length spans two bytes (low 6 bits << 8 | next). 300 zeros
+        # into a 400-wide buffer.
+        second = 0x40 | ((300 >> 8) & 0x3F)  # 0x41
+        low = 300 & 0xFF  # 0x2C
+        out = _decode_rle(bytes([0x00, second, low]), width=400, height=1)
+        assert out[:300] == bytearray(300)
+        assert len(out) == 400
+
+    def test_extended_length_coloured_run(self) -> None:
+        # 0x40 | 0x80: two-byte length AND a trailing colour byte. 100 px of 7.
+        second = 0x40 | 0x80 | ((100 >> 8) & 0x3F)  # 0xC0
+        low = 100 & 0xFF  # 0x64
+        out = _decode_rle(bytes([0x00, second, low, 0x07]), width=100, height=1)
+        assert list(out) == [7] * 100
+
+    def test_run_overflowing_buffer_is_clamped(self) -> None:
+        # A run longer than width*height clamps rather than overrunning.
+        out = _decode_rle(bytes([0x00, 0x8A, 0x03]), width=2, height=1)  # len 10, colour 3
+        assert list(out) == [3, 3]
+
+    def test_mixed_literal_run_and_eol(self) -> None:
+        out = _decode_rle(
+            bytes([0x09, 0x00, 0x82, 0x04, 0x00, 0x00, 0x08]),  # px9, run(2x4), eol, px8
+            width=4,
+            height=2,
+        )
+        assert list(out) == [9, 4, 4, 0, 8, 0, 0, 0]
+
+    def test_truncated_run_header_stops_cleanly(self) -> None:
+        # A lone 0x00 with no following byte just ends the loop.
+        assert list(_decode_rle(bytes([0x02, 0x00]), width=2, height=1)) == [2, 0]

--- a/tests/modules/media/unit/infrastructure/video/test_frame_hasher.py
+++ b/tests/modules/media/unit/infrastructure/video/test_frame_hasher.py
@@ -1,0 +1,73 @@
+"""Tests for the perceptual-hash core of FrameHasher.
+
+Exercise ``_hash_raw_frames`` directly on synthetic rgb24 bytes — the
+consumers (correlator / intro detector) stub FrameHasher out, so the
+reshape + dHash-replication that produces a hash from real pixels was
+otherwise unverified.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from src.modules.media.infrastructure.video.frame_hasher import FrameHasher
+
+_SCALE = 64
+_CHANNELS = 3
+
+
+def _hasher() -> FrameHasher:
+    """A FrameHasher with a stub config port — ``_hash_raw_frames`` ignores it."""
+    return FrameHasher(runtime_settings=MagicMock())
+
+
+def _gradient_frame(*, reverse: bool = False) -> np.ndarray:
+    """A greyscale left-to-right gradient as an rgb24 ``(_SCALE, _SCALE, 3)`` frame."""
+    cols = np.linspace(0, 255, _SCALE, dtype=np.uint8)
+    if reverse:
+        cols = cols[::-1]
+    plane = np.repeat(cols[None, :], _SCALE, axis=0)  # (_SCALE, _SCALE)
+    return np.repeat(plane[:, :, None], _CHANNELS, axis=2).astype(np.uint8)
+
+
+@pytest.mark.unit
+class TestHashRawFrames:
+    def test_identical_frames_hash_equal(self) -> None:
+        hasher = _hasher()
+        frame = _gradient_frame()
+        raw = frame.tobytes() * 2
+
+        hashes = hasher._hash_raw_frames(raw, "test.mkv")
+
+        assert hashes is not None
+        assert hashes.dtype == np.uint64
+        assert hashes.shape == (2,)
+        assert hashes[0] == hashes[1]  # same pixels -> same hash (Hamming 0)
+
+    def test_gradient_and_its_mirror_differ(self) -> None:
+        hasher = _hasher()
+        raw = _gradient_frame().tobytes() + _gradient_frame(reverse=True).tobytes()
+
+        hashes = hasher._hash_raw_frames(raw, "test.mkv")
+
+        assert hashes is not None
+        # dHash compares each pixel to its right neighbour: the increasing
+        # gradient sets every bit, the decreasing mirror clears every bit.
+        assert hashes[0] != hashes[1]
+
+    def test_truncated_buffer_returns_none(self) -> None:
+        hasher = _hasher()
+        # One byte short of a full frame -> zero complete frames.
+        raw = bytes(_SCALE * _SCALE * _CHANNELS - 1)
+
+        assert hasher._hash_raw_frames(raw, "test.mkv") is None
+
+    def test_hash_length_matches_frame_count(self) -> None:
+        hasher = _hasher()
+        raw = _gradient_frame().tobytes() * 5
+
+        hashes = hasher._hash_raw_frames(raw, "test.mkv")
+
+        assert hashes is not None
+        assert hashes.shape == (5,)


### PR DESCRIPTION
## Summary

**Onda 0** — fecha as duas lacunas de teste que a auditoria marcou como HIGH/MEDIUM (caminho dominante de dado real, hoje sem cobertura).

- **`pgs_parser._decode_rle`** — 9 casos por branch (run curto `0x01..0x3F`, estendido `0x40`, colorido `0x80`, overflow com clamp, end-of-line, misto literal+run+EOL, header truncado). Antes só o caminho literal era exercido, embora RLE seja o esquema **dominante** em legendas PGS reais — um off-by-one corromperia toda legenda bitmap e a suíte ficaria verde.
- **`frame_hasher._hash_raw_frames`** — auto-consistência com FrameHasher **real** sobre bytes rgb24 sintéticos (frames idênticos → Hamming 0; gradiente vs espelho → hashes diferentes; buffer truncado → None; shape == frame_count). Antes 100% stubado com MagicMock — o coração perceptual da detecção de intro não tinha teste real. (Cross-check com `imagehash` omitido de propósito: o módulo replica o dhash justamente para não puxar a dependência.)

## Test plan

- [x] `pytest` dos dois arquivos — 4 + 15 passed
- [x] `ruff` / `mypy` — clean (via pre-commit)
- [x] Suíte completa — via CI

## Summary by Sourcery

Add unit tests to cover PGS RLE decoding branches and the FrameHasher raw frame hashing core.

Tests:
- Add per-branch unit tests for `_decode_rle` to cover literal pixels, runs, end-of-line handling, overflow clamping, and truncated headers.
- Introduce unit tests for `FrameHasher._hash_raw_frames` validating hash equality for identical frames, differences for mirrored gradients, handling of truncated buffers, and alignment of hash count with frame count.