### PR TITLE
docs: add ADR-032 (decompose media) and ADR-033 (repository ISP)

### DIFF
--- a/docs/adr/ADR-032-decompose-media-into-subdomains.md
+++ b/docs/adr/ADR-032-decompose-media-into-subdomains.md
@@ -1,0 +1,107 @@
+# ADR-032: Decompor o módulo `media` em subdomínios
+
+**Status:** Aceito
+**Data:** 2026-08-16
+**Deciders:** Lucas Cristovam
+**Technical Story:** Auditoria de débito técnico (multi-agente, 2026-08-16) — achado dominante: `media` é um monólito de ~39.8k LOC que solda subdomínios de volatilidade independente. Onda 2 do `docs/tech-debt-remediation-plan.md`. Depende do ADR-033 (ISP em repositórios) como enabler.
+
+---
+
+## Contexto
+
+O bounded context `media` (`src/modules/media/`) tem **~39.8k LOC — cerca de 10× o próximo módulo** (collections, 4.8k). Ele concentra responsabilidades que mudam por razões diferentes:
+
+- **Catálogo** (core): agregados Movie / Series / Season / Episode, CRUD, busca (FTS5), navegação por gênero, variantes de arquivo, dedup/conflitos.
+- **Streaming / Playback**: geração HLS, probe (ffprobe/NVENC), thumbnails/trickplay, range/file streaming, OCR de legendas.
+- **Metadata / Enrichment**: cliente TMDB, reconciliação de metadados, artwork mirror.
+- **Detecção de playback** (marcadores): skip-intro (frame-hash), créditos (sinais visuais), scrub-preview.
+
+A auditoria mediu a assimetria de volatilidade: `infrastructure/streaming/` teve **44 commits** contra 9 de `file_system/`. Isso é **Divergent Change** materializado — um ajuste de flag de codec, um quirk de NVENC, um fix de timing WebVTT e uma mudança de política de enrichment editam o **mesmo** módulo, e cada mudança re-testa e re-deploya os 39.8k LOC inteiros.
+
+Crucialmente, a auditoria confirmou que **os seams já estão desenhados**: `hls_service.py` importa **zero entidades** (só ports + `track_naming`) e `GenerateHlsPlaylistUseCase` opera inteiramente via `HlsPlaylistPort` recebendo `file_path: str`. O trabalho pesado de desacoplamento já foi feito; falta formalizar a fronteira.
+
+O ADR-008 estabeleceu módulos como bounded contexts; este ADR **refina a fronteira interna do `media`**, que cresceu além de um único subdomínio coeso.
+
+## Decisão
+
+Nós iremos **extrair os subdomínios do `media` em módulos próprios de forma incremental (Strangler-Fig)**, um por vez, na ordem de menor fricção → maior acoplamento. A comunicação cross-BC continua por **ports + ACL + integration events** (ADR-009, ADR-024) — nunca import direto entre módulos.
+
+**Ordem de extração:**
+
+1. **Streaming / Playback** (subdomínio *Generic*) — **primeiro**. O seam já existe: consome `file_path`/probe primitives via ports e devolve playlists/streams/ranges. Novo módulo `playback` (ou `streaming`) com HLS, probe, thumbnail, range streaming e OCR de legendas. Contrato de port: `file_path` in → m3u8/range out. A fatia de OCR de legendas é levemente mais acoplada (resolve o `file_path` a partir da entidade), então recebe um **media-lookup port** dedicado.
+
+2. **Metadata / Enrichment + Artwork** (subdomínio *Supporting*) — **segundo**. Mais acoplado: `enrich_movie_metadata` chama `uow.movies.save`. Resolver a escrita de volta com um **evento de integração `MetadataResolved`** ou um write-port estreito, em vez de o módulo de metadata escrever direto no agregado de catálogo.
+
+3. **Marcadores de playback** (intro / créditos / scrub) — **terceiro**. Hoje vazados como colunas nos agregados Episode/Season/Movie. Modelar como **read-model keyed by `media_id`** (ex.: `PlaybackMarkers`), removendo as colunas dos agregados de catálogo (requer migration).
+
+**O que permanece em `media`:** o núcleo de catálogo — os agregados Movie/Series/Season/Episode, CRUD, busca, navegação por gênero, variantes e dedup/conflitos.
+
+Cada extração é seu próprio PR faseado, precedido pela segregação do repositório correspondente (ADR-033), e validado contra a suíte antes do merge.
+
+## Consequências
+
+### Positivas
+
+- **Blast radius menor**: uma mudança de HLS/transcode deixa de re-testar/re-deployar o catálogo inteiro.
+- **Volatilidade isolada**: o subdomínio de maior churn (streaming) sai do caminho crítico do catálogo.
+- **Fronteiras de subdomínio explícitas** (Core vs Generic vs Supporting), alinhadas à linguagem ubíqua.
+- **Deploy/teste independentes** por subdomínio; menor superfície de colisão em reviews/merges.
+
+### Negativas
+
+- Mais módulos e mais plumbing cross-BC (ports, ACL, eventos) — overhead real de indireção.
+- Alguns fluxos hoje síncronos (enrichment escrevendo no catálogo) viram assíncronos/event-driven, com a complexidade de consistência eventual associada.
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Extração introduz regressão de comportamento | Média | Alto | Strangler-Fig um-por-vez; os seams já existem (streaming não importa entidades); ~3.340 testes como rede; cada fatia é PR isolado com CI. |
+| Extração de marcadores toca o schema do catálogo | Média | Médio | Migration dedicada movendo as colunas para o read-model; feature-flag/backfill se necessário. |
+| Módulos acabam anêmicos (só transporte) | Baixa | Médio | Só extrair subdomínios com volatilidade e linguagem próprias (streaming, metadata, markers têm); não fatiar por camada. |
+| Over-plumbing de eventos antes da necessidade | Baixa | Baixo | Começar por streaming (port simples, sem evento); introduzir eventos só onde o acoplamento de escrita exige (metadata). |
+
+## Alternativas Consideradas
+
+### 1. Manter `media` como monólito
+
+Não fazer nada.
+
+**Rejeitado porque:** o imposto de Divergent Change cresce com cada feature de streaming/detecção; a auditoria já mostra 44 commits concentrados num subdomínio que não pertence ao catálogo.
+
+### 2. Reescrita big-bang (extrair tudo de uma vez)
+
+Quebrar `media` em N módulos num único esforço.
+
+**Rejeitado porque:** risco desproporcional num agregado central com integrações vivas (watch_progress, collections, catalog_requests). Strangler-Fig entrega valor incremental e reversível.
+
+### 3. Fatiar por camada (separar toda a infrastructure, etc.)
+
+**Rejeitado porque:** não reduz acoplamento — os subdomínios continuam soldados horizontalmente. A fronteira que importa é vertical (por subdomínio de negócio), não por camada técnica.
+
+## Referências
+
+- ADR-008: Screaming Architecture com Módulos (fronteira de bounded context)
+- ADR-009: Cross-BC Read Ports + ACL
+- ADR-024: Contratos de Presentation Publicados para Imports Cross-BC
+- ADR-033: Interface Segregation em Repositórios (enabler desta decomposição)
+- `docs/tech-debt-remediation-plan.md` — Ondas 3-4
+- Vlad Khononov, *Balancing Coupling in Software Design* (volatilidade × distância × força)
+
+---
+
+## Notas de Implementação
+
+Sequência por subdomínio (cada um seguindo o plano de remediação):
+
+1. **Enabler (ADR-033):** segregar o repositório do subdomínio em role-interface antes de mover o código.
+2. **Mover** infra + application + use cases do subdomínio para o novo módulo.
+3. **Contrato cross-BC:** definir o port/ACL (e evento, quando houver escrita de volta) na fronteira; nunca `from src.modules.<outro>` direto.
+4. **Container próprio** (`StreamingContainer`, `MetadataContainer`), composto no `main.py` — o padrão já existente (Onda 5 do plano).
+5. **Validar** contra a suíte + smoke, então merge.
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-08-16 | Lucas Cristovam | Criação inicial |

--- a/docs/adr/ADR-033-repository-interface-segregation.md
+++ b/docs/adr/ADR-033-repository-interface-segregation.md
@@ -1,0 +1,113 @@
+# ADR-033: Interface Segregation em Repositórios
+
+**Status:** Aceito
+**Data:** 2026-08-16
+**Deciders:** Lucas Cristovam
+**Technical Story:** Auditoria de débito técnico (multi-agente, 2026-08-16) — as ABCs `series_repository` (~36 métodos) e `movie_repository` (29) são god-interfaces que misturam concerns de subdomínios. Onda 2 do `docs/tech-debt-remediation-plan.md`. Enabler do ADR-032 (decomposição do `media`).
+
+---
+
+## Contexto
+
+As interfaces (ABCs) de repositório do catálogo cresceram em god-interfaces que misturam **razões-de-mudar não relacionadas**:
+
+- `src/modules/media/domain/repositories/series_repository.py` (~724 LOC) declara **~36 métodos**: CRUD/busca de catálogo **+** artwork-mirror (`update_series_artwork`, `find_with_remote_artwork`) **+** intro-detection (`find_seasons_pending_intro_detection`) **+** credits-detection (`count_episode_credits_states`) **+** scrub-preview (`update_episode_scrub_preview_path`) **+** stats.
+- `movie_repository.py` (~29 métodos) repete o padrão, incluindo cirurgia de FK em raw-SQL (relink/promote) ao lado de reads simples.
+
+Isso viola o **Interface Segregation Principle**: um job agendado que precisa de 2-3 métodos (ex.: o intro-detection job) recebe o **port inteiro** via `uow.series` / `uow.movies`. Pior, é o **mecanismo concreto que solda os subdomínios** — cada nova feature (skip-intro, créditos, artwork, scrub) altera a **mesma** interface, e nenhum subdomínio pode ser extraído (ADR-032) sem carvar o repositório primeiro.
+
+A auditoria observou que **o padrão certo já é idiomático no próprio repo**: `intro_detection_run_repository`, `scan_run_repository`, `media_conflict_repository` e `subtitle_ocr_run_repository` são ports estreitos, focados. As god-interfaces são a exceção, não a regra.
+
+## Decisão
+
+Nós iremos adotar a política **"um port por razão-de-mudar"** nos repositórios de catálogo:
+
+- Um **repositório de catálogo enxuto** por agregado (Movie, Series): CRUD, busca, paginação, variantes — o núcleo estável.
+- **Role-interfaces** por subdomínio, cada uma migrando junto com seu subdomínio na decomposição (ADR-032):
+  - `ArtworkMirrorRepository`
+  - `IntroDetectionRepository`
+  - `CreditsDetectionRepository`
+  - `ScrubPreviewRepository`
+- Use cases e jobs dependem **apenas da role-interface que usam**, não do port inteiro.
+- **A classe SQLAlchemy pode implementar várias role-interfaces** contra a mesma tabela — a segregação é na *interface* (o contrato que o consumidor vê), não obrigatoriamente na implementação de persistência.
+
+Ressalva de escopo: métodos que atualizam **atributos das entidades-filhas do agregado** (marcadores de intro/créditos, artwork de season/episode) são coesão-por-agregado legítima enquanto essas colunas viverem no agregado Series/Movie. A segregação de interface **sozinha não desacopla** os subdomínios — as entidades ainda carregam as colunas; o desacoplamento completo vem quando os marcadores viram read-model próprio (ADR-032, fatia 3). O que é claramente fora de lugar e sai agora são as **projeções/counters orientados a job** (ex.: `find_with_remote_artwork → RemoteArtworkRow`, `count_episode_credits_states → dict[str,int]`).
+
+## Consequências
+
+### Positivas
+
+- **ISP respeitado**: cada consumidor vê só o contrato que precisa; a intenção fica explícita na assinatura da dependência.
+- **Desbloqueia a decomposição** (ADR-032): cada role-interface é a unidade que migra com seu subdomínio.
+- **Menor superfície de mudança**: uma feature de créditos altera a `CreditsDetectionRepository`, não a interface do catálogo inteiro.
+
+### Negativas
+
+- Mais interfaces (uma por role) — mais arquivos, embora cada um seja pequeno e focado.
+- A classe SQLAlchemy passa a implementar múltiplas ABCs — mais declarações de herança (mitigado: a impl continua uma só, contra uma tabela).
+
+### Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|-------|---------------|---------|-----------|
+| Over-segregação (um port por método) | Baixa | Médio | Segregar por **razão-de-mudar** (subdomínio), não por método; o teste é "isso muda por um motivo diferente?". |
+| Confundir coesão-de-agregado com concern separado | Média | Médio | Manter no repo de catálogo os updates que são atributos legítimos do agregado; só extrair projeções/counters orientados a job (ver ressalva). |
+
+## Alternativas Consideradas
+
+### 1. Manter as god-interfaces
+
+**Rejeitado porque:** viola ISP, força jobs a receberem o port inteiro, e trava a decomposição do ADR-032 (não dá para mover um subdomínio sem carvar a interface).
+
+### 2. Um repositório por método
+
+Segregação máxima.
+
+**Rejeitado porque:** granularidade excessiva — explode o número de interfaces sem ganho; a unidade correta é o subdomínio (razão-de-mudar), não a operação.
+
+### 3. Query-objects avulsos sem role-interfaces
+
+Extrair só as queries pesadas para funções/objetos soltos.
+
+**Rejeitado porque:** resolve o tamanho do arquivo mas não a segregação do contrato — os consumidores continuariam dependendo do port inteiro. Role-interfaces atacam o acoplamento na dependência.
+
+## Referências
+
+- ADR-032: Decompor o módulo `media` em subdomínios (esta é o enabler)
+- ADR-004: Injeção de Dependências (ports, não concretos)
+- Precedente no repo: `intro_detection_run_repository`, `scan_run_repository`, `media_conflict_repository`, `subtitle_ocr_run_repository`
+- `docs/tech-debt-remediation-plan.md` — Onda 3.1
+
+---
+
+## Notas de Implementação
+
+```python
+# domain/repositories/ — role-interfaces por subdomínio
+class SeriesRepository(ABC):  # catálogo enxuto
+    async def find_by_id(self, series_id: SeriesId) -> Series | None: ...
+    async def save(self, series: Series) -> Series: ...
+    # ... CRUD / busca / paginação
+
+class IntroDetectionRepository(ABC):  # role-interface (migra com o subdomínio)
+    async def find_seasons_pending_intro_detection(self) -> list[...]: ...
+    async def update_episode_intro_marker(self, ...) -> None: ...
+
+# infrastructure/ — uma classe SQLAlchemy pode satisfazer várias contra a mesma tabela
+class SQLAlchemySeriesRepository(
+    SeriesRepository, IntroDetectionRepository, CreditsDetectionRepository
+):
+    ...
+
+# use case / job — depende só da role que usa
+class RunIntroDetectionJob:
+    def __init__(self, repo: IntroDetectionRepository) -> None: ...
+```
+
+Ordem: segregar a interface **antes** de mover o subdomínio (ADR-032). As projeções/counters orientados a job (`RemoteArtworkRow`, `count_episode_credits_states`, ...) saem para a role-interface correspondente; os updates que são atributos do agregado ficam no repo de catálogo até a fatia de read-model dos marcadores.
+
+## Histórico de Revisões
+
+| Data | Autor | Mudança |
+|------|-------|---------|
+| 2026-08-16 | Lucas Cristovam | Criação inicial |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,6 +41,8 @@ Um ADR (Architecture Decision Record) documenta uma decisão arquitetural signif
 | [ADR-029](./ADR-029-artwork-mirroring-storage.md) | Mirror de Artwork de Provider via Port de Storage | ✅ Aceito | 2026-07-18 |
 | [ADR-030](./ADR-030-multi-episode-file-segments.md) | Segmentos de Arquivo Multi-Episódio | ✅ Aceito | 2026-08-09 |
 | [ADR-031](./ADR-031-tmdb-id-shared-kernel-value-object.md) | TmdbId como Value Object no Shared Kernel | ✅ Aceito | 2026-08-16 |
+| [ADR-032](./ADR-032-decompose-media-into-subdomains.md) | Decompor o módulo `media` em subdomínios | ✅ Aceito | 2026-08-16 |
+| [ADR-033](./ADR-033-repository-interface-segregation.md) | Interface Segregation em Repositórios | ✅ Aceito | 2026-08-16 |
 
 ## Como Criar um Novo ADR
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,3 +117,5 @@ nav:
       - adr/ADR-029-artwork-mirroring-storage.md
       - adr/ADR-030-multi-episode-file-segments.md
       - adr/ADR-031-tmdb-id-shared-kernel-value-object.md
+      - adr/ADR-032-decompose-media-into-subdomains.md
+      - adr/ADR-033-repository-interface-segregation.md


### PR DESCRIPTION
## Summary

**Onda 2** do plano de remediação de débito técnico — os ADRs que destravam as extrações (Ondas 3-4).

- **ADR-032 — Decompor o `media` em subdomínios**: estratégia Strangler-Fig, ordem (Streaming/Playback → Metadata/Enrichment+Artwork → Playback-markers read-model), o que fica no catálogo core, e contratos cross-BC (ports/ACL/eventos, ADR-009/024). Motivado pelo achado dominante da auditoria (40k LOC, 44 commits concentrados em streaming).
- **ADR-033 — Interface Segregation em repositórios**: política "um port por razão-de-mudar" (repo de catálogo enxuto + role-interfaces por subdomínio; a classe SQLAlchemy implementa várias). É o **enabler** do ADR-032 — carvar as god-interfaces (`series` ~36 métodos, `movie` 29) antes de mover os subdomínios.

Indexados no `docs/adr/README.md` e na nav do mkdocs.

## Test plan

- [x] Docs-only; páginas na nav → strict docs build verde
- [x] Cross-referências entre ADR-032/033 e com ADR-008/009/024/004 consistentes

## Summary by Sourcery

Document architecture decisions to decompose the monolithic `media` module into subdomains and apply interface segregation to catalog repositories as a prerequisite for that decomposition.

Documentation:
- Add ADR-032 describing the incremental extraction of streaming, metadata/enrichment, and playback-marker subdomains out of the `media` bounded context.
- Add ADR-033 defining an interface-segregation policy for catalog repositories with role-specific ports per subdomain.
- Index ADR-032 and ADR-033 in the ADR README and mkdocs navigation for discoverability.