### PR TITLE
test(media,library): cover LibraryRepository and stream routes

### DIFF
--- a/tests/modules/library/integration/persistence/repositories/test_library_repository.py
+++ b/tests/modules/library/integration/persistence/repositories/test_library_repository.py
@@ -1,0 +1,182 @@
+"""Integration tests for SqlAlchemyLibraryRepository.
+
+Exercises the repository against a real (in-memory SQLite) session,
+covering the paths the unit-level mocks cannot: id generation on save,
+upsert of an existing row (no duplicate), the restore-on-save branch for
+a soft-deleted row, and the soft-delete-aware query methods.
+"""
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from src.modules.library.domain.entities.library import Library
+from src.modules.library.domain.value_objects.library_type import LibraryType
+from src.modules.library.infrastructure.persistence.models.library_model import (
+    LibraryModel,
+)
+from src.modules.library.infrastructure.persistence.repositories.sqlalchemy_library_repository import (
+    SqlAlchemyLibraryRepository,
+)
+from src.shared_kernel.value_objects.library_id import LibraryId
+
+pytestmark = pytest.mark.integration
+
+
+def _make_library(
+    name: str = "Movies",
+    library_type: LibraryType = LibraryType.MOVIES,
+    path: str = "/media/movies",
+    library_id: LibraryId | None = None,
+) -> Library:
+    """Build a Library entity for persistence tests.
+
+    When ``library_id`` is omitted the entity is constructed with
+    ``id=None`` so ``save`` exercises the generate-if-absent branch.
+    """
+    return Library(
+        id=library_id,
+        name=name,
+        library_type=library_type,
+        paths=[path],
+    )
+
+
+async def _row_count(session: AsyncSession) -> int:
+    """Count every library row, including soft-deleted ones."""
+    result = await session.execute(select(func.count()).select_from(LibraryModel))
+    return int(result.scalar_one())
+
+
+class TestSave:
+    async def test_assigns_id_when_absent_and_round_trips_fields(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+
+            saved = await repo.save(_make_library(name="Anime", path="/media/anime"))
+            await session.commit()
+
+            assert saved.id is not None
+            assert str(saved.id).startswith("lib_")
+            assert saved.name.value == "Anime"
+            assert [p.value for p in saved.paths] == ["/media/anime"]
+
+    async def test_preserves_explicit_id(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        explicit = LibraryId.generate()
+        async with session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+
+            saved = await repo.save(_make_library(library_id=explicit))
+            await session.commit()
+
+            assert saved.id == explicit
+
+    async def test_upsert_updates_in_place_without_duplicating_row(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+            first = await repo.save(_make_library(name="Films"))
+            await session.commit()
+            assert first.id is not None
+
+            renamed = first.with_updates(name="Cinema")
+            updated = await repo.save(renamed)
+            await session.commit()
+
+            assert updated.id == first.id
+            assert updated.name.value == "Cinema"
+            assert await _row_count(session) == 1
+
+    async def test_restores_soft_deleted_row_on_save(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+            original = await repo.save(_make_library(name="Docs"))
+            await session.commit()
+            assert original.id is not None
+
+            assert await repo.delete(original.id) is True
+            await session.commit()
+            assert await repo.find_by_id(original.id) is None
+
+            revived = await repo.save(original.with_updates(name="Documentaries"))
+            await session.commit()
+
+            assert revived.id == original.id
+            assert revived.name.value == "Documentaries"
+            # Restored in place — the soft-delete tombstone is reused,
+            # never a second row for the same external id.
+            assert await _row_count(session) == 1
+            assert await repo.find_by_id(original.id) is not None
+
+
+class TestQueries:
+    async def test_find_by_id_returns_none_for_unknown(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+            assert await repo.find_by_id(LibraryId.generate()) is None
+
+    async def test_find_all_orders_by_name_and_excludes_deleted(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+            await repo.save(_make_library(name="Zed", path="/z"))
+            await repo.save(_make_library(name="Alpha", path="/a"))
+            doomed = await repo.save(_make_library(name="Mid", path="/m"))
+            await session.commit()
+            assert doomed.id is not None
+            await repo.delete(doomed.id)
+            await session.commit()
+
+            names = [lib.name.value for lib in await repo.find_all()]
+
+            assert names == ["Alpha", "Zed"]
+
+
+class TestDeleteAndExists:
+    async def test_delete_is_idempotent_and_reports_outcome(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+            lib = await repo.save(_make_library())
+            await session.commit()
+            assert lib.id is not None
+
+            assert await repo.delete(lib.id) is True
+            await session.commit()
+            # Second delete: already a tombstone → nothing to soft-delete.
+            assert await repo.delete(lib.id) is False
+            assert await repo.delete(LibraryId.generate()) is False
+
+    async def test_exists_reflects_live_and_deleted_state(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with session_factory() as session:
+            repo = SqlAlchemyLibraryRepository(session)
+            lib = await repo.save(_make_library())
+            await session.commit()
+            assert lib.id is not None
+
+            assert await repo.exists(lib.id) is True
+            await repo.delete(lib.id)
+            await session.commit()
+            assert await repo.exists(lib.id) is False
+            assert await repo.exists(LibraryId.generate()) is False

--- a/tests/modules/media/unit/presentation/routes/test_stream_routes.py
+++ b/tests/modules/media/unit/presentation/routes/test_stream_routes.py
@@ -1,0 +1,337 @@
+"""Unit tests for the streaming route handlers.
+
+The routes are deliberately thin: resolve the movie/episode, validate the
+file, hand the path to a streaming use case, and map the returned DTO onto
+a FastAPI response. These tests call the handler coroutines directly with
+mocked use cases (mirroring ``test_admin_subtitle_ocr_routes``) so the
+presentation branches — status mapping, response wiring, the eager-backfill
+trigger, and the episode segment-translation math — are covered without
+FFmpeg, disk, auth, or a live ASGI stack.
+"""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import FileResponse, Response, StreamingResponse
+
+from src.building_blocks.application.errors import ResourceNotFoundException
+from src.modules.media.application.dtos.stream_dtos import (
+    HlsFileOutput,
+    RangeStreamOutput,
+    TrackListOutput,
+)
+from src.modules.media.presentation.routes import stream_routes as mod
+
+pytestmark = pytest.mark.unit
+
+
+def _request(range_header: str | None = None, user_agent: str | None = "pytest-UA") -> object:
+    """Minimal stand-in for a Starlette ``Request``.
+
+    Only ``.client.host`` and ``.headers.get`` are touched by the handlers.
+    """
+    headers = {}
+    if range_header is not None:
+        headers["range"] = range_header
+    if user_agent is not None:
+        headers["user-agent"] = user_agent
+    return SimpleNamespace(client=SimpleNamespace(host="10.0.0.1"), headers=headers)
+
+
+async def _drain_eager() -> None:
+    """Await any fire-and-forget scrub-preview backfill tasks."""
+    while mod._eager_thumbnail_tasks:
+        await asyncio.gather(*list(mod._eager_thumbnail_tasks), return_exceptions=True)
+
+
+def _movie(
+    *,
+    file_path: str | None,
+    scrub_preview_path: str | None = "/prev/sprite.vtt",
+) -> object:
+    return SimpleNamespace(
+        file_path=file_path,
+        scrub_preview_path=scrub_preview_path,
+        title="The Movie",
+        year=2024,
+        resolution="1080p",
+        poster_path="/posters/m.jpg",
+        duration_seconds=7200,
+    )
+
+
+def _episode(
+    *,
+    file_path: str | None,
+    episode_number: int = 1,
+    scrub_preview_path: str | None = "/prev/e.vtt",
+    segment_start_seconds: int | None = None,
+    segment_end_seconds: int | None = None,
+) -> object:
+    return SimpleNamespace(
+        id="epi_aaaaaaaaaaaa",
+        file_path=file_path,
+        episode_number=episode_number,
+        scrub_preview_path=scrub_preview_path,
+        segment_start_seconds=segment_start_seconds,
+        segment_end_seconds=segment_end_seconds,
+        title="Pilot",
+        duration_seconds=1400,
+    )
+
+
+def _series(*, season_number: int = 1, episodes: list[object] | None = None) -> object:
+    return SimpleNamespace(
+        title="The Series",
+        seasons=[
+            SimpleNamespace(
+                season_number=season_number,
+                episodes=episodes if episodes is not None else [_episode(file_path="/s/e.mkv")],
+            )
+        ],
+    )
+
+
+class TestHlsFile:
+    async def test_returns_no_cache_response_for_playlist_output(self) -> None:
+        use_case = AsyncMock()
+        use_case.execute.return_value = HlsFileOutput(
+            kind="playlist",
+            media_type="application/vnd.apple.mpegurl",
+            content="#EXTM3U",
+        )
+
+        result = await mod.hls_file("hash123", "index.m3u8", use_case=use_case)
+
+        assert isinstance(result, Response)
+        assert result.body == b"#EXTM3U"
+        assert result.headers["Cache-Control"] == "no-cache"
+
+    async def test_returns_file_response_for_segment_output(self, tmp_path: Path) -> None:
+        seg = tmp_path / "seg0.ts"
+        seg.write_bytes(b"\x00\x01")
+        use_case = AsyncMock()
+        use_case.execute.return_value = HlsFileOutput(
+            kind="file",
+            media_type="video/mp2t",
+            path=seg,
+        )
+
+        result = await mod.hls_file("hash123", "seg0.ts", use_case=use_case)
+
+        assert isinstance(result, FileResponse)
+        assert result.media_type == "video/mp2t"
+
+    async def test_maps_not_found_to_404(self) -> None:
+        use_case = AsyncMock()
+        use_case.execute.side_effect = ResourceNotFoundException.for_resource("HlsFile", "x")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await mod.hls_file("hash123", "missing.ts", use_case=use_case)
+
+        assert exc_info.value.status_code == 404
+
+    async def test_raises_when_file_output_has_no_path(self) -> None:
+        use_case = AsyncMock()
+        use_case.execute.return_value = HlsFileOutput(kind="file", media_type="video/mp2t")
+
+        with pytest.raises(RuntimeError):
+            await mod.hls_file("hash123", "seg0.ts", use_case=use_case)
+
+
+class TestMovieHlsPlaylist:
+    async def test_serves_master_and_fires_backfill_when_no_preview(self, tmp_path: Path) -> None:
+        video = tmp_path / "movie.mkv"
+        video.write_bytes(b"\x00")
+        movie_uc = AsyncMock()
+        movie_uc.execute.return_value = _movie(file_path=str(video), scrub_preview_path=None)
+        hls_uc = AsyncMock()
+        hls_uc.execute.return_value = SimpleNamespace(rewritten_content="#EXTM3U:master")
+        backfill = SimpleNamespace(process_movie_by_id=AsyncMock(return_value=True))
+
+        try:
+            result = await mod.movie_hls_playlist(
+                "mov_aaaaaaaaaaaa",
+                _request(),
+                start=0,
+                profile_id="prf_aaaaaaaaaaaa",
+                movie_uc=movie_uc,
+                hls_uc=hls_uc,
+                backfill_job=backfill,
+            )
+            await _drain_eager()
+        finally:
+            await _drain_eager()
+
+        assert isinstance(result, Response)
+        assert result.body == b"#EXTM3U:master"
+        backfill.process_movie_by_id.assert_awaited_once_with("mov_aaaaaaaaaaaa")
+
+    async def test_does_not_fire_backfill_when_preview_exists(self, tmp_path: Path) -> None:
+        video = tmp_path / "movie.mkv"
+        video.write_bytes(b"\x00")
+        movie_uc = AsyncMock()
+        movie_uc.execute.return_value = _movie(file_path=str(video))  # preview present
+        hls_uc = AsyncMock()
+        hls_uc.execute.return_value = SimpleNamespace(rewritten_content="#EXTM3U")
+        backfill = SimpleNamespace(process_movie_by_id=AsyncMock(return_value=True))
+
+        await mod.movie_hls_playlist(
+            "mov_aaaaaaaaaaaa",
+            _request(),
+            start=0,
+            profile_id="prf_aaaaaaaaaaaa",
+            movie_uc=movie_uc,
+            hls_uc=hls_uc,
+            backfill_job=backfill,
+        )
+        await _drain_eager()
+
+        backfill.process_movie_by_id.assert_not_awaited()
+
+    async def test_404_when_movie_file_missing_on_disk(self) -> None:
+        movie_uc = AsyncMock()
+        movie_uc.execute.return_value = _movie(file_path="/nope/ghost.mkv")
+        with pytest.raises(HTTPException) as exc_info:
+            await mod.movie_hls_playlist(
+                "mov_aaaaaaaaaaaa",
+                _request(),
+                start=0,
+                profile_id="prf_aaaaaaaaaaaa",
+                movie_uc=movie_uc,
+                hls_uc=AsyncMock(),
+                backfill_job=SimpleNamespace(process_movie_by_id=AsyncMock()),
+            )
+        assert exc_info.value.status_code == 404
+
+
+class TestEpisodeHlsPlaylist:
+    async def test_404_when_episode_absent_from_series(self) -> None:
+        series_uc = AsyncMock()
+        series_uc.execute.return_value = _series(episodes=[])  # season present, no episodes
+        with pytest.raises(HTTPException) as exc_info:
+            await mod.episode_hls_playlist(
+                "ser_aaaaaaaaaaaa",
+                1,
+                99,
+                _request(),
+                start=0,
+                profile_id="prf_aaaaaaaaaaaa",
+                series_uc=series_uc,
+                hls_uc=AsyncMock(),
+                backfill_job=SimpleNamespace(process_episode_by_id=AsyncMock()),
+            )
+        assert exc_info.value.status_code == 404
+
+    async def test_translates_start_into_file_coordinates_for_shared_file(
+        self, tmp_path: Path
+    ) -> None:
+        # ADR-030: an episode that is a sub-range [600, 1800) of a shared
+        # file. A player-relative start of 120 must map to file-absolute
+        # 720, and the encode must stop at the segment end (1800).
+        video = tmp_path / "shared.mkv"
+        video.write_bytes(b"\x00")
+        ep = _episode(
+            file_path=str(video),
+            episode_number=1,
+            segment_start_seconds=600,
+            segment_end_seconds=1800,
+        )
+        series_uc = AsyncMock()
+        series_uc.execute.return_value = _series(episodes=[ep])
+        hls_uc = AsyncMock()
+        hls_uc.execute.return_value = SimpleNamespace(rewritten_content="#EXTM3U")
+
+        await mod.episode_hls_playlist(
+            "ser_aaaaaaaaaaaa",
+            1,
+            1,
+            _request(),
+            start=120,
+            profile_id="prf_aaaaaaaaaaaa",
+            series_uc=series_uc,
+            hls_uc=hls_uc,
+            backfill_job=SimpleNamespace(process_episode_by_id=AsyncMock()),
+        )
+        await _drain_eager()
+
+        sent = hls_uc.execute.await_args.args[0]
+        assert sent.start == 720
+        assert sent.end == 1800
+
+
+class TestMovieTracks:
+    async def test_serializes_track_list_output(self, tmp_path: Path) -> None:
+        video = tmp_path / "movie.mkv"
+        video.write_bytes(b"\x00")
+        movie_uc = AsyncMock()
+        movie_uc.execute.return_value = _movie(file_path=str(video))
+        tracks_uc = AsyncMock()
+        tracks_uc.execute.return_value = TrackListOutput(
+            audio_tracks=[{"index": 0, "language": "eng"}],
+            subtitle_tracks=[],
+        )
+
+        result = await mod.movie_tracks(
+            "mov_aaaaaaaaaaaa",
+            profile_id="prf_aaaaaaaaaaaa",
+            movie_uc=movie_uc,
+            tracks_uc=tracks_uc,
+        )
+
+        assert result == {
+            "audio_tracks": [{"index": 0, "language": "eng"}],
+            "subtitle_tracks": [],
+        }
+
+
+class TestClearMovieHlsCache:
+    async def test_returns_204(self) -> None:
+        movie_uc = AsyncMock()
+        movie_uc.execute.return_value = _movie(file_path="/movies/m.mkv")
+        clear_uc = AsyncMock()
+
+        result = await mod.clear_movie_hls_cache(
+            "mov_aaaaaaaaaaaa",
+            _admin=SimpleNamespace(),
+            profile_id="prf_aaaaaaaaaaaa",
+            movie_uc=movie_uc,
+            clear_uc=clear_uc,
+        )
+
+        assert result.status_code == 204
+        clear_uc.execute.assert_awaited_once()
+
+
+class TestStreamMovie:
+    async def test_wraps_range_output_in_streaming_response(self, tmp_path: Path) -> None:
+        video = tmp_path / "movie.mp4"
+        video.write_bytes(b"\x00")
+        movie_uc = AsyncMock()
+        movie_uc.execute.return_value = _movie(file_path=str(video))
+
+        async def _body() -> object:
+            yield b"chunk"
+
+        stream_uc = AsyncMock()
+        stream_uc.execute.return_value = RangeStreamOutput(
+            status_code=206,
+            media_type="video/mp4",
+            headers={"Content-Range": "bytes 0-4/5"},
+            body=_body(),
+        )
+
+        result = await mod.stream_movie(
+            "mov_aaaaaaaaaaaa",
+            _request(range_header="bytes=0-"),
+            profile_id="prf_aaaaaaaaaaaa",
+            movie_uc=movie_uc,
+            stream_uc=stream_uc,
+        )
+
+        assert isinstance(result, StreamingResponse)
+        assert result.status_code == 206


### PR DESCRIPTION
## Summary

Onda 1 item 1.4 (test-gaps) of the tech-debt remediation plan — closes the two coverage holes the audit flagged.

- **LibraryRepository integration** (`test_library_repository.py`): id generation on save, in-place upsert (asserts a single row after rename), the **restore-on-save** branch for a soft-deleted tombstone, `find_all` ordering + soft-delete exclusion, idempotent `delete`, and `exists` live/deleted state — against a real in-memory SQLite session.
- **stream_routes handlers** (`test_stream_routes.py`, 558-LOC module previously without route tests): `hls_file` playlist/file/404/no-path branches, `_require_file` 404 through the movie playlist route, episode-absent 404, the ADR-030 segment-start → file-coordinate translation, the eager scrub-preview backfill trigger (fires only when no preview), cache-clear 204, and range-stream response wrapping. Handlers are called directly with mocked use cases, mirroring `test_admin_subtitle_ocr_routes`.

No production code changes.

## Test plan

- [x] `pytest tests/modules/library` + `tests/modules/media/unit/presentation` — 141 passed
- [x] `ruff check` on both new files — clean
- [x] New tests: 8 (library repo) + 12 (stream routes)

## Summary by Sourcery

Add integration coverage for the library repository and unit coverage for media streaming route handlers.

Tests:
- Add integration tests for SqlAlchemyLibraryRepository covering id assignment, upsert behavior, soft-delete restore, query ordering, idempotent delete, and existence checks against a real SQLite session.
- Add unit tests for media stream route handlers to validate HLS file responses, error handling, eager scrub-preview backfill triggering, episode segment coordinate translation, track serialization, cache clearing, and range streaming responses.