### PR TITLE
refactor(identity): publish auth guards via the ADR-024 contract

### DIFF
--- a/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/admin_catalog_request_routes.py
@@ -17,7 +17,7 @@ from src.modules.catalog_requests.application.use_cases import (
     IncludeCatalogRequestUseCase,
     ListAdminCatalogRequestsUseCase,
 )
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 
 router = APIRouter(prefix="/api/v1/admin", tags=["Admin — Catalog Requests"])
 

--- a/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
+++ b/src/modules/catalog_requests/presentation/routes/catalog_request_routes.py
@@ -24,7 +24,7 @@ from src.modules.catalog_requests.application.use_cases import (
 from src.modules.catalog_requests.application.use_cases.list_catalog_request_feed import (
     ListCatalogRequestFeedInput,
 )
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_user
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_user
 from src.shared_kernel.value_objects import MediaType
 
 router = APIRouter(prefix="/api/v1/catalog-requests", tags=["Catalog Requests"])

--- a/src/modules/identity/presentation/public.py
+++ b/src/modules/identity/presentation/public.py
@@ -30,6 +30,22 @@ module lets ``identity`` refactor its internal ``dependencies.py`` freely
 without rippling into four other bounded contexts.
 """
 
+from src.modules.identity.infrastructure.auth import (
+    AuthenticatedUser,
+    authenticated_admin,
+    authenticated_user,
+)
 from src.modules.identity.presentation.dependencies import resolve_profile_id
 
-__all__ = ["resolve_profile_id"]
+# The route guards are the other half of the published contract: every
+# authenticated route in every BC needs "who is the caller" (and "is the
+# caller an admin"). They live in ``infrastructure/auth`` because they are
+# FastAPI ``Depends`` chains, but they are re-exported here so consumers
+# import the sanctioned surface rather than reaching into identity's
+# internals — keeping identity free to refactor the auth wiring (ADR-024).
+__all__ = [
+    "AuthenticatedUser",
+    "authenticated_admin",
+    "authenticated_user",
+    "resolve_profile_id",
+]

--- a/src/modules/library/presentation/routes/library_routes.py
+++ b/src/modules/library/presentation/routes/library_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.library.application.dtos.library_dtos import (
     CreateLibraryInput,
     DeleteLibraryInput,

--- a/src/modules/media/presentation/routes/admin_conflicts_routes.py
+++ b/src/modules/media/presentation/routes/admin_conflicts_routes.py
@@ -19,7 +19,7 @@ from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PA
 from src.building_blocks.presentation import api_list, api_single
 from src.building_blocks.presentation.responses import Pagination
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.conflict_dtos import (
     BulkMarkDistinctInput,
     ListConflictsInput,

--- a/src/modules/media/presentation/routes/admin_credits_routes.py
+++ b/src/modules/media/presentation/routes/admin_credits_routes.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.credits_dtos import (
     ListCreditsStatusInput,
     ResetCreditsDetectionInput,

--- a/src/modules/media/presentation/routes/admin_intro_detection_routes.py
+++ b/src/modules/media/presentation/routes/admin_intro_detection_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.intro_detection_run_dtos import (
     GetIntroDetectionRunInput,
     ListIntroDetectionRunsInput,

--- a/src/modules/media/presentation/routes/admin_jobs_routes.py
+++ b/src/modules/media/presentation/routes/admin_jobs_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.job_dtos import ListJobRunsInput, TriggerJobInput
 from src.modules.media.application.use_cases.list_job_runs import ListJobRunsUseCase
 from src.modules.media.application.use_cases.list_jobs import ListJobsUseCase

--- a/src/modules/media/presentation/routes/admin_overview_routes.py
+++ b/src/modules/media/presentation/routes/admin_overview_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.use_cases.get_library_usage import (
     GetLibraryUsageUseCase,
 )

--- a/src/modules/media/presentation/routes/admin_relink_routes.py
+++ b/src/modules/media/presentation/routes/admin_relink_routes.py
@@ -31,7 +31,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.admin_relink_dtos import (
     FlagMovieEnrichmentReviewInput,
     FlagSeriesEnrichmentReviewInput,

--- a/src/modules/media/presentation/routes/admin_scan_routes.py
+++ b/src/modules/media/presentation/routes/admin_scan_routes.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.scan_run_dtos import (
     GetScanRunInput,
     ListScanRunsInput,

--- a/src/modules/media/presentation/routes/admin_segments_routes.py
+++ b/src/modules/media/presentation/routes/admin_segments_routes.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.segment_dtos import (
     DefineEpisodeSegmentsInput,
     EpisodeSegmentSpec,

--- a/src/modules/media/presentation/routes/admin_subtitle_ocr_routes.py
+++ b/src/modules/media/presentation/routes/admin_subtitle_ocr_routes.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
 from src.config.logging import get_logger
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.subtitle_ocr_run_dtos import (
     GetSubtitleOcrRunInput,
     ListSubtitleOcrRunsInput,

--- a/src/modules/media/presentation/routes/admin_system_routes.py
+++ b/src/modules/media/presentation/routes/admin_system_routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.use_cases.clear_hls_cache_global import (
     ClearHlsCacheGlobalUseCase,
 )

--- a/src/modules/media/presentation/routes/enrichment_routes.py
+++ b/src/modules/media/presentation/routes/enrichment_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.enrichment_dtos import (
     BulkEnrichInput,
     EnrichMediaInput,

--- a/src/modules/media/presentation/routes/movie_routes.py
+++ b/src/modules/media/presentation/routes/movie_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.building_blocks.presentation import Pagination, api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.media_file_dtos import (
     AddFileVariantInput,
     GetFileVariantsInput,

--- a/src/modules/media/presentation/routes/scan_routes.py
+++ b/src/modules/media/presentation/routes/scan_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.scan_dtos import ScanMediaInput
 from src.modules.media.application.ports.library_lookup_port import LibraryLookupPort
 from src.modules.media.application.use_cases.scan_media_directories import (

--- a/src/modules/media/presentation/routes/series_routes.py
+++ b/src/modules/media/presentation/routes/series_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends
 from src.building_blocks.application.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE
 from src.building_blocks.presentation import Pagination, api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.intro_dtos import (
     ClearEpisodeIntroInput,
     ResetSeasonIntroDetectionInput,

--- a/src/modules/media/presentation/routes/stream_routes.py
+++ b/src/modules/media/presentation/routes/stream_routes.py
@@ -22,7 +22,7 @@ from fastapi.responses import FileResponse, Response, StreamingResponse
 from src.building_blocks.application.errors import ResourceNotFoundException
 from src.config.containers import ApplicationContainer
 from src.infrastructure.scheduling import ThumbnailBackfillJob
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.media.application.dtos.movie_dtos import GetMovieByIdInput
 from src.modules.media.application.dtos.series_dtos import (
     EpisodeOutput,

--- a/src/modules/media/presentation/routes/tmdb_lookup_routes.py
+++ b/src/modules/media/presentation/routes/tmdb_lookup_routes.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Depends, Query
 
 from src.building_blocks.presentation import api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_user
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_user
 from src.modules.media.application.dtos.tmdb_lookup_dtos import SearchTmdbTitlesInput
 from src.modules.media.application.use_cases.search_tmdb_titles import (
     SearchTmdbTitlesUseCase,

--- a/src/modules/notifications/presentation/routes/notification_routes.py
+++ b/src/modules/notifications/presentation/routes/notification_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Query
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_user
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_user
 from src.modules.notifications.application.dtos import (
     ListUserNotificationsInput,
     MarkAllNotificationsReadInput,

--- a/src/modules/settings/presentation/routes/admin_settings_routes.py
+++ b/src/modules/settings/presentation/routes/admin_settings_routes.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends
 
 from src.building_blocks.presentation import api_list, api_single
 from src.config.containers import ApplicationContainer
-from src.modules.identity.infrastructure.auth import AuthenticatedUser, authenticated_admin
+from src.modules.identity.presentation.public import AuthenticatedUser, authenticated_admin
 from src.modules.settings.application.dtos import UpdateSettingInput
 from src.modules.settings.application.use_cases import (
     ListSettingsUseCase,

--- a/tests/modules/identity/unit/presentation/test_public_contract.py
+++ b/tests/modules/identity/unit/presentation/test_public_contract.py
@@ -7,11 +7,29 @@ import pytest
 class TestIdentityPublicContract:
     """``identity.presentation.public`` is the sanctioned cross-BC surface."""
 
-    def test_exposes_resolve_profile_id(self) -> None:
+    def test_exposes_the_sanctioned_surface(self) -> None:
         from src.modules.identity.presentation import public
 
-        assert public.__all__ == ["resolve_profile_id"]
+        # The published surface is resolve_profile_id + the route guards
+        # (ADR-024). Nothing else from identity may be imported cross-BC.
+        assert public.__all__ == [
+            "AuthenticatedUser",
+            "authenticated_admin",
+            "authenticated_user",
+            "resolve_profile_id",
+        ]
         assert callable(public.resolve_profile_id)
+        assert callable(public.authenticated_admin)
+        assert callable(public.authenticated_user)
+
+    def test_guards_are_the_infrastructure_ones(self) -> None:
+        from src.modules.identity.infrastructure import auth
+        from src.modules.identity.presentation import public
+
+        # Re-exports the real guards — no fork.
+        assert public.authenticated_admin is auth.authenticated_admin
+        assert public.authenticated_user is auth.authenticated_user
+        assert public.AuthenticatedUser is auth.AuthenticatedUser
 
     def test_resolve_profile_id_is_the_canonical_dependency(self) -> None:
         from src.modules.identity.presentation import dependencies, public


### PR DESCRIPTION
## Summary

**Onda 1** (higiene arquitetural). **21 rotas em 5 bounded contexts** (catalog_requests, library, media, notifications, settings) importavam `AuthenticatedUser` / `authenticated_admin` / `authenticated_user` **direto de `identity.infrastructure.auth`**, furando o contrato publicado do ADR-024.

- Publica os 3 guards no `identity/presentation/public.py` — a superfície sancionada, ao lado do `resolve_profile_id` que já morava lá.
- Migra as 21 rotas para importar do `public.py`.

Sem mudança de comportamento — só a fronteira de import. Agora `identity` pode refatorar o wiring interno de auth sem rippling nos outros 4 BCs (exatamente o que o docstring do `public.py` promete).

## Test plan

- [x] `mypy src` — 0 errors (774 files)
- [x] `ruff` — clean
- [x] Testes de rota/auth/e2e/admin — 154 passed (guards resolvem via o contrato publicado)
- [x] Nenhum import cross-BC de `identity.infrastructure.auth` restante
- [x] Suíte completa — via CI

## Summary by Sourcery

Route authentication guards are now exposed through the identity presentation public contract and all bounded contexts import them from this sanctioned surface instead of the internal auth infrastructure.

Enhancements:
- Re-export AuthenticatedUser, authenticated_admin, and authenticated_user via identity.presentation.public alongside resolve_profile_id to complete the ADR-024 published contract.
- Align catalog_requests, library, media, notifications, and settings routes to depend on the identity public presentation module for auth guards, removing cross-bounded-context imports of identity infrastructure internals.