### PR TITLE
refactor(identity,settings): split errors by layer + settings port

### DIFF
--- a/src/modules/identity/application/errors.py
+++ b/src/modules/identity/application/errors.py
@@ -1,0 +1,136 @@
+"""Identity application-level exceptions.
+
+Application errors (not-found, forbidden, unauthorized, conflict) raised by
+the identity use cases. They reuse the shared application-exception bases
+from ``building_blocks`` so the global handler maps them to the correct HTTP
+status (keyed by ``code``, ADR-012) without per-BC wiring. Domain-invariant
+violations raised by the domain layer live in ``domain/errors.py`` instead.
+"""
+
+from dataclasses import dataclass
+
+from src.building_blocks.application.errors import (
+    ApplicationException,
+    ForbiddenOperationException,
+    ResourceNotFoundException,
+    UnauthorizedOperationException,
+)
+from src.modules.identity.domain.rule_codes import IdentityRuleCodes
+
+
+@dataclass
+class ProfileNotFoundException(ResourceNotFoundException):
+    """The requested profile does not exist (or is soft-deleted).
+
+    Maps to HTTP 404.
+    """
+
+    code: str = "PROFILE_NOT_FOUND"
+    message_code: str = IdentityRuleCodes.PROFILE_NOT_FOUND
+    resource_type: str = "Profile"
+
+
+@dataclass
+class ProfileOwnershipViolation(ForbiddenOperationException):
+    """Authenticated user attempted to act on a profile they do not own.
+
+    Maps to HTTP 403. Raised by ``UpdateProfileUseCase``,
+    ``DeleteProfileUseCase`` and ``SwitchProfileUseCase`` when the
+    target profile's ``user_id`` does not match the caller.
+    """
+
+    code: str = "PROFILE_OWNERSHIP_VIOLATION"
+    message_code: str = IdentityRuleCodes.PROFILE_OWNERSHIP_VIOLATION
+
+
+@dataclass
+class CannotDeleteLastProfileError(ApplicationException):
+    """User attempted to delete their final remaining profile.
+
+    Every authenticated user must have at least one profile so that
+    ``get_current_profile`` always has something to resolve. Raised by
+    ``DeleteProfileUseCase``. Maps to HTTP 409 (conflict) — distinct
+    from a generic 400 because the request is well-formed but conflicts
+    with a domain invariant. Status registered in
+    ``modules/identity/presentation/error_mapping.py`` (ADR-012).
+    """
+
+    code: str = "CANNOT_DELETE_LAST_PROFILE"
+    message_code: str = IdentityRuleCodes.CANNOT_DELETE_LAST_PROFILE
+
+
+@dataclass
+class NoActiveSessionError(UnauthorizedOperationException):
+    """The request has no session cookie, so no current profile can be resolved.
+
+    Maps to HTTP 401. Raised by the ``get_current_profile`` dependency
+    when the cookie is missing or the cookie's token is unknown.
+    """
+
+    code: str = "NO_ACTIVE_SESSION"
+    message_code: str = IdentityRuleCodes.NO_ACTIVE_SESSION
+
+
+@dataclass
+class NoActiveProfileSelectedError(ApplicationException):
+    """The session is valid but the user has not selected a profile yet.
+
+    Returned as HTTP 409 (conflict) so the frontend can distinguish "not
+    logged in" (401) from "logged in but profile picker required" (409).
+    Raised by ``get_current_profile``. Status registered in
+    ``modules/identity/presentation/error_mapping.py`` (ADR-012).
+    """
+
+    code: str = "NO_ACTIVE_PROFILE"
+    message_code: str = IdentityRuleCodes.NO_ACTIVE_PROFILE
+
+
+@dataclass
+class UserNotFoundException(ResourceNotFoundException):
+    """The requested user does not exist (or is soft-deleted).
+
+    Maps to HTTP 404. Raised by the admin user use cases when the
+    path id doesn't resolve to a live user.
+    """
+
+    code: str = "USER_NOT_FOUND"
+    message_code: str = IdentityRuleCodes.USER_NOT_FOUND
+    resource_type: str = "User"
+
+
+@dataclass
+class UserEmailAlreadyExistsError(ApplicationException):
+    """Admin tried to create a user with an email already in the table.
+
+    Maps to HTTP 409 (conflict). The check covers active rows AND
+    soft-deleted tombstones because the underlying ``email`` column
+    is unique at the DB level and a re-insert would crash.
+    """
+
+    code: str = "USER_EMAIL_ALREADY_EXISTS"
+    message_code: str = IdentityRuleCodes.USER_EMAIL_ALREADY_EXISTS
+
+
+@dataclass
+class CannotDeleteSelfError(ApplicationException):
+    """Admin tried to delete their own user account.
+
+    Maps to HTTP 409. The UI also hides the delete button on the
+    self row, but the server-side guard is the source of truth — a
+    direct curl call still gets refused.
+    """
+
+    code: str = "USER_CANNOT_DELETE_SELF"
+    message_code: str = IdentityRuleCodes.USER_CANNOT_DELETE_SELF
+
+
+__all__ = [
+    "CannotDeleteLastProfileError",
+    "CannotDeleteSelfError",
+    "NoActiveProfileSelectedError",
+    "NoActiveSessionError",
+    "ProfileNotFoundException",
+    "ProfileOwnershipViolation",
+    "UserEmailAlreadyExistsError",
+    "UserNotFoundException",
+]

--- a/src/modules/identity/application/use_cases/create_admin_user.py
+++ b/src/modules/identity/application/use_cases/create_admin_user.py
@@ -4,10 +4,10 @@ from src.modules.identity.application.dtos.identity_dtos import (
     CreateAdminUserInput,
     UserSummary,
 )
+from src.modules.identity.application.errors import UserEmailAlreadyExistsError
 from src.modules.identity.application.ports import PasswordHasherPort
 from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.modules.identity.domain.entities.user import User
-from src.modules.identity.domain.errors import UserEmailAlreadyExistsError
 from src.modules.identity.domain.value_objects.email import Email
 
 

--- a/src/modules/identity/application/use_cases/delete_admin_user.py
+++ b/src/modules/identity/application/use_cases/delete_admin_user.py
@@ -4,11 +4,11 @@ import logging
 
 from src.building_blocks.application.event_bus import EventBus
 from src.modules.identity.application.dtos.identity_dtos import DeleteAdminUserInput
-from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
-from src.modules.identity.domain.errors import (
+from src.modules.identity.application.errors import (
     CannotDeleteSelfError,
     UserNotFoundException,
 )
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.modules.identity.domain.services import AdminQuorum
 from src.modules.identity.domain.value_objects.user_role import UserRole
 from src.shared_kernel.integration_events import UserDeletedEvent

--- a/src/modules/identity/application/use_cases/delete_profile.py
+++ b/src/modules/identity/application/use_cases/delete_profile.py
@@ -1,13 +1,13 @@
 """DeleteProfileUseCase."""
 
 from src.modules.identity.application.dtos.identity_dtos import DeleteProfileInput
-from src.modules.identity.application.ports import AvatarStoragePort
-from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
-from src.modules.identity.domain.errors import (
+from src.modules.identity.application.errors import (
     CannotDeleteLastProfileError,
     ProfileNotFoundException,
     ProfileOwnershipViolation,
 )
+from src.modules.identity.application.ports import AvatarStoragePort
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId
 

--- a/src/modules/identity/application/use_cases/delete_profile_avatar.py
+++ b/src/modules/identity/application/use_cases/delete_profile_avatar.py
@@ -4,13 +4,13 @@ from src.modules.identity.application.dtos.identity_dtos import (
     DeleteProfileAvatarInput,
     ProfileOutput,
 )
-from src.modules.identity.application.ports import AvatarStoragePort
-from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
-from src.modules.identity.application.use_cases._to_output import profile_to_output
-from src.modules.identity.domain.errors import (
+from src.modules.identity.application.errors import (
     ProfileNotFoundException,
     ProfileOwnershipViolation,
 )
+from src.modules.identity.application.ports import AvatarStoragePort
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.identity.application.use_cases._to_output import profile_to_output
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId
 

--- a/src/modules/identity/application/use_cases/get_user_detail.py
+++ b/src/modules/identity/application/use_cases/get_user_detail.py
@@ -4,9 +4,9 @@ from src.modules.identity.application.dtos.identity_dtos import (
     GetUserDetailInput,
     UserDetail,
 )
+from src.modules.identity.application.errors import UserNotFoundException
 from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.modules.identity.application.use_cases._to_output import profile_to_output
-from src.modules.identity.domain.errors import UserNotFoundException
 from src.shared_kernel.value_objects.user_id import UserId
 
 

--- a/src/modules/identity/application/use_cases/switch_profile.py
+++ b/src/modules/identity/application/use_cases/switch_profile.py
@@ -1,12 +1,12 @@
 """SwitchProfileUseCase."""
 
 from src.modules.identity.application.dtos.identity_dtos import SwitchProfileInput
-from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
-from src.modules.identity.domain.errors import (
+from src.modules.identity.application.errors import (
     NoActiveSessionError,
     ProfileNotFoundException,
     ProfileOwnershipViolation,
 )
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId
 

--- a/src/modules/identity/application/use_cases/update_profile.py
+++ b/src/modules/identity/application/use_cases/update_profile.py
@@ -4,12 +4,12 @@ from src.modules.identity.application.dtos.identity_dtos import (
     ProfileOutput,
     UpdateProfileInput,
 )
-from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
-from src.modules.identity.application.use_cases._to_output import profile_to_output
-from src.modules.identity.domain.errors import (
+from src.modules.identity.application.errors import (
     ProfileNotFoundException,
     ProfileOwnershipViolation,
 )
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.identity.application.use_cases._to_output import profile_to_output
 from src.modules.identity.domain.value_objects.profile_name import ProfileName
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId

--- a/src/modules/identity/application/use_cases/update_user_role.py
+++ b/src/modules/identity/application/use_cases/update_user_role.py
@@ -6,8 +6,8 @@ from src.modules.identity.application.dtos.identity_dtos import (
     UpdateUserRoleInput,
     UserSummary,
 )
+from src.modules.identity.application.errors import UserNotFoundException
 from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
-from src.modules.identity.domain.errors import UserNotFoundException
 from src.modules.identity.domain.services import AdminQuorum
 from src.modules.identity.domain.value_objects.user_role import UserRole
 from src.shared_kernel.value_objects.user_id import UserId

--- a/src/modules/identity/application/use_cases/upload_profile_avatar.py
+++ b/src/modules/identity/application/use_cases/upload_profile_avatar.py
@@ -4,13 +4,13 @@ from src.modules.identity.application.dtos.identity_dtos import (
     ProfileOutput,
     UploadProfileAvatarInput,
 )
-from src.modules.identity.application.ports import AvatarStoragePort
-from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
-from src.modules.identity.application.use_cases._to_output import profile_to_output
-from src.modules.identity.domain.errors import (
+from src.modules.identity.application.errors import (
     ProfileNotFoundException,
     ProfileOwnershipViolation,
 )
+from src.modules.identity.application.ports import AvatarStoragePort
+from src.modules.identity.application.unit_of_work import IdentityUnitOfWorkFactory
+from src.modules.identity.application.use_cases._to_output import profile_to_output
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId
 

--- a/src/modules/identity/domain/errors.py
+++ b/src/modules/identity/domain/errors.py
@@ -1,148 +1,34 @@
-"""Identity bounded context exceptions.
+"""Identity domain-level exceptions.
 
-Domain- and application-level errors specific to identity. Reuses the
-shared exception bases from ``building_blocks`` so the global handler
-maps them to the correct HTTP status without per-BC wiring.
+Only genuine domain-invariant violations raised **from the domain layer**
+live here (subclassing the domain exception bases). Application-level errors
+(not-found, forbidden, unauthorized, conflict) raised by the use cases live
+in ``identity/application/errors.py`` — keeping the domain layer free of any
+dependency on ``building_blocks.application``.
 """
 
 from dataclasses import dataclass
 
-from src.building_blocks.application.errors import (
-    ApplicationException,
-    ForbiddenOperationException,
-    ResourceNotFoundException,
-    UnauthorizedOperationException,
-)
+from src.building_blocks.domain.errors import BusinessRuleViolationException
 from src.modules.identity.domain.rule_codes import IdentityRuleCodes
 
 
 @dataclass
-class ProfileNotFoundException(ResourceNotFoundException):
-    """The requested profile does not exist (or is soft-deleted).
-
-    Maps to HTTP 404.
-    """
-
-    code: str = "PROFILE_NOT_FOUND"
-    message_code: str = IdentityRuleCodes.PROFILE_NOT_FOUND
-    resource_type: str = "Profile"
-
-
-@dataclass
-class ProfileOwnershipViolation(ForbiddenOperationException):
-    """Authenticated user attempted to act on a profile they do not own.
-
-    Maps to HTTP 403. Raised by ``UpdateProfileUseCase``,
-    ``DeleteProfileUseCase`` and ``SwitchProfileUseCase`` when the
-    target profile's ``user_id`` does not match the caller.
-    """
-
-    code: str = "PROFILE_OWNERSHIP_VIOLATION"
-    message_code: str = IdentityRuleCodes.PROFILE_OWNERSHIP_VIOLATION
-
-
-@dataclass
-class CannotDeleteLastProfileError(ApplicationException):
-    """User attempted to delete their final remaining profile.
-
-    Every authenticated user must have at least one profile so that
-    ``get_current_profile`` always has something to resolve. Raised by
-    ``DeleteProfileUseCase``. Maps to HTTP 409 (conflict) — distinct
-    from a generic 400 because the request is well-formed but conflicts
-    with a domain invariant. Status registered in
-    ``modules/identity/presentation/error_mapping.py`` (ADR-012).
-    """
-
-    code: str = "CANNOT_DELETE_LAST_PROFILE"
-    message_code: str = IdentityRuleCodes.CANNOT_DELETE_LAST_PROFILE
-
-
-@dataclass
-class NoActiveSessionError(UnauthorizedOperationException):
-    """The request has no session cookie, so no current profile can be resolved.
-
-    Maps to HTTP 401. Raised by the ``get_current_profile`` dependency
-    when the cookie is missing or the cookie's token is unknown.
-    """
-
-    code: str = "NO_ACTIVE_SESSION"
-    message_code: str = IdentityRuleCodes.NO_ACTIVE_SESSION
-
-
-@dataclass
-class NoActiveProfileSelectedError(ApplicationException):
-    """The session is valid but the user has not selected a profile yet.
-
-    Returned as HTTP 409 (conflict) so the frontend can distinguish "not
-    logged in" (401) from "logged in but profile picker required" (409).
-    Raised by ``get_current_profile``. Status registered in
-    ``modules/identity/presentation/error_mapping.py`` (ADR-012).
-    """
-
-    code: str = "NO_ACTIVE_PROFILE"
-    message_code: str = IdentityRuleCodes.NO_ACTIVE_PROFILE
-
-
-@dataclass
-class UserNotFoundException(ResourceNotFoundException):
-    """The requested user does not exist (or is soft-deleted).
-
-    Maps to HTTP 404. Raised by the admin user use cases when the
-    path id doesn't resolve to a live user.
-    """
-
-    code: str = "USER_NOT_FOUND"
-    message_code: str = IdentityRuleCodes.USER_NOT_FOUND
-    resource_type: str = "User"
-
-
-@dataclass
-class UserEmailAlreadyExistsError(ApplicationException):
-    """Admin tried to create a user with an email already in the table.
-
-    Maps to HTTP 409 (conflict). The check covers active rows AND
-    soft-deleted tombstones because the underlying ``email`` column
-    is unique at the DB level and a re-insert would crash.
-    """
-
-    code: str = "USER_EMAIL_ALREADY_EXISTS"
-    message_code: str = IdentityRuleCodes.USER_EMAIL_ALREADY_EXISTS
-
-
-@dataclass
-class CannotDeleteSelfError(ApplicationException):
-    """Admin tried to delete their own user account.
-
-    Maps to HTTP 409. The UI also hides the delete button on the
-    self row, but the server-side guard is the source of truth — a
-    direct curl call still gets refused.
-    """
-
-    code: str = "USER_CANNOT_DELETE_SELF"
-    message_code: str = IdentityRuleCodes.USER_CANNOT_DELETE_SELF
-
-
-@dataclass
-class CannotDemoteLastAdminError(ApplicationException):
+class CannotDemoteLastAdminError(BusinessRuleViolationException):
     """Operation would leave the system with zero active admins.
 
-    Maps to HTTP 409. Fires from both the role-flip (demoting the
-    last admin) and the delete (removing the last admin even when
-    not self-targeting) paths.
+    A domain invariant — the household must always retain at least one
+    active administrator — enforced by the ``admin_quorum`` domain service.
+    Fires from both the role-flip (demoting the last admin) and the delete
+    (removing the last admin even when not self-targeting) paths.
+
+    Maps to HTTP 409 via ``error_mapping.py`` (keyed on ``code``, ADR-012),
+    unchanged by the domain re-base.
     """
 
     code: str = "USER_CANNOT_DEMOTE_LAST_ADMIN"
     message_code: str = IdentityRuleCodes.USER_CANNOT_DEMOTE_LAST_ADMIN
+    rule_code: str = IdentityRuleCodes.USER_CANNOT_DEMOTE_LAST_ADMIN
 
 
-__all__ = [
-    "CannotDeleteLastProfileError",
-    "CannotDeleteSelfError",
-    "CannotDemoteLastAdminError",
-    "NoActiveProfileSelectedError",
-    "NoActiveSessionError",
-    "ProfileNotFoundException",
-    "ProfileOwnershipViolation",
-    "UserEmailAlreadyExistsError",
-    "UserNotFoundException",
-]
+__all__ = ["CannotDemoteLastAdminError"]

--- a/src/modules/identity/infrastructure/auth/dependencies.py
+++ b/src/modules/identity/infrastructure/auth/dependencies.py
@@ -25,7 +25,7 @@ from fastapi_users_db_sqlalchemy.access_token import SQLAlchemyAccessTokenDataba
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config.settings import get_settings
-from src.modules.identity.domain.errors import NoActiveSessionError
+from src.modules.identity.application.errors import NoActiveSessionError
 from src.modules.identity.infrastructure.auth.user_manager import UserManager
 from src.modules.identity.infrastructure.persistence.models.access_token_model import (
     AccessTokenModel,

--- a/src/modules/identity/presentation/dependencies.py
+++ b/src/modules/identity/presentation/dependencies.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from fastapi import Depends, Request
 
 from src.config.settings import get_settings
-from src.modules.identity.domain.errors import (
+from src.modules.identity.application.errors import (
     NoActiveProfileSelectedError,
     NoActiveSessionError,
 )

--- a/src/modules/settings/application/ports/__init__.py
+++ b/src/modules/settings/application/ports/__init__.py
@@ -1,0 +1,7 @@
+"""Application ports for the settings bounded context."""
+
+from src.modules.settings.application.ports.runtime_settings_port import (
+    RuntimeSettingsInvalidatorPort,
+)
+
+__all__ = ["RuntimeSettingsInvalidatorPort"]

--- a/src/modules/settings/application/ports/runtime_settings_port.py
+++ b/src/modules/settings/application/ports/runtime_settings_port.py
@@ -1,0 +1,21 @@
+"""Port for invalidating the runtime-settings cache."""
+
+from typing import Protocol
+
+
+class RuntimeSettingsInvalidatorPort(Protocol):
+    """Drops the cached runtime-settings snapshot so the next read refreshes.
+
+    Lets ``UpdateSettingUseCase`` depend only on the invalidation capability
+    it needs, instead of importing the concrete ``RuntimeSettings``
+    infrastructure class (ADR-004 — application depends on ports, not
+    concretes). Satisfied structurally by ``RuntimeSettings`` at the
+    composition root.
+    """
+
+    async def invalidate(self) -> None:
+        """Discard the cached snapshot; the next read rebuilds it from the DB."""
+        ...
+
+
+__all__ = ["RuntimeSettingsInvalidatorPort"]

--- a/src/modules/settings/application/use_cases/update_setting.py
+++ b/src/modules/settings/application/use_cases/update_setting.py
@@ -13,10 +13,10 @@ from src.modules.settings.domain.value_objects import (
 )
 
 if TYPE_CHECKING:
+    from src.modules.settings.application.ports import RuntimeSettingsInvalidatorPort
     from src.modules.settings.application.unit_of_work import (
         SettingsUnitOfWorkFactory,
     )
-    from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 
 class UpdateSettingUseCase:
@@ -45,7 +45,7 @@ class UpdateSettingUseCase:
     def __init__(
         self,
         uow_factory: SettingsUnitOfWorkFactory,
-        runtime_settings: RuntimeSettings,
+        runtime_settings: RuntimeSettingsInvalidatorPort,
     ) -> None:
         self._uow_factory = uow_factory
         self._runtime_settings = runtime_settings

--- a/tests/modules/identity/unit/application/use_cases/test_create_admin_user.py
+++ b/tests/modules/identity/unit/application/use_cases/test_create_admin_user.py
@@ -3,12 +3,12 @@
 import pytest
 
 from src.modules.identity.application.dtos.identity_dtos import CreateAdminUserInput
+from src.modules.identity.application.errors import UserEmailAlreadyExistsError
 from src.modules.identity.application.ports import PasswordHasherPort
 from src.modules.identity.application.use_cases.create_admin_user import (
     CreateAdminUserUseCase,
 )
 from src.modules.identity.domain.entities.user import User
-from src.modules.identity.domain.errors import UserEmailAlreadyExistsError
 from src.modules.identity.domain.value_objects.email import Email
 from src.modules.identity.domain.value_objects.user_role import UserRole
 

--- a/tests/modules/identity/unit/application/use_cases/test_delete_admin_user.py
+++ b/tests/modules/identity/unit/application/use_cases/test_delete_admin_user.py
@@ -10,6 +10,10 @@ from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
     DeleteAdminUserInput,
 )
+from src.modules.identity.application.errors import (
+    CannotDeleteSelfError,
+    UserNotFoundException,
+)
 from src.modules.identity.application.use_cases.create_profile import (
     CreateProfileUseCase,
 )
@@ -17,11 +21,7 @@ from src.modules.identity.application.use_cases.delete_admin_user import (
     DeleteAdminUserUseCase,
 )
 from src.modules.identity.domain.entities.user import User
-from src.modules.identity.domain.errors import (
-    CannotDeleteSelfError,
-    CannotDemoteLastAdminError,
-    UserNotFoundException,
-)
+from src.modules.identity.domain.errors import CannotDemoteLastAdminError
 from src.modules.identity.domain.value_objects.email import Email
 from src.modules.identity.domain.value_objects.user_role import UserRole
 from src.shared_kernel.integration_events import UserDeletedEvent

--- a/tests/modules/identity/unit/application/use_cases/test_delete_profile.py
+++ b/tests/modules/identity/unit/application/use_cases/test_delete_profile.py
@@ -6,16 +6,16 @@ from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
     DeleteProfileInput,
 )
+from src.modules.identity.application.errors import (
+    CannotDeleteLastProfileError,
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
 from src.modules.identity.application.use_cases.create_profile import (
     CreateProfileUseCase,
 )
 from src.modules.identity.application.use_cases.delete_profile import (
     DeleteProfileUseCase,
-)
-from src.modules.identity.domain.errors import (
-    CannotDeleteLastProfileError,
-    ProfileNotFoundException,
-    ProfileOwnershipViolation,
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId

--- a/tests/modules/identity/unit/application/use_cases/test_delete_profile_avatar.py
+++ b/tests/modules/identity/unit/application/use_cases/test_delete_profile_avatar.py
@@ -6,15 +6,15 @@ from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
     DeleteProfileAvatarInput,
 )
+from src.modules.identity.application.errors import (
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
 from src.modules.identity.application.use_cases.create_profile import (
     CreateProfileUseCase,
 )
 from src.modules.identity.application.use_cases.delete_profile_avatar import (
     DeleteProfileAvatarUseCase,
-)
-from src.modules.identity.domain.errors import (
-    ProfileNotFoundException,
-    ProfileOwnershipViolation,
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId

--- a/tests/modules/identity/unit/application/use_cases/test_get_user_detail.py
+++ b/tests/modules/identity/unit/application/use_cases/test_get_user_detail.py
@@ -6,6 +6,7 @@ from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
     GetUserDetailInput,
 )
+from src.modules.identity.application.errors import UserNotFoundException
 from src.modules.identity.application.use_cases.create_profile import (
     CreateProfileUseCase,
 )
@@ -13,7 +14,6 @@ from src.modules.identity.application.use_cases.get_user_detail import (
     GetUserDetailUseCase,
 )
 from src.modules.identity.domain.entities.user import User
-from src.modules.identity.domain.errors import UserNotFoundException
 from src.modules.identity.domain.value_objects.email import Email
 from src.shared_kernel.value_objects.user_id import UserId
 

--- a/tests/modules/identity/unit/application/use_cases/test_switch_profile.py
+++ b/tests/modules/identity/unit/application/use_cases/test_switch_profile.py
@@ -6,16 +6,16 @@ from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
     SwitchProfileInput,
 )
+from src.modules.identity.application.errors import (
+    NoActiveSessionError,
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
 from src.modules.identity.application.use_cases.create_profile import (
     CreateProfileUseCase,
 )
 from src.modules.identity.application.use_cases.switch_profile import (
     SwitchProfileUseCase,
-)
-from src.modules.identity.domain.errors import (
-    NoActiveSessionError,
-    ProfileNotFoundException,
-    ProfileOwnershipViolation,
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId

--- a/tests/modules/identity/unit/application/use_cases/test_update_profile.py
+++ b/tests/modules/identity/unit/application/use_cases/test_update_profile.py
@@ -6,15 +6,15 @@ from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
     UpdateProfileInput,
 )
+from src.modules.identity.application.errors import (
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
 from src.modules.identity.application.use_cases.create_profile import (
     CreateProfileUseCase,
 )
 from src.modules.identity.application.use_cases.update_profile import (
     UpdateProfileUseCase,
-)
-from src.modules.identity.domain.errors import (
-    ProfileNotFoundException,
-    ProfileOwnershipViolation,
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId

--- a/tests/modules/identity/unit/application/use_cases/test_update_user_role.py
+++ b/tests/modules/identity/unit/application/use_cases/test_update_user_role.py
@@ -3,14 +3,12 @@
 import pytest
 
 from src.modules.identity.application.dtos.identity_dtos import UpdateUserRoleInput
+from src.modules.identity.application.errors import UserNotFoundException
 from src.modules.identity.application.use_cases.update_user_role import (
     UpdateUserRoleUseCase,
 )
 from src.modules.identity.domain.entities.user import User
-from src.modules.identity.domain.errors import (
-    CannotDemoteLastAdminError,
-    UserNotFoundException,
-)
+from src.modules.identity.domain.errors import CannotDemoteLastAdminError
 from src.modules.identity.domain.value_objects.email import Email
 from src.modules.identity.domain.value_objects.user_role import UserRole
 from src.shared_kernel.value_objects.user_id import UserId

--- a/tests/modules/identity/unit/application/use_cases/test_upload_profile_avatar.py
+++ b/tests/modules/identity/unit/application/use_cases/test_upload_profile_avatar.py
@@ -6,15 +6,15 @@ from src.modules.identity.application.dtos.identity_dtos import (
     CreateProfileInput,
     UploadProfileAvatarInput,
 )
+from src.modules.identity.application.errors import (
+    ProfileNotFoundException,
+    ProfileOwnershipViolation,
+)
 from src.modules.identity.application.use_cases.create_profile import (
     CreateProfileUseCase,
 )
 from src.modules.identity.application.use_cases.upload_profile_avatar import (
     UploadProfileAvatarUseCase,
-)
-from src.modules.identity.domain.errors import (
-    ProfileNotFoundException,
-    ProfileOwnershipViolation,
 )
 from src.shared_kernel.value_objects.profile_id import ProfileId
 from src.shared_kernel.value_objects.user_id import UserId


### PR DESCRIPTION
## Summary

Onda 1 (arquitetural hygiene) — items 1.2 and 1.3 of the tech-debt remediation plan. Removes two `domain -> application`/`application -> config` dependency-rule inversions.

- **1.2 settings port**: `UpdateSettingUseCase` depended on the concrete `RuntimeSettings` (config layer). Introduce `RuntimeSettingsInvalidatorPort` (Protocol) in `settings/application/ports/` and type the use case against it; infra `RuntimeSettings` stays as the implementer.
- **1.3 identity errors split**: `identity/domain/errors.py` mixed genuine domain-invariant violations with application-level errors (not-found/forbidden/conflict) that imported `building_blocks.application`. Move the 8 application errors to `identity/application/errors.py`; keep only `CannotDemoteLastAdminError` (raised by the `admin_quorum` domain service) in `domain/errors.py`. Re-point the 20 importers.

HTTP status is keyed on `exc.code` (ADR-012), so the 409/404/403/401 mappings are unchanged by the domain/application re-base.

## Test plan

- [x] `mypy src` — clean (777 files)
- [x] `ruff check` — clean
- [x] `pytest tests/modules/identity` — 222 passed (incl. e2e status mapping)
- [x] `pytest tests/modules/settings` — 92 passed

## Summary by Sourcery

Split identity exceptions into domain-level and application-level layers and introduce a settings runtime cache invalidation port to decouple application from infrastructure.

Enhancements:
- Move identity application-level errors into a dedicated application errors module while keeping only true domain invariants in the domain errors module.
- Refine the CannotDemoteLastAdminError to use domain business-rule violation semantics without changing external HTTP status mappings.
- Update identity use cases, dependencies, and tests to consume the new application-level errors module.
- Introduce a RuntimeSettingsInvalidatorPort so the settings update use case depends on an application port rather than the concrete RuntimeSettings infrastructure implementation.