### PR TITLE
refactor(media): segregate catalog repositories into role-interfaces

### DIFF
--- a/src/infrastructure/scheduling/artwork_mirror_job.py
+++ b/src/infrastructure/scheduling/artwork_mirror_job.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
         MediaUnitOfWork,
         MediaUnitOfWorkFactory,
     )
-    from src.modules.media.domain.repositories.movie_repository import RemoteArtworkRow
+    from src.modules.media.domain.repositories.artwork_mirror_repository import RemoteArtworkRow
     from src.modules.settings.infrastructure.runtime_settings import RuntimeSettings
 
 _logger = get_logger()

--- a/src/modules/media/application/use_cases/list_credits_status.py
+++ b/src/modules/media/application/use_cases/list_credits_status.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from src.modules.media.application.unit_of_work import MediaUnitOfWorkFactory
-    from src.modules.media.domain.repositories.movie_repository import CreditsStatusRow
+    from src.modules.media.domain.repositories.credits_detection_repository import CreditsStatusRow
 
 _MOVIE = "movie"
 

--- a/src/modules/media/domain/repositories/__init__.py
+++ b/src/modules/media/domain/repositories/__init__.py
@@ -1,5 +1,18 @@
 """Media domain repository interfaces."""
 
+from src.modules.media.domain.repositories.artwork_mirror_repository import (
+    MovieArtworkMirrorRepository,
+    RemoteArtworkRow,
+    SeriesArtworkMirrorRepository,
+)
+from src.modules.media.domain.repositories.credits_detection_repository import (
+    CreditsStatusRow,
+    MovieCreditsDetectionRepository,
+    SeriesCreditsDetectionRepository,
+)
+from src.modules.media.domain.repositories.intro_detection_repository import (
+    SeriesIntroDetectionRepository,
+)
 from src.modules.media.domain.repositories.intro_detection_run_repository import (
     IntroDetectionRunRepository,
 )
@@ -7,19 +20,42 @@ from src.modules.media.domain.repositories.job_run_repository import JobRunRepos
 from src.modules.media.domain.repositories.media_conflict_repository import (
     MediaConflictRepository,
 )
-from src.modules.media.domain.repositories.movie_repository import MovieRepository
+from src.modules.media.domain.repositories.movie_repository import (
+    GenreRow,
+    MovieCatalogRepository,
+    MovieRepository,
+)
 from src.modules.media.domain.repositories.scan_run_repository import ScanRunRepository
-from src.modules.media.domain.repositories.series_repository import SeriesRepository
+from src.modules.media.domain.repositories.scrub_preview_repository import (
+    MovieScrubPreviewRepository,
+    SeriesScrubPreviewRepository,
+)
+from src.modules.media.domain.repositories.series_repository import (
+    SeriesCatalogRepository,
+    SeriesRepository,
+)
 from src.modules.media.domain.repositories.subtitle_ocr_run_repository import (
     SubtitleOcrRunRepository,
 )
 
 __all__ = [
+    "CreditsStatusRow",
+    "GenreRow",
     "IntroDetectionRunRepository",
     "JobRunRepository",
     "MediaConflictRepository",
+    "MovieArtworkMirrorRepository",
+    "MovieCatalogRepository",
+    "MovieCreditsDetectionRepository",
     "MovieRepository",
+    "MovieScrubPreviewRepository",
+    "RemoteArtworkRow",
     "ScanRunRepository",
+    "SeriesArtworkMirrorRepository",
+    "SeriesCatalogRepository",
+    "SeriesCreditsDetectionRepository",
+    "SeriesIntroDetectionRepository",
     "SeriesRepository",
+    "SeriesScrubPreviewRepository",
     "SubtitleOcrRunRepository",
 ]

--- a/src/modules/media/domain/repositories/artwork_mirror_repository.py
+++ b/src/modules/media/domain/repositories/artwork_mirror_repository.py
@@ -1,0 +1,144 @@
+"""Artwork-mirror role interfaces (ADR-033).
+
+Role-interfaces carved out of the movie/series catalog god-repositories:
+the narrow contract the artwork-mirror job (ADR-029) depends on. A movie
+or series row is *mirrorable* when one of its artwork columns still holds a
+remote provider URL; the job finds those rows and rewrites just the artwork
+columns without round-tripping the aggregate (which a full ``save`` would
+risk persisting with unloaded children).
+
+The concrete SQLAlchemy repository implements these alongside the catalog
+role against the same table (ADR-033 §Decisão). When the artwork subdomain
+is extracted (ADR-032), this file moves with it.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from src.modules.media.domain.value_objects import (
+    ArtworkColumns,
+    EpisodeId,
+    MovieId,
+    SeasonId,
+    SeriesId,
+)
+
+
+@dataclass(frozen=True)
+class RemoteArtworkRow:
+    """Lightweight projection of a title's artwork references.
+
+    Used by the artwork-mirror job (ADR-029) to find titles whose
+    poster/backdrop/logo is still a remote provider URL and update just
+    those columns directly — without loading the aggregate, which a full
+    ``save`` would risk persisting with unloaded children (file variants,
+    seasons). ``media_id`` is the external id (``mov_xxx`` / ``ser_xxx`` /
+    ``ssn_xxx`` / ``epi_xxx``); ``artwork`` carries the references as
+    ``ImageUrl`` values, so ``.is_remote`` is available without re-parsing
+    strings. Reused across movies, series, seasons, and episodes.
+    """
+
+    media_id: str
+    artwork: ArtworkColumns
+
+
+class MovieArtworkMirrorRepository(ABC):
+    """Artwork-mirror operations over the ``movies`` table."""
+
+    @abstractmethod
+    async def find_with_remote_artwork(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` movies with a still-remote artwork URL.
+
+        A row is returned when any of ``poster_path`` / ``backdrop_path``
+        / ``logo_path`` is still an ``http(s)`` provider URL (not yet
+        mirrored). Soft-deleted rows are excluded and results are ordered
+        by id so the mirror job makes steady forward progress.
+        """
+        ...
+
+    @abstractmethod
+    async def update_movie_artwork(self, movie_id: MovieId, artwork: ArtworkColumns) -> None:
+        """Set the three artwork columns directly (mirror job).
+
+        A targeted column update rather than an aggregate ``save`` so the
+        mirror job never risks persisting the movie with unloaded file
+        variants. ``artwork`` carries the final value for every column
+        (the mirrored local reference where one was produced, the
+        original value otherwise).
+        """
+        ...
+
+
+class SeriesArtworkMirrorRepository(ABC):
+    """Artwork-mirror operations over ``series`` / ``seasons`` / ``episodes``."""
+
+    @abstractmethod
+    async def find_with_remote_artwork(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` series with a still-remote artwork URL.
+
+        Mirror of ``MovieArtworkMirrorRepository.find_with_remote_artwork``
+        over series ``poster_path`` / ``backdrop_path`` / ``logo_path``.
+        Season posters and episode stills are handled separately.
+        """
+        ...
+
+    @abstractmethod
+    async def update_series_artwork(self, series_id: SeriesId, artwork: ArtworkColumns) -> None:
+        """Set the three artwork columns for one series by external id.
+
+        A targeted column update rather than an aggregate ``save`` so the
+        mirror job never risks persisting the series with its seasons and
+        episodes unloaded. ``artwork`` carries the final value for every
+        column.
+        """
+        ...
+
+    @abstractmethod
+    async def find_seasons_with_remote_poster(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` seasons whose poster is still a remote URL.
+
+        ``RemoteArtworkRow.media_id`` is the season external id (``ssn_xxx``)
+        and only ``artwork.poster`` is populated — seasons carry no
+        backdrop/logo column.
+        """
+        ...
+
+    @abstractmethod
+    async def update_season_artwork(self, season_id: SeasonId, artwork: ArtworkColumns) -> None:
+        """Set a single season's poster column by external id.
+
+        Direct column update on the ``seasons`` table — the mirror job
+        never round-trips the ``Series`` aggregate. Only ``artwork.poster``
+        is written; the other fields are ignored (no such columns).
+        """
+        ...
+
+    @abstractmethod
+    async def find_episodes_with_remote_thumbnail(self, limit: int) -> Sequence[RemoteArtworkRow]:
+        """Return up to ``limit`` episodes whose still is still a remote URL.
+
+        ``RemoteArtworkRow.media_id`` is the episode external id
+        (``epi_xxx``) and only ``artwork.still`` is populated — the
+        episode still is its single mirrorable image. Soft-deleted
+        episodes are excluded.
+        """
+        ...
+
+    @abstractmethod
+    async def update_episode_thumbnail(
+        self, episode_id: EpisodeId, artwork: ArtworkColumns
+    ) -> None:
+        """Set a single episode's still (``thumbnail_path``) by external id.
+
+        Direct column update on the ``episodes`` table — no aggregate
+        round-trip. Only ``artwork.still`` is written.
+        """
+        ...
+
+
+__all__ = [
+    "MovieArtworkMirrorRepository",
+    "RemoteArtworkRow",
+    "SeriesArtworkMirrorRepository",
+]

--- a/src/modules/media/domain/repositories/credits_detection_repository.py
+++ b/src/modules/media/domain/repositories/credits_detection_repository.py
@@ -1,0 +1,159 @@
+"""Credits-detection role interfaces (ADR-033).
+
+The narrow contract the credits-detection job and the admin credits-status
+listing depend on: pending-work queues, per-title state counters, the
+status projection, and the direct marker/state update that avoids an
+aggregate round-trip. Carved out of the movie/series catalog
+god-repositories; migrates with the credits subdomain (ADR-032).
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from src.modules.media.domain.entities.episode import Episode
+from src.modules.media.domain.entities.movie import Movie
+from src.modules.media.domain.value_objects import (
+    CreditsDetectionState,
+    CreditsMarker,
+    EpisodeId,
+    MovieId,
+)
+
+
+@dataclass(frozen=True)
+class CreditsStatusRow:
+    """Lightweight projection of a title's credits-detection status.
+
+    Used by the admin "credits status" listing so it can show every
+    title's state + marker without loading entities and their file
+    variants. Episode-only context (``series_id``/``season_number``/
+    ``episode_number``) is ``None`` for movies; the admin UI uses it to
+    deep-link into the per-episode editor.
+    """
+
+    media_id: str
+    title: str
+    state: str
+    start_seconds: int | None
+    source: str | None
+    confidence: float | None
+    series_id: str | None = None
+    season_number: int | None = None
+    episode_number: int | None = None
+
+
+class MovieCreditsDetectionRepository(ABC):
+    """Credits-detection operations over the ``movies`` table."""
+
+    @abstractmethod
+    async def count_credits_states(self) -> dict[str, int]:
+        """Return ``{credits_detection_state: count}`` over non-deleted movies."""
+        ...
+
+    @abstractmethod
+    async def list_credits_status(
+        self, state: str | None, limit: int, offset: int
+    ) -> tuple[Sequence[CreditsStatusRow], int]:
+        """Return a page of movie credits-status rows + the total count.
+
+        Args:
+            state: Filter by ``credits_detection_state``, or ``None`` for all.
+            limit: Page size.
+            offset: Page offset.
+
+        Returns:
+            ``(rows, total)`` — newest-marker-first, then by title.
+        """
+        ...
+
+    @abstractmethod
+    async def find_pending_credits_detection(self, limit: int) -> Sequence[Movie]:
+        """Return up to ``limit`` movies whose credits detection has not run.
+
+        Filters for ``credits_detection_state == NOT_STARTED`` with
+        file variants eager-loaded (the job needs ``primary_file``).
+        Soft-deleted rows excluded; sorted ``id ASC`` for steady forward
+        progress across ticks.
+        """
+        ...
+
+    @abstractmethod
+    async def update_movie_credits(
+        self,
+        movie_id: MovieId,
+        marker: CreditsMarker | None,
+        state: CreditsDetectionState,
+    ) -> bool:
+        """Persist the credits marker + detection state for one movie.
+
+        Direct UPDATE of the four credits-marker columns plus
+        ``credits_detection_state`` on the ``movies`` row. ``marker=None``
+        clears the marker columns (IN_PROGRESS / NO_CREDITS_FOUND /
+        FAILED / clear); a non-null marker writes the onset (COMPLETED /
+        manual edit).
+
+        Returns:
+            ``True`` if a row was updated, ``False`` if no movie matched.
+        """
+        ...
+
+
+class SeriesCreditsDetectionRepository(ABC):
+    """Credits-detection operations over the ``episodes`` table."""
+
+    @abstractmethod
+    async def count_episode_credits_states(self) -> dict[str, int]:
+        """Return ``{credits_detection_state: count}`` over non-deleted episodes."""
+        ...
+
+    @abstractmethod
+    async def list_episode_credits_status(
+        self, state: str | None, limit: int, offset: int
+    ) -> tuple[Sequence[CreditsStatusRow], int]:
+        """Return a page of episode credits-status rows + the total count.
+
+        Rows carry ``series_id``/``season_number``/``episode_number`` so the
+        admin UI can deep-link into the per-episode editor. Newest-marker
+        first, then by series + season + episode.
+        """
+        ...
+
+    @abstractmethod
+    async def find_episodes_pending_credits_detection(self, limit: int) -> Sequence[Episode]:
+        """Return episodes whose credits detection has not run yet.
+
+        Filters for episodes in ``NOT_STARTED`` credits-detection state
+        (per-file, unlike the season-scoped intro detection), with their
+        file variants eager-loaded so the job can read the primary file
+        path without an N+1. Soft-deleted episodes are excluded.
+        """
+        ...
+
+    @abstractmethod
+    async def update_episode_credits(
+        self,
+        episode_id: EpisodeId,
+        marker: CreditsMarker | None,
+        state: CreditsDetectionState,
+    ) -> bool:
+        """Persist the credits marker + detection state for one episode.
+
+        Direct UPDATE of the four credits-marker columns plus
+        ``credits_detection_state`` on the ``episodes`` row, avoiding a
+        round-trip through the ``Series`` aggregate. ``marker=None`` clears
+        the marker columns (used for IN_PROGRESS / NO_CREDITS_FOUND /
+        FAILED transitions and for clearing); a non-null marker writes the
+        onset (used on COMPLETED and manual edits).
+
+        Returns:
+            ``True`` if a row was updated, ``False`` if no episode matched.
+        """
+        ...
+
+
+__all__ = [
+    "CreditsStatusRow",
+    "MovieCreditsDetectionRepository",
+    "SeriesCreditsDetectionRepository",
+]

--- a/src/modules/media/domain/repositories/intro_detection_repository.py
+++ b/src/modules/media/domain/repositories/intro_detection_repository.py
@@ -1,0 +1,153 @@
+"""Intro-detection role interface (ADR-033).
+
+The narrow contract the season-scoped intro-detection job and the manual
+intro-edit use cases depend on: the eligibility queue, the per-season job
+state transition, and the per-episode marker writes — all direct table
+updates that avoid round-tripping the ``Series`` aggregate. Carved out of
+the series catalog god-repository; migrates with the intro subdomain
+(ADR-032). Intro detection is series-only (movies have no intro markers).
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from datetime import datetime
+
+from src.modules.media.domain.entities.season import Season
+from src.modules.media.domain.value_objects import (
+    EpisodeId,
+    IntroDetectionState,
+    IntroMarker,
+    SeasonId,
+)
+
+
+class SeriesIntroDetectionRepository(ABC):
+    """Intro-detection operations over ``seasons`` / ``episodes``."""
+
+    @abstractmethod
+    async def find_seasons_pending_intro_detection(
+        self,
+        limit: int,
+        *,
+        stale_before: datetime,
+    ) -> Sequence[Season]:
+        """Return seasons whose intro-detection job has not converged yet.
+
+        A season is eligible when it is:
+
+        * ``NOT_STARTED`` — never attempted; or
+        * ``INSUFFICIENT_EPISODES`` *and* its current (non-deleted)
+          episode count exceeds ``intro_detection_attempted_episode_count``
+          — i.e. new episodes landed since the last attempt, so the
+          outcome could now differ. A season whose episode set hasn't
+          grown is NOT retried, so a permanently-small season (e.g. a
+          2-part miniseries) stops monopolising the queue; or
+        * ``IN_PROGRESS`` with ``intro_detection_attempted_at`` older than
+          ``stale_before`` — an orphaned claim (the worker died
+          mid-detection), reclaimed so it self-heals.
+
+        ``COMPLETED``, ``FAILED``, and ``DISABLED`` are excluded;
+        ``FAILED`` and ``DISABLED`` require an explicit operator reset.
+
+        Ordered by ``intro_detection_attempted_at`` ascending with NULLs
+        first, then ``id``, so never-attempted seasons run before any
+        already-attempted one.
+
+        Returned ``Season`` entities have their ``episodes`` collection
+        eagerly loaded (with file variants) so the detection job can
+        iterate file paths without N+1 queries. Soft-deleted seasons
+        and episodes are filtered out.
+
+        Args:
+            limit: Maximum number of seasons to return.
+            stale_before: Cutoff for reclaiming orphaned ``IN_PROGRESS``
+                seasons — those last attempted before this instant are
+                considered abandoned and made eligible again.
+
+        Returns:
+            Sequence of seasons eligible for the next detection tick.
+        """
+        ...
+
+    @abstractmethod
+    async def update_season_intro_detection(
+        self,
+        season_id: SeasonId,
+        state: IntroDetectionState,
+        *,
+        attempted_at: datetime | None = None,
+        attempted_episode_count: int | None = None,
+        error: str | None = None,
+    ) -> bool:
+        """Persist intro-detection job state for a season.
+
+        Direct UPDATE on the ``seasons`` table so the detection job can
+        record progress and outcomes without round-tripping the parent
+        ``Series`` aggregate per season. Domain-side state machine
+        validation belongs on the ``Season`` entity; callers are expected
+        to drive transitions via ``with_detection_started`` etc. and pass
+        the resulting state here.
+
+        Args:
+            season_id: External id of the season (ssn_xxx).
+            state: New ``IntroDetectionState`` value.
+            attempted_at: When the job ran. Pass ``None`` to leave the
+                column unchanged for transient transitions like
+                ``IN_PROGRESS``.
+            attempted_episode_count: Episode count observed this attempt,
+                used to decide whether an ``INSUFFICIENT_EPISODES`` season
+                is worth retrying later. Pass ``None`` to leave it
+                unchanged (e.g. on the ``IN_PROGRESS`` claim).
+            error: Diagnostic message for ``FAILED`` runs, or ``None`` to
+                clear.
+
+        Returns:
+            ``True`` if a row was updated, ``False`` if no season with
+            that id exists.
+        """
+        ...
+
+    @abstractmethod
+    async def update_episode_intro(
+        self,
+        episode_id: EpisodeId,
+        marker: IntroMarker | None,
+    ) -> bool:
+        """Persist (or clear) the intro marker for a single episode.
+
+        Direct UPDATE on the ``episodes`` table covering all five intro
+        columns at once. The detection job calls this per-episode after
+        cross-correlation; the manual-edit endpoint also uses it to set
+        a ``MANUAL`` marker without rewriting the entire ``Series``
+        aggregate.
+
+        Args:
+            episode_id: External id of the episode (epi_xxx).
+            marker: The marker to persist, or ``None`` to clear all five
+                intro columns.
+
+        Returns:
+            ``True`` if a row was updated, ``False`` if no episode with
+            that id exists.
+        """
+        ...
+
+    @abstractmethod
+    async def clear_auto_intro_markers_for_season(self, season_id: SeasonId) -> int:
+        """Clear AUTO_DETECTED intro markers on a season's episodes.
+
+        Bulk UPDATE that nulls the five intro columns for every episode
+        of the season whose marker source is ``AUTO_DETECTED``. MANUAL
+        markers are left untouched. Used by the re-detect flow so a
+        re-run starts from a clean slate without dropping operator edits.
+
+        Args:
+            season_id: External id of the season (ssn_xxx).
+
+        Returns:
+            The number of episode rows cleared.
+        """
+        ...
+
+
+__all__ = ["SeriesIntroDetectionRepository"]

--- a/src/modules/media/domain/repositories/movie_repository.py
+++ b/src/modules/media/domain/repositories/movie_repository.py
@@ -1,4 +1,17 @@
-"""Movie repository interface."""
+"""Movie repository interfaces.
+
+``MovieCatalogRepository`` is the lean catalog port — CRUD, search,
+pagination, variant surgery, stats — the stable core. The job-oriented
+concerns are segregated into role-interfaces (ADR-033):
+:class:`~...scrub_preview_repository.MovieScrubPreviewRepository`,
+:class:`~...artwork_mirror_repository.MovieArtworkMirrorRepository`, and
+:class:`~...credits_detection_repository.MovieCreditsDetectionRepository`.
+
+``MovieRepository`` is the composite facade the ``MediaUnitOfWork`` exposes
+and the SQLAlchemy adapter implements — a single class against the
+``movies`` table satisfying every role (ADR-033 §Decisão). Consumers that
+only need one concern can depend on the narrow role directly.
+"""
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -6,11 +19,17 @@ from dataclasses import dataclass
 
 from src.building_blocks.domain.pagination import PaginatedResult
 from src.modules.media.domain.entities.movie import Movie
+from src.modules.media.domain.repositories.artwork_mirror_repository import (
+    MovieArtworkMirrorRepository,
+)
+from src.modules.media.domain.repositories.credits_detection_repository import (
+    MovieCreditsDetectionRepository,
+)
+from src.modules.media.domain.repositories.scrub_preview_repository import (
+    MovieScrubPreviewRepository,
+)
 from src.modules.media.domain.value_objects import (
-    ArtworkColumns,
     CatalogSort,
-    CreditsDetectionState,
-    CreditsMarker,
     EpisodeId,
     FilePath,
     Genre,
@@ -35,51 +54,13 @@ class GenreRow:
     localized_genres: list[str]
 
 
-@dataclass(frozen=True)
-class CreditsStatusRow:
-    """Lightweight projection of a title's credits-detection status.
+class MovieCatalogRepository(ABC):
+    """Lean catalog port for the Movie aggregate.
 
-    Used by the admin "credits status" listing so it can show every
-    title's state + marker without loading entities and their file
-    variants. Episode-only context (``series_id``/``season_number``/
-    ``episode_number``) is ``None`` for movies; the admin UI uses it to
-    deep-link into the per-episode editor.
-    """
-
-    media_id: str
-    title: str
-    state: str
-    start_seconds: int | None
-    source: str | None
-    confidence: float | None
-    series_id: str | None = None
-    season_number: int | None = None
-    episode_number: int | None = None
-
-
-@dataclass(frozen=True)
-class RemoteArtworkRow:
-    """Lightweight projection of a title's artwork references.
-
-    Used by the artwork-mirror job (ADR-029) to find titles whose
-    poster/backdrop/logo is still a remote provider URL and update just
-    those columns directly — without loading the aggregate, which a full
-    ``save`` would risk persisting with unloaded children (file variants,
-    seasons). ``media_id`` is the external id (``mov_xxx`` / ``ser_xxx``);
-    ``artwork`` carries the three references as ``ImageUrl`` values, so
-    ``.is_remote`` is available without re-parsing strings. Reused for
-    both movies and series (same three columns).
-    """
-
-    media_id: str
-    artwork: ArtworkColumns
-
-
-class MovieRepository(ABC):
-    """Repository interface for Movie aggregate.
-
-    This is a port in the hexagonal architecture pattern.
-    Implementations (adapters) will be in the infrastructure layer.
+    CRUD, search, pagination, variant surgery, and stats — the stable
+    core that every catalog consumer depends on. Job-oriented concerns
+    (artwork mirror, credits detection, scrub preview) live in their own
+    role-interfaces (ADR-033).
     """
 
     @abstractmethod
@@ -605,113 +586,8 @@ class MovieRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_missing_scrub_preview(self, limit: int) -> Sequence[Movie]:
-        """Return up to ``limit`` movies that have no scrub-preview thumbnails yet.
-
-        Used by the periodic backfill job to throttle work — every tick
-        picks at most ``limit`` movies and generates their sprites,
-        which keeps CPU bounded on large catalogs. Soft-deleted rows
-        are excluded; movies without a primary file are included so the
-        caller can decide to skip them.
-
-        Args:
-            limit: Maximum number of movies to return. Caller controls
-                CPU/IO budget by tuning this with the run interval.
-
-        Returns:
-            Sequence of movies whose ``scrub_preview_path`` is null.
-        """
-        ...
-
-    @abstractmethod
-    async def find_with_remote_artwork(self, limit: int) -> Sequence[RemoteArtworkRow]:
-        """Return up to ``limit`` movies with a still-remote artwork URL.
-
-        A row is returned when any of ``poster_path`` / ``backdrop_path``
-        / ``logo_path`` is still an ``http(s)`` provider URL (not yet
-        mirrored). Soft-deleted rows are excluded and results are ordered
-        by id so the mirror job makes steady forward progress.
-        """
-        ...
-
-    @abstractmethod
-    async def update_movie_artwork(self, movie_id: MovieId, artwork: ArtworkColumns) -> None:
-        """Set the three artwork columns directly (mirror job).
-
-        A targeted column update rather than an aggregate ``save`` so the
-        mirror job never risks persisting the movie with unloaded file
-        variants. ``artwork`` carries the final value for every column
-        (the mirrored local reference where one was produced, the
-        original value otherwise).
-        """
-        ...
-
-    @abstractmethod
-    async def count_credits_states(self) -> dict[str, int]:
-        """Return ``{credits_detection_state: count}`` over non-deleted movies."""
-        ...
-
-    @abstractmethod
     async def total_file_size_by_library(self) -> dict[str, int]:
         """Return ``{library_id: total primary-file bytes}`` over movies."""
-        ...
-
-    @abstractmethod
-    async def list_credits_status(
-        self, state: str | None, limit: int, offset: int
-    ) -> tuple[Sequence[CreditsStatusRow], int]:
-        """Return a page of movie credits-status rows + the total count.
-
-        Args:
-            state: Filter by ``credits_detection_state``, or ``None`` for all.
-            limit: Page size.
-            offset: Page offset.
-
-        Returns:
-            ``(rows, total)`` — newest-marker-first, then by title.
-        """
-        ...
-
-    @abstractmethod
-    async def find_pending_credits_detection(self, limit: int) -> Sequence[Movie]:
-        """Return up to ``limit`` movies whose credits detection has not run.
-
-        Filters for ``credits_detection_state == NOT_STARTED`` with
-        file variants eager-loaded (the job needs ``primary_file``).
-        Soft-deleted rows excluded; sorted ``id ASC`` for steady forward
-        progress across ticks.
-
-        Args:
-            limit: Maximum number of movies to return.
-
-        Returns:
-            Sequence of movies eligible for the next credits tick.
-        """
-        ...
-
-    @abstractmethod
-    async def update_movie_credits(
-        self,
-        movie_id: MovieId,
-        marker: CreditsMarker | None,
-        state: CreditsDetectionState,
-    ) -> bool:
-        """Persist the credits marker + detection state for one movie.
-
-        Direct UPDATE of the four credits-marker columns plus
-        ``credits_detection_state`` on the ``movies`` row. ``marker=None``
-        clears the marker columns (IN_PROGRESS / NO_CREDITS_FOUND /
-        FAILED / clear); a non-null marker writes the onset (COMPLETED /
-        manual edit).
-
-        Args:
-            movie_id: External id of the movie (mov_xxx).
-            marker: The marker to persist, or ``None`` to clear it.
-            state: New ``CreditsDetectionState`` value.
-
-        Returns:
-            ``True`` if a row was updated, ``False`` if no movie matched.
-        """
         ...
 
     @abstractmethod
@@ -745,4 +621,19 @@ class MovieRepository(ABC):
         ...
 
 
-__all__ = ["GenreRow", "MovieRepository"]
+class MovieRepository(
+    MovieCatalogRepository,
+    MovieScrubPreviewRepository,
+    MovieArtworkMirrorRepository,
+    MovieCreditsDetectionRepository,
+):
+    """Composite Movie repository — the full port over the ``movies`` table.
+
+    Unions the lean catalog with every job-oriented role-interface
+    (ADR-033). This is the type the ``MediaUnitOfWork`` exposes as
+    ``.movies`` and the SQLAlchemy adapter implements; a consumer that
+    only needs one concern should depend on the narrow role instead.
+    """
+
+
+__all__ = ["GenreRow", "MovieCatalogRepository", "MovieRepository"]

--- a/src/modules/media/domain/repositories/scrub_preview_repository.py
+++ b/src/modules/media/domain/repositories/scrub_preview_repository.py
@@ -1,0 +1,76 @@
+"""Scrub-preview role interfaces (ADR-033).
+
+The narrow contract the scrub-preview backfill job depends on: the
+throttled "missing preview" queue and, for episodes, the direct
+scrub-path write that marks an item processed without round-tripping the
+``Series`` aggregate. Carved out of the movie/series catalog
+god-repositories; migrates with the scrub-preview subdomain (ADR-032).
+
+Movies have no dedicated scrub-path update — the job persists the path
+through the aggregate ``save`` on the lean catalog repository — so the
+movie role is read-only here.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from src.modules.media.domain.entities.episode import Episode
+from src.modules.media.domain.entities.movie import Movie
+from src.modules.media.domain.value_objects import EpisodeId
+
+
+class MovieScrubPreviewRepository(ABC):
+    """Scrub-preview read queue over the ``movies`` table."""
+
+    @abstractmethod
+    async def find_missing_scrub_preview(self, limit: int) -> Sequence[Movie]:
+        """Return up to ``limit`` movies that have no scrub-preview thumbnails yet.
+
+        Used by the periodic backfill job to throttle work — every tick
+        picks at most ``limit`` movies and generates their sprites,
+        which keeps CPU bounded on large catalogs. Soft-deleted rows
+        are excluded; movies without a primary file are included so the
+        caller can decide to skip them.
+        """
+        ...
+
+
+class SeriesScrubPreviewRepository(ABC):
+    """Scrub-preview read queue + direct path write over the ``episodes`` table."""
+
+    @abstractmethod
+    async def find_episodes_missing_scrub_preview(self, limit: int) -> Sequence[Episode]:
+        """Return up to ``limit`` episodes that have no scrub-preview thumbnails yet.
+
+        Returned ``Episode`` aggregates are detached from their parent
+        ``Series``; the backfill job only needs the file path and id to
+        do its work and this avoids loading a full series hierarchy per
+        episode. Soft-deleted episodes are excluded.
+        """
+        ...
+
+    @abstractmethod
+    async def update_episode_scrub_preview_path(
+        self,
+        episode_id: EpisodeId,
+        path: str | None,
+    ) -> bool:
+        """Persist the scrub-preview path for a single episode.
+
+        Provided alongside ``find_episodes_missing_scrub_preview`` so
+        the backfill job can mark items processed without round-tripping
+        the entire ``Series`` aggregate — that round-trip would dominate
+        runtime on series with many episodes.
+
+        Args:
+            episode_id: External id of the episode to update.
+            path: Absolute path to the sprite VTT, or ``None`` to clear.
+
+        Returns:
+            ``True`` if a row was updated, ``False`` if no episode with
+            that id exists.
+        """
+        ...
+
+
+__all__ = ["MovieScrubPreviewRepository", "SeriesScrubPreviewRepository"]

--- a/src/modules/media/domain/repositories/series_repository.py
+++ b/src/modules/media/domain/repositories/series_repository.py
@@ -1,40 +1,56 @@
-"""Series repository interface."""
+"""Series repository interfaces.
+
+``SeriesCatalogRepository`` is the lean catalog port — CRUD, search,
+pagination, episode lookup, stats — the stable core. The job-oriented
+concerns are segregated into role-interfaces (ADR-033):
+:class:`~...scrub_preview_repository.SeriesScrubPreviewRepository`,
+:class:`~...artwork_mirror_repository.SeriesArtworkMirrorRepository`,
+:class:`~...intro_detection_repository.SeriesIntroDetectionRepository`, and
+:class:`~...credits_detection_repository.SeriesCreditsDetectionRepository`.
+
+``SeriesRepository`` is the composite facade the ``MediaUnitOfWork`` exposes
+and the SQLAlchemy adapter implements — a single class against the
+``series`` / ``seasons`` / ``episodes`` tables satisfying every role
+(ADR-033 §Decisão).
+"""
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from datetime import datetime
 
 from src.building_blocks.domain.pagination import PaginatedResult
 from src.modules.media.domain.entities.episode import Episode
-from src.modules.media.domain.entities.season import Season
 from src.modules.media.domain.entities.series import Series
-from src.modules.media.domain.repositories.movie_repository import (
-    CreditsStatusRow,
-    GenreRow,
-    RemoteArtworkRow,
+from src.modules.media.domain.repositories.artwork_mirror_repository import (
+    SeriesArtworkMirrorRepository,
+)
+from src.modules.media.domain.repositories.credits_detection_repository import (
+    SeriesCreditsDetectionRepository,
+)
+from src.modules.media.domain.repositories.intro_detection_repository import (
+    SeriesIntroDetectionRepository,
+)
+from src.modules.media.domain.repositories.movie_repository import GenreRow
+from src.modules.media.domain.repositories.scrub_preview_repository import (
+    SeriesScrubPreviewRepository,
 )
 from src.modules.media.domain.value_objects import (
-    ArtworkColumns,
     CatalogSort,
-    CreditsDetectionState,
-    CreditsMarker,
     EpisodeId,
     FilePath,
     Genre,
-    IntroDetectionState,
-    IntroMarker,
-    SeasonId,
     SeriesId,
     Title,
 )
 from src.shared_kernel.value_objects.library_id import LibraryId
 
 
-class SeriesRepository(ABC):
-    """Repository interface for Series aggregate.
+class SeriesCatalogRepository(ABC):
+    """Lean catalog port for the Series aggregate.
 
-    This is a port in the hexagonal architecture pattern.
-    Implementations (adapters) will be in the infrastructure layer.
+    CRUD, search, pagination, episode lookup, and stats — the stable
+    core that every catalog consumer depends on. Job-oriented concerns
+    (artwork mirror, intro detection, credits detection, scrub preview)
+    live in their own role-interfaces (ADR-033).
     """
 
     @abstractmethod
@@ -182,7 +198,7 @@ class SeriesRepository(ABC):
         """List the most recently added series.
 
         Sorted by ``id DESC`` — same justification as
-        ``MovieRepository.list_recently_added``. The home-page
+        ``MovieCatalogRepository.list_recently_added``. The home-page
         carousel consumes a fixed top N, so no cursor or pagination
         metadata is involved.
 
@@ -208,7 +224,7 @@ class SeriesRepository(ABC):
     ) -> Sequence[GenreRow]:
         """Project the genre columns of every non-deleted series row.
 
-        Same contract as ``MovieRepository.list_genre_rows`` — see
+        Same contract as ``MovieCatalogRepository.list_genre_rows`` — see
         that method for the full description. Used by the catalog
         genres aggregation use case to compute counts and resolve
         localized labels without loading the full series hierarchy.
@@ -232,10 +248,10 @@ class SeriesRepository(ABC):
         defaulting to ``(LOWER(COALESCE(localized[lang].title, title))
         ASC, id ASC)``. For ``year_*`` sorts the series ``start_year``
         is the release-year key. Same contract as
-        ``MovieRepository.list_paginated_by_genre`` — see that method
-        for the full description of the sort-bound cursor format and the
-        genre filter (whole-word LIKE on the comma-separated ``genres``
-        column).
+        ``MovieCatalogRepository.list_paginated_by_genre`` — see that
+        method for the full description of the sort-bound cursor format and
+        the genre filter (whole-word LIKE on the comma-separated
+        ``genres`` column).
         """
         ...
 
@@ -252,7 +268,7 @@ class SeriesRepository(ABC):
     ) -> list[tuple[Series, float]]:
         """Full-text search over title, synopsis, and genres.
 
-        Same contract as ``MovieRepository.search`` — returns
+        Same contract as ``MovieCatalogRepository.search`` — returns
         ``(series, rank)`` tuples ordered by relevance.
         """
         ...
@@ -386,9 +402,9 @@ class SeriesRepository(ABC):
     async def find_episode_by_id(self, episode_id: EpisodeId) -> Episode | None:
         """Return a single episode by external id, detached from its series.
 
-        Used by orchestration code (eager scrub-preview generation) that
-        needs to act on one episode without loading its parent ``Series``
-        and all sibling episodes.
+        Used by orchestration code (eager scrub-preview generation, manual
+        intro/credits edits) that needs to act on one episode without
+        loading its parent ``Series`` and all sibling episodes.
 
         Args:
             episode_id: External id of the episode (epi_xxx).
@@ -400,297 +416,8 @@ class SeriesRepository(ABC):
         ...
 
     @abstractmethod
-    async def find_episodes_missing_scrub_preview(self, limit: int) -> Sequence[Episode]:
-        """Return up to ``limit`` episodes that have no scrub-preview thumbnails yet.
-
-        Returned ``Episode`` aggregates are detached from their parent
-        ``Series``; the backfill job only needs the file path and id to
-        do its work and this avoids loading a full series hierarchy per
-        episode. Soft-deleted episodes are excluded.
-
-        Args:
-            limit: Maximum number of episodes to return.
-
-        Returns:
-            Sequence of episodes whose ``scrub_preview_path`` is null.
-        """
-        ...
-
-    @abstractmethod
-    async def update_episode_scrub_preview_path(
-        self,
-        episode_id: EpisodeId,
-        path: str | None,
-    ) -> bool:
-        """Persist the scrub-preview path for a single episode.
-
-        Provided alongside ``find_episodes_missing_scrub_preview`` so
-        the backfill job can mark items processed without round-tripping
-        the entire ``Series`` aggregate — that round-trip would dominate
-        runtime on series with many episodes.
-
-        Args:
-            episode_id: External id of the episode to update.
-            path: Absolute path to the sprite VTT, or ``None`` to clear.
-
-        Returns:
-            ``True`` if a row was updated, ``False`` if no episode with
-            that id exists.
-        """
-        ...
-
-    @abstractmethod
-    async def find_with_remote_artwork(self, limit: int) -> Sequence[RemoteArtworkRow]:
-        """Return up to ``limit`` series with a still-remote artwork URL.
-
-        Mirror of ``MovieRepository.find_with_remote_artwork`` over
-        series ``poster_path`` / ``backdrop_path`` / ``logo_path``. Season
-        posters and episode stills are handled separately (ADR-029 PR 3).
-        """
-        ...
-
-    @abstractmethod
-    async def update_series_artwork(self, series_id: SeriesId, artwork: ArtworkColumns) -> None:
-        """Set the three artwork columns for one series by external id.
-
-        A targeted column update rather than an aggregate ``save`` so the
-        mirror job never risks persisting the series with its seasons and
-        episodes unloaded. ``artwork`` carries the final value for every
-        column.
-        """
-        ...
-
-    @abstractmethod
-    async def find_seasons_with_remote_poster(self, limit: int) -> Sequence[RemoteArtworkRow]:
-        """Return up to ``limit`` seasons whose poster is still a remote URL.
-
-        ``RemoteArtworkRow.media_id`` is the season external id (``ssn_xxx``)
-        and only ``artwork.poster`` is populated — seasons carry no
-        backdrop/logo column.
-        """
-        ...
-
-    @abstractmethod
-    async def update_season_artwork(self, season_id: SeasonId, artwork: ArtworkColumns) -> None:
-        """Set a single season's poster column by external id.
-
-        Direct column update on the ``seasons`` table — the mirror job
-        never round-trips the ``Series`` aggregate. Only ``artwork.poster``
-        is written; the other fields are ignored (no such columns).
-        """
-        ...
-
-    @abstractmethod
-    async def find_episodes_with_remote_thumbnail(self, limit: int) -> Sequence[RemoteArtworkRow]:
-        """Return up to ``limit`` episodes whose still is still a remote URL.
-
-        ``RemoteArtworkRow.media_id`` is the episode external id
-        (``epi_xxx``) and only ``artwork.still`` is populated — the
-        episode still is its single mirrorable image. Soft-deleted
-        episodes are excluded.
-        """
-        ...
-
-    @abstractmethod
-    async def update_episode_thumbnail(
-        self, episode_id: EpisodeId, artwork: ArtworkColumns
-    ) -> None:
-        """Set a single episode's still (``thumbnail_path``) by external id.
-
-        Direct column update on the ``episodes`` table — no aggregate
-        round-trip. Only ``artwork.still`` is written.
-        """
-        ...
-
-    @abstractmethod
-    async def find_seasons_pending_intro_detection(
-        self,
-        limit: int,
-        *,
-        stale_before: datetime,
-    ) -> Sequence[Season]:
-        """Return seasons whose intro-detection job has not converged yet.
-
-        A season is eligible when it is:
-
-        * ``NOT_STARTED`` — never attempted; or
-        * ``INSUFFICIENT_EPISODES`` *and* its current (non-deleted)
-          episode count exceeds ``intro_detection_attempted_episode_count``
-          — i.e. new episodes landed since the last attempt, so the
-          outcome could now differ. A season whose episode set hasn't
-          grown is NOT retried, so a permanently-small season (e.g. a
-          2-part miniseries) stops monopolising the queue; or
-        * ``IN_PROGRESS`` with ``intro_detection_attempted_at`` older than
-          ``stale_before`` — an orphaned claim (the worker died
-          mid-detection), reclaimed so it self-heals.
-
-        ``COMPLETED``, ``FAILED``, and ``DISABLED`` are excluded;
-        ``FAILED`` and ``DISABLED`` require an explicit operator reset.
-
-        Ordered by ``intro_detection_attempted_at`` ascending with NULLs
-        first, then ``id``, so never-attempted seasons run before any
-        already-attempted one.
-
-        Returned ``Season`` entities have their ``episodes`` collection
-        eagerly loaded (with file variants) so the detection job can
-        iterate file paths without N+1 queries. Soft-deleted seasons
-        and episodes are filtered out.
-
-        Args:
-            limit: Maximum number of seasons to return.
-            stale_before: Cutoff for reclaiming orphaned ``IN_PROGRESS``
-                seasons — those last attempted before this instant are
-                considered abandoned and made eligible again.
-
-        Returns:
-            Sequence of seasons eligible for the next detection tick.
-        """
-        ...
-
-    @abstractmethod
-    async def update_season_intro_detection(
-        self,
-        season_id: SeasonId,
-        state: IntroDetectionState,
-        *,
-        attempted_at: datetime | None = None,
-        attempted_episode_count: int | None = None,
-        error: str | None = None,
-    ) -> bool:
-        """Persist intro-detection job state for a season.
-
-        Direct UPDATE on the ``seasons`` table — analogous to
-        ``update_episode_scrub_preview_path`` — so the detection job can
-        record progress and outcomes without round-tripping the parent
-        ``Series`` aggregate per season. Domain-side state machine
-        validation belongs on the ``Season`` entity; callers are expected
-        to drive transitions via ``with_detection_started`` etc. and pass
-        the resulting state here.
-
-        Args:
-            season_id: External id of the season (sea_xxx).
-            state: New ``IntroDetectionState`` value.
-            attempted_at: When the job ran. Pass ``None`` to leave the
-                column unchanged for transient transitions like
-                ``IN_PROGRESS``.
-            attempted_episode_count: Episode count observed this attempt,
-                used to decide whether an ``INSUFFICIENT_EPISODES`` season
-                is worth retrying later. Pass ``None`` to leave it
-                unchanged (e.g. on the ``IN_PROGRESS`` claim).
-            error: Diagnostic message for ``FAILED`` runs, or ``None`` to
-                clear.
-
-        Returns:
-            ``True`` if a row was updated, ``False`` if no season with
-            that id exists.
-        """
-        ...
-
-    @abstractmethod
-    async def update_episode_intro(
-        self,
-        episode_id: EpisodeId,
-        marker: IntroMarker | None,
-    ) -> bool:
-        """Persist (or clear) the intro marker for a single episode.
-
-        Direct UPDATE on the ``episodes`` table covering all five intro
-        columns at once. The detection job calls this per-episode after
-        cross-correlation; the manual-edit endpoint also uses it to set
-        a ``MANUAL`` marker without rewriting the entire ``Series``
-        aggregate.
-
-        Args:
-            episode_id: External id of the episode (epi_xxx).
-            marker: The marker to persist, or ``None`` to clear all five
-                intro columns.
-
-        Returns:
-            ``True`` if a row was updated, ``False`` if no episode with
-            that id exists.
-        """
-        ...
-
-    @abstractmethod
-    async def clear_auto_intro_markers_for_season(self, season_id: SeasonId) -> int:
-        """Clear AUTO_DETECTED intro markers on a season's episodes.
-
-        Bulk UPDATE that nulls the five intro columns for every episode
-        of the season whose marker source is ``AUTO_DETECTED``. MANUAL
-        markers are left untouched. Used by the re-detect flow so a
-        re-run starts from a clean slate without dropping operator edits.
-
-        Args:
-            season_id: External id of the season (ssn_xxx).
-
-        Returns:
-            The number of episode rows cleared.
-        """
-        ...
-
-    @abstractmethod
-    async def count_episode_credits_states(self) -> dict[str, int]:
-        """Return ``{credits_detection_state: count}`` over non-deleted episodes."""
-        ...
-
-    @abstractmethod
     async def episode_file_size_by_library(self) -> dict[str, int]:
         """Return ``{library_id: total episode primary-file bytes}``."""
-        ...
-
-    @abstractmethod
-    async def list_episode_credits_status(
-        self, state: str | None, limit: int, offset: int
-    ) -> tuple[Sequence[CreditsStatusRow], int]:
-        """Return a page of episode credits-status rows + the total count.
-
-        Rows carry ``series_id``/``season_number``/``episode_number`` so the
-        admin UI can deep-link into the per-episode editor. Newest-marker
-        first, then by series + season + episode.
-        """
-        ...
-
-    @abstractmethod
-    async def find_episodes_pending_credits_detection(self, limit: int) -> Sequence[Episode]:
-        """Return episodes whose credits detection has not run yet.
-
-        Filters for episodes in ``NOT_STARTED`` credits-detection state
-        (per-file, unlike the season-scoped intro detection), with their
-        file variants eager-loaded so the job can read the primary file
-        path without an N+1. Soft-deleted episodes are excluded.
-
-        Args:
-            limit: Maximum number of episodes to return.
-
-        Returns:
-            Sequence of episodes eligible for the next credits tick.
-        """
-        ...
-
-    @abstractmethod
-    async def update_episode_credits(
-        self,
-        episode_id: EpisodeId,
-        marker: CreditsMarker | None,
-        state: CreditsDetectionState,
-    ) -> bool:
-        """Persist the credits marker + detection state for one episode.
-
-        Direct UPDATE of the four credits-marker columns plus
-        ``credits_detection_state`` on the ``episodes`` row, avoiding a
-        round-trip through the ``Series`` aggregate. ``marker=None`` clears
-        the marker columns (used for IN_PROGRESS / NO_CREDITS_FOUND /
-        FAILED transitions and for clearing); a non-null marker writes the
-        onset (used on COMPLETED and manual edits).
-
-        Args:
-            episode_id: External id of the episode (epi_xxx).
-            marker: The marker to persist, or ``None`` to clear it.
-            state: New ``CreditsDetectionState`` value.
-
-        Returns:
-            ``True`` if a row was updated, ``False`` if no episode matched.
-        """
         ...
 
     @abstractmethod
@@ -721,4 +448,20 @@ class SeriesRepository(ABC):
         ...
 
 
-__all__ = ["SeriesRepository"]
+class SeriesRepository(
+    SeriesCatalogRepository,
+    SeriesScrubPreviewRepository,
+    SeriesArtworkMirrorRepository,
+    SeriesIntroDetectionRepository,
+    SeriesCreditsDetectionRepository,
+):
+    """Composite Series repository — the full port over the series tables.
+
+    Unions the lean catalog with every job-oriented role-interface
+    (ADR-033). This is the type the ``MediaUnitOfWork`` exposes as
+    ``.series`` and the SQLAlchemy adapter implements; a consumer that
+    only needs one concern should depend on the narrow role instead.
+    """
+
+
+__all__ = ["SeriesCatalogRepository", "SeriesRepository"]

--- a/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/movie_repository.py
@@ -15,10 +15,10 @@ from src.building_blocks.application.pagination import (
 )
 from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.entities import Movie
-from src.modules.media.domain.repositories import MovieRepository
-from src.modules.media.domain.repositories.movie_repository import (
+from src.modules.media.domain.repositories import (
     CreditsStatusRow,
     GenreRow,
+    MovieRepository,
     RemoteArtworkRow,
 )
 from src.modules.media.domain.value_objects import (

--- a/src/modules/media/infrastructure/persistence/repositories/series_repository.py
+++ b/src/modules/media/infrastructure/persistence/repositories/series_repository.py
@@ -14,11 +14,11 @@ from src.building_blocks.application.pagination import (
 )
 from src.building_blocks.domain.pagination import PaginatedResult, Pagination
 from src.modules.media.domain.entities import Episode, Season, Series
-from src.modules.media.domain.repositories import SeriesRepository
-from src.modules.media.domain.repositories.movie_repository import (
+from src.modules.media.domain.repositories import (
     CreditsStatusRow,
     GenreRow,
     RemoteArtworkRow,
+    SeriesRepository,
 )
 from src.modules.media.domain.value_objects import (
     ArtworkColumns,

--- a/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
+++ b/tests/modules/media/unit/infrastructure/scheduling/test_artwork_mirror_job.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from src.building_blocks.infrastructure.errors import GatewayUnavailableException
 from src.infrastructure.scheduling.artwork_mirror_job import ArtworkMirrorJob
 from src.modules.media.application.ports.artwork_downloader_port import DownloadedImage
-from src.modules.media.domain.repositories.movie_repository import RemoteArtworkRow
+from src.modules.media.domain.repositories.artwork_mirror_repository import RemoteArtworkRow
 from src.modules.media.domain.value_objects import ArtworkColumns, ImageUrl
 from src.modules.settings.domain.value_objects import ArtworkMirrorConfig
 


### PR DESCRIPTION
## Summary

Onda 3 item 3.1 of the tech-debt remediation plan — implements **ADR-033 (Interface Segregation em Repositórios)**. The enabler for the media subdomain extraction (ADR-032).

The `MovieRepository` (29 methods) and `SeriesRepository` (36) ABCs were god-interfaces mixing unrelated reasons-to-change: catalog CRUD/search alongside artwork-mirror, credits-detection, intro-detection, and scrub-preview job concerns. Split into:

- **Lean catalog ports** — `MovieCatalogRepository`, `SeriesCatalogRepository` (CRUD, search, pagination, variant surgery, stats).
- **Role-interfaces** (the unit that migrates with its subdomain in ADR-032):
  - `MovieArtworkMirrorRepository` / `SeriesArtworkMirrorRepository`
  - `MovieCreditsDetectionRepository` / `SeriesCreditsDetectionRepository`
  - `SeriesIntroDetectionRepository` (series-only — movies have no intro markers)
  - `MovieScrubPreviewRepository` / `SeriesScrubPreviewRepository`
- **Composite facades** — `MovieRepository` / `SeriesRepository` now union the lean catalog + their roles, so the `MediaUnitOfWork.movies`/`.series` accessors and the SQLAlchemy adapters are **unchanged** (one class per table satisfies every role, ADR-033 §Decisão). Zero consumer signature changes — every consumer already reaches the repos through the UoW.
- The `RemoteArtworkRow` / `CreditsStatusRow` projections move to their role modules; `GenreRow` stays with the catalog.

## Test plan

- [x] `mypy src` — clean (781 files)
- [x] `ruff check` — clean
- [x] `pytest tests/modules/media` — 1982 passed, 3 skipped (1 failure is a pre-existing Windows `os.symlink` privilege flake in `test_scanner`, unrelated; passes on Linux CI)

## Related issues

- ADR-033 (this PR), enabler for ADR-032 (media subdomain decomposition)

## Summary by Sourcery

Segregate media catalog repositories into lean catalog interfaces and focused role-specific interfaces while preserving existing unit-of-work and adapter contracts.

Enhancements:
- Introduce MovieCatalogRepository and SeriesCatalogRepository as lean catalog ports for CRUD, search, pagination, and stats.
- Extract artwork-mirror, credits-detection, intro-detection, and scrub-preview responsibilities into dedicated role interfaces shared by movies and series.
- Recompose MovieRepository and SeriesRepository as composite facades that implement the catalog and all role interfaces without changing MediaUnitOfWork usage or SQLAlchemy adapters.
- Centralize shared projections like CreditsStatusRow, RemoteArtworkRow, and GenreRow in role-specific modules and the media.repositories package for clearer reuse.
- Update infrastructure repositories, jobs, use cases, and tests to depend on the new role interfaces and consolidated exports without altering behavior.