### PR TITLE
refactor(notifications,settings): type user ids as UserId VO

### DIFF
--- a/src/modules/notifications/application/dtos/notification_dtos.py
+++ b/src/modules/notifications/application/dtos/notification_dtos.py
@@ -124,7 +124,7 @@ class NotificationOutput:
         """Build the DTO from a domain ``Notification`` aggregate."""
         return cls(
             id=str(entity.id),
-            recipient_user_id=entity.recipient_user_id,
+            recipient_user_id=entity.recipient_user_id.value,
             kind=entity.kind.value,
             title=entity.title,
             body=entity.body,

--- a/src/modules/notifications/application/use_cases/create_notification.py
+++ b/src/modules/notifications/application/use_cases/create_notification.py
@@ -21,7 +21,7 @@ class CreateNotificationUseCase:
     Example:
         >>> uc = CreateNotificationUseCase(uow_factory)
         >>> out = await uc.execute(CreateNotificationInput(
-        ...     recipient_user_id="usr_alice",
+        ...     recipient_user_id="usr_alice0000000",
         ...     kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
         ...     title="Alien chegou ao catálogo",
         ...     payload={"tmdb_id": 348, "media_type": "movie",

--- a/src/modules/notifications/domain/entities/notification.py
+++ b/src/modules/notifications/domain/entities/notification.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from src.building_blocks.domain import AggregateRoot
 from src.modules.notifications.domain.value_objects import (
     NotificationId,
     NotificationKind,
 )
+from src.shared_kernel.value_objects import UserId  # — runtime for Pydantic
 from src.shared_kernel.value_objects.media_type import MediaType
 
 _PAYLOAD_MEDIA_TYPE_KEY = "media_type"
@@ -47,7 +48,7 @@ class Notification(AggregateRoot[NotificationId]):
 
     Example:
         >>> n = Notification.create(
-        ...     recipient_user_id="usr_alice",
+        ...     recipient_user_id="usr_alice0000000",
         ...     kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
         ...     title="Alien chegou ao catálogo",
         ...     body="O filme que você solicitou já está disponível.",
@@ -58,12 +59,23 @@ class Notification(AggregateRoot[NotificationId]):
 
     id: NotificationId | None = Field(default=None)
 
-    recipient_user_id: str
+    recipient_user_id: UserId
     kind: NotificationKind
     title: str
     body: str | None = None
     payload: dict[str, Any] = Field(default_factory=dict)
     read_at: datetime | None = None
+
+    @field_validator("recipient_user_id", mode="before")
+    @classmethod
+    def _convert_recipient(cls, v: str | UserId) -> UserId:
+        """Accept a raw ``usr_xxx`` string at the boundary and validate it once.
+
+        The recipient is the addressing key for the whole inbox; typing it as
+        ``UserId`` validates the prefixed-external-id format on write instead
+        of trusting an unchecked string (ADR-002, ADR-018).
+        """
+        return v if isinstance(v, UserId) else UserId(v)
 
     @model_validator(mode="after")
     def _validate_payload_media_type(self) -> Notification:
@@ -87,7 +99,7 @@ class Notification(AggregateRoot[NotificationId]):
     @classmethod
     def create(
         cls,
-        recipient_user_id: str,
+        recipient_user_id: str | UserId,
         kind: NotificationKind,
         title: str,
         body: str | None = None,

--- a/src/modules/notifications/infrastructure/persistence/mappers/notification_mapper.py
+++ b/src/modules/notifications/infrastructure/persistence/mappers/notification_mapper.py
@@ -35,7 +35,7 @@ class NotificationMapper:
 
         return NotificationModel(
             external_id=str(entity.id),
-            recipient_user_id=entity.recipient_user_id,
+            recipient_user_id=entity.recipient_user_id.value,
             kind=entity.kind.value,
             title=entity.title,
             body=entity.body,

--- a/src/modules/notifications/infrastructure/persistence/repositories/notification_repository.py
+++ b/src/modules/notifications/infrastructure/persistence/repositories/notification_repository.py
@@ -17,7 +17,7 @@ class SQLAlchemyNotificationRepository(NotificationRepository):
 
     Example:
         >>> repo = SQLAlchemyNotificationRepository(session)
-        >>> rows = await repo.list_for_user("usr_alice", limit=20)
+        >>> rows = await repo.list_for_user("usr_alice0000000", limit=20)
     """
 
     def __init__(self, session: AsyncSession) -> None:

--- a/src/modules/settings/application/use_cases/list_settings.py
+++ b/src/modules/settings/application/use_cases/list_settings.py
@@ -49,7 +49,9 @@ def _to_detail(setting: Setting) -> SettingDetail:
         key=setting.id.value,
         value=setting.value.model_dump(mode="json"),
         source=setting.source.value,
-        updated_by_user_id=setting.updated_by_user_id,
+        updated_by_user_id=(
+            setting.updated_by_user_id.value if setting.updated_by_user_id else None
+        ),
         updated_at=setting.updated_at.isoformat() if setting.updated_at else None,
     )
 

--- a/src/modules/settings/application/use_cases/update_setting.py
+++ b/src/modules/settings/application/use_cases/update_setting.py
@@ -72,7 +72,9 @@ class UpdateSettingUseCase:
             key=persisted.id.value,
             value=persisted.value.model_dump(mode="json"),
             source=persisted.source.value,
-            updated_by_user_id=persisted.updated_by_user_id,
+            updated_by_user_id=(
+                persisted.updated_by_user_id.value if persisted.updated_by_user_id else None
+            ),
             updated_at=persisted.updated_at.isoformat() if persisted.updated_at else None,
         )
 

--- a/src/modules/settings/domain/entities/setting.py
+++ b/src/modules/settings/domain/entities/setting.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Self
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 
 from src.building_blocks.domain.entity import AggregateRoot
 from src.modules.settings.domain.value_objects import (
@@ -13,6 +13,7 @@ from src.modules.settings.domain.value_objects import (
     SettingSource,
     vo_type_for,
 )
+from src.shared_kernel.value_objects import UserId  # — runtime for Pydantic
 
 
 class Setting(AggregateRoot[SettingKey]):
@@ -42,7 +43,7 @@ class Setting(AggregateRoot[SettingKey]):
         ...     id=SettingKey.INTRO_DETECTION,
         ...     value=IntroDetectionConfig(enabled=True),
         ...     source=SettingSource.ADMIN,
-        ...     updated_by_user_id="usr_abc123",
+        ...     updated_by_user_id="usr_abc123abcd00",
         ... )
         >>> updated = setting.with_updates(
         ...     value=setting.value.with_updates(min_confidence=0.85),
@@ -52,7 +53,15 @@ class Setting(AggregateRoot[SettingKey]):
     id: SettingKey
     value: ConfigVO
     source: SettingSource
-    updated_by_user_id: str | None = None
+    updated_by_user_id: UserId | None = None
+
+    @field_validator("updated_by_user_id", mode="before")
+    @classmethod
+    def _convert_updated_by(cls, v: str | UserId | None) -> UserId | None:
+        """Accept a raw ``usr_xxx`` string (or ``None``) and validate the id."""
+        if v is None or isinstance(v, UserId):
+            return v
+        return UserId(v)
 
     @model_validator(mode="after")
     def _validate_value_matches_key(self) -> Self:

--- a/src/modules/settings/infrastructure/persistence/mappers/setting_mapper.py
+++ b/src/modules/settings/infrastructure/persistence/mappers/setting_mapper.py
@@ -32,7 +32,9 @@ class SettingMapper:
             key=entity.id.value,
             value_json=entity.value.model_dump(mode="json"),
             source=entity.source.value,
-            updated_by_user_id=entity.updated_by_user_id,
+            updated_by_user_id=(
+                entity.updated_by_user_id.value if entity.updated_by_user_id else None
+            ),
         )
 
     @staticmethod
@@ -68,7 +70,9 @@ class SettingMapper:
         """
         model.value_json = entity.value.model_dump(mode="json")
         model.source = entity.source.value
-        model.updated_by_user_id = entity.updated_by_user_id
+        model.updated_by_user_id = (
+            entity.updated_by_user_id.value if entity.updated_by_user_id else None
+        )
         return model
 
 

--- a/tests/modules/notifications/unit/application/use_cases/test_create_notification.py
+++ b/tests/modules/notifications/unit/application/use_cases/test_create_notification.py
@@ -20,7 +20,7 @@ class TestCreateNotificationUseCase:
 
         result = await use_case.execute(
             CreateNotificationInput(
-                recipient_user_id="usr_alice",
+                recipient_user_id="usr_alice0000000",
                 kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
                 title="Alien chegou ao catálogo",
                 payload={
@@ -31,7 +31,7 @@ class TestCreateNotificationUseCase:
             ),
         )
 
-        assert result.recipient_user_id == "usr_alice"
+        assert result.recipient_user_id == "usr_alice0000000"
         assert result.kind == "catalog_request_fulfilled"
         assert result.title == "Alien chegou ao catálogo"
         assert result.payload["tmdb_id"] == 348

--- a/tests/modules/notifications/unit/application/use_cases/test_list_user_notifications.py
+++ b/tests/modules/notifications/unit/application/use_cases/test_list_user_notifications.py
@@ -11,7 +11,7 @@ from tests.modules.notifications.unit.conftest import make_notifications_uow_moc
 
 def _make_notification(title: str = "Alien") -> Notification:
     return Notification.create(
-        recipient_user_id="usr_alice",
+        recipient_user_id="usr_alice0000000",
         kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
         title=title,
     )
@@ -30,13 +30,13 @@ class TestListUserNotificationsUseCase:
         use_case = ListUserNotificationsUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
-            ListUserNotificationsInput(recipient_user_id="usr_alice"),
+            ListUserNotificationsInput(recipient_user_id="usr_alice0000000"),
         )
 
         assert len(result.items) == 2
         assert result.unread_count == 2
         mocks.notifications.list_for_user.assert_awaited_once_with(
-            recipient_user_id="usr_alice",
+            recipient_user_id="usr_alice0000000",
             unread_only=False,
             limit=50,
         )
@@ -50,14 +50,14 @@ class TestListUserNotificationsUseCase:
 
         await use_case.execute(
             ListUserNotificationsInput(
-                recipient_user_id="usr_alice",
+                recipient_user_id="usr_alice0000000",
                 unread_only=True,
                 limit=10,
             ),
         )
 
         mocks.notifications.list_for_user.assert_awaited_once_with(
-            recipient_user_id="usr_alice",
+            recipient_user_id="usr_alice0000000",
             unread_only=True,
             limit=10,
         )
@@ -74,7 +74,7 @@ class TestListUserNotificationsUseCase:
 
         result = await use_case.execute(
             ListUserNotificationsInput(
-                recipient_user_id="usr_alice",
+                recipient_user_id="usr_alice0000000",
                 unread_only=False,
             ),
         )

--- a/tests/modules/notifications/unit/application/use_cases/test_mark_all_notifications_read.py
+++ b/tests/modules/notifications/unit/application/use_cases/test_mark_all_notifications_read.py
@@ -20,12 +20,12 @@ class TestMarkAllNotificationsReadUseCase:
         use_case = MarkAllNotificationsReadUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
-            MarkAllNotificationsReadInput(recipient_user_id="usr_alice"),
+            MarkAllNotificationsReadInput(recipient_user_id="usr_alice0000000"),
         )
 
         assert result.marked_read == 4
         mocks.notifications.mark_all_read_for_user.assert_awaited_once_with(
-            "usr_alice",
+            "usr_alice0000000",
         )
 
     @pytest.mark.asyncio
@@ -37,7 +37,7 @@ class TestMarkAllNotificationsReadUseCase:
         use_case = MarkAllNotificationsReadUseCase(uow_factory=mocks.factory)
 
         result = await use_case.execute(
-            MarkAllNotificationsReadInput(recipient_user_id="usr_alice"),
+            MarkAllNotificationsReadInput(recipient_user_id="usr_alice0000000"),
         )
 
         assert result.marked_read == 0

--- a/tests/modules/notifications/unit/application/use_cases/test_mark_notification_read.py
+++ b/tests/modules/notifications/unit/application/use_cases/test_mark_notification_read.py
@@ -12,7 +12,7 @@ from tests.modules.notifications.unit.conftest import make_notifications_uow_moc
 
 def _make_notification() -> Notification:
     return Notification.create(
-        recipient_user_id="usr_alice",
+        recipient_user_id="usr_alice0000000",
         kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
         title="Alien",
     )
@@ -33,7 +33,7 @@ class TestMarkNotificationReadUseCase:
         result = await use_case.execute(
             MarkNotificationReadInput(
                 notification_id=str(existing.id),
-                recipient_user_id="usr_alice",
+                recipient_user_id="usr_alice0000000",
             ),
         )
 
@@ -52,7 +52,7 @@ class TestMarkNotificationReadUseCase:
         result = await use_case.execute(
             MarkNotificationReadInput(
                 notification_id=str(existing.id),
-                recipient_user_id="usr_alice",
+                recipient_user_id="usr_alice0000000",
             ),
         )
 
@@ -72,6 +72,6 @@ class TestMarkNotificationReadUseCase:
             await use_case.execute(
                 MarkNotificationReadInput(
                     notification_id="nfy_abcdefghij12",
-                    recipient_user_id="usr_bob",
+                    recipient_user_id="usr_bob000000000",
                 ),
             )

--- a/tests/modules/notifications/unit/domain/entities/test_notification.py
+++ b/tests/modules/notifications/unit/domain/entities/test_notification.py
@@ -19,7 +19,7 @@ class TestNotification:
 
     def test_create_generates_id_and_defaults(self) -> None:
         notification = Notification.create(
-            recipient_user_id="usr_alice",
+            recipient_user_id="usr_alice0000000",
             kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
             title="Alien chegou ao catálogo",
         )
@@ -32,7 +32,7 @@ class TestNotification:
 
     def test_create_carries_payload(self) -> None:
         notification = Notification.create(
-            recipient_user_id="usr_alice",
+            recipient_user_id="usr_alice0000000",
             kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
             title="Alien",
             payload={"tmdb_id": 348, "media_id": "mov_abc", "media_type": "movie"},
@@ -43,7 +43,7 @@ class TestNotification:
 
     def test_mark_read_stamps_timestamp(self) -> None:
         notification = Notification.create(
-            recipient_user_id="usr_alice",
+            recipient_user_id="usr_alice0000000",
             kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
             title="Alien",
         )
@@ -55,7 +55,7 @@ class TestNotification:
 
     def test_mark_read_respects_explicit_timestamp(self) -> None:
         notification = Notification.create(
-            recipient_user_id="usr_alice",
+            recipient_user_id="usr_alice0000000",
             kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
             title="Alien",
         )
@@ -73,7 +73,7 @@ class TestNotificationPayloadMediaType:
     @pytest.mark.parametrize("value", [MediaType.MOVIE, MediaType.SERIES, "movie", "series"])
     def test_accepts_valid_media_type(self, value: object) -> None:
         notification = Notification.create(
-            recipient_user_id="usr_alice",
+            recipient_user_id="usr_alice0000000",
             kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
             title="Alien",
             payload={"media_type": value},
@@ -84,7 +84,7 @@ class TestNotificationPayloadMediaType:
     def test_rejects_unknown_media_type(self) -> None:
         with pytest.raises(DomainValidationException, match="media_type"):
             Notification.create(
-                recipient_user_id="usr_alice",
+                recipient_user_id="usr_alice0000000",
                 kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
                 title="Alien",
                 payload={"media_type": "film"},
@@ -92,7 +92,7 @@ class TestNotificationPayloadMediaType:
 
     def test_payload_without_media_type_is_allowed(self) -> None:
         notification = Notification.create(
-            recipient_user_id="usr_alice",
+            recipient_user_id="usr_alice0000000",
             kind=NotificationKind.CATALOG_REQUEST_FULFILLED,
             title="Alien",
             payload={"tmdb_id": 348},

--- a/tests/modules/notifications/unit/infrastructure/acl/test_notification_publisher_adapter.py
+++ b/tests/modules/notifications/unit/infrastructure/acl/test_notification_publisher_adapter.py
@@ -23,7 +23,7 @@ class TestNotificationPublisherAdapter:
 
         await adapter.publish_catalog_arrival(
             CatalogArrivalNotification(
-                recipient_user_id="usr_alice",
+                recipient_user_id="usr_alice0000000",
                 title="Alien",
                 tmdb_id=348,
                 media_id=MovieId("mov_abcabcabcabc"),
@@ -34,7 +34,7 @@ class TestNotificationPublisherAdapter:
         create_uc.execute.assert_awaited_once()
         called_input = create_uc.execute.await_args.args[0]
         assert isinstance(called_input, CreateNotificationInput)
-        assert called_input.recipient_user_id == "usr_alice"
+        assert called_input.recipient_user_id == "usr_alice0000000"
         assert called_input.kind == NotificationKind.CATALOG_REQUEST_FULFILLED
         assert called_input.title == "Alien"
         assert called_input.payload == {

--- a/tests/modules/settings/integration/infrastructure/test_runtime_settings_integration.py
+++ b/tests/modules/settings/integration/infrastructure/test_runtime_settings_integration.py
@@ -52,7 +52,7 @@ class TestRuntimeSettingsIntegration:
                 id=SettingKey.SCHEDULER,
                 value=SchedulerConfig(enabled=False, reconcile_interval_minutes=42),
                 source=SettingSource.ADMIN,
-                updated_by_user_id="usr_admin",
+                updated_by_user_id="usr_admin0000000",
             ),
         )
 

--- a/tests/modules/settings/integration/persistence/repositories/test_sqlalchemy_setting_repository.py
+++ b/tests/modules/settings/integration/persistence/repositories/test_sqlalchemy_setting_repository.py
@@ -41,7 +41,7 @@ class TestSQLAlchemySettingRepository:
             id=SettingKey.SCHEDULER,
             value=SchedulerConfig(enabled=False, reconcile_interval_minutes=15),
             source=SettingSource.ADMIN,
-            updated_by_user_id="usr_admin",
+            updated_by_user_id="usr_admin0000000",
         )
         await repo.upsert(admin_edit)
 
@@ -53,7 +53,8 @@ class TestSQLAlchemySettingRepository:
         assert only.value.enabled is False
         assert only.value.reconcile_interval_minutes == 15
         assert only.source is SettingSource.ADMIN
-        assert only.updated_by_user_id == "usr_admin"
+        assert only.updated_by_user_id is not None
+        assert only.updated_by_user_id.value == "usr_admin0000000"
 
     async def test_upsert_preserves_polymorphic_value_type(self, db_session: AsyncSession) -> None:
         repo = SQLAlchemySettingRepository(db_session)

--- a/tests/modules/settings/unit/application/use_cases/test_list_settings.py
+++ b/tests/modules/settings/unit/application/use_cases/test_list_settings.py
@@ -77,7 +77,7 @@ class TestListSettings:
             id=SettingKey.INTRO_DETECTION,
             value=IntroDetectionConfig(enabled=True, min_confidence=0.9),
             source=SettingSource.ADMIN,
-            updated_by_user_id="usr_admin",
+            updated_by_user_id="usr_admin0000000",
         )
         use_case = ListSettingsUseCase(_FakeUoWFactory(_FakeRepo(rows=[row])))
 
@@ -85,7 +85,7 @@ class TestListSettings:
 
         intro = next(d for d in details if d.key == "intro_detection")
         assert intro.source == "admin"
-        assert intro.updated_by_user_id == "usr_admin"
+        assert intro.updated_by_user_id == "usr_admin0000000"
         assert intro.updated_at is not None
         assert intro.value["min_confidence"] == 0.9
         assert intro.value["enabled"] is True
@@ -95,7 +95,7 @@ class TestListSettings:
             id=SettingKey.SCHEDULER,
             value=SchedulerConfig(enabled=False, reconcile_interval_minutes=99),
             source=SettingSource.ADMIN,
-            updated_by_user_id="usr_admin",
+            updated_by_user_id="usr_admin0000000",
         )
         use_case = ListSettingsUseCase(_FakeUoWFactory(_FakeRepo(rows=[scheduler_row])))
 

--- a/tests/modules/settings/unit/application/use_cases/test_update_setting.py
+++ b/tests/modules/settings/unit/application/use_cases/test_update_setting.py
@@ -84,7 +84,7 @@ class TestUpdateSetting:
                 value=SchedulerConfig(enabled=False, reconcile_interval_minutes=10).model_dump(
                     mode="json"
                 ),
-                acting_admin_id="usr_admin",
+                acting_admin_id="usr_admin0000000",
             ),
         )
 
@@ -92,7 +92,8 @@ class TestUpdateSetting:
         persisted = repo.upserts[0]
         assert persisted.id is SettingKey.SCHEDULER
         assert persisted.source is SettingSource.ADMIN
-        assert persisted.updated_by_user_id == "usr_admin"
+        assert persisted.updated_by_user_id is not None
+        assert persisted.updated_by_user_id.value == "usr_admin0000000"
         assert isinstance(persisted.value, SchedulerConfig)
         assert persisted.value.enabled is False
         assert persisted.value.reconcile_interval_minutes == 10
@@ -111,7 +112,7 @@ class TestUpdateSetting:
             UpdateSettingInput(
                 key=SettingKey.INTRO_DETECTION.value,
                 value=IntroDetectionConfig(min_confidence=0.85).model_dump(mode="json"),
-                acting_admin_id="usr_admin",
+                acting_admin_id="usr_admin0000000",
             ),
         )
 
@@ -135,7 +136,7 @@ class TestUpdateSetting:
                 value=SchedulerConfig(enabled=False, reconcile_interval_minutes=30).model_dump(
                     mode="json"
                 ),
-                acting_admin_id="usr_admin",
+                acting_admin_id="usr_admin0000000",
             ),
         )
 
@@ -156,7 +157,7 @@ class TestUpdateSetting:
                 UpdateSettingInput(
                     key=SettingKey.INTRO_DETECTION.value,
                     value={"min_confidence": 5.0},  # out of [0, 1]
-                    acting_admin_id="usr_admin",
+                    acting_admin_id="usr_admin0000000",
                 ),
             )
 
@@ -175,7 +176,7 @@ class TestUpdateSetting:
                 UpdateSettingInput(
                     key="nonexistent",
                     value={},
-                    acting_admin_id="usr_admin",
+                    acting_admin_id="usr_admin0000000",
                 ),
             )
 

--- a/tests/modules/settings/unit/domain/entities/test_setting.py
+++ b/tests/modules/settings/unit/domain/entities/test_setting.py
@@ -61,12 +61,13 @@ class TestSettingWithUpdates:
         updated = original.with_updates(
             value=updated_value,
             source=SettingSource.ADMIN,
-            updated_by_user_id="usr_admin",
+            updated_by_user_id="usr_admin0000000",
         )
 
         assert updated.value.min_confidence == 0.9
         assert updated.source is SettingSource.ADMIN
-        assert updated.updated_by_user_id == "usr_admin"
+        assert updated.updated_by_user_id is not None
+        assert updated.updated_by_user_id.value == "usr_admin0000000"
         assert updated.updated_at >= original.updated_at
 
     def test_with_updates_rejects_mismatched_value_type(self) -> None:

--- a/tests/modules/settings/unit/infrastructure/persistence/mappers/test_setting_mapper.py
+++ b/tests/modules/settings/unit/infrastructure/persistence/mappers/test_setting_mapper.py
@@ -49,7 +49,7 @@ class TestSettingMapper:
                 "frame_hash": {"hash_distance_threshold": 8, "frame_sample_fps": 2.0},
             },
             source="admin",
-            updated_by_user_id="usr_alice",
+            updated_by_user_id="usr_alice0000000",
         )
         model.created_at = now
         model.updated_at = now
@@ -63,7 +63,8 @@ class TestSettingMapper:
         assert entity.value.algorithm.value == "frame_hash"
         assert entity.value.chromaprint.max_hash_hamming == 10
         assert entity.source is SettingSource.ADMIN
-        assert entity.updated_by_user_id == "usr_alice"
+        assert entity.updated_by_user_id is not None
+        assert entity.updated_by_user_id.value == "usr_alice0000000"
         assert entity.created_at == now
         assert entity.updated_at == now
 
@@ -73,7 +74,7 @@ class TestSettingMapper:
             id=SettingKey.AVATAR,
             value=AvatarConfig(max_size_mb=5, size_pixels=512),
             source=SettingSource.ADMIN,
-            updated_by_user_id="usr_admin",
+            updated_by_user_id="usr_admin0000000",
         )
         model = SettingMapper.to_model(original)
         model.created_at = now
@@ -101,7 +102,7 @@ class TestSettingMapper:
             id=SettingKey.SCHEDULER,
             value=SchedulerConfig(enabled=False, reconcile_interval_minutes=20),
             source=SettingSource.ADMIN,
-            updated_by_user_id="usr_admin",
+            updated_by_user_id="usr_admin0000000",
         )
 
         SettingMapper.update_model(model, updated_entity)
@@ -112,4 +113,4 @@ class TestSettingMapper:
             "reconcile_interval_minutes": 20,
         }
         assert model.source == "admin"
-        assert model.updated_by_user_id == "usr_admin"
+        assert model.updated_by_user_id == "usr_admin0000000"

--- a/tests/modules/settings/unit/infrastructure/test_runtime_settings.py
+++ b/tests/modules/settings/unit/infrastructure/test_runtime_settings.py
@@ -68,7 +68,7 @@ def admin_intro_row() -> Setting:
         id=SettingKey.INTRO_DETECTION,
         value=IntroDetectionConfig(enabled=True, min_confidence=0.9),
         source=SettingSource.ADMIN,
-        updated_by_user_id="usr_admin",
+        updated_by_user_id="usr_admin0000000",
     )
 
 


### PR DESCRIPTION
## Summary

**Onda 0** (fecha o item de primitive obsession da auditoria; continua o 2.2). `Notification.recipient_user_id` e `Setting.updated_by_user_id` passam de `str` cru para o **`UserId`** VO — validando o formato `usr_xxx` no boundary (ADR-002/018) em vez de confiar numa string não checada. A auditoria apontou que a chave de endereçamento do inbox nunca era validada no write-path.

- Campo tipado como `UserId` (`| None` no Setting) + `@field_validator(mode="before")` que converte `str → UserId`.
- **Bordas continuam `str`**: colunas do DB, DTOs de Output e schemas HTTP inalterados; mapper e `from_entity` desembrulham via `.value`.
- Fixtures de teste atualizados para ids `usr_` de 12 chars (o formato agora é enforçado — dummies como `usr_alice` deixam de ser aceitos, que é o ponto).

## Test plan

- [x] `mypy src` — 0 errors (774 files)
- [x] `ruff` — clean
- [x] `pytest tests/modules/{notifications,settings}` — 112 passed
- [x] catalog_requests (que ainda usa str) intacto — sem regressão
- [x] Suíte completa — via CI

## Summary by Sourcery

Introduce the UserId value object for notification recipients and setting audit fields, enforcing validated user identifiers while preserving existing string-based boundaries.

Enhancements:
- Type Notification.recipient_user_id and Setting.updated_by_user_id as UserId in the domain model to validate prefixed external user ids at write time.
- Adapt notification and setting mappers and use cases to unwrap UserId to raw strings for persistence and output DTOs, keeping external interfaces unchanged.

Tests:
- Update notifications and settings unit and integration tests to use valid usr_ identifiers and to assert the new UserId-based fields and mapping behavior.