### PR TITLE
refactor(streaming): extract pure seams from hls_service

### DIFF
--- a/src/modules/media/infrastructure/streaming/_hls_common.py
+++ b/src/modules/media/infrastructure/streaming/_hls_common.py
@@ -1,0 +1,28 @@
+"""Neutral shared helpers and constants for the HLS streaming package.
+
+Housed here — rather than on ``hls_service`` — so the extracted seams
+(the transcode command builder and the master-playlist writer) can depend
+on them without importing ``hls_service`` back. ``hls_service`` imports the
+seams, so a seam importing ``hls_service`` would be a circular import; this
+module has no such dependency and stays safe to import from either side.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.modules.media.application.ports.media_probe_port import ProbeResult
+
+# seconds per segment
+SEGMENT_DURATION = 10
+
+# Video codecs a browser can play as-is, so the pipeline can remux instead
+# of transcoding. Shared by the command builder (video cmd) and the
+# orchestrator (HW-transcode eligibility decision).
+BROWSER_SAFE_CODECS = {"h264"}
+
+
+def primary_audio_index(probe: ProbeResult) -> int:
+    """Get the index of the primary audio track (first one, always index 0)."""
+    return probe.audio_tracks[0].index if probe.audio_tracks else 0

--- a/src/modules/media/infrastructure/streaming/hardware_acceleration_probe.py
+++ b/src/modules/media/infrastructure/streaming/hardware_acceleration_probe.py
@@ -1,0 +1,144 @@
+"""Hardware-acceleration (NVENC/CUDA) capability probing for HLS transcodes.
+
+Extracted from ``HlsService`` (pure, no locks/threads): decides whether a
+transcode should run on the GPU. Wraps the persisted ``hw_accel`` knob and
+memoises the one-time functional NVENC probe so the first AUTO-mode
+transcode pays the cold CUDA init once and every later call reads a cached
+boolean.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import TYPE_CHECKING
+
+from src.modules.media.infrastructure.streaming._subprocess import (
+    HW_ACCEL_NVENC,
+    HW_ACCEL_OFF,
+    SUBPROCESS_TEXT_KWARGS,
+)
+
+if TYPE_CHECKING:
+    from src.modules.media.application.ports.runtime_config_ports import HlsRuntimeConfigPort
+
+_logger = logging.getLogger(__name__)
+
+# Wall-clock cap for the one-time NVENC functional probe. Deliberately
+# generous: the probe is the process's first CUDA call, so it absorbs the
+# cold driver / context init, which was measured at ~20s on a cold but
+# perfectly working GPU. Cutting this to a few seconds would time out
+# that cold init and make AUTO mode fall back to software on a host that
+# actually has a usable encoder — the exact false negative this feature
+# exists to avoid. The cost (a longer first play once per process on a
+# hung driver) fits inside the 120s first-segment budget.
+_NVENC_PROBE_TIMEOUT = 30
+
+
+class HardwareAccelerationProbe:
+    """Resolve whether a transcode should use NVENC, honouring ``hw_accel``.
+
+    Args:
+        runtime_settings: Snapshot facade for :class:`StreamingConfig`.
+            ``hw_accel`` is read fresh per decision via the sync snapshot.
+    """
+
+    def __init__(self, runtime_settings: HlsRuntimeConfigPort) -> None:
+        self._runtime_settings = runtime_settings
+        # Memoised result of the one-time NVENC functional probe (None
+        # until first transcode in AUTO mode forces the check).
+        self._nvenc_probe: bool | None = None
+
+    @staticmethod
+    def probe_video_codec(file_path: str) -> str | None:
+        """Detect video codec using ffprobe."""
+        try:
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=codec_name",
+                    "-of",
+                    "default=noprint_wrappers=1:nokey=1",
+                    file_path,
+                ],
+                **SUBPROCESS_TEXT_KWARGS,
+                check=False,
+                timeout=10,
+            )
+            codec = result.stdout.strip().lower()
+            return codec if codec else None
+        except Exception:
+            return None
+
+    @staticmethod
+    def detect_nvenc() -> bool:
+        """Functionally probe whether ``h264_nvenc`` can actually encode.
+
+        The encoder being *listed* by ffmpeg is not enough — a host can
+        ship an ffmpeg with NVENC compiled in while lacking the GPU,
+        driver, or a free encode session. We run a sub-second throwaway
+        encode of a synthetic source through CUDA so AUTO mode only
+        commits to NVENC when the full decode→encode path works.
+
+        Returns ``True`` only on a clean (exit 0) probe encode.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-hide_banner",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=c=black:s=256x256:r=10",
+                    "-t",
+                    "0.2",
+                    "-c:v",
+                    "h264_nvenc",
+                    "-f",
+                    "null",
+                    "-",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=_NVENC_PROBE_TIMEOUT,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return result.returncode == 0
+
+    def nvenc_available(self) -> bool:
+        """Return the memoised NVENC functional-probe result.
+
+        Probed at most once per instance — the first transcode in AUTO
+        mode pays the ~1s cold-start CUDA init, every later call reads
+        the cached boolean.
+        """
+        if self._nvenc_probe is None:
+            self._nvenc_probe = self.detect_nvenc()
+            _logger.info("NVENC functional probe result: %s", self._nvenc_probe)
+        return self._nvenc_probe
+
+    def use_nvenc(self) -> bool:
+        """Decide whether this transcode should use NVENC.
+
+        Honours the persisted ``hw_accel`` knob: ``off`` forces
+        software, ``nvenc`` forces hardware (a broken encoder then
+        surfaces as a transcode failure rather than silently falling
+        back), and ``auto`` defers to the cached functional probe.
+        """
+        mode = self._runtime_settings.streaming_snapshot_sync().hw_accel
+        if mode == HW_ACCEL_OFF:
+            return False
+        if mode == HW_ACCEL_NVENC:
+            return True
+        return self.nvenc_available()
+
+
+__all__ = ["HardwareAccelerationProbe"]

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -789,7 +789,9 @@ class HlsService(HlsPlaylistPort):
                 audio_dir = output_dir / f"audio_{track.index}"
                 audio_dir.mkdir()
                 cmd = with_ffmpeg_threads(
-                    self._cmd_builder.build_audio_cmd(safe_path, audio_dir, track, bucket_start, end),
+                    self._cmd_builder.build_audio_cmd(
+                        safe_path, audio_dir, track, bucket_start, end
+                    ),
                     ffmpeg_threads,
                 )
                 _logger.info(

--- a/src/modules/media/infrastructure/streaming/hls_service.py
+++ b/src/modules/media/infrastructure/streaming/hls_service.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-import json
 import logging
 import re
 import shutil
@@ -49,34 +48,36 @@ from src.modules.media.application.ports.hls_playlist_port import (
     HlsCacheStats,
     HlsPlaylistPort,
 )
-from src.modules.media.application.ports.media_probe_port import ProbeResult
-from src.modules.media.domain.services.track_naming import (
-    TrackVersion,
-    audio_version_labels,
-    render_version_token,
-    subtitle_version_labels,
+from src.modules.media.infrastructure.streaming._hls_common import (
+    BROWSER_SAFE_CODECS,
+    primary_audio_index,
 )
 from src.modules.media.infrastructure.streaming._subprocess import (
-    HW_ACCEL_NVENC,
-    HW_ACCEL_OFF,
     SUBPROCESS_TEXT_KWARGS,
     with_ffmpeg_threads,
 )
+from src.modules.media.infrastructure.streaming.hardware_acceleration_probe import (
+    HardwareAccelerationProbe,
+)
+from src.modules.media.infrastructure.streaming.master_playlist_writer import MasterPlaylistWriter
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
+from src.modules.media.infrastructure.streaming.probe_cache_store import ProbeCacheStore
 from src.modules.media.infrastructure.streaming.subtitle_ocr_surfacing import (
     attach_ocr_subtitles,
 )
+from src.modules.media.infrastructure.streaming.transcode_command_builder import (
+    TranscodeCommandBuilder,
+)
 
 if TYPE_CHECKING:
+    from src.modules.media.application.ports.media_probe_port import ProbeResult
     from src.modules.media.application.ports.runtime_config_ports import HlsRuntimeConfigPort
-    from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+    from src.shared_kernel.value_objects.tracks import SubtitleTrack
 
 _logger = logging.getLogger(__name__)
 
-_SEGMENT_DURATION = 10  # seconds per segment
 _POLL_INTERVAL = 0.5  # seconds between readiness checks
 _POLL_TIMEOUT = 120  # max seconds to wait for first segment
-_BROWSER_SAFE_CODECS = {"h264"}
 
 # Number of segments ffmpeg must produce before ensure_playlist returns.
 # The transcode always starts at t=0, so one segment is enough to give
@@ -97,165 +98,6 @@ _VIDEO_DIR = "video"
 # path and is awaiting deletion. The eviction scan skips (and retries
 # cleaning) these so they are never mistaken for a real bucket.
 _EVICTING_PREFIX = ".evicting-"
-
-# Wall-clock cap for the one-time NVENC functional probe. Deliberately
-# generous: the probe is the process's first CUDA call, so it absorbs the
-# cold driver / context init, which was measured at ~20s on a cold but
-# perfectly working GPU. Cutting this to a few seconds would time out
-# that cold init and make AUTO mode fall back to software on a host that
-# actually has a usable encoder — the exact false negative this feature
-# exists to avoid. The cost (a longer first play once per process on a
-# hung driver) fits inside the 120s first-segment budget.
-_NVENC_PROBE_TIMEOUT = 30
-
-# -- Module helpers -----------------------------------------------------------
-
-
-def _primary_audio_index(probe: ProbeResult) -> int:
-    """Get the index of the primary audio track (first one, always index 0)."""
-    return probe.audio_tracks[0].index if probe.audio_tracks else 0
-
-
-# A leading audio offset above this many seconds is treated as a gap that
-# must be padded with silence (see ``_first_audio_pts``). The threshold is
-# generous — normal muxing jitter is a few milliseconds, so anything past a
-# quarter-second is a real hole at the head of the track, not noise.
-_AUDIO_LEADING_GAP_THRESHOLD = 0.25
-
-
-def _first_audio_pts(file_path: str, audio_index: int) -> float | None:
-    """Return the PTS (seconds) of the first packet of one audio stream.
-
-    Some source files carry an audio track whose first sample lands well
-    after t=0 (e.g. an 11-second silent hole at the head of the stream).
-    Muxed into HLS from t=0, the leading segments then declare an audio
-    stream that has *no* frames yet, and hls.js — which needs the audio
-    codec from the first fragment — stalls forever on that phantom track
-    instead of ever appending a buffer. Detecting the offset lets the
-    caller pad it with silence and keep the copy fast-path off files that
-    would otherwise ship an empty-audio first segment.
-
-    Args:
-        file_path: Absolute path to the source video file.
-        audio_index: Stream index *within the audio streams* (the ``N`` in
-            ffmpeg's ``0:a:N``), matching how the transcode maps it.
-
-    Returns:
-        The first packet's presentation timestamp in seconds, or ``None``
-        if ffprobe fails or reports no readable timestamp (caller then
-        assumes no gap).
-    """
-    try:
-        result = subprocess.run(
-            [
-                "ffprobe",
-                "-v",
-                "error",
-                "-select_streams",
-                f"a:{audio_index}",
-                "-read_intervals",
-                "%+#1",
-                "-show_entries",
-                "packet=pts_time",
-                "-of",
-                "default=noprint_wrappers=1:nokey=1",
-                file_path,
-            ],
-            **SUBPROCESS_TEXT_KWARGS,
-            check=False,
-            timeout=10,
-        )
-    except Exception:
-        return None
-    raw = result.stdout.strip().splitlines()
-    if not raw:
-        return None
-    try:
-        return float(raw[0])
-    except ValueError:
-        return None
-
-
-def _has_leading_audio_gap(file_path: str, audio_index: int, start: int) -> bool:
-    """Whether a mapped audio stream begins meaningfully after t=0.
-
-    Only meaningful for the initial (``start == 0``) bucket — a seek
-    bucket lands mid-stream where audio already exists and normalises its
-    own timestamps, so we skip the probe there and never treat it as a
-    gap. See :func:`_first_audio_pts` for why the gap matters.
-    """
-    if start != 0:
-        return False
-    pts = _first_audio_pts(file_path, audio_index)
-    return pts is not None and pts > _AUDIO_LEADING_GAP_THRESHOLD
-
-
-def _manifest_track_name(language: str, version: TrackVersion | None) -> str:
-    """Compose a fallback ``NAME=`` for a manifest rendition.
-
-    The manifest can't carry structured data and isn't localized, so we
-    use the language code plus a short version token (e.g. "PT",
-    "PT · Herbert Richers", "PT · 5.1"). Clients should prefer the
-    structured ``/tracks`` payload and localize it themselves.
-    """
-    base = language.upper()
-    token = render_version_token(version)
-    return f"{base} · {token}" if token else base
-
-
-def _audio_args_for(
-    track: AudioTrack | None,
-    start: int,
-    leading_gap: bool = False,
-) -> list[str]:
-    """Pick the ffmpeg audio args for one HLS track: copy or re-encode.
-
-    Re-encoding every audio track to AAC stereo 48 kHz is wasted work
-    when the source already *is* browser-playable AAC. We remux with
-    ``-c:a copy`` only when the track is unambiguously safe to drop into
-    MPEG-TS untouched:
-
-    - **AAC-LC** — the one AAC profile MSE/hls.js decode everywhere;
-      HE-AAC (SBR/PS) is excluded because browser support is spotty.
-    - **stereo** — multichannel must be downmixed to 2.0 for the player.
-    - **48 kHz** — matches the rate the re-encode path normalises to, so
-      a copied stream is byte-for-byte what a transcode would have
-      targeted.
-    - **start == 0** — a non-zero resume offset re-encodes the video with
-      ``-accurate_seek``; copying the audio there would land it at the
-      nearest packet instead of the exact second and drift out of sync.
-    - **no leading gap** — a track whose first sample lands after t=0
-      (``leading_gap``) must be re-encoded so the silence filter below
-      can backfill the hole; copying would preserve it and ship an
-      empty-audio first segment that stalls hls.js.
-
-    Anything else (unknown profile/rate, non-AAC, surround, mid-stream
-    seek, leading gap) falls back to the safe AAC re-encode.
-
-    On the re-encode path for an initial (``start == 0``) bucket we add
-    ``aresample=async=1:first_pts=0``. It pads any leading offset with
-    silence so the audio starts at t=0 and the first HLS segment carries
-    decodable frames — without it, a file whose audio begins late (a real
-    silent intro) yields a first segment with a declared-but-empty audio
-    stream, and hls.js hangs on "preparing" forever. It is a no-op for a
-    track that already starts at zero. The seek path (``start > 0``)
-    already normalises timestamps via ``-avoid_negative_ts make_zero`` and
-    is left untouched.
-    """
-    if (
-        track is not None
-        and start == 0
-        and not leading_gap
-        and track.codec == "aac"
-        and track.is_stereo
-        and track.sample_rate == 48000
-        and (track.profile or "").strip().upper() == "LC"
-    ):
-        return ["-c:a", "copy"]
-    args = ["-c:a", "aac", "-ac", "2", "-ar", "48000"]
-    if start == 0:
-        args += ["-af", "aresample=async=1:first_pts=0"]
-    return args
 
 
 class HlsService(HlsPlaylistPort):
@@ -288,6 +130,11 @@ class HlsService(HlsPlaylistPort):
         self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._probe = probe_service or MediaProbeService()
         self._runtime_settings = runtime_settings
+        # Extracted collaborators (pure — no locks/threads/process state).
+        self._hw_probe = HardwareAccelerationProbe(runtime_settings)
+        self._cmd_builder = TranscodeCommandBuilder(self._hw_probe)
+        self._probe_cache = ProbeCacheStore(self._cache_dir)
+        self._master_writer = MasterPlaylistWriter()
         self._processes: dict[str, list[subprocess.Popen[bytes]]] = {}
         # path_hash → monotonic timestamp of the most recent activity
         # (playlist request OR segment fetch). The eviction loop reads
@@ -300,9 +147,6 @@ class HlsService(HlsPlaylistPort):
         self._subtitle_events: dict[str, dict[int, threading.Event]] = {}
         self._lock = threading.Lock()
         self._idle_timeout = idle_timeout
-        # Memoised result of the one-time NVENC functional probe (None
-        # until first transcode in AUTO mode forces the check).
-        self._nvenc_probe: bool | None = None
         if enable_eviction:
             self._start_eviction_thread()
 
@@ -594,14 +438,7 @@ class HlsService(HlsPlaylistPort):
 
     def get_cached_tracks(self, path_hash: str) -> dict[str, Any] | None:
         """Get cached probe result from tracks.json."""
-        tracks_file = self._cache_dir / path_hash / "tracks.json"
-        if not tracks_file.is_file():
-            return None
-        try:
-            data: dict[str, Any] = json.loads(tracks_file.read_text(encoding="utf-8"))
-            return data
-        except (OSError, json.JSONDecodeError):
-            return None
+        return self._probe_cache.get_cached_tracks(path_hash)
 
     async def ensure_playlist(self, file_path: str, start: int = 0, end: int | None = None) -> str:
         """Start generation and wait until the first segments are ready.
@@ -674,11 +511,11 @@ class HlsService(HlsPlaylistPort):
         init, NVDEC capability, transient GPU contention) recovers on the
         libx264 path, whereas a software failure would just repeat.
         """
-        if not self._use_nvenc():
+        if not self._hw_probe.use_nvenc():
             return False
         if start > 0:
             return True
-        return self._probe_video_codec(file_path) not in _BROWSER_SAFE_CODECS
+        return self._hw_probe.probe_video_codec(file_path) not in BROWSER_SAFE_CODECS
 
     async def _generate_and_wait(
         self,
@@ -731,7 +568,7 @@ class HlsService(HlsPlaylistPort):
         """
         path_hash = self.get_path_hash(file_path)
         cached = self.get_cached_tracks(path_hash)
-        base = self._deserialize_probe(cached) if cached else self._probe.probe(file_path)
+        base = self._probe_cache.deserialize(cached) if cached else self._probe.probe(file_path)
         return attach_ocr_subtitles(
             base, file_path, self._runtime_settings.subtitle_ocr_snapshot_sync()
         )
@@ -926,7 +763,7 @@ class HlsService(HlsPlaylistPort):
                 shutil.rmtree(output_dir, ignore_errors=True)
 
             output_dir.mkdir(parents=True, exist_ok=True)
-            self._save_probe_cache(output_dir, probe_result)
+            self._probe_cache.save(output_dir, probe_result)
 
             procs: list[subprocess.Popen[bytes]] = []
 
@@ -934,7 +771,7 @@ class HlsService(HlsPlaylistPort):
             video_dir = output_dir / _VIDEO_DIR
             video_dir.mkdir()
             cmd = with_ffmpeg_threads(
-                self._build_video_cmd(
+                self._cmd_builder.build_video_cmd(
                     safe_path, video_dir, probe_result, bucket_start, force_software, end
                 ),
                 ffmpeg_threads,
@@ -945,14 +782,14 @@ class HlsService(HlsPlaylistPort):
             )
 
             # 2. Additional audio tracks (audio-only HLS)
-            primary_audio_idx = _primary_audio_index(probe_result)
+            primary_audio_idx = primary_audio_index(probe_result)
             for track in probe_result.audio_tracks:
                 if track.index == primary_audio_idx:
                     continue
                 audio_dir = output_dir / f"audio_{track.index}"
                 audio_dir.mkdir()
                 cmd = with_ffmpeg_threads(
-                    self._build_audio_cmd(safe_path, audio_dir, track, bucket_start, end),
+                    self._cmd_builder.build_audio_cmd(safe_path, audio_dir, track, bucket_start, end),
                     ffmpeg_threads,
                 )
                 _logger.info(
@@ -973,7 +810,7 @@ class HlsService(HlsPlaylistPort):
             # so racing them against playback start is safe. Uses ``probe_view``
             # so surfaced OCR text tracks (ADR-027) get a ``sub_N`` rendition
             # matching ``text_subs``.
-            self._build_master_playlist(output_dir, probe_view)
+            self._master_writer.write(output_dir, probe_view)
 
             # 4. Pre-create per-subtitle readiness events. They MUST be
             # registered before _start_generation returns so the file
@@ -1055,324 +892,6 @@ class HlsService(HlsPlaylistPort):
             _logger.info("Sealed HLS playlist with ENDLIST: %s", playlist_path)
         except OSError:
             _logger.exception("Failed to append ENDLIST to %s", playlist_path)
-
-    # -- Private: FFmpeg commands ----------------------------------------------
-
-    @staticmethod
-    def _probe_video_codec(file_path: str) -> str | None:
-        """Detect video codec using ffprobe."""
-        try:
-            result = subprocess.run(
-                [
-                    "ffprobe",
-                    "-v",
-                    "error",
-                    "-select_streams",
-                    "v:0",
-                    "-show_entries",
-                    "stream=codec_name",
-                    "-of",
-                    "default=noprint_wrappers=1:nokey=1",
-                    file_path,
-                ],
-                **SUBPROCESS_TEXT_KWARGS,
-                check=False,
-                timeout=10,
-            )
-            codec = result.stdout.strip().lower()
-            return codec if codec else None
-        except Exception:
-            return None
-
-    @staticmethod
-    def _detect_nvenc() -> bool:
-        """Functionally probe whether ``h264_nvenc`` can actually encode.
-
-        The encoder being *listed* by ffmpeg is not enough — a host can
-        ship an ffmpeg with NVENC compiled in while lacking the GPU,
-        driver, or a free encode session. We run a sub-second throwaway
-        encode of a synthetic source through CUDA so AUTO mode only
-        commits to NVENC when the full decode→encode path works.
-
-        Returns ``True`` only on a clean (exit 0) probe encode.
-        """
-        try:
-            result = subprocess.run(
-                [
-                    "ffmpeg",
-                    "-hide_banner",
-                    "-f",
-                    "lavfi",
-                    "-i",
-                    "color=c=black:s=256x256:r=10",
-                    "-t",
-                    "0.2",
-                    "-c:v",
-                    "h264_nvenc",
-                    "-f",
-                    "null",
-                    "-",
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=False,
-                timeout=_NVENC_PROBE_TIMEOUT,
-            )
-        except (OSError, subprocess.SubprocessError):
-            return False
-        return result.returncode == 0
-
-    def _nvenc_available(self) -> bool:
-        """Return the memoised NVENC functional-probe result.
-
-        Probed at most once per service instance — the first transcode
-        in AUTO mode pays the ~1s cold-start CUDA init, every later call
-        reads the cached boolean.
-        """
-        if self._nvenc_probe is None:
-            self._nvenc_probe = self._detect_nvenc()
-            _logger.info("NVENC functional probe result: %s", self._nvenc_probe)
-        return self._nvenc_probe
-
-    def _use_nvenc(self) -> bool:
-        """Decide whether this transcode should use NVENC.
-
-        Honours the persisted ``hw_accel`` knob: ``off`` forces
-        software, ``nvenc`` forces hardware (a broken encoder then
-        surfaces as a transcode failure rather than silently falling
-        back), and ``auto`` defers to the cached functional probe.
-        """
-        mode = self._runtime_settings.streaming_snapshot_sync().hw_accel
-        if mode == HW_ACCEL_OFF:
-            return False
-        if mode == HW_ACCEL_NVENC:
-            return True
-        return self._nvenc_available()
-
-    def _build_video_cmd(
-        self,
-        file_path: str,
-        output_dir: Path,
-        probe: ProbeResult,
-        start: int = 0,
-        force_software: bool = False,
-        end: int | None = None,
-    ) -> list[str]:
-        """Build FFmpeg command for video + default audio.
-
-        Transcodes (or remuxes, for already-H.264 sources) from the
-        ``start`` second of the file. ``-ss`` is placed BEFORE ``-i``
-        so ffmpeg does an input seek — fast and keyframe-accurate —
-        and the resulting segments carry timestamps starting near zero
-        in bucket-local time. Bucket-local timestamps are why the
-        frontend computes ``video.currentTime = saved - bucket_start``
-        instead of ``video.currentTime = saved`` (which would only
-        work with ``-copyts`` / source-time preserved, a path the
-        prior attempts at this refactor never landed reliably).
-
-        When ``start > 0`` we also emit ``-accurate_seek`` and
-        ``-avoid_negative_ts make_zero``. The first forces ffmpeg to
-        decode-and-drop frames between the preceding keyframe and the
-        exact requested second; without it, video opens at the
-        keyframe while audio opens at ``start`` and the two streams
-        play out of sync by that gap. The second clamps the minimum
-        PTS to zero across streams so any residual offset surfaces as
-        a tiny silence prefix instead of an audio-leads-video drift.
-
-        The H.264 ``-c:v copy`` fast path is bypassed for non-zero
-        ``start`` because copying skips the decode pass that
-        ``-accurate_seek`` relies on to drop pre-target frames — the
-        copied video would land at the preceding keyframe while the
-        re-encoded audio lands at the exact ``start``, recreating the
-        same 1-3s gap the seek flag was meant to close.
-
-        When a transcode is required and ``hw_accel`` resolves to NVENC,
-        the whole pipeline runs on the GPU: ``-hwaccel cuda`` decodes
-        with NVDEC, ``scale_cuda=format=nv12`` does the 10-bit→8-bit
-        conversion in VRAM, and ``h264_nvenc`` encodes — keeping the CPU
-        almost idle and staying well above real-time on 4K HEVC. The
-        software ``libx264`` path is the fallback.
-        """
-        codec = self._probe_video_codec(file_path)
-        needs_transcode = codec not in _BROWSER_SAFE_CODECS or start > 0
-
-        hwaccel_input_args: list[str] = []
-        vf_args: list[str] = []
-
-        if needs_transcode and self._use_nvenc() and not force_software:
-            _logger.info("Source codec %s — transcoding via NVENC (start=%d)", codec, start)
-            # Full-GPU pipeline: NVDEC decode → scale_cuda (10→8 bit in
-            # VRAM) → NVENC encode. ``spatial_aq`` redistributes bits to
-            # flat regions, which is what keeps sky/fog gradients from
-            # banding. ``-cq 19`` is constant-quality VBR (``-b:v 0``).
-            hwaccel_input_args = ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
-            vf_args = ["-vf", "scale_cuda=format=nv12"]
-            video_args = [
-                "-c:v",
-                "h264_nvenc",
-                "-preset",
-                "p5",
-                "-tune",
-                "hq",
-                "-rc",
-                "vbr",
-                "-cq",
-                "19",
-                "-b:v",
-                "0",
-                "-spatial_aq",
-                "1",
-            ]
-        elif needs_transcode:
-            _logger.info("Source codec %s — transcoding via libx264 (start=%d)", codec, start)
-            # ``superfast`` (not ``ultrafast``) is the floor here: ultrafast
-            # disables CABAC and adaptive quantization, which is exactly what
-            # collapses smooth gradients (sky, fog) into visible macroblocks
-            # on HEVC/10-bit sources re-encoded to H.264. superfast turns both
-            # back on for a moderate CPU cost while staying real-time on 4K.
-            # ``-pix_fmt yuv420p`` forces a clean 8-bit output so 10-bit
-            # sources (yuv420p10le) downconvert through swscale's dithering
-            # instead of producing an unplayable High 10 stream.
-            video_args = [
-                "-c:v",
-                "libx264",
-                "-preset",
-                "superfast",
-                "-crf",
-                "20",
-                "-pix_fmt",
-                "yuv420p",
-            ]
-        else:
-            _logger.info("Source codec %s — copying", codec)
-            # H.264 inside MP4/MKV is AVCC (length-prefixed NALs) with
-            # SPS/PPS only in container extradata. The HLS muxer does not
-            # reliably auto-insert the Annex-B conversion the bare mpegts
-            # muxer applies, so sources that don't repeat parameter sets
-            # in-band lose them in the .ts segments — the browser decodes
-            # zero frames (black video, audio fine). h264_mp4toannexb
-            # converts to Annex-B and writes SPS/PPS in-band; it is a
-            # no-op for streams already in Annex-B form.
-            video_args = ["-c:v", "copy", "-bsf:v", "h264_mp4toannexb"]
-
-        primary_idx = _primary_audio_index(probe)
-        audio_map = f"0:a:{primary_idx}"
-        primary_track = probe.audio_tracks[0] if probe.audio_tracks else None
-        leading_gap = _has_leading_audio_gap(file_path, primary_idx, start)
-        audio_args = _audio_args_for(primary_track, start, leading_gap)
-
-        seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
-        ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
-        # Clamp the encode to a sub-range when this title occupies only part
-        # of a shared physical file (ADR-030). ``-t`` is an output option, so
-        # with the input seek above it measures from ``start``: the emitted
-        # stream is exactly ``[start, end)`` source seconds.
-        duration_args = ["-t", str(end - start)] if end is not None else []
-
-        return [
-            "ffmpeg",
-            *hwaccel_input_args,
-            *seek_args,
-            "-i",
-            file_path,
-            "-map",
-            "0:v:0",
-            "-map",
-            audio_map,
-            "-sn",
-            *vf_args,
-            *video_args,
-            *audio_args,
-            *ts_normalize_args,
-            *duration_args,
-            # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
-            # segment PTS starts at ~0, keeping the video / audio / subtitle
-            # timelines aligned (the WebVTT X-TIMESTAMP-MAP anchors to MPEGTS:0).
-            "-muxdelay",
-            "0",
-            "-muxpreload",
-            "0",
-            "-hls_time",
-            str(_SEGMENT_DURATION),
-            "-hls_list_size",
-            "0",
-            "-hls_playlist_type",
-            "event",
-            # temp_file: write each segment to .ts.tmp and rename to .ts
-            # only after it's fully written. Prevents the player from
-            # racing the encoder and grabbing partial bytes.
-            "-hls_flags",
-            "temp_file",
-            "-hls_segment_filename",
-            str(output_dir / "segment_%04d.ts"),
-            "-loglevel",
-            "error",
-            "-y",
-            str(output_dir / "playlist.m3u8"),
-        ]
-
-    @staticmethod
-    def _build_audio_cmd(
-        file_path: str,
-        output_dir: Path,
-        track: AudioTrack,
-        start: int = 0,
-        end: int | None = None,
-    ) -> list[str]:
-        """Build FFmpeg command for audio-only HLS track.
-
-        ``-ss`` placed before ``-i`` when ``start > 0`` — same input-seek
-        rationale as ``_build_video_cmd``. The alternate-audio playlist
-        is consumed independently by the player; even though there is
-        no video stream here, we still match the video pipeline's
-        ``-accurate_seek`` / ``-avoid_negative_ts make_zero`` so a
-        switch from primary to alternate audio at a non-zero bucket
-        lands on the same source-time second.
-
-        Like the primary audio in ``_build_video_cmd``, a browser-ready
-        AAC-LC stereo 48 kHz source is remuxed with ``-c:a copy`` instead
-        of re-encoded; see :func:`_audio_args_for`.
-        """
-        seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
-        ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
-        # Clamp to the same sub-range as the video track (ADR-030) so an
-        # alternate-audio playlist ends at the title boundary, not the file's.
-        duration_args = ["-t", str(end - start)] if end is not None else []
-        leading_gap = _has_leading_audio_gap(file_path, track.index, start)
-        return [
-            "ffmpeg",
-            *seek_args,
-            "-i",
-            file_path,
-            "-map",
-            f"0:a:{track.index}",
-            "-vn",
-            "-sn",
-            *_audio_args_for(track, start, leading_gap),
-            *ts_normalize_args,
-            *duration_args,
-            # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
-            # segment PTS starts at ~0, keeping the video / audio / subtitle
-            # timelines aligned (the WebVTT X-TIMESTAMP-MAP anchors to MPEGTS:0).
-            "-muxdelay",
-            "0",
-            "-muxpreload",
-            "0",
-            "-hls_time",
-            str(_SEGMENT_DURATION),
-            "-hls_list_size",
-            "0",
-            "-hls_playlist_type",
-            "event",
-            "-hls_flags",
-            "temp_file",
-            "-hls_segment_filename",
-            str(output_dir / "segment_%04d.ts"),
-            "-loglevel",
-            "error",
-            "-y",
-            str(output_dir / "playlist.m3u8"),
-        ]
 
     # -- Private: subtitle extraction ------------------------------------------
 
@@ -1492,155 +1011,6 @@ class HlsService(HlsPlaylistPort):
             _logger.warning("Extraction timed out for %s", log_label)
             return False
         return True
-
-    # -- Private: master playlist ----------------------------------------------
-
-    @staticmethod
-    def _build_master_playlist(output_dir: Path, probe: ProbeResult) -> None:
-        """Generate master.m3u8 with audio renditions and subtitle tracks."""
-        lines = ["#EXTM3U", "#EXT-X-VERSION:3"]
-
-        has_alt_audio = len(probe.audio_tracks) > 1
-        audio_group = 'AUDIO="audio"' if has_alt_audio else ""
-        text_subs = [s for s in probe.all_subtitles if s.is_text_based]
-        sub_group = 'SUBTITLES="subs"' if text_subs else ""
-
-        audio_versions = audio_version_labels(probe.audio_tracks)
-        sub_versions = subtitle_version_labels(text_subs)
-
-        primary_idx = _primary_audio_index(probe)
-        if has_alt_audio:
-            for track in probe.audio_tracks:
-                is_primary = track.index == primary_idx
-                name = _manifest_track_name(track.language.value, audio_versions.get(track.index))
-                if is_primary:
-                    lines.append(
-                        f'#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",'
-                        f'NAME="{name}",LANGUAGE="{track.language.value}",'
-                        f"DEFAULT=YES,AUTOSELECT=YES"
-                    )
-                else:
-                    lines.append(
-                        f'#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",'
-                        f'NAME="{name}",LANGUAGE="{track.language.value}",'
-                        f"DEFAULT=NO,AUTOSELECT=NO,"
-                        f'URI="audio_{track.index}/playlist.m3u8"'
-                    )
-
-        for sub in text_subs:
-            sub_name = _manifest_track_name(sub.language.value, sub_versions.get(sub.index))
-            is_forced = "YES" if sub.is_forced else "NO"
-            lines.append(
-                f'#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",'
-                f'NAME="{sub_name}",LANGUAGE="{sub.language.value}",'
-                f"DEFAULT=NO,AUTOSELECT=NO,FORCED={is_forced},"
-                f'URI="sub_{sub.index}/playlist.m3u8"'
-            )
-
-        groups = ",".join(filter(None, [audio_group, sub_group]))
-        stream_inf = "#EXT-X-STREAM-INF:BANDWIDTH=5000000"
-        if groups:
-            stream_inf += f",{groups}"
-        lines.append(stream_inf)
-        lines.append("video/playlist.m3u8")
-
-        master_path = output_dir / "master.m3u8"
-        master_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-        _logger.info("Master playlist written to %s", master_path)
-
-    # -- Private: probe cache --------------------------------------------------
-
-    @staticmethod
-    def _save_probe_cache(output_dir: Path, probe: ProbeResult) -> None:
-        """Save probe result as JSON for the tracks API."""
-        data = {
-            "resolution": probe.resolution,
-            "audio_tracks": [
-                {
-                    "index": t.index,
-                    "language": t.language.value,
-                    "codec": t.codec,
-                    "channels": t.channels,
-                    "title": t.title,
-                    "is_default": t.is_default,
-                    "bitrate": t.bitrate,
-                    "sample_rate": t.sample_rate,
-                    "profile": t.profile,
-                }
-                for t in probe.audio_tracks
-            ],
-            "subtitle_tracks": [
-                {
-                    "index": t.index,
-                    "language": t.language.value,
-                    "format": t.format,
-                    "title": t.title,
-                    "is_default": t.is_default,
-                    "is_forced": t.is_forced,
-                    "is_external": t.is_external,
-                    "is_image_based": t.is_image_based,
-                }
-                for t in probe.all_subtitles
-            ],
-        }
-        (output_dir / "tracks.json").write_text(
-            json.dumps(data, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
-
-    @staticmethod
-    def _deserialize_probe(data: dict[str, Any]) -> ProbeResult:
-        """Reconstruct ProbeResult from cached JSON."""
-        from src.shared_kernel.value_objects.language_code import LanguageCode
-        from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
-
-        audio = [
-            AudioTrack(
-                index=t["index"],
-                language=LanguageCode(t["language"]),
-                codec=t["codec"],
-                channels=t["channels"],
-                title=t.get("title"),
-                is_default=t["is_default"],
-                bitrate=t.get("bitrate"),
-                sample_rate=t.get("sample_rate"),
-                profile=t.get("profile"),
-            )
-            for t in data.get("audio_tracks", [])
-        ]
-        subs = [
-            SubtitleTrack(
-                index=t["index"],
-                language=LanguageCode(t["language"]),
-                format=t["format"],
-                title=t.get("title"),
-                is_default=t.get("is_default", False),
-                is_forced=t.get("is_forced", False),
-                is_external=t.get("is_external", False),
-            )
-            for t in data.get("subtitle_tracks", [])
-            if not t.get("is_external", False)
-        ]
-        ext = [
-            SubtitleTrack(
-                index=t["index"],
-                language=LanguageCode(t["language"]),
-                format=t["format"],
-                title=t.get("title"),
-                is_default=t.get("is_default", False),
-                is_forced=t.get("is_forced", False),
-                is_external=True,
-                file_path=None,
-            )
-            for t in data.get("subtitle_tracks", [])
-            if t.get("is_external", False)
-        ]
-        return ProbeResult(
-            audio_tracks=audio,
-            subtitle_tracks=subs,
-            external_subtitles=ext,
-            resolution=data.get("resolution"),
-        )
 
     # -- Private: validation ---------------------------------------------------
 

--- a/src/modules/media/infrastructure/streaming/master_playlist_writer.py
+++ b/src/modules/media/infrastructure/streaming/master_playlist_writer.py
@@ -1,0 +1,101 @@
+"""Master (multivariant) HLS playlist generation.
+
+Extracted from ``HlsService`` (pure: builds one ``master.m3u8`` on disk
+from a probe result). Emits ``#EXT-X-MEDIA`` renditions for alternate
+audio and text subtitle tracks, with fallback display names composed from
+the language code plus a structured version token (dub studio, channel
+layout, ordinal, SDH).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from src.modules.media.domain.services.track_naming import (
+    audio_version_labels,
+    render_version_token,
+    subtitle_version_labels,
+)
+from src.modules.media.infrastructure.streaming._hls_common import primary_audio_index
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.modules.media.application.ports.media_probe_port import ProbeResult
+    from src.modules.media.domain.services.track_naming import TrackVersion
+
+_logger = logging.getLogger(__name__)
+
+
+def _manifest_track_name(language: str, version: TrackVersion | None) -> str:
+    """Compose a fallback ``NAME=`` for a manifest rendition.
+
+    The manifest can't carry structured data and isn't localized, so we
+    use the language code plus a short version token (e.g. "PT",
+    "PT · Herbert Richers", "PT · 5.1"). Clients should prefer the
+    structured ``/tracks`` payload and localize it themselves.
+    """
+    base = language.upper()
+    token = render_version_token(version)
+    return f"{base} · {token}" if token else base
+
+
+class MasterPlaylistWriter:
+    """Write ``master.m3u8`` with audio renditions and subtitle tracks."""
+
+    @staticmethod
+    def write(output_dir: Path, probe: ProbeResult) -> None:
+        """Generate master.m3u8 with audio renditions and subtitle tracks."""
+        lines = ["#EXTM3U", "#EXT-X-VERSION:3"]
+
+        has_alt_audio = len(probe.audio_tracks) > 1
+        audio_group = 'AUDIO="audio"' if has_alt_audio else ""
+        text_subs = [s for s in probe.all_subtitles if s.is_text_based]
+        sub_group = 'SUBTITLES="subs"' if text_subs else ""
+
+        audio_versions = audio_version_labels(probe.audio_tracks)
+        sub_versions = subtitle_version_labels(text_subs)
+
+        primary_idx = primary_audio_index(probe)
+        if has_alt_audio:
+            for track in probe.audio_tracks:
+                is_primary = track.index == primary_idx
+                name = _manifest_track_name(track.language.value, audio_versions.get(track.index))
+                if is_primary:
+                    lines.append(
+                        f'#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",'
+                        f'NAME="{name}",LANGUAGE="{track.language.value}",'
+                        f"DEFAULT=YES,AUTOSELECT=YES"
+                    )
+                else:
+                    lines.append(
+                        f'#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",'
+                        f'NAME="{name}",LANGUAGE="{track.language.value}",'
+                        f"DEFAULT=NO,AUTOSELECT=NO,"
+                        f'URI="audio_{track.index}/playlist.m3u8"'
+                    )
+
+        for sub in text_subs:
+            sub_name = _manifest_track_name(sub.language.value, sub_versions.get(sub.index))
+            is_forced = "YES" if sub.is_forced else "NO"
+            lines.append(
+                f'#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",'
+                f'NAME="{sub_name}",LANGUAGE="{sub.language.value}",'
+                f"DEFAULT=NO,AUTOSELECT=NO,FORCED={is_forced},"
+                f'URI="sub_{sub.index}/playlist.m3u8"'
+            )
+
+        groups = ",".join(filter(None, [audio_group, sub_group]))
+        stream_inf = "#EXT-X-STREAM-INF:BANDWIDTH=5000000"
+        if groups:
+            stream_inf += f",{groups}"
+        lines.append(stream_inf)
+        lines.append("video/playlist.m3u8")
+
+        master_path = output_dir / "master.m3u8"
+        master_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        _logger.info("Master playlist written to %s", master_path)
+
+
+__all__ = ["MasterPlaylistWriter"]

--- a/src/modules/media/infrastructure/streaming/probe_cache_store.py
+++ b/src/modules/media/infrastructure/streaming/probe_cache_store.py
@@ -1,0 +1,136 @@
+"""Persistence of probe results (``tracks.json``) in the HLS cache.
+
+Extracted from ``HlsService`` (pure: filesystem reads/writes only, no
+locks or threads). Serialises a :class:`ProbeResult` for the tracks API
+and reconstructs it on cache hits, and reads the raw cached payload for
+a bucket.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.modules.media.application.ports.media_probe_port import ProbeResult
+
+
+class ProbeCacheStore:
+    """Read and write ``tracks.json`` probe caches under a cache root.
+
+    Args:
+        cache_dir: Root cache directory; each bucket lives at
+            ``<cache_dir>/<path_hash>/``.
+    """
+
+    def __init__(self, cache_dir: Path) -> None:
+        self._cache_dir = cache_dir
+
+    def get_cached_tracks(self, path_hash: str) -> dict[str, Any] | None:
+        """Get cached probe result from tracks.json."""
+        tracks_file = self._cache_dir / path_hash / "tracks.json"
+        if not tracks_file.is_file():
+            return None
+        try:
+            data: dict[str, Any] = json.loads(tracks_file.read_text(encoding="utf-8"))
+            return data
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    @staticmethod
+    def save(output_dir: Path, probe: ProbeResult) -> None:
+        """Save probe result as JSON for the tracks API."""
+        data = {
+            "resolution": probe.resolution,
+            "audio_tracks": [
+                {
+                    "index": t.index,
+                    "language": t.language.value,
+                    "codec": t.codec,
+                    "channels": t.channels,
+                    "title": t.title,
+                    "is_default": t.is_default,
+                    "bitrate": t.bitrate,
+                    "sample_rate": t.sample_rate,
+                    "profile": t.profile,
+                }
+                for t in probe.audio_tracks
+            ],
+            "subtitle_tracks": [
+                {
+                    "index": t.index,
+                    "language": t.language.value,
+                    "format": t.format,
+                    "title": t.title,
+                    "is_default": t.is_default,
+                    "is_forced": t.is_forced,
+                    "is_external": t.is_external,
+                    "is_image_based": t.is_image_based,
+                }
+                for t in probe.all_subtitles
+            ],
+        }
+        (output_dir / "tracks.json").write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def deserialize(data: dict[str, Any]) -> ProbeResult:
+        """Reconstruct ProbeResult from cached JSON."""
+        from src.modules.media.application.ports.media_probe_port import ProbeResult
+        from src.shared_kernel.value_objects.language_code import LanguageCode
+        from src.shared_kernel.value_objects.tracks import AudioTrack, SubtitleTrack
+
+        audio = [
+            AudioTrack(
+                index=t["index"],
+                language=LanguageCode(t["language"]),
+                codec=t["codec"],
+                channels=t["channels"],
+                title=t.get("title"),
+                is_default=t["is_default"],
+                bitrate=t.get("bitrate"),
+                sample_rate=t.get("sample_rate"),
+                profile=t.get("profile"),
+            )
+            for t in data.get("audio_tracks", [])
+        ]
+        subs = [
+            SubtitleTrack(
+                index=t["index"],
+                language=LanguageCode(t["language"]),
+                format=t["format"],
+                title=t.get("title"),
+                is_default=t.get("is_default", False),
+                is_forced=t.get("is_forced", False),
+                is_external=t.get("is_external", False),
+            )
+            for t in data.get("subtitle_tracks", [])
+            if not t.get("is_external", False)
+        ]
+        ext = [
+            SubtitleTrack(
+                index=t["index"],
+                language=LanguageCode(t["language"]),
+                format=t["format"],
+                title=t.get("title"),
+                is_default=t.get("is_default", False),
+                is_forced=t.get("is_forced", False),
+                is_external=True,
+                file_path=None,
+            )
+            for t in data.get("subtitle_tracks", [])
+            if t.get("is_external", False)
+        ]
+        return ProbeResult(
+            audio_tracks=audio,
+            subtitle_tracks=subs,
+            external_subtitles=ext,
+            resolution=data.get("resolution"),
+        )
+
+
+__all__ = ["ProbeCacheStore"]

--- a/src/modules/media/infrastructure/streaming/transcode_command_builder.py
+++ b/src/modules/media/infrastructure/streaming/transcode_command_builder.py
@@ -1,0 +1,401 @@
+"""FFmpeg command construction for HLS video and audio tracks.
+
+Extracted from ``HlsService`` (pure: no locks, no threads, no subprocess
+*spawning* — it only builds argv lists). The video command consults an
+injected :class:`HardwareAccelerationProbe` to pick the NVENC or libx264
+pipeline; the audio helpers decide copy-vs-re-encode and probe for a
+leading silent gap.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import TYPE_CHECKING
+
+from src.modules.media.infrastructure.streaming._hls_common import (
+    BROWSER_SAFE_CODECS,
+    SEGMENT_DURATION,
+    primary_audio_index,
+)
+from src.modules.media.infrastructure.streaming._subprocess import SUBPROCESS_TEXT_KWARGS
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from src.modules.media.application.ports.media_probe_port import ProbeResult
+    from src.modules.media.infrastructure.streaming.hardware_acceleration_probe import (
+        HardwareAccelerationProbe,
+    )
+    from src.shared_kernel.value_objects.tracks import AudioTrack
+
+_logger = logging.getLogger(__name__)
+
+
+# A leading audio offset above this many seconds is treated as a gap that
+# must be padded with silence (see ``_first_audio_pts``). The threshold is
+# generous — normal muxing jitter is a few milliseconds, so anything past a
+# quarter-second is a real hole at the head of the track, not noise.
+_AUDIO_LEADING_GAP_THRESHOLD = 0.25
+
+
+def _first_audio_pts(file_path: str, audio_index: int) -> float | None:
+    """Return the PTS (seconds) of the first packet of one audio stream.
+
+    Some source files carry an audio track whose first sample lands well
+    after t=0 (e.g. an 11-second silent hole at the head of the stream).
+    Muxed into HLS from t=0, the leading segments then declare an audio
+    stream that has *no* frames yet, and hls.js — which needs the audio
+    codec from the first fragment — stalls forever on that phantom track
+    instead of ever appending a buffer. Detecting the offset lets the
+    caller pad it with silence and keep the copy fast-path off files that
+    would otherwise ship an empty-audio first segment.
+
+    Args:
+        file_path: Absolute path to the source video file.
+        audio_index: Stream index *within the audio streams* (the ``N`` in
+            ffmpeg's ``0:a:N``), matching how the transcode maps it.
+
+    Returns:
+        The first packet's presentation timestamp in seconds, or ``None``
+        if ffprobe fails or reports no readable timestamp (caller then
+        assumes no gap).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                f"a:{audio_index}",
+                "-read_intervals",
+                "%+#1",
+                "-show_entries",
+                "packet=pts_time",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                file_path,
+            ],
+            **SUBPROCESS_TEXT_KWARGS,
+            check=False,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    raw = result.stdout.strip().splitlines()
+    if not raw:
+        return None
+    try:
+        return float(raw[0])
+    except ValueError:
+        return None
+
+
+def _has_leading_audio_gap(file_path: str, audio_index: int, start: int) -> bool:
+    """Whether a mapped audio stream begins meaningfully after t=0.
+
+    Only meaningful for the initial (``start == 0``) bucket — a seek
+    bucket lands mid-stream where audio already exists and normalises its
+    own timestamps, so we skip the probe there and never treat it as a
+    gap. See :func:`_first_audio_pts` for why the gap matters.
+    """
+    if start != 0:
+        return False
+    pts = _first_audio_pts(file_path, audio_index)
+    return pts is not None and pts > _AUDIO_LEADING_GAP_THRESHOLD
+
+
+def _audio_args_for(
+    track: AudioTrack | None,
+    start: int,
+    leading_gap: bool = False,
+) -> list[str]:
+    """Pick the ffmpeg audio args for one HLS track: copy or re-encode.
+
+    Re-encoding every audio track to AAC stereo 48 kHz is wasted work
+    when the source already *is* browser-playable AAC. We remux with
+    ``-c:a copy`` only when the track is unambiguously safe to drop into
+    MPEG-TS untouched:
+
+    - **AAC-LC** — the one AAC profile MSE/hls.js decode everywhere;
+      HE-AAC (SBR/PS) is excluded because browser support is spotty.
+    - **stereo** — multichannel must be downmixed to 2.0 for the player.
+    - **48 kHz** — matches the rate the re-encode path normalises to, so
+      a copied stream is byte-for-byte what a transcode would have
+      targeted.
+    - **start == 0** — a non-zero resume offset re-encodes the video with
+      ``-accurate_seek``; copying the audio there would land it at the
+      nearest packet instead of the exact second and drift out of sync.
+    - **no leading gap** — a track whose first sample lands after t=0
+      (``leading_gap``) must be re-encoded so the silence filter below
+      can backfill the hole; copying would preserve it and ship an
+      empty-audio first segment that stalls hls.js.
+
+    Anything else (unknown profile/rate, non-AAC, surround, mid-stream
+    seek, leading gap) falls back to the safe AAC re-encode.
+
+    On the re-encode path for an initial (``start == 0``) bucket we add
+    ``aresample=async=1:first_pts=0``. It pads any leading offset with
+    silence so the audio starts at t=0 and the first HLS segment carries
+    decodable frames — without it, a file whose audio begins late (a real
+    silent intro) yields a first segment with a declared-but-empty audio
+    stream, and hls.js hangs on "preparing" forever. It is a no-op for a
+    track that already starts at zero. The seek path (``start > 0``)
+    already normalises timestamps via ``-avoid_negative_ts make_zero`` and
+    is left untouched.
+    """
+    if (
+        track is not None
+        and start == 0
+        and not leading_gap
+        and track.codec == "aac"
+        and track.is_stereo
+        and track.sample_rate == 48000
+        and (track.profile or "").strip().upper() == "LC"
+    ):
+        return ["-c:a", "copy"]
+    args = ["-c:a", "aac", "-ac", "2", "-ar", "48000"]
+    if start == 0:
+        args += ["-af", "aresample=async=1:first_pts=0"]
+    return args
+
+
+class TranscodeCommandBuilder:
+    """Build the ffmpeg argv lists for the video and audio HLS tracks.
+
+    Args:
+        hw_probe: Resolves whether a transcode runs on NVENC or libx264
+            and detects the source video codec.
+    """
+
+    def __init__(self, hw_probe: HardwareAccelerationProbe) -> None:
+        self._hw_probe = hw_probe
+
+    def build_video_cmd(
+        self,
+        file_path: str,
+        output_dir: Path,
+        probe: ProbeResult,
+        start: int = 0,
+        force_software: bool = False,
+        end: int | None = None,
+    ) -> list[str]:
+        """Build FFmpeg command for video + default audio.
+
+        Transcodes (or remuxes, for already-H.264 sources) from the
+        ``start`` second of the file. ``-ss`` is placed BEFORE ``-i``
+        so ffmpeg does an input seek — fast and keyframe-accurate —
+        and the resulting segments carry timestamps starting near zero
+        in bucket-local time. Bucket-local timestamps are why the
+        frontend computes ``video.currentTime = saved - bucket_start``
+        instead of ``video.currentTime = saved`` (which would only
+        work with ``-copyts`` / source-time preserved, a path the
+        prior attempts at this refactor never landed reliably).
+
+        When ``start > 0`` we also emit ``-accurate_seek`` and
+        ``-avoid_negative_ts make_zero``. The first forces ffmpeg to
+        decode-and-drop frames between the preceding keyframe and the
+        exact requested second; without it, video opens at the
+        keyframe while audio opens at ``start`` and the two streams
+        play out of sync by that gap. The second clamps the minimum
+        PTS to zero across streams so any residual offset surfaces as
+        a tiny silence prefix instead of an audio-leads-video drift.
+
+        The H.264 ``-c:v copy`` fast path is bypassed for non-zero
+        ``start`` because copying skips the decode pass that
+        ``-accurate_seek`` relies on to drop pre-target frames — the
+        copied video would land at the preceding keyframe while the
+        re-encoded audio lands at the exact ``start``, recreating the
+        same 1-3s gap the seek flag was meant to close.
+
+        When a transcode is required and ``hw_accel`` resolves to NVENC,
+        the whole pipeline runs on the GPU: ``-hwaccel cuda`` decodes
+        with NVDEC, ``scale_cuda=format=nv12`` does the 10-bit→8-bit
+        conversion in VRAM, and ``h264_nvenc`` encodes — keeping the CPU
+        almost idle and staying well above real-time on 4K HEVC. The
+        software ``libx264`` path is the fallback.
+        """
+        codec = self._hw_probe.probe_video_codec(file_path)
+        needs_transcode = codec not in BROWSER_SAFE_CODECS or start > 0
+
+        hwaccel_input_args: list[str] = []
+        vf_args: list[str] = []
+
+        if needs_transcode and self._hw_probe.use_nvenc() and not force_software:
+            _logger.info("Source codec %s — transcoding via NVENC (start=%d)", codec, start)
+            # Full-GPU pipeline: NVDEC decode → scale_cuda (10→8 bit in
+            # VRAM) → NVENC encode. ``spatial_aq`` redistributes bits to
+            # flat regions, which is what keeps sky/fog gradients from
+            # banding. ``-cq 19`` is constant-quality VBR (``-b:v 0``).
+            hwaccel_input_args = ["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"]
+            vf_args = ["-vf", "scale_cuda=format=nv12"]
+            video_args = [
+                "-c:v",
+                "h264_nvenc",
+                "-preset",
+                "p5",
+                "-tune",
+                "hq",
+                "-rc",
+                "vbr",
+                "-cq",
+                "19",
+                "-b:v",
+                "0",
+                "-spatial_aq",
+                "1",
+            ]
+        elif needs_transcode:
+            _logger.info("Source codec %s — transcoding via libx264 (start=%d)", codec, start)
+            # ``superfast`` (not ``ultrafast``) is the floor here: ultrafast
+            # disables CABAC and adaptive quantization, which is exactly what
+            # collapses smooth gradients (sky, fog) into visible macroblocks
+            # on HEVC/10-bit sources re-encoded to H.264. superfast turns both
+            # back on for a moderate CPU cost while staying real-time on 4K.
+            # ``-pix_fmt yuv420p`` forces a clean 8-bit output so 10-bit
+            # sources (yuv420p10le) downconvert through swscale's dithering
+            # instead of producing an unplayable High 10 stream.
+            video_args = [
+                "-c:v",
+                "libx264",
+                "-preset",
+                "superfast",
+                "-crf",
+                "20",
+                "-pix_fmt",
+                "yuv420p",
+            ]
+        else:
+            _logger.info("Source codec %s — copying", codec)
+            # H.264 inside MP4/MKV is AVCC (length-prefixed NALs) with
+            # SPS/PPS only in container extradata. The HLS muxer does not
+            # reliably auto-insert the Annex-B conversion the bare mpegts
+            # muxer applies, so sources that don't repeat parameter sets
+            # in-band lose them in the .ts segments — the browser decodes
+            # zero frames (black video, audio fine). h264_mp4toannexb
+            # converts to Annex-B and writes SPS/PPS in-band; it is a
+            # no-op for streams already in Annex-B form.
+            video_args = ["-c:v", "copy", "-bsf:v", "h264_mp4toannexb"]
+
+        primary_idx = primary_audio_index(probe)
+        audio_map = f"0:a:{primary_idx}"
+        primary_track = probe.audio_tracks[0] if probe.audio_tracks else None
+        leading_gap = _has_leading_audio_gap(file_path, primary_idx, start)
+        audio_args = _audio_args_for(primary_track, start, leading_gap)
+
+        seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
+        ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
+        # Clamp the encode to a sub-range when this title occupies only part
+        # of a shared physical file (ADR-030). ``-t`` is an output option, so
+        # with the input seek above it measures from ``start``: the emitted
+        # stream is exactly ``[start, end)`` source seconds.
+        duration_args = ["-t", str(end - start)] if end is not None else []
+
+        return [
+            "ffmpeg",
+            *hwaccel_input_args,
+            *seek_args,
+            "-i",
+            file_path,
+            "-map",
+            "0:v:0",
+            "-map",
+            audio_map,
+            "-sn",
+            *vf_args,
+            *video_args,
+            *audio_args,
+            *ts_normalize_args,
+            *duration_args,
+            # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
+            # segment PTS starts at ~0, keeping the video / audio / subtitle
+            # timelines aligned (the WebVTT X-TIMESTAMP-MAP anchors to MPEGTS:0).
+            "-muxdelay",
+            "0",
+            "-muxpreload",
+            "0",
+            "-hls_time",
+            str(SEGMENT_DURATION),
+            "-hls_list_size",
+            "0",
+            "-hls_playlist_type",
+            "event",
+            # temp_file: write each segment to .ts.tmp and rename to .ts
+            # only after it's fully written. Prevents the player from
+            # racing the encoder and grabbing partial bytes.
+            "-hls_flags",
+            "temp_file",
+            "-hls_segment_filename",
+            str(output_dir / "segment_%04d.ts"),
+            "-loglevel",
+            "error",
+            "-y",
+            str(output_dir / "playlist.m3u8"),
+        ]
+
+    @staticmethod
+    def build_audio_cmd(
+        file_path: str,
+        output_dir: Path,
+        track: AudioTrack,
+        start: int = 0,
+        end: int | None = None,
+    ) -> list[str]:
+        """Build FFmpeg command for audio-only HLS track.
+
+        ``-ss`` placed before ``-i`` when ``start > 0`` — same input-seek
+        rationale as ``build_video_cmd``. The alternate-audio playlist
+        is consumed independently by the player; even though there is
+        no video stream here, we still match the video pipeline's
+        ``-accurate_seek`` / ``-avoid_negative_ts make_zero`` so a
+        switch from primary to alternate audio at a non-zero bucket
+        lands on the same source-time second.
+
+        Like the primary audio in ``build_video_cmd``, a browser-ready
+        AAC-LC stereo 48 kHz source is remuxed with ``-c:a copy`` instead
+        of re-encoded; see :func:`_audio_args_for`.
+        """
+        seek_args = ["-ss", str(start), "-accurate_seek"] if start > 0 else []
+        ts_normalize_args = ["-avoid_negative_ts", "make_zero"] if start > 0 else []
+        # Clamp to the same sub-range as the video track (ADR-030) so an
+        # alternate-audio playlist ends at the title boundary, not the file's.
+        duration_args = ["-t", str(end - start)] if end is not None else []
+        leading_gap = _has_leading_audio_gap(file_path, track.index, start)
+        return [
+            "ffmpeg",
+            *seek_args,
+            "-i",
+            file_path,
+            "-map",
+            f"0:a:{track.index}",
+            "-vn",
+            "-sn",
+            *_audio_args_for(track, start, leading_gap),
+            *ts_normalize_args,
+            *duration_args,
+            # Zero the MPEG-TS muxer's ~1.4s initial offset so the first
+            # segment PTS starts at ~0, keeping the video / audio / subtitle
+            # timelines aligned (the WebVTT X-TIMESTAMP-MAP anchors to MPEGTS:0).
+            "-muxdelay",
+            "0",
+            "-muxpreload",
+            "0",
+            "-hls_time",
+            str(SEGMENT_DURATION),
+            "-hls_list_size",
+            "0",
+            "-hls_playlist_type",
+            "event",
+            "-hls_flags",
+            "temp_file",
+            "-hls_segment_filename",
+            str(output_dir / "segment_%04d.ts"),
+            "-loglevel",
+            "error",
+            "-y",
+            str(output_dir / "playlist.m3u8"),
+        ]
+
+
+__all__ = ["TranscodeCommandBuilder"]

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -10,19 +10,27 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.modules.media.application.ports import ProbeResult
+from src.modules.media.infrastructure.streaming._hls_common import primary_audio_index
+from src.modules.media.infrastructure.streaming.hardware_acceleration_probe import (
+    HardwareAccelerationProbe,
+)
 from src.modules.media.infrastructure.streaming.hls_service import (
     HlsService,
     _append_endlist_atomic,
     _atomic_write_text,
-    _audio_args_for,
     _ensure_vtt_timestamp_map,
-    _first_audio_pts,
     _has_endlist,
-    _has_leading_audio_gap,
-    _primary_audio_index,
     _shift_webvtt_to_bucket_local,
 )
+from src.modules.media.infrastructure.streaming.master_playlist_writer import MasterPlaylistWriter
 from src.modules.media.infrastructure.streaming.media_probe_service import MediaProbeService
+from src.modules.media.infrastructure.streaming.probe_cache_store import ProbeCacheStore
+from src.modules.media.infrastructure.streaming.transcode_command_builder import (
+    TranscodeCommandBuilder,
+    _audio_args_for,
+    _first_audio_pts,
+    _has_leading_audio_gap,
+)
 from src.modules.settings.domain.value_objects import (
     HardwareAccel,
     StreamingConfig,
@@ -112,11 +120,11 @@ class TestPrimaryAudioIndex:
         probe = ProbeResult(
             audio_tracks=[_make_audio_track(index=2), _make_audio_track(index=5)],
         )
-        assert _primary_audio_index(probe) == 2
+        assert primary_audio_index(probe) == 2
 
     def test_should_return_zero_when_no_tracks(self) -> None:
         probe = ProbeResult(audio_tracks=[])
-        assert _primary_audio_index(probe) == 0
+        assert primary_audio_index(probe) == 0
 
 
 @pytest.mark.unit
@@ -396,26 +404,26 @@ class TestHlsServiceBuildAudioCmd:
         # start==0 build shells out to a real ffprobe on the fake path.
         # Default to "no gap"; the gap-specific tests patch it themselves.
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder._first_audio_pts",
             return_value=None,
         ):
             yield
 
     def test_should_include_input_file(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
 
         assert "-i" in cmd
         assert "/movies/test.mkv" in cmd
 
     def test_should_map_to_correct_audio_stream(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=2))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=2))
 
         assert "0:a:2" in cmd
 
     def test_should_clamp_duration_to_segment(self, tmp_path: Path) -> None:
         # Alternate-audio track for a segmented episode (ADR-030) ends at the
         # same title boundary as the video track.
-        cmd = HlsService._build_audio_cmd(
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
             "/series/shared.mkv", tmp_path, _make_audio_track(index=1), start=4740, end=9480
         )
 
@@ -423,24 +431,24 @@ class TestHlsServiceBuildAudioCmd:
         assert cmd[cmd.index("-t") + 1] == "4740"
 
     def test_should_not_clamp_duration_without_end(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
 
         assert "-t" not in cmd
 
     def test_should_disable_video_and_subtitle(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
 
         assert "-vn" in cmd
         assert "-sn" in cmd
 
     def test_should_use_aac_codec(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
 
         assert "aac" in cmd
 
     def test_should_omit_seek_flag_when_start_is_zero(self, tmp_path: Path) -> None:
         # Default cold-cache transcode starts at t=0 — no ``-ss``.
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
 
         assert "-ss" not in cmd
 
@@ -448,7 +456,7 @@ class TestHlsServiceBuildAudioCmd:
         # ``-ss N`` must come BEFORE ``-i`` so ffmpeg does an input
         # seek (fast, keyframe-accurate) rather than decoding from 0
         # and dropping output.
-        cmd = HlsService._build_audio_cmd(
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
             "/movies/test.mkv", tmp_path, _make_audio_track(index=0), start=1800
         )
 
@@ -462,7 +470,7 @@ class TestHlsServiceBuildAudioCmd:
         # Without ``-accurate_seek`` ffmpeg drops to the preceding
         # keyframe but audio starts at exactly ``start`` — the two
         # streams open out of sync by ``start - keyframe_pos``.
-        cmd = HlsService._build_audio_cmd(
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
             "/movies/test.mkv", tmp_path, _make_audio_track(index=0), start=1800
         )
 
@@ -475,7 +483,7 @@ class TestHlsServiceBuildAudioCmd:
         # ``-avoid_negative_ts make_zero`` clamps the per-stream PTS
         # minimum to zero so any residual offset surfaces as a tiny
         # leading silence instead of an audio-leads-video drift.
-        cmd = HlsService._build_audio_cmd(
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
             "/movies/test.mkv", tmp_path, _make_audio_track(index=0), start=1800
         )
 
@@ -487,14 +495,14 @@ class TestHlsServiceBuildAudioCmd:
         # Sync hardening only kicks in for non-zero ``start`` since the
         # legacy cold-cache transcode never hits the keyframe-vs-audio
         # gap (it begins at t=0 of the source).
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
 
         assert "-accurate_seek" not in cmd
         assert "-avoid_negative_ts" not in cmd
 
     def test_should_copy_aac_lc_stereo_48k_at_start_zero(self, tmp_path: Path) -> None:
         # Already browser-ready audio is remuxed, not re-encoded.
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _aac_lc_stereo_48k(index=1))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _aac_lc_stereo_48k(index=1))
 
         assert cmd[cmd.index("-c:a") + 1] == "copy"
         assert "-ar" not in cmd  # no encode params on the copy path
@@ -502,7 +510,7 @@ class TestHlsServiceBuildAudioCmd:
     def test_should_reencode_when_seeking_even_if_aac_lc(self, tmp_path: Path) -> None:
         # A non-zero start re-encodes audio so it lands at the exact
         # second instead of the nearest packet (A/V sync).
-        cmd = HlsService._build_audio_cmd(
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
             "/movies/test.mkv", tmp_path, _aac_lc_stereo_48k(index=0), start=1800
         )
 
@@ -521,7 +529,7 @@ class TestHlsServiceBuildAudioCmd:
         ids=["not-aac", "surround", "wrong-rate", "he-aac", "unknown-profile"],
     )
     def test_should_reencode_when_not_safe_to_copy(self, tmp_path: Path, track: AudioTrack) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, track)
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, track)
 
         assert "copy" not in cmd
         assert cmd[cmd.index("-c:a") + 1] == "aac"
@@ -531,10 +539,10 @@ class TestHlsServiceBuildAudioCmd:
         # re-encoded (not copied) so the silence pad can backfill the hole
         # even though it is otherwise copy-eligible AAC-LC stereo 48k.
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder._first_audio_pts",
             return_value=11.0,
         ):
-            cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _aac_lc_stereo_48k())
+            cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _aac_lc_stereo_48k())
 
         assert "copy" not in cmd
         assert cmd[cmd.index("-c:a") + 1] == "aac"
@@ -578,7 +586,7 @@ class TestLeadingAudioGap:
     def test_first_pts_parses_ffprobe_output(self) -> None:
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="11.000000\n")
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service.subprocess.run",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder.subprocess.run",
             return_value=completed,
         ):
             assert _first_audio_pts("/movies/test.mkv", 0) == pytest.approx(11.0)
@@ -586,14 +594,14 @@ class TestLeadingAudioGap:
     def test_first_pts_returns_none_on_empty_output(self) -> None:
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="")
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service.subprocess.run",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder.subprocess.run",
             return_value=completed,
         ):
             assert _first_audio_pts("/movies/test.mkv", 0) is None
 
     def test_first_pts_returns_none_when_ffprobe_missing(self) -> None:
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service.subprocess.run",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder.subprocess.run",
             side_effect=FileNotFoundError,
         ):
             assert _first_audio_pts("/movies/test.mkv", 0) is None
@@ -603,21 +611,21 @@ class TestLeadingAudioGap:
         # must degrade to None (no gap) instead of raising ValueError.
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="N/A\n")
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service.subprocess.run",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder.subprocess.run",
             return_value=completed,
         ):
             assert _first_audio_pts("/movies/test.mkv", 0) is None
 
     def test_gap_detected_above_threshold(self) -> None:
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder._first_audio_pts",
             return_value=11.0,
         ):
             assert _has_leading_audio_gap("/movies/test.mkv", 0, start=0) is True
 
     def test_no_gap_within_threshold(self) -> None:
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder._first_audio_pts",
             return_value=0.02,
         ):
             assert _has_leading_audio_gap("/movies/test.mkv", 0, start=0) is False
@@ -625,7 +633,7 @@ class TestLeadingAudioGap:
     def test_no_gap_probe_skipped_when_seeking(self) -> None:
         # A seek bucket lands mid-stream; never probe or treat it as a gap.
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder._first_audio_pts",
         ) as probe:
             assert _has_leading_audio_gap("/movies/test.mkv", 0, start=1800) is False
             probe.assert_not_called()
@@ -640,7 +648,7 @@ class TestHlsServiceBuildVideoCmd:
         # Keep these hermetic — otherwise each start==0 build spawns a
         # real ffprobe on the fake path. The gap test patches it itself.
         with patch(
-            "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+            "src.modules.media.infrastructure.streaming.transcode_command_builder._first_audio_pts",
             return_value=None,
         ):
             yield
@@ -651,8 +659,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "copy" in cmd
         assert "libx264" not in cmd
@@ -667,8 +675,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "-bsf:v" in cmd
         assert cmd[cmd.index("-bsf:v") + 1] == "h264_mp4toannexb"
@@ -684,8 +692,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
 
         assert "libx264" in cmd
         assert "copy" not in cmd
@@ -696,8 +704,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="hevc"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="hevc"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "libx264" in cmd
 
@@ -709,8 +717,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "-t" not in cmd
 
@@ -722,8 +730,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd(
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd(
                 "/series/shared.mkv", tmp_path, probe, start=4740, end=9480
             )
 
@@ -738,8 +746,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_aac_lc_stereo_48k()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="hevc"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="hevc"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert cmd[cmd.index("-c:a") + 1] == "copy"
         assert "libx264" in cmd  # video still re-encoded
@@ -755,13 +763,13 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_aac_lc_stereo_48k()])
 
         with (
-            patch.object(HlsService, "_probe_video_codec", return_value="h264"),
+            patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"),
             patch(
-                "src.modules.media.infrastructure.streaming.hls_service._first_audio_pts",
+                "src.modules.media.infrastructure.streaming.transcode_command_builder._first_audio_pts",
                 return_value=11.0,
             ),
         ):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert cmd[cmd.index("-c:a") + 1] == "aac"
         assert cmd[cmd.index("-af") + 1] == "aresample=async=1:first_pts=0"
@@ -775,10 +783,10 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with (
-            patch.object(HlsService, "_probe_video_codec", return_value="hevc"),
-            patch.object(HlsService, "_detect_nvenc", return_value=True),
+            patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="hevc"),
+            patch.object(HardwareAccelerationProbe, "detect_nvenc", return_value=True),
         ):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "h264_nvenc" in cmd
         assert "libx264" not in cmd
@@ -798,10 +806,10 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with (
-            patch.object(HlsService, "_probe_video_codec", return_value="hevc"),
-            patch.object(HlsService, "_detect_nvenc", return_value=False),
+            patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="hevc"),
+            patch.object(HardwareAccelerationProbe, "detect_nvenc", return_value=False),
         ):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "libx264" in cmd
         assert "h264_nvenc" not in cmd
@@ -816,10 +824,10 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with (
-            patch.object(HlsService, "_probe_video_codec", return_value="hevc"),
-            patch.object(HlsService, "_detect_nvenc", return_value=True) as detect,
+            patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="hevc"),
+            patch.object(HardwareAccelerationProbe, "detect_nvenc", return_value=True) as detect,
         ):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "libx264" in cmd
         assert "h264_nvenc" not in cmd
@@ -834,10 +842,10 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with (
-            patch.object(HlsService, "_probe_video_codec", return_value="hevc"),
-            patch.object(HlsService, "_detect_nvenc", return_value=False) as detect,
+            patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="hevc"),
+            patch.object(HardwareAccelerationProbe, "detect_nvenc", return_value=False) as detect,
         ):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "h264_nvenc" in cmd
         detect.assert_not_called()
@@ -852,10 +860,10 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with (
-            patch.object(HlsService, "_probe_video_codec", return_value="h264"),
-            patch.object(HlsService, "_detect_nvenc", return_value=True),
+            patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"),
+            patch.object(HardwareAccelerationProbe, "detect_nvenc", return_value=True),
         ):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "copy" in cmd
         assert "h264_nvenc" not in cmd
@@ -868,9 +876,9 @@ class TestHlsServiceBuildVideoCmd:
             cache_dir=str(tmp_path / "cache"),
         )
 
-        with patch.object(HlsService, "_detect_nvenc", return_value=True) as detect:
-            assert service._nvenc_available() is True
-            assert service._nvenc_available() is True
+        with patch.object(HardwareAccelerationProbe, "detect_nvenc", return_value=True) as detect:
+            assert service._hw_probe.nvenc_available() is True
+            assert service._hw_probe.nvenc_available() is True
 
         detect.assert_called_once()
 
@@ -882,8 +890,8 @@ class TestHlsServiceBuildVideoCmd:
             audio_tracks=[_make_audio_track(index=3)],
         )
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "0:a:3" in cmd
 
@@ -894,8 +902,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "-ss" not in cmd
 
@@ -908,8 +916,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
 
         assert "-ss" in cmd
         ss_index = cmd.index("-ss")
@@ -926,8 +934,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
 
         assert "-accurate_seek" in cmd
         accurate_index = cmd.index("-accurate_seek")
@@ -940,8 +948,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
 
         assert "-avoid_negative_ts" in cmd
         idx = cmd.index("-avoid_negative_ts")
@@ -953,8 +961,8 @@ class TestHlsServiceBuildVideoCmd:
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
 
         assert "-accurate_seek" not in cmd
         assert "-avoid_negative_ts" not in cmd
@@ -967,7 +975,7 @@ class TestHlsServiceBuildMasterPlaylist:
     def test_should_write_master_m3u8(self, tmp_path: Path) -> None:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
-        HlsService._build_master_playlist(tmp_path, probe)
+        MasterPlaylistWriter.write(tmp_path, probe)
 
         master = tmp_path / "master.m3u8"
         assert master.is_file()
@@ -983,7 +991,7 @@ class TestHlsServiceBuildMasterPlaylist:
             ],
         )
 
-        HlsService._build_master_playlist(tmp_path, probe)
+        MasterPlaylistWriter.write(tmp_path, probe)
 
         content = (tmp_path / "master.m3u8").read_text()
         assert "#EXT-X-MEDIA:TYPE=AUDIO" in content
@@ -997,7 +1005,7 @@ class TestHlsServiceBuildMasterPlaylist:
             subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="srt")],
         )
 
-        HlsService._build_master_playlist(tmp_path, probe)
+        MasterPlaylistWriter.write(tmp_path, probe)
 
         content = (tmp_path / "master.m3u8").read_text()
         assert "#EXT-X-MEDIA:TYPE=SUBTITLES" in content
@@ -1009,7 +1017,7 @@ class TestHlsServiceBuildMasterPlaylist:
             subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="pgs")],
         )
 
-        HlsService._build_master_playlist(tmp_path, probe)
+        MasterPlaylistWriter.write(tmp_path, probe)
 
         content = (tmp_path / "master.m3u8").read_text()
         assert 'URI="sub_0/playlist.m3u8"' not in content
@@ -1022,7 +1030,7 @@ class TestHlsServiceBuildMasterPlaylist:
             ],
         )
 
-        HlsService._build_master_playlist(tmp_path, probe)
+        MasterPlaylistWriter.write(tmp_path, probe)
 
         content = (tmp_path / "master.m3u8").read_text()
         assert "FORCED=YES" in content
@@ -1038,7 +1046,7 @@ class TestHlsServiceSaveAndDeserializeProbe:
             subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="srt")],
         )
 
-        HlsService._save_probe_cache(tmp_path, probe)
+        ProbeCacheStore.save(tmp_path, probe)
 
         tracks_file = tmp_path / "tracks.json"
         assert tracks_file.is_file()
@@ -1055,9 +1063,9 @@ class TestHlsServiceSaveAndDeserializeProbe:
             subtitle_tracks=[_make_subtitle_track(index=0, lang="en", fmt="srt")],
         )
 
-        HlsService._save_probe_cache(tmp_path, probe)
+        ProbeCacheStore.save(tmp_path, probe)
         data = json.loads((tmp_path / "tracks.json").read_text())
-        result = HlsService._deserialize_probe(data)
+        result = ProbeCacheStore.deserialize(data)
 
         assert len(result.audio_tracks) == 2
         assert result.audio_tracks[0].title == "English"
@@ -2109,14 +2117,14 @@ class TestMpegtsZeroStart:
             runtime_settings=_fake_runtime_settings(), cache_dir=str(tmp_path / "cache")
         )
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
-        with patch.object(HlsService, "_probe_video_codec", return_value="h264"):
-            cmd = service._build_video_cmd("/movies/test.mkv", tmp_path, probe)
+        with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
+            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe)
         assert cmd[cmd.index("-muxdelay") + 1] == "0"
         assert cmd[cmd.index("-muxpreload") + 1] == "0"
 
     @pytest.mark.unit
     def test_audio_cmd_zeroes_muxer_offset(self, tmp_path: Path) -> None:
-        cmd = HlsService._build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
         assert cmd[cmd.index("-muxdelay") + 1] == "0"
         assert cmd[cmd.index("-muxpreload") + 1] == "0"
 

--- a/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
+++ b/tests/modules/media/unit/infrastructure/streaming/test_hls_service.py
@@ -410,13 +410,17 @@ class TestHlsServiceBuildAudioCmd:
             yield
 
     def test_should_include_input_file(self, tmp_path: Path) -> None:
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=1)
+        )
 
         assert "-i" in cmd
         assert "/movies/test.mkv" in cmd
 
     def test_should_map_to_correct_audio_stream(self, tmp_path: Path) -> None:
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=2))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=2)
+        )
 
         assert "0:a:2" in cmd
 
@@ -431,24 +435,32 @@ class TestHlsServiceBuildAudioCmd:
         assert cmd[cmd.index("-t") + 1] == "4740"
 
     def test_should_not_clamp_duration_without_end(self, tmp_path: Path) -> None:
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=1))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=1)
+        )
 
         assert "-t" not in cmd
 
     def test_should_disable_video_and_subtitle(self, tmp_path: Path) -> None:
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=0)
+        )
 
         assert "-vn" in cmd
         assert "-sn" in cmd
 
     def test_should_use_aac_codec(self, tmp_path: Path) -> None:
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=0)
+        )
 
         assert "aac" in cmd
 
     def test_should_omit_seek_flag_when_start_is_zero(self, tmp_path: Path) -> None:
         # Default cold-cache transcode starts at t=0 — no ``-ss``.
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=0)
+        )
 
         assert "-ss" not in cmd
 
@@ -495,14 +507,18 @@ class TestHlsServiceBuildAudioCmd:
         # Sync hardening only kicks in for non-zero ``start`` since the
         # legacy cold-cache transcode never hits the keyframe-vs-audio
         # gap (it begins at t=0 of the source).
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=0)
+        )
 
         assert "-accurate_seek" not in cmd
         assert "-avoid_negative_ts" not in cmd
 
     def test_should_copy_aac_lc_stereo_48k_at_start_zero(self, tmp_path: Path) -> None:
         # Already browser-ready audio is remuxed, not re-encoded.
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _aac_lc_stereo_48k(index=1))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _aac_lc_stereo_48k(index=1)
+        )
 
         assert cmd[cmd.index("-c:a") + 1] == "copy"
         assert "-ar" not in cmd  # no encode params on the copy path
@@ -542,7 +558,9 @@ class TestHlsServiceBuildAudioCmd:
             "src.modules.media.infrastructure.streaming.transcode_command_builder._first_audio_pts",
             return_value=11.0,
         ):
-            cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _aac_lc_stereo_48k())
+            cmd = TranscodeCommandBuilder.build_audio_cmd(
+                "/movies/test.mkv", tmp_path, _aac_lc_stereo_48k()
+            )
 
         assert "copy" not in cmd
         assert cmd[cmd.index("-c:a") + 1] == "aac"
@@ -693,7 +711,9 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
-            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+            cmd = service._cmd_builder.build_video_cmd(
+                "/movies/test.mkv", tmp_path, probe, start=1800
+            )
 
         assert "libx264" in cmd
         assert "copy" not in cmd
@@ -917,7 +937,9 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
-            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+            cmd = service._cmd_builder.build_video_cmd(
+                "/movies/test.mkv", tmp_path, probe, start=1800
+            )
 
         assert "-ss" in cmd
         ss_index = cmd.index("-ss")
@@ -935,7 +957,9 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
-            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+            cmd = service._cmd_builder.build_video_cmd(
+                "/movies/test.mkv", tmp_path, probe, start=1800
+            )
 
         assert "-accurate_seek" in cmd
         accurate_index = cmd.index("-accurate_seek")
@@ -949,7 +973,9 @@ class TestHlsServiceBuildVideoCmd:
         probe = ProbeResult(audio_tracks=[_make_audio_track()])
 
         with patch.object(HardwareAccelerationProbe, "probe_video_codec", return_value="h264"):
-            cmd = service._cmd_builder.build_video_cmd("/movies/test.mkv", tmp_path, probe, start=1800)
+            cmd = service._cmd_builder.build_video_cmd(
+                "/movies/test.mkv", tmp_path, probe, start=1800
+            )
 
         assert "-avoid_negative_ts" in cmd
         idx = cmd.index("-avoid_negative_ts")
@@ -2124,7 +2150,9 @@ class TestMpegtsZeroStart:
 
     @pytest.mark.unit
     def test_audio_cmd_zeroes_muxer_offset(self, tmp_path: Path) -> None:
-        cmd = TranscodeCommandBuilder.build_audio_cmd("/movies/test.mkv", tmp_path, _make_audio_track(index=0))
+        cmd = TranscodeCommandBuilder.build_audio_cmd(
+            "/movies/test.mkv", tmp_path, _make_audio_track(index=0)
+        )
         assert cmd[cmd.index("-muxdelay") + 1] == "0"
         assert cmd[cmd.index("-muxpreload") + 1] == "0"
 


### PR DESCRIPTION
## Summary

Onda 3 item 3.2 (part 1 of 2) of the tech-debt remediation plan — Extract-Class on the 1824-LOC `HlsService` god-object (ADR-032 prep). This PR extracts the four **pure, lock-free** seams; the delicate threading/process/subtitle/cache-eviction trio (which share a single `threading.Lock`) is a focused follow-up.

Extracted collaborators (new modules under `streaming/`):

- **`HardwareAccelerationProbe`** — NVENC/CUDA capability: `probe_video_codec`, `detect_nvenc`, memoised `nvenc_available`, `use_nvenc`. Owns the `_nvenc_probe` state.
- **`TranscodeCommandBuilder`** — `build_video_cmd` / `build_audio_cmd` ffmpeg argv + the audio-gap helpers (`_first_audio_pts`, `_has_leading_audio_gap`, `_audio_args_for`). Depends on the HW probe.
- **`ProbeCacheStore`** — `tracks.json` read (`get_cached_tracks`) + `save` / `deserialize`.
- **`MasterPlaylistWriter`** — `master.m3u8` multivariant playlist (`write`) + `_manifest_track_name`.
- **`_hls_common`** — neutral module for the shared pure helpers/constants (`primary_audio_index`, `SEGMENT_DURATION`, `BROWSER_SAFE_CODECS`), so a seam never imports `hls_service` back (no cycle).

`HlsService` constructs and delegates to the seams. Every `HlsPlaylistPort` signature is unchanged, so the DI container needs no edits. `hls_service.py` drops **630 LOC** (1824 → 1194). ffmpeg args, log messages, and behaviour are byte-identical.

## Test plan

- [x] `mypy src` — clean (786 files)
- [x] `ruff check` (streaming src + tests) — clean
- [x] `pytest tests/modules/media/unit/infrastructure/streaming` — 297 passed
- [x] Port-consumer + facade tests (generate/serve/get_file_tracks use cases, stream routes) — 328 passed together
- Behaviour preserved: the big `test_hls_service.py` was repointed at the new seam objects (build cmds, NVENC probe, master writer, probe cache) with identical assertions.

## Related issues

- Tech-debt plan 3.2 (part 1); ADR-032 prep. Follow-up: extract the `FfmpegProcessManager` + `SubtitlePipeline` + `HlsCacheStore` trio (shared lock).

## Summary by Sourcery

Refactor the HLS streaming module by extracting pure, lock-free collaborators for hardware acceleration probing, ffmpeg command construction, probe cache persistence, and master playlist generation, leaving HlsService as an orchestrator while preserving behaviour and public interfaces.

Enhancements:
- Introduce HardwareAccelerationProbe to encapsulate NVENC/CUDA capability detection and hw_accel decision logic.
- Introduce TranscodeCommandBuilder to build ffmpeg video and audio commands, including audio-gap handling and browser-safe codec logic.
- Introduce ProbeCacheStore to manage tracks.json probe cache persistence and reconstruction under the HLS cache directory.
- Introduce MasterPlaylistWriter to generate master.m3u8 playlists with audio and subtitle renditions based on probe results.
- Extract shared HLS constants and helpers into a neutral _hls_common module to avoid circular imports and share logic across streaming components.
- Simplify HlsService by delegating hardware probing, command building, probe caching, and master playlist writing to the new collaborators, reducing class size without changing its public API.

Tests:
- Update and extend streaming unit tests to target the new HardwareAccelerationProbe, TranscodeCommandBuilder, ProbeCacheStore, MasterPlaylistWriter, and shared helpers while maintaining existing behavioural coverage for HlsService.